### PR TITLE
AVM1 DefineFunction support

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -648,13 +648,22 @@ impl<'gc> Avm1<'gc> {
 
     fn action_define_function(
         &mut self,
-        _context: &mut ActionContext,
-        _name: &str,
-        _params: &[&str],
-        _actions: &[u8],
+        context: &mut ActionContext<'_, 'gc, '_>,
+        name: &str,
+        params: &[&str],
+        actions: &[u8],
     ) -> Result<(), Error> {
-        // TODO(Herschel)
-        Err("Unimplemented action: DefineFunction".into())
+        let swf_version = self.current_stack_frame().unwrap().swf_version();
+        let func_data = self.current_stack_frame().unwrap().data().to_subslice(actions).unwrap();
+        let func = Value::Object(GcCell::allocate(context.gc_context, Object::action_function(swf_version, func_data, name, params)));
+        
+        if name == "" {
+            self.current_stack_frame_mut().unwrap().stack_mut().push(func);
+        } else {
+            self.current_stack_frame_mut().unwrap().locals_mut().insert(name.to_string(), func);
+        }
+
+        Ok(())
     }
 
     fn action_define_local(&mut self, _context: &mut ActionContext) -> Result<(), Error> {

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -744,10 +744,13 @@ impl<'gc> Avm1<'gc> {
     }
 
     fn action_get_member(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
-        let _name = self.pop()?.as_string()?;
-        let _object = self.pop()?.as_object()?;
-        // TODO(Herschel)
-        Err("Unimplemented action: GetMember".into())
+        let name_val = self.pop()?;
+        let name = name_val.as_string()?;
+        let object = self.pop()?.as_object()?;
+        let value = object.read().get(name);
+        self.push(value);
+
+        Ok(())
     }
 
     fn action_get_property(

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1399,11 +1399,11 @@ impl<'gc> Avm1<'gc> {
                 }
             }
         } else {
-            match self.current_stack_frame().unwrap().scope().overwrite(var_path, value, context.gc_context) {
-                None => {},
-                Some(value) => {
-                    self.current_stack_frame().unwrap().define(var_path, value, context.gc_context);
-                }
+            let this = self.current_stack_frame().unwrap().this_cell();
+            let scope = self.current_stack_frame().unwrap().scope_cell();
+            let unused_value = scope.read().overwrite(var_path, value, self, context, this);
+            if let Some(value) = unused_value {
+                self.current_stack_frame().unwrap().define(var_path, value, context.gc_context);
             }
         }
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -634,8 +634,13 @@ impl<'gc> Avm1<'gc> {
         let name_val = self.pop()?;
         let name = name_val.as_string()?;
         let object = self.pop()?.as_object()?;
+
+        //Fun fact: This isn't in the Adobe SWF19 spec, but this opcode returns
+        //a boolean based on if the delete actually deleted something.
+        let did_exist = Value::Bool(object.read().has_property(name));
         
         object.write(context.gc_context).delete(name);
+        self.push(did_exist);
 
         Ok(())
     }
@@ -643,7 +648,13 @@ impl<'gc> Avm1<'gc> {
     fn action_delete_2(&mut self, context: &mut ActionContext<'_, 'gc, '_>) -> Result<(), Error> {
         let name_val = self.pop()?;
         let name = name_val.as_string()?;
+
+        //Fun fact: This isn't in the Adobe SWF19 spec, but this opcode returns
+        //a boolean based on if the delete actually deleted something.
+        let did_exist = Value::Bool(self.current_stack_frame().unwrap().is_defined(name));
+
         self.current_stack_frame().unwrap().scope().delete(name, context.gc_context);
+        self.push(did_exist);
 
         Ok(())
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -883,6 +883,11 @@ impl<'gc> Avm1<'gc> {
         Value::Object(self.globals)
     }
 
+    /// Obtain a reference to `_global`.
+    pub fn global_object_cell(&self) -> GcCell<'gc, Object<'gc>> {
+        self.globals
+    }
+
     fn action_get_variable(
         &mut self,
         context: &mut ActionContext<'_, 'gc, '_>,

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1249,12 +1249,15 @@ impl<'gc> Avm1<'gc> {
         Ok(())
     }
 
-    fn action_set_member(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
-        let _value = self.pop()?;
-        let _name = self.pop()?;
-        let _object = self.pop()?;
-        // TODO(Herschel)
-        Err("Unimplemented action: SetMember".into())
+    fn action_set_member(&mut self, context: &mut ActionContext<'_, 'gc, '_>) -> Result<(), Error> {
+        let value = self.pop()?;
+        let name_val = self.pop()?;
+        let name = name_val.as_string()?;
+        let object = self.pop()?.as_object()?;
+        
+        object.write(context.gc_context).set(name, value);
+
+        Ok(())
     }
 
     fn action_set_property(&mut self, context: &mut ActionContext) -> Result<(), Error> {

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -414,15 +414,6 @@ impl<'gc> Avm1<'gc> {
         self.stack.pop().ok_or_else(|| "Stack underflow".into())
     }
 
-    /// Allocate a register set for the current stack frame.
-    /// 
-    /// The allocated register set replaces the current local register set, if
-    /// any, and remains until the current function returns. With registers
-    /// allocated, the global register set becomes inactive for the current
-    /// activation.
-    pub fn allocate_registers(&mut self, num: u8, context: &mut ActionContext<'_, 'gc, '_>) {
-    }
-
     /// Retrieve a given register value.
     /// 
     /// If a given register does not exist, this function yields

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -630,17 +630,22 @@ impl<'gc> Avm1<'gc> {
         Ok(())
     }
 
-    fn action_delete(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
-        let _name = self.pop()?.as_string()?;
-        let _object = self.pop()?.as_object()?;
-        Err("Unimplemented action: Delete".into())
-        // TODO(Herschel)
+    fn action_delete(&mut self, context: &mut ActionContext<'_, 'gc, '_>) -> Result<(), Error> {
+        let name_val = self.pop()?;
+        let name = name_val.as_string()?;
+        let object = self.pop()?.as_object()?;
+        
+        object.write(context.gc_context).delete(name);
+
+        Ok(())
     }
 
-    fn action_delete_2(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
-        let _name = self.pop()?.as_string()?;
-        Err("Unimplemented action: Delete2".into())
-        // TODO(Herschel)
+    fn action_delete_2(&mut self, context: &mut ActionContext<'_, 'gc, '_>) -> Result<(), Error> {
+        let name_val = self.pop()?;
+        let name = name_val.as_string()?;
+        self.current_stack_frame().unwrap().scope().delete(name, context.gc_context);
+
+        Ok(())
     }
 
     fn action_divide(&mut self, _context: &mut ActionContext) -> Result<(), Error> {

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -123,27 +123,9 @@ impl<'gc> Avm1<'gc> {
         self.stack_frames.push(Activation::from_action(swf_version, code, child_scope, clip_obj, None));
     }
 
-    /// Add a stack frame that executes code in function scope
-    /// TODO: `function::Executable` should do this
-    pub fn insert_stack_frame_for_function(&mut self,
-            avm1func: &function::Avm1Function<'gc>,
-            this: GcCell<'gc, Object<'gc>>,
-            args: GcCell<'gc, Object<'gc>>,
-            action_context: &mut ActionContext<'_, 'gc, '_>) {
-        let child_scope = GcCell::allocate(action_context.gc_context, Scope::new_local_scope(avm1func.scope(), action_context.gc_context));
-        self.stack_frames.push(Activation::from_function(avm1func.swf_version(), avm1func.data(), child_scope, this, Some(args)));
-    }
-
-    /// Add a stack frame that executes code in function scope
-    /// TODO: `function::Executable` should do this
-    pub fn insert_stack_frame_for_function2(&mut self,
-            avm1func: &function::Avm1Function2<'gc>,
-            this: GcCell<'gc, Object<'gc>>,
-            args: GcCell<'gc, Object<'gc>>,
-            action_context: &mut ActionContext<'_, 'gc, '_>) {
-        let child_scope = GcCell::allocate(action_context.gc_context, Scope::new_local_scope(avm1func.scope(), action_context.gc_context));
-        self.stack_frames.push(Activation::from_function(avm1func.swf_version(), avm1func.data(), child_scope, this, Some(args)));
-        self.stack_frames.last_mut().unwrap().allocate_local_registers(avm1func.register_count(), action_context.gc_context);
+    /// Add a stack frame for any arbitrary code.
+    pub fn insert_stack_frame(&mut self, frame: Activation<'gc>) {
+        self.stack_frames.push(frame);
     }
 
     /// Retrieve the current AVM execution frame.

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -745,9 +745,9 @@ impl<'gc> Avm1<'gc> {
 
     fn action_get_member(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
         let name_val = self.pop()?;
-        let name = name_val.as_string()?;
+        let name = name_val.into_string();
         let object = self.pop()?.as_object()?;
-        let value = object.read().get(name);
+        let value = object.read().get(&name);
         self.push(value);
 
         Ok(())

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -14,6 +14,7 @@ use swf::avm1::types::Action;
 use crate::tag_utils::SwfSlice;
 
 mod fscommand;
+mod function;
 mod scope;
 mod activation;
 mod globals;
@@ -113,13 +114,13 @@ impl<'gc> Avm1<'gc> {
         let global_scope = GcCell::allocate(action_context.gc_context, Scope::from_global_object(self.globals));
         let clip_obj = action_context.active_clip.read().object().as_object().unwrap().to_owned();
         let child_scope = GcCell::allocate(action_context.gc_context, Scope::from_parent_scope_with_object(global_scope, clip_obj));
-        self.stack_frames.push(Activation::from_action(swf_version, code, child_scope, clip_obj));
+        self.stack_frames.push(Activation::from_action(swf_version, code, child_scope, clip_obj, None));
     }
 
     /// Add a stack frame that executes code in function scope
-    pub fn insert_stack_frame_for_function(&mut self, swf_version: u8, code: SwfSlice, this: GcCell<'gc, Object<'gc>>, action_context: &mut ActionContext<'_, 'gc, '_>) {
+    pub fn insert_stack_frame_for_function(&mut self, avm1func: &function::Avm1Function, this: GcCell<'gc, Object<'gc>>, args: GcCell<'gc, Object<'gc>>, action_context: &mut ActionContext<'_, 'gc, '_>) {
         let scope = GcCell::allocate(action_context.gc_context, Scope::from_global_object(self.globals));
-        self.stack_frames.push(Activation::from_action(swf_version, code, scope, this));
+        self.stack_frames.push(Activation::from_action(avm1func.swf_version(), avm1func.data(), scope, this, Some(args)));
     }
 
     /// Retrieve the current AVM execution frame.

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -687,6 +687,7 @@ impl<'gc> Avm1<'gc> {
             action_func.preload_arguments,
             action_func.suppress_this,
             action_func.preload_this,
+            action_func.preload_global,
             &action_func.params,
             scope
         );
@@ -877,20 +878,29 @@ impl<'gc> Avm1<'gc> {
         Ok(())
     }
 
+    /// Obtain the value of `_root`.
+    pub fn root_object(&self, context: &mut ActionContext<'_, 'gc, '_>) -> Value<'gc> {
+        context.start_clip.read().object()
+    }
+
+    /// Obtain the value of `_global`.
+    pub fn global_object(&self, _context: &mut ActionContext<'_, 'gc, '_>) -> Value<'gc> {
+        Value::Object(self.globals)
+    }
+
     fn action_get_variable(
         &mut self,
         context: &mut ActionContext<'_, 'gc, '_>,
     ) -> Result<(), Error> {
         let var_path = self.pop()?;
         let path = var_path.as_string()?;
-        let globals = self.globals;
 
         // Special hardcoded variables
         if path == "_root" {
-            self.push(context.start_clip.read().object());
+            self.push(self.root_object(context));
             return Ok(());
         } else if path == "_global" {
-            self.push(Value::Object(globals));
+            self.push(self.global_object(context));
             return Ok(());
         }
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -255,11 +255,11 @@ impl<'gc> Avm1<'gc> {
                     scene_offset,
                 } => self.action_goto_frame_2(context, set_playing, scene_offset),
                 Action::GotoLabel(label) => self.action_goto_label(context, &label),
-                Action::If { offset } => self.action_if(context, offset),
+                Action::If { offset } => self.action_if(context, offset, reader),
                 Action::Increment => self.action_increment(context),
                 Action::InitArray => self.action_init_array(context),
                 Action::InitObject => self.action_init_object(context),
-                Action::Jump { offset } => self.action_jump(context, offset),
+                Action::Jump { offset } => self.action_jump(context, offset, reader),
                 Action::Less => self.action_less(context),
                 Action::Less2 => self.action_less_2(context),
                 Action::MBAsciiToChar => self.action_mb_ascii_to_char(context),
@@ -980,11 +980,12 @@ impl<'gc> Avm1<'gc> {
     fn action_if(
         &mut self,
         _context: &mut ActionContext,
-        jump_offset: i16
+        jump_offset: i16,
+        reader: &mut Reader<'_>
     ) -> Result<(), Error> {
         let val = self.pop()?;
         if val.as_bool() {
-            self.with_current_reader_mut(|_this, r| r.seek(jump_offset.into()));
+            reader.seek(jump_offset.into());
         }
         Ok(())
     }
@@ -1019,10 +1020,11 @@ impl<'gc> Avm1<'gc> {
     fn action_jump(
         &mut self,
         _context: &mut ActionContext,
-        jump_offset: i16
+        jump_offset: i16,
+        reader: &mut Reader<'_>
     ) -> Result<(), Error> {
         // TODO(Herschel): Handle out-of-bounds.
-        self.with_current_reader_mut(|_this, r| r.seek(jump_offset.into()));
+        reader.seek(jump_offset.into());
         Ok(())
     }
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -376,8 +376,9 @@ impl<'gc> Avm1<'gc> {
                 return result;
             }
         } else {
-            //Out of code. Return to the parent function.
+            //Implicit return undefined
             self.retire_stack_frame();
+            self.current_stack_frame_mut().map(|sf| sf.stack_mut().push(Value::Undefined));
         }
 
         Ok(())

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -9,6 +9,7 @@ use crate::avm1::object::Object;
 use crate::avm1::Value;
 
 /// Represents a single activation of a given AVM1 function or keyframe.
+#[derive(Clone)]
 pub struct Activation<'gc> {
     /// Represents the SWF version of a given function.
     /// 
@@ -54,6 +55,18 @@ impl<'gc> Activation<'gc> {
         }
     }
 
+    /// Create a new activation to run a block of code with a given scope.
+    pub fn to_rescope(&self, code: SwfSlice, scope: GcCell<'gc, Scope<'gc>>) -> Self {
+        Activation {
+            swf_version: self.swf_version,
+            data: code,
+            pc: 0,
+            scope: scope,
+            this: self.this,
+            arguments: self.arguments
+        }
+    }
+
     /// Returns the SWF version of the action or function being executed.
     pub fn swf_version(&self) -> u8 {
         self.swf_version
@@ -62,6 +75,11 @@ impl<'gc> Activation<'gc> {
     /// Returns the data this stack frame executes from.
     pub fn data(&self) -> SwfSlice {
         self.data.clone()
+    }
+
+    /// Change the data being executed.
+    pub fn set_data(&mut self, new_data: SwfSlice) {
+        self.data = new_data;
     }
 
     /// Determines if a stack frame references the same function as a given

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1,0 +1,111 @@
+//! Activation records
+
+use std::sync::Arc;
+use std::cell::{Ref, RefMut};
+use gc_arena::{GcCell, MutationContext};
+use crate::tag_utils::SwfSlice;
+use crate::avm1::scope::Scope;
+use crate::avm1::Value;
+
+/// Represents a single activation of a given AVM1 function or keyframe.
+pub struct Activation<'gc> {
+    /// Represents the SWF version of a given function.
+    /// 
+    /// Certain AVM1 operations change behavior based on the version of the SWF
+    /// file they were defined in. For example, case sensitivity changes based
+    /// on the SWF version.
+    swf_version: u8,
+
+    /// Action data being executed by the reader below.
+    data: SwfSlice,
+
+    /// The current location of the instruction stream being executed.
+    pc: usize,
+
+    /// The opcode stack values for the current stack frame.
+    stack: Vec<Value<'gc>>,
+
+    /// All defined local variables in this stack frame.
+    scope: GcCell<'gc, Scope<'gc>>,
+}
+
+unsafe impl<'gc> gc_arena::Collect for Activation<'gc> {
+    #[inline]
+    fn trace(&self, cc: gc_arena::CollectionContext) {
+        self.stack.trace(cc);
+        self.scope.trace(cc);
+    }
+}
+
+impl<'gc> Activation<'gc> {
+    pub fn from_action(swf_version: u8, code: SwfSlice, scope: GcCell<'gc, Scope<'gc>>) -> Activation<'gc> {
+        Activation {
+            swf_version: swf_version,
+            data: code,
+            pc: 0,
+            stack: Vec::new(),
+            scope: scope
+        }
+    }
+
+    /// Returns the SWF version of the action or function being executed.
+    pub fn swf_version(&self) -> u8 {
+        self.swf_version
+    }
+
+    /// Returns the data this stack frame executes from.
+    pub fn data(&self) -> SwfSlice {
+        self.data.clone()
+    }
+
+    /// Determines if a stack frame references the same function as a given
+    /// SwfSlice.
+    pub fn is_identical_fn(&self, other: &SwfSlice) -> bool {
+        Arc::ptr_eq(&self.data.data, &other.data)
+    }
+
+    /// Returns a mutable reference to the current data offset.
+    pub fn pc(&self) -> usize {
+        self.pc
+    }
+    
+    /// Change the current PC.
+    pub fn set_pc(&mut self, new_pc: usize) {
+        self.pc = new_pc;
+    }
+
+    /// Returns the value stack.
+    pub fn stack(&self) -> &Vec<Value<'gc>> {
+        &self.stack
+    }
+
+    /// Returns the value stack for mutation.
+    pub fn stack_mut(&mut self) -> &mut Vec<Value<'gc>> {
+        &mut self.stack
+    }
+
+    /// Returns AVM local variable scope.
+    pub fn scope(&self) -> Ref<Scope<'gc>> {
+        self.scope.read()
+    }
+
+    /// Returns AVM local variable scope for mutation.
+    pub fn scope_mut(&mut self, mc: MutationContext<'gc, '_>) -> RefMut<Scope<'gc>> {
+        self.scope.write(mc)
+    }
+
+    /// Resolve a particular named local variable within this activation.
+    pub fn resolve(&self, name: &str) -> Value<'gc> {
+        self.scope().resolve(name)
+    }
+
+    /// Check if a particular property in the scope chain is defined.
+    pub fn is_defined(&self, name: &str) -> bool {
+        self.scope().is_defined(name)
+    }
+
+    /// Define a named local variable within this activation.
+    pub fn define(&self, name: &str, value: Value<'gc>, mc: MutationContext<'gc, '_>) {
+        self.scope().define(name, value, mc)
+    }
+}

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -88,6 +88,32 @@ impl<'gc> Activation<'gc> {
         }
     }
 
+    /// Construct an empty stack frame with no code.
+    /// 
+    /// This is primarily intended for testing purposes: the activation given
+    /// will prevent the AVM from panicking without a current activation.
+    /// We construct a single scope chain from a global object, and that's about
+    /// it.
+    pub fn from_nothing(swf_version: u8, globals: GcCell<'gc, Object<'gc>>, mc: MutationContext<'gc, '_>) -> Activation<'gc> {
+        let global_scope = GcCell::allocate(mc, Scope::from_global_object(globals));
+        let child_scope = GcCell::allocate(mc, Scope::new_local_scope(global_scope, mc));
+
+        Activation {
+            swf_version: swf_version,
+            data: SwfSlice {
+                data: Arc::new(Vec::new()),
+                start: 0,
+                end: 0
+            },
+            pc: 0,
+            scope: child_scope,
+            this: globals,
+            arguments: None,
+            is_function: false,
+            local_registers: None
+        }
+    }
+
     /// Create a new activation to run a block of code with a given scope.
     pub fn to_rescope(&self, code: SwfSlice, scope: GcCell<'gc, Scope<'gc>>) -> Self {
         Activation {

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -90,6 +90,11 @@ impl<'gc> Activation<'gc> {
         self.scope.write(mc)
     }
 
+    /// Returns AVM local variable scope for reference.
+    pub fn scope_cell(&self) -> GcCell<'gc, Scope<'gc>> {
+        self.scope.clone()
+    }
+
     /// Resolve a particular named local variable within this activation.
     pub fn resolve(&self, name: &str) -> Value<'gc> {
         if name == "this" {
@@ -119,5 +124,10 @@ impl<'gc> Activation<'gc> {
     /// Define a named local variable within this activation.
     pub fn define(&self, name: &str, value: Value<'gc>, mc: MutationContext<'gc, '_>) {
         self.scope().define(name, value, mc)
+    }
+
+    /// Returns value of `this` as a reference.
+    pub fn this_cell(&self) -> GcCell<'gc, Object<'gc>> {
+        self.this
     }
 }

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -22,9 +22,6 @@ pub struct Activation<'gc> {
     /// The current location of the instruction stream being executed.
     pc: usize,
 
-    /// The opcode stack values for the current stack frame.
-    stack: Vec<Value<'gc>>,
-
     /// All defined local variables in this stack frame.
     scope: GcCell<'gc, Scope<'gc>>,
 }
@@ -32,7 +29,6 @@ pub struct Activation<'gc> {
 unsafe impl<'gc> gc_arena::Collect for Activation<'gc> {
     #[inline]
     fn trace(&self, cc: gc_arena::CollectionContext) {
-        self.stack.trace(cc);
         self.scope.trace(cc);
     }
 }
@@ -43,7 +39,6 @@ impl<'gc> Activation<'gc> {
             swf_version: swf_version,
             data: code,
             pc: 0,
-            stack: Vec::new(),
             scope: scope
         }
     }
@@ -72,16 +67,6 @@ impl<'gc> Activation<'gc> {
     /// Change the current PC.
     pub fn set_pc(&mut self, new_pc: usize) {
         self.pc = new_pc;
-    }
-
-    /// Returns the value stack.
-    pub fn stack(&self) -> &Vec<Value<'gc>> {
-        &self.stack
-    }
-
-    /// Returns the value stack for mutation.
-    pub fn stack_mut(&mut self) -> &mut Vec<Value<'gc>> {
-        &mut self.stack
     }
 
     /// Returns AVM local variable scope.

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -174,6 +174,11 @@ impl<'gc> Activation<'gc> {
         self.scope.clone()
     }
 
+    /// Completely replace the current scope with a new one.
+    pub fn set_scope(&mut self, scope: GcCell<'gc, Scope<'gc>>) {
+        self.scope = scope;
+    }
+
     /// Indicates whether or not the end of this scope should be handled as an
     /// implicit function return or the end of a block.
     pub fn can_implicit_return(&self) -> bool {

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -195,6 +195,10 @@ impl<'gc> Activation<'gc> {
         self.local_registers.is_some()
     }
 
+    pub fn allocate_local_registers(&mut self, num: u8, mc: MutationContext<'gc, '_>) {
+        self.local_registers = Some(GcCell::allocate(mc, vec![Value::Undefined; num as usize]));
+    }
+
     /// Retrieve a local register.
     pub fn local_register(&self, id: u8) -> Value<'gc> {
         if let Some(local_registers) = self.local_registers {

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -1,0 +1,98 @@
+//! Code relating to executable functions + calling conventions.
+
+use gc_arena::GcCell;
+use crate::tag_utils::SwfSlice;
+use crate::avm1::{Avm1, ActionContext};
+use crate::avm1::object::Object;
+use crate::avm1::value::Value;
+
+pub type NativeFunction<'gc> = fn(
+    &mut Avm1<'gc>,
+    &mut ActionContext<'_, 'gc, '_>,
+    GcCell<'gc, Object<'gc>>,
+    &[Value<'gc>],
+) -> Value<'gc>;
+
+/// Represents a function defined in the AVM1 runtime.
+#[derive(Clone)]
+pub struct Avm1Function {
+    /// The file format version of the SWF that generated this function.
+    swf_version: u8,
+
+    /// A reference to the underlying SWF data.
+    data: SwfSlice,
+    
+    /// The name of the function, if not anonymous.
+    name: Option<String>,
+
+    /// The names of the function parameters.
+    params: Vec<String>,
+}
+
+impl Avm1Function {
+    pub fn new(swf_version: u8, actions: SwfSlice, name: &str, params: &[&str]) -> Avm1Function {
+        let name = match name {
+            "" => None,
+            name => Some(name.to_string())
+        };
+
+        Avm1Function {
+            swf_version: swf_version,
+            data: actions,
+            name: name,
+            params: params.into_iter().map(|s| s.to_string()).collect()
+        }
+    }
+
+    pub fn swf_version(&self) -> u8 {
+        self.swf_version
+    }
+
+    pub fn data(&self) -> SwfSlice {
+        self.data.clone()
+    }
+}
+
+/// Represents a function that can be defined in the Ruffle runtime or by the
+/// AVM1 bytecode itself.
+#[derive(Clone)]
+pub enum Executable<'gc> {
+    /// A function provided by the Ruffle runtime and implemented in Rust.
+    Native(NativeFunction<'gc>),
+
+    /// ActionScript data defined by a previous action.
+    Action(Avm1Function)
+}
+
+impl<'gc> Executable<'gc> {
+    /// Execute the given code.
+    /// 
+    /// Execution is not guaranteed to have completed when this function
+    /// returns. If on-stack execution is possible, then this function returns
+    /// a return value you must push onto the stack. Otherwise, you must
+    /// create a new stack frame and execute the action data yourself.
+    pub fn exec(&self, avm: &mut Avm1<'gc>, ac: &mut ActionContext<'_, 'gc, '_>, this: GcCell<'gc, Object<'gc>>, args: &[Value<'gc>]) -> Option<Value<'gc>> {
+        match self {
+            Executable::Native(nf) => Some(nf(avm, ac, this, args)),
+            Executable::Action(af) => {
+                let mut arguments = Object::object(ac.gc_context);
+
+                for i in 0..args.len() {
+                    arguments.set(&format!("{}", i), args.get(i).unwrap().clone())
+                }
+
+                arguments.set("length", Value::Number(args.len() as f64));
+
+                avm.insert_stack_frame_for_function(af, this, GcCell::allocate(ac.gc_context, arguments), ac);
+
+                for i in 0..args.len() {
+                    if let Some(argname) = af.params.get(i) {
+                        avm.current_stack_frame_mut().unwrap().define(argname, args.get(i).unwrap().clone(), ac.gc_context);
+                    }
+                }
+
+                None
+            }
+        }
+    }
+}

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -1,6 +1,7 @@
 //! Code relating to executable functions + calling conventions.
 
 use gc_arena::GcCell;
+use swf::avm1::types::FunctionParam;
 use crate::tag_utils::SwfSlice;
 use crate::avm1::{Avm1, ActionContext};
 use crate::avm1::object::Object;
@@ -68,6 +69,102 @@ unsafe impl<'gc> gc_arena::Collect for Avm1Function<'gc> {
     }
 }
 
+/// Represents a function defined in the AVM1 runtime's `ActionDefineFunction2`
+/// opcode.
+#[derive(Clone)]
+pub struct Avm1Function2<'gc> {
+    /// The file format version of the SWF that generated this function.
+    swf_version: u8,
+
+    /// A reference to the underlying SWF data.
+    data: SwfSlice,
+    
+    /// The name of the function, if not anonymous.
+    name: Option<String>,
+
+    /// The number of registers to allocate for this function's private register
+    /// set.
+    register_count: u8,
+
+    preload_parent: bool,
+    preload_root: bool,
+    supress_super: bool,
+    preload_super: bool,
+    supress_arguments: bool,
+    preload_arguments: bool,
+    supress_this: bool,
+    preload_this: bool,
+
+    /// The names of the function parameters and their register mappings.
+    /// r0 indicates that no register shall be written and the parameter stored
+    /// as a Variable instead.
+    params: Vec<(Option<u8>, String)>,
+
+    /// The scope the function was born into.
+    scope: GcCell<'gc, Scope<'gc>>
+}
+
+impl<'gc> Avm1Function2<'gc> {
+    pub fn new(swf_version: u8,
+        actions: SwfSlice,
+        name: &str,
+        register_count: u8,
+        preload_parent: bool,
+        preload_root: bool,
+        supress_super: bool,
+        preload_super: bool,
+        supress_arguments: bool,
+        preload_arguments: bool,
+        supress_this: bool,
+        preload_this: bool,
+        params: &Vec<FunctionParam>,
+        scope: GcCell<'gc, Scope<'gc>>) -> Self {
+        
+        let name = match name {
+            "" => None,
+            name => Some(name.to_string())
+        };
+
+        let mut owned_params = Vec::new();
+        for FunctionParam{name: s, register_index: r} in params.into_iter() {
+            owned_params.push((r.clone(), s.to_string()))
+        }
+
+        Avm1Function2 {
+            swf_version: swf_version,
+            data: actions,
+            name: name,
+            register_count: register_count,
+            preload_parent: preload_parent,
+            preload_root: preload_root,
+            supress_super: supress_super,
+            preload_super: preload_super,
+            supress_arguments: supress_arguments,
+            preload_arguments: preload_arguments,
+            supress_this: supress_this,
+            preload_this: preload_this,
+            params: owned_params,
+            scope: scope
+        }
+    }
+
+    pub fn swf_version(&self) -> u8 {
+        self.swf_version
+    }
+
+    pub fn data(&self) -> SwfSlice {
+        self.data.clone()
+    }
+
+    pub fn scope(&self) -> GcCell<'gc, Scope<'gc>> {
+        self.scope.clone()
+    }
+
+    pub fn register_count(&self) -> u8 {
+        self.register_count
+    }
+}
+
 /// Represents a function that can be defined in the Ruffle runtime or by the
 /// AVM1 bytecode itself.
 #[derive(Clone)]
@@ -75,8 +172,11 @@ pub enum Executable<'gc> {
     /// A function provided by the Ruffle runtime and implemented in Rust.
     Native(NativeFunction<'gc>),
 
-    /// ActionScript data defined by a previous action.
-    Action(Avm1Function<'gc>)
+    /// ActionScript data defined by a previous `DefineFunction` action.
+    Action(Avm1Function<'gc>),
+
+    /// ActionScript data defined by a previous `DefineFunction2` action.
+    Action2(Avm1Function2<'gc>)
 }
 
 impl<'gc> Executable<'gc> {
@@ -103,6 +203,29 @@ impl<'gc> Executable<'gc> {
                 for i in 0..args.len() {
                     if let Some(argname) = af.params.get(i) {
                         avm.current_stack_frame_mut().unwrap().define(argname, args.get(i).unwrap().clone(), ac.gc_context);
+                    }
+                }
+
+                None
+            },
+            Executable::Action2(af) => {
+                let mut arguments = Object::object(ac.gc_context);
+                if !af.supress_arguments {
+                    for i in 0..args.len() {
+                        arguments.set(&format!("{}", i), args.get(i).unwrap().clone())
+                    }
+
+                    arguments.set("length", Value::Number(args.len() as f64));
+                }
+
+                avm.insert_stack_frame_for_function2(af, this, GcCell::allocate(ac.gc_context, arguments), ac);
+
+                for i in 0..args.len() {
+                    match (args.get(i), af.params.get(i)) {
+                        (Some(arg), Some((Some(argreg), argname))) => avm.set_current_register(*argreg, arg.clone(), ac),
+                        (Some(arg), Some((None, argname))) => avm.current_stack_frame_mut().unwrap().define(argname, arg.clone(), ac.gc_context),
+                        (Some(arg), _) => {},
+                        _ => panic!("Missing argument value")
                     }
                 }
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -93,11 +93,11 @@ pub struct Avm1Function2<'gc> {
 
     preload_parent: bool,
     preload_root: bool,
-    supress_super: bool,
+    suppress_super: bool,
     preload_super: bool,
-    supress_arguments: bool,
+    suppress_arguments: bool,
     preload_arguments: bool,
-    supress_this: bool,
+    suppress_this: bool,
     preload_this: bool,
     preload_global: bool,
 
@@ -138,11 +138,11 @@ impl<'gc> Avm1Function2<'gc> {
             register_count: swf_function.params.capacity() as u8,
             preload_parent: swf_function.preload_parent,
             preload_root: swf_function.preload_root,
-            supress_super: swf_function.suppress_super,
+            suppress_super: swf_function.suppress_super,
             preload_super: swf_function.preload_super,
-            supress_arguments: swf_function.suppress_super,
+            suppress_arguments: swf_function.suppress_super,
             preload_arguments: swf_function.preload_arguments,
-            supress_this: swf_function.suppress_this,
+            suppress_this: swf_function.suppress_this,
             preload_this: swf_function.preload_this,
             preload_global: swf_function.preload_global,
             params: owned_params,
@@ -238,7 +238,7 @@ impl<'gc> Executable<'gc> {
                     Scope::new_local_scope(af.scope(), ac.gc_context),
                 );
                 let mut arguments = Object::object(ac.gc_context);
-                if !af.supress_arguments {
+                if !af.suppress_arguments {
                     for i in 0..args.len() {
                         arguments.force_set(&format!("{}", i), args.get(i).unwrap().clone())
                     }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -83,6 +83,7 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
 mod tests {
     use super::*;
     use crate::avm1::Error;
+    use crate::avm1::activation::Activation;
     use crate::backend::audio::NullAudioBackend;
     use crate::backend::navigator::NullNavigatorBackend;
     use crate::display_object::DisplayObject;
@@ -128,6 +129,9 @@ mod tests {
                 audio: &mut NullAudioBackend::new(),
                 navigator: &mut NullNavigatorBackend::new(),
             };
+
+            let globals = avm.global_object_cell();
+            avm.insert_stack_frame(Activation::from_nothing(swf_version, globals, gc_context));
 
             test(&mut avm, &mut context)
         })

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -82,8 +82,8 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::avm1::Error;
     use crate::avm1::activation::Activation;
+    use crate::avm1::Error;
     use crate::backend::audio::NullAudioBackend;
     use crate::backend::navigator::NullNavigatorBackend;
     use crate::display_object::DisplayObject;

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -99,7 +99,7 @@ mod tests {
                     let function = math.read().get($name, avm, context, math);
 
                     $(
-                        assert_eq!(function.call(avm, context, math, $args)?, $out);
+                        assert_eq!(function.call(avm, context, math, $args)?, Some($out));
                     )*
 
                     Ok(())

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -113,7 +113,7 @@ mod tests {
         F: for<'a, 'gc> FnOnce(&mut Avm1<'gc>, &mut ActionContext<'a, 'gc, '_>) -> R,
     {
         rootless_arena(|gc_context| {
-            let mut avm = Avm1::new(gc_context, swf_version);
+            let mut avm = Avm1::new(gc_context);
             let movie_clip: Box<dyn DisplayObject> = Box::new(MovieClip::new(gc_context));
             let root = GcCell::allocate(gc_context, movie_clip);
             let mut context = ActionContext {

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,6 +1,6 @@
-use crate::avm1::{ActionContext, Avm1, Value};
-use crate::avm1::function::{Executable, NativeFunction, Avm1Function, Avm1Function2};
+use crate::avm1::function::{Avm1Function, Avm1Function2, Executable, NativeFunction};
 use crate::avm1::scope::Scope;
+use crate::avm1::{ActionContext, Avm1, Value};
 use crate::display_object::DisplayNode;
 use crate::tag_utils::SwfSlice;
 use core::fmt;
@@ -135,7 +135,7 @@ impl<'gc> Object<'gc> {
     }
 
     /// Constructs an object with no values, not even builtins.
-    /// 
+    ///
     /// Intended for constructing scope chains, since they exclusively use the
     /// object values, but can't just have a hashmap because of `with` and
     /// friends.
@@ -157,12 +157,24 @@ impl<'gc> Object<'gc> {
         }
     }
 
-    pub fn action_function(swf_version: u8, actions: SwfSlice, name: &str, params: &[&str], scope: GcCell<'gc, Scope<'gc>>) -> Self {
+    pub fn action_function(
+        swf_version: u8,
+        actions: SwfSlice,
+        name: &str,
+        params: &[&str],
+        scope: GcCell<'gc, Scope<'gc>>,
+    ) -> Self {
         Self {
             type_of: TYPE_OF_FUNCTION,
-            function: Some(Executable::Action(Avm1Function::new(swf_version, actions, name, params, scope))),
+            function: Some(Executable::Action(Avm1Function::new(
+                swf_version,
+                actions,
+                name,
+                params,
+                scope,
+            ))),
             display_node: None,
-            values: HashMap::new()
+            values: HashMap::new(),
         }
     }
 
@@ -171,7 +183,7 @@ impl<'gc> Object<'gc> {
             type_of: TYPE_OF_FUNCTION,
             function: Some(Executable::Action2(func)),
             display_node: None,
-            values: HashMap::new()
+            values: HashMap::new(),
         }
     }
 
@@ -244,7 +256,10 @@ impl<'gc> Object<'gc> {
     ) {
         self.force_set(
             name,
-            Value::Object(GcCell::allocate(gc_context, Object::native_function(function))),
+            Value::Object(GcCell::allocate(
+                gc_context,
+                Object::native_function(function),
+            )),
         )
     }
 
@@ -283,10 +298,10 @@ impl<'gc> Object<'gc> {
         self.values.contains_key(name)
     }
 
-    pub fn iter_values(&self) -> impl Iterator<Item=(&String, &Value<'gc>)> {
+    pub fn iter_values(&self) -> impl Iterator<Item = (&String, &Value<'gc>)> {
         self.values.iter().filter_map(|(k, p)| match p {
-            Property::Virtual {..} => None,
-            Property::Stored { value, .. } => Some((k, value))
+            Property::Virtual { .. } => None,
+            Property::Stored { value, .. } => Some((k, value)),
         })
     }
 
@@ -325,11 +340,11 @@ impl<'gc> Object<'gc> {
 mod tests {
     use super::*;
 
+    use crate::avm1::activation::Activation;
     use crate::backend::audio::NullAudioBackend;
     use crate::backend::navigator::NullNavigatorBackend;
     use crate::display_object::DisplayObject;
     use crate::movie_clip::MovieClip;
-    use crate::avm1::activation::Activation;
     use gc_arena::rootless_arena;
     use rand::{rngs::SmallRng, SeedableRng};
 

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,5 +1,5 @@
 use crate::avm1::{ActionContext, Avm1, Value};
-use crate::avm1::function::{Executable, NativeFunction, Avm1Function};
+use crate::avm1::function::{Executable, NativeFunction, Avm1Function, Avm1Function2};
 use crate::avm1::scope::Scope;
 use crate::display_object::DisplayNode;
 use crate::tag_utils::SwfSlice;
@@ -161,6 +161,15 @@ impl<'gc> Object<'gc> {
         Self {
             type_of: TYPE_OF_FUNCTION,
             function: Some(Executable::Action(Avm1Function::new(swf_version, actions, name, params, scope))),
+            display_node: None,
+            values: HashMap::new()
+        }
+    }
+
+    pub fn action_function2(func: Avm1Function2<'gc>) -> Self {
+        Self {
+            type_of: TYPE_OF_FUNCTION,
+            function: Some(Executable::Action2(func)),
             display_node: None,
             values: HashMap::new()
         }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -68,7 +68,7 @@ impl<'gc> Executable<'gc> {
         match self {
             Executable::Native(nf) => Some(nf(avm, ac, this, args)),
             Executable::Action(af) => {
-                avm.insert_stack_frame_from_action(af.swf_version, af.data.clone(), ac.gc_context);
+                avm.insert_stack_frame_for_function(af.swf_version, af.data.clone(), ac.gc_context);
 
                 for i in 0..args.len() {
                     avm.push(args.get(i).unwrap().clone());

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -329,6 +329,7 @@ mod tests {
     use crate::backend::navigator::NullNavigatorBackend;
     use crate::display_object::DisplayObject;
     use crate::movie_clip::MovieClip;
+    use crate::avm1::activation::Activation;
     use gc_arena::rootless_arena;
     use rand::{rngs::SmallRng, SeedableRng};
 
@@ -341,7 +342,7 @@ mod tests {
         ) -> R,
     {
         rootless_arena(|gc_context| {
-            let mut avm = Avm1::new(gc_context, swf_version);
+            let mut avm = Avm1::new(gc_context);
             let movie_clip: Box<dyn DisplayObject> = Box::new(MovieClip::new(gc_context));
             let root = GcCell::allocate(gc_context, movie_clip);
             let mut context = ActionContext {
@@ -357,6 +358,9 @@ mod tests {
                 navigator: &mut NullNavigatorBackend::new(),
             };
             let object = GcCell::allocate(gc_context, Object::object(gc_context));
+
+            let globals = avm.global_object_cell();
+            avm.insert_stack_frame(Activation::from_nothing(swf_version, globals, gc_context));
 
             test(&mut avm, &mut context, object)
         })

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -71,7 +71,7 @@ impl<'gc> Executable<'gc> {
                 avm.insert_stack_frame_from_action(af.swf_version, af.data.clone(), ac.gc_context);
 
                 for arg in args {
-                    avm.current_stack_frame_mut().unwrap().stack_mut().push(arg.clone());
+                    avm.push(arg.clone());
                 }
 
                 avm.current_stack_frame_mut().unwrap().define("this", Value::Object(this), ac.gc_context);

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -67,7 +67,17 @@ impl<'gc> Executable<'gc> {
     pub fn exec(&self, avm: &mut Avm1<'gc>, ac: &mut ActionContext<'_, 'gc, '_>, this: GcCell<'gc, Object<'gc>>, args: &[Value<'gc>]) -> Option<Value<'gc>> {
         match self {
             Executable::Native(nf) => Some(nf(avm, ac, this, args)),
-            Executable::Action(af) => None
+            Executable::Action(af) => {
+                avm.insert_stack_frame_from_action(af.swf_version, af.data.clone());
+
+                for arg in args {
+                    avm.current_stack_frame_mut().unwrap().stack_mut().push(arg.clone());
+                }
+
+                avm.current_stack_frame_mut().unwrap().locals_mut().insert("this".to_string(), Value::Object(this));
+
+                None
+            }
         }
     }
 }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -68,7 +68,7 @@ impl<'gc> Executable<'gc> {
         match self {
             Executable::Native(nf) => Some(nf(avm, ac, this, args)),
             Executable::Action(af) => {
-                avm.insert_stack_frame_for_function(af.swf_version, af.data.clone(), ac.gc_context);
+                avm.insert_stack_frame_for_function(af.swf_version, af.data.clone(), this, ac);
 
                 for i in 0..args.len() {
                     avm.push(args.get(i).unwrap().clone());
@@ -76,8 +76,6 @@ impl<'gc> Executable<'gc> {
                         avm.current_stack_frame_mut().unwrap().define(argname, args.get(i).unwrap().clone(), ac.gc_context);
                     }
                 }
-
-                avm.current_stack_frame_mut().unwrap().define("this", Value::Object(this), ac.gc_context);
 
                 None
             }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -261,6 +261,11 @@ impl<'gc> Object<'gc> {
         Value::Undefined
     }
 
+    /// Delete a given value off the object.
+    pub fn delete(&mut self, name: &str) {
+        self.values.remove(name);
+    }
+
     pub fn has_property(&self, name: &str) -> bool {
         self.values.contains_key(name)
     }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -70,8 +70,11 @@ impl<'gc> Executable<'gc> {
             Executable::Action(af) => {
                 avm.insert_stack_frame_from_action(af.swf_version, af.data.clone(), ac.gc_context);
 
-                for arg in args {
-                    avm.push(arg.clone());
+                for i in 0..args.len() {
+                    avm.push(args.get(i).unwrap().clone());
+                    if let Some(argname) = af.params.get(i) {
+                        avm.current_stack_frame_mut().unwrap().define(argname, args.get(i).unwrap().clone(), ac.gc_context);
+                    }
                 }
 
                 avm.current_stack_frame_mut().unwrap().define("this", Value::Object(this), ac.gc_context);

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,4 +1,5 @@
 use crate::avm1::{ActionContext, Avm1, Value};
+use crate::avm1::function::{Executable, NativeFunction, Avm1Function};
 use crate::display_object::DisplayNode;
 use crate::tag_utils::SwfSlice;
 use core::fmt;
@@ -6,82 +7,6 @@ use gc_arena::{GcCell, MutationContext};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::mem::replace;
-
-pub type NativeFunction<'gc> = fn(
-    &mut Avm1<'gc>,
-    &mut ActionContext<'_, 'gc, '_>,
-    GcCell<'gc, Object<'gc>>,
-    &[Value<'gc>],
-) -> Value<'gc>;
-
-/// Represents a function defined in the AVM1 runtime.
-#[derive(Clone)]
-struct Avm1Function {
-    /// The file format version of the SWF that generated this function.
-    swf_version: u8,
-
-    /// A reference to the underlying SWF data.
-    data: SwfSlice,
-    
-    /// The name of the function, if not anonymous.
-    name: Option<String>,
-
-    /// The names of the function parameters.
-    params: Vec<String>,
-}
-
-impl Avm1Function {
-    pub fn new(swf_version: u8, actions: SwfSlice, name: &str, params: &[&str]) -> Avm1Function {
-        let name = match name {
-            "" => None,
-            name => Some(name.to_string())
-        };
-
-        Avm1Function {
-            swf_version: swf_version,
-            data: actions,
-            name: name,
-            params: params.into_iter().map(|s| s.to_string()).collect()
-        }
-    }
-}
-
-/// Represents a function that can be defined in the Ruffle runtime or by the
-/// AVM1 bytecode itself.
-#[derive(Clone)]
-enum Executable<'gc> {
-    /// A function provided by the Ruffle runtime and implemented in Rust.
-    Native(NativeFunction<'gc>),
-
-    /// ActionScript data defined by a previous action.
-    Action(Avm1Function)
-}
-
-impl<'gc> Executable<'gc> {
-    /// Execute the given code.
-    /// 
-    /// Execution is not guaranteed to have completed when this function
-    /// returns. If on-stack execution is possible, then this function returns
-    /// a return value you must push onto the stack. Otherwise, you must
-    /// create a new stack frame and execute the action data yourself.
-    pub fn exec(&self, avm: &mut Avm1<'gc>, ac: &mut ActionContext<'_, 'gc, '_>, this: GcCell<'gc, Object<'gc>>, args: &[Value<'gc>]) -> Option<Value<'gc>> {
-        match self {
-            Executable::Native(nf) => Some(nf(avm, ac, this, args)),
-            Executable::Action(af) => {
-                avm.insert_stack_frame_for_function(af.swf_version, af.data.clone(), this, ac);
-
-                for i in 0..args.len() {
-                    avm.push(args.get(i).unwrap().clone());
-                    if let Some(argname) = af.params.get(i) {
-                        avm.current_stack_frame_mut().unwrap().define(argname, args.get(i).unwrap().clone(), ac.gc_context);
-                    }
-                }
-
-                None
-            }
-        }
-    }
-}
 
 pub const TYPE_OF_OBJECT: &str = "object";
 pub const TYPE_OF_FUNCTION: &str = "function";

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -27,11 +27,21 @@ impl<'gc> Scope<'gc> {
         }
     }
 
-    /// Construct a child scope (one with a parent).
+    /// Construct a child scope of another scope.
     pub fn from_parent_scope(parent: GcCell<'gc, Self>, mc: MutationContext<'gc, '_>) -> Scope<'gc> {
         Scope {
             parent: Some(parent.clone()),
             values: GcCell::allocate(mc, Object::bare_object())
+        }
+    }
+
+    /// Construct a child scope with a given object
+    /// 
+    /// Rejected titles: `from_oyako_scope`
+    pub fn from_parent_scope_with_object(parent: GcCell<'gc, Self>, with_object: GcCell<'gc, Object<'gc>>) -> Scope<'gc> {
+        Scope {
+            parent: Some(parent),
+            values: with_object
         }
     }
 

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -193,4 +193,15 @@ impl<'gc> Scope<'gc> {
     pub fn define(&self, name: &str, value: Value<'gc>, mc: MutationContext<'gc, '_>) {
         self.locals_mut(mc).force_set(name, value);
     }
+
+    /// Delete a value from scope
+    pub fn delete(&self, name: &str, mc: MutationContext<'gc, '_>) {
+        if self.locals().has_property(name) {
+            return self.locals_mut(mc).delete(name);
+        }
+
+        if let Some(scope) = self.parent() {
+            return scope.delete(name, mc);
+        }
+    }
 }

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -1,12 +1,11 @@
 //! Represents AVM1 scope chain resolution.
 
-use std::cell::{Ref, RefMut};
+use crate::avm1::{ActionContext, Avm1, Object, Value};
 use gc_arena::{GcCell, MutationContext};
-use crate::avm1::{Avm1, ActionContext, Object, Value};
+use std::cell::{Ref, RefMut};
 
 /// Indicates what kind of scope a scope is.
-#[derive(Copy, Clone, 
-Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ScopeClass {
     /// Scope represents global scope.
     Global,
@@ -21,7 +20,7 @@ pub enum ScopeClass {
 
     /// Scope represents an object added to the scope chain with `with`.
     /// It is not inherited when closures are defined.
-    With
+    With,
 }
 
 /// Represents a scope chain for an AVM1 activation.
@@ -29,7 +28,7 @@ pub enum ScopeClass {
 pub struct Scope<'gc> {
     parent: Option<GcCell<'gc, Scope<'gc>>>,
     class: ScopeClass,
-    values: GcCell<'gc, Object<'gc>>
+    values: GcCell<'gc, Object<'gc>>,
 }
 
 unsafe impl<'gc> gc_arena::Collect for Scope<'gc> {
@@ -46,30 +45,33 @@ impl<'gc> Scope<'gc> {
         Scope {
             parent: None,
             class: ScopeClass::Global,
-            values: globals
+            values: globals,
         }
     }
 
     /// Construct a child scope of another scope.
     pub fn new_local_scope(parent: GcCell<'gc, Self>, mc: MutationContext<'gc, '_>) -> Scope<'gc> {
         Scope {
-            parent: Some(parent.clone()),
+            parent: Some(parent),
             class: ScopeClass::Local,
-            values: GcCell::allocate(mc, Object::bare_object())
+            values: GcCell::allocate(mc, Object::bare_object()),
         }
     }
 
     /// Construct a closure scope to be used as the parent of all local scopes
     /// when invoking a function.
-    pub fn new_closure_scope(mut parent: GcCell<'gc, Self>, mc: MutationContext<'gc, '_>) -> GcCell<'gc, Self> {
+    pub fn new_closure_scope(
+        mut parent: GcCell<'gc, Self>,
+        mc: MutationContext<'gc, '_>,
+    ) -> GcCell<'gc, Self> {
         let mut closure_scope_list = Vec::new();
 
         loop {
             if parent.read().class != ScopeClass::With {
-                closure_scope_list.push(parent.clone());
+                closure_scope_list.push(parent);
             }
 
-            let grandparent = parent.read().parent.clone();
+            let grandparent = parent.read().parent;
             if let Some(grandparent) = grandparent {
                 parent = grandparent;
             } else {
@@ -79,42 +81,52 @@ impl<'gc> Scope<'gc> {
 
         let mut parent_scope = None;
         for scope in closure_scope_list.iter().rev() {
-            parent_scope = Some(GcCell::allocate(mc, Scope {
-                parent: parent_scope,
-                class: scope.read().class,
-                values: scope.read().values.clone()
-            }));
+            parent_scope = Some(GcCell::allocate(
+                mc,
+                Scope {
+                    parent: parent_scope,
+                    class: scope.read().class,
+                    values: scope.read().values,
+                },
+            ));
         }
 
         if let Some(parent_scope) = parent_scope {
             parent_scope
         } else {
-            GcCell::allocate(mc, Scope {
-                parent: None,
-                class: ScopeClass::Global,
-                values: GcCell::allocate(mc, Object::bare_object())
-            })
+            GcCell::allocate(
+                mc,
+                Scope {
+                    parent: None,
+                    class: ScopeClass::Global,
+                    values: GcCell::allocate(mc, Object::bare_object()),
+                },
+            )
         }
     }
 
     /// Construct a scope for use with `tellTarget` code where the timeline
     /// scope has been replaced with another given object.
-    pub fn new_target_scope(mut parent: GcCell<'gc, Self>, clip: GcCell<'gc, Object<'gc>>, mc: MutationContext<'gc, '_>) -> GcCell<'gc, Self> {
+    pub fn new_target_scope(
+        mut parent: GcCell<'gc, Self>,
+        clip: GcCell<'gc, Object<'gc>>,
+        mc: MutationContext<'gc, '_>,
+    ) -> GcCell<'gc, Self> {
         let mut timeline_scope_list = Vec::new();
 
         loop {
             if parent.read().class != ScopeClass::Target {
-                timeline_scope_list.push(parent.clone());
+                timeline_scope_list.push(parent);
             } else {
                 let new_scope = Self {
                     parent: None,
                     class: ScopeClass::Target,
-                    values: clip
+                    values: clip,
                 };
                 timeline_scope_list.push(GcCell::allocate(mc, new_scope));
             }
 
-            let grandparent = parent.read().parent.clone();
+            let grandparent = parent.read().parent;
             if let Some(grandparent) = grandparent {
                 parent = grandparent;
             } else {
@@ -124,53 +136,71 @@ impl<'gc> Scope<'gc> {
 
         let mut parent_scope = None;
         for scope in timeline_scope_list.iter().rev() {
-            parent_scope = Some(GcCell::allocate(mc, Scope {
-                parent: parent_scope,
-                class: scope.read().class,
-                values: scope.read().values.clone()
-            }));
+            parent_scope = Some(GcCell::allocate(
+                mc,
+                Scope {
+                    parent: parent_scope,
+                    class: scope.read().class,
+                    values: scope.read().values,
+                },
+            ));
         }
 
         if let Some(parent_scope) = parent_scope {
             parent_scope
         } else {
-            GcCell::allocate(mc, Scope {
-                parent: None,
-                class: ScopeClass::Global,
-                values: GcCell::allocate(mc, Object::bare_object())
-            })
+            GcCell::allocate(
+                mc,
+                Scope {
+                    parent: None,
+                    class: ScopeClass::Global,
+                    values: GcCell::allocate(mc, Object::bare_object()),
+                },
+            )
         }
     }
 
     /// Construct a with scope to be used as the scope during a with block.
-    /// 
+    ///
     /// A with block inserts the values of a particular object into the scope
     /// of currently running code, while still maintaining the same local
     /// scope. This requires some scope chain juggling.
-    pub fn new_with_scope(locals: GcCell<'gc, Self>,
-            with_object: GcCell<'gc, Object<'gc>>,
-            mc: MutationContext<'gc, '_>) -> GcCell<'gc, Self> {
-        let parent_scope = locals.read().parent.clone();
-        let local_values = locals.read().values.clone();
-        let with_scope = GcCell::allocate(mc, Scope {
-            parent: parent_scope,
-            class: ScopeClass::With,
-            values: with_object
-        });
+    pub fn new_with_scope(
+        locals: GcCell<'gc, Self>,
+        with_object: GcCell<'gc, Object<'gc>>,
+        mc: MutationContext<'gc, '_>,
+    ) -> GcCell<'gc, Self> {
+        let parent_scope = locals.read().parent;
+        let local_values = locals.read().values;
+        let with_scope = GcCell::allocate(
+            mc,
+            Scope {
+                parent: parent_scope,
+                class: ScopeClass::With,
+                values: with_object,
+            },
+        );
 
-        GcCell::allocate(mc, Scope {
-            parent: Some(with_scope),
-            class: ScopeClass::Local,
-            values: local_values
-        })
+        GcCell::allocate(
+            mc,
+            Scope {
+                parent: Some(with_scope),
+                class: ScopeClass::Local,
+                values: local_values,
+            },
+        )
     }
 
     /// Construct an arbitrary scope
-    pub fn new(parent: GcCell<'gc, Self>, class: ScopeClass, with_object: GcCell<'gc, Object<'gc>>) -> Scope<'gc> {
+    pub fn new(
+        parent: GcCell<'gc, Self>,
+        class: ScopeClass,
+        with_object: GcCell<'gc, Object<'gc>>,
+    ) -> Scope<'gc> {
         Scope {
-            parent: Some(parent.clone()),
-            class: class,
-            values: with_object
+            parent: Some(parent),
+            class,
+            values: with_object,
         }
     }
 
@@ -188,7 +218,7 @@ impl<'gc> Scope<'gc> {
     pub fn parent(&self) -> Option<Ref<Scope<'gc>>> {
         match self.parent {
             Some(ref p) => Some(p.read()),
-            None => None
+            None => None,
         }
     }
 
@@ -197,7 +227,6 @@ impl<'gc> Scope<'gc> {
         if self.locals().has_property(name) {
             return self.locals().force_get(name);
         }
-        
         if let Some(scope) = self.parent() {
             return scope.resolve(name);
         }
@@ -220,20 +249,23 @@ impl<'gc> Scope<'gc> {
 
     /// Update a particular value in the scope chain, but only if it was
     /// previously defined.
-    /// 
+    ///
     /// If the value is currently already defined in this scope, then it will
     /// be overwritten. If it is not defined, then we traverse the scope chain
     /// until we find a defined value to overwrite. We do not define a property
     /// if it is not already defined somewhere in the scope chain, and instead
     /// return it so that the caller may manually define the property itself.
-    pub fn overwrite(&self,
+    pub fn overwrite(
+        &self,
         name: &str,
-        value: Value<'gc>, 
+        value: Value<'gc>,
         avm: &mut Avm1<'gc>,
         context: &mut ActionContext<'_, 'gc, '_>,
-        this: GcCell<'gc, Object<'gc>>) -> Option<Value<'gc>> {
+        this: GcCell<'gc, Object<'gc>>,
+    ) -> Option<Value<'gc>> {
         if self.locals().has_property(name) {
-            self.locals_mut(context.gc_context).set(name, value, avm, context, this);
+            self.locals_mut(context.gc_context)
+                .set(name, value, avm, context, this);
             return None;
         }
 
@@ -245,7 +277,7 @@ impl<'gc> Scope<'gc> {
     }
 
     /// Set a particular value in the locals for this scope.
-    /// 
+    ///
     /// By convention, the locals for a given function are always defined as
     /// stored (e.g. not virtual) properties on the lowest object in the scope
     /// chain. As a result, this function always force sets a property on the

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -1,0 +1,77 @@
+//! Represents AVM1 scope chain resolution.
+
+use std::cell::Ref;
+use gc_arena::{GcCell, MutationContext};
+use crate::avm1::{Object, Value};
+
+/// Represents a scope chain for an AVM1 activation.
+pub struct Scope<'gc> {
+    parent: Option<GcCell<'gc, Scope<'gc>>>,
+    values: GcCell<'gc, Object<'gc>>
+}
+
+unsafe impl<'gc> gc_arena::Collect for Scope<'gc> {
+    #[inline]
+    fn trace(&self, cc: gc_arena::CollectionContext) {
+        self.parent.trace(cc);
+        self.values.trace(cc);
+    }
+}
+
+impl<'gc> Scope<'gc> {
+    /// Construct a global scope (one without a parent).
+    pub fn from_global_object(globals: GcCell<'gc, Object<'gc>>) -> Scope<'gc> {
+        Scope {
+            parent: None,
+            values: globals
+        }
+    }
+
+    /// Construct a child scope (one with a parent).
+    pub fn from_parent_scope(parent: GcCell<'gc, Self>, mc: MutationContext<'gc, '_>) -> Scope<'gc> {
+        Scope {
+            parent: Some(parent.clone()),
+            values: GcCell::allocate(mc, Object::bare_object())
+        }
+    }
+
+    /// Returns a reference to the current local scope object.
+    pub fn locals(&self) -> Ref<Object<'gc>> {
+        self.values.read()
+    }
+
+    /// Resolve a particular value in the scope chain.
+    pub fn resolve(&self, name: &str) -> Value<'gc> {
+        let mut current_values = Some(self.values);
+
+        while let Some(scope) = current_values {
+            if scope.read().has_property(name) {
+                return scope.read().get(name);
+            }
+
+            current_values = self.parent.map(|p| p.read().values);
+        }
+
+        Value::Undefined
+    }
+
+    /// Check if a particular property in the scope chain is defined.
+    pub fn is_defined(&self, name: &str) -> bool {
+        let mut current_values = Some(self.values);
+
+        while let Some(scope) = current_values {
+            if scope.read().has_property(name) {
+                return true;
+            }
+
+            current_values = self.parent.map(|p| p.read().values);
+        }
+
+        false
+    }
+
+    /// Set a particular value in the current scope (and all child scopes)
+    pub fn define(&self, name: &str, value: Value<'gc>, mc: MutationContext<'gc, '_>) {
+        self.values.write(mc).set(name, value);
+    }
+}

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -166,7 +166,7 @@ impl<'gc> Value<'gc> {
         context: &mut ActionContext<'_, 'gc, '_>,
         this: GcCell<'gc, Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<Value<'gc>, Error> {
+    ) -> Result<Option<Value<'gc>>, Error> {
         if let Value::Object(object) = self {
             Ok(object.read().call(avm, context, this, args))
         } else {

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -629,8 +629,8 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::DefineShape4 => self.define_shape(context, reader, 4),
             TagCode::DefineSound => self.define_sound(context, reader, tag_len),
             TagCode::DefineSprite => self.define_sprite(context, reader, tag_len, morph_shapes),
-            TagCode::DefineText => self.define_text(context, reader),
-            TagCode::DefineText2 => self.define_text2(context, reader),
+            TagCode::DefineText => self.define_text_1(context, reader),
+            TagCode::DefineText2 => self.define_text_2(context, reader),
             TagCode::FrameLabel => {
                 self.frame_label(context, reader, tag_len, cur_frame, &mut static_data)
             }
@@ -1051,12 +1051,12 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     #[inline]
-    fn define_text(
+    fn define_text_1(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
-        let text = reader.read_define_text()?;
+        let text = reader.read_define_text_1()?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library
@@ -1065,12 +1065,12 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     #[inline]
-    fn define_text2(
+    fn define_text_2(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
-        let text = reader.read_define_text2()?;
+        let text = reader.read_define_text_2()?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -630,6 +630,7 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::DefineSound => self.define_sound(context, reader, tag_len),
             TagCode::DefineSprite => self.define_sprite(context, reader, tag_len, morph_shapes),
             TagCode::DefineText => self.define_text(context, reader),
+            TagCode::DefineText2 => self.define_text2(context, reader),
             TagCode::FrameLabel => {
                 self.frame_label(context, reader, tag_len, cur_frame, &mut static_data)
             }
@@ -1056,6 +1057,20 @@ impl<'gc, 'a> MovieClip<'gc> {
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
         let text = reader.read_define_text()?;
+        let text_object = Text::from_swf_tag(context, &text);
+        context
+            .library
+            .register_character(text.id, Character::Text(Box::new(text_object)));
+        Ok(())
+    }
+
+    #[inline]
+    fn define_text2(
+        &mut self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        reader: &mut SwfStream<&'a [u8]>,
+    ) -> DecodeResult {
+        let text = reader.read_define_text2()?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -629,8 +629,8 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::DefineShape4 => self.define_shape(context, reader, 4),
             TagCode::DefineSound => self.define_sound(context, reader, tag_len),
             TagCode::DefineSprite => self.define_sprite(context, reader, tag_len, morph_shapes),
-            TagCode::DefineText => self.define_text_1(context, reader),
-            TagCode::DefineText2 => self.define_text_2(context, reader),
+            TagCode::DefineText => self.define_text(context, reader, 1),
+            TagCode::DefineText2 => self.define_text(context, reader, 2),
             TagCode::FrameLabel => {
                 self.frame_label(context, reader, tag_len, cur_frame, &mut static_data)
             }
@@ -1051,26 +1051,13 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     #[inline]
-    fn define_text_1(
+    fn define_text(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
+        version: u8,
     ) -> DecodeResult {
-        let text = reader.read_define_text_1()?;
-        let text_object = Text::from_swf_tag(context, &text);
-        context
-            .library
-            .register_character(text.id, Character::Text(Box::new(text_object)));
-        Ok(())
-    }
-
-    #[inline]
-    fn define_text_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        reader: &mut SwfStream<&'a [u8]>,
-    ) -> DecodeResult {
-        let text = reader.read_define_text_2()?;
+        let text = reader.read_define_text(version)?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -515,7 +515,11 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                     action_context.start_clip = active_clip;
                     action_context.active_clip = active_clip;
                     action_context.target_clip = Some(active_clip);
-                    update_context.avm.insert_stack_frame_for_action(update_context.swf_version, action, &mut action_context);
+                    update_context.avm.insert_stack_frame_for_action(
+                        update_context.swf_version,
+                        action,
+                        &mut action_context,
+                    );
                     let _ = update_context.avm.run_stack_till_empty(&mut action_context);
                 }
             }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -515,8 +515,8 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                     action_context.start_clip = active_clip;
                     action_context.active_clip = active_clip;
                     action_context.target_clip = Some(active_clip);
-                    update_context.avm.insert_stack_frame(update_context.swf_version, action.as_ref(), action_context.gc_context);
-                    let _ = update_context.avm.do_action(&mut action_context);
+                    update_context.avm.insert_stack_frame_from_action(update_context.swf_version, action);
+                    let _ = update_context.avm.run_stack_till_empty(&mut action_context);
                 }
             }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -110,7 +110,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                     )),
                 ),
                 mouse_hover_node: GcCell::allocate(gc_context, None),
-                avm: GcCell::allocate(gc_context, Avm1::new(gc_context, header.version)),
+                avm: GcCell::allocate(gc_context, Avm1::new(gc_context)),
             }),
 
             frame_rate: header.frame_rate.into(),
@@ -515,9 +515,8 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                     action_context.start_clip = active_clip;
                     action_context.active_clip = active_clip;
                     action_context.target_clip = Some(active_clip);
-                    let _ = update_context
-                        .avm
-                        .do_action(&mut action_context, action.as_ref());
+                    update_context.avm.insert_stack_frame(update_context.swf_version, action.as_ref(), action_context.gc_context);
+                    let _ = update_context.avm.do_action(&mut action_context);
                 }
             }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -515,7 +515,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                     action_context.start_clip = active_clip;
                     action_context.active_clip = active_clip;
                     action_context.target_clip = Some(active_clip);
-                    update_context.avm.insert_stack_frame_from_action(update_context.swf_version, action, update_context.gc_context);
+                    update_context.avm.insert_stack_frame_for_action(update_context.swf_version, action, &mut action_context);
                     let _ = update_context.avm.run_stack_till_empty(&mut action_context);
                 }
             }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -515,7 +515,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                     action_context.start_clip = active_clip;
                     action_context.active_clip = active_clip;
                     action_context.target_clip = Some(active_clip);
-                    update_context.avm.insert_stack_frame_from_action(update_context.swf_version, action);
+                    update_context.avm.insert_stack_frame_from_action(update_context.swf_version, action, update_context.gc_context);
                     let _ = update_context.avm.run_stack_till_empty(&mut action_context);
                 }
             }

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -19,7 +19,7 @@ impl AsRef<[u8]> for SwfSlice {
 
 impl SwfSlice {
     /// Construct a new SwfSlice from a regular slice.
-    /// 
+    ///
     /// This function returns None if the given slice is not a subslice of the
     /// current slice.
     pub fn to_subslice(&self, slice: &[u8]) -> Option<SwfSlice> {
@@ -30,7 +30,7 @@ impl SwfSlice {
             Some(SwfSlice {
                 data: self.data.clone(),
                 start: slice_pval - self_pval,
-                end: (slice_pval - self_pval) + slice.len()
+                end: (slice_pval - self_pval) + slice.len(),
             })
         } else {
             None

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -3,6 +3,7 @@ use swf::TagCode;
 pub type DecodeResult = Result<(), Box<dyn std::error::Error>>;
 pub type SwfStream<R> = swf::read::Reader<std::io::Cursor<R>>;
 
+/// A shared-ownership reference to some portion of an immutable datastream.
 #[derive(Debug, Clone)]
 pub struct SwfSlice {
     pub data: std::sync::Arc<Vec<u8>>,
@@ -13,6 +14,27 @@ pub struct SwfSlice {
 impl AsRef<[u8]> for SwfSlice {
     fn as_ref(&self) -> &[u8] {
         &self.data[self.start..self.end]
+    }
+}
+
+impl SwfSlice {
+    /// Construct a new SwfSlice from a regular slice.
+    /// 
+    /// This function returns None if the given slice is not a subslice of the
+    /// current slice.
+    pub fn to_subslice(&self, slice: &[u8]) -> Option<SwfSlice> {
+        let self_pval = self.data.as_ptr() as usize;
+        let slice_pval = slice.as_ptr() as usize;
+
+        if (self_pval + self.start) <= slice_pval && slice_pval < (self_pval + self.end) {
+            Some(SwfSlice {
+                data: self.data.clone(),
+                start: slice_pval - self_pval,
+                end: (slice_pval - self_pval) + slice.len()
+            })
+        } else {
+            None
+        }
     }
 }
 

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -400,8 +400,12 @@ impl<R: Read> Reader<R> {
             Some(TagCode::DefineSound) => {
                 Tag::DefineSound(Box::new(tag_reader.read_define_sound()?))
             }
-            Some(TagCode::DefineText) => Tag::DefineText(Box::new(tag_reader.read_define_text()?)),
-            Some(TagCode::DefineText2) => Tag::DefineText(Box::new(tag_reader.read_define_text2()?)),
+            Some(TagCode::DefineText) => {
+                Tag::DefineText(Box::new(tag_reader.read_define_text_1()?))
+            }
+            Some(TagCode::DefineText2) => {
+                Tag::DefineText(Box::new(tag_reader.read_define_text_2()?))
+            }
             Some(TagCode::DefineVideoStream) => tag_reader.read_define_video_stream()?,
             Some(TagCode::EnableTelemetry) => {
                 tag_reader.read_u16()?; // Reserved
@@ -2428,7 +2432,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
-    pub fn read_define_text(&mut self) -> Result<Text> {
+    pub fn read_define_text_1(&mut self) -> Result<Text> {
         let id = self.read_character_id()?;
         let bounds = self.read_rectangle()?;
         let matrix = self.read_matrix()?;
@@ -2436,7 +2440,7 @@ impl<R: Read> Reader<R> {
         let num_advance_bits = self.read_u8()?;
 
         let mut records = vec![];
-        while let Some(record) = self.read_text_record(num_glyph_bits, num_advance_bits)? {
+        while let Some(record) = self.read_text_record_1(num_glyph_bits, num_advance_bits)? {
             records.push(record);
         }
 
@@ -2448,7 +2452,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
-    pub fn read_define_text2(&mut self) -> Result<Text> {
+    pub fn read_define_text_2(&mut self) -> Result<Text> {
         let id = self.read_character_id()?;
         let bounds = self.read_rectangle()?;
         let matrix = self.read_matrix()?;
@@ -2456,7 +2460,7 @@ impl<R: Read> Reader<R> {
         let num_advance_bits = self.read_u8()?;
 
         let mut records = vec![];
-        while let Some(record) = self.read_text_record2(num_glyph_bits, num_advance_bits)? {
+        while let Some(record) = self.read_text_record_2(num_glyph_bits, num_advance_bits)? {
             records.push(record);
         }
 
@@ -2468,7 +2472,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
-    fn read_text_record(
+    fn read_text_record_1(
         &mut self,
         num_glyph_bits: u8,
         num_advance_bits: u8,
@@ -2525,7 +2529,7 @@ impl<R: Read> Reader<R> {
         }))
     }
 
-    fn read_text_record2(
+    fn read_text_record_2(
         &mut self,
         num_glyph_bits: u8,
         num_advance_bits: u8,


### PR DESCRIPTION
This PR constitutes an implementation of activation objects, scope chains, and user-defined functions for ActionScript 1/2 (AVM1) code. User functions are defined as a reference to some part of the SWF they were loaded from, as well as the version of that SWF (so we can emulate version-specific behavior).

# TODOs
- [x] Activation object stack
- [x] Scope chains
- [x] User-defined function representation
- [x] `ActionDefineFunction` impl
- [x] `ActionCallFunction` impl
- [x] Implicit return through off-the-end execution
- [x] Argument locals
- [x] Immutable `this`
- [x] `arguments` object
- [x] Closures
- [x] `ActionWith` impl
- [ ] ~`ActionCall` impl (call a timeline frame as if it was a function)~
- [x] `ActionDelete` / `ActionDelete2` impl
- [x] `ActionEnumerate` impl
- [x] Current clip/timeline as local scope for timeline actions
- [x] Registers (global and local)
- [x] Register push to stack
- [x] `ActionStoreRegister` impl
- [x] `ActionGetMember` / `ActionSetMember` impl
- [x] `ActionDefineFunction2` impl