### PR TITLE
desktop: Fixes for winit 0.20

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -58,6 +58,8 @@ fn run_player(input_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let logical_size: LogicalSize = (player.movie_width(), player.movie_height()).into();
     let hidpi_factor = display.gl_window().window().hidpi_factor();
 
+    // Set initial size to movie dimensions.
+    display.gl_window().window().set_inner_size(logical_size);
     display
         .gl_window()
         .resize(logical_size.to_physical(hidpi_factor));


### PR DESCRIPTION
Some more quick fixes due to the updated API in winit 0.20.
 * Using cpal with the latest winit was crashing immediately on Windows due to https://github.com/RustAudio/cpal/pull/348. I moved to cpal initialization code into another thread to workaround this.
 * Properly use the new `ControlFlow` API introduced in winit. Previously it was using `ControlFlow::Poll` along with `sleep` which caused a busy-loop on windows. Now I use `ControlFlow::WaitUntil`.