### PR TITLE
avm1: Rough pass of Sound object

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -29,6 +29,7 @@ mod property;
 mod return_value;
 mod scope;
 pub mod script_object;
+mod sound_object;
 mod stage_object;
 mod super_object;
 mod value;
@@ -42,6 +43,7 @@ pub use globals::SystemPrototypes;
 pub use object::{Object, ObjectPtr, TObject};
 use scope::Scope;
 pub use script_object::ScriptObject;
+pub use sound_object::SoundObject;
 pub use stage_object::StageObject;
 pub use value::Value;
 

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -16,6 +16,7 @@ mod math;
 pub(crate) mod mouse;
 pub(crate) mod movie_clip;
 mod object;
+mod sound;
 mod stage;
 pub(crate) mod text_field;
 
@@ -133,6 +134,7 @@ pub struct SystemPrototypes<'gc> {
     pub object: Object<'gc>,
     pub function: Object<'gc>,
     pub movie_clip: Object<'gc>,
+    pub sound: Object<'gc>,
     pub text_field: Object<'gc>,
     pub array: Object<'gc>,
 }
@@ -143,6 +145,7 @@ unsafe impl<'gc> gc_arena::Collect for SystemPrototypes<'gc> {
         self.object.trace(cc);
         self.function.trace(cc);
         self.movie_clip.trace(cc);
+        self.sound.trace(cc);
         self.text_field.trace(cc);
         self.array.trace(cc);
     }
@@ -159,6 +162,8 @@ pub fn create_globals<'gc>(
 
     let movie_clip_proto: Object<'gc> =
         movie_clip::create_proto(gc_context, object_proto, function_proto);
+
+    let sound_proto: Object<'gc> = sound::create_proto(gc_context, object_proto, function_proto);
 
     let text_field_proto: Object<'gc> =
         text_field::create_proto(gc_context, object_proto, function_proto);
@@ -185,6 +190,12 @@ pub fn create_globals<'gc>(
         Some(function_proto),
         Some(movie_clip_proto),
     );
+    let sound = ScriptObject::function(
+        gc_context,
+        Executable::Native(sound::constructor),
+        Some(function_proto),
+        Some(sound_proto),
+    );
     let text_field = ScriptObject::function(
         gc_context,
         Executable::Native(text_field::constructor),
@@ -205,6 +216,7 @@ pub fn create_globals<'gc>(
     globals.define_value(gc_context, "Object", object.into(), EnumSet::empty());
     globals.define_value(gc_context, "Function", function.into(), EnumSet::empty());
     globals.define_value(gc_context, "MovieClip", movie_clip.into(), EnumSet::empty());
+    globals.define_value(gc_context, "Sound", sound.into(), EnumSet::empty());
     globals.define_value(gc_context, "TextField", text_field.into(), EnumSet::empty());
     globals.force_set_function(
         "Number",
@@ -320,6 +332,7 @@ pub fn create_globals<'gc>(
             object: object_proto,
             function: function_proto,
             movie_clip: movie_clip_proto,
+            sound: sound_proto,
             text_field: text_field_proto,
             array: array_proto,
         },

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -1,0 +1,362 @@
+//! AVM1 Sound object
+
+use crate::avm1::function::Executable;
+use crate::avm1::property::Attribute::*;
+use crate::avm1::return_value::ReturnValue;
+use crate::avm1::{Avm1, Error, Object, SoundObject, TObject, UpdateContext, Value};
+use crate::character::Character;
+use gc_arena::MutationContext;
+
+/// Implements `Sound`
+pub fn constructor<'gc>(
+    _avm: &mut Avm1<'gc>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    // 1st parameter is the movie clip that "owns" all sounds started by this object.
+    // `Sound.setTransform`, `Sound.stop`, etc. will affect all sounds owned by this clip.
+    let owner = args
+        .get(0)
+        .and_then(|o| o.as_object().ok())
+        .and_then(|o| o.as_display_object());
+
+    let sound = this.as_sound_object().unwrap();
+    sound.set_owner(context.gc_context, owner);
+
+    Ok(this.into())
+}
+
+pub fn create_proto<'gc>(
+    gc_context: MutationContext<'gc, '_>,
+    proto: Object<'gc>,
+    fn_proto: Object<'gc>,
+) -> Object<'gc> {
+    let object = SoundObject::empty_sound(gc_context, Some(proto));
+
+    object.as_script_object().unwrap().force_set_function(
+        "attachSound",
+        attach_sound,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.add_property(
+        gc_context,
+        "duration",
+        Executable::Native(duration),
+        None,
+        DontDelete | ReadOnly | DontEnum,
+    );
+
+    object.add_property(
+        gc_context,
+        "id3",
+        Executable::Native(id3),
+        None,
+        DontDelete | ReadOnly | DontEnum,
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "getBytesLoaded",
+        get_bytes_loaded,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "getBytesTotal",
+        get_bytes_total,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "getPan",
+        get_pan,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "get_transform",
+        get_transform,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "get_volume",
+        get_volume,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "load_sound",
+        load_sound,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.add_property(
+        gc_context,
+        "position",
+        Executable::Native(position),
+        None,
+        DontDelete | ReadOnly | DontEnum,
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "set_pan",
+        set_pan,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "set_transform",
+        set_transform,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "set_volume",
+        set_volume,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "start",
+        start,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.as_script_object().unwrap().force_set_function(
+        "stop",
+        stop,
+        gc_context,
+        DontDelete | ReadOnly | DontEnum,
+        Some(fn_proto),
+    );
+
+    object.into()
+}
+
+fn attach_sound<'gc>(
+    avm: &mut Avm1<'gc>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    let name = args.get(0).unwrap_or(&Value::Undefined);
+    if let Some(sound_object) = this.as_sound_object() {
+        let name = name.clone().coerce_to_string(avm, context)?;
+        if let Some(Character::Sound(sound)) = context.library.get_character_by_export_name(&name) {
+            sound_object.set_sound(context.gc_context, Some(*sound));
+        } else {
+            log::warn!("Sound.attachSound: Sound '{}' not found", name);
+        }
+    } else {
+        log::warn!("Sound.attachSound: this is not a Sound");
+    }
+    Ok(Value::Undefined.into())
+}
+
+fn duration<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.duration: Unimplemented");
+    Ok(1.into())
+}
+
+fn get_bytes_loaded<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.getBytesLoaded: Unimplemented");
+    Ok(1.into())
+}
+
+fn get_bytes_total<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.getBytesTotal: Unimplemented");
+    Ok(1.into())
+}
+
+fn get_pan<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.getPan: Unimplemented");
+    Ok(0.into())
+}
+
+fn get_transform<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.getTransform: Unimplemented");
+    Ok(Value::Undefined.into())
+}
+
+fn get_volume<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.getVolume: Unimplemented");
+    Ok(100.into())
+}
+
+fn id3<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.id3: Unimplemented");
+    Ok(Value::Undefined.into())
+}
+
+fn load_sound<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.loadSound: Unimplemented");
+    Ok(Value::Undefined.into())
+}
+
+fn position<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.position: Unimplemented");
+    Ok(0.into())
+}
+
+fn set_pan<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.setPan: Unimplemented");
+    Ok(Value::Undefined.into())
+}
+
+fn set_transform<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.setTransform: Unimplemented");
+    Ok(Value::Undefined.into())
+}
+
+fn set_volume<'gc>(
+    _avm: &mut Avm1<'gc>,
+    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    log::warn!("Sound.setVolume: Unimplemented");
+    Ok(Value::Undefined.into())
+}
+
+fn start<'gc>(
+    avm: &mut Avm1<'gc>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    let start_offset = args
+        .get(0)
+        .unwrap_or(&Value::Number(0.0))
+        .as_number(avm, context)?;
+    let loops = args
+        .get(1)
+        .unwrap_or(&Value::Number(1.0))
+        .as_number(avm, context)?;
+
+    let loops = if loops >= 1.0 && loops <= f64::from(std::i16::MAX) {
+        loops as u16
+    } else {
+        1
+    };
+
+    use swf::{SoundEvent, SoundInfo};
+    if let Some(sound) = this.as_sound_object().and_then(|o| o.sound()) {
+        context.audio.start_sound(
+            sound,
+            &SoundInfo {
+                event: SoundEvent::Start,
+                in_sample: if start_offset > 0.0 {
+                    Some((start_offset * 44100.0) as u32)
+                } else {
+                    None
+                },
+                out_sample: None,
+                num_loops: loops,
+                envelope: None,
+            },
+        );
+    } else {
+        log::error!("Sound.start: Invalid sound");
+    }
+
+    Ok(Value::Undefined.into())
+}
+
+fn stop<'gc>(
+    _avm: &mut Avm1<'gc>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    if let Some(sound) = this.as_sound_object() {
+        if let Some(_owner) = sound.owner() {
+            // TODO
+        } else {
+            // If there is no owner, this call acts like `stopAllSounds()`.
+            context.audio.stop_all_sounds();
+        }
+    } else {
+        log::warn!("Sound.stop: this is not a Sound");
+    }
+
+    Ok(Value::Undefined.into())
+}

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -1,4 +1,5 @@
 //! AVM1 Sound object
+//! TODO: Sound position, transform, loadSound
 
 use crate::avm1::function::Executable;
 use crate::avm1::property::Attribute::*;
@@ -168,6 +169,11 @@ fn attach_sound<'gc>(
         let name = name.clone().coerce_to_string(avm, context)?;
         if let Some(Character::Sound(sound)) = context.library.get_character_by_export_name(&name) {
             sound_object.set_sound(context.gc_context, Some(*sound));
+            sound_object.set_duration(
+                context.gc_context,
+                context.audio.get_sound_duration(*sound).unwrap_or(0),
+            );
+            sound_object.set_position(context.gc_context, 0);
         } else {
             log::warn!("Sound.attachSound: Sound '{}' not found", name);
         }
@@ -178,33 +184,48 @@ fn attach_sound<'gc>(
 }
 
 fn duration<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: Object<'gc>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Sound.duration: Unimplemented");
-    Ok(1.into())
+    if avm.current_swf_version() >= 6 {
+        if let Some(sound_object) = this.as_sound_object() {
+            return Ok(sound_object.duration().into());
+        } else {
+            log::warn!("Sound.duration: this is not a Sound");
+        }
+    }
+
+    Ok(Value::Undefined.into())
 }
 
 fn get_bytes_loaded<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Sound.getBytesLoaded: Unimplemented");
-    Ok(1.into())
+    if avm.current_swf_version() >= 6 {
+        log::warn!("Sound.getBytesLoaded: Unimplemented");
+        Ok(1.into())
+    } else {
+        Ok(Value::Undefined.into())
+    }
 }
 
 fn get_bytes_total<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Sound.getBytesTotal: Unimplemented");
-    Ok(1.into())
+    if avm.current_swf_version() >= 6 {
+        log::warn!("Sound.getBytesTotal: Unimplemented");
+        Ok(1.into())
+    } else {
+        Ok(Value::Undefined.into())
+    }
 }
 
 fn get_pan<'gc>(
@@ -238,33 +259,51 @@ fn get_volume<'gc>(
 }
 
 fn id3<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Sound.id3: Unimplemented");
+    if avm.current_swf_version() >= 6 {
+        log::warn!("Sound.id3: Unimplemented");
+    }
     Ok(Value::Undefined.into())
 }
 
 fn load_sound<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Sound.loadSound: Unimplemented");
+    if avm.current_swf_version() >= 6 {
+        log::warn!("Sound.loadSound: Unimplemented");
+    }
     Ok(Value::Undefined.into())
 }
 
 fn position<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: Object<'gc>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    log::warn!("Sound.position: Unimplemented");
-    Ok(0.into())
+    if avm.current_swf_version() >= 6 {
+        if let Some(sound_object) = this.as_sound_object() {
+            // TODO: The position is "sticky"; even if the sound is no longer playing, it should return
+            // the previous valid position.
+            // Needs some audio backend work for this.
+            if sound_object.sound().is_some() {
+                if let Some(_sound_instance) = sound_object.sound_instance() {
+                    log::warn!("Sound.position: Unimplemented");
+                }
+                return Ok(sound_object.position().into());
+            }
+        } else {
+            log::warn!("Sound.position: this is not a Sound");
+        }
+    }
+    Ok(Value::Undefined.into())
 }
 
 fn set_pan<'gc>(

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -4,7 +4,7 @@ use crate::avm1::function::Executable;
 use crate::avm1::property::Attribute;
 use crate::avm1::return_value::ReturnValue;
 use crate::avm1::super_object::SuperObject;
-use crate::avm1::{Avm1, Error, ScriptObject, StageObject, UpdateContext, Value};
+use crate::avm1::{Avm1, Error, ScriptObject, SoundObject, StageObject, UpdateContext, Value};
 use crate::display_object::DisplayObject;
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
@@ -19,6 +19,7 @@ use std::fmt::Debug;
     #[collect(no_drop)]
     pub enum Object<'gc> {
         ScriptObject(ScriptObject<'gc>),
+        SoundObject(SoundObject<'gc>),
         StageObject(StageObject<'gc>),
         SuperObject(SuperObject<'gc>),
     }
@@ -245,6 +246,11 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
     /// Get the underlying script object, if it exists.
     fn as_script_object(&self) -> Option<ScriptObject<'gc>>;
+
+    /// Get the underlying sound object, if it exists.
+    fn as_sound_object(&self) -> Option<SoundObject<'gc>> {
+        None
+    }
 
     /// Get the underlying super object, if it exists.
     fn as_super_object(&self) -> Option<SuperObject<'gc>> {

--- a/core/src/avm1/sound_object.rs
+++ b/core/src/avm1/sound_object.rs
@@ -1,0 +1,262 @@
+//! AVM1 object type to represent Sound objects.
+
+use crate::avm1::function::Executable;
+use crate::avm1::property::Attribute;
+use crate::avm1::return_value::ReturnValue;
+use crate::avm1::{Avm1, Error, Object, ObjectPtr, ScriptObject, TObject, Value};
+use crate::backend::audio::SoundHandle;
+use crate::context::UpdateContext;
+use crate::display_object::DisplayObject;
+use enumset::EnumSet;
+use gc_arena::{Collect, GcCell, MutationContext};
+use std::collections::HashSet;
+use std::fmt;
+
+/// A SounObject that is tied to a sound from the AudioBackend.
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+pub struct SoundObject<'gc>(GcCell<'gc, SoundObjectData<'gc>>);
+
+pub struct SoundObjectData<'gc> {
+    /// The underlying script object.
+    ///
+    /// This is used to handle "expando properties" on AVM1 display nodes, as
+    /// well as the underlying prototype chain.
+    base: ScriptObject<'gc>,
+
+    /// The sound that is attached to this object.
+    sound: Option<SoundHandle>,
+
+    /// Sounds in AVM1 are tied to a speicifc movie clip.
+    owner: Option<DisplayObject<'gc>>,
+}
+
+unsafe impl<'gc> Collect for SoundObjectData<'gc> {
+    fn trace(&self, cc: gc_arena::CollectionContext) {
+        self.base.trace(cc);
+        self.owner.trace(cc);
+    }
+}
+
+impl fmt::Debug for SoundObject<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SoundObject")
+            .field("sound", &self.0.read().sound)
+            .field("owner", &self.0.read().owner)
+            .finish()
+    }
+}
+
+impl<'gc> SoundObject<'gc> {
+    pub fn empty_sound(
+        gc_context: MutationContext<'gc, '_>,
+        proto: Option<Object<'gc>>,
+    ) -> SoundObject<'gc> {
+        SoundObject(GcCell::allocate(
+            gc_context,
+            SoundObjectData {
+                base: ScriptObject::object(gc_context, proto),
+                sound: None,
+                owner: None,
+            },
+        ))
+    }
+
+    pub fn sound(self) -> Option<SoundHandle> {
+        self.0.read().sound
+    }
+
+    pub fn set_sound(self, gc_context: MutationContext<'gc, '_>, sound: Option<SoundHandle>) {
+        self.0.write(gc_context).sound = sound;
+    }
+
+    pub fn owner(self) -> Option<DisplayObject<'gc>> {
+        self.0.read().owner
+    }
+
+    pub fn set_owner(
+        self,
+        gc_context: MutationContext<'gc, '_>,
+        owner: Option<DisplayObject<'gc>>,
+    ) {
+        self.0.write(gc_context).owner = owner;
+    }
+
+    fn base(self) -> ScriptObject<'gc> {
+        self.0.read().base
+    }
+}
+
+impl<'gc> TObject<'gc> for SoundObject<'gc> {
+    fn get_local(
+        &self,
+        name: &str,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        this: Object<'gc>,
+    ) -> Result<ReturnValue<'gc>, Error> {
+        self.base().get_local(name, avm, context, this)
+    }
+
+    fn set(
+        &self,
+        name: &str,
+        value: Value<'gc>,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+    ) -> Result<(), Error> {
+        self.base().set(name, value, avm, context)
+    }
+
+    fn call(
+        &self,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        this: Object<'gc>,
+        args: &[Value<'gc>],
+    ) -> Result<ReturnValue<'gc>, Error> {
+        self.base().call(avm, context, this, args)
+    }
+
+    #[allow(clippy::new_ret_no_self)]
+    fn new(
+        &self,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        _this: Object<'gc>,
+        _args: &[Value<'gc>],
+    ) -> Result<Object<'gc>, Error> {
+        Ok(SoundObject::empty_sound(context.gc_context, Some(avm.prototypes.sound)).into())
+    }
+
+    fn delete(&self, gc_context: MutationContext<'gc, '_>, name: &str) -> bool {
+        self.base().delete(gc_context, name)
+    }
+
+    fn proto(&self) -> Option<Object<'gc>> {
+        self.base().proto()
+    }
+
+    fn define_value(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+        name: &str,
+        value: Value<'gc>,
+        attributes: EnumSet<Attribute>,
+    ) {
+        self.base()
+            .define_value(gc_context, name, value, attributes)
+    }
+
+    fn set_attributes(
+        &mut self,
+        gc_context: MutationContext<'gc, '_>,
+        name: Option<&str>,
+        set_attributes: EnumSet<Attribute>,
+        clear_attributes: EnumSet<Attribute>,
+    ) {
+        self.base()
+            .set_attributes(gc_context, name, set_attributes, clear_attributes)
+    }
+
+    fn add_property(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+        name: &str,
+        get: Executable<'gc>,
+        set: Option<Executable<'gc>>,
+        attributes: EnumSet<Attribute>,
+    ) {
+        self.base()
+            .add_property(gc_context, name, get, set, attributes)
+    }
+
+    fn has_property(&self, name: &str) -> bool {
+        self.base().has_property(name)
+    }
+
+    fn has_own_property(&self, name: &str) -> bool {
+        self.base().has_own_property(name)
+    }
+
+    fn is_property_overwritable(&self, name: &str) -> bool {
+        self.base().is_property_overwritable(name)
+    }
+
+    fn is_property_enumerable(&self, name: &str) -> bool {
+        self.base().is_property_enumerable(name)
+    }
+
+    fn get_keys(&self) -> HashSet<String> {
+        self.base().get_keys()
+    }
+
+    fn as_string(&self) -> String {
+        self.base().as_string()
+    }
+
+    fn type_of(&self) -> &'static str {
+        self.base().type_of()
+    }
+
+    fn interfaces(&self) -> Vec<Object<'gc>> {
+        self.base().interfaces()
+    }
+
+    fn set_interfaces(
+        &mut self,
+        gc_context: MutationContext<'gc, '_>,
+        iface_list: Vec<Object<'gc>>,
+    ) {
+        self.base().set_interfaces(gc_context, iface_list)
+    }
+
+    fn as_script_object(&self) -> Option<ScriptObject<'gc>> {
+        Some(self.base())
+    }
+
+    fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
+        None
+    }
+
+    fn as_executable(&self) -> Option<Executable<'gc>> {
+        None
+    }
+
+    fn as_sound_object(&self) -> Option<SoundObject<'gc>> {
+        Some(*self)
+    }
+
+    fn as_ptr(&self) -> *const ObjectPtr {
+        self.0.as_ptr() as *const ObjectPtr
+    }
+
+    fn length(&self) -> usize {
+        self.base().length()
+    }
+
+    fn array(&self) -> Vec<Value<'gc>> {
+        self.base().array()
+    }
+
+    fn set_length(&self, gc_context: MutationContext<'gc, '_>, length: usize) {
+        self.base().set_length(gc_context, length)
+    }
+
+    fn array_element(&self, index: usize) -> Value<'gc> {
+        self.base().array_element(index)
+    }
+
+    fn set_array_element(
+        &self,
+        index: usize,
+        value: Value<'gc>,
+        gc_context: MutationContext<'gc, '_>,
+    ) -> usize {
+        self.base().set_array_element(index, value, gc_context)
+    }
+
+    fn delete_array_element(&self, index: usize, gc_context: MutationContext<'gc, '_>) {
+        self.base().delete_array_element(index, gc_context)
+    }
+}

--- a/core/src/avm1/sound_object.rs
+++ b/core/src/avm1/sound_object.rs
@@ -32,6 +32,12 @@ pub struct SoundObjectData<'gc> {
 
     /// Sounds in AVM1 are tied to a speicifc movie clip.
     owner: Option<DisplayObject<'gc>>,
+
+    /// Position of the last playing sound in milliseconds.
+    position: u32,
+
+    /// Duration of the currently attached sound in milliseconds.
+    duration: u32,
 }
 
 unsafe impl<'gc> Collect for SoundObjectData<'gc> {
@@ -64,8 +70,18 @@ impl<'gc> SoundObject<'gc> {
                 sound: None,
                 sound_instance: None,
                 owner: None,
+                position: 0,
+                duration: 0,
             },
         ))
+    }
+
+    pub fn duration(self) -> u32 {
+        self.0.read().duration
+    }
+
+    pub fn set_duration(self, gc_context: MutationContext<'gc, '_>, duration: u32) {
+        self.0.write(gc_context).duration = duration;
     }
 
     pub fn sound(self) -> Option<SoundHandle> {
@@ -98,6 +114,14 @@ impl<'gc> SoundObject<'gc> {
         owner: Option<DisplayObject<'gc>>,
     ) {
         self.0.write(gc_context).owner = owner;
+    }
+
+    pub fn position(self) -> u32 {
+        self.0.read().position
+    }
+
+    pub fn set_position(self, gc_context: MutationContext<'gc, '_>, position: u32) {
+        self.0.write(gc_context).position = position;
     }
 
     fn base(self) -> ScriptObject<'gc> {

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -67,6 +67,10 @@ pub trait AudioBackend {
     /// which only plays a sound if that sound is not already playing.
     fn is_sound_playing_with_handle(&mut self, handle: SoundHandle) -> bool;
 
+    /// Get the duration of a sound in milliseconds.
+    /// Returns `None` if sound is not registered.
+    fn get_sound_duration(&self, sound: SoundHandle) -> Option<u32>;
+
     // TODO: Eventually remove this/move it to library.
     fn is_loading_complete(&self) -> bool {
         true
@@ -143,6 +147,10 @@ impl<T: AudioBackend + ?Sized> AudioBackend for Box<T> {
         self.deref_mut().is_sound_playing_with_handle(handle)
     }
 
+    fn get_sound_duration(&self, sound: SoundHandle) -> Option<u32> {
+        self.deref().get_sound_duration(sound)
+    }
+
     fn is_loading_complete(&self) -> bool {
         self.deref().is_loading_complete()
     }
@@ -198,6 +206,10 @@ impl AudioBackend for NullAudioBackend {
     fn stop_sounds_with_handle(&mut self, _handle: SoundHandle) {}
     fn is_sound_playing_with_handle(&mut self, _handle: SoundHandle) -> bool {
         false
+    }
+
+    fn get_sound_duration(&self, _sound: SoundHandle) -> Option<u32> {
+        None
     }
 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1684,7 +1684,9 @@ impl<'gc, 'a> MovieClipData<'gc> {
             // The sound event type is controlled by the "Sync" setting in the Flash IDE.
             match start_sound.sound_info.event {
                 // "Event" sounds always play, independent of the timeline.
-                SoundEvent::Event => context.audio.start_sound(handle, &start_sound.sound_info),
+                SoundEvent::Event => {
+                    context.audio.start_sound(handle, &start_sound.sound_info);
+                }
 
                 // "Start" sounds only play if an instance of the same sound is not already playing.
                 SoundEvent::Start => {

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -400,6 +400,17 @@ impl AudioBackend for CpalAudioBackend {
         sound_instances.retain(|_, instance| instance.handle != handle);
     }
 
+    fn get_sound_duration(&self, sound: SoundHandle) -> Option<u32> {
+        if let Some(sound) = self.sounds.get(sound) {
+            // AS duration does not subtract skip_sample_frames.
+            let num_sample_frames = u64::from(sound.num_sample_frames);
+            let ms = num_sample_frames * 1000 / u64::from(sound.format.sample_rate);
+            Some(ms as u32)
+        } else {
+            None
+        }
+    }
+
     fn is_sound_playing_with_handle(&mut self, handle: SoundHandle) -> bool {
         let sound_instances = self.sound_instances.lock().unwrap();
         let handle = Some(handle);

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -763,6 +763,17 @@ impl AudioBackend for WebAudioBackend {
                 .any(|(_, instance)| instance.handle == handle)
         })
     }
+
+    fn get_sound_duration(&self, sound: SoundHandle) -> Option<u32> {
+        if let Some(sound) = self.sounds.get(sound) {
+            // AS duration does not subtract skip_sample_frames.
+            let num_sample_frames = u64::from(sound.num_sample_frames);
+            let ms = num_sample_frames * 1000 / u64::from(sound.format.sample_rate);
+            Some(ms as u32)
+        } else {
+            None
+        }
+    }
 }
 
 #[wasm_bindgen(module = "/js-src/ruffle-imports.js")]


### PR DESCRIPTION
This implements basics of the AVM1 Sound object:
 * Sound.attachSound
 * Sound.start
 * Sound.stop (partial)
 * Sound.duration

This is enough for support of most games, and will fix missing sounds in, for example, Alien Hominid and Marvin Spectrum.

Full implementation is a little involved; Particularly, you can attach a Sound object to a particular movie clip, allowing you to adjust the volume/pan of all sounds of that MC and its children. Each display object has a sound transform that gets concatenated similar to their normal display transform.

Also, Sound.position will require a new audio backend method. On Web, this will be annoying because the Web Audio API doesn't provide an easy way to get the position of an `AudioBufferSourceNode`.