### PR TITLE
core: Refactor usage of GcCell in DisplayObject/ScriptObject traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ dependencies = [
  "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -578,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -640,7 +640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1207,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1387,7 +1387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1563,6 +1563,7 @@ dependencies = [
  "minimp3 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "puremp3 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruffle_macros 0.1.0",
  "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "swf 0.1.2",
 ]
@@ -1586,6 +1587,14 @@ dependencies = [
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webbrowser 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.20.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ruffle_macros"
+version = "0.1.0"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1726,7 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1840,7 +1849,7 @@ dependencies = [
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1873,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1888,7 +1897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2050,7 +2059,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2081,7 +2090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2123,7 +2132,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2541,7 +2550,7 @@ dependencies = [
 "checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
 "checksum svg 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f57a11872ea3f38eb99622ef7877fe207b3eeefbe877a49f08f9995d00f34a5"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum takeable-option 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "core",
+    "core/macros",
     "desktop",
     "swf",
     "web",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ libflate = "0.1.26"
 log = "0.4"
 minimp3 = { version = "0.3.3", optional = true }
 puremp3 = { version = "0.1", optional = true }
+ruffle_macros = { path = "macros" }
 swf = { path = "../swf" }
 enumset = "0.4.2"
 smallvec = "1.0.0"

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ruffle_macros"
+version = "0.1.0"
+authors = ["Mike Welsh <mwelsh@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+
+[dependencies.syn]
+version = "1.0.11"
+features = ["full"]

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -1,0 +1,145 @@
+//! Proc macros used by Ruffle to generate various boilerplate.
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, parse_quote, FnArg, ImplItem, ImplItemMethod, ItemEnum, ItemTrait, Pat,
+    TraitItem, Visibility,
+};
+
+/// `enum_trat_object` will define an enum whose variants each implement a trait.
+/// It can be used as faux-dynamic dispatch. This is used as an alternative to a
+/// trait object, which doesn't get along with GC'd types.
+///
+/// This will auto-implement the trait for the enum, delegating all methods to the
+/// underlying type. Additionally, `From` will be implemented for all of the variants,
+/// so an underlying type can easily be converted into the enum.
+///
+/// TODO: This isn't completely robust for all cases, but should be good enough
+/// for our usage.
+///
+/// Usage:
+/// ```
+/// use ruffle_macros::enum_trait_object;
+///
+/// #[enum_trait_object(
+///     pub enum MyTraitEnum {
+///         Object(Object)
+///     }
+/// )]
+/// trait MyTrait {}
+///
+/// struct Object {}
+/// impl MyTrait for Object {}
+/// ```
+#[proc_macro_attribute]
+pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse the input.
+    let input_trait = parse_macro_input!(item as ItemTrait);
+    let trait_name = input_trait.ident.clone();
+    let trait_generics = input_trait.generics.clone();
+    let enum_input = parse_macro_input!(args as ItemEnum);
+    let enum_name = enum_input.ident.clone();
+
+    if trait_generics.lifetimes().count() > 1 {
+        panic!("Only one lifetime parameter is currently supported");
+    }
+
+    if trait_generics.type_params().count() > 1 {
+        panic!("Generic type parameters are currently unsupported");
+    }
+
+    if trait_generics != enum_input.generics {
+        panic!("Trait and enum should have the same generic parameters");
+    }
+    // Implement each trait. This will match against each enum variant and delegate
+    // to the underlying type.
+    let trait_methods: Vec<_> = input_trait
+        .items
+        .iter()
+        .map(|item| match item {
+            TraitItem::Method(method) => {
+                let method_name = method.sig.ident.clone();
+                let params: Vec<_> = method
+                    .sig
+                    .inputs
+                    .iter()
+                    .filter_map(|arg| {
+                        if let FnArg::Typed(arg) = arg {
+                            if let Pat::Ident(i) = &*arg.pat {
+                                let arg_name = i.ident.clone();
+                                return Some(quote!(#arg_name,));
+                            }
+                        }
+                        None
+                    })
+                    .collect();
+
+                let match_arms: Vec<_> = enum_input
+                    .variants
+                    .iter()
+                    .map(|variant| {
+                        let variant_name = variant.ident.clone();
+                        quote! {
+                            #enum_name::#variant_name(o) => o.#method_name(#(#params)*),
+                        }
+                    })
+                    .collect();
+                let method_block = quote!({
+                    match self {
+                        #(#match_arms)*
+                    }
+                });
+
+                ImplItem::Method(ImplItemMethod {
+                    attrs: method.attrs.clone(),
+                    vis: Visibility::Inherited,
+                    defaultness: None,
+                    sig: method.sig.clone(),
+                    block: parse_quote!(#method_block),
+                })
+            }
+            _ => panic!("Unsupported trait item: {:?}", item),
+        })
+        .collect();
+
+    let (impl_generics, ty_generics, where_clause) = trait_generics.split_for_impl();
+
+    // Implement `From` for each variant type.
+    let from_impls: Vec<_> = enum_input
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_name = variant.ident.clone();
+            let variant_type = variant
+                .fields
+                .iter()
+                .nth(0)
+                .expect("Missing field for enum variant")
+                .ty
+                .clone();
+
+            quote!(
+                impl #impl_generics From<#variant_type> for #enum_name #ty_generics {
+                    fn from(obj: #variant_type) -> #enum_name #trait_generics {
+                        #enum_name::#variant_name(obj)
+                    }
+                }
+            )
+        })
+        .collect();
+
+    let out = quote!(
+        #input_trait
+
+        #enum_input
+
+        impl #impl_generics #trait_name #ty_generics for #enum_name #ty_generics #where_clause {
+            #(#trait_methods)*
+        }
+
+        #(#from_impls)*
+    );
+
+    out.into()
+}

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1203,8 +1203,7 @@ impl<'gc> Avm1<'gc> {
         frame: u16,
     ) -> Result<(), Error> {
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 // The frame on the stack is 0-based, not 1-based.
                 clip.goto_frame(context, frame + 1, true);
             } else {
@@ -1225,8 +1224,7 @@ impl<'gc> Avm1<'gc> {
         // Version 4+ gotoAndPlay/gotoAndStop
         // Param can either be a frame number or a frame label.
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 match self.pop()? {
                     Value::Number(frame) => {
                         // The frame on the stack is 1-based, not 0-based.
@@ -1260,8 +1258,7 @@ impl<'gc> Avm1<'gc> {
         label: &str,
     ) -> Result<(), Error> {
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 if let Some(frame) = clip.frame_label_to_number(label) {
                     clip.goto_frame(context, frame, true);
                 } else {
@@ -1452,8 +1449,7 @@ impl<'gc> Avm1<'gc> {
 
     fn action_next_frame(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) -> Result<(), Error> {
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 clip.next_frame(context);
             } else {
                 log::warn!("NextFrame: Target is not a MovieClip");
@@ -1538,8 +1534,7 @@ impl<'gc> Avm1<'gc> {
 
     fn action_play(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) -> Result<(), Error> {
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 clip.play(context)
             } else {
                 log::warn!("Play: Target is not a MovieClip");
@@ -1552,8 +1547,7 @@ impl<'gc> Avm1<'gc> {
 
     fn action_prev_frame(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) -> Result<(), Error> {
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 clip.prev_frame(context);
             } else {
                 log::warn!("PrevFrame: Target is not a MovieClip");
@@ -1648,8 +1642,8 @@ impl<'gc> Avm1<'gc> {
         let clip_path = self.pop()?;
         let path = clip_path.as_string()?;
         if let Some(base_clip) = context.target_clip {
-            if let Some(mut clip) = Avm1::resolve_slash_path(base_clip, context.root, path) {
-                if let Some(clip) = clip.as_movie_clip_mut() {
+            if let Some(clip) = Avm1::resolve_slash_path(base_clip, context.root, path) {
+                if let Some(clip) = clip.as_movie_clip() {
                     match prop_index {
                         0 => clip.set_x(context.gc_context, value),
                         1 => clip.set_y(context.gc_context, value),
@@ -1700,10 +1694,10 @@ impl<'gc> Avm1<'gc> {
         let is_slashpath = Self::variable_name_is_slash_path(var_path);
 
         if is_slashpath {
-            if let Some((mut node, var_name)) =
+            if let Some((node, var_name)) =
                 Self::resolve_slash_path_variable(context.target_clip, context.root, var_path)
             {
-                if let Some(clip) = node.as_movie_clip_mut() {
+                if let Some(clip) = node.as_movie_clip() {
                     clip.object()
                         .as_object()?
                         .set(var_name, value.clone(), self, context, this)?;
@@ -1802,8 +1796,7 @@ impl<'gc> Avm1<'gc> {
 
     fn action_stop(&mut self, context: &mut UpdateContext) -> Result<(), Error> {
         if let Some(clip) = context.target_clip {
-            let mut display_object = clip;
-            if let Some(clip) = display_object.as_movie_clip_mut() {
+            if let Some(clip) = clip.as_movie_clip() {
                 clip.stop(context);
             } else {
                 log::warn!("Stop: Target is not a MovieClip");

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -144,15 +144,19 @@ impl<'gc> Avm1<'gc> {
     /// Add a stack frame that executes code in timeline scope
     pub fn insert_stack_frame_for_action(
         &mut self,
+        active_clip: DisplayObject<'gc>,
         swf_version: u8,
         code: SwfSlice,
         action_context: &mut UpdateContext<'_, 'gc, '_>,
     ) {
+        action_context.start_clip = active_clip;
+        action_context.active_clip = active_clip;
+        action_context.target_clip = Some(active_clip);
         let global_scope = GcCell::allocate(
             action_context.gc_context,
             Scope::from_global_object(self.globals),
         );
-        let clip_obj = action_context.active_clip.object().as_object().unwrap();
+        let clip_obj = active_clip.object().as_object().unwrap();
         let child_scope = GcCell::allocate(
             action_context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
@@ -166,15 +170,19 @@ impl<'gc> Avm1<'gc> {
     /// Add a stack frame that executes code in initializer scope
     pub fn insert_stack_frame_for_init_action(
         &mut self,
+        active_clip: DisplayObject<'gc>,
         swf_version: u8,
         code: SwfSlice,
         action_context: &mut UpdateContext<'_, 'gc, '_>,
     ) {
+        action_context.start_clip = active_clip;
+        action_context.active_clip = active_clip;
+        action_context.target_clip = Some(active_clip);
         let global_scope = GcCell::allocate(
             action_context.gc_context,
             Scope::from_global_object(self.globals),
         );
-        let clip_obj = action_context.active_clip.object().as_object().unwrap();
+        let clip_obj = active_clip.object().as_object().unwrap();
         let child_scope = GcCell::allocate(
             action_context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::return_value::ReturnValue;
 use crate::avm1::scope::Scope;
-use crate::avm1::{Avm1, Error, ObjectCell, Value};
+use crate::avm1::{Avm1, Error, Object, Value};
 use crate::context::UpdateContext;
 use crate::tag_utils::SwfSlice;
 use gc_arena::{GcCell, MutationContext};
@@ -67,10 +67,10 @@ pub struct Activation<'gc> {
     scope: GcCell<'gc, Scope<'gc>>,
 
     /// The immutable value of `this`.
-    this: ObjectCell<'gc>,
+    this: Object<'gc>,
 
     /// The arguments this function was called by.
-    arguments: Option<ObjectCell<'gc>>,
+    arguments: Option<Object<'gc>>,
 
     /// The return value of the activation.
     return_value: Option<Value<'gc>>,
@@ -114,8 +114,8 @@ impl<'gc> Activation<'gc> {
         swf_version: u8,
         code: SwfSlice,
         scope: GcCell<'gc, Scope<'gc>>,
-        this: ObjectCell<'gc>,
-        arguments: Option<ObjectCell<'gc>>,
+        this: Object<'gc>,
+        arguments: Option<Object<'gc>>,
     ) -> Activation<'gc> {
         Activation {
             swf_version,
@@ -135,8 +135,8 @@ impl<'gc> Activation<'gc> {
         swf_version: u8,
         code: SwfSlice,
         scope: GcCell<'gc, Scope<'gc>>,
-        this: ObjectCell<'gc>,
-        arguments: Option<ObjectCell<'gc>>,
+        this: Object<'gc>,
+        arguments: Option<Object<'gc>>,
     ) -> Activation<'gc> {
         Activation {
             swf_version,
@@ -158,9 +158,10 @@ impl<'gc> Activation<'gc> {
     /// will prevent the AVM from panicking without a current activation.
     /// We construct a single scope chain from a global object, and that's about
     /// it.
+    #[cfg(test)]
     pub fn from_nothing(
         swf_version: u8,
-        globals: ObjectCell<'gc>,
+        globals: Object<'gc>,
         mc: MutationContext<'gc, '_>,
     ) -> Activation<'gc> {
         let global_scope = GcCell::allocate(mc, Scope::from_global_object(globals));
@@ -211,12 +212,14 @@ impl<'gc> Activation<'gc> {
     }
 
     /// Change the data being executed.
+    #[allow(dead_code)]
     pub fn set_data(&mut self, new_data: SwfSlice) {
         self.data = new_data;
     }
 
     /// Determines if a stack frame references the same function as a given
     /// SwfSlice.
+    #[allow(dead_code)]
     pub fn is_identical_fn(&self, other: &SwfSlice) -> bool {
         Arc::ptr_eq(&self.data.data, &other.data)
     }
@@ -236,6 +239,7 @@ impl<'gc> Activation<'gc> {
     }
 
     /// Returns AVM local variable scope for mutation.
+    #[allow(dead_code)]
     pub fn scope_mut(&mut self, mc: MutationContext<'gc, '_>) -> RefMut<Scope<'gc>> {
         self.scope.write(mc)
     }
@@ -252,6 +256,7 @@ impl<'gc> Activation<'gc> {
 
     /// Indicates whether or not the end of this scope should be handled as an
     /// implicit function return or the end of a block.
+    #[allow(dead_code)]
     pub fn can_implicit_return(&self) -> bool {
         self.is_function
     }
@@ -296,7 +301,7 @@ impl<'gc> Activation<'gc> {
     }
 
     /// Returns value of `this` as a reference.
-    pub fn this_cell(&self) -> ObjectCell<'gc> {
+    pub fn this_cell(&self) -> Object<'gc> {
         self.this
     }
 
@@ -358,6 +363,7 @@ impl<'gc> Activation<'gc> {
 
     /// Retrieve the return value from a completed activation, if the function
     /// has already returned.
+    #[allow(dead_code)]
     pub fn return_value(&self) -> Option<Value<'gc>> {
         self.return_value.clone()
     }

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -6,6 +6,7 @@ use crate::avm1::return_value::ReturnValue;
 use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
 use crate::avm1::{Avm1, Error, Object, ScriptObject, TObject, UpdateContext};
+use crate::display_object::TDisplayObject;
 use crate::tag_utils::SwfSlice;
 use gc_arena::{Collect, CollectionContext, GcCell};
 use swf::avm1::types::FunctionParam;
@@ -226,7 +227,7 @@ impl<'gc> Executable<'gc> {
                     af.swf_version()
                 } else {
                     this.as_display_node()
-                        .map(|dn| dn.read().swf_version())
+                        .map(|dn| dn.swf_version())
                         .unwrap_or(ac.player_version)
                 };
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -226,7 +226,7 @@ impl<'gc> Executable<'gc> {
                 let effective_ver = if avm.current_swf_version() > 5 {
                     af.swf_version()
                 } else {
-                    this.as_display_node()
+                    this.as_display_object()
                         .map(|dn| dn.swf_version())
                         .unwrap_or(ac.player_version)
                 };

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -1,7 +1,7 @@
 //! Function prototype
 
 use crate::avm1::return_value::ReturnValue;
-use crate::avm1::{Avm1, Error, ObjectCell, ScriptObject, UpdateContext, Value};
+use crate::avm1::{Avm1, Error, Object, ScriptObject, TObject, UpdateContext, Value};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
@@ -9,7 +9,7 @@ use gc_arena::MutationContext;
 pub fn constructor<'gc>(
     _avm: &mut Avm1<'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: ObjectCell<'gc>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     Ok(Value::Undefined.into())
@@ -18,7 +18,7 @@ pub fn constructor<'gc>(
 pub fn call<'gc>(
     _avm: &mut Avm1<'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: ObjectCell<'gc>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     Ok(Value::Undefined.into())
@@ -27,7 +27,7 @@ pub fn call<'gc>(
 pub fn apply<'gc>(
     _avm: &mut Avm1<'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: ObjectCell<'gc>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     Ok(Value::Undefined.into())
@@ -40,34 +40,17 @@ pub fn apply<'gc>(
 /// them in order to obtain a valid ECMAScript `Function` prototype. The
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
-pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
-    proto: ObjectCell<'gc>,
-) -> ObjectCell<'gc> {
-    let function_proto = ScriptObject::object_cell(gc_context, Some(proto));
-
+pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
+    let mut function_proto = ScriptObject::object_cell(gc_context, Some(proto));
+    let this = Some(function_proto);
     function_proto
-        .write(gc_context)
         .as_script_object_mut()
         .unwrap()
-        .force_set_function(
-            "call",
-            call,
-            gc_context,
-            EnumSet::empty(),
-            Some(function_proto),
-        );
+        .force_set_function("call", call, gc_context, EnumSet::empty(), this);
     function_proto
-        .write(gc_context)
         .as_script_object_mut()
         .unwrap()
-        .force_set_function(
-            "apply",
-            apply,
-            gc_context,
-            EnumSet::empty(),
-            Some(function_proto),
-        );
+        .force_set_function("apply", apply, gc_context, EnumSet::empty(), this);
 
     function_proto
 }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -41,14 +41,14 @@ pub fn apply<'gc>(
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
 pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
-    let mut function_proto = ScriptObject::object_cell(gc_context, Some(proto));
+    let function_proto = ScriptObject::object_cell(gc_context, Some(proto));
     let this = Some(function_proto);
     function_proto
-        .as_script_object_mut()
+        .as_script_object()
         .unwrap()
         .force_set_function("call", call, gc_context, EnumSet::empty(), this);
     function_proto
-        .as_script_object_mut()
+        .as_script_object()
         .unwrap()
         .force_set_function("apply", apply, gc_context, EnumSet::empty(), this);
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -24,7 +24,7 @@ macro_rules! with_movie_clip {
             $object.force_set_function(
                 $name,
                 |_avm, context: &mut UpdateContext<'_, 'gc, '_>, this, args| -> Result<ReturnValue<'gc>, Error> {
-                    if let Some(display_object) = this.as_display_node() {
+                    if let Some(display_object) = this.as_display_object() {
                         if let Some(movie_clip) = display_object.as_movie_clip() {
                             let ret: ReturnValue<'gc> = $fn(movie_clip, context, display_object, args);
                             return Ok(ret);
@@ -131,7 +131,7 @@ pub fn create_proto<'gc>(
         "_parent",
         Executable::Native(|_avm, _context, this, _args| {
             Ok(this
-                .as_display_node()
+                .as_display_object()
                 .and_then(|mc| mc.parent())
                 .and_then(|dn| dn.object().as_object().ok())
                 .map(Value::Object)

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -140,67 +140,49 @@ fn value_of<'gc>(
 /// bare objects for both and let this function fill Object for you.
 pub fn fill_proto<'gc>(
     gc_context: MutationContext<'gc, '_>,
-    mut object_proto: Object<'gc>,
+    object_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) {
-    object_proto
-        .as_script_object_mut()
-        .unwrap()
-        .force_set_function(
-            "addProperty",
-            add_property,
-            gc_context,
-            DontDelete | DontEnum,
-            Some(fn_proto),
-        );
-    object_proto
-        .as_script_object_mut()
-        .unwrap()
-        .force_set_function(
-            "hasOwnProperty",
-            has_own_property,
-            gc_context,
-            DontDelete | DontEnum,
-            Some(fn_proto),
-        );
-    object_proto
-        .as_script_object_mut()
-        .unwrap()
-        .force_set_function(
-            "isPropertyEnumerable",
-            is_property_enumerable,
-            gc_context,
-            DontDelete | DontEnum,
-            Some(fn_proto),
-        );
-    object_proto
-        .as_script_object_mut()
-        .unwrap()
-        .force_set_function(
-            "isPrototypeOf",
-            is_prototype_of,
-            gc_context,
-            DontDelete | DontEnum,
-            Some(fn_proto),
-        );
-    object_proto
-        .as_script_object_mut()
-        .unwrap()
-        .force_set_function(
-            "toString",
-            to_string,
-            gc_context,
-            DontDelete | DontEnum,
-            Some(fn_proto),
-        );
-    object_proto
-        .as_script_object_mut()
-        .unwrap()
-        .force_set_function(
-            "valueOf",
-            value_of,
-            gc_context,
-            DontDelete | DontEnum,
-            Some(fn_proto),
-        );
+    object_proto.as_script_object().unwrap().force_set_function(
+        "addProperty",
+        add_property,
+        gc_context,
+        DontDelete | DontEnum,
+        Some(fn_proto),
+    );
+    object_proto.as_script_object().unwrap().force_set_function(
+        "hasOwnProperty",
+        has_own_property,
+        gc_context,
+        DontDelete | DontEnum,
+        Some(fn_proto),
+    );
+    object_proto.as_script_object().unwrap().force_set_function(
+        "isPropertyEnumerable",
+        is_property_enumerable,
+        gc_context,
+        DontDelete | DontEnum,
+        Some(fn_proto),
+    );
+    object_proto.as_script_object().unwrap().force_set_function(
+        "isPrototypeOf",
+        is_prototype_of,
+        gc_context,
+        DontDelete | DontEnum,
+        Some(fn_proto),
+    );
+    object_proto.as_script_object().unwrap().force_set_function(
+        "toString",
+        to_string,
+        gc_context,
+        DontDelete | DontEnum,
+        Some(fn_proto),
+    );
+    object_proto.as_script_object().unwrap().force_set_function(
+        "valueOf",
+        value_of,
+        gc_context,
+        DontDelete | DontEnum,
+        Some(fn_proto),
+    );
 }

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -1,15 +1,15 @@
 //! Object prototype
 use crate::avm1::property::Attribute::*;
 use crate::avm1::return_value::ReturnValue;
-use crate::avm1::{Avm1, Error, ObjectCell, UpdateContext, Value};
+use crate::avm1::{Avm1, Error, Object, TObject, UpdateContext, Value};
 use enumset::EnumSet;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::MutationContext;
 
 /// Implements `Object`
 pub fn constructor<'gc>(
     _avm: &mut Avm1<'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: ObjectCell<'gc>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     Ok(Value::Undefined.into())
@@ -19,7 +19,7 @@ pub fn constructor<'gc>(
 pub fn add_property<'gc>(
     _avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
-    this: ObjectCell<'gc>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let name = args.get(0).unwrap_or(&Value::Undefined);
@@ -28,10 +28,11 @@ pub fn add_property<'gc>(
 
     match (name, getter) {
         (Value::String(name), Value::Object(get)) if !name.is_empty() => {
-            if let Some(get_func) = get.read().as_executable() {
+            if let Some(get_func) = get.as_executable() {
                 if let Value::Object(set) = setter {
-                    if let Some(set_func) = set.read().as_executable() {
-                        this.write(context.gc_context).add_property(
+                    if let Some(set_func) = set.as_executable() {
+                        this.add_property(
+                            context.gc_context,
                             name,
                             get_func,
                             Some(set_func),
@@ -41,12 +42,7 @@ pub fn add_property<'gc>(
                         return Ok(false.into());
                     }
                 } else if let Value::Null = setter {
-                    this.write(context.gc_context).add_property(
-                        name,
-                        get_func,
-                        None,
-                        ReadOnly.into(),
-                    );
+                    this.add_property(context.gc_context, name, get_func, None, ReadOnly.into());
                 } else {
                     return Ok(false.into());
                 }
@@ -62,11 +58,11 @@ pub fn add_property<'gc>(
 pub fn has_own_property<'gc>(
     _avm: &mut Avm1<'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
-    this: ObjectCell<'gc>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     match args.get(0) {
-        Some(Value::String(name)) => Ok(Value::Bool(this.read().has_own_property(name)).into()),
+        Some(Value::String(name)) => Ok(Value::Bool(this.has_own_property(name)).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
@@ -75,7 +71,7 @@ pub fn has_own_property<'gc>(
 fn to_string<'gc>(
     _: &mut Avm1<'gc>,
     _: &mut UpdateContext<'_, 'gc, '_>,
-    _: ObjectCell<'gc>,
+    _: Object<'gc>,
     _: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     Ok(ReturnValue::Immediate("[object Object]".into()))
@@ -85,13 +81,11 @@ fn to_string<'gc>(
 fn is_property_enumerable<'gc>(
     _: &mut Avm1<'gc>,
     _: &mut UpdateContext<'_, 'gc, '_>,
-    this: ObjectCell<'gc>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     match args.get(0) {
-        Some(Value::String(name)) => {
-            Ok(Value::Bool(this.read().is_property_enumerable(name)).into())
-        }
+        Some(Value::String(name)) => Ok(Value::Bool(this.is_property_enumerable(name)).into()),
         _ => Ok(Value::Bool(false).into()),
     }
 }
@@ -100,7 +94,7 @@ fn is_property_enumerable<'gc>(
 fn is_prototype_of<'gc>(
     _: &mut Avm1<'gc>,
     _: &mut UpdateContext<'_, 'gc, '_>,
-    this: ObjectCell<'gc>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     match args.get(0) {
@@ -109,14 +103,14 @@ fn is_prototype_of<'gc>(
                 Ok(ob) => ob,
                 Err(_) => return Ok(Value::Bool(false).into()),
             };
-            let mut proto = ob.read().proto();
+            let mut proto = ob.proto();
 
             while let Some(proto_ob) = proto {
-                if GcCell::ptr_eq(this, proto_ob) {
+                if Object::ptr_eq(this, proto_ob) {
                     return Ok(Value::Bool(true).into());
                 }
 
-                proto = proto_ob.read().proto();
+                proto = proto_ob.proto();
             }
 
             Ok(Value::Bool(false).into())
@@ -129,7 +123,7 @@ fn is_prototype_of<'gc>(
 fn value_of<'gc>(
     _: &mut Avm1<'gc>,
     _: &mut UpdateContext<'_, 'gc, '_>,
-    this: ObjectCell<'gc>,
+    this: Object<'gc>,
     _: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     Ok(ReturnValue::Immediate(this.into()))
@@ -146,12 +140,10 @@ fn value_of<'gc>(
 /// bare objects for both and let this function fill Object for you.
 pub fn fill_proto<'gc>(
     gc_context: MutationContext<'gc, '_>,
-    object_proto: ObjectCell<'gc>,
-    fn_proto: ObjectCell<'gc>,
+    mut object_proto: Object<'gc>,
+    fn_proto: Object<'gc>,
 ) {
-    let mut ob_proto_write = object_proto.write(gc_context);
-
-    ob_proto_write
+    object_proto
         .as_script_object_mut()
         .unwrap()
         .force_set_function(
@@ -161,7 +153,7 @@ pub fn fill_proto<'gc>(
             DontDelete | DontEnum,
             Some(fn_proto),
         );
-    ob_proto_write
+    object_proto
         .as_script_object_mut()
         .unwrap()
         .force_set_function(
@@ -171,7 +163,7 @@ pub fn fill_proto<'gc>(
             DontDelete | DontEnum,
             Some(fn_proto),
         );
-    ob_proto_write
+    object_proto
         .as_script_object_mut()
         .unwrap()
         .force_set_function(
@@ -181,7 +173,7 @@ pub fn fill_proto<'gc>(
             DontDelete | DontEnum,
             Some(fn_proto),
         );
-    ob_proto_write
+    object_proto
         .as_script_object_mut()
         .unwrap()
         .force_set_function(
@@ -191,7 +183,7 @@ pub fn fill_proto<'gc>(
             DontDelete | DontEnum,
             Some(fn_proto),
         );
-    ob_proto_write
+    object_proto
         .as_script_object_mut()
         .unwrap()
         .force_set_function(
@@ -201,7 +193,7 @@ pub fn fill_proto<'gc>(
             DontDelete | DontEnum,
             Some(fn_proto),
         );
-    ob_proto_write
+    object_proto
         .as_script_object_mut()
         .unwrap()
         .force_set_function(

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -190,7 +190,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug {
     fn as_script_object(&self) -> Option<ScriptObject<'gc>>;
 
     /// Get the underlying display node for this object, if it exists.
-    fn as_display_node(&self) -> Option<DisplayObject<'gc>>;
+    fn as_display_object(&self) -> Option<DisplayObject<'gc>>;
 
     /// Get the underlying executable for this object, if it exists.
     fn as_executable(&self) -> Option<Executable<'gc>>;

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -187,10 +187,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug {
     fn type_of(&self) -> &'static str;
 
     /// Get the underlying script object, if it exists.
-    fn as_script_object(&self) -> Option<&ScriptObject<'gc>>;
-
-    /// Get the underlying script object, if it exists.
-    fn as_script_object_mut(&mut self) -> Option<&mut ScriptObject<'gc>>;
+    fn as_script_object(&self) -> Option<ScriptObject<'gc>>;
 
     /// Get the underlying display node for this object, if it exists.
     fn as_display_node(&self) -> Option<DisplayObject<'gc>>;

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::Executable;
 use crate::avm1::property::Attribute;
 use crate::avm1::return_value::ReturnValue;
 use crate::avm1::{Avm1, Error, ScriptObject, UpdateContext, Value};
-use crate::display_object::DisplayNode;
+use crate::display_object::DisplayObject;
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
 use ruffle_macros::enum_trait_object;
@@ -193,7 +193,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug {
     fn as_script_object_mut(&mut self) -> Option<&mut ScriptObject<'gc>>;
 
     /// Get the underlying display node for this object, if it exists.
-    fn as_display_node(&self) -> Option<DisplayNode<'gc>>;
+    fn as_display_node(&self) -> Option<DisplayObject<'gc>>;
 
     /// Get the underlying executable for this object, if it exists.
     fn as_executable(&self) -> Option<Executable<'gc>>;

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -3,7 +3,7 @@
 use self::Attribute::*;
 use crate::avm1::function::Executable;
 use crate::avm1::return_value::ReturnValue;
-use crate::avm1::{Avm1, Error, ObjectCell, UpdateContext, Value};
+use crate::avm1::{Avm1, Error, Object, UpdateContext, Value};
 use core::fmt;
 use enumset::{EnumSet, EnumSetType};
 use std::mem::replace;
@@ -37,7 +37,7 @@ impl<'gc> Property<'gc> {
         &self,
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        this: ObjectCell<'gc>,
+        this: Object<'gc>,
     ) -> Result<ReturnValue<'gc>, Error> {
         match self {
             Property::Virtual { get, .. } => get.exec(avm, context, this, &[]),
@@ -55,7 +55,7 @@ impl<'gc> Property<'gc> {
         &mut self,
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        this: ObjectCell<'gc>,
+        this: Object<'gc>,
         new_value: impl Into<Value<'gc>>,
     ) -> Result<bool, Error> {
         match self {

--- a/core/src/avm1/return_value.rs
+++ b/core/src/avm1/return_value.rs
@@ -1,7 +1,7 @@
 //! Return value enum
 
 use crate::avm1::activation::Activation;
-use crate::avm1::{Avm1, Error, ObjectCell, Value};
+use crate::avm1::{Avm1, Error, Object, Value};
 use crate::context::UpdateContext;
 use gc_arena::{Collect, GcCell};
 use std::fmt;
@@ -112,6 +112,7 @@ impl<'gc> ReturnValue<'gc> {
     /// Panic if a value is not immediate.
     ///
     /// This should only be used in test assertions.
+    #[cfg(test)]
     pub fn unwrap_immediate(self) -> Value<'gc> {
         use ReturnValue::*;
 
@@ -146,8 +147,8 @@ impl<'gc> From<bool> for ReturnValue<'gc> {
     }
 }
 
-impl<'gc> From<ObjectCell<'gc>> for ReturnValue<'gc> {
-    fn from(object: ObjectCell<'gc>) -> Self {
+impl<'gc> From<Object<'gc>> for ReturnValue<'gc> {
+    fn from(object: Object<'gc>) -> Self {
         ReturnValue::Immediate(Value::Object(object))
     }
 }

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -1,10 +1,10 @@
 //! Represents AVM1 scope chain resolution.
 
 use crate::avm1::return_value::ReturnValue;
-use crate::avm1::{Avm1, Error, Object, ObjectCell, ScriptObject, UpdateContext, Value};
+use crate::avm1::{Avm1, Error, Object, ScriptObject, TObject, UpdateContext, Value};
 use enumset::EnumSet;
 use gc_arena::{GcCell, MutationContext};
-use std::cell::{Ref, RefMut};
+use std::cell::Ref;
 
 /// Indicates what kind of scope a scope is.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -30,7 +30,7 @@ pub enum ScopeClass {
 pub struct Scope<'gc> {
     parent: Option<GcCell<'gc, Scope<'gc>>>,
     class: ScopeClass,
-    values: ObjectCell<'gc>,
+    values: Object<'gc>,
 }
 
 unsafe impl<'gc> gc_arena::Collect for Scope<'gc> {
@@ -43,7 +43,7 @@ unsafe impl<'gc> gc_arena::Collect for Scope<'gc> {
 
 impl<'gc> Scope<'gc> {
     /// Construct a global scope (one without a parent).
-    pub fn from_global_object(globals: ObjectCell<'gc>) -> Scope<'gc> {
+    pub fn from_global_object(globals: Object<'gc>) -> Scope<'gc> {
         Scope {
             parent: None,
             class: ScopeClass::Global,
@@ -119,7 +119,7 @@ impl<'gc> Scope<'gc> {
     /// scope has been replaced with another given object.
     pub fn new_target_scope(
         mut parent: GcCell<'gc, Self>,
-        clip: ObjectCell<'gc>,
+        clip: Object<'gc>,
         mc: MutationContext<'gc, '_>,
     ) -> GcCell<'gc, Self> {
         let mut bottom_scope = None;
@@ -176,7 +176,7 @@ impl<'gc> Scope<'gc> {
     /// scope. This requires some scope chain juggling.
     pub fn new_with_scope(
         locals: GcCell<'gc, Self>,
-        with_object: ObjectCell<'gc>,
+        with_object: Object<'gc>,
         mc: MutationContext<'gc, '_>,
     ) -> GcCell<'gc, Self> {
         let parent_scope = locals.read().parent;
@@ -204,7 +204,7 @@ impl<'gc> Scope<'gc> {
     pub fn new(
         parent: GcCell<'gc, Self>,
         class: ScopeClass,
-        with_object: ObjectCell<'gc>,
+        with_object: Object<'gc>,
     ) -> Scope<'gc> {
         Scope {
             parent: Some(parent),
@@ -214,18 +214,14 @@ impl<'gc> Scope<'gc> {
     }
 
     /// Returns a reference to the current local scope object.
-    pub fn locals(&self) -> Ref<Box<dyn Object<'gc>>> {
-        self.values.read()
-    }
-
-    /// Returns a gc cell of the current local scope object.
-    pub fn locals_cell(&self) -> ObjectCell<'gc> {
-        self.values.to_owned()
+    pub fn locals(&self) -> &Object<'gc> {
+        &self.values
     }
 
     /// Returns a reference to the current local scope object for mutation.
-    pub fn locals_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<Box<dyn Object<'gc>>> {
-        self.values.write(mc)
+    #[allow(dead_code)]
+    pub fn locals_mut(&mut self) -> &mut Object<'gc> {
+        &mut self.values
     }
 
     /// Returns a reference to the parent scope object.
@@ -246,7 +242,7 @@ impl<'gc> Scope<'gc> {
         name: &str,
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        this: ObjectCell<'gc>,
+        this: Object<'gc>,
     ) -> Result<ReturnValue<'gc>, Error> {
         if self.locals().has_property(name) {
             return self.locals().get(name, avm, context, this);
@@ -286,11 +282,10 @@ impl<'gc> Scope<'gc> {
         value: Value<'gc>,
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        this: ObjectCell<'gc>,
+        this: Object<'gc>,
     ) -> Result<Option<Value<'gc>>, Error> {
         if self.locals().has_property(name) && self.locals().is_property_overwritable(name) {
-            self.locals_mut(context.gc_context)
-                .set(name, value, avm, context, this)?;
+            self.locals().set(name, value, avm, context, this)?;
             return Ok(None);
         }
 
@@ -308,14 +303,14 @@ impl<'gc> Scope<'gc> {
     /// chain. As a result, this function always force sets a property on the
     /// local object and does not traverse the scope chain.
     pub fn define(&self, name: &str, value: impl Into<Value<'gc>>, mc: MutationContext<'gc, '_>) {
-        self.locals_mut(mc)
-            .define_value(name, value.into(), EnumSet::empty());
+        self.locals()
+            .define_value(mc, name, value.into(), EnumSet::empty());
     }
 
     /// Delete a value from scope
     pub fn delete(&self, name: &str, mc: MutationContext<'gc, '_>) -> bool {
         if self.locals().has_property(name) {
-            return self.locals_mut(mc).delete(name);
+            return self.locals().delete(mc, name);
         }
 
         if let Some(scope) = self.parent() {

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -245,7 +245,7 @@ impl<'gc> Scope<'gc> {
         this: Object<'gc>,
     ) -> Result<ReturnValue<'gc>, Error> {
         if self.locals().has_property(name) {
-            return self.locals().get(name, avm, context, this);
+            return self.locals().get(name, avm, context);
         }
         if let Some(scope) = self.parent() {
             return scope.resolve(name, avm, context, this);
@@ -285,7 +285,7 @@ impl<'gc> Scope<'gc> {
         this: Object<'gc>,
     ) -> Result<Option<Value<'gc>>, Error> {
         if self.locals().has_property(name) && self.locals().is_property_overwritable(name) {
-            self.locals().set(name, value, avm, context, this)?;
+            self.locals().set(name, value, avm, context)?;
             return Ok(None);
         }
 

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -19,7 +19,7 @@ pub struct ScriptObject<'gc>(GcCell<'gc, ScriptObjectData<'gc>>);
 
 pub struct ScriptObjectData<'gc> {
     prototype: Option<Object<'gc>>,
-    display_node: Option<DisplayObject<'gc>>,
+    display_object: Option<DisplayObject<'gc>>,
     values: HashMap<String, Property<'gc>>,
     function: Option<Executable<'gc>>,
     type_of: &'static str,
@@ -28,7 +28,7 @@ pub struct ScriptObjectData<'gc> {
 unsafe impl<'gc> Collect for ScriptObjectData<'gc> {
     fn trace(&self, cc: gc_arena::CollectionContext) {
         self.prototype.trace(cc);
-        self.display_node.trace(cc);
+        self.display_object.trace(cc);
         self.values.trace(cc);
         self.function.trace(cc);
     }
@@ -38,7 +38,7 @@ impl fmt::Debug for ScriptObjectData<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Object")
             .field("prototype", &self.prototype)
-            .field("display_node", &self.display_node)
+            .field("display_object", &self.display_object)
             .field("values", &self.values)
             .field("function", &self.function.is_some())
             .finish()
@@ -55,7 +55,7 @@ impl<'gc> ScriptObject<'gc> {
             ScriptObjectData {
                 prototype: proto,
                 type_of: TYPE_OF_OBJECT,
-                display_node: None,
+                display_object: None,
                 values: HashMap::new(),
                 function: None,
             },
@@ -72,7 +72,7 @@ impl<'gc> ScriptObject<'gc> {
             ScriptObjectData {
                 prototype: proto,
                 type_of: TYPE_OF_OBJECT,
-                display_node: None,
+                display_object: None,
                 values: HashMap::new(),
                 function: None,
             },
@@ -91,7 +91,7 @@ impl<'gc> ScriptObject<'gc> {
             ScriptObjectData {
                 prototype: None,
                 type_of: TYPE_OF_OBJECT,
-                display_node: None,
+                display_object: None,
                 values: HashMap::new(),
                 function: None,
             },
@@ -110,7 +110,7 @@ impl<'gc> ScriptObject<'gc> {
                 prototype: fn_proto,
                 type_of: TYPE_OF_FUNCTION,
                 function: Some(function.into()),
-                display_node: None,
+                display_object: None,
                 values: HashMap::new(),
             },
         ))
@@ -146,17 +146,17 @@ impl<'gc> ScriptObject<'gc> {
         function
     }
 
-    pub fn set_display_node(
+    pub fn set_display_object(
         self,
         gc_context: MutationContext<'gc, '_>,
-        display_node: DisplayObject<'gc>,
+        display_object: DisplayObject<'gc>,
     ) {
-        self.0.write(gc_context).display_node = Some(display_node);
+        self.0.write(gc_context).display_object = Some(display_object);
     }
 
     #[allow(dead_code)]
-    pub fn display_node(self) -> Option<DisplayObject<'gc>> {
-        self.0.read().display_node
+    pub fn display_object(self) -> Option<DisplayObject<'gc>> {
+        self.0.read().display_object
     }
 
     /// Declare a native function on the current object.
@@ -411,8 +411,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         Some(*self)
     }
     /// Get the underlying display node for this object, if it exists.
-    fn as_display_node(&self) -> Option<DisplayObject<'gc>> {
-        self.0.read().display_node
+    fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
+        self.0.read().display_object
     }
 
     /// Returns a copy of a given function.

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -480,6 +480,7 @@ mod tests {
                 renderer: &mut NullRenderer::new(),
                 swf_data: &mut Arc::new(vec![]),
                 system_prototypes: avm.prototypes().clone(),
+                mouse_hovered_object: None,
             };
 
             let object = ScriptObject::object(gc_context, Some(avm.prototypes().object)).into();

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -155,7 +155,7 @@ impl<'gc> ScriptObject<'gc> {
     }
 
     #[allow(dead_code)]
-    pub fn display_node(&self) -> Option<DisplayObject<'gc>> {
+    pub fn display_node(self) -> Option<DisplayObject<'gc>> {
         self.0.read().display_node
     }
 
@@ -407,14 +407,9 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         self.0.read().type_of
     }
 
-    fn as_script_object(&self) -> Option<&ScriptObject<'gc>> {
-        Some(self)
+    fn as_script_object(&self) -> Option<ScriptObject<'gc>> {
+        Some(*self)
     }
-
-    fn as_script_object_mut(&mut self) -> Option<&mut ScriptObject<'gc>> {
-        Some(self)
-    }
-
     /// Get the underlying display node for this object, if it exists.
     fn as_display_node(&self) -> Option<DisplayObject<'gc>> {
         self.0.read().display_node
@@ -507,8 +502,8 @@ mod tests {
 
     #[test]
     fn test_set_get() {
-        with_object(0, |avm, context, mut object| {
-            object.as_script_object_mut().unwrap().define_value(
+        with_object(0, |avm, context, object| {
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "forced",
                 "forced".into(),
@@ -531,14 +526,14 @@ mod tests {
 
     #[test]
     fn test_set_readonly() {
-        with_object(0, |avm, context, mut object| {
-            object.as_script_object_mut().unwrap().define_value(
+        with_object(0, |avm, context, object| {
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "normal",
                 "initial".into(),
                 EnumSet::empty(),
             );
-            object.as_script_object_mut().unwrap().define_value(
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "readonly",
                 "initial".into(),
@@ -565,8 +560,8 @@ mod tests {
 
     #[test]
     fn test_deletable_not_readonly() {
-        with_object(0, |avm, context, mut object| {
-            object.as_script_object_mut().unwrap().define_value(
+        with_object(0, |avm, context, object| {
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "test",
                 "initial".into(),
@@ -581,7 +576,7 @@ mod tests {
 
             let this = object;
             object
-                .as_script_object_mut()
+                .as_script_object()
                 .unwrap()
                 .set("test", "replaced".into(), avm, context, this)
                 .unwrap();
@@ -596,12 +591,12 @@ mod tests {
 
     #[test]
     fn test_virtual_get() {
-        with_object(0, |avm, context, mut object| {
+        with_object(0, |avm, context, object| {
             let getter = Executable::Native(|_avm, _context, _this, _args| {
                 Ok(ReturnValue::Immediate("Virtual!".into()))
             });
 
-            object.as_script_object_mut().unwrap().add_property(
+            object.as_script_object().unwrap().add_property(
                 context.gc_context,
                 "test",
                 getter,
@@ -627,32 +622,32 @@ mod tests {
 
     #[test]
     fn test_delete() {
-        with_object(0, |avm, context, mut object| {
+        with_object(0, |avm, context, object| {
             let getter = Executable::Native(|_avm, _context, _this, _args| {
                 Ok(ReturnValue::Immediate("Virtual!".into()))
             });
 
-            object.as_script_object_mut().unwrap().add_property(
+            object.as_script_object().unwrap().add_property(
                 context.gc_context,
                 "virtual",
                 getter.clone(),
                 None,
                 EnumSet::empty(),
             );
-            object.as_script_object_mut().unwrap().add_property(
+            object.as_script_object().unwrap().add_property(
                 context.gc_context,
                 "virtual_un",
                 getter,
                 None,
                 DontDelete.into(),
             );
-            object.as_script_object_mut().unwrap().define_value(
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "stored",
                 "Stored!".into(),
                 EnumSet::empty(),
             );
-            object.as_script_object_mut().unwrap().define_value(
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "stored_un",
                 "Stored!".into(),
@@ -686,31 +681,31 @@ mod tests {
 
     #[test]
     fn test_iter_values() {
-        with_object(0, |_avm, context, mut object| {
+        with_object(0, |_avm, context, object| {
             let getter = Executable::Native(|_avm, _context, _this, _args| {
                 Ok(ReturnValue::Immediate(Value::Null))
             });
 
-            object.as_script_object_mut().unwrap().define_value(
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "stored",
                 Value::Null,
                 EnumSet::empty(),
             );
-            object.as_script_object_mut().unwrap().define_value(
+            object.as_script_object().unwrap().define_value(
                 context.gc_context,
                 "stored_hidden",
                 Value::Null,
                 DontEnum.into(),
             );
-            object.as_script_object_mut().unwrap().add_property(
+            object.as_script_object().unwrap().add_property(
                 context.gc_context,
                 "virtual",
                 getter.clone(),
                 None,
                 EnumSet::empty(),
             );
-            object.as_script_object_mut().unwrap().add_property(
+            object.as_script_object().unwrap().add_property(
                 context.gc_context,
                 "virtual_hidden",
                 getter,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -4,7 +4,7 @@ use crate::backend::audio::NullAudioBackend;
 use crate::backend::navigator::NullNavigatorBackend;
 use crate::backend::render::NullRenderer;
 use crate::context::ActionQueue;
-use crate::display_object::{DisplayObject, MovieClip};
+use crate::display_object::{MovieClip, TDisplayObject};
 use crate::library::Library;
 use crate::prelude::*;
 use gc_arena::{rootless_arena, GcCell, MutationContext};
@@ -20,8 +20,7 @@ where
         F: for<'a> FnOnce(&mut Avm1<'gc>, &mut UpdateContext<'a, 'gc, '_>, Object<'gc>) -> R,
     {
         let mut avm = Avm1::new(gc_context, swf_version);
-        let movie_clip: Box<dyn DisplayObject> = Box::new(MovieClip::new(swf_version, gc_context));
-        let root = GcCell::allocate(gc_context, movie_clip);
+        let root = MovieClip::new(swf_version, gc_context).into();
         let mut context = UpdateContext {
             gc_context,
             global_time: 0,
@@ -54,7 +53,7 @@ where
             Activation::from_nothing(swf_version, globals, gc_context),
         ));
 
-        let this = root.read().object().as_object().unwrap();
+        let this = root.object().as_object().unwrap();
 
         test(&mut avm, &mut context, this)
     }

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -71,7 +71,7 @@ macro_rules! test_method {
                 for version in &$versions {
                     let _ = with_avm(*version, |avm, context, _root| -> Result<(), Error> {
                         let object = $object(avm, context);
-                        let function = object.get($name, avm, context, object)?.unwrap_immediate();
+                        let function = object.get($name, avm, context)?.unwrap_immediate();
 
                         $(
                             #[allow(unused_mut)]

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -45,6 +45,7 @@ where
             renderer: &mut NullRenderer::new(),
             swf_data: &mut Arc::new(vec![]),
             system_prototypes: avm.prototypes().clone(),
+            mouse_hovered_object: None,
         };
 
         let globals = avm.global_object_cell();

--- a/core/src/avm1/tests.rs
+++ b/core/src/avm1/tests.rs
@@ -1,5 +1,6 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::test_utils::with_avm;
+use crate::avm1::TObject;
 use gc_arena::GcCell;
 
 #[test]
@@ -7,14 +8,12 @@ fn locals_into_form_values() {
     with_avm(19, |avm, context, _this| {
         let my_activation =
             Activation::from_nothing(19, avm.global_object_cell(), context.gc_context);
-        let my_locals = my_activation.scope().locals_cell();
+        let my_locals = my_activation.scope().locals().to_owned();
 
         my_locals
-            .write(context.gc_context)
             .set("value1", "string".into(), avm, context, my_locals)
             .unwrap();
         my_locals
-            .write(context.gc_context)
             .set("value2", 2.0.into(), avm, context, my_locals)
             .unwrap();
 

--- a/core/src/avm1/tests.rs
+++ b/core/src/avm1/tests.rs
@@ -11,11 +11,9 @@ fn locals_into_form_values() {
         let my_locals = my_activation.scope().locals().to_owned();
 
         my_locals
-            .set("value1", "string".into(), avm, context, my_locals)
+            .set("value1", "string".into(), avm, context)
             .unwrap();
-        my_locals
-            .set("value2", 2.0.into(), avm, context, my_locals)
-            .unwrap();
+        my_locals.set("value2", 2.0.into(), avm, context).unwrap();
 
         avm.insert_stack_frame(GcCell::allocate(context.gc_context, my_activation));
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -211,9 +211,7 @@ impl<'gc> Value<'gc> {
     ) -> Result<Value<'gc>, Error> {
         Ok(match self {
             Value::Object(object) => {
-                let value_of_impl = object
-                    .get("valueOf", avm, context, *object)?
-                    .resolve(avm, context)?;
+                let value_of_impl = object.get("valueOf", avm, context)?.resolve(avm, context)?;
 
                 let fake_args = Vec::new();
                 value_of_impl
@@ -387,7 +385,7 @@ impl<'gc> Value<'gc> {
         Ok(match self {
             Value::Object(object) => {
                 let to_string_impl = object
-                    .get("toString", avm, context, object)?
+                    .get("toString", avm, context)?
                     .resolve(avm, context)?;
                 let fake_args = Vec::new();
                 match to_string_impl

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -57,23 +57,25 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// The RNG, used by the AVM `RandomNumber` opcode,  `Math.random(),` and `random()`.
     pub rng: &'a mut SmallRng,
 
-    /// The `DisplayObject` that this code is running in.
-    /// Used by all `DisplayObject` methods and AVM1 `GetVariable`/`SetVariable`/`this`.
-    pub active_clip: DisplayObject<'gc>,
-
     /// The root of the current timeline.
     /// This will generally be `_level0`, except for loadMovie/loadMovieNum.
     pub root: DisplayObject<'gc>,
 
-    /// The base clip for Flash 4-era actions.
-    /// Used by `Play`, `GetProperty`, etc.
-    pub start_clip: DisplayObject<'gc>,
+    /// The `DisplayObject` that this code is running in.
+    /// Used by all `DisplayObject` methods and AVM1 `GetVariable`/`SetVariable`/`this`.
+    /// Can be changed via a `SetTarget` action.
+    /// This will be `root` after an invalid tell target.
+    pub active_clip: DisplayObject<'gc>,
 
-    /// The object targeted with `tellTarget`.
-    /// This is used for Flash 4-era actions, such as
-    /// `Play`, `GetProperty`, etc.
-    /// This will be `None` after an invalid tell target.
+    /// Target clip used by Flash 4-era actions (`Play` etc.)
+    /// Can be changed via a `SetTarget` action.
+    /// This is the same as `active_clip` except in the cases of an invalid tell target:
+    /// This is `None` after an invalid tell target.
     pub target_clip: Option<DisplayObject<'gc>>,
+
+    /// The initial target clip.
+    /// `target_clip` will reset to this value with `SetTarget ""` action.
+    pub start_clip: DisplayObject<'gc>,
 
     /// The last path string used by `tellTarget`.
     /// Returned by `GetProperty`.

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -85,6 +85,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// The current set of system-specified prototypes to use when constructing
     /// new built-in objects.
     pub system_prototypes: avm1::SystemPrototypes<'gc>,
+
+    /// The display object that the mouse is currently hovering over.
+    pub mouse_hovered_object: Option<DisplayObject<'gc>>,
 }
 
 /// A queued ActionScript call.

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -57,23 +57,23 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// The RNG, used by the AVM `RandomNumber` opcode,  `Math.random(),` and `random()`.
     pub rng: &'a mut SmallRng,
 
-    /// The `DisplayNode` that this code is running in.
+    /// The `DisplayObject` that this code is running in.
     /// Used by all `DisplayObject` methods and AVM1 `GetVariable`/`SetVariable`/`this`.
-    pub active_clip: DisplayNode<'gc>,
+    pub active_clip: DisplayObject<'gc>,
 
     /// The root of the current timeline.
     /// This will generally be `_level0`, except for loadMovie/loadMovieNum.
-    pub root: DisplayNode<'gc>,
+    pub root: DisplayObject<'gc>,
 
     /// The base clip for Flash 4-era actions.
     /// Used by `Play`, `GetProperty`, etc.
-    pub start_clip: DisplayNode<'gc>,
+    pub start_clip: DisplayObject<'gc>,
 
     /// The object targeted with `tellTarget`.
     /// This is used for Flash 4-era actions, such as
     /// `Play`, `GetProperty`, etc.
     /// This will be `None` after an invalid tell target.
-    pub target_clip: Option<DisplayNode<'gc>>,
+    pub target_clip: Option<DisplayObject<'gc>>,
 
     /// The last path string used by `tellTarget`.
     /// Returned by `GetProperty`.
@@ -90,7 +90,7 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 /// A queued ActionScript call.
 pub struct QueuedActions<'gc> {
     /// The movie clip this ActionScript is running on.
-    pub clip: DisplayNode<'gc>,
+    pub clip: DisplayObject<'gc>,
 
     /// The ActionScript bytecode.
     pub actions: SwfSlice,
@@ -117,7 +117,7 @@ impl<'gc> ActionQueue<'gc> {
     /// Queues ActionScript to run for the given movie clip.
     /// `actions` is the slice of ActionScript bytecode to run.
     /// The actions will be skipped if the clip is removed before the actions run.
-    pub fn queue_actions(&mut self, clip: DisplayNode<'gc>, actions: SwfSlice, is_init: bool) {
+    pub fn queue_actions(&mut self, clip: DisplayObject<'gc>, actions: SwfSlice, is_init: bool) {
         self.queue.push_back(QueuedActions {
             clip,
             actions,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -240,22 +240,13 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug {
     fn run_frame(&mut self, _context: &mut UpdateContext<'_, 'gc, '_>) {}
     fn render(&self, _context: &mut RenderContext<'_, 'gc>) {}
 
-    fn as_button(&self) -> Option<&Button<'gc>> {
+    fn as_button(&self) -> Option<Button<'gc>> {
         None
     }
-    fn as_button_mut(&mut self) -> Option<&mut Button<'gc>> {
+    fn as_movie_clip(&self) -> Option<MovieClip<'gc>> {
         None
     }
-    fn as_movie_clip(&self) -> Option<&MovieClip<'gc>> {
-        None
-    }
-    fn as_movie_clip_mut(&mut self) -> Option<&mut MovieClip<'gc>> {
-        None
-    }
-    fn as_morph_shape(&self) -> Option<&MorphShape<'gc>> {
-        None
-    }
-    fn as_morph_shape_mut(&mut self) -> Option<&mut MorphShape<'gc>> {
+    fn as_morph_shape(&self) -> Option<MorphShape<'gc>> {
         None
     }
     fn apply_place_object(
@@ -276,7 +267,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug {
             self.set_clip_depth(gc_context, clip_depth);
         }
         if let Some(ratio) = place_object.ratio {
-            if let Some(morph_shape) = self.as_morph_shape_mut() {
+            if let Some(mut morph_shape) = self.as_morph_shape() {
                 morph_shape.set_ratio(gc_context, ratio);
             }
         }
@@ -292,7 +283,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug {
         self.set_color_transform(gc_context, &*other.color_transform());
         self.set_clip_depth(gc_context, other.clip_depth());
         self.set_name(gc_context, &*other.name());
-        if let (Some(me), Some(other)) = (self.as_morph_shape_mut(), other.as_morph_shape()) {
+        if let (Some(mut me), Some(other)) = (self.as_morph_shape(), other.as_morph_shape()) {
             me.set_ratio(gc_context, other.ratio());
         }
         // TODO: More in here eventually.

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{ObjectCell, Value};
+use crate::avm1::{Object, Value};
 use crate::context::{RenderContext, UpdateContext};
 use crate::player::NEWEST_PLAYER_VERSION;
 use crate::prelude::*;
@@ -259,7 +259,7 @@ pub trait DisplayObject<'gc>: 'gc + Collect + Debug {
         &mut self,
         _gc_context: MutationContext<'gc, '_>,
         _display_object: DisplayNode<'gc>,
-        _proto: ObjectCell<'gc>,
+        _proto: Object<'gc>,
     ) {
     }
 

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -122,12 +122,8 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         }
     }
 
-    fn as_button(&self) -> Option<&Self> {
-        Some(self)
-    }
-
-    fn as_button_mut(&mut self) -> Option<&mut Self> {
-        Some(self)
+    fn as_button(&self) -> Option<Self> {
+        Some(*self)
     }
 }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -47,12 +47,8 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         self.0.read().static_data.id
     }
 
-    fn as_morph_shape(&self) -> Option<&Self> {
-        Some(self)
-    }
-
-    fn as_morph_shape_mut(&mut self) -> Option<&mut Self> {
-        Some(self)
+    fn as_morph_shape(&self) -> Option<Self> {
+        Some(*self)
     }
 
     fn run_frame(&mut self, _context: &mut UpdateContext) {

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -1,13 +1,18 @@
 use crate::backend::render::{RenderBackend, ShapeHandle};
 use crate::context::{RenderContext, UpdateContext};
-use crate::display_object::{DisplayObject, DisplayObjectBase};
+use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::prelude::*;
+use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use swf::Twips;
 
+#[derive(Clone, Debug, Collect, Copy)]
+#[collect(no_drop)]
+pub struct MorphShape<'gc>(GcCell<'gc, MorphShapeData<'gc>>);
+
 #[derive(Clone, Debug)]
-pub struct MorphShape<'gc> {
+pub struct MorphShapeData<'gc> {
     base: DisplayObjectBase<'gc>,
-    static_data: gc_arena::Gc<'gc, MorphShapeStatic>,
+    static_data: Gc<'gc, MorphShapeStatic>,
     ratio: u16,
 }
 
@@ -16,27 +21,30 @@ impl<'gc> MorphShape<'gc> {
         gc_context: gc_arena::MutationContext<'gc, '_>,
         static_data: MorphShapeStatic,
     ) -> Self {
-        Self {
-            base: Default::default(),
-            static_data: gc_arena::Gc::allocate(gc_context, static_data),
-            ratio: 0,
-        }
+        MorphShape(GcCell::allocate(
+            gc_context,
+            MorphShapeData {
+                base: Default::default(),
+                static_data: Gc::allocate(gc_context, static_data),
+                ratio: 0,
+            },
+        ))
     }
 
-    pub fn ratio(&self) -> u16 {
-        self.ratio
+    pub fn ratio(self) -> u16 {
+        self.0.read().ratio
     }
 
-    pub fn set_ratio(&mut self, ratio: u16) {
-        self.ratio = ratio;
+    pub fn set_ratio(&mut self, gc_context: MutationContext<'gc, '_>, ratio: u16) {
+        self.0.write(gc_context).ratio = ratio;
     }
 }
 
-impl<'gc> DisplayObject<'gc> for MorphShape<'gc> {
+impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
     impl_display_object!(base);
 
     fn id(&self) -> CharacterId {
-        self.static_data.id
+        self.0.read().static_data.id
     }
 
     fn as_morph_shape(&self) -> Option<&Self> {
@@ -52,9 +60,9 @@ impl<'gc> DisplayObject<'gc> for MorphShape<'gc> {
     }
 
     fn render(&self, context: &mut RenderContext) {
-        context.transform_stack.push(self.transform());
+        context.transform_stack.push(&*self.transform());
 
-        if let Some(shape) = self.static_data.frames.get(&self.ratio) {
+        if let Some(shape) = self.0.read().static_data.frames.get(&self.ratio()) {
             context
                 .renderer
                 .render_shape(*shape, context.transform_stack.transform());
@@ -66,7 +74,7 @@ impl<'gc> DisplayObject<'gc> for MorphShape<'gc> {
     }
 }
 
-unsafe impl<'gc> gc_arena::Collect for MorphShape<'gc> {
+unsafe impl<'gc> gc_arena::Collect for MorphShapeData<'gc> {
     #[inline]
     fn trace(&self, cc: gc_arena::CollectionContext) {
         self.base.trace(cc);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -271,12 +271,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         None
     }
 
-    fn as_movie_clip(&self) -> Option<&MovieClip<'gc>> {
-        Some(self)
-    }
-
-    fn as_movie_clip_mut(&mut self) -> Option<&mut MovieClip<'gc>> {
-        Some(self)
+    fn as_movie_clip(&self) -> Option<MovieClip<'gc>> {
+        Some(*self)
     }
 
     fn post_instantiation(
@@ -285,8 +281,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         display_object: DisplayObject<'gc>,
         proto: Object<'gc>,
     ) {
-        let mut mc = self.0.write(gc_context);
-        let object = mc.object.as_script_object_mut().unwrap();
+        let mc = self.0.write(gc_context);
+        let mut object = mc.object.as_script_object().unwrap();
         object.set_display_node(gc_context, display_object);
         object.set_type_of(gc_context, TYPE_OF_MOVIE_CLIP);
         object.set_prototype(gc_context, proto);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -283,7 +283,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     ) {
         let mc = self.0.write(gc_context);
         let mut object = mc.object.as_script_object().unwrap();
-        object.set_display_node(gc_context, display_object);
+        object.set_display_object(gc_context, display_object);
         object.set_type_of(gc_context, TYPE_OF_MOVIE_CLIP);
         object.set_prototype(gc_context, proto);
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1,6 +1,6 @@
 //! `MovieClip` display object and support code.
 use crate::avm1::script_object::TYPE_OF_MOVIE_CLIP;
-use crate::avm1::{ObjectCell, ScriptObject, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::backend::audio::AudioStreamHandle;
 use crate::character::Character;
 use crate::context::{RenderContext, UpdateContext};
@@ -33,7 +33,7 @@ pub struct MovieClip<'gc> {
     current_frame: FrameNumber,
     audio_stream: Option<AudioStreamHandle>,
     children: BTreeMap<Depth, DisplayNode<'gc>>,
-    object: ObjectCell<'gc>,
+    object: Object<'gc>,
 }
 
 impl<'gc> MovieClip<'gc> {
@@ -47,7 +47,7 @@ impl<'gc> MovieClip<'gc> {
             current_frame: 0,
             audio_stream: None,
             children: BTreeMap::new(),
-            object: GcCell::allocate(gc_context, Box::new(ScriptObject::bare_object())),
+            object: ScriptObject::bare_object(gc_context).into(),
         }
     }
 
@@ -78,7 +78,7 @@ impl<'gc> MovieClip<'gc> {
             current_frame: 0,
             audio_stream: None,
             children: BTreeMap::new(),
-            object: GcCell::allocate(gc_context, Box::new(ScriptObject::bare_object())),
+            object: ScriptObject::bare_object(gc_context).into(),
         }
     }
 
@@ -626,18 +626,12 @@ impl<'gc> DisplayObject<'gc> for MovieClip<'gc> {
         &mut self,
         gc_context: MutationContext<'gc, '_>,
         display_object: DisplayNode<'gc>,
-        proto: ObjectCell<'gc>,
+        proto: Object<'gc>,
     ) {
-        let mut object = self.object.write(gc_context);
-        object
-            .as_script_object_mut()
-            .unwrap()
-            .set_display_node(display_object);
-        object
-            .as_script_object_mut()
-            .unwrap()
-            .set_type_of(TYPE_OF_MOVIE_CLIP);
-        object.as_script_object_mut().unwrap().set_prototype(proto);
+        let object = self.object.as_script_object_mut().unwrap();
+        object.set_display_node(gc_context, display_object);
+        object.set_type_of(gc_context, TYPE_OF_MOVIE_CLIP);
+        object.set_prototype(gc_context, proto);
     }
 
     fn object(&self) -> Value<'gc> {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -16,6 +16,7 @@ pub enum PlayerEvent {
 /// }
 /// ```
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ButtonEvent {
     Press,
     Release,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unneeded_field_pattern)]
+#![allow(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
 mod display_object;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::unneeded_field_pattern)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
 
 #[macro_use]
 mod display_object;

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -2,10 +2,10 @@ use crate::avm1::globals::SystemPrototypes;
 use crate::avm1::Object;
 use crate::backend::audio::SoundHandle;
 use crate::character::Character;
-use crate::display_object::DisplayObject;
+use crate::display_object::TDisplayObject;
 use crate::font::Font;
 use crate::prelude::*;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::MutationContext;
 use std::collections::HashMap;
 use swf::CharacterId;
 
@@ -37,10 +37,12 @@ impl<'gc> Library<'gc> {
         self.characters.contains_key(&id)
     }
 
+    #[allow(dead_code)]
     pub fn get_character(&self, id: CharacterId) -> Option<&Character<'gc>> {
         self.characters.get(&id)
     }
 
+    #[allow(dead_code)]
     pub fn get_character_mut(&mut self, id: CharacterId) -> Option<&mut Character<'gc>> {
         self.characters.get_mut(&id)
     }
@@ -50,29 +52,31 @@ impl<'gc> Library<'gc> {
         id: CharacterId,
         gc_context: MutationContext<'gc, '_>,
         prototypes: &SystemPrototypes<'gc>,
-    ) -> Result<DisplayNode<'gc>, Box<dyn std::error::Error>> {
-        let (obj, proto): (Box<dyn DisplayObject<'gc>>, Object<'gc>) = match self
-            .characters
-            .get(&id)
-        {
-            Some(Character::Bitmap(bitmap)) => (bitmap.clone(), prototypes.object),
-            Some(Character::EditText(edit_text)) => (edit_text.clone(), prototypes.object),
-            Some(Character::Graphic(graphic)) => (graphic.clone(), prototypes.object),
-            Some(Character::MorphShape(morph_shape)) => (morph_shape.clone(), prototypes.object),
-            Some(Character::MovieClip(movie_clip)) => (movie_clip.clone(), prototypes.movie_clip),
-            Some(Character::Button(button)) => (button.clone(), prototypes.object),
-            Some(Character::Text(text)) => (text.clone(), prototypes.object),
+    ) -> Result<DisplayObject<'gc>, Box<dyn std::error::Error>> {
+        let (mut obj, proto): (DisplayObject<'gc>, Object<'gc>) = match self.characters.get(&id) {
+            Some(Character::Bitmap(bitmap)) => (bitmap.instantiate(gc_context), prototypes.object),
+            Some(Character::EditText(edit_text)) => {
+                (edit_text.instantiate(gc_context), prototypes.object)
+            }
+            Some(Character::Graphic(graphic)) => {
+                (graphic.instantiate(gc_context), prototypes.object)
+            }
+            Some(Character::MorphShape(morph_shape)) => {
+                (morph_shape.instantiate(gc_context), prototypes.object)
+            }
+            Some(Character::MovieClip(movie_clip)) => {
+                (movie_clip.instantiate(gc_context), prototypes.movie_clip)
+            }
+            Some(Character::Button(button)) => (button.instantiate(gc_context), prototypes.object),
+            Some(Character::Text(text)) => (text.instantiate(gc_context), prototypes.object),
             Some(_) => return Err("Not a DisplayObject".into()),
             None => {
                 log::error!("Tried to instantiate non-registered character ID {}", id);
                 return Err("Character id doesn't exist".into());
             }
         };
-        let result = GcCell::allocate(gc_context, obj);
-        result
-            .write(gc_context)
-            .post_instantiation(gc_context, result, proto);
-        Ok(result)
+        obj.post_instantiation(gc_context, obj, proto);
+        Ok(obj)
     }
 
     pub fn get_font(&self, id: CharacterId) -> Option<&Font> {

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -1,5 +1,5 @@
 use crate::avm1::globals::SystemPrototypes;
-use crate::avm1::ObjectCell;
+use crate::avm1::Object;
 use crate::backend::audio::SoundHandle;
 use crate::character::Character;
 use crate::display_object::DisplayObject;
@@ -51,7 +51,7 @@ impl<'gc> Library<'gc> {
         gc_context: MutationContext<'gc, '_>,
         prototypes: &SystemPrototypes<'gc>,
     ) -> Result<DisplayNode<'gc>, Box<dyn std::error::Error>> {
-        let (obj, proto): (Box<dyn DisplayObject<'gc>>, ObjectCell<'gc>) = match self
+        let (obj, proto): (Box<dyn DisplayObject<'gc>>, Object<'gc>) = match self
             .characters
             .get(&id)
         {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -326,14 +326,12 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                         PlayerEvent::MouseDown { .. } => {
                             is_mouse_down = true;
                             needs_render = true;
-                            context.active_clip = node;
                             button.handle_button_event(context, ButtonEvent::Press);
                         }
 
                         PlayerEvent::MouseUp { .. } => {
                             is_mouse_down = false;
                             needs_render = true;
-                            context.active_clip = node;
                             button.handle_button_event(context, ButtonEvent::Release);
                         }
 
@@ -366,7 +364,6 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                 // RollOut of previous node.
                 if let Some(mut node) = cur_hovered {
                     if let Some(mut button) = node.as_button_mut().copied() {
-                        context.active_clip = node;
                         button.handle_button_event(context, ButtonEvent::RollOut);
                     }
                 }
@@ -374,7 +371,6 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                 // RollOver on new node.
                 if let Some(mut node) = new_hovered {
                     if let Some(mut button) = node.as_button_mut().copied() {
-                        context.active_clip = node;
                         button.handle_button_event(context, ButtonEvent::RollOver);
                     }
                 }
@@ -490,18 +486,20 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                 continue;
             }
 
-            context.start_clip = actions.clip;
-            context.active_clip = actions.clip;
-            context.target_clip = Some(actions.clip);
-
             if actions.is_init {
                 avm.insert_stack_frame_for_init_action(
+                    actions.clip,
                     context.swf_version,
                     actions.actions,
                     context,
                 );
             } else {
-                avm.insert_stack_frame_for_action(context.swf_version, actions.actions, context);
+                avm.insert_stack_frame_for_action(
+                    actions.clip,
+                    context.swf_version,
+                    actions.actions,
+                    context,
+                );
             }
             let _ = avm.run_stack_till_empty(context);
         }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -321,7 +321,7 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
         let mut is_mouse_down = self.is_mouse_down;
         self.mutate_with_update_context(|avm, context| {
             if let Some(node) = context.mouse_hovered_object {
-                if let Some(button) = node.clone().as_button_mut() {
+                if let Some(mut button) = node.clone().as_button() {
                     match event {
                         PlayerEvent::MouseDown { .. } => {
                             is_mouse_down = true;
@@ -362,15 +362,15 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
             let cur_hovered = context.mouse_hovered_object;
             if cur_hovered.map(|d| d.as_ptr()) != new_hovered.map(|d| d.as_ptr()) {
                 // RollOut of previous node.
-                if let Some(mut node) = cur_hovered {
-                    if let Some(mut button) = node.as_button_mut().copied() {
+                if let Some(node) = cur_hovered {
+                    if let Some(mut button) = node.as_button() {
                         button.handle_button_event(context, ButtonEvent::RollOut);
                     }
                 }
 
                 // RollOver on new node.
-                if let Some(mut node) = new_hovered {
-                    if let Some(mut button) = node.as_button_mut().copied() {
+                if let Some(node) = new_hovered {
+                    if let Some(mut button) = node.as_button() {
                         button.handle_button_event(context, ButtonEvent::RollOver);
                     }
                 }
@@ -388,8 +388,8 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
     fn preload(&mut self) {
         self.mutate_with_update_context(|_avm, context| {
             let mut morph_shapes = fnv::FnvHashMap::default();
-            let mut root = context.root;
-            root.as_movie_clip_mut()
+            let root = context.root;
+            root.as_movie_clip()
                 .unwrap()
                 .preload(context, &mut morph_shapes);
 

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use crate::bounding_box::BoundingBox;
 pub use crate::color_transform::ColorTransform;
-pub use crate::display_object::{DisplayNode, DisplayObject};
+pub use crate::display_object::{DisplayObject, TDisplayObject};
 pub use crate::impl_display_object;
 pub use crate::matrix::Matrix;
 pub use log::{error, info, trace, warn};

--- a/web/selfhosted/package-lock.json
+++ b/web/selfhosted/package-lock.json
@@ -1973,12 +1973,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1993,17 +1995,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2120,7 +2125,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2132,6 +2138,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2146,6 +2153,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2153,12 +2161,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2177,6 +2187,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2257,7 +2268,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2269,6 +2281,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2390,6 +2403,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
 * `GcCell` is moved inside of the trait implementations. For example, `MovieClip` is now `struct MovieClip(GcCell<MovieClipData>>)` instead of `GcCell<MovieClip>` on the outside.
 * Renamed traits `Object` and `DisplayObject` to `TObject` and `TDisplayObject`.
 * Instead of trait objects, switch to enums for "dynamic" dispatch. `enum DisplayObject` contains a variant for each display object type, and `impl TDisplayObject for DisplayObject` delegates to the underlying type. This gets along better with the GC types than using trait objects and removes the extraneous `Box` we had previously.
 * Added a `enum_trait` procedural macro to auto-implement the above boilerplate. (This could be replaced with the [enum_dispatch](https://gitlab.com/antonok/enum_dispatch) crate, but RLS didn't like this (https://github.com/rust-lang/rls/issues/1212)
 * Above procedural macro is placed into the `core/ruffle_macros` subcrate. Further proc macros could be added here.
 * Added `Player::mutate_with_update_context`, which cleans up a lot of the duplicated `UpdateContext` code.

Benefits:
 * The objects now get finer grained control of `GcCell::read`/`write`, avoiding double-borrow issues when traversing the object graph. For example, setting `_x` would require you to mutably borrow a clip to access its property map, and then later borrow it again to set the actual value. Now these borrows can be released before recursing down, if necessary.
 * Objects now have access to their GC pointer, so `self` vs `self_cell` management gets a little easier. MovieClips no longer have to fiddle with `context.active_clip` when running their children, for example.
 * Since these objects are just simple `GcCell` wrappers, they're all marked as `Copy` and passing them around is simpler.

Cons:
 * Lots of boilerplate from the enum implementations, but this goes away thanks to macros.
 * More calls to `GcCell::read`/`write` which is non-zero-cost. But I think it's minimal, and we want the more fine-grained control.
 * Duplicated methods between `MovieClip`/`MovieClipData`, and this may get worse with the deep DisplayObject hierarchy in AVM2. Not quite sure if this is an issue yet, maybe it could be automated with more macros.
