### PR TITLE
web: Avoid `copyToChannel` on Safari

### DIFF
--- a/web/js-src/ruffle-imports.js
+++ b/web/js-src/ruffle-imports.js
@@ -1,0 +1,19 @@
+/**
+ * Functions improted from JS into Ruffle.
+ */
+
+/**
+ * Copies data into the given audio channel.
+ * This is necessary because Safari does not support `AudioBuffer.copyToChannel`.
+ */
+export function copy_to_audio_buffer(audio_buffer, left_data, right_data) {
+    if (left_data) {
+        let dst_buffer = audio_buffer.getChannelData(0);
+        dst_buffer.set(left_data);
+    }
+
+    if (right_data) {
+        let dst_buffer = audio_buffer.getChannelData(1);
+        dst_buffer.set(right_data);
+    }
+}


### PR DESCRIPTION
`AudioBuffer.copyToChannel` does not work on Safari, so switch to
using `getChannelData` to fill the audio buffers.

Limitations in wasm-bindgen prevent us from actually modifying the
data returned by `getChannelData` on the Rust side, so import a JS
function to fill the audio buffer (js-src/ruffle-imports.js).