### PR TITLE
Implement "Event/Start/Stop" event sounds

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -37,6 +37,15 @@ pub trait AudioBackend {
     /// Good ol' stopAllSounds() :-)
     fn stop_all_sounds(&mut self);
 
+    /// Stops all active sound instances of a particular sound.
+    /// Used by SWF `StartSound` tag with `SoundEvent::Stop`.
+    fn stop_sounds_with_handle(&mut self, handle: SoundHandle);
+
+    /// Returns wheter a sound clip is playing.
+    /// Used by SWF `StartSouynd` tag with `SoundEvent:Start`,
+    /// which only plays a sound if that sound is not already playing.
+    fn is_sound_playing_with_handle(&mut self, handle: SoundHandle) -> bool;
+
     // TODO: Eventually remove this/move it to library.
     fn is_loading_complete(&self) -> bool {
         true
@@ -74,8 +83,11 @@ impl AudioBackend for NullAudioBackend {
     ) -> AudioStreamHandle {
         self.streams.insert(())
     }
-
     fn stop_all_sounds(&mut self) {}
+    fn stop_sounds_with_handle(&mut self, _handle: SoundHandle) {}
+    fn is_sound_playing_with_handle(&mut self, _handle: SoundHandle) -> bool {
+        false
+    }
 }
 
 impl Default for NullAudioBackend {

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -354,7 +354,7 @@ impl AudioBackend for CpalAudioBackend {
     fn stop_sounds_with_handle(&mut self, handle: SoundHandle) {
         let mut sound_instances = self.sound_instances.lock().unwrap();
         let handle = Some(handle);
-        sound_instances.retain(|_, instance| instance.handle == handle);
+        sound_instances.retain(|_, instance| instance.handle != handle);
     }
 
     fn is_sound_playing_with_handle(&mut self, handle: SoundHandle) -> bool {

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -351,6 +351,20 @@ impl AudioBackend for CpalAudioBackend {
         sound_instances.clear();
     }
 
+    fn stop_sounds_with_handle(&mut self, handle: SoundHandle) {
+        let mut sound_instances = self.sound_instances.lock().unwrap();
+        let handle = Some(handle);
+        sound_instances.retain(|_, instance| instance.handle == handle);
+    }
+
+    fn is_sound_playing_with_handle(&mut self, handle: SoundHandle) -> bool {
+        let sound_instances = self.sound_instances.lock().unwrap();
+        let handle = Some(handle);
+        sound_instances
+            .iter()
+            .any(|(_, instance)| instance.handle == handle && instance.active)
+    }
+
     fn tick(&mut self) {}
 }
 

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -512,7 +512,7 @@ impl AudioBackend for WebAudioBackend {
         SOUND_INSTANCES.with(|instances| {
             let mut instances = instances.borrow_mut();
             let handle = Some(handle);
-            instances.retain(|_, instance| instance.handle == handle);
+            instances.retain(|_, instance| instance.handle != handle);
         })
     }
 


### PR DESCRIPTION
Implements the "sync" setting on Flash event sounds:
 * Event always plays the sound (independent of the timeline)
 * Start plays the sound only if there is not already an instance of the sound playing
 * Stop will stop any active instances of a particular sound.