### PR TITLE
AVM1 browser interactions

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -4,7 +4,7 @@ use crate::backend::navigator::NavigationMethod;
 
 use crate::prelude::*;
 use gc_arena::{GcCell, MutationContext};
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{rngs::SmallRng, Rng};
 use std::collections::HashMap;
 
 use swf::avm1::read::Reader;

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -22,6 +22,7 @@ pub struct ActionContext<'a, 'gc, 'gc_context> {
     pub start_clip: DisplayNode<'gc>,
     pub active_clip: DisplayNode<'gc>,
     pub audio: &'a mut dyn crate::backend::audio::AudioBackend,
+    pub navigator: &'a mut dyn crate::backend::navigator::NavigatorBackend
 }
 
 pub struct Avm1<'gc> {

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -21,6 +21,7 @@ pub struct ActionContext<'a, 'gc, 'gc_context> {
     pub root: DisplayNode<'gc>,
     pub start_clip: DisplayNode<'gc>,
     pub active_clip: DisplayNode<'gc>,
+    pub rng: &'a mut SmallRng,
     pub audio: &'a mut dyn crate::backend::audio::AudioBackend,
     pub navigator: &'a mut dyn crate::backend::navigator::NavigatorBackend
 }
@@ -28,7 +29,6 @@ pub struct ActionContext<'a, 'gc, 'gc_context> {
 pub struct Avm1<'gc> {
     swf_version: u8,
     stack: Vec<Value<'gc>>,
-    rng: SmallRng,
     constant_pool: Vec<String>,
     locals: HashMap<String, Value<'gc>>,
     globals: GcCell<'gc, Object<'gc>>,
@@ -50,7 +50,6 @@ impl<'gc> Avm1<'gc> {
         Self {
             swf_version,
             stack: vec![],
-            rng: SmallRng::from_seed([0u8; 16]), // TODO(Herschel): Get a proper seed on all platforms.
             constant_pool: vec![],
             locals: HashMap::new(),
             globals: GcCell::allocate(gc_context, create_globals(gc_context)),
@@ -912,9 +911,9 @@ impl<'gc> Avm1<'gc> {
         Ok(())
     }
 
-    fn action_random_number(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
+    fn action_random_number(&mut self, context: &mut ActionContext) -> Result<(), Error> {
         let max = self.pop()?.as_f64()? as u32;
-        let val = self.rng.gen_range(0, max);
+        let val = context.rng.gen_range(0, max);
         self.push(Value::Number(val.into()));
         Ok(())
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -609,7 +609,12 @@ impl<'gc> Avm1<'gc> {
         url: &str,
         target: &str,
     ) -> Result<(), Error> {
-        //TODO: support `_level0`, `_level1`
+        //TODO: support `_level0` thru `_level9`
+        if target.starts_with("_level") {
+            log::warn!("Remote SWF loads into target {} not yet implemented", target);
+            return Ok(());
+        }
+
         context.navigator.navigate_to_url(url.to_owned(), Some(target.to_owned()), None);
 
         Ok(())

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -387,7 +387,13 @@ impl<'gc> Avm1<'gc> {
                     self.stack
                         .push(object.call(context, object.as_object()?.to_owned(), &args)?);
                 } else {
-                    self.stack.push(object.as_object()?.read().get(&name).call(
+                    let callable = object.as_object()?.read().get(&name);
+
+                    if let Value::Undefined = callable {
+                        return Err(format!("Object method {} is not defined", name).into());
+                    }
+
+                    self.stack.push(callable.call(
                         context,
                         object.as_object()?.to_owned(),
                         &args,

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -379,12 +379,13 @@ impl<'gc> Avm1<'gc> {
         match method_name {
             Value::Undefined | Value::Null => {
                 let this = context.active_clip.read().object().as_object()?.to_owned();
-                self.stack.push(object.call(context, this, &args)?);
+                let return_value = object.call(self, context, this, &args)?;
+                self.stack.push(return_value);
             }
             Value::String(name) => {
                 if name.is_empty() {
-                    self.stack
-                        .push(object.call(context, object.as_object()?.to_owned(), &args)?);
+                    let return_value = object.call(self, context, object.as_object()?.to_owned(), &args)?;
+                    self.stack.push(return_value);
                 } else {
                     let callable = object.as_object()?.read().get(&name);
 
@@ -392,11 +393,9 @@ impl<'gc> Avm1<'gc> {
                         return Err(format!("Object method {} is not defined", name).into());
                     }
 
-                    self.stack.push(callable.call(
-                        context,
-                        object.as_object()?.to_owned(),
-                        &args,
-                    )?);
+                    let return_value = callable.call(self, context, object.as_object()?.to_owned(), &args)?;
+
+                    self.stack.push(return_value);
                 }
             }
             _ => {

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -605,25 +605,39 @@ impl<'gc> Avm1<'gc> {
 
     fn action_get_url(
         &mut self,
-        _context: &mut ActionContext,
-        _url: &str,
-        _target: &str,
+        context: &mut ActionContext,
+        url: &str,
+        target: &str,
     ) -> Result<(), Error> {
-        // TODO(Herschel): Noop for now. Need a UI/ActionScript/network backend
-        // to handle network requests appropriately for the platform.
+        //TODO: support `_level0`, `_level1`
+        context.navigator.navigate_to_url(url.to_owned(), Some(target.to_owned()), None);
+
         Ok(())
     }
 
     fn action_get_url_2(
         &mut self,
-        _context: &mut ActionContext,
+        context: &mut ActionContext,
         _method: swf::avm1::types::SendVarsMethod,
-        _is_target_sprite: bool,
-        _is_load_vars: bool,
+        is_target_sprite: bool,
+        is_load_vars: bool,
     ) -> Result<(), Error> {
-        // TODO(Herschel): Noop for now. Need a UI/ActionScript/network backend
-        // to handle network requests appropriately for the platform.
-        let _url = self.pop()?.into_string();
+        // TODO: Support `LoadVariablesFlag`, `LoadTargetFlag`
+        // TODO: What happens if there's only one string?
+        let target = self.pop()?.into_string();
+        let url = self.pop()?.into_string();
+
+        if is_target_sprite {
+            log::warn!("GetURL into target sprite is not yet implemented");
+            return Ok(()); //maybe error?
+        }
+
+        if is_load_vars {
+            log::warn!("Loading AVM locals into forms is not yet implemented");
+            return Ok(()); //maybe error?
+        }
+        
+        context.navigator.navigate_to_url(url, Some(target), None);
 
         Ok(())
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -24,7 +24,7 @@ pub struct ActionContext<'a, 'gc, 'gc_context> {
     pub active_clip: DisplayNode<'gc>,
     pub rng: &'a mut SmallRng,
     pub audio: &'a mut dyn crate::backend::audio::AudioBackend,
-    pub navigator: &'a mut dyn crate::backend::navigator::NavigatorBackend
+    pub navigator: &'a mut dyn crate::backend::navigator::NavigatorBackend,
 }
 
 pub struct Avm1<'gc> {
@@ -58,7 +58,7 @@ impl<'gc> Avm1<'gc> {
     }
 
     /// Convert the current locals pool into a set of form values.
-    /// 
+    ///
     /// This is necessary to support form submission from Flash via a couple of
     /// legacy methods, such as the `ActionGetURL2` opcode or `getURL` function.
     pub fn locals_into_form_values(&self) -> HashMap<String, String> {
@@ -399,7 +399,8 @@ impl<'gc> Avm1<'gc> {
             }
             Value::String(name) => {
                 if name.is_empty() {
-                    let return_value = object.call(self, context, object.as_object()?.to_owned(), &args)?;
+                    let return_value =
+                        object.call(self, context, object.as_object()?.to_owned(), &args)?;
                     self.stack.push(return_value);
                 } else {
                     let callable = object.as_object()?.read().get(&name);
@@ -408,7 +409,8 @@ impl<'gc> Avm1<'gc> {
                         return Err(format!("Object method {} is not defined", name).into());
                     }
 
-                    let return_value = callable.call(self, context, object.as_object()?.to_owned(), &args)?;
+                    let return_value =
+                        callable.call(self, context, object.as_object()?.to_owned(), &args)?;
 
                     self.stack.push(return_value);
                 }
@@ -625,11 +627,16 @@ impl<'gc> Avm1<'gc> {
     ) -> Result<(), Error> {
         //TODO: support `_level0` thru `_level9`
         if target.starts_with("_level") {
-            log::warn!("Remote SWF loads into target {} not yet implemented", target);
+            log::warn!(
+                "Remote SWF loads into target {} not yet implemented",
+                target
+            );
             return Ok(());
         }
 
-        context.navigator.navigate_to_url(url.to_owned(), Some(target.to_owned()), None);
+        context
+            .navigator
+            .navigate_to_url(url.to_owned(), Some(target.to_owned()), None);
 
         Ok(())
     }
@@ -655,10 +662,10 @@ impl<'gc> Avm1<'gc> {
             log::warn!("Reading AVM locals from forms is not yet implemented");
             return Ok(()); //maybe error?
         }
-        
+
         let vars = match NavigationMethod::from_send_vars_method(swf_method) {
             Some(method) => Some((method, self.locals_into_form_values())),
-            None => None
+            None => None,
         };
 
         context.navigator.navigate_to_url(url, Some(target), vars);

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -1,12 +1,36 @@
-use crate::avm1::object::Object;
-use gc_arena::MutationContext;
+use crate::avm1::{Object, Value, ActionContext};
+use gc_arena::{MutationContext, GcCell};
 
 mod math;
+
+#[allow(non_snake_case)]
+pub fn getURL<'a, 'gc>(
+    context: &mut ActionContext<'a, 'gc, '_>,
+    _this: GcCell<'gc, Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Value<'gc> {
+    match args.get(0) {
+        Some(url_val) => {
+            let url = url_val.clone().into_string();
+            let window = args.get(1).map(|v| v.clone().into_string());
+            let method = args.get(2).map(|v| v.clone().into_string());
+
+            //TODO: Pull AVM1 locals into key-value storage
+            context.navigator.navigate_to_url(url, window, None);
+        },
+        None => {
+            //TODO: Does AVM1 error out?
+        }
+    }
+
+    Value::Undefined
+}
 
 pub fn create_globals<'gc>(gc_context: MutationContext<'gc, '_>) -> Object<'gc> {
     let mut globals = Object::object(gc_context);
 
     globals.set_object("Math", math::create(gc_context));
+    globals.set_function("getURL", getURL, gc_context);
 
     globals
 }

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -26,11 +26,20 @@ pub fn getURL<'a, 'gc>(
     Value::Undefined
 }
 
+pub fn random<'gc>(
+    _action_context: &mut ActionContext<'_, 'gc, '_>,
+    _this: GcCell<'gc, Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Value<'gc> {
+    Value::Number(4.0) //chosen by fair dice roll. guaranteed to be random.
+}
+
 pub fn create_globals<'gc>(gc_context: MutationContext<'gc, '_>) -> Object<'gc> {
     let mut globals = Object::object(gc_context);
 
     globals.set_object("Math", math::create(gc_context));
     globals.set_function("getURL", getURL, gc_context);
+    globals.set_function("random", random, gc_context);
 
     globals
 }

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{Object, Value, ActionContext};
+use crate::avm1::{Object, Value, ActionContext, Avm1};
 use gc_arena::{MutationContext, GcCell};
 use rand::Rng;
 
@@ -6,6 +6,7 @@ mod math;
 
 #[allow(non_snake_case)]
 pub fn getURL<'a, 'gc>(
+    _avm: &mut Avm1<'gc>,
     context: &mut ActionContext<'a, 'gc, '_>,
     _this: GcCell<'gc, Object<'gc>>,
     args: &[Value<'gc>],
@@ -28,6 +29,7 @@ pub fn getURL<'a, 'gc>(
 }
 
 pub fn random<'gc>(
+    _avm: &mut Avm1<'gc>,
     action_context: &mut ActionContext<'_, 'gc, '_>,
     _this: GcCell<'gc, Object<'gc>>,
     args: &[Value<'gc>],

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -12,22 +12,18 @@ pub fn getURL<'a, 'gc>(
     _this: GcCell<'gc, Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Value<'gc> {
-    match args.get(0) {
-        Some(url_val) => {
-            let url = url_val.clone().into_string();
-            let window = args.get(1).map(|v| v.clone().into_string());
-            let method = match args.get(2) {
-                Some(Value::String(s)) if s == "GET" => Some(NavigationMethod::GET),
-                Some(Value::String(s)) if s == "POST" => Some(NavigationMethod::POST),
-                _ => None
-            };
-            let vars_method = method.map(|m| (m, avm.locals_into_form_values()));
-            
-            context.navigator.navigate_to_url(url, window, vars_method);
-        },
-        None => {
-            //TODO: Does AVM1 error out?
-        }
+    //TODO: Error behavior if no arguments are present
+    if let Some(url_val) = args.get(0) {
+        let url = url_val.clone().into_string();
+        let window = args.get(1).map(|v| v.clone().into_string());
+        let method = match args.get(2) {
+            Some(Value::String(s)) if s == "GET" => Some(NavigationMethod::GET),
+            Some(Value::String(s)) if s == "POST" => Some(NavigationMethod::POST),
+            _ => None
+        };
+        let vars_method = method.map(|m| (m, avm.locals_into_form_values()));
+        
+        context.navigator.navigate_to_url(url, window, vars_method);
     }
 
     Value::Undefined

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -1,5 +1,6 @@
 use crate::avm1::{Object, Value, ActionContext};
 use gc_arena::{MutationContext, GcCell};
+use rand::Rng;
 
 mod math;
 
@@ -27,11 +28,14 @@ pub fn getURL<'a, 'gc>(
 }
 
 pub fn random<'gc>(
-    _action_context: &mut ActionContext<'_, 'gc, '_>,
+    action_context: &mut ActionContext<'_, 'gc, '_>,
     _this: GcCell<'gc, Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Value<'gc> {
-    Value::Number(4.0) //chosen by fair dice roll. guaranteed to be random.
+    match args.get(0) {
+        Some(Value::Number(max)) => Value::Number(action_context.rng.gen_range(0.0f64, max).floor()),
+        _ => Value::Undefined //TODO: Shouldn't this be an error condition?
+    }
 }
 
 pub fn create_globals<'gc>(gc_context: MutationContext<'gc, '_>) -> Object<'gc> {

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -1,6 +1,6 @@
-use crate::avm1::{Object, Value, ActionContext, Avm1};
+use crate::avm1::{ActionContext, Avm1, Object, Value};
 use crate::backend::navigator::NavigationMethod;
-use gc_arena::{MutationContext, GcCell};
+use gc_arena::{GcCell, MutationContext};
 use rand::Rng;
 
 mod math;
@@ -19,10 +19,10 @@ pub fn getURL<'a, 'gc>(
         let method = match args.get(2) {
             Some(Value::String(s)) if s == "GET" => Some(NavigationMethod::GET),
             Some(Value::String(s)) if s == "POST" => Some(NavigationMethod::POST),
-            _ => None
+            _ => None,
         };
         let vars_method = method.map(|m| (m, avm.locals_into_form_values()));
-        
+
         context.navigator.navigate_to_url(url, window, vars_method);
     }
 
@@ -36,8 +36,10 @@ pub fn random<'gc>(
     args: &[Value<'gc>],
 ) -> Value<'gc> {
     match args.get(0) {
-        Some(Value::Number(max)) => Value::Number(action_context.rng.gen_range(0.0f64, max).floor()),
-        _ => Value::Undefined //TODO: Shouldn't this be an error condition?
+        Some(Value::Number(max)) => {
+            Value::Number(action_context.rng.gen_range(0.0f64, max).floor())
+        }
+        _ => Value::Undefined, //TODO: Shouldn't this be an error condition?
     }
 }
 

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -35,6 +35,14 @@ fn atan2<'gc>(
     Value::Number(NAN)
 }
 
+pub fn random<'gc>(
+    _action_context: &mut ActionContext<'_, 'gc, '_>,
+    _this: GcCell<'gc, Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Value<'gc> {
+    Value::Number(0.4) //chosen by fair dice roll. guaranteed to be random.
+}
+
 pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'gc>> {
     let mut math = Object::object(gc_context);
 
@@ -63,6 +71,7 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
     );
 
     math.set_function("atan2", atan2, gc_context);
+    math.set_function("random", random, gc_context);
 
     GcCell::allocate(gc_context, math)
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,7 +1,7 @@
-use crate::avm1::{ActionContext, Object, Value, Avm1};
+use crate::avm1::{ActionContext, Avm1, Object, Value};
 use gc_arena::{GcCell, MutationContext};
-use std::f64::NAN;
 use rand::Rng;
+use std::f64::NAN;
 
 macro_rules! wrap_std {
     ( $object: ident, $gc_context: ident, $($name:expr => $std:path),* ) => {{
@@ -112,7 +112,7 @@ mod tests {
 
     fn with_avm<F, R>(swf_version: u8, test: F) -> R
     where
-        F: for <'a, 'gc> FnOnce(&mut Avm1<'gc>, &mut ActionContext<'a, 'gc, '_>) -> R,
+        F: for<'a, 'gc> FnOnce(&mut Avm1<'gc>, &mut ActionContext<'a, 'gc, '_>) -> R,
     {
         rootless_arena(|gc_context| {
             let mut avm = Avm1::new(gc_context, swf_version);
@@ -126,7 +126,7 @@ mod tests {
                 active_clip: root,
                 rng: &mut SmallRng::from_seed([0u8; 16]),
                 audio: &mut NullAudioBackend::new(),
-                navigator: &mut NullNavigatorBackend::new()
+                navigator: &mut NullNavigatorBackend::new(),
             };
 
             test(&mut avm, &mut context)
@@ -224,7 +224,12 @@ mod tests {
             let math = GcCell::allocate(context.gc_context, create(context.gc_context));
             assert_eq!(atan2(avm, context, *math.read(), &[]), Value::Number(NAN));
             assert_eq!(
-                atan2(avm, context, *math.read(), &[Value::Number(1.0), Value::Null]),
+                atan2(
+                    avm,
+                    context,
+                    *math.read(),
+                    &[Value::Number(1.0), Value::Null]
+                ),
                 Value::Number(NAN)
             );
             assert_eq!(

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,6 +1,7 @@
 use crate::avm1::{ActionContext, Object, Value};
 use gc_arena::{GcCell, MutationContext};
 use std::f64::NAN;
+use rand::Rng;
 
 macro_rules! wrap_std {
     ( $object: ident, $gc_context: ident, $($name:expr => $std:path),* ) => {{
@@ -36,11 +37,11 @@ fn atan2<'gc>(
 }
 
 pub fn random<'gc>(
-    _action_context: &mut ActionContext<'_, 'gc, '_>,
+    action_context: &mut ActionContext<'_, 'gc, '_>,
     _this: GcCell<'gc, Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Value<'gc> {
-    Value::Number(0.4) //chosen by fair dice roll. guaranteed to be random.
+    Value::Number(action_context.rng.gen_range(0.0f64, 1.0f64))
 }
 
 pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'gc>> {
@@ -87,6 +88,7 @@ mod tests {
     use crate::display_object::DisplayObject;
     use crate::movie_clip::MovieClip;
     use gc_arena::rootless_arena;
+    use rand::{rngs::SmallRng, SeedableRng};
 
     macro_rules! test_std {
     ( $test: ident, $name: expr, $($args: expr => $out: expr),* ) => {
@@ -119,6 +121,7 @@ mod tests {
                 root,
                 start_clip: root,
                 active_clip: root,
+                rng: &mut SmallRng::from_seed([0u8; 16]),
                 audio: &mut NullAudioBackend::new(),
                 navigator: &mut NullNavigatorBackend::new()
             };

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -74,6 +74,7 @@ mod tests {
     use super::*;
     use crate::avm1::Error;
     use crate::backend::audio::NullAudioBackend;
+    use crate::backend::navigator::NullNavigatorBackend;
     use crate::display_object::DisplayObject;
     use crate::movie_clip::MovieClip;
     use gc_arena::rootless_arena;
@@ -110,6 +111,7 @@ mod tests {
                 start_clip: root,
                 active_clip: root,
                 audio: &mut NullAudioBackend::new(),
+                navigator: &mut NullNavigatorBackend::new()
             };
             test(&mut context)
         })

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{ActionContext, Object, Value};
+use crate::avm1::{ActionContext, Object, Value, Avm1};
 use gc_arena::{GcCell, MutationContext};
 use std::f64::NAN;
 use rand::Rng;
@@ -8,7 +8,7 @@ macro_rules! wrap_std {
         $(
             $object.set_function(
                 $name,
-                |_context, _this, args| -> Value<'gc> {
+                |_avm, _context, _this, args| -> Value<'gc> {
                     if let Some(input) = args.get(0) {
                         Value::Number($std(input.as_number()))
                     } else {
@@ -22,6 +22,7 @@ macro_rules! wrap_std {
 }
 
 fn atan2<'gc>(
+    _avm: &mut Avm1<'gc>,
     _context: &mut ActionContext<'_, 'gc, '_>,
     _this: GcCell<'gc, Object<'gc>>,
     args: &[Value<'gc>],
@@ -37,6 +38,7 @@ fn atan2<'gc>(
 }
 
 pub fn random<'gc>(
+    _avm: &mut Avm1<'gc>,
     action_context: &mut ActionContext<'_, 'gc, '_>,
     _this: GcCell<'gc, Object<'gc>>,
     _args: &[Value<'gc>],
@@ -91,28 +93,29 @@ mod tests {
     use rand::{rngs::SmallRng, SeedableRng};
 
     macro_rules! test_std {
-    ( $test: ident, $name: expr, $($args: expr => $out: expr),* ) => {
-        #[test]
-        fn $test() -> Result<(), Error> {
-            with_avm(|context| {
-                let math = create(context.gc_context);
-                let function = math.read().get($name);
+        ( $test: ident, $name: expr, $($args: expr => $out: expr),* ) => {
+            #[test]
+            fn $test() -> Result<(), Error> {
+                with_avm(19, |avm, context| {
+                    let math = create(context.gc_context);
+                    let function = math.read().get($name);
 
-                $(
-                    assert_eq!(function.call(context, math, $args)?, $out);
-                )*
+                    $(
+                        assert_eq!(function.call(avm, context, math, $args)?, $out);
+                    )*
 
-                Ok(())
-            })
-        }
-    };
-}
+                    Ok(())
+                })
+            }
+        };
+    }
 
-    fn with_avm<F, R>(test: F) -> R
+    fn with_avm<F, R>(swf_version: u8, test: F) -> R
     where
-        F: FnOnce(&mut ActionContext) -> R,
+        F: for <'a, 'gc> FnOnce(&mut Avm1<'gc>, &mut ActionContext<'a, 'gc, '_>) -> R,
     {
         rootless_arena(|gc_context| {
+            let mut avm = Avm1::new(gc_context, swf_version);
             let movie_clip: Box<dyn DisplayObject> = Box::new(MovieClip::new(gc_context));
             let root = GcCell::allocate(gc_context, movie_clip);
             let mut context = ActionContext {
@@ -125,7 +128,8 @@ mod tests {
                 audio: &mut NullAudioBackend::new(),
                 navigator: &mut NullNavigatorBackend::new()
             };
-            test(&mut context)
+
+            test(&mut avm, &mut context)
         })
     }
 
@@ -216,15 +220,16 @@ mod tests {
 
     #[test]
     fn test_atan2_nan() {
-        with_avm(|context| {
+        with_avm(19, |avm, context| {
             let math = GcCell::allocate(context.gc_context, create(context.gc_context));
-            assert_eq!(atan2(context, *math.read(), &[]), Value::Number(NAN));
+            assert_eq!(atan2(avm, context, *math.read(), &[]), Value::Number(NAN));
             assert_eq!(
-                atan2(context, *math.read(), &[Value::Number(1.0), Value::Null]),
+                atan2(avm, context, *math.read(), &[Value::Number(1.0), Value::Null]),
                 Value::Number(NAN)
             );
             assert_eq!(
                 atan2(
+                    avm,
                     context,
                     *math.read(),
                     &[Value::Number(1.0), Value::Undefined]
@@ -233,6 +238,7 @@ mod tests {
             );
             assert_eq!(
                 atan2(
+                    avm,
                     context,
                     *math.read(),
                     &[Value::Undefined, Value::Number(1.0)]
@@ -244,14 +250,15 @@ mod tests {
 
     #[test]
     fn test_atan2_valid() {
-        with_avm(|context| {
+        with_avm(19, |avm, context| {
             let math = GcCell::allocate(context.gc_context, create(context.gc_context));
             assert_eq!(
-                atan2(context, *math.read(), &[Value::Number(10.0)]),
+                atan2(avm, context, *math.read(), &[Value::Number(10.0)]),
                 Value::Number(std::f64::consts::FRAC_PI_2)
             );
             assert_eq!(
                 atan2(
+                    avm,
                     context,
                     *math.read(),
                     &[Value::Number(1.0), Value::Number(2.0)]

--- a/core/src/avm1/movie_clip.rs
+++ b/core/src/avm1/movie_clip.rs
@@ -8,7 +8,7 @@ macro_rules! with_movie_clip {
         $(
             $object.set_function(
                 $name,
-                |_context, this, args| -> Value<'gc> {
+                |_avm, _context, this, args| -> Value<'gc> {
                     if let Some(display_object) = this.read().display_node() {
                         if let Some(movie_clip) = display_object.read().as_movie_clip() {
                             return $fn(movie_clip, args);
@@ -27,7 +27,7 @@ macro_rules! with_movie_clip_mut {
         $(
             $object.set_function(
                 $name,
-                |context, this, args| -> Value<'gc> {
+                |_avm, context, this, args| -> Value<'gc> {
                     if let Some(display_object) = this.read().display_node() {
                         if let Some(movie_clip) = display_object.write(context.gc_context).as_movie_clip_mut() {
                             return $fn(movie_clip, args);

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,17 +1,18 @@
-use crate::avm1::{ActionContext, Value};
+use crate::avm1::{ActionContext, Value, Avm1};
 use crate::display_object::DisplayNode;
 use core::fmt;
 use gc_arena::{GcCell, MutationContext};
 use std::collections::HashMap;
 
 pub type NativeFunction<'gc> =
-    fn(&mut ActionContext<'_, 'gc, '_>, GcCell<'gc, Object<'gc>>, &[Value<'gc>]) -> Value<'gc>;
+    fn(&mut Avm1<'gc>, &mut ActionContext<'_, 'gc, '_>, GcCell<'gc, Object<'gc>>, &[Value<'gc>]) -> Value<'gc>;
 
 pub const TYPE_OF_OBJECT: &str = "object";
 pub const TYPE_OF_FUNCTION: &str = "function";
 pub const TYPE_OF_MOVIE_CLIP: &str = "movieclip";
 
 fn default_to_string<'gc>(
+    _: &mut Avm1<'gc>,
     _: &mut ActionContext<'_, 'gc, '_>,
     _: GcCell<'gc, Object<'gc>>,
     _: &[Value<'gc>],
@@ -112,12 +113,13 @@ impl<'gc> Object<'gc> {
 
     pub fn call(
         &self,
+        avm: &mut Avm1<'gc>,
         context: &mut ActionContext<'_, 'gc, '_>,
         this: GcCell<'gc, Object<'gc>>,
         args: &[Value<'gc>],
     ) -> Value<'gc> {
         if let Some(function) = self.function {
-            function(context, this, args)
+            function(avm, context, this, args)
         } else {
             Value::Undefined
         }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,11 +1,15 @@
-use crate::avm1::{ActionContext, Value, Avm1};
+use crate::avm1::{ActionContext, Avm1, Value};
 use crate::display_object::DisplayNode;
 use core::fmt;
 use gc_arena::{GcCell, MutationContext};
 use std::collections::HashMap;
 
-pub type NativeFunction<'gc> =
-    fn(&mut Avm1<'gc>, &mut ActionContext<'_, 'gc, '_>, GcCell<'gc, Object<'gc>>, &[Value<'gc>]) -> Value<'gc>;
+pub type NativeFunction<'gc> = fn(
+    &mut Avm1<'gc>,
+    &mut ActionContext<'_, 'gc, '_>,
+    GcCell<'gc, Object<'gc>>,
+    &[Value<'gc>],
+) -> Value<'gc>;
 
 pub const TYPE_OF_OBJECT: &str = "object";
 pub const TYPE_OF_FUNCTION: &str = "function";

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -1,5 +1,5 @@
 use crate::avm1::object::Object;
-use crate::avm1::{ActionContext, Error, Avm1};
+use crate::avm1::{ActionContext, Avm1, Error};
 use gc_arena::GcCell;
 
 #[derive(Clone, Debug)]

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -1,5 +1,5 @@
 use crate::avm1::object::Object;
-use crate::avm1::{ActionContext, Error};
+use crate::avm1::{ActionContext, Error, Avm1};
 use gc_arena::GcCell;
 
 #[derive(Clone, Debug)]
@@ -162,12 +162,13 @@ impl<'gc> Value<'gc> {
 
     pub fn call(
         &self,
+        avm: &mut Avm1<'gc>,
         context: &mut ActionContext<'_, 'gc, '_>,
         this: GcCell<'gc, Object<'gc>>,
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error> {
         if let Value::Object(object) = self {
-            Ok(object.read().call(context, this, args))
+            Ok(object.read().call(avm, context, this, args))
         } else {
             Err(format!("Expected function, found {:?}", self).into())
         }

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -1,3 +1,3 @@
 pub mod audio;
-pub mod render;
 pub mod navigator;
+pub mod render;

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -1,2 +1,3 @@
 pub mod audio;
 pub mod render;
+pub mod navigator;

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -1,0 +1,63 @@
+//! Browser-related platform functions
+
+use std::collections::HashMap;
+
+/// Enumerates all possible navigation methods.
+pub enum NavigationMethod {
+    /// Indicates that navigation should generate a GET request.
+    GET,
+
+    /// Indicates that navigation should generate a POST request.
+    POST
+}
+
+/// A backend interacting with a browser environment.
+pub trait NavigatorBackend {
+    /// Cause a browser navigation to a given URL.
+    /// 
+    /// The URL given may be any URL scheme a browser can support. This may not
+    /// be meaningful for all environments: for example, `javascript:` URLs may
+    /// not be executable in a desktop context.
+    /// 
+    /// The `window` parameter, if provided, should be treated identically to
+    /// the `window` parameter on an HTML `<a>nchor` tag.
+    /// 
+    /// This function may be used to send variables to an eligible target. If
+    /// desired, the `vars_method` will be specified with a suitable
+    /// `NavigationMethod` and a key-value representation of the variables to
+    /// be sent. What the backend needs to do depends on the `NavigationMethod`:
+    /// 
+    /// * `GET` - Variables are appended onto the query parameters of the given
+    ///   URL.
+    /// * `POST` - Variables are sent as form data in a POST request, as if the
+    ///   user had filled out and submitted an HTML form.
+    /// 
+    /// Flash Player implemented sandboxing to prevent certain kinds of XSS
+    /// attacks. The `NavigatorBackend` is not responsible for enforcing this
+    /// sandbox.
+    fn navigate_to_url(&self, url: String, window: Option<String>, vars_method: Option<(NavigationMethod, HashMap<String, String>)>);
+}
+
+/// A null implementation for platforms that do not live in a web browser.
+pub struct NullNavigatorBackend {
+}
+
+impl NullNavigatorBackend {
+    pub fn new() -> Self {
+        NullNavigatorBackend {
+
+        }
+    }
+}
+
+impl Default for NullNavigatorBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NavigatorBackend for NullNavigatorBackend {
+    fn navigate_to_url(&self, _url: String, _window: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+
+    }
+}

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -9,7 +9,7 @@ pub enum NavigationMethod {
     GET,
 
     /// Indicates that navigation should generate a POST request.
-    POST
+    POST,
 }
 
 impl NavigationMethod {
@@ -26,39 +26,41 @@ impl NavigationMethod {
 /// A backend interacting with a browser environment.
 pub trait NavigatorBackend {
     /// Cause a browser navigation to a given URL.
-    /// 
+    ///
     /// The URL given may be any URL scheme a browser can support. This may not
     /// be meaningful for all environments: for example, `javascript:` URLs may
     /// not be executable in a desktop context.
-    /// 
+    ///
     /// The `window` parameter, if provided, should be treated identically to
     /// the `window` parameter on an HTML `<a>nchor` tag.
-    /// 
+    ///
     /// This function may be used to send variables to an eligible target. If
     /// desired, the `vars_method` will be specified with a suitable
     /// `NavigationMethod` and a key-value representation of the variables to
     /// be sent. What the backend needs to do depends on the `NavigationMethod`:
-    /// 
+    ///
     /// * `GET` - Variables are appended onto the query parameters of the given
     ///   URL.
     /// * `POST` - Variables are sent as form data in a POST request, as if the
     ///   user had filled out and submitted an HTML form.
-    /// 
+    ///
     /// Flash Player implemented sandboxing to prevent certain kinds of XSS
     /// attacks. The `NavigatorBackend` is not responsible for enforcing this
     /// sandbox.
-    fn navigate_to_url(&self, url: String, window: Option<String>, vars_method: Option<(NavigationMethod, HashMap<String, String>)>);
+    fn navigate_to_url(
+        &self,
+        url: String,
+        window: Option<String>,
+        vars_method: Option<(NavigationMethod, HashMap<String, String>)>,
+    );
 }
 
 /// A null implementation for platforms that do not live in a web browser.
-pub struct NullNavigatorBackend {
-}
+pub struct NullNavigatorBackend {}
 
 impl NullNavigatorBackend {
     pub fn new() -> Self {
-        NullNavigatorBackend {
-
-        }
+        NullNavigatorBackend {}
     }
 }
 
@@ -69,7 +71,12 @@ impl Default for NullNavigatorBackend {
 }
 
 impl NavigatorBackend for NullNavigatorBackend {
-    fn navigate_to_url(&self, _url: String, _window: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+    fn navigate_to_url(
+        &self,
+        _url: String,
+        _window: Option<String>,
+        _vars_method: Option<(NavigationMethod, HashMap<String, String>)>,
+    ) {
 
     }
 }

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -1,6 +1,7 @@
 //! Browser-related platform functions
 
 use std::collections::HashMap;
+use swf::avm1::types::SendVarsMethod;
 
 /// Enumerates all possible navigation methods.
 pub enum NavigationMethod {
@@ -9,6 +10,17 @@ pub enum NavigationMethod {
 
     /// Indicates that navigation should generate a POST request.
     POST
+}
+
+impl NavigationMethod {
+    /// Convert an SWF method enum into a NavigationMethod.
+    pub fn from_send_vars_method(s: SendVarsMethod) -> Option<Self> {
+        match s {
+            SendVarsMethod::None => None,
+            SendVarsMethod::Get => Some(Self::GET),
+            SendVarsMethod::Post => Some(Self::POST),
+        }
+    }
 }
 
 /// A backend interacting with a browser environment.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,13 +1,15 @@
 use crate::avm1::Avm1;
-use crate::backend::{audio::AudioBackend, render::Letterbox, render::RenderBackend, navigator::NavigatorBackend};
+use crate::backend::{
+    audio::AudioBackend, navigator::NavigatorBackend, render::Letterbox, render::RenderBackend,
+};
 use crate::events::{ButtonEvent, PlayerEvent};
 use crate::library::Library;
 use crate::movie_clip::MovieClip;
 use crate::prelude::*;
 use crate::transform::TransformStack;
-use rand::{rngs::SmallRng, SeedableRng};
 use gc_arena::{make_arena, ArenaParameters, Collect, GcCell, MutationContext};
 use log::info;
+use rand::{rngs::SmallRng, SeedableRng};
 use std::sync::Arc;
 
 #[derive(Collect)]
@@ -53,7 +55,9 @@ pub struct Player<Audio: AudioBackend, Renderer: RenderBackend, Navigator: Navig
     is_mouse_down: bool,
 }
 
-impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend> Player<Audio, Renderer, Navigator> {
+impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
+    Player<Audio, Renderer, Navigator>
+{
     pub fn new(
         renderer: Renderer,
         audio: Audio,
@@ -210,7 +214,17 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend> 
             }
         }
 
-        let (global_time, swf_data, swf_version, background_color, renderer, audio, navigator, rng, is_mouse_down) = (
+        let (
+            global_time,
+            swf_data,
+            swf_version,
+            background_color,
+            renderer,
+            audio,
+            navigator,
+            rng,
+            is_mouse_down,
+        ) = (
             self.global_time,
             &mut self.swf_data,
             self.swf_version,
@@ -284,7 +298,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend> 
             &mut self.renderer,
             &mut self.audio,
             &mut self.navigator,
-            &mut self.rng
+            &mut self.rng,
         );
 
         let mouse_pos = &self.mouse_pos;
@@ -347,7 +361,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend> 
             &mut self.renderer,
             &mut self.audio,
             &mut self.navigator,
-            &mut self.rng
+            &mut self.rng,
         );
 
         self.gc_arena.mutate(|gc_context, gc_root| {
@@ -395,7 +409,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend> 
             &mut self.renderer,
             &mut self.audio,
             &mut self.navigator,
-            &mut self.rng
+            &mut self.rng,
         );
 
         self.gc_arena.mutate(|gc_context, gc_root| {

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -3,7 +3,9 @@
 //! Trace output can be compared with correct output from the official Flash Payer.
 
 use log::{Metadata, Record};
-use ruffle_core::backend::{audio::NullAudioBackend, render::NullRenderer, navigator::NullNavigatorBackend};
+use ruffle_core::backend::{
+    audio::NullAudioBackend, navigator::NullNavigatorBackend, render::NullRenderer,
+};
 use ruffle_core::Player;
 use std::cell::RefCell;
 
@@ -45,7 +47,12 @@ fn test_swf(swf_path: &str, num_frames: u32, expected_output_path: &str) -> Resu
     let expected_output = std::fs::read_to_string(expected_output_path)?.replace("\r\n", "\n");
 
     let swf_data = std::fs::read(swf_path)?;
-    let mut player = Player::new(NullRenderer, NullAudioBackend::new(), NullNavigatorBackend::new(), swf_data)?;
+    let mut player = Player::new(
+        NullRenderer,
+        NullAudioBackend::new(),
+        NullNavigatorBackend::new(),
+        swf_data,
+    )?;
 
     for _ in 0..num_frames {
         player.run_frame();

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -3,7 +3,7 @@
 //! Trace output can be compared with correct output from the official Flash Payer.
 
 use log::{Metadata, Record};
-use ruffle_core::backend::{audio::NullAudioBackend, render::NullRenderer};
+use ruffle_core::backend::{audio::NullAudioBackend, render::NullRenderer, navigator::NullNavigatorBackend};
 use ruffle_core::Player;
 use std::cell::RefCell;
 
@@ -45,7 +45,7 @@ fn test_swf(swf_path: &str, num_frames: u32, expected_output_path: &str) -> Resu
     let expected_output = std::fs::read_to_string(expected_output_path)?.replace("\r\n", "\n");
 
     let swf_data = std::fs::read(swf_path)?;
-    let mut player = Player::new(NullRenderer, NullAudioBackend::new(), swf_data)?;
+    let mut player = Player::new(NullRenderer, NullAudioBackend::new(), NullNavigatorBackend::new(), swf_data)?;
 
     for _ in 0..num_frames {
         player.run_frame();

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 lyon = "0.13.3"
 structopt = "0.2.15"
 winit = "0.19.1"
+webbrowser = "0.5.2"
 
 [dependencies.rodio]
 version = "0.8.1"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -17,6 +17,7 @@ lyon = "0.13.3"
 structopt = "0.2.15"
 winit = "0.19.1"
 webbrowser = "0.5.2"
+url = "2.1.0"
 
 [dependencies.rodio]
 version = "0.8.1"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,6 +1,6 @@
 mod audio;
-mod render;
 mod navigator;
+mod render;
 
 use crate::render::GliumRenderBackend;
 use glutin::{

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,12 +1,13 @@
 mod audio;
 mod render;
+mod navigator;
 
 use crate::render::GliumRenderBackend;
 use glutin::{
     dpi::{LogicalSize, PhysicalPosition},
     ContextBuilder, ElementState, EventsLoop, MouseButton, WindowBuilder, WindowEvent,
 };
-use ruffle_core::{backend::render::RenderBackend, Player, backend::navigator::NullNavigatorBackend};
+use ruffle_core::{backend::render::RenderBackend, Player};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
@@ -44,7 +45,7 @@ fn run_player(input_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         .build_windowed(window_builder, &events_loop)?;
     let audio = audio::RodioAudioBackend::new()?;
     let renderer = GliumRenderBackend::new(windowed_context)?;
-    let navigator = NullNavigatorBackend::new(); //TODO: actually implement this backend type
+    let navigator = navigator::ExternalNavigatorBackend::new(); //TODO: actually implement this backend type
     let display = renderer.display().clone();
     let mut player = Player::new(renderer, audio, navigator, swf_data)?;
     player.set_is_playing(true); // Desktop player will auto-play.

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -6,7 +6,7 @@ use glutin::{
     dpi::{LogicalSize, PhysicalPosition},
     ContextBuilder, ElementState, EventsLoop, MouseButton, WindowBuilder, WindowEvent,
 };
-use ruffle_core::{backend::render::RenderBackend, Player};
+use ruffle_core::{backend::render::RenderBackend, Player, backend::navigator::NullNavigatorBackend};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
@@ -44,8 +44,9 @@ fn run_player(input_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         .build_windowed(window_builder, &events_loop)?;
     let audio = audio::RodioAudioBackend::new()?;
     let renderer = GliumRenderBackend::new(windowed_context)?;
+    let navigator = NullNavigatorBackend::new(); //TODO: actually implement this backend type
     let display = renderer.display().clone();
-    let mut player = Player::new(renderer, audio, swf_data)?;
+    let mut player = Player::new(renderer, audio, navigator, swf_data)?;
     player.set_is_playing(true); // Desktop player will auto-play.
 
     let logical_size: LogicalSize = (player.movie_width(), player.movie_height()).into();

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -20,14 +20,14 @@ impl ExternalNavigatorBackend {
 }
 
 impl NavigatorBackend for ExternalNavigatorBackend {
-    fn navigate_to_url(&self, url: String, window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+    fn navigate_to_url(&self, url: String, _window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
         //TODO: How does Flash interpret the target on desktop?
         //TODO: Explicitly reject relative URLs, since `webbrowser` sometimes loads them
         //TODO: Support `vars_method`
         //TODO: Should we return a result for failed opens? Does Flash care?
         
         match webbrowser::open(&url) {
-            Ok(output) => {},
+            Ok(_output) => {},
             Err(e) => log::error!("Could not open URL {}: {}", url, e)
         };
     }

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -1,0 +1,34 @@
+//! Navigator backend for web
+
+use std::collections::HashMap;
+use ruffle_core::backend::navigator::{NavigatorBackend, NavigationMethod};
+use webbrowser;
+use log;
+
+/// Implementation of `NavigatorBackend` for non-web environments that can call
+/// out to a web browser.
+pub struct ExternalNavigatorBackend {
+
+}
+
+impl ExternalNavigatorBackend {
+    pub fn new() -> Self {
+        ExternalNavigatorBackend {
+
+        }
+    }
+}
+
+impl NavigatorBackend for ExternalNavigatorBackend {
+    fn navigate_to_url(&self, url: String, window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+        //TODO: How does Flash interpret the target on desktop?
+        //TODO: Explicitly reject relative URLs, since `webbrowser` sometimes loads them
+        //TODO: Support `vars_method`
+        //TODO: Should we return a result for failed opens? Does Flash care?
+        
+        match webbrowser::open(&url) {
+            Ok(output) => {},
+            Err(e) => log::error!("Could not open URL {}: {}", url, e)
+        };
+    }
+}

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use ruffle_core::backend::navigator::{NavigatorBackend, NavigationMethod};
 use webbrowser;
 use log;
+use url::Url;
 
 /// Implementation of `NavigatorBackend` for non-web environments that can call
 /// out to a web browser.
@@ -20,15 +21,37 @@ impl ExternalNavigatorBackend {
 }
 
 impl NavigatorBackend for ExternalNavigatorBackend {
-    fn navigate_to_url(&self, url: String, _window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
-        //TODO: How does Flash interpret the target on desktop?
-        //TODO: Explicitly reject relative URLs, since `webbrowser` sometimes loads them
-        //TODO: Support `vars_method`
+    fn navigate_to_url(&self, url: String, _window_spec: Option<String>, vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
         //TODO: Should we return a result for failed opens? Does Flash care?
         
-        match webbrowser::open(&url) {
+        //NOTE: Flash desktop players / projectors ignore the window parameter,
+        //      unless it's a `_layer`, and we shouldn't handle that anyway.
+        let mut parsed_url = match Url::parse(&url) {
+            Ok(parsed_url) => parsed_url,
+            Err(e) => {
+                log::error!("Could not parse URL because of {}, the corrupt URL was: {}", e, url);
+                return;
+            }
+        };
+
+        let modified_url = match vars_method {
+            Some((_, query_pairs)) => {
+                { //lifetime limiter because we don't have NLL yet
+                    let mut modifier = parsed_url.query_pairs_mut();
+
+                    for (k, v) in query_pairs.iter() {
+                        modifier.append_pair(k, v);
+                    }
+                }
+
+                parsed_url.into_string()
+            },
+            None => url
+        };
+        
+        match webbrowser::open(&modified_url) {
             Ok(_output) => {},
-            Err(e) => log::error!("Could not open URL {}: {}", url, e)
+            Err(e) => log::error!("Could not open URL {}: {}", modified_url, e)
         };
     }
 }

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -1,42 +1,48 @@
 //! Navigator backend for web
 
-use std::collections::HashMap;
-use ruffle_core::backend::navigator::{NavigatorBackend, NavigationMethod};
-use webbrowser;
 use log;
+use ruffle_core::backend::navigator::{NavigationMethod, NavigatorBackend};
+use std::collections::HashMap;
 use url::Url;
+use webbrowser;
 
 /// Implementation of `NavigatorBackend` for non-web environments that can call
 /// out to a web browser.
-pub struct ExternalNavigatorBackend {
-
-}
+pub struct ExternalNavigatorBackend {}
 
 impl ExternalNavigatorBackend {
     pub fn new() -> Self {
-        ExternalNavigatorBackend {
-
-        }
+        ExternalNavigatorBackend {}
     }
 }
 
 impl NavigatorBackend for ExternalNavigatorBackend {
-    fn navigate_to_url(&self, url: String, _window_spec: Option<String>, vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+    fn navigate_to_url(
+        &self,
+        url: String,
+        _window_spec: Option<String>,
+        vars_method: Option<(NavigationMethod, HashMap<String, String>)>,
+    ) {
         //TODO: Should we return a result for failed opens? Does Flash care?
-        
+
         //NOTE: Flash desktop players / projectors ignore the window parameter,
         //      unless it's a `_layer`, and we shouldn't handle that anyway.
         let mut parsed_url = match Url::parse(&url) {
             Ok(parsed_url) => parsed_url,
             Err(e) => {
-                log::error!("Could not parse URL because of {}, the corrupt URL was: {}", e, url);
+                log::error!(
+                    "Could not parse URL because of {}, the corrupt URL was: {}",
+                    e,
+                    url
+                );
                 return;
             }
         };
 
         let modified_url = match vars_method {
             Some((_, query_pairs)) => {
-                { //lifetime limiter because we don't have NLL yet
+                {
+                    //lifetime limiter because we don't have NLL yet
                     let mut modifier = parsed_url.query_pairs_mut();
 
                     for (k, v) in query_pairs.iter() {
@@ -45,13 +51,13 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                 }
 
                 parsed_url.into_string()
-            },
-            None => url
+            }
+            None => url,
         };
-        
+
         match webbrowser::open(&modified_url) {
-            Ok(_output) => {},
-            Err(e) => log::error!("Could not open URL {}: {}", modified_url, e)
+            Ok(_output) => {}
+            Err(e) => log::error!("Could not open URL {}: {}", modified_url, e),
         };
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -39,7 +39,7 @@ features = [
     "AudioBuffer", "AudioBufferSourceNode", "AudioProcessingEvent", "AudioContext", "AudioDestinationNode", "AudioNode", 
     "CanvasRenderingContext2d", "CssStyleDeclaration", "Document", "Element", "Event", "EventTarget", "HtmlCanvasElement",
     "HtmlElement", "HtmlImageElement", "MouseEvent", "Navigator", "Node", "Performance", "ScriptProcessorNode", "Window",
-    "Location"]
+    "Location", "HtmlFormElement"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2.48"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -38,7 +38,8 @@ version = "0.3.25"
 features = [
     "AudioBuffer", "AudioBufferSourceNode", "AudioProcessingEvent", "AudioContext", "AudioDestinationNode", "AudioNode", 
     "CanvasRenderingContext2d", "CssStyleDeclaration", "Document", "Element", "Event", "EventTarget", "HtmlCanvasElement",
-    "HtmlElement", "HtmlImageElement", "MouseEvent", "Navigator", "Node", "Performance", "ScriptProcessorNode", "Window"]
+    "HtmlElement", "HtmlImageElement", "MouseEvent", "Navigator", "Node", "Performance", "ScriptProcessorNode", "Window",
+    "Location"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2.48"

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,9 +1,10 @@
 //! Ruffle web frontend.
 mod audio;
 mod render;
+mod navigator;
 mod utils;
 
-use crate::{audio::WebAudioBackend, render::WebCanvasRenderBackend};
+use crate::{audio::WebAudioBackend, render::WebCanvasRenderBackend, navigator::WebNavigatorBackend};
 use generational_arena::{Arena, Index};
 use js_sys::Uint8Array;
 use ruffle_core::{backend::render::RenderBackend, PlayerEvent};
@@ -21,7 +22,7 @@ thread_local! {
 type AnimationHandler = Closure<dyn FnMut(f64)>;
 
 struct RuffleInstance {
-    core: ruffle_core::Player<WebAudioBackend, WebCanvasRenderBackend>,
+    core: ruffle_core::Player<WebAudioBackend, WebCanvasRenderBackend, WebNavigatorBackend>,
     canvas: HtmlCanvasElement,
     canvas_width: i32,
     canvas_height: i32,
@@ -82,8 +83,9 @@ impl Ruffle {
         let window = web_sys::window().ok_or_else(|| "Expected window")?;
         let renderer = WebCanvasRenderBackend::new(&canvas)?;
         let audio = WebAudioBackend::new()?;
+        let navigator = WebNavigatorBackend::new();
 
-        let core = ruffle_core::Player::new(renderer, audio, data)?;
+        let core = ruffle_core::Player::new(renderer, audio, navigator, data)?;
 
         // Create instance.
         let instance = RuffleInstance {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,10 +1,12 @@
 //! Ruffle web frontend.
 mod audio;
-mod render;
 mod navigator;
+mod render;
 mod utils;
 
-use crate::{audio::WebAudioBackend, render::WebCanvasRenderBackend, navigator::WebNavigatorBackend};
+use crate::{
+    audio::WebAudioBackend, navigator::WebNavigatorBackend, render::WebCanvasRenderBackend,
+};
 use generational_arena::{Arena, Index};
 use js_sys::Uint8Array;
 use ruffle_core::{backend::render::RenderBackend, PlayerEvent};

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -1,0 +1,27 @@
+//! Navigator backend for web
+
+use std::collections::HashMap;
+use web_sys::window;
+use ruffle_core::backend::navigator::{NavigatorBackend, NavigationMethod};
+
+pub struct WebNavigatorBackend {
+
+}
+
+impl WebNavigatorBackend {
+    pub fn new() -> Self {
+        WebNavigatorBackend {
+
+        }
+    }
+}
+
+impl NavigatorBackend for WebNavigatorBackend {
+    fn navigate_to_url(&self, url: String, _window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+        if let Some(window) = window() {
+            //TODO: Support `window`
+            //TODO: Support `vars_method`
+            window.location().assign(&url);
+        }
+    }
+}

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -1,7 +1,8 @@
 //! Navigator backend for web
 
 use std::collections::HashMap;
-use web_sys::window;
+use web_sys::{window};
+use wasm_bindgen::JsCast;
 use ruffle_core::backend::navigator::{NavigatorBackend, NavigationMethod};
 
 pub struct WebNavigatorBackend {
@@ -17,13 +18,44 @@ impl WebNavigatorBackend {
 }
 
 impl NavigatorBackend for WebNavigatorBackend {
-    fn navigate_to_url(&self, url: String, window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+    fn navigate_to_url(&self, url: String, window_spec: Option<String>, vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
         if let Some(window) = window() {
-            //TODO: Support `vars_method`
             //TODO: Should we return a result for failed opens? Does Flash care?
             #[allow(unused_must_use)]
-            match window_spec {
-                Some(ref window_name) if window_name != "" => { window.open_with_url_and_target(&url, window_name); },
+            match (vars_method, window_spec) {
+                (Some((navmethod, formvars)), window_spec) => {
+                    let document = match window.document() {
+                        Some(document) => document,
+                        None => return
+                    };
+
+                    let form = document.create_element("form").unwrap().dyn_into::<web_sys::HtmlFormElement>().unwrap();
+
+                    form.set_attribute("method", match navmethod {
+                        NavigationMethod::GET => "get",
+                        NavigationMethod::POST => "post"
+                    });
+
+                    form.set_attribute("action", &url);
+
+                    if let Some(target) = window_spec {
+                        form.set_attribute("target", &target);
+                    }
+
+                    for (k, v) in formvars.iter() {
+                        let hidden = document.create_element("hidden").unwrap();
+
+                        hidden.set_attribute("type", "hidden");
+                        hidden.set_attribute("name", k);
+                        hidden.set_attribute("value", v);
+
+                        form.append_child(&hidden);
+                    }
+
+                    document.body().unwrap().append_child(&form);
+                    form.submit();
+                },
+                (_, Some(ref window_name)) if window_name != "" => { window.open_with_url_and_target(&url, window_name); },
                 _ => { window.location().assign(&url); }
             };
         }

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -1,24 +1,25 @@
 //! Navigator backend for web
 
+use ruffle_core::backend::navigator::{NavigationMethod, NavigatorBackend};
 use std::collections::HashMap;
-use web_sys::{window};
 use wasm_bindgen::JsCast;
-use ruffle_core::backend::navigator::{NavigatorBackend, NavigationMethod};
+use web_sys::window;
 
-pub struct WebNavigatorBackend {
-
-}
+pub struct WebNavigatorBackend {}
 
 impl WebNavigatorBackend {
     pub fn new() -> Self {
-        WebNavigatorBackend {
-
-        }
+        WebNavigatorBackend {}
     }
 }
 
 impl NavigatorBackend for WebNavigatorBackend {
-    fn navigate_to_url(&self, url: String, window_spec: Option<String>, vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+    fn navigate_to_url(
+        &self,
+        url: String,
+        window_spec: Option<String>,
+        vars_method: Option<(NavigationMethod, HashMap<String, String>)>,
+    ) {
         if let Some(window) = window() {
             //TODO: Should we return a result for failed opens? Does Flash care?
             #[allow(unused_must_use)]
@@ -26,15 +27,22 @@ impl NavigatorBackend for WebNavigatorBackend {
                 (Some((navmethod, formvars)), window_spec) => {
                     let document = match window.document() {
                         Some(document) => document,
-                        None => return
+                        None => return,
                     };
 
-                    let form = document.create_element("form").unwrap().dyn_into::<web_sys::HtmlFormElement>().unwrap();
+                    let form = document
+                        .create_element("form")
+                        .unwrap()
+                        .dyn_into::<web_sys::HtmlFormElement>()
+                        .unwrap();
 
-                    form.set_attribute("method", match navmethod {
-                        NavigationMethod::GET => "get",
-                        NavigationMethod::POST => "post"
-                    });
+                    form.set_attribute(
+                        "method",
+                        match navmethod {
+                            NavigationMethod::GET => "get",
+                            NavigationMethod::POST => "post",
+                        },
+                    );
 
                     form.set_attribute("action", &url);
 
@@ -54,9 +62,13 @@ impl NavigatorBackend for WebNavigatorBackend {
 
                     document.body().unwrap().append_child(&form);
                     form.submit();
-                },
-                (_, Some(ref window_name)) if window_name != "" => { window.open_with_url_and_target(&url, window_name); },
-                _ => { window.location().assign(&url); }
+                }
+                (_, Some(ref window_name)) if window_name != "" => {
+                    window.open_with_url_and_target(&url, window_name);
+                }
+                _ => {
+                    window.location().assign(&url);
+                }
             };
         }
     }

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -17,11 +17,15 @@ impl WebNavigatorBackend {
 }
 
 impl NavigatorBackend for WebNavigatorBackend {
-    fn navigate_to_url(&self, url: String, _window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
+    fn navigate_to_url(&self, url: String, window_spec: Option<String>, _vars_method: Option<(NavigationMethod, HashMap<String, String>)>) {
         if let Some(window) = window() {
-            //TODO: Support `window`
             //TODO: Support `vars_method`
-            window.location().assign(&url);
+            //TODO: Should we return a result for failed opens? Does Flash care?
+            #[allow(unused_must_use)]
+            match window_spec {
+                Some(ref window_name) if window_name != "" => { window.open_with_url_and_target(&url, window_name); },
+                _ => { window.location().assign(&url); }
+            };
         }
     }
 }


### PR DESCRIPTION
This is a draft PR for interactions between ActionScript and the browser - namely GetURL, in it's various forms. ~~It relies on @Dinnerbone's PR #52 in order to work - please do not consider merging this PR in unless that PR has already been merged. It is technically independent of the WebExtension PR but isn't very useful without it. (I've been testing on a temporary merged branch of this PR and #53.)~~

## Progress & scope

The following are implemented:

- [x] Navigation to new webpages via legacy `ActionGetURL`/`ActionGetURL2` opcodes or `getURL` function
- [x] `Math.random` ~~and `Math.floor`~~ (Not technically necessary, but I needed it in here for Homestar to work)
- [x] Navigation to arbitrary target windows/frames
- [x] Navigation in Desktop mode (currently uses `NullNavigatorBackend`)
- [x] Form submission through `getURL` via AVM1 locals
- ~~Parsing of returned form data as new AVM1 locals~~

### Future work
GetURL functionality which implies the loading or execution of remote SWF content into a sprite, legacy `_layer` target, or movie clip is currently considered out of scope for this PR. Such functionality issues warnings in the console if used. (Rationale: We don't have test cases for this yet, I don't know how Flash Player handles some of these cases, and our MovieClip representation doesn't support remote SWFs yet)

Functionality of `getURL` or it's AVM1 opcode equivalents that allow Flash to retrieve and process data are also out of scope because Rust's async ecosystem isn't ready yet. When that is ready, a hypothetical future PR would need to enforce the following sandboxing rules that Flash did:

 * Only local content in a local page is allowed to open `javascript:` URLs
 * Filesystem content window names are obfuscated to `_flashXXXXXXXX` (where `X` is a random hexdigit)

## Implementation details

We create a new backend type called `NavigatorBackend` which represents communication between the SWF player and a browser. This allows ActionScript to control the browser it's hosted in. It currently only has one method, which causes a navigation to a new URL. Future methods for this backend are planned for future PRs.