### PR TITLE
Newgrounds support

### DIFF
--- a/web/js-src/element.js
+++ b/web/js-src/element.js
@@ -9,22 +9,28 @@ import { install_plugin, FLASH_PLUGIN } from "./plugin-polyfill";
  * access to a pre-interdiction element, then this will break horribly. We can
  * keep native objects out of the DOM, and thus out of JavaScript's grubby
  * little hands, but only if we load first.
- * 
- * The requirement to wait for WASM is a huge problem in practice.
  */
 function wrap_tree(elem) {
     try {
-        for (let node of Array.from(elem.getElementsByTagName("object"))) {
-            if (RuffleObject.is_interdictable(node)) {
-                let ruffle_obj = RuffleObject.from_native_object_element(node);
-                node.parentElement.replaceChild(ruffle_obj, node);
+        if (elem.nodeName.toLowerCase() === "object" && RuffleObject.is_interdictable(elem)) {
+            let ruffle_obj = RuffleObject.from_native_object_element(elem);
+            elem.parentElement.replaceChild(ruffle_obj, elem);
+        } else if (elem.nodeName.toLowerCase() === "embed" && RuffleEmbed.is_interdictable(elem)) {
+            let ruffle_obj = RuffleEmbed.from_native_object_element(elem);
+            elem.parentElement.replaceChild(ruffle_obj, elem);
+        } else {
+            for (let node of Array.from(elem.getElementsByTagName("object"))) {
+                if (RuffleObject.is_interdictable(node)) {
+                    let ruffle_obj = RuffleObject.from_native_object_element(node);
+                    node.parentElement.replaceChild(ruffle_obj, node);
+                }
             }
-        }
 
-        for (let node of Array.from(elem.getElementsByTagName("embed"))) {
-            if (RuffleEmbed.is_interdictable(node)) {
-                let ruffle_obj = RuffleEmbed.from_native_embed_element(node);
-                node.parentElement.replaceChild(ruffle_obj, node);
+            for (let node of Array.from(elem.getElementsByTagName("embed"))) {
+                if (RuffleEmbed.is_interdictable(node)) {
+                    let ruffle_obj = RuffleEmbed.from_native_embed_element(node);
+                    node.parentElement.replaceChild(ruffle_obj, node);
+                }
             }
         }
     } catch (err) {

--- a/web/js-src/ruffle-embed.js
+++ b/web/js-src/ruffle-embed.js
@@ -13,11 +13,11 @@ export default class RuffleEmbed extends RufflePlayer {
     }
 
     get src() {
-        return self.attributes.src;
+        return this.attributes.src.value;
     }
 
     set src(srcval) {
-        self.attributes.src = srcval;
+        this.attributes.src = srcval;
     }
 
     static get observedAttributes() {

--- a/web/js-src/ruffle-object.js
+++ b/web/js-src/ruffle-object.js
@@ -11,9 +11,19 @@ export default class RuffleObject extends RufflePlayer {
         this.params = RuffleObject.params_of(this);
         
         //Kick off the SWF download.
-        if (this.params.movie) {
+        if (this.attributes.data) {
+            this.stream_swf_url(this.attributes.data.value);
+        } else if (this.params.movie) {
             this.stream_swf_url(this.params.movie);
         }
+    }
+
+    get data() {
+        return this.attributes.data.value;
+    }
+
+    set data(href) {
+        this.attributes.data = href;
     }
 
     static is_interdictable(elem) {


### PR DESCRIPTION
I've added bugfixes for the way Newgrounds dynamically adds objects to the page. This allows Newgrounds to work in Ruffle (when it decides to serve a Flash object).

Another branch, which isn't ready to PR yet, will allow self-hosting Ruffle. It will also add an extension opt-out and interdiction control so that sites can indicate how much, if any, they want Ruffle to work with them. I expect Newgrounds to use those functions, so this PR won't be testable after that functionality is merged.