### PR TITLE
Implemented more of Key

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -296,16 +296,6 @@ pub fn create_globals<'gc>(
     );
     globals.define_value(
         gc_context,
-        "Key",
-        Value::Object(key::create_key_object(
-            gc_context,
-            Some(object_proto),
-            Some(function_proto),
-        )),
-        EnumSet::empty(),
-    );
-    globals.define_value(
-        gc_context,
         "Stage",
         Value::Object(stage::create_stage_object(
             gc_context,

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -1,6 +1,6 @@
 use crate::avm1::property::Attribute;
 use crate::avm1::return_value::ReturnValue;
-use crate::avm1::{Avm1, Error, Object, ScriptObject, UpdateContext, Value};
+use crate::avm1::{Avm1, Error, Object, ScriptObject, TObject, UpdateContext, Value};
 
 use crate::events::KeyCode;
 use gc_arena::MutationContext;
@@ -29,6 +29,121 @@ pub fn create_key_object<'gc>(
     fn_proto: Option<Object<'gc>>,
 ) -> Object<'gc> {
     let mut key = ScriptObject::object(gc_context, proto);
+
+    key.define_value(
+        gc_context,
+        "ALT",
+        18.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "BACKSPACE",
+        8.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "CAPSLOCK",
+        20.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "CONTROL",
+        17.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "DELETEKEY",
+        46.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "DOWN",
+        40.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "END",
+        35.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "ENTER",
+        13.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "ESCAPE",
+        27.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "HOME",
+        36.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "INSERT",
+        45.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "LEFT",
+        37.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "PGDN",
+        34.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "PGUP",
+        33.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "RIGHT",
+        39.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "SHIFT",
+        16.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "SPACE",
+        32.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "TAB",
+        9.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
+    key.define_value(
+        gc_context,
+        "UP",
+        38.into(),
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+    );
 
     key.force_set_function(
         "isDown",

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -23,6 +23,16 @@ pub fn is_down<'gc>(
     }
 }
 
+pub fn get_code<'gc>(
+    _avm: &mut Avm1<'gc>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    let code: u8 = context.input.get_last_key_code().into();
+    Ok(code.into())
+}
+
 pub fn create_key_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     proto: Option<Object<'gc>>,
@@ -148,6 +158,14 @@ pub fn create_key_object<'gc>(
     key.force_set_function(
         "isDown",
         is_down,
+        gc_context,
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        fn_proto,
+    );
+
+    key.force_set_function(
+        "getCode",
+        get_code,
         gc_context,
         Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
         fn_proto,

--- a/core/src/backend/input.rs
+++ b/core/src/backend/input.rs
@@ -3,6 +3,8 @@ use crate::events::KeyCode;
 pub trait InputBackend {
     fn is_key_down(&self, key: KeyCode) -> bool;
 
+    fn get_last_key_code(&self) -> KeyCode;
+
     fn mouse_visible(&self) -> bool;
 
     fn hide_mouse(&mut self);
@@ -22,6 +24,10 @@ impl NullInputBackend {
 impl InputBackend for NullInputBackend {
     fn is_key_down(&self, _key: KeyCode) -> bool {
         false
+    }
+
+    fn get_last_key_code(&self) -> KeyCode {
+        KeyCode::Unknown
     }
 
     fn mouse_visible(&self) -> bool {

--- a/desktop/src/input.rs
+++ b/desktop/src/input.rs
@@ -8,6 +8,7 @@ pub struct WinitInputBackend {
     keys_down: HashSet<VirtualKeyCode>,
     display: Display,
     cursor_visible: bool,
+    last_key: KeyCode,
 }
 
 impl WinitInputBackend {
@@ -15,6 +16,7 @@ impl WinitInputBackend {
         Self {
             keys_down: HashSet::new(),
             cursor_visible: true,
+            last_key: KeyCode::Unknown,
             display,
         }
     }
@@ -27,7 +29,10 @@ impl WinitInputBackend {
                     if let Some(key) = input.virtual_keycode {
                         self.keys_down.insert(key);
                         if let Some(key_code) = winit_to_ruffle_key_code(key) {
+                            self.last_key = key_code;
                             return Some(PlayerEvent::KeyDown { key_code });
+                        } else {
+                            self.last_key = KeyCode::Unknown;
                         }
                     }
                 }
@@ -154,6 +159,10 @@ impl InputBackend for WinitInputBackend {
             KeyCode::F11 => self.keys_down.contains(&VirtualKeyCode::F11),
             KeyCode::F12 => self.keys_down.contains(&VirtualKeyCode::F12),
         }
+    }
+
+    fn get_last_key_code(&self) -> KeyCode {
+        self.last_key
     }
 
     fn mouse_visible(&self) -> bool {

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -10,6 +10,7 @@ pub struct WebInputBackend {
     keys_down: HashSet<String>,
     canvas: HtmlCanvasElement,
     cursor_visible: bool,
+    last_key: KeyCode,
 }
 
 impl WebInputBackend {
@@ -18,11 +19,13 @@ impl WebInputBackend {
             keys_down: HashSet::new(),
             canvas: canvas.clone(),
             cursor_visible: true,
+            last_key: KeyCode::Unknown,
         }
     }
 
     /// Register a key press for a given code string.
     pub fn keydown(&mut self, code: String) {
+        self.last_key = web_to_ruffle_key_code(&code).unwrap_or_else(|| KeyCode::Unknown);
         self.keys_down.insert(code);
     }
 
@@ -137,6 +140,10 @@ impl InputBackend for WebInputBackend {
             KeyCode::F11 => self.keys_down.contains("F11"),
             KeyCode::F12 => self.keys_down.contains("F12"),
         }
+    }
+
+    fn get_last_key_code(&self) -> KeyCode {
+        self.last_key
     }
 
     fn mouse_visible(&self) -> bool {


### PR DESCRIPTION
This implements the following of #257:

## `Key`
- [X] `ALT`
- [X] `BACKSPACE`
- [X] `CAPSLOCK`
- [X] `CONTROL`
- [X] `DELETEKEY`
- [X] `DOWN`
- [X] `END`
- [X] `ENTER`
- [X] `ESCAPE`
- [X] `HOME`
- [X] `INSERT`
- [X] `LEFT`
- [X] `PGDN`
- [X] `PGUP`
- [X] `RIGHT`
- [X] `SHIFT`
- [X] `SPACE`
- [X] `TAB`
- [X] `UP`
- [X] `getCode()`


I'm not even going to try to touch `getAscii` right now. Ouch. Someone else can feel free...

No tests for these because we still don't have a good way to test input, and the constants are just constants.