### PR TITLE
Refactor system listeners into a reusable system

### DIFF
--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -1,59 +1,9 @@
+use crate::avm1::listeners::Listeners;
 use crate::avm1::property::Attribute;
 use crate::avm1::return_value::ReturnValue;
 use crate::avm1::{Avm1, Error, Object, ScriptObject, TObject, UpdateContext, Value};
 
 use gc_arena::MutationContext;
-
-pub fn add_listener<'gc>(
-    avm: &mut Avm1<'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
-    this: Object<'gc>,
-    args: &[Value<'gc>],
-) -> Result<ReturnValue<'gc>, Error> {
-    let listeners = this
-        .get_local("_listeners", avm, context, this)
-        .and_then(|v| v.resolve(avm, context))?
-        .as_object()?;
-    let listener = args.get(0).unwrap_or(&Value::Undefined).to_owned();
-    for i in 0..listeners.length() {
-        if listeners.array_element(i) == listener {
-            return Ok(true.into());
-        }
-    }
-
-    listeners.set_array_element(listeners.length(), listener, context.gc_context);
-    Ok(true.into())
-}
-
-pub fn remove_listener<'gc>(
-    avm: &mut Avm1<'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
-    this: Object<'gc>,
-    args: &[Value<'gc>],
-) -> Result<ReturnValue<'gc>, Error> {
-    let listeners = this
-        .get_local("_listeners", avm, context, this)
-        .and_then(|v| v.resolve(avm, context))?
-        .as_object()?;
-    let listener = args.get(0).unwrap_or(&Value::Undefined).to_owned();
-    for index in 0..listeners.length() {
-        if listeners.array_element(index) == listener {
-            let new_length = listeners.length() - 1;
-
-            for i in index..new_length {
-                listeners.set_array_element(i, listeners.array_element(i + 1), context.gc_context);
-            }
-
-            listeners.delete_array_element(new_length, context.gc_context);
-            listeners.delete(context.gc_context, &new_length.to_string());
-            listeners.set_length(context.gc_context, new_length);
-
-            return Ok(true.into());
-        }
-    }
-
-    Ok(false.into())
-}
 
 pub fn show_mouse<'gc>(
     _avm: &mut Avm1<'gc>,
@@ -78,33 +28,12 @@ pub fn hide_mouse<'gc>(
 pub fn create_mouse_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     proto: Option<Object<'gc>>,
-    array_proto: Option<Object<'gc>>,
     fn_proto: Option<Object<'gc>>,
+    listener: &Listeners<'gc>,
 ) -> Object<'gc> {
     let mut mouse = ScriptObject::object(gc_context, proto);
 
-    mouse.define_value(
-        gc_context,
-        "_listeners",
-        ScriptObject::array(gc_context, array_proto).into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-
-    mouse.force_set_function(
-        "addListener",
-        add_listener,
-        gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-        fn_proto,
-    );
-
-    mouse.force_set_function(
-        "removeListener",
-        remove_listener,
-        gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-        fn_proto,
-    );
+    register_listener!(gc_context, mouse, listener, fn_proto, mouse);
 
     mouse.force_set_function(
         "show",
@@ -123,33 +52,4 @@ pub fn create_mouse_object<'gc>(
     );
 
     mouse.into()
-}
-
-pub fn notify_listeners<'gc>(
-    avm: &mut Avm1<'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: Object<'gc>,
-    args: &[Value<'gc>],
-) -> Result<ReturnValue<'gc>, Error> {
-    let method = args.get(0).unwrap().as_string()?;
-    let globals = avm.globals;
-    let mouse = globals
-        .get_local("Mouse", avm, context, globals)
-        .and_then(|v| v.resolve(avm, context))?
-        .as_object()?;
-    let listeners = mouse
-        .get_local("_listeners", avm, context, mouse)
-        .and_then(|v| v.resolve(avm, context))?
-        .as_object()?;
-
-    for i in 0..listeners.length() {
-        if let Ok(listener) = listeners.array_element(i).as_object() {
-            let handler = listener
-                .get(method, avm, context)
-                .and_then(|v| v.resolve(avm, context))?;
-            let _ = handler.call(avm, context, listener, &[]);
-        }
-    }
-
-    Ok(Value::Undefined.into())
 }

--- a/core/src/avm1/listeners.rs
+++ b/core/src/avm1/listeners.rs
@@ -1,0 +1,162 @@
+use crate::avm1::return_value::ReturnValue;
+use crate::avm1::{Avm1, Error, Object, ScriptObject, TObject, UpdateContext, Value};
+
+use gc_arena::{Collect, MutationContext};
+
+#[derive(Clone, Collect, Debug, Copy)]
+#[collect(no_drop)]
+pub struct Listeners<'gc>(Object<'gc>);
+
+macro_rules! register_listener {
+    ( $gc_context: ident, $object:ident, $listener: ident, $fn_proto: ident, $system_listeners_key: ident ) => {{
+        pub fn add_listener<'gc>(
+            avm: &mut Avm1<'gc>,
+            context: &mut UpdateContext<'_, 'gc, '_>,
+            _this: Object<'gc>,
+            args: &[Value<'gc>],
+        ) -> Result<ReturnValue<'gc>, Error> {
+            avm.system_listeners
+                .$system_listeners_key
+                .add_listener(context, args)
+        }
+
+        pub fn remove_listener<'gc>(
+            avm: &mut Avm1<'gc>,
+            context: &mut UpdateContext<'_, 'gc, '_>,
+            _this: Object<'gc>,
+            args: &[Value<'gc>],
+        ) -> Result<ReturnValue<'gc>, Error> {
+            avm.system_listeners
+                .$system_listeners_key
+                .remove_listener(context, args)
+        }
+
+        $object.define_value(
+            $gc_context,
+            "_listeners",
+            $listener.object().into(),
+            Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        );
+
+        $object.force_set_function(
+            "addListener",
+            add_listener,
+            $gc_context,
+            Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+            $fn_proto,
+        );
+
+        $object.force_set_function(
+            "removeListener",
+            remove_listener,
+            $gc_context,
+            Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+            $fn_proto,
+        );
+    }};
+}
+
+impl<'gc> Listeners<'gc> {
+    pub fn new(gc_context: MutationContext<'gc, '_>, array_proto: Option<Object<'gc>>) -> Self {
+        Self(ScriptObject::array(gc_context, array_proto).into())
+    }
+
+    pub fn add_listener(
+        &self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        args: &[Value<'gc>],
+    ) -> Result<ReturnValue<'gc>, Error> {
+        let listeners = self.0;
+        let listener = args.get(0).unwrap_or(&Value::Undefined).to_owned();
+        for i in 0..listeners.length() {
+            if listeners.array_element(i) == listener {
+                return Ok(true.into());
+            }
+        }
+
+        listeners.set_array_element(listeners.length(), listener, context.gc_context);
+        Ok(true.into())
+    }
+
+    pub fn remove_listener(
+        &self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        args: &[Value<'gc>],
+    ) -> Result<ReturnValue<'gc>, Error> {
+        let listeners = self.0;
+        let listener = args.get(0).unwrap_or(&Value::Undefined).to_owned();
+        for index in 0..listeners.length() {
+            if listeners.array_element(index) == listener {
+                let new_length = listeners.length() - 1;
+
+                for i in index..new_length {
+                    listeners.set_array_element(
+                        i,
+                        listeners.array_element(i + 1),
+                        context.gc_context,
+                    );
+                }
+
+                listeners.delete_array_element(new_length, context.gc_context);
+                listeners.delete(context.gc_context, &new_length.to_string());
+                listeners.set_length(context.gc_context, new_length);
+
+                return Ok(true.into());
+            }
+        }
+
+        Ok(false.into())
+    }
+
+    pub fn prepare_handlers(
+        &self,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        method: &str,
+    ) -> Vec<(Object<'gc>, Value<'gc>)> {
+        let listeners = self.0;
+        let mut handlers = Vec::with_capacity(listeners.length());
+
+        for i in 0..listeners.length() {
+            if let Ok(listener) = listeners.array_element(i).as_object() {
+                if let Ok(handler) = listener
+                    .get(method, avm, context)
+                    .and_then(|v| v.resolve(avm, context))
+                {
+                    handlers.push((listener, handler));
+                }
+            }
+        }
+
+        handlers
+    }
+
+    pub fn object(&self) -> Object<'gc> {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SystemListener {
+    Mouse,
+}
+
+#[derive(Clone, Collect, Debug, Copy)]
+#[collect(no_drop)]
+pub struct SystemListeners<'gc> {
+    pub mouse: Listeners<'gc>,
+}
+
+impl<'gc> SystemListeners<'gc> {
+    pub fn new(gc_context: MutationContext<'gc, '_>, array_proto: Option<Object<'gc>>) -> Self {
+        Self {
+            mouse: Listeners::new(gc_context, array_proto),
+        }
+    }
+
+    pub fn get(&self, listener: SystemListener) -> Listeners<'gc> {
+        match listener {
+            SystemListener::Mouse => self.mouse,
+        }
+    }
+}

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -546,7 +546,7 @@ mod test {
             assert_eq!(f.to_primitive_num(avm, context).unwrap(), f);
             assert_eq!(n.to_primitive_num(avm, context).unwrap(), n);
 
-            let (protos, global) = create_globals(context.gc_context);
+            let (protos, global, _) = create_globals(context.gc_context);
             let vglobal = Value::Object(global);
 
             assert_eq!(vglobal.to_primitive_num(avm, context).unwrap(), u);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,4 +1,4 @@
-use crate::avm1::globals::mouse::notify_listeners;
+use crate::avm1::listeners::SystemListener;
 use crate::avm1::Avm1;
 use crate::backend::{
     audio::AudioBackend, navigator::NavigatorBackend, render::Letterbox, render::RenderBackend,
@@ -338,9 +338,10 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                 if let Some(mouse_event_name) = mouse_event_name {
                     context.action_queue.queue_actions(
                         root,
-                        ActionType::Native {
-                            function: notify_listeners,
-                            args: vec![mouse_event_name.into()],
+                        ActionType::NotifyListeners {
+                            listener: SystemListener::Mouse,
+                            method: mouse_event_name,
+                            args: vec![],
                         },
                         false,
                     );
@@ -545,15 +546,20 @@ impl<Audio: AudioBackend, Renderer: RenderBackend, Navigator: NavigatorBackend>
                 }
 
                 // Event handler method call (e.g. onEnterFrame)
-                ActionType::Native { function, args } => {
+                ActionType::NotifyListeners {
+                    listener,
+                    method,
+                    args,
+                } => {
                     // A native function ends up resolving immediately,
                     // so this doesn't require any further execution.
-                    avm.run_native_function(
+                    avm.notify_system_listeners(
                         actions.clip,
                         context.swf_version,
                         context,
-                        function,
-                        &args[..],
+                        listener,
+                        method,
+                        &args,
                     );
                 }
             }


### PR DESCRIPTION
This should let us create the other system listener types with a macro and few lines of registration.