### PR TITLE
web: Fix #412, incorrect bitmap rendering when cached

### DIFF
--- a/web/src/render.rs
+++ b/web/src/render.rs
@@ -1191,8 +1191,6 @@ fn swf_shape_to_canvas_commands(
                         )
                         .expect("html image element");
 
-                        image.set_src(*bitmap_data);
-
                         if !*is_smoothed {
                             //image = image.set("image-rendering", pixelated_property_value);
                         }
@@ -1206,6 +1204,10 @@ fn swf_shape_to_canvas_commands(
                         let bitmap_pattern = context
                             .create_pattern_with_html_image_element(&image, repeat)
                             .expect("pattern creation success")?;
+
+                        // Set source below the pattern creation because otherwise the bitmap gets screwed up
+                        // when cached? (Issue #412)
+                        image.set_src(*bitmap_data);
 
                         let a = Matrix::from(matrix.clone());
 


### PR DESCRIPTION
If a page was reloaded, bitmaps in canvas shapes could be cached, causing incorrect rendering. This seems to occur because of the image being decoded immediately when it's cached, as opposed to asynchronously when not (image.naturalWidth will be 0 vs non-zero). This applied to shapes using the newer canvas command rendering path.

Tweak the creation order of the canvas pattern to avoid this issue.