### PR TITLE
Implement Mouse.show() and Mouse.hide()

### DIFF
--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -7,22 +7,32 @@ use gc_arena::MutationContext;
 
 pub fn show_mouse<'gc>(
     _avm: &mut Avm1<'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Mouse.show() is intentionally not yet implemented");
-    Ok(1.into())
+    let was_visible = context.input.mouse_visible();
+    context.input.show_mouse();
+    if was_visible {
+        Ok(0.into())
+    } else {
+        Ok(1.into())
+    }
 }
 
 pub fn hide_mouse<'gc>(
     _avm: &mut Avm1<'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Mouse.hide() is intentionally not yet implemented");
-    Ok(1.into())
+    let was_visible = context.input.mouse_visible();
+    context.input.hide_mouse();
+    if was_visible {
+        Ok(0.into())
+    } else {
+        Ok(1.into())
+    }
 }
 
 pub fn create_mouse_object<'gc>(

--- a/core/src/backend/input.rs
+++ b/core/src/backend/input.rs
@@ -2,6 +2,12 @@ use crate::events::KeyCode;
 
 pub trait InputBackend {
     fn is_key_down(&self, key: KeyCode) -> bool;
+
+    fn mouse_visible(&self) -> bool;
+
+    fn hide_mouse(&mut self);
+
+    fn show_mouse(&mut self);
 }
 
 /// Input backend that does nothing
@@ -17,6 +23,14 @@ impl InputBackend for NullInputBackend {
     fn is_key_down(&self, _key: KeyCode) -> bool {
         false
     }
+
+    fn mouse_visible(&self) -> bool {
+        true
+    }
+
+    fn hide_mouse(&mut self) {}
+
+    fn show_mouse(&mut self) {}
 }
 
 impl Default for NullInputBackend {

--- a/desktop/src/input.rs
+++ b/desktop/src/input.rs
@@ -1,3 +1,4 @@
+use glium::Display;
 use ruffle_core::backend::input::InputBackend;
 use ruffle_core::events::KeyCode;
 use std::collections::HashSet;
@@ -5,12 +6,16 @@ use winit::event::{ElementState, KeyboardInput, VirtualKeyCode};
 
 pub struct WinitInputBackend {
     keys_down: HashSet<VirtualKeyCode>,
+    display: Display,
+    cursor_visible: bool,
 }
 
 impl WinitInputBackend {
-    pub fn new() -> Self {
+    pub fn new(display: Display) -> Self {
         Self {
             keys_down: HashSet::new(),
+            cursor_visible: true,
+            display,
         }
     }
 
@@ -138,5 +143,19 @@ impl InputBackend for WinitInputBackend {
             KeyCode::F11 => self.keys_down.contains(&VirtualKeyCode::F11),
             KeyCode::F12 => self.keys_down.contains(&VirtualKeyCode::F12),
         }
+    }
+
+    fn mouse_visible(&self) -> bool {
+        self.cursor_visible
+    }
+
+    fn hide_mouse(&mut self) {
+        self.display.gl_window().window().set_cursor_visible(false);
+        self.cursor_visible = false;
+    }
+
+    fn show_mouse(&mut self) {
+        self.display.gl_window().window().set_cursor_visible(true);
+        self.cursor_visible = true;
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -63,7 +63,7 @@ fn run_player(input_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let renderer = GliumRenderBackend::new(windowed_context)?;
     let navigator = navigator::ExternalNavigatorBackend::new(); //TODO: actually implement this backend type
     let display = renderer.display().clone();
-    let input = input::WinitInputBackend::new();
+    let input = input::WinitInputBackend::new(display.clone());
     let mut player = Player::new(renderer, audio, navigator, input, swf_data)?;
     player.set_is_playing(true); // Desktop player will auto-play.
 

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -1,17 +1,23 @@
+use crate::utils::JsResult;
 use ruffle_core::backend::input::InputBackend;
 use ruffle_core::events::KeyCode;
 use std::collections::HashSet;
+use web_sys::HtmlCanvasElement;
 
 /// An implementation of `InputBackend` utilizing `web_sys` bindings to input
 /// APIs
 pub struct WebInputBackend {
     keys_down: HashSet<String>,
+    canvas: HtmlCanvasElement,
+    cursor_visible: bool,
 }
 
 impl WebInputBackend {
-    pub fn new() -> Self {
+    pub fn new(canvas: &HtmlCanvasElement) -> Self {
         Self {
             keys_down: HashSet::new(),
+            canvas: canvas.clone(),
+            cursor_visible: true,
         }
     }
 
@@ -131,5 +137,25 @@ impl InputBackend for WebInputBackend {
             KeyCode::F11 => self.keys_down.contains("F11"),
             KeyCode::F12 => self.keys_down.contains("F12"),
         }
+    }
+
+    fn mouse_visible(&self) -> bool {
+        self.cursor_visible
+    }
+
+    fn hide_mouse(&mut self) {
+        self.canvas
+            .style()
+            .set_property("cursor", "none")
+            .warn_on_error();
+        self.cursor_visible = false;
+    }
+
+    fn show_mouse(&mut self) {
+        self.canvas
+            .style()
+            .set_property("cursor", "auto")
+            .warn_on_error();
+        self.cursor_visible = true;
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -97,7 +97,7 @@ impl Ruffle {
         let renderer = WebCanvasRenderBackend::new(&canvas)?;
         let audio = WebAudioBackend::new()?;
         let navigator = WebNavigatorBackend::new();
-        let input = WebInputBackend::new();
+        let input = WebInputBackend::new(&canvas);
 
         let mut core = ruffle_core::Player::new(renderer, audio, navigator, input, data)?;
         let frame_rate = core.frame_rate();


### PR DESCRIPTION
As #204 is in, this will no longer be super annoying to have.

The return value logic looks like a mistake, but it's what the documentation says.

I initially had this in `InputBackend` as I figured "mouse is input", but ultimately both implementations needed to work over their renderer counterparts, and in the future we need a "set this movieclip to be a hand or a pointer", so renderer made sense.