### PR TITLE
Improve error handling in SWF parsing

### DIFF
--- a/swf/src/avm1.rs
+++ b/swf/src/avm1.rs
@@ -1,4 +1,4 @@
-mod opcode;
+pub(crate) mod opcode;
 pub mod read;
 pub mod types;
 pub mod write;

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -404,6 +404,19 @@ pub mod tests {
         }
     }
 
+    /// Ensure that we return an error on invalid data.
+    #[test]
+    fn read_parse_error() {
+        let action_bytes = [0xff, 0xff, 0xff, 0x00, 0x00];
+        let mut reader = Reader::new(&action_bytes[..], 5);
+        match reader.read_action() {
+            Err(crate::error::Error::Avm1ParseError { .. }) => (),
+            result => {
+                panic!("Expected Avm1ParseError, got {:?}", result);
+            }
+        }
+    }
+
     #[test]
     fn read_define_function() {
         // Ensure we read a function properly along with the function data.

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -1,6 +1,7 @@
 use crate::avm2::types::*;
+use crate::error::{Error, Result};
 use crate::read::SwfRead;
-use std::io::{Error, ErrorKind, Read, Result};
+use std::io::Read;
 
 pub struct Reader<R: Read> {
     inner: R,
@@ -138,7 +139,7 @@ impl<R: Read> Reader<R> {
             0x18 => Namespace::Protected(name),
             0x19 => Namespace::Explicit(name),
             0x1a => Namespace::StaticProtected(name),
-            _ => return Err(Error::new(ErrorKind::InvalidData, "Invalid namespace kind")),
+            _ => return Err(Error::invalid_data("Invalid namespace kind")),
         })
     }
 
@@ -184,7 +185,7 @@ impl<R: Read> Reader<R> {
             0x1c => Multiname::MultinameLA {
                 namespace_set: self.read_index()?,
             },
-            _ => return Err(Error::new(ErrorKind::InvalidData, "Invalid multiname kind")),
+            _ => return Err(Error::invalid_data("Invalid multiname kind")),
         })
     }
 
@@ -314,7 +315,7 @@ impl<R: Read> Reader<R> {
             0x18 => DefaultValue::Protected(Index::new(index)),
             0x19 => DefaultValue::Explicit(Index::new(index)),
             0x1a => DefaultValue::StaticProtected(Index::new(index)),
-            _ => return Err(Error::new(ErrorKind::InvalidData, "Invalid default value")),
+            _ => return Err(Error::invalid_data("Invalid default value")),
         })
     }
 
@@ -339,7 +340,7 @@ impl<R: Read> Reader<R> {
                 0x18 => DefaultValue::Protected(Index::new(index)),
                 0x19 => DefaultValue::Explicit(Index::new(index)),
                 0x1a => DefaultValue::StaticProtected(Index::new(index)),
-                _ => return Err(Error::new(ErrorKind::InvalidData, "Invalid default value")),
+                _ => return Err(Error::invalid_data("Invalid default value")),
             }))
         }
     }
@@ -455,7 +456,7 @@ impl<R: Read> Reader<R> {
                 type_name: self.read_index()?,
                 value: self.read_optional_value()?,
             },
-            _ => return Err(Error::new(ErrorKind::InvalidData, "Invalid trait kind")),
+            _ => return Err(Error::invalid_data("Invalid trait kind")),
         };
 
         let mut metadata = vec![];
@@ -522,7 +523,7 @@ impl<R: Read> Reader<R> {
 
         let opcode = match OpCode::from_u8(self.read_u8()?) {
             Some(o) => o,
-            None => return Err(Error::new(ErrorKind::InvalidData, "Invalid opcode")),
+            None => return Err(Error::invalid_data("Invalid opcode")),
         };
 
         let op = match opcode {

--- a/swf/src/error.rs
+++ b/swf/src/error.rs
@@ -1,0 +1,129 @@
+use std::{borrow, error, fmt, io};
+
+/// A `Result` from reading SWF data.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    /// An error occurred while parsing an AVM1 action.
+    /// This can contain sub-errors with further information (`Error::source`)
+    Avm1ParseError {
+        opcode: u8,
+        source: Option<Box<dyn error::Error + 'static>>,
+    },
+
+    /// Invalid or unknown data was encountered.
+    InvalidData(borrow::Cow<'static, str>),
+
+    /// An error occurred while parsing an SWF tag.
+    /// This can contain sub-errors with further information (`Error::source`)
+    SwfParseError {
+        tag_code: u16,
+        source: Option<Box<dyn error::Error + 'static>>,
+    },
+    /// An IO error occurred (probably unexpected EOF).
+    IoError(io::Error),
+    /// This SWF requires unsupported features.
+    Unsupported(borrow::Cow<'static, str>),
+}
+
+impl Error {
+    /// Helper method to create `Error::Avm1ParseError`.
+    #[inline]
+    pub fn avm1_parse_error(opcode: u8) -> Self {
+        Error::Avm1ParseError {
+            opcode,
+            source: None,
+        }
+    }
+    /// Helper method to create `Error::Avm1ParseError`.
+    #[inline]
+    pub fn avm1_parse_error_with_source(opcode: u8, source: impl error::Error + 'static) -> Self {
+        Error::Avm1ParseError {
+            opcode,
+            source: Some(Box::new(source)),
+        }
+    }
+    /// Helper method to create `Error::InvalidData`.
+    #[inline]
+    pub fn invalid_data(message: impl Into<borrow::Cow<'static, str>>) -> Self {
+        Error::InvalidData(message.into())
+    }
+    /// Helper method to create `Error::SwfParseError`.
+    #[inline]
+    pub fn swf_parse_error(tag_code: u16) -> Self {
+        Error::SwfParseError {
+            tag_code,
+            source: None,
+        }
+    }
+    /// Helper method to create `Error::SwfParseError`.
+    #[inline]
+    pub fn swf_parse_error_with_source(tag_code: u16, source: impl error::Error + 'static) -> Self {
+        Error::SwfParseError {
+            tag_code,
+            source: Some(Box::new(source)),
+        }
+    }
+    /// Helper method to create `Error::Unsupported`.
+    #[inline]
+    pub fn unsupported(message: impl Into<borrow::Cow<'static, str>>) -> Self {
+        Error::Unsupported(message.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use crate::num_traits::FromPrimitive;
+        match self {
+            Error::Avm1ParseError { opcode, source } => {
+                let op = crate::avm1::opcode::OpCode::from_u8(*opcode);
+                "Error parsing AVM1 action ".fmt(f)?;
+                if let Some(op) = op {
+                    write!(f, "{:?}", op)?;
+                } else {
+                    write!(f, "Unknown({})", opcode)?;
+                };
+                if let Some(source) = source {
+                    write!(f, ": {}", source)?;
+                }
+                Ok(())
+            }
+            Error::SwfParseError { tag_code, source } => {
+                let tag = crate::tag_code::TagCode::from_u16(*tag_code);
+                "Error parsing SWF tag ".fmt(f)?;
+                if let Some(tag) = tag {
+                    write!(f, "{:?}", tag)?;
+                } else {
+                    write!(f, "Unknown({})", tag_code)?;
+                };
+                if let Some(source) = source {
+                    write!(f, ": {}", source)?;
+                }
+                Ok(())
+            }
+            Error::IoError(e) => e.fmt(f),
+            Error::InvalidData(message) => write!(f, "Invalid data: {}", message),
+            Error::Unsupported(message) => write!(f, "Unsupported data: {}", message),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use std::ops::Deref;
+        match self {
+            Error::Avm1ParseError { source, .. } => source.as_ref().map(|s| s.deref()),
+            Error::IoError(e) => e.source(),
+            Error::InvalidData(_) => None,
+            Error::SwfParseError { source, .. } => source.as_ref().map(|s| s.deref()),
+            Error::Unsupported(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Error {
+        Error::IoError(error)
+    }
+}

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -20,6 +20,7 @@ extern crate xz2;
 
 pub mod avm1;
 pub mod avm2;
+pub mod error;
 pub mod read;
 mod tag_code;
 mod types;

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -3136,4 +3136,17 @@ pub mod tests {
             assert_eq!(reader.read_tag_list().unwrap(), [Tag::ShowFrame]);
         }
     }
+
+    /// Ensure that we return an error on invalid data.
+    #[test]
+    fn read_invalid_tag() {
+        let tag_bytes = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+        let mut reader = Reader::new(&tag_bytes[..], 5);
+        match reader.read_tag() {
+            Err(crate::error::Error::SwfParseError { .. }) => (),
+            result => {
+                panic!("Expected SwfParseError, got {:?}", result);
+            }
+        }
+    }
 }


### PR DESCRIPTION
 * Custom swf::error::Error type added to handle various errors
   in SWF parsing.
 * Invalid parsing of tags/AVM1 ops results in a Error::ParseError
   that can include info about the underlying failure.
 * Implement Display for these errors. Output descriptive
   names for the tag/opcode when it fails to parse.
 * Handle out of bounds reads in avm1::Reader::read_slice.
   Previously this would panic, now it returns an io::Error.

Closes #85.