### PR TITLE
Form values regression

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -102,11 +102,10 @@ impl<'gc> Avm1<'gc> {
             .read()
             .scope()
             .locals_cell();
+        let keys = locals.read().get_keys();
 
-        for k in locals.read().get_keys() {
-            let v = locals
-                .write(context.gc_context)
-                .get(&k, self, context, locals);
+        for k in keys {
+            let v = locals.read().get(&k, self, context, locals);
             form_values.insert(k, v.clone().into_string());
         }
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -21,9 +21,13 @@ mod globals;
 pub mod movie_clip;
 pub mod object;
 mod scope;
+mod value;
+
 #[cfg(test)]
 mod test_utils;
-mod value;
+
+#[cfg(test)]
+mod tests;
 
 use activation::Activation;
 use scope::Scope;

--- a/core/src/avm1/tests.rs
+++ b/core/src/avm1/tests.rs
@@ -1,0 +1,26 @@
+use crate::avm1::activation::Activation;
+use crate::avm1::test_utils::with_avm;
+
+#[test]
+fn locals_into_form_values() {
+    with_avm(19, |avm, context, _this| {
+        let my_activation =
+            Activation::from_nothing(19, avm.global_object_cell(), context.gc_context);
+        let my_locals = my_activation.scope().locals_cell();
+
+        my_locals
+            .write(context.gc_context)
+            .set("value1", "string", avm, context, my_locals);
+        my_locals
+            .write(context.gc_context)
+            .set("value2", 2.0, avm, context, my_locals);
+
+        avm.insert_stack_frame(my_activation, context);
+
+        let my_local_values = avm.locals_into_form_values(context);
+
+        assert_eq!(my_local_values.len(), 2);
+        assert_eq!(my_local_values.get("value1"), Some(&"string".to_string()));
+        assert_eq!(my_local_values.get("value2"), Some(&"2".to_string()));
+    });
+}


### PR DESCRIPTION
Due to some recent cleanups, there's a double-borrow panic in `locals_into_form_values`. This causes certain Homestar Runner menus to panic - as well as anything that uses `getURL` or `ActionGetUrl`. This adds a regression test and bug fix.