### PR TITLE
Added object property attributes

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ minimp3 = { version = "0.3.3", optional = true }
 puremp3 = { version = "0.1", optional = true }
 rand = "0.6.5"
 swf = { path = "../swf" }
+enumset = "0.4.2"
 
 [dependencies.jpeg-decoder]
 version = "0.1.16"

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -822,11 +822,8 @@ impl<'gc> Avm1<'gc> {
         let name = name_val.as_string()?;
         let object = self.pop()?.as_object()?;
 
-        //Fun fact: This isn't in the Adobe SWF19 spec, but this opcode returns
-        //a boolean based on if the delete actually deleted something.
-        let did_exist = Value::Bool(object.read().has_property(name));
-        object.write(context.gc_context).delete(name);
-        self.push(did_exist);
+        let success = object.write(context.gc_context).delete(name);
+        self.push(Value::Bool(success));
 
         Ok(())
     }

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -211,7 +211,7 @@ impl<'gc> Executable<'gc> {
                 arguments.force_set(
                     "length",
                     Value::Number(args.len() as f64),
-                    Attribute::DontDelete,
+                    Attribute::DontDelete | Attribute::DontEnum,
                 );
                 let argcell = GcCell::allocate(ac.gc_context, arguments);
                 let child_scope = GcCell::allocate(
@@ -258,7 +258,7 @@ impl<'gc> Executable<'gc> {
                     arguments.force_set(
                         "length",
                         Value::Number(args.len() as f64),
-                        Attribute::DontDelete,
+                        Attribute::DontDelete | Attribute::DontEnum,
                     );
                 }
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -1,7 +1,7 @@
 //! Code relating to executable functions + calling conventions.
 
 use crate::avm1::activation::Activation;
-use crate::avm1::object::Object;
+use crate::avm1::object::{Attribute, Object};
 use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
 use crate::avm1::{ActionContext, Avm1};
@@ -201,10 +201,18 @@ impl<'gc> Executable<'gc> {
                 let mut arguments = Object::object(ac.gc_context);
 
                 for i in 0..args.len() {
-                    arguments.force_set(&format!("{}", i), args.get(i).unwrap().clone());
+                    arguments.force_set(
+                        &format!("{}", i),
+                        args.get(i).unwrap().clone(),
+                        Attribute::DontDelete,
+                    );
                 }
 
-                arguments.force_set("length", Value::Number(args.len() as f64));
+                arguments.force_set(
+                    "length",
+                    Value::Number(args.len() as f64),
+                    Attribute::DontDelete,
+                );
                 let argcell = GcCell::allocate(ac.gc_context, arguments);
                 let child_scope = GcCell::allocate(
                     ac.gc_context,
@@ -240,10 +248,18 @@ impl<'gc> Executable<'gc> {
                 let mut arguments = Object::object(ac.gc_context);
                 if !af.suppress_arguments {
                     for i in 0..args.len() {
-                        arguments.force_set(&format!("{}", i), args.get(i).unwrap().clone())
+                        arguments.force_set(
+                            &format!("{}", i),
+                            args.get(i).unwrap().clone(),
+                            Attribute::DontDelete,
+                        )
                     }
 
-                    arguments.force_set("length", Value::Number(args.len() as f64));
+                    arguments.force_set(
+                        "length",
+                        Value::Number(args.len() as f64),
+                        Attribute::DontDelete,
+                    );
                 }
 
                 let argcell = GcCell::allocate(ac.gc_context, arguments);

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -1,7 +1,7 @@
 //! Code relating to executable functions + calling conventions.
 
 use crate::avm1::activation::Activation;
-use crate::avm1::object::{Attribute, Object};
+use crate::avm1::object::{Attribute::*, Object};
 use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
 use crate::avm1::{ActionContext, Avm1};
@@ -204,14 +204,14 @@ impl<'gc> Executable<'gc> {
                     arguments.force_set(
                         &format!("{}", i),
                         args.get(i).unwrap().clone(),
-                        Attribute::DontDelete,
+                        DontDelete,
                     );
                 }
 
                 arguments.force_set(
                     "length",
                     Value::Number(args.len() as f64),
-                    Attribute::DontDelete | Attribute::DontEnum,
+                    DontDelete | DontEnum,
                 );
                 let argcell = GcCell::allocate(ac.gc_context, arguments);
                 let child_scope = GcCell::allocate(
@@ -251,14 +251,14 @@ impl<'gc> Executable<'gc> {
                         arguments.force_set(
                             &format!("{}", i),
                             args.get(i).unwrap().clone(),
-                            Attribute::DontDelete,
+                            DontDelete,
                         )
                     }
 
                     arguments.force_set(
                         "length",
                         Value::Number(args.len() as f64),
-                        Attribute::DontDelete | Attribute::DontEnum,
+                        DontDelete | DontEnum,
                     );
                 }
 

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -28,7 +28,7 @@ pub fn getURL<'a, 'gc>(
             Some(Value::String(s)) if s == "POST" => Some(NavigationMethod::POST),
             _ => None,
         };
-        let vars_method = method.map(|m| (m, avm.locals_into_form_values()));
+        let vars_method = method.map(|m| (m, avm.locals_into_form_values(context)));
 
         context.navigator.navigate_to_url(url, window, vars_method);
     }

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -1,6 +1,7 @@
 use crate::avm1::fscommand;
 use crate::avm1::{ActionContext, Avm1, Object, Value};
 use crate::backend::navigator::NavigationMethod;
+use enumset::EnumSet;
 use gc_arena::{GcCell, MutationContext};
 use rand::Rng;
 
@@ -52,11 +53,19 @@ pub fn random<'gc>(
 pub fn create_globals<'gc>(gc_context: MutationContext<'gc, '_>) -> Object<'gc> {
     let mut globals = Object::object(gc_context);
 
-    globals.force_set("Math", Value::Object(math::create(gc_context)));
-    globals.force_set_function("getURL", getURL, gc_context);
-    globals.force_set_function("random", random, gc_context);
-    globals.force_set("NaN", Value::Number(std::f64::NAN));
-    globals.force_set("Infinity", Value::Number(std::f64::INFINITY));
+    globals.force_set(
+        "Math",
+        Value::Object(math::create(gc_context)),
+        EnumSet::empty(),
+    );
+    globals.force_set_function("getURL", getURL, gc_context, EnumSet::empty());
+    globals.force_set_function("random", random, gc_context, EnumSet::empty());
+    globals.force_set("NaN", Value::Number(std::f64::NAN), EnumSet::empty());
+    globals.force_set(
+        "Infinity",
+        Value::Number(std::f64::INFINITY),
+        EnumSet::empty(),
+    );
 
     globals
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,4 +1,4 @@
-use crate::avm1::object::Attribute;
+use crate::avm1::object::Attribute::*;
 use crate::avm1::{ActionContext, Avm1, Object, Value};
 use gc_arena::{GcCell, MutationContext};
 use rand::Rng;
@@ -17,7 +17,7 @@ macro_rules! wrap_std {
                     }
                 },
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+                DontDelete | ReadOnly | DontEnum,
             );
         )*
     }};
@@ -54,42 +54,42 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
     math.force_set(
         "E",
         Value::Number(std::f64::consts::E),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "LN10",
         Value::Number(std::f64::consts::LN_10),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "LN2",
         Value::Number(std::f64::consts::LN_2),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "LOG10E",
         Value::Number(std::f64::consts::LOG10_E),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "LOG2E",
         Value::Number(std::f64::consts::LOG2_E),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "PI",
         Value::Number(std::f64::consts::PI),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "SQRT1_2",
         Value::Number(std::f64::consts::FRAC_1_SQRT_2),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
     math.force_set(
         "SQRT2",
         Value::Number(std::f64::consts::SQRT_2),
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
 
     wrap_std!(math, gc_context,
@@ -107,17 +107,12 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
         "tan" => f64::tan
     );
 
-    math.force_set_function(
-        "atan2",
-        atan2,
-        gc_context,
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
-    );
+    math.force_set_function("atan2", atan2, gc_context, DontDelete | ReadOnly | DontEnum);
     math.force_set_function(
         "random",
         random,
         gc_context,
-        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+        DontDelete | ReadOnly | DontEnum,
     );
 
     GcCell::allocate(gc_context, math)

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -17,7 +17,7 @@ macro_rules! wrap_std {
                     }
                 },
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly,
+                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
             );
         )*
     }};
@@ -54,42 +54,42 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
     math.force_set(
         "E",
         Value::Number(std::f64::consts::E),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "LN10",
         Value::Number(std::f64::consts::LN_10),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "LN2",
         Value::Number(std::f64::consts::LN_2),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "LOG10E",
         Value::Number(std::f64::consts::LOG10_E),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "LOG2E",
         Value::Number(std::f64::consts::LOG2_E),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "PI",
         Value::Number(std::f64::consts::PI),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "SQRT1_2",
         Value::Number(std::f64::consts::FRAC_1_SQRT_2),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
     math.force_set(
         "SQRT2",
         Value::Number(std::f64::consts::SQRT_2),
-        Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
     );
 
     wrap_std!(math, gc_context,
@@ -107,8 +107,18 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
         "tan" => f64::tan
     );
 
-    math.force_set_function("atan2", atan2, gc_context, Attribute::DontDelete | Attribute::ReadOnly);
-    math.force_set_function("random", random, gc_context, Attribute::DontDelete | Attribute::ReadOnly);
+    math.force_set_function(
+        "atan2",
+        atan2,
+        gc_context,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+    );
+    math.force_set_function(
+        "random",
+        random,
+        gc_context,
+        Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+    );
 
     GcCell::allocate(gc_context, math)
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -17,7 +17,7 @@ macro_rules! wrap_std {
                     }
                 },
                 $gc_context,
-                Attribute::DontDelete,
+                Attribute::DontDelete | Attribute::ReadOnly,
             );
         )*
     }};
@@ -54,42 +54,42 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
     math.force_set(
         "E",
         Value::Number(std::f64::consts::E),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "LN10",
         Value::Number(std::f64::consts::LN_10),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "LN2",
         Value::Number(std::f64::consts::LN_2),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "LOG10E",
         Value::Number(std::f64::consts::LOG10_E),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "LOG2E",
         Value::Number(std::f64::consts::LOG2_E),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "PI",
         Value::Number(std::f64::consts::PI),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "SQRT1_2",
         Value::Number(std::f64::consts::FRAC_1_SQRT_2),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
     math.force_set(
         "SQRT2",
         Value::Number(std::f64::consts::SQRT_2),
-        Attribute::DontDelete,
+        Attribute::DontDelete | Attribute::ReadOnly,
     );
 
     wrap_std!(math, gc_context,
@@ -107,8 +107,8 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
         "tan" => f64::tan
     );
 
-    math.force_set_function("atan2", atan2, gc_context, Attribute::DontDelete);
-    math.force_set_function("random", random, gc_context, Attribute::DontDelete);
+    math.force_set_function("atan2", atan2, gc_context, Attribute::DontDelete | Attribute::ReadOnly);
+    math.force_set_function("random", random, gc_context, Attribute::DontDelete | Attribute::ReadOnly);
 
     GcCell::allocate(gc_context, math)
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,3 +1,4 @@
+use crate::avm1::object::Attribute;
 use crate::avm1::{ActionContext, Avm1, Object, Value};
 use gc_arena::{GcCell, MutationContext};
 use rand::Rng;
@@ -16,6 +17,7 @@ macro_rules! wrap_std {
                     }
                 },
                 $gc_context,
+                Attribute::DontDelete,
             );
         )*
     }};
@@ -49,14 +51,46 @@ pub fn random<'gc>(
 pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'gc>> {
     let mut math = Object::object(gc_context);
 
-    math.force_set("E", Value::Number(std::f64::consts::E));
-    math.force_set("LN10", Value::Number(std::f64::consts::LN_10));
-    math.force_set("LN2", Value::Number(std::f64::consts::LN_2));
-    math.force_set("LOG10E", Value::Number(std::f64::consts::LOG10_E));
-    math.force_set("LOG2E", Value::Number(std::f64::consts::LOG2_E));
-    math.force_set("PI", Value::Number(std::f64::consts::PI));
-    math.force_set("SQRT1_2", Value::Number(std::f64::consts::FRAC_1_SQRT_2));
-    math.force_set("SQRT2", Value::Number(std::f64::consts::SQRT_2));
+    math.force_set(
+        "E",
+        Value::Number(std::f64::consts::E),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "LN10",
+        Value::Number(std::f64::consts::LN_10),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "LN2",
+        Value::Number(std::f64::consts::LN_2),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "LOG10E",
+        Value::Number(std::f64::consts::LOG10_E),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "LOG2E",
+        Value::Number(std::f64::consts::LOG2_E),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "PI",
+        Value::Number(std::f64::consts::PI),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "SQRT1_2",
+        Value::Number(std::f64::consts::FRAC_1_SQRT_2),
+        Attribute::DontDelete,
+    );
+    math.force_set(
+        "SQRT2",
+        Value::Number(std::f64::consts::SQRT_2),
+        Attribute::DontDelete,
+    );
 
     wrap_std!(math, gc_context,
         "abs" => f64::abs,
@@ -73,8 +107,8 @@ pub fn create<'gc>(gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Object<'
         "tan" => f64::tan
     );
 
-    math.force_set_function("atan2", atan2, gc_context);
-    math.force_set_function("random", random, gc_context);
+    math.force_set_function("atan2", atan2, gc_context, Attribute::DontDelete);
+    math.force_set_function("random", random, gc_context, Attribute::DontDelete);
 
     GcCell::allocate(gc_context, math)
 }

--- a/core/src/avm1/movie_clip.rs
+++ b/core/src/avm1/movie_clip.rs
@@ -1,4 +1,4 @@
-use crate::avm1::object::Object;
+use crate::avm1::object::{Attribute, Object};
 use crate::avm1::Value;
 use crate::movie_clip::MovieClip;
 use gc_arena::MutationContext;
@@ -17,6 +17,7 @@ macro_rules! with_movie_clip {
                     Value::Undefined
                 },
                 $gc_context,
+                Attribute::DontDelete,
             );
         )*
     }};
@@ -36,6 +37,7 @@ macro_rules! with_movie_clip_mut {
                     Value::Undefined
                 },
                 $gc_context,
+                Attribute::DontDelete,
             );
         )*
     }};

--- a/core/src/avm1/movie_clip.rs
+++ b/core/src/avm1/movie_clip.rs
@@ -17,7 +17,7 @@ macro_rules! with_movie_clip {
                     Value::Undefined
                 },
                 $gc_context,
-                Attribute::DontDelete,
+                Attribute::DontDelete | Attribute::ReadOnly,
             );
         )*
     }};
@@ -37,7 +37,7 @@ macro_rules! with_movie_clip_mut {
                     Value::Undefined
                 },
                 $gc_context,
-                Attribute::DontDelete,
+                Attribute::DontDelete | Attribute::ReadOnly,
             );
         )*
     }};

--- a/core/src/avm1/movie_clip.rs
+++ b/core/src/avm1/movie_clip.rs
@@ -17,7 +17,7 @@ macro_rules! with_movie_clip {
                     Value::Undefined
                 },
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly,
+                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
             );
         )*
     }};
@@ -37,7 +37,7 @@ macro_rules! with_movie_clip_mut {
                     Value::Undefined
                 },
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly,
+                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
             );
         )*
     }};

--- a/core/src/avm1/movie_clip.rs
+++ b/core/src/avm1/movie_clip.rs
@@ -1,4 +1,4 @@
-use crate::avm1::object::{Attribute, Object};
+use crate::avm1::object::{Attribute::*, Object};
 use crate::avm1::Value;
 use crate::movie_clip::MovieClip;
 use gc_arena::MutationContext;
@@ -17,7 +17,7 @@ macro_rules! with_movie_clip {
                     Value::Undefined
                 },
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+                DontDelete | ReadOnly | DontEnum,
             );
         )*
     }};
@@ -37,7 +37,7 @@ macro_rules! with_movie_clip_mut {
                     Value::Undefined
                 },
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+                DontDelete | ReadOnly | DontEnum,
             );
         )*
     }};

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,3 +1,4 @@
+use self::Attribute::*;
 use crate::avm1::function::{Avm1Function, Avm1Function2, Executable, NativeFunction};
 use crate::avm1::scope::Scope;
 use crate::avm1::{ActionContext, Avm1, Value};
@@ -72,7 +73,7 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(Attribute::ReadOnly) {
+                if !attributes.contains(ReadOnly) {
                     replace::<Value<'gc>>(value, new_value);
                 }
             }
@@ -81,15 +82,15 @@ impl<'gc> Property<'gc> {
 
     pub fn can_delete(&self) -> bool {
         match self {
-            Property::Virtual { attributes, .. } => !attributes.contains(Attribute::DontDelete),
-            Property::Stored { attributes, .. } => !attributes.contains(Attribute::DontDelete),
+            Property::Virtual { attributes, .. } => !attributes.contains(DontDelete),
+            Property::Stored { attributes, .. } => !attributes.contains(DontDelete),
         }
     }
 
     pub fn is_enumerable(&self) -> bool {
         match self {
-            Property::Virtual { attributes, .. } => !attributes.contains(Attribute::DontEnum),
-            Property::Stored { attributes, .. } => !attributes.contains(Attribute::DontEnum),
+            Property::Virtual { attributes, .. } => !attributes.contains(DontEnum),
+            Property::Stored { attributes, .. } => !attributes.contains(DontEnum),
         }
     }
 }
@@ -166,7 +167,7 @@ impl<'gc> Object<'gc> {
             "toString",
             default_to_string,
             gc_context,
-            Attribute::DontDelete | Attribute::DontEnum,
+            DontDelete | DontEnum,
         );
 
         result
@@ -484,7 +485,7 @@ mod tests {
             object.write(context.gc_context).force_set(
                 "readonly",
                 Value::String("initial".to_string()),
-                Attribute::ReadOnly,
+                ReadOnly,
             );
 
             object.write(context.gc_context).set(
@@ -519,7 +520,7 @@ mod tests {
             object.write(context.gc_context).force_set(
                 "test",
                 Value::String("initial".to_string()),
-                Attribute::DontDelete,
+                DontDelete,
             );
 
             assert_eq!(object.write(context.gc_context).delete("test"), false);
@@ -592,7 +593,7 @@ mod tests {
                 "virtual_un",
                 getter,
                 None,
-                Attribute::DontDelete,
+                DontDelete,
             );
             object.write(context.gc_context).force_set(
                 "stored",
@@ -602,7 +603,7 @@ mod tests {
             object.write(context.gc_context).force_set(
                 "stored_un",
                 Value::String("Stored!".to_string()),
-                Attribute::DontDelete,
+                DontDelete,
             );
 
             assert_eq!(object.write(context.gc_context).delete("virtual"), true);
@@ -641,11 +642,9 @@ mod tests {
             object
                 .write(context.gc_context)
                 .force_set("stored", Value::Null, EnumSet::empty());
-            object.write(context.gc_context).force_set(
-                "stored_hidden",
-                Value::Null,
-                Attribute::DontEnum,
-            );
+            object
+                .write(context.gc_context)
+                .force_set("stored_hidden", Value::Null, DontEnum);
             object.write(context.gc_context).force_set_virtual(
                 "virtual",
                 getter,
@@ -656,7 +655,7 @@ mod tests {
                 "virtual_hidden",
                 getter,
                 None,
-                Attribute::DontEnum,
+                DontEnum,
             );
 
             let keys = object.read().get_keys();

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -210,6 +210,11 @@ impl<'gc> Scope<'gc> {
         self.values.read()
     }
 
+    /// Returns a gc cell of the current local scope object.
+    pub fn locals_cell(&self) -> GcCell<'gc, Object<'gc>> {
+        self.values.to_owned()
+    }
+
     /// Returns a reference to the current local scope object for mutation.
     pub fn locals_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<Object<'gc>> {
         self.values.write(mc)

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -1,6 +1,7 @@
 //! Represents AVM1 scope chain resolution.
 
 use crate::avm1::{ActionContext, Avm1, Object, Value};
+use enumset::EnumSet;
 use gc_arena::{GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
 
@@ -283,11 +284,11 @@ impl<'gc> Scope<'gc> {
     /// chain. As a result, this function always force sets a property on the
     /// local object and does not traverse the scope chain.
     pub fn define(&self, name: &str, value: Value<'gc>, mc: MutationContext<'gc, '_>) {
-        self.locals_mut(mc).force_set(name, value);
+        self.locals_mut(mc).force_set(name, value, EnumSet::empty());
     }
 
     /// Delete a value from scope
-    pub fn delete(&self, name: &str, mc: MutationContext<'gc, '_>) {
+    pub fn delete(&self, name: &str, mc: MutationContext<'gc, '_>) -> bool {
         if self.locals().has_property(name) {
             return self.locals_mut(mc).delete(name);
         }
@@ -295,5 +296,7 @@ impl<'gc> Scope<'gc> {
         if let Some(scope) = self.parent() {
             return scope.delete(name, mc);
         }
+
+        false
     }
 }


### PR DESCRIPTION
This adds a dependency on enumset, as I think it's so much more ergonomic than `true, false, false` everywhere.

The three property attributes `DontEnum`, `ReadOnly` and `DontDelete` are implemented and correctly set (as far as I can tell) for all places that set properties right now. It includes tests to ensure they're behaving correctly, too.

A side effect of this is that I also made virtual properties enumerable, they weren't previously.