### PR TITLE
Test improvements

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -13,6 +13,10 @@ use swf::avm1::types::{Action, Function};
 
 use crate::tag_utils::SwfSlice;
 
+#[cfg(test)]
+#[macro_use]
+mod test_utils;
+
 mod activation;
 mod fscommand;
 mod function;
@@ -23,9 +27,6 @@ mod return_value;
 mod scope;
 pub mod script_object;
 mod value;
-
-#[cfg(test)]
-mod test_utils;
 
 #[cfg(test)]
 mod tests;
@@ -84,7 +85,7 @@ impl<'gc> Avm1<'gc> {
         Self {
             player_version,
             constant_pool: vec![],
-            globals: GcCell::allocate(gc_context, globals),
+            globals,
             prototypes,
             stack_frames: vec![],
             stack: vec![],

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -245,103 +245,112 @@ mod tests {
     use crate::avm1::Error;
 
     macro_rules! test_std {
-        ( $test: ident, $fun: expr, $version: expr, $([$($arg: expr),*] => $out: expr),* ) => {
+        ( $test: ident, $fun: expr, $($versions: expr => { $([$($arg: expr),*] => $out: expr),* }),* ) => {
             #[test]
             fn $test() -> Result<(), Error> {
-                with_avm($version, |avm, context, this| {
+                $(
+                    for version in &$versions {
+                        with_avm(*version, |avm, context, this| {
 
-                    $(
-                        #[allow(unused_mut)]
-                        let mut args: Vec<Value> = Vec::new();
-                        $(
-                            args.push($arg.into());
-                        )*
-                        assert_eq!($fun(avm, context, this, &args).unwrap(), ReturnValue::Immediate($out.into()));
-                    )*
+                            $(
+                                #[allow(unused_mut)]
+                                let mut args: Vec<Value> = Vec::new();
+                                $(
+                                    args.push($arg.into());
+                                )*
+                                assert_eq!($fun(avm, context, this, &args).unwrap(), ReturnValue::Immediate($out.into()), "{:?} => {:?} in swf {}", args, $out, version);
+                            )*
+                        });
+                    }
+                )*
 
-                    Ok(())
-                })
+                Ok(())
             }
         };
     }
 
-    test_std!(boolean_function, boolean, 19,
-        [true] => true,
-        [false] => false,
-        [10.0] => true,
-        [-10.0] => true,
-        [0.0] => false,
-        [std::f64::INFINITY] => true,
-        [std::f64::NAN] => false,
-        [""] => false,
-        ["Hello"] => true,
-        [" "] => true,
-        ["0"] => true,
-        ["1"] => true,
-        [] => false
+    test_std!(boolean_function, boolean,
+        [19] => {
+            [true] => true,
+            [false] => false,
+            [10.0] => true,
+            [-10.0] => true,
+            [0.0] => false,
+            [std::f64::INFINITY] => true,
+            [std::f64::NAN] => false,
+            [""] => false,
+            ["Hello"] => true,
+            [" "] => true,
+            ["0"] => true,
+            ["1"] => true,
+            [] => false
+        },
+        [6] => {
+            [true] => true,
+            [false] => false,
+            [10.0] => true,
+            [-10.0] => true,
+            [0.0] => false,
+            [std::f64::INFINITY] => true,
+            [std::f64::NAN] => false,
+            [""] => false,
+            ["Hello"] => false,
+            [" "] => false,
+            ["0"] => false,
+            ["1"] => true,
+            [] => false
+        }
     );
 
-    test_std!(boolean_function_swf6, boolean, 6,
-        [true] => true,
-        [false] => false,
-        [10.0] => true,
-        [-10.0] => true,
-        [0.0] => false,
-        [std::f64::INFINITY] => true,
-        [std::f64::NAN] => false,
-        [""] => false,
-        ["Hello"] => false,
-        [" "] => false,
-        ["0"] => false,
-        ["1"] => true,
-        [] => false
+    test_std!(is_nan_function, is_nan,
+        [19] => {
+            [true] => false,
+            [false] => false,
+            [10.0] => false,
+            [-10.0] => false,
+            [0.0] => false,
+            [std::f64::INFINITY] => false,
+            [std::f64::NAN] => true,
+            [""] => false,
+            ["Hello"] => true,
+            [" "] => true,
+            ["  5  "] => true,
+            ["0"] => false,
+            ["1"] => false,
+            ["Infinity"] => true,
+            ["100a"] => true,
+            ["0x10"] => false,
+            ["0xhello"] => true,
+            ["0x1999999981ffffff"] => false,
+            ["0xUIXUIDFKHJDF012345678"] => true,
+            ["123e-1"] => false,
+            [] => true
+        }
     );
 
-    test_std!(is_nan_function, is_nan, 19,
-        [true] => false,
-        [false] => false,
-        [10.0] => false,
-        [-10.0] => false,
-        [0.0] => false,
-        [std::f64::INFINITY] => false,
-        [std::f64::NAN] => true,
-        [""] => false,
-        ["Hello"] => true,
-        [" "] => true,
-        ["  5  "] => true,
-        ["0"] => false,
-        ["1"] => false,
-        ["Infinity"] => true,
-        ["100a"] => true,
-        ["0x10"] => false,
-        ["0xhello"] => true,
-        ["0x1999999981ffffff"] => false,
-        ["0xUIXUIDFKHJDF012345678"] => true,
-        ["123e-1"] => false,
-        [] => true
-    );
-
-    test_std!(number_function, number, 19,
-        [true] => 1.0,
-        [false] => 0.0,
-        [10.0] => 10.0,
-        [-10.0] => -10.0,
-        [0.0] => 0.0,
-        [std::f64::INFINITY] => std::f64::INFINITY,
-        [std::f64::NAN] => std::f64::NAN,
-        [""] => 0.0,
-        ["Hello"] => std::f64::NAN,
-        [" "] => std::f64::NAN,
-        ["  5  "] => std::f64::NAN,
-        ["0"] => 0.0,
-        ["1"] => 1.0,
-        ["Infinity"] => std::f64::NAN,
-        ["100a"] => std::f64::NAN,
-        ["0x10"] => 16.0,
-        ["0xhello"] => std::f64::NAN,
-        ["123e-1"] => 12.3,
-        ["0x1999999981ffffff"] => -2113929217.0,
-        ["0xUIXUIDFKHJDF012345678"] => std::f64::NAN,
-        [] => 0.0
+    test_std!(number_function, number,
+        [19] => {
+            [true] => 1.0,
+            [false] => 0.0,
+            [10.0] => 10.0,
+            [-10.0] => -10.0,
+            [0.0] => 0.0,
+            [std::f64::INFINITY] => std::f64::INFINITY,
+            [std::f64::NAN] => std::f64::NAN,
+            [""] => 0.0,
+            ["Hello"] => std::f64::NAN,
+            [" "] => std::f64::NAN,
+            ["  5  "] => std::f64::NAN,
+            ["0"] => 0.0,
+            ["1"] => 1.0,
+            ["Infinity"] => std::f64::NAN,
+            ["100a"] => std::f64::NAN,
+            ["0x10"] => 16.0,
+            ["0xhello"] => std::f64::NAN,
+            ["123e-1"] => 12.3,
+            ["0x1999999981ffffff"] => -2113929217.0,
+            ["0xUIXUIDFKHJDF012345678"] => std::f64::NAN,
+            [] => 0.0
+        }
     );
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -139,38 +139,19 @@ pub fn create<'gc>(
 mod tests {
     use super::*;
     use crate::avm1::test_utils::with_avm;
-    use crate::avm1::Error;
 
-    macro_rules! test_std {
-        ( $test: ident, $name: expr, $($versions: expr => { $([$($arg: expr),*] => $out: expr),* }),* ) => {
-            #[test]
-            fn $test() -> Result<(), Error> {
-                $(
-                    for version in &$versions {
-                        let _ = with_avm(*version, |avm, context, _root| -> Result<(), Error> {
-                            let math = create(context.gc_context, Some(avm.prototypes().object), Some(avm.prototypes().function));
-                            let function = math.read().get($name, avm, context, math)?.unwrap_immediate();
-
-                            $(
-                                #[allow(unused_mut)]
-                                let mut args: Vec<Value> = Vec::new();
-                                $(
-                                    args.push($arg.into());
-                                )*
-                                assert_eq!(function.call(avm, context, math, &args)?, ReturnValue::Immediate($out.into()), "{:?} => {:?} in swf {}", args, $out, version);
-                            )*
-
-                            Ok(())
-                        })?;
-                    }
-                )*
-
-                Ok(())
-            }
-        };
+    fn setup<'gc>(
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+    ) -> ObjectCell<'gc> {
+        create(
+            context.gc_context,
+            Some(avm.prototypes().object),
+            Some(avm.prototypes().function),
+        )
     }
 
-    test_std!(test_abs, "abs",
+    test_method!(test_abs, "abs", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -179,7 +160,7 @@ mod tests {
         }
     );
 
-    test_std!(test_acos, "acos",
+    test_method!(test_acos, "acos", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -189,7 +170,7 @@ mod tests {
         }
     );
 
-    test_std!(test_asin, "asin",
+    test_method!(test_asin, "asin", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -199,7 +180,7 @@ mod tests {
         }
     );
 
-    test_std!(test_atan, "atan",
+    test_method!(test_atan, "atan", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -209,7 +190,7 @@ mod tests {
         }
     );
 
-    test_std!(test_ceil, "ceil",
+    test_method!(test_ceil, "ceil", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -217,7 +198,7 @@ mod tests {
         }
     );
 
-    test_std!(test_cos, "cos",
+    test_method!(test_cos, "cos", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -226,7 +207,7 @@ mod tests {
         }
     );
 
-    test_std!(test_exp, "exp",
+    test_method!(test_exp, "exp", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -235,7 +216,7 @@ mod tests {
         }
     );
 
-    test_std!(test_floor, "floor",
+    test_method!(test_floor, "floor", setup,
         [19] => {
             [] => NAN,
             [Value::Undefined] => NAN,
@@ -254,7 +235,7 @@ mod tests {
         }
     );
 
-    test_std!(test_round, "round",
+    test_method!(test_round, "round", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -263,7 +244,7 @@ mod tests {
         }
     );
 
-    test_std!(test_sin, "sin",
+    test_method!(test_sin, "sin", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -272,7 +253,7 @@ mod tests {
         }
     );
 
-    test_std!(test_sqrt, "sqrt",
+    test_method!(test_sqrt, "sqrt", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,
@@ -281,7 +262,7 @@ mod tests {
         }
     );
 
-    test_std!(test_tan, "tan",
+    test_method!(test_tan, "tan", setup,
         [19] => {
             [] => NAN,
             [Value::Null] => NAN,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -516,7 +516,7 @@ mod test {
             assert_eq!(n.to_primitive_num(avm, context).unwrap(), n);
 
             let (protos, global) = create_globals(context.gc_context);
-            let vglobal = Value::Object(GcCell::allocate(context.gc_context, global));
+            let vglobal = Value::Object(global);
 
             assert_eq!(vglobal.to_primitive_num(avm, context).unwrap(), u);
 


### PR DESCRIPTION
This cleans up tests by creating a reusable `test_method` macro, which takes an object and a method name.

It also allows tests to check results per-version.