### PR TITLE
input: Change cursor on button hover, add InputBackend::set_mouse_cursor

### DIFF
--- a/core/src/backend/input.rs
+++ b/core/src/backend/input.rs
@@ -11,6 +11,9 @@ pub trait InputBackend: Downcast {
     fn hide_mouse(&mut self);
 
     fn show_mouse(&mut self);
+
+    /// Changes the mouse cursor image.
+    fn set_mouse_cursor(&mut self, cursor: MouseCursor);
 }
 impl_downcast!(InputBackend);
 
@@ -39,10 +42,33 @@ impl InputBackend for NullInputBackend {
     fn hide_mouse(&mut self) {}
 
     fn show_mouse(&mut self) {}
+
+    fn set_mouse_cursor(&mut self, _cursor: MouseCursor) {}
 }
 
 impl Default for NullInputBackend {
     fn default() -> Self {
         NullInputBackend::new()
     }
+}
+
+/// A mouse cursor icon displayed by the Flash Player.
+/// Communicated from the core to the input backend via `InputBackend::set_mouse_cursor`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MouseCursor {
+    /// The default arrow icon.
+    /// Equivalent to AS3 `MouseCursor.ARROW`.
+    Arrow,
+
+    /// The hand icon incdicating a button or link.
+    /// Equivalent to AS3 `MouseCursor.BUTTON`.
+    Hand,
+
+    /// The text I-beam.
+    /// Equivalent to AS3 `MouseCursor.IBEAM`.
+    IBeam,
+
+    /// The grabby-dragging hand icon.
+    /// Equivalent to AS3 `MouseCursor.HAND`.
+    Grab,
 }

--- a/desktop/src/input.rs
+++ b/desktop/src/input.rs
@@ -1,5 +1,5 @@
 use glium::Display;
-use ruffle_core::backend::input::InputBackend;
+use ruffle_core::backend::input::{InputBackend, MouseCursor};
 use ruffle_core::events::{KeyCode, PlayerEvent};
 use std::collections::HashSet;
 use winit::event::{ElementState, VirtualKeyCode, WindowEvent};
@@ -177,6 +177,17 @@ impl InputBackend for WinitInputBackend {
     fn show_mouse(&mut self) {
         self.display.gl_window().window().set_cursor_visible(true);
         self.cursor_visible = true;
+    }
+
+    fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
+        use winit::window::CursorIcon;
+        let icon = match cursor {
+            MouseCursor::Arrow => CursorIcon::Arrow,
+            MouseCursor::Hand => CursorIcon::Hand,
+            MouseCursor::IBeam => CursorIcon::Text,
+            MouseCursor::Grab => CursorIcon::Grab,
+        };
+        self.display.gl_window().window().set_cursor_icon(icon);
     }
 }
 


### PR DESCRIPTION
It doesn't feel like Flash without having the hand cursor display
when hovering over buttons. First pass at implementing this;
core communicates which mouse cursor to use via
`InputBackend::set_mouse_cursor`.

TODO: Hand cursor only displayed for Button display objects
currently. Movie clips should also display this when they are in
"button mode" (when a button mouse event is set on them in AVM1,
or `buttonMode` property in AVM2).