### PR TITLE
Shape-drawing performance improvements

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@ extern crate smallvec;
 mod avm1;
 mod bounding_box;
 mod character;
-mod color_transform;
+pub mod color_transform;
 mod context;
 pub mod events;
 mod font;

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -41,7 +41,7 @@ features = [
     "AudioNode", "CanvasRenderingContext2d", "ChannelMergerNode", "ChannelSplitterNode", "CssStyleDeclaration", "Document",
     "Element", "Event", "EventTarget", "GainNode", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "MouseEvent",
     "Navigator", "Node", "Performance", "PointerEvent", "ScriptProcessorNode", "UiEvent", "Window", "Location", "HtmlFormElement",
-    "KeyboardEvent"]
+    "KeyboardEvent", "Path2d", "CanvasGradient", "CanvasPattern"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.7"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -41,7 +41,7 @@ features = [
     "AudioNode", "CanvasRenderingContext2d", "ChannelMergerNode", "ChannelSplitterNode", "CssStyleDeclaration", "Document",
     "Element", "Event", "EventTarget", "GainNode", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "MouseEvent",
     "Navigator", "Node", "Performance", "PointerEvent", "ScriptProcessorNode", "UiEvent", "Window", "Location", "HtmlFormElement",
-    "KeyboardEvent", "Path2d", "CanvasGradient", "CanvasPattern"]
+    "KeyboardEvent", "Path2d", "CanvasGradient", "CanvasPattern", "SvgMatrix", "SvgsvgElement"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.7"

--- a/web/src/render.rs
+++ b/web/src/render.rs
@@ -19,6 +19,7 @@ pub struct WebCanvasRenderBackend {
     render_targets: Vec<(HtmlCanvasElement, CanvasRenderingContext2d)>,
     cur_render_target: usize,
     color_matrix: Element,
+    last_matrix_str: Option<String>,
     shapes: Vec<ShapeData>,
     bitmaps: Vec<BitmapData>,
     id_to_bitmap: HashMap<CharacterId, BitmapHandle>,
@@ -165,6 +166,7 @@ impl WebCanvasRenderBackend {
             render_targets,
             cur_render_target: 0,
             color_matrix,
+            last_matrix_str: None,
             context,
             shapes: vec![],
             bitmaps: vec![],
@@ -303,17 +305,23 @@ impl WebCanvasRenderBackend {
                 a_mult,
                 a_add
             );
-            self.color_matrix
-                .set_attribute("values", &matrix_str)
-                .unwrap();
 
-            self.context.set_filter("url('#_cm')");
+            if self.last_matrix_str.as_ref() != Some(&matrix_str) {
+                self.color_matrix
+                    .set_attribute("values", &matrix_str)
+                    .unwrap();
+
+                self.context.set_filter("url('#_cm')");
+
+                self.last_matrix_str = Some(matrix_str);
+            }
         }
     }
 
     #[inline]
     fn clear_transform(&mut self) {
         self.context.set_filter("none");
+        self.last_matrix_str = None;
         self.context.set_global_alpha(1.0);
     }
 }

--- a/web/src/render.rs
+++ b/web/src/render.rs
@@ -1219,11 +1219,11 @@ fn swf_shape_to_canvas_commands(
 
                 canvas_data.0.push(CanvasDrawCommand::Stroke {
                     path,
-                    line_width: line_width.into(),
+                    line_width: line_width as f64 / 20.0,
                     stroke_style,
                     line_cap: line_cap.to_string(),
                     line_join: line_join.to_string(),
-                    miter_limit: miter_limit.into(),
+                    miter_limit: miter_limit as f64 / 20.0,
                 });
             }
         }

--- a/web/src/render.rs
+++ b/web/src/render.rs
@@ -49,10 +49,10 @@ impl CanvasColor {
     /// Apply a color transformation to this color.
     fn color_transform(&self, cxform: &ColorTransform) -> CanvasColor {
         let CanvasColor(_, r, g, b, a) = self;
-        let r = clamped_u8_color(*r as f32 * cxform.r_mult + (cxform.r_add * 256.0));
-        let g = clamped_u8_color(*g as f32 * cxform.g_mult + (cxform.g_add * 256.0));
-        let b = clamped_u8_color(*b as f32 * cxform.b_mult + (cxform.b_add * 256.0));
-        let a = clamped_u8_color(*a as f32 * cxform.a_mult + (cxform.a_add * 256.0));
+        let r = clamped_u8_color(*r as f32 * cxform.r_mult + (cxform.r_add * 255.0));
+        let g = clamped_u8_color(*g as f32 * cxform.g_mult + (cxform.g_add * 255.0));
+        let b = clamped_u8_color(*b as f32 * cxform.b_mult + (cxform.b_add * 255.0));
+        let a = clamped_u8_color(*a as f32 * cxform.a_mult + (cxform.a_add * 255.0));
         let colstring = format!("rgba({},{},{},{})", r, g, b, f32::from(a) / 255.0);
         CanvasColor(colstring, r, g, b, a)
     }
@@ -599,9 +599,11 @@ impl RenderBackend for WebCanvasRenderBackend {
                         x_min,
                         y_min,
                     } => {
+                        self.set_color_filter(transform);
                         let _ = self
                             .context
                             .draw_image_with_html_image_element(&image, *x_min, *y_min);
+                        self.clear_color_filter();
                     }
                 }
             }

--- a/web/src/render.rs
+++ b/web/src/render.rs
@@ -34,14 +34,25 @@ struct ShapeData(Vec<CanvasDrawCommand>);
 
 struct CanvasColor(String, u8, u8, u8, u8);
 
+/// Convert an f32 to a u8, clamping all out-of-range values to the `u8` range.
+fn clamped_u8_color(v: f32) -> u8 {
+    if v < 0.0 {
+        0
+    } else if v > 255.0 {
+        255
+    } else {
+        v as u8
+    }
+}
+
 impl CanvasColor {
     /// Apply a color transformation to this color.
     fn color_transform(&self, cxform: &ColorTransform) -> CanvasColor {
         let CanvasColor(_, r, g, b, a) = self;
-        let r = (*r as f32 * cxform.r_mult + (cxform.r_add * 256.0)) as u8;
-        let g = (*g as f32 * cxform.g_mult + (cxform.g_add * 256.0)) as u8;
-        let b = (*b as f32 * cxform.b_mult + (cxform.b_add * 256.0)) as u8;
-        let a = (*a as f32 * cxform.a_mult + (cxform.a_add * 256.0)) as u8;
+        let r = clamped_u8_color(*r as f32 * cxform.r_mult + (cxform.r_add * 256.0));
+        let g = clamped_u8_color(*g as f32 * cxform.g_mult + (cxform.g_add * 256.0));
+        let b = clamped_u8_color(*b as f32 * cxform.b_mult + (cxform.b_add * 256.0));
+        let a = clamped_u8_color(*a as f32 * cxform.a_mult + (cxform.a_add * 256.0));
         let colstring = format!("rgba({},{},{},{})", r, g, b, f32::from(a) / 255.0);
         CanvasColor(colstring, r, g, b, a)
     }


### PR DESCRIPTION
This PR fixes worst-case performance when drawing large numbers of shapes to the stage per frame (e.g. text). In a particularly bad case (HSR Toons Page) this PR goes from seconds-per-frame to 60fps.

Performance was increased largely due to two improvements made to rendering:

1. Replacing the SVG-in-an-image rendering mode with directly invoking `Canvas` draw commands
2. Avoiding the use of canvas filters whenever possible

First, the SVG rendering path. Previously, each shape in the SWF would be converted into an SVG, then into a `data:` url as part of an image, and then we used `drawImage` commands, canvas transforms, and color filters to manipulate the shape as the SWF rendering model allows. This is adequate for small numbers of shapes; however, each `drawImage` triggers multiple paint and layout cycles for the embedded SVG element. By switching to canvas drawing commands directly we can avoid these.

(More generally, I'm noticing that the SVG drawing model doesn't seem to be a good fit for canvas. There isn't a faster way to just render an SVG on a canvas.)

Furthermore, once we are using canvas drawing commands, we can also elide the color filter and pre-calculate the color change. I wasn't able to confirm exactly why, but this also improves performance. Current operating theory is that using any filters on the canvas causes the whole shape to get rendered separately, filtered, and then copied onto the canvas, which is overkill.

This PR has some limitations; we can only use this fast-path for solid colors and lines. Gradients could hypothetically work, but we can't render them in the fast-path renderer as the canvas drawing model doesn't support slanted gradients. Bitmaps are fast-pathed but have to be color filtered.