### PR TITLE
Use Webpack to build and package Ruffle WASM file in extension

### DIFF
--- a/web/extension/webpack.config.js
+++ b/web/extension/webpack.config.js
@@ -13,31 +13,21 @@ module.exports = (env, argv) => {
   console.log(`Building ${mode}...`);
 
   return {
-    externals: /^(ruffle_web)$/i,
-
     entry: path.resolve(__dirname, "js/index.js"),
     output: {
       path: path.resolve(__dirname, "build/dist"),
       filename: "ruffle.js",
+      chunkFilename: "core.ruffle.js",
+      jsonpFunction: "RufflePlayerExtensionLoader",
     },
     mode: mode,
     plugins: [
-      new webpack.IgnorePlugin({
-        resourceRegExp: /..\/pkg\/ruffle/
-      }),
-      new CleanWebpackPlugin({
-        protectWebpackAssets: false,
-        cleanAfterEveryBuildPatterns: ["*.module.wasm"],
-      }),
+      new CleanWebpackPlugin(),
       new WasmPackPlugin({
         crateDirectory: path.resolve(__dirname, ".."),
-        extraArgs: "--target=no-modules",
+        extraArgs: "--out-name=ruffle",
         forceMode: mode,
-      }),
-      new CopyPlugin([
-        { from: "../pkg/ruffle_web.js", to: "ruffle_web.js" },
-        { from: "../pkg/ruffle_web_bg.wasm", to: "ruffle_web_bg.wasm" },
-      ])
+      })
     ]
   }
 };

--- a/web/js-src/load-ruffle.js
+++ b/web/js-src/load-ruffle.js
@@ -14,8 +14,8 @@ async function fetch_ruffle() {
 
     try {
         //If runtime_path is defined then we are executing inside the extension
-        //closure and we can manually fetch the inner chunks of Ruffle here.
-        is_extension_running = runtime_path !== undefined;
+        //closure. In that case, we configure our local Webpack instance 
+        __webpack_public_path__ = runtime_path + "dist/";
     } catch (e) {
         //Checking an undefined closure variable usually throws ReferencError,
         //so we need to catch it here and continue onward.
@@ -25,40 +25,11 @@ async function fetch_ruffle() {
             throw e;
         }
     }
-
-    if (is_extension_running) {
-        //Download Ruffle from the URL the browser gives us.
-        let ruffle_bindings_url = runtime_path + "dist/ruffle_web.js";
-        let ruffle_wasm_url = runtime_path + "dist/ruffle_web_bg.wasm";
     
-        //We load the wasm package early so that both requests are parallelized.
-        //This won't be awaited by us at all.
-        let ruffle_wasm_request = fetch(ruffle_wasm_url);
-    
-        //One point of admin: `wasm-pack`, in no-modules mode, stores it's bindings
-        //straight in `window`, which we don't want. We grab whatever was in Window
-        //before loading in the module so we can replace what was there.
-        let ruffle_bindings_request = await fetch(ruffle_bindings_url);
-        let ruffle_bindings_src = await ruffle_bindings_request.text();
-        let noconflict_wasm_bindgen = window.wasm_bindgen;
-        (new Function(ruffle_bindings_src))();
-        let ruffle_wasm_bindgen = window.wasm_bindgen;
-        window.wasm_bindgen = noconflict_wasm_bindgen;
-    
-        //Next step: Actually initialize our bindings.
-        let ruffle_wasm_response = await ruffle_wasm_request;
-        let ruffle_wasm_data = await ruffle_wasm_response.arrayBuffer();
-        let ruffle_bindings = await ruffle_wasm_bindgen(ruffle_wasm_data).catch(function (e) {
-            console.error(e);
-        });
-    
-        return ruffle_wasm_bindgen.Ruffle;
-    } else {
-        //We currently assume that if we are not executing inside the extension,
-        //then we can use webpack to get Ruffle.
-        let ruffle_module = await import("../pkg/ruffle");
-        return ruffle_module.Ruffle;
-    }
+    //We currently assume that if we are not executing inside the extension,
+    //then we can use webpack to get Ruffle.
+    let ruffle_module = await import("../pkg/ruffle");
+    return ruffle_module.Ruffle;
 }
 
 let last_loaded_ruffle = null;


### PR DESCRIPTION
This PR transitions the WebExtension build system to a standard Webpack configuration very similar to the self-hosted version of Ruffle.

Previously, the WebExtension used webpack only to aggregate JavaScript modules, and a separate `build.sh` would manually invoke WASMPack in `no-modules` mode. At some point in the past, `build.sh` was removed and it's functionality replaced with a series of Webpack plugins that resulted in the same build product output. Shortly thereafter (29754ea), the extension stopped being buildable, because a `wasm-bindgen` JS snippet was added to the project. This was then merged without issue as our CI system does not appear to build the extension. However, you can't use JS snippets in `no-modules` mode, which is why we can't build the extension.

I originally avoided the use of webpack in the extension because I was worried about global scope pollution; notably, chunks load with a JSONP global and I mistakenly assumed that `__webpack_public_path__` was also a global name. I figured out how to rename the JSONP global and the path variable isn't global after all. Therefore, it's silly to use a completely different configuration for the extension and hit breakages whenever certain `wasm-bindgen` features are used. Instead of tying other programmers' hands, I made this PR which brings the extension build system far closer to the self-hosted one.

(For those wondering, the only other global one will get with the extension active is `RufflePlayer`, which is declared, public API surface that we need in order for self-hosted and extension to cooperate.)