### PR TITLE
web: Make polyfill work with SWFObject (fix #448)

### DIFF
--- a/web/js-src/plugin-polyfill.js
+++ b/web/js-src/plugin-polyfill.js
@@ -128,7 +128,7 @@ class RufflePluginArray {
     }
 };
 
-export const FLASH_PLUGIN = new RufflePlugin("Shockwave Flash", "Shockwave Flash 32.0 r0 (compatible; Ruffle 0.1.0)", "ruffle.js", [
+export const FLASH_PLUGIN = new RufflePlugin("Shockwave Flash", "Shockwave Flash 32.0 r0", "ruffle.js", [
     new RuffleMimeType("application/futuresplash", "Shockwave Flash", "spl"),
     new RuffleMimeType("application/x-shockwave-flash", "Shockwave Flash", "swf"),
 ]);

--- a/web/js-src/public-api.js
+++ b/web/js-src/public-api.js
@@ -242,6 +242,15 @@ export class PublicAPI {
         
         if (source_name !== undefined && source_api !== undefined) {
             public_api.register_source(source_name, source_api);
+            
+            // Install the faux plugin detection immediately.
+            // This is necessary because scripts such as SWFObject check for the
+            // Flash Player immediately when they load.
+            // TODO: Maybe there's a better place for this.
+            let polyfills = public_api.config.polyfills;
+            if (polyfills === undefined || polyfills.includes("plugin-detect")) {
+                source_api.polyfill(["plugin-detect"]);
+            }
         }
 
         return public_api;


### PR DESCRIPTION
Fix a few issues preventing Ruffle from getting along with SWFObject.

First, we install our plugin version spoof immediately when the Ruffle script first executes. This also requires the Ruffle script tag to be before the SWFObject script tag.

Secondly, the MIME type description for the plugin spoof was changed to match Flash; previously it had an additional "Ruffle" text that broke the SWFObject version parsing.