### PR TITLE
core: Add Bitmap display object

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -11,18 +11,19 @@ pub trait RenderBackend {
         id: swf::CharacterId,
         data: &[u8],
         jpeg_tables: &[u8],
-    ) -> BitmapHandle;
-    fn register_bitmap_jpeg_2(&mut self, id: swf::CharacterId, data: &[u8]) -> BitmapHandle;
+    ) -> BitmapInfo;
+    fn register_bitmap_jpeg_2(&mut self, id: swf::CharacterId, data: &[u8]) -> BitmapInfo;
     fn register_bitmap_jpeg_3(
         &mut self,
         id: swf::CharacterId,
         jpeg_data: &[u8],
         alpha_data: &[u8],
-    ) -> BitmapHandle;
-    fn register_bitmap_png(&mut self, swf_tag: &swf::DefineBitsLossless) -> BitmapHandle;
+    ) -> BitmapInfo;
+    fn register_bitmap_png(&mut self, swf_tag: &swf::DefineBitsLossless) -> BitmapInfo;
 
     fn begin_frame(&mut self);
     fn clear(&mut self, color: Color);
+    fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform);
     fn render_shape(&mut self, shape: ShapeHandle, transform: &Transform);
     fn end_frame(&mut self);
     fn draw_pause_overlay(&mut self);
@@ -37,6 +38,14 @@ pub struct ShapeHandle(pub usize);
 
 #[derive(Copy, Clone, Debug)]
 pub struct BitmapHandle(pub usize);
+
+/// Info returned by the `register_bitmap` methods.
+#[derive(Copy, Clone, Debug)]
+pub struct BitmapInfo {
+    pub handle: BitmapHandle,
+    pub width: u16,
+    pub height: u16,
+}
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Letterbox {
@@ -60,26 +69,43 @@ impl RenderBackend for NullRenderer {
         _id: swf::CharacterId,
         _data: &[u8],
         _jpeg_tables: &[u8],
-    ) -> BitmapHandle {
-        BitmapHandle(0)
+    ) -> BitmapInfo {
+        BitmapInfo {
+            handle: BitmapHandle(0),
+            width: 0,
+            height: 0,
+        }
     }
-    fn register_bitmap_jpeg_2(&mut self, _id: swf::CharacterId, _data: &[u8]) -> BitmapHandle {
-        BitmapHandle(0)
+    fn register_bitmap_jpeg_2(&mut self, _id: swf::CharacterId, _data: &[u8]) -> BitmapInfo {
+        BitmapInfo {
+            handle: BitmapHandle(0),
+            width: 0,
+            height: 0,
+        }
     }
     fn register_bitmap_jpeg_3(
         &mut self,
         _id: swf::CharacterId,
         _data: &[u8],
         _alpha_data: &[u8],
-    ) -> BitmapHandle {
-        BitmapHandle(0)
+    ) -> BitmapInfo {
+        BitmapInfo {
+            handle: BitmapHandle(0),
+            width: 0,
+            height: 0,
+        }
     }
-    fn register_bitmap_png(&mut self, _swf_tag: &swf::DefineBitsLossless) -> BitmapHandle {
-        BitmapHandle(0)
+    fn register_bitmap_png(&mut self, _swf_tag: &swf::DefineBitsLossless) -> BitmapInfo {
+        BitmapInfo {
+            handle: BitmapHandle(0),
+            width: 0,
+            height: 0,
+        }
     }
     fn begin_frame(&mut self) {}
     fn end_frame(&mut self) {}
     fn clear(&mut self, _color: Color) {}
+    fn render_bitmap(&mut self, _bitmap: BitmapHandle, _transform: &Transform) {}
     fn render_shape(&mut self, _shape: ShapeHandle, _transform: &Transform) {}
     fn draw_pause_overlay(&mut self) {}
     fn draw_letterbox(&mut self, _letterbox: Letterbox) {}

--- a/core/src/bitmap.rs
+++ b/core/src/bitmap.rs
@@ -1,0 +1,128 @@
+//! Bitmap display object
+
+use crate::backend::render::BitmapHandle;
+use crate::display_object::{DisplayObject, DisplayObjectBase};
+use crate::player::{RenderContext, UpdateContext};
+use crate::prelude::*;
+use gc_arena::Gc;
+
+/// A Bitmap display object is a raw bitamp on the stage.
+/// This can only be instanitated on the display list in SWFv9 AVM2 files.
+/// In AVM1, this is only a library symbol that is referenced by `Graphic`.
+/// Normally bitmaps are drawn in Flash as part of a Shape tag (`Graphic`),
+/// but starting in AVM2, a raw `Bitmap` display object can be crated
+/// with the `PlaceObject3` tag.
+/// It can also be crated in ActionScript using the `Bitmap` class.
+#[derive(Clone, Debug)]
+pub struct Bitmap<'gc> {
+    base: DisplayObjectBase<'gc>,
+    static_data: Gc<'gc, BitmapStatic>,
+}
+
+impl<'gc> Bitmap<'gc> {
+    pub fn new(
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        id: CharacterId,
+        bitmap_handle: BitmapHandle,
+        width: u16,
+        height: u16,
+    ) -> Self {
+        Self {
+            base: Default::default(),
+            static_data: Gc::allocate(
+                context.gc_context,
+                BitmapStatic {
+                    id,
+                    bitmap_handle,
+                    width,
+                    height,
+                },
+            ),
+        }
+    }
+
+    pub fn bitmap_handle(&self) -> BitmapHandle {
+        self.static_data.bitmap_handle
+    }
+
+    pub fn width(&self) -> u16 {
+        self.static_data.width
+    }
+
+    pub fn height(&self) -> u16 {
+        self.static_data.height
+    }
+}
+
+impl<'gc> DisplayObject<'gc> for Bitmap<'gc> {
+    impl_display_object!(base);
+
+    fn id(&self) -> CharacterId {
+        self.static_data.id
+    }
+
+    fn local_bounds(&self) -> BoundingBox {
+        BoundingBox {
+            x_min: Twips::new(0),
+            y_min: Twips::new(0),
+            x_max: Twips::new(self.width()),
+            y_max: Twips::new(self.height()),
+            valid: true,
+        }
+    }
+
+    fn world_bounds(&self) -> BoundingBox {
+        // TODO: Use dirty flags and cache this.
+        let mut bounds = self.local_bounds().transform(self.matrix());
+        let mut node = self.parent();
+        while let Some(display_object) = node {
+            let display_object = display_object.read();
+            bounds = bounds.transform(display_object.matrix());
+            node = display_object.parent();
+        }
+        bounds
+    }
+
+    fn run_frame(&mut self, _context: &mut UpdateContext) {
+        // Noop
+    }
+
+    fn render(&self, context: &mut RenderContext) {
+        if !self.world_bounds().intersects(&context.view_bounds) {
+            // Off-screen; culled
+            return;
+        }
+
+        context.transform_stack.push(self.transform());
+
+        context.renderer.render_bitmap(
+            self.static_data.bitmap_handle,
+            context.transform_stack.transform(),
+        );
+
+        context.transform_stack.pop();
+    }
+}
+
+unsafe impl<'gc> gc_arena::Collect for Bitmap<'gc> {
+    fn trace(&self, cc: gc_arena::CollectionContext) {
+        self.base.trace(cc);
+        self.static_data.trace(cc);
+    }
+}
+
+/// Static data shared between all instances of a bitmap.
+#[derive(Clone)]
+struct BitmapStatic {
+    id: CharacterId,
+    bitmap_handle: BitmapHandle,
+    width: u16,
+    height: u16,
+}
+
+unsafe impl<'gc> gc_arena::Collect for BitmapStatic {
+    #[inline]
+    fn needs_trace() -> bool {
+        true
+    }
+}

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -2,7 +2,7 @@ pub enum Character<'gc> {
     EditText(Box<crate::edit_text::EditText<'gc>>),
     Graphic(Box<crate::graphic::Graphic<'gc>>),
     MovieClip(Box<crate::movie_clip::MovieClip<'gc>>),
-    Bitmap(crate::backend::render::BitmapHandle),
+    Bitmap(Box<crate::bitmap::Bitmap<'gc>>),
     Button(Box<crate::button::Button<'gc>>),
     Font(Box<crate::font::Font>),
     MorphShape(Box<crate::morph_shape::MorphShape<'gc>>),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,7 @@
 mod display_object;
 
 mod avm1;
+mod bitmap;
 mod bounding_box;
 mod button;
 mod character;

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -49,6 +49,7 @@ impl<'gc> Library<'gc> {
         gc_context: MutationContext<'gc, '_>,
     ) -> Result<DisplayNode<'gc>, Box<dyn std::error::Error>> {
         let obj: Box<dyn DisplayObject<'gc>> = match self.characters.get(&id) {
+            Some(Character::Bitmap(bitmap)) => bitmap.clone(),
             Some(Character::EditText(edit_text)) => edit_text.clone(),
             Some(Character::Graphic(graphic)) => graphic.clone(),
             Some(Character::MorphShape(morph_shape)) => morph_shape.clone(),

--- a/core/src/movie_clip.rs
+++ b/core/src/movie_clip.rs
@@ -679,10 +679,17 @@ impl<'gc, 'a> MovieClip<'gc> {
         version: u8,
     ) -> DecodeResult {
         let define_bits_lossless = reader.read_define_bits_lossless(version)?;
-        let handle = context.renderer.register_bitmap_png(&define_bits_lossless);
+        let bitmap_info = context.renderer.register_bitmap_png(&define_bits_lossless);
+        let bitmap = crate::bitmap::Bitmap::new(
+            context,
+            define_bits_lossless.id,
+            bitmap_info.handle,
+            bitmap_info.width,
+            bitmap_info.height,
+        );
         context
             .library
-            .register_character(define_bits_lossless.id, Character::Bitmap(handle));
+            .register_character(define_bits_lossless.id, Character::Bitmap(Box::new(bitmap)));
         Ok(())
     }
 
@@ -815,14 +822,21 @@ impl<'gc, 'a> MovieClip<'gc> {
             .get_mut()
             .take(data_len as u64)
             .read_to_end(&mut jpeg_data)?;
-        let handle = context.renderer.register_bitmap_jpeg(
+        let bitmap_info = context.renderer.register_bitmap_jpeg(
             id,
             &jpeg_data,
             context.library.jpeg_tables().unwrap(),
         );
+        let bitmap = crate::bitmap::Bitmap::new(
+            context,
+            id,
+            bitmap_info.handle,
+            bitmap_info.width,
+            bitmap_info.height,
+        );
         context
             .library
-            .register_character(id, Character::Bitmap(handle));
+            .register_character(id, Character::Bitmap(Box::new(bitmap)));
         Ok(())
     }
 
@@ -841,10 +855,17 @@ impl<'gc, 'a> MovieClip<'gc> {
             .get_mut()
             .take(data_len as u64)
             .read_to_end(&mut jpeg_data)?;
-        let handle = context.renderer.register_bitmap_jpeg_2(id, &jpeg_data);
+        let bitmap_info = context.renderer.register_bitmap_jpeg_2(id, &jpeg_data);
+        let bitmap = crate::bitmap::Bitmap::new(
+            context,
+            id,
+            bitmap_info.handle,
+            bitmap_info.width,
+            bitmap_info.height,
+        );
         context
             .library
-            .register_character(id, Character::Bitmap(handle));
+            .register_character(id, Character::Bitmap(Box::new(bitmap)));
         Ok(())
     }
 
@@ -869,12 +890,19 @@ impl<'gc, 'a> MovieClip<'gc> {
             .get_mut()
             .take(alpha_len as u64)
             .read_to_end(&mut alpha_data)?;
-        let handle = context
+        let bitmap_info = context
             .renderer
             .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data);
+        let bitmap = crate::bitmap::Bitmap::new(
+            context,
+            id,
+            bitmap_info.handle,
+            bitmap_info.width,
+            bitmap_info.height,
+        );
         context
             .library
-            .register_character(id, Character::Bitmap(handle));
+            .register_character(id, Character::Bitmap(Box::new(bitmap)));
         Ok(())
     }
 
@@ -900,12 +928,19 @@ impl<'gc, 'a> MovieClip<'gc> {
             .get_mut()
             .take(alpha_len as u64)
             .read_to_end(&mut alpha_data)?;
-        let handle = context
+        let bitmap_info = context
             .renderer
             .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data);
+        let bitmap = crate::bitmap::Bitmap::new(
+            context,
+            id,
+            bitmap_info.handle,
+            bitmap_info.width,
+            bitmap_info.height,
+        );
         context
             .library
-            .register_character(id, Character::Bitmap(handle));
+            .register_character(id, Character::Bitmap(Box::new(bitmap)));
         Ok(())
     }
 


### PR DESCRIPTION
Converts the Bitmap character to a proper display object. This can
be instantiated directly in a PlaceObject tag in SWFv9 movies,
compared to the previous versions which indirectly references
bitmaps from Shape tags.