### PR TITLE
DefineText2 Support

### DIFF
--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -629,8 +629,8 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::DefineShape4 => self.define_shape(context, reader, 4),
             TagCode::DefineSound => self.define_sound(context, reader, tag_len),
             TagCode::DefineSprite => self.define_sprite(context, reader, tag_len, morph_shapes),
-            TagCode::DefineText => self.define_text(context, reader),
-            TagCode::DefineText2 => self.define_text2(context, reader),
+            TagCode::DefineText => self.define_text_1(context, reader),
+            TagCode::DefineText2 => self.define_text_2(context, reader),
             TagCode::FrameLabel => {
                 self.frame_label(context, reader, tag_len, cur_frame, &mut static_data)
             }
@@ -1051,12 +1051,12 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     #[inline]
-    fn define_text(
+    fn define_text_1(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
-        let text = reader.read_define_text()?;
+        let text = reader.read_define_text_1()?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library
@@ -1065,12 +1065,12 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     #[inline]
-    fn define_text2(
+    fn define_text_2(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
-        let text = reader.read_define_text2()?;
+        let text = reader.read_define_text_2()?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -630,6 +630,7 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::DefineSound => self.define_sound(context, reader, tag_len),
             TagCode::DefineSprite => self.define_sprite(context, reader, tag_len, morph_shapes),
             TagCode::DefineText => self.define_text(context, reader),
+            TagCode::DefineText2 => self.define_text2(context, reader),
             TagCode::FrameLabel => {
                 self.frame_label(context, reader, tag_len, cur_frame, &mut static_data)
             }
@@ -1056,6 +1057,20 @@ impl<'gc, 'a> MovieClip<'gc> {
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
         let text = reader.read_define_text()?;
+        let text_object = Text::from_swf_tag(context, &text);
+        context
+            .library
+            .register_character(text.id, Character::Text(Box::new(text_object)));
+        Ok(())
+    }
+
+    #[inline]
+    fn define_text2(
+        &mut self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        reader: &mut SwfStream<&'a [u8]>,
+    ) -> DecodeResult {
+        let text = reader.read_define_text2()?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -629,8 +629,8 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::DefineShape4 => self.define_shape(context, reader, 4),
             TagCode::DefineSound => self.define_sound(context, reader, tag_len),
             TagCode::DefineSprite => self.define_sprite(context, reader, tag_len, morph_shapes),
-            TagCode::DefineText => self.define_text_1(context, reader),
-            TagCode::DefineText2 => self.define_text_2(context, reader),
+            TagCode::DefineText => self.define_text(context, reader, 1),
+            TagCode::DefineText2 => self.define_text(context, reader, 2),
             TagCode::FrameLabel => {
                 self.frame_label(context, reader, tag_len, cur_frame, &mut static_data)
             }
@@ -1051,26 +1051,13 @@ impl<'gc, 'a> MovieClip<'gc> {
     }
 
     #[inline]
-    fn define_text_1(
+    fn define_text(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
+        version: u8,
     ) -> DecodeResult {
-        let text = reader.read_define_text_1()?;
-        let text_object = Text::from_swf_tag(context, &text);
-        context
-            .library
-            .register_character(text.id, Character::Text(Box::new(text_object)));
-        Ok(())
-    }
-
-    #[inline]
-    fn define_text_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        reader: &mut SwfStream<&'a [u8]>,
-    ) -> DecodeResult {
-        let text = reader.read_define_text_2()?;
+        let text = reader.read_define_text(version)?;
         let text_object = Text::from_swf_tag(context, &text);
         context
             .library

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -400,8 +400,12 @@ impl<R: Read> Reader<R> {
             Some(TagCode::DefineSound) => {
                 Tag::DefineSound(Box::new(tag_reader.read_define_sound()?))
             }
-            Some(TagCode::DefineText) => Tag::DefineText(Box::new(tag_reader.read_define_text()?)),
-            Some(TagCode::DefineText2) => Tag::DefineText(Box::new(tag_reader.read_define_text2()?)),
+            Some(TagCode::DefineText) => {
+                Tag::DefineText(Box::new(tag_reader.read_define_text_1()?))
+            }
+            Some(TagCode::DefineText2) => {
+                Tag::DefineText(Box::new(tag_reader.read_define_text_2()?))
+            }
             Some(TagCode::DefineVideoStream) => tag_reader.read_define_video_stream()?,
             Some(TagCode::EnableTelemetry) => {
                 tag_reader.read_u16()?; // Reserved
@@ -2428,7 +2432,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
-    pub fn read_define_text(&mut self) -> Result<Text> {
+    pub fn read_define_text_1(&mut self) -> Result<Text> {
         let id = self.read_character_id()?;
         let bounds = self.read_rectangle()?;
         let matrix = self.read_matrix()?;
@@ -2436,7 +2440,7 @@ impl<R: Read> Reader<R> {
         let num_advance_bits = self.read_u8()?;
 
         let mut records = vec![];
-        while let Some(record) = self.read_text_record(num_glyph_bits, num_advance_bits)? {
+        while let Some(record) = self.read_text_record_1(num_glyph_bits, num_advance_bits)? {
             records.push(record);
         }
 
@@ -2448,7 +2452,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
-    pub fn read_define_text2(&mut self) -> Result<Text> {
+    pub fn read_define_text_2(&mut self) -> Result<Text> {
         let id = self.read_character_id()?;
         let bounds = self.read_rectangle()?;
         let matrix = self.read_matrix()?;
@@ -2456,7 +2460,7 @@ impl<R: Read> Reader<R> {
         let num_advance_bits = self.read_u8()?;
 
         let mut records = vec![];
-        while let Some(record) = self.read_text_record2(num_glyph_bits, num_advance_bits)? {
+        while let Some(record) = self.read_text_record_2(num_glyph_bits, num_advance_bits)? {
             records.push(record);
         }
 
@@ -2468,7 +2472,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
-    fn read_text_record(
+    fn read_text_record_1(
         &mut self,
         num_glyph_bits: u8,
         num_advance_bits: u8,
@@ -2525,7 +2529,7 @@ impl<R: Read> Reader<R> {
         }))
     }
 
-    fn read_text_record2(
+    fn read_text_record_2(
         &mut self,
         num_glyph_bits: u8,
         num_advance_bits: u8,


### PR DESCRIPTION
From the spec:

> The DefineText2 tag is almost identical to the DefineText tag. The only difference is that Type 1 text records contained within a DefineText2 tag use an RGBA value (rather than an RGB value) to define TextColor.

[p171](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf)

So this is basically the same as the existing functions with that small change. I have also renamed the existing `DefineText` functions to have `_1` at the end to follow the convention used elsewhere. 

### Testing

Tested this with [DefineText2-MX.swf](https://github.com/ruffle-rs/ruffle/blob/master/swf/tests/swfs/DefineText2-MX.swf). Result before changes was a blank canvas and the following output:
```
[2019-10-04T21:13:41Z ERROR ruffle_core::library] Tried to instantiate non-registered character ID 2
[2019-10-04T21:13:41Z ERROR ruffle_core::movie_clip] Unable to instantiate display node id 2
[2019-10-04T21:13:41Z ERROR ruffle_core::library] Tried to instantiate non-registered character ID 3
[2019-10-04T21:13:41Z ERROR ruffle_core::movie_clip] Unable to instantiate display node id 3
[2019-10-04T21:13:41Z ERROR ruffle_core::library] Tried to instantiate non-registered character ID 4
[2019-10-04T21:13:41Z ERROR ruffle_core::movie_clip] Unable to instantiate display node id 4
[2019-10-04T21:13:41Z ERROR ruffle_core::library] Tried to instantiate non-registered character ID 5
[2019-10-04T21:13:41Z ERROR ruffle_core::movie_clip] Unable to instantiate display node id 5
```

Change results in no errors in output and the following canvas:
![image](https://user-images.githubusercontent.com/8310103/66240988-e1222c80-e6f5-11e9-9e6f-f6acdb585a70.png)
(May need to up contrast/look closely. Faint/transparent text near top right). This matches what is observed in flash player.