### PR TITLE
core: Handle empty JPEGTables tags (fix #116)

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -886,11 +886,10 @@ impl<'gc, 'a> MovieClip<'gc> {
             .get_mut()
             .take(data_len as u64)
             .read_to_end(&mut jpeg_data)?;
-        let bitmap_info = context.renderer.register_bitmap_jpeg(
-            id,
-            &jpeg_data,
-            context.library.jpeg_tables().unwrap(),
-        );
+        let bitmap_info =
+            context
+                .renderer
+                .register_bitmap_jpeg(id, &jpeg_data, context.library.jpeg_tables());
         let bitmap = crate::display_object::Bitmap::new(
             context,
             id,

--- a/desktop/src/render.rs
+++ b/desktop/src/render.rs
@@ -542,16 +542,10 @@ impl RenderBackend for GliumRenderBackend {
         &mut self,
         id: swf::CharacterId,
         data: &[u8],
-        jpeg_tables: &[u8],
+        jpeg_tables: Option<&[u8]>,
     ) -> BitmapInfo {
-        if !jpeg_tables.is_empty() {
-            let mut full_jpeg = jpeg_tables[..jpeg_tables.len() - 2].to_vec();
-            full_jpeg.extend_from_slice(&data[2..]);
-
-            self.register_bitmap_jpeg_2(id, &full_jpeg[..])
-        } else {
-            self.register_bitmap_jpeg_2(id, &data[..])
-        }
+        let data = ruffle_core::backend::render::glue_tables_to_jpeg(data, jpeg_tables);
+        self.register_bitmap_jpeg_2(id, &data[..])
     }
 
     fn register_bitmap_jpeg_2(&mut self, id: swf::CharacterId, data: &[u8]) -> BitmapInfo {

--- a/web/src/render.rs
+++ b/web/src/render.rs
@@ -360,12 +360,10 @@ impl RenderBackend for WebCanvasRenderBackend {
         &mut self,
         id: CharacterId,
         data: &[u8],
-        jpeg_tables: &[u8],
+        jpeg_tables: Option<&[u8]>,
     ) -> BitmapInfo {
-        let mut full_jpeg = jpeg_tables[..jpeg_tables.len() - 2].to_vec();
-        full_jpeg.extend_from_slice(&data[2..]);
-
-        self.register_bitmap_jpeg_2(id, &full_jpeg[..])
+        let data = ruffle_core::backend::render::glue_tables_to_jpeg(data, jpeg_tables);
+        self.register_bitmap_jpeg_2(id, &data[..])
     }
 
     fn register_bitmap_jpeg_2(&mut self, id: CharacterId, data: &[u8]) -> BitmapInfo {


### PR DESCRIPTION
Some SWFs have empty JPEGTables tags. The code now ignores these. Split out the JPEGTables handling code into `backend::render::glue_tables_to_jpeg` and cleaned this up to avoid potential out-of-bounds indexing.

Fixes #116