### PR TITLE
Fix misparsing of `ActionGetURL2`.

### DIFF
--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -105,6 +105,7 @@ impl<'a> Reader<'a> {
     /// The `length` passed in should be the length excluding any sub-blocks.
     /// The final `length` returned will be total length of the action, including sub-blocks.
     #[inline]
+    #[allow(clippy::inconsistent_digit_grouping)]
     fn read_op(&mut self, opcode: u8, length: &mut usize) -> Result<Option<Action<'a>>> {
         use num_traits::FromPrimitive;
         let action = if let Some(op) = OpCode::from_u8(opcode) {
@@ -158,9 +159,9 @@ impl<'a> Reader<'a> {
                 OpCode::GetUrl2 => {
                     let flags = self.read_u8()?;
                     Action::GetUrl2 {
-                        is_target_sprite: flags & 0b10 != 0,
-                        is_load_vars: flags & 0b1 != 0,
-                        send_vars_method: match flags >> 6 {
+                        is_load_vars: flags & 0b10_0000_00 != 0,
+                        is_target_sprite: flags & 0b01_0000_00 != 0,
+                        send_vars_method: match flags & 0b11 {
                             0 => SendVarsMethod::None,
                             1 => SendVarsMethod::Get,
                             2 => SendVarsMethod::Post,

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -22,6 +22,7 @@ impl<W: Write> Writer<W> {
         Writer { inner, version }
     }
 
+    #[allow(clippy::inconsistent_digit_grouping)]
     pub fn write_action(&mut self, action: &Action) -> Result<()> {
         match *action {
             Action::Add => self.write_action_header(OpCode::Add, 0)?,
@@ -144,9 +145,8 @@ impl<W: Write> Writer<W> {
                     SendVarsMethod::None => 0,
                     SendVarsMethod::Get => 1,
                     SendVarsMethod::Post => 2,
-                } << 6)
-                    | if is_target_sprite { 0b10 } else { 0 }
-                    | if is_load_vars { 0b1 } else { 0 };
+                }) | if is_target_sprite { 0b01_0000_00 } else { 0 }
+                    | if is_load_vars { 0b10_0000_00 } else { 0 };
                 self.write_u8(flags)?;
             }
             Action::GetVariable => self.write_action_header(OpCode::GetVariable, 0)?,

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -2612,7 +2612,16 @@ pub fn avm1_tests() -> Vec<Avm1TestData> {
                 is_target_sprite: true,
                 is_load_vars: false,
             },
-            vec![0x9A, 1, 0, 0b10_0000_10],
+            vec![0x9A, 1, 0, 0b01_0000_10],
+        ),
+        (
+            4,
+            Action::GetUrl2 {
+                send_vars_method: SendVarsMethod::None,
+                is_target_sprite: true,
+                is_load_vars: false,
+            },
+            vec![0x9A, 1, 0, 0b01_0000_00],
         ),
         (4, Action::GetVariable, vec![0x1C]),
         (3, Action::GotoFrame(11), vec![0x81, 2, 0, 11, 0]),


### PR DESCRIPTION
Adobe's documentation has the flags in opposite order to what they should be. This fixes that.