### PR TITLE
avm2: Don't immediately parse ABC opcode. (#156)

### DIFF
--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -522,9 +522,15 @@ impl<R: Read> Reader<R> {
         use crate::avm2::opcode::OpCode;
         use num_traits::FromPrimitive;
 
-        let opcode = match OpCode::from_u8(self.read_u8()?) {
+        let byte = self.read_u8()?;
+        let opcode = match OpCode::from_u8(byte) {
             Some(o) => o,
-            None => return Err(Error::invalid_data("Invalid opcode")),
+            None => {
+                return Err(Error::invalid_data(format!(
+                    "Unknown ABC opcode {:#x}",
+                    byte
+                )))
+            }
         };
 
         let op = match opcode {

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -90,6 +90,7 @@ impl<R: Read> Reader<R> {
         self.read_u30()
     }
 
+    #[allow(dead_code)]
     fn read_i24(&mut self) -> Result<i32> {
         Ok(i32::from(self.read_u8()?)
             | (i32::from(self.read_u8()?) << 8)
@@ -484,14 +485,13 @@ impl<R: Read> Reader<R> {
         let init_scope_depth = self.read_u30()?;
         let max_scope_depth = self.read_u30()?;
 
+        // Read the code data.
         let code_len = self.read_u30()?;
-        let mut code = vec![];
-        {
-            let mut code_reader = Reader::new(self.inner.by_ref().take(code_len.into()));
-            while let Ok(Some(op)) = code_reader.read_op() {
-                code.push(op);
-            }
-        }
+        let mut code = Vec::with_capacity(code_len as usize);
+        self.inner
+            .by_ref()
+            .take(code_len.into())
+            .read_to_end(&mut code)?;
 
         let num_exceptions = self.read_u30()? as usize;
         let mut exceptions = Vec::with_capacity(num_exceptions);
@@ -517,6 +517,7 @@ impl<R: Read> Reader<R> {
         })
     }
 
+    #[allow(dead_code)]
     fn read_op(&mut self) -> Result<Option<Op>> {
         use crate::avm2::opcode::OpCode;
         use num_traits::FromPrimitive;

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -109,7 +109,7 @@ pub struct MethodBody {
     pub num_locals: u32,
     pub init_scope_depth: u32,
     pub max_scope_depth: u32,
-    pub code: Vec<Op>,
+    pub code: Vec<u8>,
     pub exceptions: Vec<Exception>,
     pub traits: Vec<Trait>,
 }

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -75,6 +75,7 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn write_i24(&mut self, n: i32) -> Result<()> {
         // TODO: Verify n fits in 24-bits.
         self.write_u8(((n >> 16) & 0xff) as u8)?;
@@ -523,15 +524,8 @@ impl<W: Write> Writer<W> {
         self.write_u30(method_body.init_scope_depth)?;
         self.write_u30(method_body.max_scope_depth)?;
 
-        let mut buf = Vec::with_capacity(method_body.code.len());
-        {
-            let mut writer = Writer::new(&mut buf);
-            for op in &method_body.code {
-                writer.write_op(op)?;
-            }
-        }
-        self.write_u30(buf.len() as u32)?;
-        self.inner.write_all(&buf)?;
+        self.write_u30(method_body.code.len() as u32)?;
+        self.inner.write_all(&method_body.code)?;
 
         self.write_u30(method_body.exceptions.len() as u32)?;
         for exception in &method_body.exceptions {
@@ -555,6 +549,7 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn write_op(&mut self, op: &Op) -> Result<()> {
         match *op {
             Op::Add => self.write_opcode(OpCode::Add)?,

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -2866,21 +2866,7 @@ pub fn avm2_tests() -> Vec<Avm2TestData> {
                     num_locals: 1,
                     init_scope_depth: 1,
                     max_scope_depth: 2,
-                    code: vec![
-                        Op::GetLocal { index: 0 },
-                        Op::PushScope,
-                        Op::FindPropStrict {
-                            index: Index::new(3),
-                        },
-                        Op::PushString {
-                            value: Index::new(5),
-                        },
-                        Op::CallPropVoid {
-                            index: Index::new(3),
-                            num_args: 1,
-                        },
-                        Op::ReturnVoid,
-                    ],
+                    code: vec![208, 48, 93, 3, 44, 5, 79, 3, 1, 71],
                     exceptions: vec![],
                     traits: vec![],
                 },
@@ -2890,21 +2876,7 @@ pub fn avm2_tests() -> Vec<Avm2TestData> {
                     num_locals: 2,
                     init_scope_depth: 1,
                     max_scope_depth: 2,
-                    code: vec![
-                        Op::GetLocal { index: 0 },
-                        Op::PushScope,
-                        Op::FindPropStrict {
-                            index: Index::new(2),
-                        },
-                        Op::CallProperty {
-                            index: Index::new(2),
-                            num_args: 0,
-                        },
-                        Op::CoerceA,
-                        Op::SetLocal { index: 1 },
-                        Op::GetLocal { index: 1 },
-                        Op::ReturnValue,
-                    ],
+                    code: vec![208, 48, 93, 2, 70, 2, 0, 130, 213, 209, 72],
                     exceptions: vec![],
                     traits: vec![],
                 },


### PR DESCRIPTION
SWF obfuscaters will produce an opcode stream that can contain invalid data/not tightly packed ops, so we should not try to parse the opcodes ahead of time. Instead return the method bodies as a byte buffer.

The SWF in question also uses some undocumented ops which we will eventually need to impelement (see https://www.free-decompiler.com/flash/docs/as3_pcode_instructions.en.html), but this will fix the panic for now.

Fixes #156.