### PR TITLE
desktop: Improve animation sync

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -236,6 +236,20 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
         }
     }
 
+    /// Returns the approximate duration of time until the next frame is due to run.
+    /// This is only an approximation to be used for sleep durations.
+    pub fn time_til_next_frame(&self) -> std::time::Duration {
+        let frame_time = 1000.0 / self.frame_rate;
+        let dt = if self.frame_accumulator <= 0.0 {
+            frame_time
+        } else if self.frame_accumulator >= frame_time {
+            0.0
+        } else {
+            frame_time - self.frame_accumulator
+        };
+        std::time::Duration::from_micros(dt as u64 * 1000)
+    }
+
     pub fn is_playing(&self) -> bool {
         self.is_playing
     }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -9,7 +9,7 @@ use glutin::{
 };
 use ruffle_core::{backend::render::RenderBackend, Player};
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -119,12 +119,13 @@ fn run_player(input_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         }
 
         let new_time = Instant::now();
-        let dt = new_time.duration_since(time).as_millis();
-        time = new_time;
+        let dt = new_time.duration_since(time).as_micros();
+        if dt > 0 {
+            time = new_time;
+            player.tick(dt as f64 / 1000.0);
+        }
 
-        player.tick(dt as f64);
-
-        std::thread::sleep(Duration::from_millis(1000 / 60));
+        std::thread::sleep(player.time_til_next_frame());
     }
     Ok(())
 }


### PR DESCRIPTION
The timing on desktop was causing the movie to run too slow,
causing it to get out of sync. Now it should run at the correct
speed.