### PR TITLE
core: Implement keyUp event

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -4,6 +4,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[derive(Debug)]
 pub enum PlayerEvent {
     KeyDown { key_code: KeyCode },
+    KeyUp { key_code: KeyCode },
     MouseMove { x: f64, y: f64 },
     MouseUp { x: f64, y: f64 },
     MouseDown { x: f64, y: f64 },

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -391,6 +391,7 @@ impl Player {
         // Propagte clip events.
         let (clip_event, mouse_event_name) = match event {
             PlayerEvent::KeyDown { .. } => (Some(ClipEvent::KeyDown), Some("onKeyDown")),
+            PlayerEvent::KeyUp { .. } => (Some(ClipEvent::KeyUp), Some("onKeyUp")),
             PlayerEvent::MouseMove { .. } => (Some(ClipEvent::MouseMove), Some("onMouseMove")),
             PlayerEvent::MouseUp { .. } => (Some(ClipEvent::MouseUp), Some("onMouseUp")),
             PlayerEvent::MouseDown { .. } => (Some(ClipEvent::MouseDown), Some("onMouseDown")),

--- a/desktop/src/input.rs
+++ b/desktop/src/input.rs
@@ -39,6 +39,12 @@ impl WinitInputBackend {
                 ElementState::Released => {
                     if let Some(key) = input.virtual_keycode {
                         self.keys_down.remove(&key);
+                        if let Some(key_code) = winit_to_ruffle_key_code(key) {
+                            self.last_key = key_code;
+                            return Some(PlayerEvent::KeyUp { key_code });
+                        } else {
+                            self.last_key = KeyCode::Unknown;
+                        }
                     }
                 }
             },

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -342,6 +342,7 @@ impl Ruffle {
                     INSTANCES.with(|instances| {
                         if let Some(instance) = instances.borrow_mut().get_mut(index) {
                             if instance.has_focus {
+                                let code = js_event.code();
                                 instance
                                     .core
                                     .lock()
@@ -349,7 +350,16 @@ impl Ruffle {
                                     .input_mut()
                                     .downcast_mut::<WebInputBackend>()
                                     .unwrap()
-                                    .keyup(js_event.code());
+                                    .keyup(code.clone());
+
+                                if let Some(key_code) = input::web_to_ruffle_key_code(&code) {
+                                    instance
+                                        .core
+                                        .lock()
+                                        .unwrap()
+                                        .handle_event(PlayerEvent::KeyUp { key_code });
+                                }
+
                                 js_event.prevent_default();
                             }
                         }


### PR DESCRIPTION
Implement `keyUp` clip event, which uses basically the same logic as `keyDown`.

Fixes #339.