### PR TITLE
audio: Improve audio sync

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1662,7 +1662,7 @@ impl<'gc> Avm1<'gc> {
         if let Some(clip) = context.target_clip {
             let mut display_object = clip.write(context.gc_context);
             if let Some(clip) = display_object.as_movie_clip_mut() {
-                clip.stop();
+                clip.stop(context);
             } else {
                 log::warn!("Stop: Target is not a MovieClip");
             }

--- a/core/src/avm1/movie_clip.rs
+++ b/core/src/avm1/movie_clip.rs
@@ -94,8 +94,8 @@ pub fn create_movie_object<'gc>(gc_context: MutationContext<'gc, '_>) -> Object<
             movie_clip.play();
             Value::Undefined
         },
-        "stop" => |movie_clip: &mut MovieClip<'gc>, _context: &mut UpdateContext<'_, 'gc, '_>, _cell: DisplayNode<'gc>, _args| {
-            movie_clip.stop();
+        "stop" => |movie_clip: &mut MovieClip<'gc>, context: &mut UpdateContext<'_, 'gc, '_>, _cell: DisplayNode<'gc>, _args| {
+            movie_clip.stop(context);
             Value::Undefined
         }
     );

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -23,7 +23,13 @@ pub trait AudioBackend {
         _stream_info: &swf::SoundStreamHead,
     ) {
     }
-    fn preload_sound_stream_block(&mut self, _clip_id: swf::CharacterId, _audio_data: &[u8]) {}
+    fn preload_sound_stream_block(
+        &mut self,
+        _clip_id: swf::CharacterId,
+        _clip_frame: u16,
+        _audio_data: &[u8],
+    ) {
+    }
     fn preload_sound_stream_end(&mut self, _clip_id: swf::CharacterId) {}
 
     /// Starts playing a sound instance that is not tied to a MovieClip timeline.

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -707,9 +707,13 @@ impl<'gc, 'a> MovieClip<'gc> {
             TagCode::SoundStreamHead2 => {
                 self.preload_sound_stream_head(context, reader, cur_frame, &mut static_data, 2)
             }
-            TagCode::SoundStreamBlock => {
-                self.preload_sound_stream_block(context, reader, &mut static_data, tag_len)
-            }
+            TagCode::SoundStreamBlock => self.preload_sound_stream_block(
+                context,
+                reader,
+                cur_frame,
+                &mut static_data,
+                tag_len,
+            ),
             _ => Ok(()),
         };
         let _ = tag_utils::decode_tags(&mut reader, tag_callback, TagCode::End);
@@ -828,6 +832,7 @@ impl<'gc, 'a> MovieClip<'gc> {
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
+        cur_frame: FrameNumber,
         static_data: &mut MovieClipStatic,
         tag_len: usize,
     ) -> DecodeResult {
@@ -835,7 +840,9 @@ impl<'gc, 'a> MovieClip<'gc> {
             let pos = reader.get_ref().position() as usize;
             let data = reader.get_ref().get_ref();
             let data = &data[pos..pos + tag_len];
-            context.audio.preload_sound_stream_block(self.id(), data);
+            context
+                .audio
+                .preload_sound_stream_block(self.id(), cur_frame, data);
         }
 
         Ok(())

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -604,6 +604,19 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
         self.renderer.end_frame();
     }
 
+    pub fn audio(&self) -> &Audio {
+        &self.audio
+    }
+
+    pub fn audio_mut(&mut self) -> &mut Audio {
+        &mut self.audio
+    }
+
+    // The frame rate of the current movie in FPS.
+    pub fn frame_rate(&self) -> f64 {
+        self.frame_rate
+    }
+
     pub fn renderer(&self) -> &Renderer {
         &self.renderer
     }

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -288,6 +288,7 @@ impl AudioBackend for CpalAudioBackend {
     fn start_stream(
         &mut self,
         clip_id: swf::CharacterId,
+        _clip_frame: u16,
         clip_data: SwfSlice,
         stream_info: &swf::SoundStreamHead,
     ) -> AudioStreamHandle {
@@ -306,6 +307,11 @@ impl AudioBackend for CpalAudioBackend {
             signal,
             active: true,
         })
+    }
+
+    fn stop_stream(&mut self, stream: AudioStreamHandle) {
+        let mut sound_instances = self.sound_instances.lock().unwrap();
+        sound_instances.remove(stream);
     }
 
     fn start_sound(&mut self, sound_handle: SoundHandle, settings: &swf::SoundInfo) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -87,8 +87,9 @@ impl Ruffle {
         let audio = WebAudioBackend::new()?;
         let navigator = WebNavigatorBackend::new();
 
-        let core = ruffle_core::Player::new(renderer, audio, navigator, data)?;
-
+        let mut core = ruffle_core::Player::new(renderer, audio, navigator, data)?;
+        let frame_rate = core.frame_rate();
+        core.audio_mut().set_frame_rate(frame_rate);
         // Create instance.
         let instance = RuffleInstance {
             core,


### PR DESCRIPTION
 * Initial implementation of syncing "stream" sounds with their MovieClip timeline. The stream automatically stops and restarts when the MovieClip stops/seeks.
 * Skip the initial "SeekSamples" samples in MP3-encoded event sounds to account for encoder delay.
 * More accurate looping event sound behavior.

TODO:
 * Handle SeekSamples value when MovieClips run a goto.
 * Keep player in sync with stream audio if frames are dropped.
 * Clean up web audio backend (will try moving everything over to `ScriptProcessorNode`).