### PR TITLE
swf: Fix compiling with lzma feature

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,4 +26,5 @@ default-features = false # can't use rayon on web
 approx = "0.3.2"
 
 [features]
-default = ["minimp3"]
+default = ["minimp3", "lzma"]
+lzma = ["swf/lzma"]

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -16,8 +16,8 @@ num-traits = "0.2"
 libflate = {version = "0.1", optional = true}
 log = "0.4"
 flate2 = {version = "1.0", optional = true}
-xz2 = {version = "0.1.5", optional = true}
+xz2 = {version = "0.1.6", optional = true}
 
 [features]
 default = ["libflate"]
-lzma-support = ["xz2"]
+lzma = ["xz2"]

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -15,7 +15,7 @@ extern crate libflate;
 #[macro_use]
 extern crate num_derive;
 extern crate num_traits;
-#[cfg(feature = "lzma-support")]
+#[cfg(feature = "lzma")]
 extern crate xz2;
 
 pub mod avm1;


### PR DESCRIPTION
Fixes #90.
LZMA decoding still has some issues, but this should at least get the lzma feature compiling again.
Also enables the feature by default on desktop. (Need a pure Rust implementation for wasm).