### PR TITLE
desktop: Fix incorrect rendering of bitmaps w/ color transforms

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -155,7 +155,7 @@ pub fn remove_invalid_jpeg_data(mut data: &[u8]) -> std::borrow::Cow<[u8]> {
 }
 
 /// Decodes a JPEG with optional alpha data.
-///
+/// The JPEG data will already be pre-multiplied by the alpha.
 pub fn define_bits_jpeg_to_rgba(
     jpeg_data: &[u8],
     alpha_data: &[u8],

--- a/desktop/src/render.rs
+++ b/desktop/src/render.rs
@@ -1170,8 +1170,16 @@ const BITMAP_FRAGMENT_SHADER: &str = r#"
     uniform sampler2D u_texture;
 
     void main() {
+
         vec4 color = texture(u_texture, frag_uv);
-        out_color = mult_color * color + add_color;
+        // Unmultiply alpha before apply color transform.
+        if( color.a > 0 ) {
+            color.rgb /= color.a;
+            color = mult_color * color + add_color;
+            color.rgb *= color.a;
+        }
+
+        out_color = color;
     }
 "#;
 


### PR DESCRIPTION
The premultiplied alpha was not properly considered when there was
a color transform on a bitmap. Now the shader unmultiplies the
alpha before applying the color transform, and the remultiplies it.

Fixes some artifacts on bitmaps in https://www.newgrounds.com/portal/view/124117 on the desktop player.