### PR TITLE
swf: Try to recover from incorrect zlib streams

### DIFF
--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = "1.0"
 num-derive = "0.2"
 num-traits = "0.2"
 libflate = {version = "0.1", optional = true}
+log = "0.4"
 flate2 = {version = "1.0", optional = true}
 xz2 = {version = "0.1.5", optional = true}
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -13,6 +13,14 @@ pub struct Swf {
     pub tags: Vec<Tag>,
 }
 
+/// Returned by `read::read_swf_header`. Includes the decompress
+/// stream as well as the uncompressed data length.
+pub struct SwfStream<'a> {
+    pub header: Header,
+    pub uncompressed_length: usize,
+    pub reader: crate::read::Reader<Box<dyn std::io::Read + 'a>>,
+}
+
 /// The header of an SWF file.
 ///
 /// Notably contains the compression format used by the rest of the SWF data.


### PR DESCRIPTION
Some SWFs are compressed incorrectly, often with incorrect
compressed/uncompressed lengths, causing the zlib decoders
to vomit if you try to decompress them fully. However, often times
the data still decompresses all the way to the End tag, and we
still want to try to play it even if it's corrupt.
Now these errors only omit a warning, and we'll continue to run
the SWF.

Addresses #86.