### PR TITLE
Remove rodio dependecy; support looping sounds

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1194,8 +1194,8 @@ impl<'gc> Avm1<'gc> {
         Ok(())
     }
 
-    fn action_stop_sounds(&mut self, _context: &mut ActionContext) -> Result<(), Error> {
-        log::error!("Unimplemented action: StopSounds");
+    fn action_stop_sounds(&mut self, context: &mut ActionContext) -> Result<(), Error> {
+        context.audio.stop_all_sounds();
         Ok(())
     }
 

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -34,6 +34,9 @@ pub trait AudioBackend {
         handle: &swf::SoundStreamHead,
     ) -> AudioStreamHandle;
 
+    /// Good ol' stopAllSounds() :-)
+    fn stop_all_sounds(&mut self);
+
     // TODO: Eventually remove this/move it to library.
     fn is_loading_complete(&self) -> bool {
         true
@@ -71,6 +74,8 @@ impl AudioBackend for NullAudioBackend {
     ) -> AudioStreamHandle {
         self.streams.insert(())
     }
+
+    fn stop_all_sounds(&mut self) {}
 }
 
 impl Default for NullAudioBackend {

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -60,6 +60,23 @@ pub fn stream_tag_reader(
     IterRead(iter)
 }
 
+/// Adds seeking ability to decoders where the underline stream is `std::io::Seek`.
+pub trait SeekableDecoder: Decoder {
+    /// Resets the decoder to the beginning of the stream.
+    fn reset(&mut self);
+
+    /// Seeks to a specific sample frame.
+    fn seek_to_sample_frame(&mut self, frame: u32) {
+        // The default implementation simply resets the stream and steps through
+        // until the desired position.
+        // This will be slow for long sounds on heavy decoders.
+        self.reset();
+        for _ in 0..frame {
+            self.next();
+        }
+    }
+}
+
 pub struct IterRead<I: Iterator<Item = u8>>(I);
 
 impl<I: Iterator<Item = u8>> std::io::Read for IterRead<I> {

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -1,10 +1,12 @@
 mod adpcm;
 mod mp3;
+mod pcm;
 
 pub use adpcm::AdpcmDecoder;
 pub use mp3::Mp3Decoder;
+pub use pcm::PcmDecoder;
 
-pub trait Decoder: Iterator<Item = i16> {
+pub trait Decoder: Iterator<Item = [i16; 2]> {
     fn num_channels(&self) -> u8;
     fn sample_rate(&self) -> u16;
 }

--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -139,19 +139,14 @@ impl<R: Read> AdpcmDecoder<R> {
 }
 
 impl<R: Read> Iterator for AdpcmDecoder<R> {
-    type Item = i16;
-    fn next(&mut self) -> Option<i16> {
-        if self.cur_channel >= if self.is_stereo { 2 } else { 1 } {
-            self.next_sample().ok()?;
-        }
-
-        let sample = if self.cur_channel == 0 {
-            self.left_sample
+    type Item = [i16; 2];
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_sample().ok()?;
+        if self.is_stereo {
+            Some([self.left_sample as i16, self.right_sample as i16])
         } else {
-            self.right_sample
-        };
-        self.cur_channel += 1;
-        Some(sample as i16)
+            Some([self.left_sample as i16, self.left_sample as i16])
+        }
     }
 }
 

--- a/core/src/backend/audio/decoders/pcm.rs
+++ b/core/src/backend/audio/decoders/pcm.rs
@@ -1,0 +1,72 @@
+use super::Decoder;
+use std::io::Read;
+
+/// Decoder for PCM audio data in a Flash file.
+/// Flash exports this when you use the "Raw" compression setting.
+/// 8-bit unsigned or 16-bit signed PCM.
+pub struct PcmDecoder<R: Read> {
+    inner: R,
+    sample_rate: u16,
+    is_stereo: bool,
+    is_16_bit: bool,
+}
+
+impl<R: Read> PcmDecoder<R> {
+    pub fn new(inner: R, is_stereo: bool, sample_rate: u16, is_16_bit: bool) -> Self {
+        PcmDecoder {
+            inner,
+            is_stereo,
+            sample_rate,
+            is_16_bit,
+        }
+    }
+}
+
+impl<R: Read> Iterator for PcmDecoder<R> {
+    type Item = [i16; 2];
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.is_stereo {
+            if self.is_16_bit {
+                let mut left = [0u8; 2];
+                let mut right = [0u8; 2];
+                self.inner.read_exact(&mut left).ok()?;
+                self.inner.read_exact(&mut right).ok()?;
+                let left = i16::from_le_bytes(left);
+                let right = i16::from_le_bytes(right);
+                Some([left, right])
+            } else {
+                let mut bytes = [0u8];
+                self.inner.read_exact(&mut bytes).ok()?;
+                let sample = (i16::from(bytes[0]) - 127) * 128;
+                Some([sample, sample])
+            }
+        } else if self.is_16_bit {
+            let mut bytes = [0u8; 2];
+            self.inner.read_exact(&mut bytes).ok()?;
+            let sample = i16::from_le_bytes(bytes);
+            Some([sample, sample])
+        } else {
+            let mut bytes = [0u8; 2];
+            self.inner.read_exact(&mut bytes).ok()?;
+            let left = (i16::from(bytes[0]) - 127) * 128;
+            let right = (i16::from(bytes[1]) - 127) * 128;
+            Some([left, right])
+        }
+    }
+}
+
+impl<R: std::io::Read> Decoder for PcmDecoder<R> {
+    #[inline]
+    fn num_channels(&self) -> u8 {
+        if self.is_stereo {
+            2
+        } else {
+            1
+        }
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u16 {
+        self.sample_rate
+    }
+}

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -1255,7 +1255,7 @@ impl<'gc, 'a> MovieClip<'gc> {
     ) -> DecodeResult {
         let start_sound = reader.read_start_sound_1()?;
         if let Some(handle) = context.library.get_sound(start_sound.id) {
-            context.audio.play_sound(handle);
+            context.audio.start_sound(handle, &start_sound.sound_info);
         }
         Ok(())
     }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+cpal = "0.10.0"
 ruffle_core = { path = "../core" }
 glium = "0.24"
 glutin = "0.20"
@@ -14,11 +15,8 @@ image = "0.21.1"
 jpeg-decoder = "0.1.16"
 log = "0.4"
 lyon = "0.13.3"
+sample = "0.10.0"
 structopt = "0.2.15"
 winit = "0.19.1"
 webbrowser = "0.5.2"
 url = "2.1.0"
-
-[dependencies.rodio]
-version = "0.8.1"
-features = ["mp3"]

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -1,10 +1,10 @@
 use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
 use generational_arena::Arena;
 use ruffle_core::backend::audio::decoders::{
-    stream_tag_reader, AdpcmDecoder, Decoder, Mp3Decoder, PcmDecoder,
+    stream_tag_reader, AdpcmDecoder, Decoder, Mp3Decoder, PcmDecoder, SeekableDecoder,
 };
 use ruffle_core::backend::audio::{swf, AudioBackend, AudioStreamHandle, SoundHandle};
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 use std::sync::{Arc, Mutex};
 
 #[allow(dead_code)]
@@ -126,29 +126,26 @@ impl CpalAudioBackend {
         })
     }
 
-    /// Creates a `sample::signal::Signal` that decodes and resamples the audio stream
-    /// to the output format.
-    fn make_signal_from_stream<'a, R: 'a + std::io::Read + Send>(
-        &self,
+    /// Instantiate a decoder for the compression that the sound data uses.
+    fn make_decoder<'a, R: 'a + Send + Read>(
         format: &swf::SoundFormat,
-        data_stream: R,
-    ) -> Box<dyn 'a + Send + sample::signal::Signal<Frame = [i16; 2]>> {
-        // Instantiate a decoder for the compression that the sound data uses.
+        data: R,
+    ) -> Box<dyn 'a + Send + Decoder> {
         use swf::AudioCompression;
-        let decoder: Box<dyn 'a + Send + Decoder> = match format.compression {
+        match format.compression {
             AudioCompression::Uncompressed => Box::new(PcmDecoder::new(
-                data_stream,
+                data,
                 format.is_stereo,
                 format.sample_rate,
                 format.is_16_bit,
             )),
-            AudioCompression::Adpcm => Box::new(
-                AdpcmDecoder::new(data_stream, format.is_stereo, format.sample_rate).unwrap(),
-            ),
+            AudioCompression::Adpcm => {
+                Box::new(AdpcmDecoder::new(data, format.is_stereo, format.sample_rate).unwrap())
+            }
             AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
                 if format.is_stereo { 2 } else { 1 },
                 format.sample_rate.into(),
-                data_stream,
+                data,
             )),
             _ => {
                 log::error!(
@@ -157,18 +154,91 @@ impl CpalAudioBackend {
                 );
                 unimplemented!()
             }
-        };
+        }
+    }
 
-        // Convert the `Decoder` to a `Signal`, and resample it the the output
-        // sample rate.
-        let mut signal = sample::signal::from_iter(decoder);
+    /// Instantiate a seeabkle decoder for the compression that the sound data uses.
+    fn make_seekable_decoder(
+        format: &swf::SoundFormat,
+        data: Cursor<VecAsRef>,
+    ) -> Box<dyn Send + SeekableDecoder> {
+        use swf::AudioCompression;
+        match format.compression {
+            AudioCompression::Uncompressed => Box::new(PcmDecoder::new(
+                data,
+                format.is_stereo,
+                format.sample_rate,
+                format.is_16_bit,
+            )),
+            AudioCompression::Adpcm => {
+                Box::new(AdpcmDecoder::new(data, format.is_stereo, format.sample_rate).unwrap())
+            }
+            AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
+                if format.is_stereo { 2 } else { 1 },
+                format.sample_rate.into(),
+                data,
+            )),
+            _ => {
+                log::error!(
+                    "start_stream: Unhandled audio compression {:?}",
+                    format.compression
+                );
+                unimplemented!()
+            }
+        }
+    }
+
+    /// Resamples a stream.
+    /// TODO: Allow interpolator to be user-configurable?
+    fn make_resampler<S: Send + sample::signal::Signal<Frame = [i16; 2]>>(
+        &self,
+        format: &swf::SoundFormat,
+        mut signal: S,
+    ) -> sample::interpolate::Converter<S, impl sample::interpolate::Interpolator<Frame = [i16; 2]>>
+    {
         let interpolator = sample::interpolate::Linear::from_source(&mut signal);
-        Box::new(sample::interpolate::Converter::from_hz_to_hz(
+        sample::interpolate::Converter::from_hz_to_hz(
             signal,
             interpolator,
             format.sample_rate.into(),
             self.output_format.sample_rate.0.into(),
-        ))
+        )
+    }
+
+    /// Creates a `sample::signal::Signal` that decodes and resamples the audio stream
+    /// to the output format.
+    fn make_signal_from_event_sound(
+        &self,
+        format: &swf::SoundFormat,
+        settings: &swf::SoundInfo,
+        data: Cursor<VecAsRef>,
+    ) -> Box<dyn Send + sample::signal::Signal<Frame = [i16; 2]>> {
+        // Instantiate a decoder for the compression that the sound data uses.
+        let decoder = Self::make_seekable_decoder(format, data);
+
+        // Wrap the decoder in the event sound signal (controls looping/envelope)
+        let signal = EventSoundSignal::new_with_settings(decoder, settings);
+        // Convert the `Decoder` to a `Signal`, and resample it the the output
+        // sample rate.
+        let signal = self.make_resampler(format, signal);
+        Box::new(signal)
+    }
+
+    /// Creates a `sample::signal::Signal` that decodes and resamples the audio stream
+    /// to the output format.
+    fn make_signal_from_stream<'a, R: 'a + std::io::Read + Send>(
+        &self,
+        format: &swf::SoundFormat,
+        data_stream: R,
+    ) -> Box<dyn 'a + Send + sample::signal::Signal<Frame = [i16; 2]>> {
+        // Instantiate a decoder for the compression that the sound data uses.
+        let decoder = Self::make_decoder(format, data_stream);
+
+        // Convert the `Decoder` to a `Signal`, and resample it the the output
+        // sample rate.
+        let signal = sample::signal::from_iter(decoder);
+        let signal = self.make_resampler(format, signal);
+        Box::new(signal)
     }
 
     /// Callback to the audio thread.
@@ -250,11 +320,21 @@ impl AudioBackend for CpalAudioBackend {
         })
     }
 
-    fn play_sound(&mut self, sound_handle: SoundHandle) {
+    fn start_sound(&mut self, sound_handle: SoundHandle, settings: &swf::SoundInfo) {
         let sound = &self.sounds[sound_handle];
-        let data = VecAsRef(Arc::clone(&sound.data));
+        let data = Cursor::new(VecAsRef(Arc::clone(&sound.data)));
         // Create a signal that decodes and resamples the sound.
-        let signal = self.make_signal_from_stream(&sound.format, Cursor::new(data));
+        let signal = if settings.in_sample.is_none()
+            && settings.out_sample.is_none()
+            && settings.num_loops <= 1
+            && settings.envelope.is_none()
+        {
+            // For simple event sounds, just use the same signal as streams.
+            self.make_signal_from_stream(&sound.format, data)
+        } else {
+            // For event sounds with envelopes/other properties, wrap it in `EventSoundSignal`.
+            self.make_signal_from_event_sound(&sound.format, settings, data)
+        };
 
         // Add sound instance to active list.
         let mut sound_instances = self.sound_instances.lock().unwrap();
@@ -269,14 +349,90 @@ impl AudioBackend for CpalAudioBackend {
     fn tick(&mut self) {}
 }
 
-// Unfortunately `Arc<Vec<u8>>` does not implement `AsRef<[u8]>`.
-// This causes problem when trying to use `Cursor<Vec<u8>>`.
-// Use a dummy wrapper struct to implement this trait.
+/// A dummy wrapper struct to implement `AsRef<[u8]>` for `Arc<Vec<u8>`.
+/// Not having this trait causes problems when trying to use `Cursor<Vec<u8>>`.
 struct VecAsRef(Arc<Vec<u8>>);
 
 impl AsRef<[u8]> for VecAsRef {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl Default for VecAsRef {
+    fn default() -> Self {
+        VecAsRef(Arc::new(vec![]))
+    }
+}
+
+/// A signal for event sound instances using sound settings (looping, start/end point, envelope).
+struct EventSoundSignal {
+    decoder: Box<dyn SeekableDecoder + Send>,
+    num_loops: u16,
+    start_sample_frame: u32,
+    end_sample_frame: Option<u32>,
+    cur_sample_frame: u32,
+    is_exhausted: bool,
+}
+
+impl EventSoundSignal {
+    fn new_with_settings(
+        decoder: Box<dyn SeekableDecoder + Send>,
+        settings: &swf::SoundInfo,
+    ) -> Self {
+        let sample_divisor = 44100 / u32::from(decoder.sample_rate());
+        let start_sample_frame = settings.in_sample.unwrap_or(0) / sample_divisor;
+        let mut signal = Self {
+            decoder,
+            num_loops: settings.num_loops,
+            start_sample_frame,
+            end_sample_frame: settings.out_sample.map(|n| n / sample_divisor),
+            cur_sample_frame: start_sample_frame,
+            is_exhausted: false,
+        };
+        signal.next_loop();
+        signal
+    }
+}
+
+impl EventSoundSignal {
+    /// Resets the decoder to the start point of the loop.
+    fn next_loop(&mut self) {
+        if self.num_loops > 0 {
+            self.num_loops -= 1;
+            self.decoder.seek_to_sample_frame(self.start_sample_frame);
+            self.cur_sample_frame = self.start_sample_frame;
+        } else {
+            self.is_exhausted = true;
+        }
+    }
+}
+
+impl sample::signal::Signal for EventSoundSignal {
+    type Frame = [i16; 2];
+
+    fn next(&mut self) -> Self::Frame {
+        // Loop the sound if necessary, and get the next frame.
+        if !self.is_exhausted {
+            if let Some(frame) = self.decoder.next() {
+                self.cur_sample_frame += 1;
+                if let Some(end) = self.end_sample_frame {
+                    if self.cur_sample_frame > end {
+                        self.next_loop();
+                    }
+                }
+                frame
+            } else {
+                self.next_loop();
+                self.next()
+            }
+        } else {
+            [0, 0]
+        }
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.is_exhausted
     }
 }

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -346,6 +346,11 @@ impl AudioBackend for CpalAudioBackend {
         });
     }
 
+    fn stop_all_sounds(&mut self) {
+        let mut sound_instances = self.sound_instances.lock().unwrap();
+        sound_instances.clear();
+    }
+
     fn tick(&mut self) {}
 }
 

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -1,41 +1,220 @@
+use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
 use generational_arena::Arena;
-use ruffle_core::backend::audio::decoders::{stream_tag_reader, AdpcmDecoder, Decoder, Mp3Decoder};
+use ruffle_core::backend::audio::decoders::{
+    stream_tag_reader, AdpcmDecoder, Decoder, Mp3Decoder, PcmDecoder,
+};
 use ruffle_core::backend::audio::{swf, AudioBackend, AudioStreamHandle, SoundHandle};
 use std::io::Cursor;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-pub struct RodioAudioBackend {
+#[allow(dead_code)]
+pub struct CpalAudioBackend {
+    device: cpal::Device,
+    output_format: cpal::Format,
+    audio_thread_handle: std::thread::JoinHandle<()>,
+
     sounds: Arena<Sound>,
-    active_sounds: Arena<rodio::Sink>,
-    streams: Arena<AudioStream>,
-    device: rodio::Device,
+    sound_instances: Arc<Mutex<Arena<SoundInstance>>>,
 }
 
-#[allow(dead_code)]
-struct AudioStream {
-    clip_id: swf::CharacterId,
-    info: swf::SoundStreamHead,
-    sink: rodio::Sink,
-}
+type Signal = Box<dyn Send + sample::signal::Signal<Frame = [i16; 2]>>;
 
-#[allow(dead_code)]
+/// Contains the data and metadata for a sound in an SWF file.
+/// A `Sound` is defined by the `DefineSound` SWF tags.
 struct Sound {
     format: swf::SoundFormat,
     data: Arc<Vec<u8>>,
 }
 
-impl RodioAudioBackend {
+/// An actively playing instance of a sound.
+/// This sound can be either an event sound (`StartSound`) or
+/// a stream sound (`SoundStreamBlock`).
+/// The audio thread will iterate through all `SoundInstance`s
+/// to fill the audio buffer.
+#[allow(dead_code)]
+struct SoundInstance {
+    /// The handle the sound definition inside `sounds`.
+    /// `None` if this is a stream sound.
+    handle: Option<SoundHandle>,
+
+    /// The audio stream. Call `next()` to yield sample frames.
+    signal: Signal,
+
+    /// The character ID of the movie clip that contains this stream.
+    /// `None` if this sound is an event sound (`StartSound`).
+    clip_id: Option<swf::CharacterId>,
+
+    /// Flag indicating whether this sound is still playing.
+    /// If this flag is false, the sound will be cleaned up during the
+    /// next loop of the sound thread.
+    active: bool,
+}
+
+impl CpalAudioBackend {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        // Create CPAL audio device.
+        let host = cpal::default_host();
+        let event_loop = host.event_loop();
+        let device = host
+            .default_output_device()
+            .ok_or("No audio devices available")?;
+
+        // Create audio stream for device.
+        let mut supported_formats = device
+            .supported_output_formats()
+            .map_err(|_| "No supported audio format")?;
+        let format = supported_formats
+            .next()
+            .ok_or("No supported audio formats")?
+            .with_max_sample_rate();
+        let stream_id = event_loop
+            .build_output_stream(&device, &format)
+            .map_err(|_| "Unable to create audio stream")?;
+
+        let output_format = format.clone();
+        // Start the stream.
+        event_loop
+            .play_stream(stream_id)
+            .map_err(|_| "Unable to start audio stream")?;
+
+        let sound_instances: Arc<Mutex<Arena<SoundInstance>>> = Arc::new(Mutex::new(Arena::new()));
+
+        // Start the audio thread.
+        let audio_thread_handle = {
+            let sound_instances = Arc::clone(&sound_instances);
+            std::thread::spawn(move || {
+                event_loop.run(move |stream_id, stream_result| {
+                    use cpal::{StreamData, UnknownTypeOutputBuffer};
+
+                    let stream_data = match stream_result {
+                        Ok(data) => data,
+                        Err(err) => {
+                            eprintln!("an error occurred on stream {:?}: {}", stream_id, err);
+                            return;
+                        }
+                    };
+
+                    let mut sound_instances = sound_instances.lock().unwrap();
+                    match stream_data {
+                        StreamData::Output {
+                            buffer: UnknownTypeOutputBuffer::U16(buffer),
+                        } => {
+                            Self::mix_audio(&mut sound_instances, &output_format, buffer);
+                        }
+                        StreamData::Output {
+                            buffer: UnknownTypeOutputBuffer::I16(buffer),
+                        } => {
+                            Self::mix_audio(&mut sound_instances, &output_format, buffer);
+                        }
+                        StreamData::Output {
+                            buffer: UnknownTypeOutputBuffer::F32(buffer),
+                        } => {
+                            Self::mix_audio(&mut sound_instances, &output_format, buffer);
+                        }
+                        _ => (),
+                    }
+                });
+            })
+        };
+
         Ok(Self {
+            device,
+            output_format: format,
+            audio_thread_handle,
             sounds: Arena::new(),
-            streams: Arena::new(),
-            active_sounds: Arena::new(),
-            device: rodio::default_output_device().ok_or("Unable to create output device")?,
+            sound_instances,
         })
+    }
+
+    /// Creates a `sample::signal::Signal` that decodes and resamples the audio stream
+    /// to the output format.
+    fn make_signal_from_stream<'a, R: 'a + std::io::Read + Send>(
+        &self,
+        format: &swf::SoundFormat,
+        data_stream: R,
+    ) -> Box<dyn 'a + Send + sample::signal::Signal<Frame = [i16; 2]>> {
+        // Instantiate a decoder for the compression that the sound data uses.
+        use swf::AudioCompression;
+        let decoder: Box<dyn 'a + Send + Decoder> = match format.compression {
+            AudioCompression::Uncompressed => Box::new(PcmDecoder::new(
+                data_stream,
+                format.is_stereo,
+                format.sample_rate,
+                format.is_16_bit,
+            )),
+            AudioCompression::Adpcm => Box::new(
+                AdpcmDecoder::new(data_stream, format.is_stereo, format.sample_rate).unwrap(),
+            ),
+            AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
+                if format.is_stereo { 2 } else { 1 },
+                format.sample_rate.into(),
+                data_stream,
+            )),
+            _ => {
+                log::error!(
+                    "start_stream: Unhandled audio compression {:?}",
+                    format.compression
+                );
+                unimplemented!()
+            }
+        };
+
+        // Convert the `Decoder` to a `Signal`, and resample it the the output
+        // sample rate.
+        let mut signal = sample::signal::from_iter(decoder);
+        let interpolator = sample::interpolate::Linear::from_source(&mut signal);
+        Box::new(sample::interpolate::Converter::from_hz_to_hz(
+            signal,
+            interpolator,
+            format.sample_rate.into(),
+            self.output_format.sample_rate.0.into(),
+        ))
+    }
+
+    /// Callback to the audio thread.
+    /// Refill the output buffer by stepping through all active sounds
+    /// and mixing in their output.
+    fn mix_audio<'a, T>(
+        sound_instances: &mut Arena<SoundInstance>,
+        output_format: &cpal::Format,
+        mut output_buffer: cpal::OutputBuffer<'a, T>,
+    ) where
+        T: 'a + cpal::Sample + Default + sample::Sample,
+        T::Signed: sample::conv::FromSample<i16>,
+    {
+        use sample::{
+            frame::{Frame, Stereo},
+            Sample,
+        };
+        use std::ops::DerefMut;
+
+        // For each sample, mix the samples from all active sound instances.
+        for buf_frame in output_buffer
+            .deref_mut()
+            .chunks_exact_mut(output_format.channels.into())
+        {
+            let mut output_frame = Stereo::<T::Signed>::equilibrium();
+            for (_, sound) in sound_instances.iter_mut() {
+                if sound.active && !sound.signal.is_exhausted() {
+                    let sound_frame = sound.signal.next();
+                    let sound_frame: Stereo<T::Signed> = sound_frame.map(Sample::to_sample);
+                    output_frame = output_frame.add_amp(sound_frame);
+                } else {
+                    sound.active = false;
+                }
+            }
+
+            for (buf_sample, output_sample) in buf_frame.iter_mut().zip(output_frame.iter()) {
+                *buf_sample = output_sample.to_sample();
+            }
+        }
+
+        // Remove all dead sounds.
+        sound_instances.retain(|_, sound| sound.active);
     }
 }
 
-impl AudioBackend for RodioAudioBackend {
+impl AudioBackend for CpalAudioBackend {
     fn register_sound(
         &mut self,
         swf_sound: &swf::Sound,
@@ -53,104 +232,51 @@ impl AudioBackend for RodioAudioBackend {
         clip_data: ruffle_core::tag_utils::SwfSlice,
         stream_info: &swf::SoundStreamHead,
     ) -> AudioStreamHandle {
-        let sink = rodio::Sink::new(&self.device);
-
         let format = &stream_info.stream_format;
-        let decoder = Mp3Decoder::new(
-            if format.is_stereo { 2 } else { 1 },
-            format.sample_rate.into(),
-            stream_tag_reader(clip_data),
-        );
 
-        let stream = AudioStream {
-            clip_id,
-            info: stream_info.clone(),
-            sink,
-        };
-        stream.sink.append(DecoderSource(Box::new(decoder)));
-        self.streams.insert(stream)
+        // The audio data for stream sounds is distributed among the frames of a
+        // movie clip. The stream tag reader will parse through the SWF and
+        // feed the decoder audio data on the fly.
+        let clip_stream_reader = stream_tag_reader(clip_data);
+        // Create a signal that decodes and resamples the stream.
+        let signal = self.make_signal_from_stream(format, clip_stream_reader);
+
+        let mut sound_instances = self.sound_instances.lock().unwrap();
+        sound_instances.insert(SoundInstance {
+            handle: None,
+            clip_id: Some(clip_id),
+            signal,
+            active: true,
+        })
     }
 
-    fn play_sound(&mut self, sound: SoundHandle) {
-        let sound = &self.sounds[sound];
-        use swf::AudioCompression;
+    fn play_sound(&mut self, sound_handle: SoundHandle) {
+        let sound = &self.sounds[sound_handle];
+        let data = VecAsRef(Arc::clone(&sound.data));
+        // Create a signal that decodes and resamples the sound.
+        let signal = self.make_signal_from_stream(&sound.format, Cursor::new(data));
 
-        match sound.format.compression {
-            AudioCompression::Uncompressed => {
-                let mut data = Vec::with_capacity(sound.data.len() / 2);
-                let mut i = 0;
-                while i < sound.data.len() {
-                    let val = i16::from(sound.data[i]) | (i16::from(sound.data[i + 1]) << 8);
-                    data.push(val);
-                    i += 2;
-                }
-                let buffer = rodio::buffer::SamplesBuffer::new(
-                    if sound.format.is_stereo { 2 } else { 1 },
-                    sound.format.sample_rate.into(),
-                    data,
-                );
-                let sink = rodio::Sink::new(&self.device);
-                sink.append(buffer);
-                self.active_sounds.insert(sink);
-            }
-            AudioCompression::Adpcm => {
-                let decoder = AdpcmDecoder::new(
-                    Cursor::new(sound.data.to_vec()),
-                    sound.format.is_stereo,
-                    sound.format.sample_rate,
-                )
-                .unwrap();
-                let sink = rodio::Sink::new(&self.device);
-                sink.append(DecoderSource(Box::new(decoder)));
-                self.active_sounds.insert(sink);
-            }
-            AudioCompression::Mp3 => {
-                let decoder = Mp3Decoder::new(
-                    if sound.format.is_stereo { 2 } else { 1 },
-                    sound.format.sample_rate.into(),
-                    Cursor::new(sound.data.to_vec()),
-                );
-                let sink = rodio::Sink::new(&self.device);
-                sink.append(DecoderSource(Box::new(decoder)));
-                self.active_sounds.insert(sink);
-            }
-            _ => unimplemented!(),
-        }
+        // Add sound instance to active list.
+        let mut sound_instances = self.sound_instances.lock().unwrap();
+        sound_instances.insert(SoundInstance {
+            handle: Some(sound_handle),
+            clip_id: None,
+            signal,
+            active: true,
+        });
     }
 
-    fn tick(&mut self) {
-        self.active_sounds.retain(|_, sink| !sink.empty());
-    }
+    fn tick(&mut self) {}
 }
 
-struct DecoderSource(Box<dyn Decoder + Send>);
+// Unfortunately `Arc<Vec<u8>>` does not implement `AsRef<[u8]>`.
+// This causes problem when trying to use `Cursor<Vec<u8>>`.
+// Use a dummy wrapper struct to implement this trait.
+struct VecAsRef(Arc<Vec<u8>>);
 
-impl Iterator for DecoderSource {
-    type Item = i16;
-
+impl AsRef<[u8]> for VecAsRef {
     #[inline]
-    fn next(&mut self) -> Option<i16> {
-        self.0.next()
-    }
-}
-impl rodio::Source for DecoderSource {
-    #[inline]
-    fn current_frame_len(&self) -> Option<usize> {
-        None
-    }
-
-    #[inline]
-    fn channels(&self) -> u16 {
-        self.0.num_channels().into()
-    }
-
-    #[inline]
-    fn sample_rate(&self) -> u32 {
-        self.0.sample_rate().into()
-    }
-
-    #[inline]
-    fn total_duration(&self) -> Option<std::time::Duration> {
-        None
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -43,7 +43,7 @@ fn run_player(input_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         .with_srgb(true)
         .with_stencil_buffer(8)
         .build_windowed(window_builder, &events_loop)?;
-    let audio = audio::RodioAudioBackend::new()?;
+    let audio = audio::CpalAudioBackend::new()?;
     let renderer = GliumRenderBackend::new(windowed_context)?;
     let navigator = navigator::ExternalNavigatorBackend::new(); //TODO: actually implement this backend type
     let display = renderer.display().clone();

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -74,7 +74,11 @@ impl WebAudioBackend {
         })
     }
 
-    fn play_sound_internal(&mut self, handle: SoundHandle) -> SoundHandle {
+    fn start_sound_internal(
+        &mut self,
+        handle: SoundHandle,
+        _settings: Option<&swf::SoundInfo>,
+    ) -> SoundHandle {
         let sound = self.sounds.get(handle).unwrap();
         match &sound.source {
             SoundSource::AudioBuffer(audio_buffer) => {
@@ -413,8 +417,8 @@ impl AudioBackend for WebAudioBackend {
         }
     }
 
-    fn play_sound(&mut self, sound: SoundHandle) {
-        self.play_sound_internal(sound);
+    fn start_sound(&mut self, sound: SoundHandle, sound_info: &swf::SoundInfo) {
+        self.start_sound_internal(sound, Some(sound_info));
     }
 
     fn start_stream(
@@ -424,7 +428,7 @@ impl AudioBackend for WebAudioBackend {
         _stream_info: &swf::SoundStreamHead,
     ) -> AudioStreamHandle {
         if let Some(&handle) = self.id_to_sound.get(&clip_id) {
-            self.play_sound_internal(handle)
+            self.start_sound_internal(handle, None)
         } else {
             log::error!("Missing stream for clip {}", clip_id);
             // TODO: Return dummy sound.

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -482,6 +482,19 @@ impl AudioBackend for WebAudioBackend {
         // Allow audio to start playing after a user gesture.
         let _ = self.context.resume();
     }
+
+    fn stop_all_sounds(&mut self) {
+        STREAMS.with(|streams| {
+            let mut streams = streams.borrow_mut();
+            for (_, stream) in streams.iter() {
+                if let AudioStream::AudioBuffer { node } = stream {
+                    let _ = node.stop();
+                }
+                // TODO: Have to handle Decoder nodes. (These may just go into a different backend.)
+            }
+            streams.clear();
+        })
+    }
 }
 
 // Janky resmapling code.


### PR DESCRIPTION
 * Remove the dependency on `rodio` on desktop; only use `cpal` and `sample` instead
 * Support looping and start/end points in event sounds
 * Support `StopSounds`/`stopAllSounds()` action