### PR TITLE
LoadManager resiliency

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -257,6 +257,7 @@ impl<'gc> Loader<'gc> {
                             target_broadcaster,
                             ..
                         }) => (*target_clip, *target_broadcaster),
+                        None => return Err("Load cancelled".into()),
                         _ => unreachable!(),
                     };
 
@@ -296,6 +297,7 @@ impl<'gc> Loader<'gc> {
                                 target_broadcaster,
                                 ..
                             }) => (*target_clip, *target_broadcaster),
+                            None => return Err("Load cancelled".into()),
                             _ => unreachable!(),
                         };
 
@@ -363,6 +365,7 @@ impl<'gc> Loader<'gc> {
                                 target_broadcaster,
                                 ..
                             }) => (*target_clip, *target_broadcaster),
+                            None => return Err("Load cancelled".into()),
                             _ => unreachable!(),
                         };
 
@@ -410,7 +413,7 @@ impl<'gc> Loader<'gc> {
                 let loader = uc.load_manager.get_loader(handle);
                 let that = match loader {
                     Some(Loader::Form { target_object, .. }) => *target_object,
-                    None => return Err("Loader expired during loading".into()),
+                    None => return Err("Load cancelled".into()),
                     _ => return Err("Non-movie loader spawned as movie loader".into()),
                 };
 
@@ -492,6 +495,7 @@ impl<'gc> Loader<'gc> {
                                 active_clip,
                                 ..
                             }) => (*target_node, *active_clip),
+                            None => return Err("Load cancelled".into()),
                             _ => unreachable!(),
                         };
 
@@ -529,6 +533,7 @@ impl<'gc> Loader<'gc> {
                                 active_clip,
                                 ..
                             }) => (*target_node, *active_clip),
+                            None => return Err("Load cancelled".into()),
                             _ => unreachable!(),
                         };
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -149,7 +149,7 @@ impl Player {
         input: Input,
         swf_data: Vec<u8>,
     ) -> Result<Arc<Mutex<Self>>, Error> {
-        let movie = Arc::new(SwfMovie::from_data(&swf_data));
+        let movie = Arc::new(SwfMovie::from_data(&swf_data)?);
 
         info!(
             "{}x{}",

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -2,7 +2,8 @@ use gc_arena::Collect;
 use std::sync::Arc;
 use swf::{Header, TagCode};
 
-pub type DecodeResult = Result<(), Box<dyn std::error::Error>>;
+pub type Error = Box<dyn std::error::Error>;
+pub type DecodeResult = Result<(), Error>;
 pub type SwfStream<R> = swf::read::Reader<std::io::Cursor<R>>;
 
 /// An open, fully parsed SWF movie ready to play back, either in a Player or a
@@ -41,8 +42,8 @@ impl SwfMovie {
     }
 
     /// Construct a movie based on the contents of the SWF datastream.
-    pub fn from_data(swf_data: &[u8]) -> Self {
-        let swf_stream = swf::read::read_swf_header(&swf_data[..]).unwrap();
+    pub fn from_data(swf_data: &[u8]) -> Result<Self, Error> {
+        let swf_stream = swf::read::read_swf_header(&swf_data[..])?;
         let header = swf_stream.header;
         let mut reader = swf_stream.reader;
 
@@ -66,7 +67,7 @@ impl SwfMovie {
             data
         };
 
-        Self { header, data }
+        Ok(Self { header, data })
     }
 
     pub fn header(&self) -> &Header {

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -62,7 +62,7 @@ impl SwfMovie {
         } else {
             let mut data = Vec::with_capacity(swf_stream.uncompressed_length);
             if let Err(e) = reader.get_mut().read_to_end(&mut data) {
-                log::error!("Error decompressing SWF, may be corrupt: {}", e);
+                return Err(format!("Error decompressing SWF, may be corrupt: {}", e).into());
             }
             data
         };


### PR DESCRIPTION
Fixes for various errors caused by the merging of `moviefetch`, as suggested by @Herschel. These should fix #410 and #411, at least to the point of no longer panicking.

This PR does the following:

- Makes `SwfMovie::from_data` a falliable method (e.g. returns `Result`). Previously, it would either panic (due to a copy-pasted `unwrap`) or just log an error and attempt to play an empty movie; both of which are the wrong behavior and also inconsistent with each other. Callers of this method now handle the error properly depending on the context.
- Fix a race condition in which a premature `Load` event triggered by the clip would cancel all in-progress loads. Now, loads will only be removed from the list if they have already completed (either by replacing the movie in question or by erroring out).
- Fix a panic caused when a cancelled loader attempts to update the player. Instead, these will return an `Err`, which will be logged by the async runtime.