### PR TITLE
core: Render DefineFont3 at proper size (fixes #47)

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -4,6 +4,10 @@ type Error = Box<dyn std::error::Error>;
 
 pub struct Font {
     glyphs: Vec<ShapeHandle>,
+
+    /// The scaling applied to the font height to render at the proper size.
+    /// This depends on the DefineFont tag version.
+    scale: f32,
 }
 
 impl Font {
@@ -13,10 +17,21 @@ impl Font {
             let shape_handle = renderer.register_glyph_shape(glyph);
             glyphs.push(shape_handle);
         }
-        Ok(Font { glyphs })
+        Ok(Font {
+            glyphs,
+
+            /// DefineFont3 stores coordinates at 20x the scale of DefineFont1/2.
+            /// (SWF19 p.164)
+            scale: if tag.version >= 3 { 20480.0 } else { 1024.0 },
+        })
     }
 
     pub fn get_glyph(&self, i: usize) -> Option<ShapeHandle> {
         self.glyphs.get(i).cloned()
+    }
+
+    #[inline]
+    pub fn scale(&self) -> f32 {
+        self.scale
     }
 }

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -62,14 +62,14 @@ impl<'gc> DisplayObject<'gc> for Text<'gc> {
             color = block.color.as_ref().unwrap_or(&color).clone();
             font_id = block.font_id.unwrap_or(font_id);
             height = block.height.unwrap_or(height);
-            let scale = f32::from(height) / 1024.0;
-            transform.matrix.a = scale;
-            transform.matrix.d = scale;
-            transform.color_transform.r_mult = f32::from(color.r) / 255.0;
-            transform.color_transform.g_mult = f32::from(color.g) / 255.0;
-            transform.color_transform.b_mult = f32::from(color.b) / 255.0;
-            transform.color_transform.a_mult = f32::from(color.a) / 255.0;
             if let Some(font) = context.library.get_font(font_id) {
+                let scale = f32::from(height) / font.scale();
+                transform.matrix.a = scale;
+                transform.matrix.d = scale;
+                transform.color_transform.r_mult = f32::from(color.r) / 255.0;
+                transform.color_transform.g_mult = f32::from(color.g) / 255.0;
+                transform.color_transform.b_mult = f32::from(color.b) / 255.0;
+                transform.color_transform.a_mult = f32::from(color.a) / 255.0;
                 for c in &block.glyphs {
                     if let Some(glyph) = font.get_glyph(c.index as usize) {
                         context.transform_stack.push(&transform);


### PR DESCRIPTION
Per SWF19, shape coordinates in DefineFont3 are at 20x the size of
DefineFont1/2.