### PR TITLE
web: Simplify polyfill code

### DIFF
--- a/web/js-src/public-api.js
+++ b/web/js-src/public-api.js
@@ -125,7 +125,8 @@ export class PublicAPI {
 
             let polyfills = this.config.polyfills;
             if (polyfills === undefined) {
-                polyfills = ["plugin-detect", "static-content"];
+                // Default to all polyfills for simplest usage.
+                polyfills = ["plugin-detect", "dynamic-content", "static-content"];
             }
             
             this.sources[this.newest_name].polyfill(polyfills);


### PR DESCRIPTION
Addresses #464. Use `document.getElementsByTagName` to find all
object and embed tags in the document. For dynamic content,
we keep these live collections around, and re-check them whenever
a MutationObserver fires.

Also enables the dynamic content polyfill by default.