### PR TITLE
audio: Event sound envelopes

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -3,8 +3,8 @@ use generational_arena::{Arena, Index};
 pub mod decoders;
 pub mod swf {
     pub use swf::{
-        read, AudioCompression, CharacterId, Sound, SoundEvent, SoundFormat, SoundInfo,
-        SoundStreamHead,
+        read, AudioCompression, CharacterId, Sound, SoundEnvelope, SoundEnvelopePoint, SoundEvent,
+        SoundFormat, SoundInfo, SoundStreamHead,
     };
 }
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -36,10 +36,10 @@ features = ["puremp3"]
 [dependencies.web-sys]
 version = "0.3.25"
 features = [
-    "AudioBuffer", "AudioBufferSourceNode", "AudioProcessingEvent", "AudioContext", "AudioDestinationNode", "AudioNode", 
-    "CanvasRenderingContext2d", "CssStyleDeclaration", "Document", "Element", "Event", "EventTarget", "HtmlCanvasElement",
-    "HtmlElement", "HtmlImageElement", "MouseEvent", "Navigator", "Node", "Performance", "ScriptProcessorNode", "Window",
-    "Location", "HtmlFormElement"]
+    "AudioBuffer", "AudioBufferSourceNode", "AudioParam", "AudioProcessingEvent", "AudioContext", "AudioDestinationNode", 
+    "AudioNode", "CanvasRenderingContext2d", "ChannelMergerNode", "ChannelSplitterNode", "CssStyleDeclaration", "Document",
+    "Element", "Event", "EventTarget", "GainNode", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "MouseEvent",
+    "Navigator", "Node", "Performance", "ScriptProcessorNode", "Window", "Location", "HtmlFormElement"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.2.48"


### PR DESCRIPTION
Implements event sound envelopes for the `StartSound` tags. Created in the Flash IDE by setting the "Effect" on an event sound instance. Does not apply to stream sounds because the effect gets baked into the stream.