### PR TITLE
AVM debug tracing

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,3 +32,4 @@ approx = "0.3.2"
 [features]
 default = ["minimp3"]
 lzma = ["swf/lzma"]
+avm_debug = []

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -34,6 +34,13 @@ use activation::Activation;
 use scope::Scope;
 pub use value::Value;
 
+macro_rules! avm_debug {
+    ($($arg:tt)*) => (
+        #[cfg(feature = "avm_debug")]
+        log::debug!($($arg)*)
+    )
+}
+
 pub struct Avm1<'gc> {
     /// The Flash Player version we're emulating.
     player_version: u8,
@@ -331,8 +338,7 @@ impl<'gc> Avm1<'gc> {
             //Executing beyond the end of a function constitutes an implicit return.
             self.retire_stack_frame(context, Value::Undefined)?;
         } else if let Some(action) = reader.read_action()? {
-            #[cfg(feature = "avm_debug")]
-            log::debug!("Action: {:?}", action);
+            avm_debug!("Action: {:?}", action);
 
             let result = match action {
                 Action::Add => self.action_add(context),
@@ -519,8 +525,7 @@ impl<'gc> Avm1<'gc> {
 
     fn push(&mut self, value: impl Into<Value<'gc>>) {
         let value = value.into();
-        #[cfg(feature = "avm_debug")]
-        log::debug!("Stack push {}: {:?}", self.stack.len(), value);
+        avm_debug!("Stack push {}: {:?}", self.stack.len(), value);
         self.stack.push(value);
     }
 
@@ -529,8 +534,7 @@ impl<'gc> Avm1<'gc> {
             .pop()
             .ok_or_else(|| "Stack underflow".into())
             .map(|value| {
-                #[cfg(feature = "avm_debug")]
-                log::debug!("Stack pop {}: {:?}", self.stack.len(), value);
+                avm_debug!("Stack pop {}: {:?}", self.stack.len(), value);
                 value
             })
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -331,6 +331,9 @@ impl<'gc> Avm1<'gc> {
             //Executing beyond the end of a function constitutes an implicit return.
             self.retire_stack_frame(context, Value::Undefined)?;
         } else if let Some(action) = reader.read_action()? {
+            #[cfg(feature = "avm_debug")]
+            log::debug!("Action: {:?}", action);
+
             let result = match action {
                 Action::Add => self.action_add(context),
                 Action::Add2 => self.action_add_2(context),
@@ -515,11 +518,21 @@ impl<'gc> Avm1<'gc> {
     }
 
     fn push(&mut self, value: impl Into<Value<'gc>>) {
-        self.stack.push(value.into());
+        let value = value.into();
+        #[cfg(feature = "avm_debug")]
+        log::debug!("Stack push {}: {:?}", self.stack.len(), value);
+        self.stack.push(value);
     }
 
     fn pop(&mut self) -> Result<Value<'gc>, Error> {
-        self.stack.pop().ok_or_else(|| "Stack underflow".into())
+        self.stack
+            .pop()
+            .ok_or_else(|| "Stack underflow".into())
+            .map(|value| {
+                #[cfg(feature = "avm_debug")]
+                log::debug!("Stack pop {}: {:?}", self.stack.len(), value);
+                value
+            })
     }
 
     /// Retrieve a given register value.

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -21,3 +21,6 @@ structopt = "0.3.5"
 winit = "0.20.0-alpha4"
 webbrowser = "0.5.2"
 url = "2.1.0"
+
+[features]
+avm_debug = ["ruffle_core/avm_debug"]


### PR DESCRIPTION
When you turn on the feature `avm_debug`, Ruffle will start tracing all actions & stack history. Example output:

```
[2019-11-20T23:04:49Z DEBUG ruffle_core::avm1] Stack push 0: Value::Number(100.0)
[2019-11-20T23:04:49Z DEBUG ruffle_core::avm1] Stack push 1: Value::Number(150.0)
[2019-11-20T23:04:49Z DEBUG ruffle_core::avm1] Action: Subtract
[2019-11-20T23:04:49Z DEBUG ruffle_core::avm1] Stack pop 1: Value::Number(159.0)
[2019-11-20T23:04:49Z DEBUG ruffle_core::avm1] Stack pop 0: Value::Number(100.0)
[2019-11-20T23:04:49Z DEBUG ruffle_core::avm1] Stack push 0: Value::Number(50.0)
```

This is intended to help debug avm1 actions, and figure out where that pesky Unknown is coming from.