### PR TITLE
web: Polyfill is more lenient with embed and object tags (fix #457)

### DIFF
--- a/web/js-src/ruffle-embed.js
+++ b/web/js-src/ruffle-embed.js
@@ -48,7 +48,12 @@ export default class RuffleEmbed extends RufflePlayer {
         let ruffle_obj = document.createElement(external_name);
         for (let attrib of elem.attributes) {
             if (attrib.specified) {
-                ruffle_obj.setAttribute(attrib.name, attrib.value);
+                try {
+                    ruffle_obj.setAttribute(attrib.name, attrib.value);
+                } catch (err) {
+                    // The embed may have invalid attributes, so handle these gracefully.
+                    console.warn(`Unable to set attribute ${attrib.name} on Ruffle instance`);
+                }
             }
         }
 

--- a/web/js-src/ruffle-embed.js
+++ b/web/js-src/ruffle-embed.js
@@ -1,5 +1,5 @@
-import {FLASH_MIMETYPE, FUTURESPLASH_MIMETYPE, RufflePlayer} from "./ruffle-player.js";
-import {register_element} from "./register-element";
+import { FLASH_MIMETYPE, FUTURESPLASH_MIMETYPE, is_swf_filename, RufflePlayer } from "./ruffle-player.js";
+import { register_element } from "./register-element";
 
 export default class RuffleEmbed extends RufflePlayer {
     constructor(...args) {
@@ -34,7 +34,13 @@ export default class RuffleEmbed extends RufflePlayer {
     }
 
     static is_interdictable(elem) {
-        return elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE;
+        if (elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE) {
+            return true;
+        } else if (elem.type === undefined || elem.type === "") {
+            return is_swf_filename(elem.src);
+        }
+
+        return false;
     }
 
     static from_native_embed_element(elem) {

--- a/web/js-src/ruffle-object.js
+++ b/web/js-src/ruffle-object.js
@@ -1,5 +1,5 @@
-import {FLASH_MIMETYPE, FUTURESPLASH_MIMETYPE, FLASH_ACTIVEX_CLASSID, RufflePlayer} from "./ruffle-player.js";
-import {register_element} from "./register-element";
+import { FLASH_MIMETYPE, FUTURESPLASH_MIMETYPE, FLASH_ACTIVEX_CLASSID, is_swf_filename, RufflePlayer } from "./ruffle-player.js";
+import { register_element } from "./register-element";
 
 export default class RuffleObject extends RufflePlayer {
     constructor(...args) {
@@ -10,7 +10,7 @@ export default class RuffleObject extends RufflePlayer {
         super.connectedCallback();
         
         this.params = RuffleObject.params_of(this);
-        
+
         //Kick off the SWF download.
         if (this.attributes.data) {
             this.stream_swf_url(this.attributes.data.value);
@@ -28,7 +28,18 @@ export default class RuffleObject extends RufflePlayer {
     }
 
     static is_interdictable(elem) {
-        return elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE || elem.attributes.classid.value === FLASH_ACTIVEX_CLASSID;
+        if (elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE) {
+            return true;
+        } else if (elem.attributes && elem.attributes.classid && elem.attributes.classid.value === FLASH_ACTIVEX_CLASSID) {
+            return true;
+        } else if ((elem.type === undefined || elem.type === "") && elem.attributes.classid === undefined) {
+            let params = RuffleObject.params_of(elem);
+            if (params && params.movie) {
+                return is_swf_filename(params.movie);
+            }
+        }
+
+        return false;
     }
 
     static params_of(elem) {

--- a/web/js-src/ruffle-object.js
+++ b/web/js-src/ruffle-object.js
@@ -59,7 +59,12 @@ export default class RuffleObject extends RufflePlayer {
         let ruffle_obj = document.createElement(external_name);
         for (let attrib of elem.attributes) {
             if (attrib.specified) {
-                ruffle_obj.setAttribute(attrib.name, attrib.value);
+                try {
+                    ruffle_obj.setAttribute(attrib.name, attrib.value);
+                } catch (err) {
+                    // The embed may have invalid attributes, so handle these gracefully.
+                    console.warn(`Unable to set attribute ${attrib.name} on Ruffle instance`);
+                }
             }
         }
 

--- a/web/js-src/ruffle-player.js
+++ b/web/js-src/ruffle-player.js
@@ -122,3 +122,10 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 }
+
+/*
+ * Returns whether the given filename ends in an "swf" extension.
+ */
+export function is_swf_filename(filename) {
+    return filename && typeof filename === "string" && filename.search(/\.swf\s*$/i) >= 0;
+}


### PR DESCRIPTION
If an embed tag or object tag is missing the Flash MIME type/ActiveX class attribute, Ruffle will check if the source file ends with the ".swf" extension to determine whether it's a Flash embed. This matches current browser behavior.

Additionally, toss out any errors when trying to copy attributes from the embed to the Ruffle element. Previously, bogus attributes would throw in `setAttribute` and cause Ruffle to error out.

Fixes #457.