### PR TITLE
WebGL render backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,22 +1827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruffle_render_wgpu"
-version = "0.1.0"
-dependencies = [
- "bytemuck 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.23.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "jpeg-decoder 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lyon 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ruffle_core 0.1.0",
- "wgpu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ruffle_render_webgl"
 version = "0.1.0"
 dependencies = [
@@ -1856,6 +1840,22 @@ dependencies = [
  "ruffle_render_common_tess 0.1.0",
  "wasm-bindgen 0.2.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ruffle_render_wgpu"
+version = "0.1.0"
+dependencies = [
+ "bytemuck 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.23.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lyon 0.15.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruffle_core 0.1.0",
+ "wgpu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu-native 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruffle_render_webgl"
+version = "0.1.0"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jpeg-decoder 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruffle_core 0.1.0",
+ "ruffle_render_common_tess 0.1.0",
+ "wasm-bindgen 0.2.57 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ruffle_scanner"
 version = "0.1.0"
 dependencies = [
@@ -1870,6 +1886,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruffle_core 0.1.0",
  "ruffle_render_canvas 0.1.0",
+ "ruffle_render_webgl 0.1.0",
  "ruffle_web_common 0.1.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,14 +1832,15 @@ version = "0.1.0"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jpeg-decoder 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruffle_core 0.1.0",
  "ruffle_render_common_tess 0.1.0",
- "wasm-bindgen 0.2.57 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruffle_web_common 0.1.0",
+ "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1899,8 +1900,10 @@ dependencies = [
 name = "ruffle_web_common"
 version = "0.1.0"
 dependencies = [
+ "js-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "render/canvas",
     "render/wgpu",
     "render/common_tess",
+    "render/webgl",
 ]
 
 # Don't optimize build scripts and macros.

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -36,12 +36,10 @@ where
         match path {
             DrawPath::Fill { style, commands } => match style {
                 FillStyle::Color(color) => {
-                    let color = [
-                        f32::from(color.r) / 255.0,
-                        f32::from(color.g) / 255.0,
-                        f32::from(color.b) / 255.0,
-                        f32::from(color.a) / 255.0,
-                    ];
+                    let color = ((color.a as u32) << 24)
+                        | ((color.b as u32) << 16)
+                        | ((color.g as u32) << 8)
+                        | (color.r as u32);
 
                     let mut buffers_builder =
                         BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
@@ -59,12 +57,8 @@ where
                 FillStyle::LinearGradient(gradient) => {
                     flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
 
-                    let mut buffers_builder = BuffersBuilder::new(
-                        &mut lyon_mesh,
-                        RuffleVertexCtor {
-                            color: [1.0, 1.0, 1.0, 1.0],
-                        },
-                    );
+                    let mut buffers_builder =
+                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
 
                     if let Err(e) = fill_tess.tessellate_path(
                         &ruffle_path_to_lyon_path(commands, true),
@@ -103,12 +97,8 @@ where
                 FillStyle::RadialGradient(gradient) => {
                     flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
 
-                    let mut buffers_builder = BuffersBuilder::new(
-                        &mut lyon_mesh,
-                        RuffleVertexCtor {
-                            color: [1.0, 1.0, 1.0, 1.0],
-                        },
-                    );
+                    let mut buffers_builder =
+                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
 
                     if let Err(e) = fill_tess.tessellate_path(
                         &ruffle_path_to_lyon_path(commands, true),
@@ -150,12 +140,8 @@ where
                 } => {
                     flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
 
-                    let mut buffers_builder = BuffersBuilder::new(
-                        &mut lyon_mesh,
-                        RuffleVertexCtor {
-                            color: [1.0, 1.0, 1.0, 1.0],
-                        },
-                    );
+                    let mut buffers_builder =
+                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
 
                     if let Err(e) = fill_tess.tessellate_path(
                         &ruffle_path_to_lyon_path(commands, true),
@@ -199,12 +185,8 @@ where
                 } => {
                     flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
 
-                    let mut buffers_builder = BuffersBuilder::new(
-                        &mut lyon_mesh,
-                        RuffleVertexCtor {
-                            color: [1.0, 1.0, 1.0, 1.0],
-                        },
-                    );
+                    let mut buffers_builder =
+                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
 
                     if let Err(e) = fill_tess.tessellate_path(
                         &ruffle_path_to_lyon_path(commands, true),
@@ -237,12 +219,10 @@ where
                 commands,
                 is_closed,
             } => {
-                let color = [
-                    f32::from(style.color.r) / 255.0,
-                    f32::from(style.color.g) / 255.0,
-                    f32::from(style.color.b) / 255.0,
-                    f32::from(style.color.a) / 255.0,
-                ];
+                let color = ((style.color.a as u32) << 24)
+                    | ((style.color.b as u32) << 16)
+                    | ((style.color.g as u32) << 8)
+                    | (style.color.r as u32);
 
                 let mut buffers_builder =
                     BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
@@ -328,7 +308,7 @@ pub struct Gradient {
 #[derive(Copy, Clone, Debug)]
 pub struct Vertex {
     pub position: [f32; 2],
-    pub color: [f32; 4],
+    pub color: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -417,7 +397,7 @@ fn ruffle_path_to_lyon_path(commands: Vec<DrawCommand>, is_closed: bool) -> Path
 }
 
 struct RuffleVertexCtor {
-    color: [f32; 4],
+    color: u32,
 }
 
 impl FillVertexConstructor<Vertex> for RuffleVertexCtor {

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -8,270 +8,291 @@ use lyon::tessellation::{FillOptions, StrokeOptions};
 use ruffle_core::backend::render::swf::{self, FillStyle, Twips};
 use ruffle_core::shape_utils::{DrawCommand, DrawPath};
 
-pub fn tessellate_shape<F>(shape: &swf::Shape, get_bitmap_dimenions: F) -> Mesh
-where
-    F: Fn(swf::CharacterId) -> Option<(u32, u32)>,
-{
-    let paths = ruffle_core::shape_utils::swf_shape_to_paths(shape);
-    let mut mesh = Vec::new();
+pub struct ShapeTessellator {
+    fill_tess: FillTessellator,
+    stroke_tess: StrokeTessellator,
+}
 
-    let mut fill_tess = FillTessellator::new();
-    let mut stroke_tess = StrokeTessellator::new();
-    let mut lyon_mesh: VertexBuffers<_, u32> = VertexBuffers::new();
-
-    fn flush_draw(draw: DrawType, mesh: &mut Mesh, lyon_mesh: &mut VertexBuffers<Vertex, u32>) {
-        if lyon_mesh.vertices.is_empty() {
-            return;
+impl ShapeTessellator {
+    pub fn new() -> Self {
+        Self {
+            fill_tess: FillTessellator::new(),
+            stroke_tess: StrokeTessellator::new(),
         }
-
-        let draw_mesh = std::mem::replace(lyon_mesh, VertexBuffers::new());
-        mesh.push(Draw {
-            draw_type: draw,
-            vertices: draw_mesh.vertices,
-            indices: draw_mesh.indices,
-        });
     }
 
-    for path in paths {
-        match path {
-            DrawPath::Fill { style, commands } => match style {
-                FillStyle::Color(color) => {
-                    let color = ((color.a as u32) << 24)
-                        | ((color.b as u32) << 16)
-                        | ((color.g as u32) << 8)
-                        | (color.r as u32);
+    pub fn tessellate_shape<F>(&mut self, shape: &swf::Shape, get_bitmap_dimensions: F) -> Mesh
+    where
+        F: Fn(swf::CharacterId) -> Option<(u32, u32)>,
+    {
+        let paths = ruffle_core::shape_utils::swf_shape_to_paths(shape);
+        let mut mesh = Vec::new();
+
+        let mut lyon_mesh: VertexBuffers<_, u32> = VertexBuffers::new();
+
+        fn flush_draw(draw: DrawType, mesh: &mut Mesh, lyon_mesh: &mut VertexBuffers<Vertex, u32>) {
+            if lyon_mesh.vertices.is_empty() {
+                return;
+            }
+
+            let draw_mesh = std::mem::replace(lyon_mesh, VertexBuffers::new());
+            mesh.push(Draw {
+                draw_type: draw,
+                vertices: draw_mesh.vertices,
+                indices: draw_mesh.indices,
+            });
+        }
+
+        for path in paths {
+            match path {
+                DrawPath::Fill { style, commands } => match style {
+                    FillStyle::Color(color) => {
+                        let color = ((color.a as u32) << 24)
+                            | ((color.b as u32) << 16)
+                            | ((color.g as u32) << 8)
+                            | (color.r as u32);
+
+                        let mut buffers_builder =
+                            BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
+
+                        if let Err(e) = self.fill_tess.tessellate_path(
+                            &ruffle_path_to_lyon_path(commands, true),
+                            &FillOptions::even_odd(),
+                            &mut buffers_builder,
+                        ) {
+                            // This may just be a degenerate path; skip it.
+                            log::error!("Tessellation failure: {:?}", e);
+                            continue;
+                        }
+                    }
+                    FillStyle::LinearGradient(gradient) => {
+                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+
+                        let mut buffers_builder = BuffersBuilder::new(
+                            &mut lyon_mesh,
+                            RuffleVertexCtor { color: 0xffff_ffff },
+                        );
+
+                        if let Err(e) = self.fill_tess.tessellate_path(
+                            &ruffle_path_to_lyon_path(commands, true),
+                            &FillOptions::even_odd(),
+                            &mut buffers_builder,
+                        ) {
+                            // This may just be a degenerate path; skip it.
+                            log::error!("Tessellation failure: {:?}", e);
+                            continue;
+                        }
+
+                        let mut colors: Vec<[f32; 4]> = Vec::with_capacity(8);
+                        let mut ratios: Vec<f32> = Vec::with_capacity(8);
+                        for record in &gradient.records {
+                            colors.push([
+                                f32::from(record.color.r) / 255.0,
+                                f32::from(record.color.g) / 255.0,
+                                f32::from(record.color.b) / 255.0,
+                                f32::from(record.color.a) / 255.0,
+                            ]);
+                            ratios.push(f32::from(record.ratio) / 255.0);
+                        }
+
+                        let gradient = Gradient {
+                            gradient_type: GradientType::Linear,
+                            ratios,
+                            colors,
+                            num_colors: gradient.records.len() as u32,
+                            matrix: swf_to_gl_matrix(gradient.matrix.clone()),
+                            repeat_mode: gradient.spread,
+                            focal_point: 0.0,
+                        };
+
+                        flush_draw(DrawType::Gradient(gradient), &mut mesh, &mut lyon_mesh);
+                    }
+                    FillStyle::RadialGradient(gradient) => {
+                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+
+                        let mut buffers_builder = BuffersBuilder::new(
+                            &mut lyon_mesh,
+                            RuffleVertexCtor { color: 0xffff_ffff },
+                        );
+
+                        if let Err(e) = self.fill_tess.tessellate_path(
+                            &ruffle_path_to_lyon_path(commands, true),
+                            &FillOptions::even_odd(),
+                            &mut buffers_builder,
+                        ) {
+                            // This may just be a degenerate path; skip it.
+                            log::error!("Tessellation failure: {:?}", e);
+                            continue;
+                        }
+
+                        let mut colors: Vec<[f32; 4]> = Vec::with_capacity(8);
+                        let mut ratios: Vec<f32> = Vec::with_capacity(8);
+                        for record in &gradient.records {
+                            colors.push([
+                                f32::from(record.color.r) / 255.0,
+                                f32::from(record.color.g) / 255.0,
+                                f32::from(record.color.b) / 255.0,
+                                f32::from(record.color.a) / 255.0,
+                            ]);
+                            ratios.push(f32::from(record.ratio) / 255.0);
+                        }
+
+                        let gradient = Gradient {
+                            gradient_type: GradientType::Radial,
+                            ratios,
+                            colors,
+                            num_colors: gradient.records.len() as u32,
+                            matrix: swf_to_gl_matrix(gradient.matrix.clone()),
+                            repeat_mode: gradient.spread,
+                            focal_point: 0.0,
+                        };
+
+                        flush_draw(DrawType::Gradient(gradient), &mut mesh, &mut lyon_mesh);
+                    }
+                    FillStyle::FocalGradient {
+                        gradient,
+                        focal_point,
+                    } => {
+                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+
+                        let mut buffers_builder = BuffersBuilder::new(
+                            &mut lyon_mesh,
+                            RuffleVertexCtor { color: 0xffff_ffff },
+                        );
+
+                        if let Err(e) = self.fill_tess.tessellate_path(
+                            &ruffle_path_to_lyon_path(commands, true),
+                            &FillOptions::even_odd(),
+                            &mut buffers_builder,
+                        ) {
+                            // This may just be a degenerate path; skip it.
+                            log::error!("Tessellation failure: {:?}", e);
+                            continue;
+                        }
+
+                        let mut colors: Vec<[f32; 4]> = Vec::with_capacity(8);
+                        let mut ratios: Vec<f32> = Vec::with_capacity(8);
+                        for record in &gradient.records {
+                            colors.push([
+                                f32::from(record.color.r) / 255.0,
+                                f32::from(record.color.g) / 255.0,
+                                f32::from(record.color.b) / 255.0,
+                                f32::from(record.color.a) / 255.0,
+                            ]);
+                            ratios.push(f32::from(record.ratio) / 255.0);
+                        }
+
+                        let gradient = Gradient {
+                            gradient_type: GradientType::Focal,
+                            ratios,
+                            colors,
+                            num_colors: gradient.records.len() as u32,
+                            matrix: swf_to_gl_matrix(gradient.matrix.clone()),
+                            repeat_mode: gradient.spread,
+                            focal_point: *focal_point,
+                        };
+
+                        flush_draw(DrawType::Gradient(gradient), &mut mesh, &mut lyon_mesh);
+                    }
+                    FillStyle::Bitmap {
+                        id,
+                        matrix,
+                        is_smoothed,
+                        is_repeating,
+                    } => {
+                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+
+                        let mut buffers_builder = BuffersBuilder::new(
+                            &mut lyon_mesh,
+                            RuffleVertexCtor { color: 0xffff_ffff },
+                        );
+
+                        if let Err(e) = self.fill_tess.tessellate_path(
+                            &ruffle_path_to_lyon_path(commands, true),
+                            &FillOptions::even_odd(),
+                            &mut buffers_builder,
+                        ) {
+                            // This may just be a degenerate path; skip it.
+                            log::error!("Tessellation failure: {:?}", e);
+                            continue;
+                        }
+
+                        let (bitmap_width, bitmap_height) =
+                            (get_bitmap_dimensions)(*id).unwrap_or((1, 1));
+
+                        let bitmap = Bitmap {
+                            matrix: swf_bitmap_to_gl_matrix(
+                                matrix.clone(),
+                                bitmap_width,
+                                bitmap_height,
+                            ),
+                            id: *id,
+                            is_smoothed: *is_smoothed,
+                            is_repeating: *is_repeating,
+                        };
+
+                        flush_draw(DrawType::Bitmap(bitmap), &mut mesh, &mut lyon_mesh);
+                    }
+                },
+                DrawPath::Stroke {
+                    style,
+                    commands,
+                    is_closed,
+                } => {
+                    let color = ((style.color.a as u32) << 24)
+                        | ((style.color.b as u32) << 16)
+                        | ((style.color.g as u32) << 8)
+                        | (style.color.r as u32);
 
                     let mut buffers_builder =
                         BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
 
-                    if let Err(e) = fill_tess.tessellate_path(
-                        &ruffle_path_to_lyon_path(commands, true),
-                        &FillOptions::even_odd(),
-                        &mut buffers_builder,
-                    ) {
-                        // This may just be a degenerate path; skip it.
-                        log::error!("Tessellation failure: {:?}", e);
-                        continue;
-                    }
-                }
-                FillStyle::LinearGradient(gradient) => {
-                    flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                    let mut buffers_builder =
-                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
-
-                    if let Err(e) = fill_tess.tessellate_path(
-                        &ruffle_path_to_lyon_path(commands, true),
-                        &FillOptions::even_odd(),
-                        &mut buffers_builder,
-                    ) {
-                        // This may just be a degenerate path; skip it.
-                        log::error!("Tessellation failure: {:?}", e);
-                        continue;
-                    }
-
-                    let mut colors: Vec<[f32; 4]> = Vec::with_capacity(8);
-                    let mut ratios: Vec<f32> = Vec::with_capacity(8);
-                    for record in &gradient.records {
-                        colors.push([
-                            f32::from(record.color.r) / 255.0,
-                            f32::from(record.color.g) / 255.0,
-                            f32::from(record.color.b) / 255.0,
-                            f32::from(record.color.a) / 255.0,
-                        ]);
-                        ratios.push(f32::from(record.ratio) / 255.0);
-                    }
-
-                    let gradient = Gradient {
-                        gradient_type: 0,
-                        ratios,
-                        colors,
-                        num_colors: gradient.records.len() as u32,
-                        matrix: swf_to_gl_matrix(gradient.matrix.clone()),
-                        repeat_mode: 0,
-                        focal_point: 0.0,
+                    // TODO(Herschel): 0 width indicates "hairline".
+                    let width = if style.width.to_pixels() >= 1.0 {
+                        style.width.to_pixels() as f32
+                    } else {
+                        1.0
                     };
 
-                    flush_draw(DrawType::Gradient(gradient), &mut mesh, &mut lyon_mesh);
-                }
-                FillStyle::RadialGradient(gradient) => {
-                    flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+                    let mut options = StrokeOptions::default()
+                        .with_line_width(width)
+                        .with_line_join(match style.join_style {
+                            swf::LineJoinStyle::Round => tessellation::LineJoin::Round,
+                            swf::LineJoinStyle::Bevel => tessellation::LineJoin::Bevel,
+                            swf::LineJoinStyle::Miter(_) => tessellation::LineJoin::MiterClip,
+                        })
+                        .with_start_cap(match style.start_cap {
+                            swf::LineCapStyle::None => tessellation::LineCap::Butt,
+                            swf::LineCapStyle::Round => tessellation::LineCap::Round,
+                            swf::LineCapStyle::Square => tessellation::LineCap::Square,
+                        })
+                        .with_end_cap(match style.end_cap {
+                            swf::LineCapStyle::None => tessellation::LineCap::Butt,
+                            swf::LineCapStyle::Round => tessellation::LineCap::Round,
+                            swf::LineCapStyle::Square => tessellation::LineCap::Square,
+                        });
 
-                    let mut buffers_builder =
-                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
+                    if let swf::LineJoinStyle::Miter(limit) = style.join_style {
+                        options = options.with_miter_limit(limit);
+                    }
 
-                    if let Err(e) = fill_tess.tessellate_path(
-                        &ruffle_path_to_lyon_path(commands, true),
-                        &FillOptions::even_odd(),
+                    if let Err(e) = self.stroke_tess.tessellate_path(
+                        &ruffle_path_to_lyon_path(commands, is_closed),
+                        &options,
                         &mut buffers_builder,
                     ) {
                         // This may just be a degenerate path; skip it.
                         log::error!("Tessellation failure: {:?}", e);
                         continue;
                     }
-
-                    let mut colors: Vec<[f32; 4]> = Vec::with_capacity(8);
-                    let mut ratios: Vec<f32> = Vec::with_capacity(8);
-                    for record in &gradient.records {
-                        colors.push([
-                            f32::from(record.color.r) / 255.0,
-                            f32::from(record.color.g) / 255.0,
-                            f32::from(record.color.b) / 255.0,
-                            f32::from(record.color.a) / 255.0,
-                        ]);
-                        ratios.push(f32::from(record.ratio) / 255.0);
-                    }
-
-                    let gradient = Gradient {
-                        gradient_type: 1,
-                        ratios,
-                        colors,
-                        num_colors: gradient.records.len() as u32,
-                        matrix: swf_to_gl_matrix(gradient.matrix.clone()),
-                        repeat_mode: 0,
-                        focal_point: 0.0,
-                    };
-
-                    flush_draw(DrawType::Gradient(gradient), &mut mesh, &mut lyon_mesh);
-                }
-                FillStyle::FocalGradient {
-                    gradient,
-                    focal_point,
-                } => {
-                    flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                    let mut buffers_builder =
-                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
-
-                    if let Err(e) = fill_tess.tessellate_path(
-                        &ruffle_path_to_lyon_path(commands, true),
-                        &FillOptions::even_odd(),
-                        &mut buffers_builder,
-                    ) {
-                        // This may just be a degenerate path; skip it.
-                        log::error!("Tessellation failure: {:?}", e);
-                        continue;
-                    }
-
-                    let mut colors: Vec<[f32; 4]> = Vec::with_capacity(8);
-                    let mut ratios: Vec<f32> = Vec::with_capacity(8);
-                    for record in &gradient.records {
-                        colors.push([
-                            f32::from(record.color.r) / 255.0,
-                            f32::from(record.color.g) / 255.0,
-                            f32::from(record.color.b) / 255.0,
-                            f32::from(record.color.a) / 255.0,
-                        ]);
-                        ratios.push(f32::from(record.ratio) / 255.0);
-                    }
-
-                    let gradient = Gradient {
-                        gradient_type: 1,
-                        ratios,
-                        colors,
-                        num_colors: gradient.records.len() as u32,
-                        matrix: swf_to_gl_matrix(gradient.matrix.clone()),
-                        repeat_mode: 0,
-                        focal_point: *focal_point,
-                    };
-
-                    flush_draw(DrawType::Gradient(gradient), &mut mesh, &mut lyon_mesh);
-                }
-                FillStyle::Bitmap {
-                    id,
-                    matrix,
-                    is_smoothed,
-                    is_repeating,
-                } => {
-                    flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                    let mut buffers_builder =
-                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color: 0xffffff });
-
-                    if let Err(e) = fill_tess.tessellate_path(
-                        &ruffle_path_to_lyon_path(commands, true),
-                        &FillOptions::even_odd(),
-                        &mut buffers_builder,
-                    ) {
-                        // This may just be a degenerate path; skip it.
-                        log::error!("Tessellation failure: {:?}", e);
-                        continue;
-                    }
-
-                    let (bitmap_width, bitmap_height) = get_bitmap_dimenions(*id).unwrap_or((1, 1));
-
-                    let bitmap = Bitmap {
-                        matrix: swf_bitmap_to_gl_matrix(
-                            matrix.clone(),
-                            bitmap_width,
-                            bitmap_height,
-                        ),
-                        id: *id,
-                        is_smoothed: *is_smoothed,
-                        is_repeating: *is_repeating,
-                    };
-
-                    flush_draw(DrawType::Bitmap(bitmap), &mut mesh, &mut lyon_mesh);
-                }
-            },
-            DrawPath::Stroke {
-                style,
-                commands,
-                is_closed,
-            } => {
-                let color = ((style.color.a as u32) << 24)
-                    | ((style.color.b as u32) << 16)
-                    | ((style.color.g as u32) << 8)
-                    | (style.color.r as u32);
-
-                let mut buffers_builder =
-                    BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
-
-                // TODO(Herschel): 0 width indicates "hairline".
-                let width = if style.width.to_pixels() >= 1.0 {
-                    style.width.to_pixels() as f32
-                } else {
-                    1.0
-                };
-
-                let mut options = StrokeOptions::default()
-                    .with_line_width(width)
-                    .with_line_join(match style.join_style {
-                        swf::LineJoinStyle::Round => tessellation::LineJoin::Round,
-                        swf::LineJoinStyle::Bevel => tessellation::LineJoin::Bevel,
-                        swf::LineJoinStyle::Miter(_) => tessellation::LineJoin::MiterClip,
-                    })
-                    .with_start_cap(match style.start_cap {
-                        swf::LineCapStyle::None => tessellation::LineCap::Butt,
-                        swf::LineCapStyle::Round => tessellation::LineCap::Round,
-                        swf::LineCapStyle::Square => tessellation::LineCap::Square,
-                    })
-                    .with_end_cap(match style.end_cap {
-                        swf::LineCapStyle::None => tessellation::LineCap::Butt,
-                        swf::LineCapStyle::Round => tessellation::LineCap::Round,
-                        swf::LineCapStyle::Square => tessellation::LineCap::Square,
-                    });
-
-                if let swf::LineJoinStyle::Miter(limit) = style.join_style {
-                    options = options.with_miter_limit(limit);
-                }
-
-                if let Err(e) = stroke_tess.tessellate_path(
-                    &ruffle_path_to_lyon_path(commands, is_closed),
-                    &options,
-                    &mut buffers_builder,
-                ) {
-                    // This may just be a degenerate path; skip it.
-                    log::error!("Tessellation failure: {:?}", e);
-                    continue;
                 }
             }
         }
+
+        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+
+        mesh
     }
-
-    flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-    mesh
 }
 
 impl Default for ShapeTessellator {
@@ -297,15 +318,16 @@ pub enum DrawType {
 #[derive(Clone, Debug)]
 pub struct Gradient {
     pub matrix: [[f32; 3]; 3],
-    pub gradient_type: i32,
+    pub gradient_type: GradientType,
     pub ratios: Vec<f32>,
     pub colors: Vec<[f32; 4]>,
     pub num_colors: u32,
-    pub repeat_mode: i32,
+    pub repeat_mode: GradientSpread,
     pub focal_point: f32,
 }
 
 #[derive(Copy, Clone, Debug)]
+#[repr(C)]
 pub struct Vertex {
     pub position: [f32; 2],
     pub color: u32,
@@ -416,4 +438,13 @@ impl StrokeVertexConstructor<Vertex> for RuffleVertexCtor {
             color: self.color,
         }
     }
+}
+
+pub use swf::GradientSpread;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum GradientType {
+    Linear,
+    Radial,
+    Focal,
 }

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -294,6 +294,12 @@ where
     mesh
 }
 
+impl Default for ShapeTessellator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 type Mesh = Vec<Draw>;
 
 pub struct Draw {

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -25,4 +25,4 @@ default-features = false
 [dependencies.web-sys]
 version = "0.3.34"
 features = ["HtmlCanvasElement", "HtmlElement", "Node", "WebGlBuffer", "WebGlProgram", "WebGlRenderingContext", 
-            "WebGlShader", "WebGlTexture", "WebGlUniformLocation"]
+            "WebGl2RenderingContext", "WebGlShader", "WebGlTexture", "WebGlUniformLocation"]

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -24,5 +24,5 @@ default-features = false
 
 [dependencies.web-sys]
 version = "0.3.34"
-features = ["HtmlCanvasElement", "HtmlElement", "Node", "WebGlBuffer", "WebGlProgram", "WebGlRenderingContext", 
-            "WebGl2RenderingContext", "WebGlShader", "WebGlTexture", "WebGlUniformLocation"]
+features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebGlProgram", "WebGlRenderingContext",
+            "WebGl2RenderingContext", "WebGlShader", "WebGlTexture", "WebGlUniformLocation", "WebGlVertexArrayObject"]

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ruffle_render_webgl"
+version = "0.1.0"
+authors = ["Mike Welsh <mwelsh@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+fnv = "1.0.3"
+js-sys = "0.3.25"
+log = "0.4" 
+percent-encoding = "2.1.0"
+png = "0.16.3"
+ruffle_render_common_tess = { path = "../common_tess" }
+ruffle_web_common = { path = "../../web/common" }
+wasm-bindgen = "0.2.57"
+
+[dependencies.jpeg-decoder]
+version = "0.1.18"
+default-features = false
+
+[dependencies.ruffle_core]
+path = "../../core"
+default-features = false
+
+[dependencies.web-sys]
+version = "0.3.34"
+features = ["HtmlCanvasElement", "HtmlElement", "Node", "WebGlBuffer", "WebGlProgram", "WebGlRenderingContext", 
+            "WebGlShader", "WebGlTexture", "WebGlUniformLocation"]

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -24,5 +24,6 @@ default-features = false
 
 [dependencies.web-sys]
 version = "0.3.34"
-features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebGlProgram", "WebGlRenderingContext",
-            "WebGl2RenderingContext", "WebGlShader", "WebGlTexture", "WebGlUniformLocation", "WebGlVertexArrayObject"]
+features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebGlFramebuffer", "WebGlProgram", 
+            "WebGlRenderbuffer", "WebGlRenderingContext", "WebGl2RenderingContext", "WebGlShader", "WebGlTexture", "WebGlUniformLocation", 
+            "WebGlVertexArrayObject"]

--- a/render/webgl/shaders/bitmap.frag
+++ b/render/webgl/shaders/bitmap.frag
@@ -1,0 +1,25 @@
+#version 100
+precision mediump float;
+
+uniform mat4 view_matrix;
+uniform mat4 world_matrix;
+uniform vec4 mult_color;
+uniform vec4 add_color;
+uniform mat3 u_matrix;
+
+uniform sampler2D u_texture;
+
+varying vec2 frag_uv;
+
+void main() {
+    vec4 color = texture2D(u_texture, frag_uv);
+
+    // Unmultiply alpha before apply color transform.
+    if( color.a > 0.0 ) {
+        color.rgb /= color.a;
+        color = mult_color * color + add_color;
+        color.rgb *= color.a;
+    }
+
+    gl_FragColor = color;
+}

--- a/render/webgl/shaders/color.frag
+++ b/render/webgl/shaders/color.frag
@@ -1,0 +1,13 @@
+#version 100
+precision mediump float;
+
+uniform mat4 view_matrix;
+uniform mat4 world_matrix;
+uniform vec4 mult_color;
+uniform vec4 add_color;
+
+varying vec4 frag_color;
+
+void main() {
+    gl_FragColor = frag_color;
+}

--- a/render/webgl/shaders/color.vert
+++ b/render/webgl/shaders/color.vert
@@ -1,0 +1,16 @@
+#version 100
+precision mediump float;
+
+uniform mat4 view_matrix;
+uniform mat4 world_matrix;
+uniform vec4 mult_color;
+uniform vec4 add_color;
+
+attribute vec2 position;
+attribute vec4 color;
+varying vec4 frag_color;
+
+void main() {
+    frag_color = color * mult_color + add_color;
+    gl_Position = view_matrix * world_matrix * vec4(position, 0.0, 1.0);
+}

--- a/render/webgl/shaders/gradient.frag
+++ b/render/webgl/shaders/gradient.frag
@@ -1,0 +1,94 @@
+#version 100
+precision mediump float;
+
+uniform mat4 view_matrix;
+uniform mat4 world_matrix;
+uniform vec4 mult_color;
+uniform vec4 add_color;
+uniform mat3 u_matrix;
+
+uniform int u_gradient_type;
+uniform float u_ratios[8];
+uniform vec4 u_colors[8];
+uniform int u_num_colors;
+uniform int u_repeat_mode;
+uniform float u_focal_point;
+
+varying vec2 frag_uv;
+
+void main() {
+    float t;
+    if( u_gradient_type == 0 )
+    {
+        t = frag_uv.x;
+    }
+    else if( u_gradient_type == 1 )
+    {
+        t = length(frag_uv * 2.0 - 1.0);
+    }
+    else if( u_gradient_type == 2 )
+    {
+        vec2 uv = frag_uv * 2.0 - 1.0;
+        vec2 d = vec2(u_focal_point, 0.0) - uv;
+        float l = length(d);
+        d /= l;
+        t = l / (sqrt(1.0 -  u_focal_point*u_focal_point*d.y*d.y) + u_focal_point*d.x);
+    }
+    if( u_repeat_mode == 0 )
+    {
+        // Clamp
+        t = clamp(t, 0.0, 1.0);
+    }
+    else if( u_repeat_mode == 1 )
+    {
+        // Repeat
+        t = fract(t);
+    }
+    else
+    {
+        // Mirror
+        if( t < 0.0 )
+        {
+            t = -t;
+        }
+
+        if( int(mod(t, 2.0)) == 0 ) {
+            t = fract(t);
+        } else {
+            t = 1.0 - fract(t);
+        }
+    }
+
+    // TODO: No non-constant array access in WebGL 1, so the following is kind of painful.
+    // We'd probably be better off passing in the gradient as a texture and sampling from there.
+    vec4 color;
+    float a;
+    if( t <= u_ratios[0] ) {
+        color = u_colors[0];
+    } else if( t <= u_ratios[1] ) {    
+        a = (t - u_ratios[0]) / (u_ratios[1] - u_ratios[0]);
+        color = mix(u_colors[0], u_colors[1], a);
+    } else if( t <= u_ratios[2] ) {    
+        a = (t - u_ratios[1]) / (u_ratios[2] - u_ratios[1]);
+        color = mix(u_colors[1], u_colors[2], a);
+    } else if( t <= u_ratios[3] ) {    
+        a = (t - u_ratios[2]) / (u_ratios[3] - u_ratios[2]);
+        color = mix(u_colors[2], u_colors[3], a);
+    } else if( t <= u_ratios[4] ) {    
+        a = (t - u_ratios[3]) / (u_ratios[4] - u_ratios[3]);
+        color = mix(u_colors[3], u_colors[4], a);
+    } else if( t <= u_ratios[5] ) {    
+        a = (t - u_ratios[4]) / (u_ratios[5] - u_ratios[4]);
+        color = mix(u_colors[4], u_colors[5], a);
+    } else if( t <= u_ratios[6] ) {    
+        a = (t - u_ratios[5]) / (u_ratios[6] - u_ratios[5]);
+        color = mix(u_colors[5], u_colors[6], a);
+    } else if( t <= u_ratios[7] ) {
+        a = (t - u_ratios[6]) / (u_ratios[7] - u_ratios[6]);
+        color = mix(u_colors[6], u_colors[7], a);
+    } else {
+        color = u_colors[7];
+    }
+
+    gl_FragColor = mult_color * color + add_color;
+}

--- a/render/webgl/shaders/texture.vert
+++ b/render/webgl/shaders/texture.vert
@@ -1,0 +1,18 @@
+#version 100
+precision mediump float;
+
+uniform mat4 view_matrix;
+uniform mat4 world_matrix;
+uniform vec4 mult_color;
+uniform vec4 add_color;
+uniform mat3 u_matrix;
+
+attribute vec2 position;
+attribute vec4 color;
+
+varying vec2 frag_uv;
+
+void main() {
+    frag_uv = vec2(u_matrix * vec3(position, 1.0));
+    gl_Position = view_matrix * world_matrix * vec4(position, 0.0, 1.0);
+}

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -47,19 +47,17 @@ pub struct WebGlRenderBackend {
 impl WebGlRenderBackend {
     pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, Error> {
         // Create WebGL context.
+        let options = [
+            ("stencil", JsValue::TRUE),
+            ("alpha", JsValue::FALSE),
+            ("antialias", JsValue::TRUE),
+            ("depth", JsValue::FALSE),
+        ];
+
         let context_options = js_sys::Object::new();
-        js_sys::Reflect::set(
-            &context_options,
-            &"stencil".into(),
-            &wasm_bindgen::JsValue::TRUE,
-        )
-        .warn_on_error();
-        js_sys::Reflect::set(
-            &context_options,
-            &"alpha".into(),
-            &wasm_bindgen::JsValue::FALSE,
-        )
-        .warn_on_error();
+        for (name, value) in options.iter() {
+            js_sys::Reflect::set(&context_options, &JsValue::from(*name), value).warn_on_error();
+        }
 
         let gl = canvas
             .get_context_with_context_options("webgl", &context_options)

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -43,6 +43,13 @@ pub struct WebGlRenderBackend {
     test_stencil_mask: u32,
     next_stencil_mask: u32,
     mask_stack: Vec<(u32, u32)>,
+
+    active_program: *const ShaderProgram,
+    mask_state_dirty: bool,
+    blend_func: (u32, u32),
+    mult_color: Option<[f32; 4]>,
+    add_color: Option<[f32; 4]>,
+
     viewport_width: f32,
     viewport_height: f32,
     view_matrix: [[f32; 4]; 4],
@@ -123,6 +130,7 @@ impl WebGlRenderBackend {
         );
 
         gl.enable(Gl::BLEND);
+        gl.blend_func(Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA);
 
         // Necessary to load RGB textures (alignment defaults to 4).
         gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
@@ -147,6 +155,12 @@ impl WebGlRenderBackend {
             test_stencil_mask: 0,
             next_stencil_mask: 1,
             mask_stack: vec![],
+
+            active_program: std::ptr::null(),
+            mask_state_dirty: true,
+            blend_func: (Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA),
+            mult_color: None,
+            add_color: None,
 
             vertex_position_location,
             vertex_color_location,
@@ -512,6 +526,12 @@ impl RenderBackend for WebGlRenderBackend {
         self.write_stencil_mask = 0;
         self.test_stencil_mask = 0;
         self.next_stencil_mask = 1;
+
+        self.active_program = std::ptr::null();
+        self.mask_state_dirty = true;
+
+        self.mult_color = None;
+        self.add_color = None;
     }
 
     fn end_frame(&mut self) {}
@@ -587,28 +607,30 @@ impl RenderBackend for WebGlRenderBackend {
         ];
 
         // Set masking state.
-        // TODO: Keep a dirty flag and minimize state changes.
-        if self.num_masks > 0 {
-            self.gl.enable(Gl::STENCIL_TEST);
-            if self.num_masks_active < self.num_masks {
-                self.gl.stencil_mask(self.write_stencil_mask);
-                self.gl
-                    .stencil_func(Gl::ALWAYS, self.write_stencil_mask as i32, 0xff);
-                self.gl.stencil_op(Gl::KEEP, Gl::KEEP, Gl::REPLACE);
-                self.gl.color_mask(false, false, false, false);
+        if self.mask_state_dirty {
+            if self.num_masks > 0 {
+                self.gl.enable(Gl::STENCIL_TEST);
+                if self.num_masks_active < self.num_masks {
+                    self.gl.stencil_mask(self.write_stencil_mask);
+                    self.gl
+                        .stencil_func(Gl::ALWAYS, self.write_stencil_mask as i32, 0xff);
+                    self.gl.stencil_op(Gl::KEEP, Gl::KEEP, Gl::REPLACE);
+                    self.gl.color_mask(false, false, false, false);
+                } else {
+                    self.gl.stencil_mask(0);
+                    self.gl.stencil_func(
+                        Gl::EQUAL,
+                        self.test_stencil_mask as i32,
+                        self.test_stencil_mask,
+                    );
+                    self.gl.stencil_op(Gl::KEEP, Gl::KEEP, Gl::KEEP);
+                    self.gl.color_mask(true, true, true, true);
+                }
             } else {
-                self.gl.stencil_mask(0);
-                self.gl.stencil_func(
-                    Gl::EQUAL,
-                    self.test_stencil_mask as i32,
-                    self.test_stencil_mask,
-                );
-                self.gl.stencil_op(Gl::KEEP, Gl::KEEP, Gl::KEEP);
+                self.gl.disable(Gl::STENCIL_TEST);
                 self.gl.color_mask(true, true, true, true);
             }
-        } else {
-            self.gl.disable(Gl::STENCIL_TEST);
-            self.gl.color_mask(true, true, true, true);
+            self.mask_state_dirty = false;
         }
 
         for draw in &mesh.draws {
@@ -633,26 +655,49 @@ impl RenderBackend for WebGlRenderBackend {
                 8,
             );
 
-            let program = match &draw.draw_type {
-                DrawType::Color => &self.color_program,
-                DrawType::Gradient(_) => &self.gradient_program,
-                DrawType::Bitmap { .. } => &self.bitmap_program,
+            let (program, src_blend, dst_blend) = match &draw.draw_type {
+                DrawType::Color => (&self.color_program, Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA),
+                DrawType::Gradient(_) => (
+                    &self.gradient_program,
+                    Gl::SRC_ALPHA,
+                    Gl::ONE_MINUS_SRC_ALPHA,
+                ),
+                // Bitmaps use pre-multiplied alpha.
+                DrawType::Bitmap { .. } => (&self.bitmap_program, Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA),
             };
-            self.gl.use_program(Some(&program.program));
 
-            // Set common uniforms.
+            // Set common render state, while minimizing unnecessary state changes.
+            // TODO: Using designated layout specifiers in WebGL2/OpenGL ES 3, we could guarantee that uniforms
+            // are in the same location between shaders, and avoid changing them unless necessary.
+            if program as *const ShaderProgram != self.active_program {
+                self.gl.use_program(Some(&program.program));
+                self.active_program = program as *const ShaderProgram;
+
+                program.uniform_matrix4fv(&self.gl, ShaderUniform::ViewMatrix, &self.view_matrix);
+
+                self.mult_color = None;
+                self.add_color = None;
+
+                if (src_blend, dst_blend) != self.blend_func {
+                    self.gl.blend_func(src_blend, dst_blend);
+                    self.blend_func = (src_blend, dst_blend);
+                }
+            }
+
             program.uniform_matrix4fv(&self.gl, ShaderUniform::WorldMatrix, &world_matrix);
-            program.uniform_matrix4fv(&self.gl, ShaderUniform::ViewMatrix, &self.view_matrix);
-            program.uniform4fv(&self.gl, ShaderUniform::MultColor, &mult_color);
-            program.uniform4fv(&self.gl, ShaderUniform::AddColor, &add_color);
+            if Some(mult_color) != self.mult_color {
+                program.uniform4fv(&self.gl, ShaderUniform::MultColor, &mult_color);
+                self.mult_color = Some(mult_color);
+            }
+            if Some(add_color) != self.add_color {
+                program.uniform4fv(&self.gl, ShaderUniform::AddColor, &add_color);
+                self.add_color = Some(add_color);
+            }
 
             // Set shader specific uniforms.
             match &draw.draw_type {
-                DrawType::Color => {
-                    self.gl.blend_func(Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA);
-                }
+                DrawType::Color => (),
                 DrawType::Gradient(gradient) => {
-                    self.gl.blend_func(Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA);
                     program.uniform_matrix3fv(
                         &self.gl,
                         ShaderUniform::TextureMatrix,
@@ -684,9 +729,6 @@ impl RenderBackend for WebGlRenderBackend {
                     );
                 }
                 DrawType::Bitmap(bitmap) => {
-                    // Bitmaps use pre-multiplied alpha.
-                    self.gl.blend_func(Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA);
-
                     let texture = &self
                         .textures
                         .iter()
@@ -796,10 +838,12 @@ impl RenderBackend for WebGlRenderBackend {
         self.write_stencil_mask = self.next_stencil_mask;
         self.test_stencil_mask |= self.next_stencil_mask;
         self.next_stencil_mask <<= 1;
+        self.mask_state_dirty = true;
     }
 
     fn activate_mask(&mut self) {
         self.num_masks_active += 1;
+        self.mask_state_dirty = true;
     }
 
     fn pop_mask(&mut self) {
@@ -809,6 +853,7 @@ impl RenderBackend for WebGlRenderBackend {
             let (write, test) = self.mask_stack.pop().unwrap();
             self.write_stencil_mask = write;
             self.test_stencil_mask = test;
+            self.mask_state_dirty = true;
         } else {
             log::warn!("Mask stack underflow\n");
         }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1,0 +1,955 @@
+use ruffle_core::backend::render::swf::{self, FillStyle};
+use ruffle_core::backend::render::{
+    BitmapHandle, BitmapInfo, Color, Letterbox, RenderBackend, ShapeHandle, Transform,
+};
+use ruffle_web_common::JsResult;
+use std::convert::TryInto;
+use wasm_bindgen::{JsCast, JsValue};
+use web_sys::{
+    HtmlCanvasElement, WebGlBuffer, WebGlProgram, WebGlRenderingContext as Gl, WebGlShader,
+    WebGlTexture, WebGlUniformLocation,
+};
+
+type Error = Box<dyn std::error::Error>;
+
+const COLOR_VERTEX_GLSL: &str = include_str!("../shaders/color.vert");
+const COLOR_FRAGMENT_GLSL: &str = include_str!("../shaders/color.frag");
+const TEXTURE_VERTEX_GLSL: &str = include_str!("../shaders/texture.vert");
+const GRADIENT_FRAGMENT_GLSL: &str = include_str!("../shaders/gradient.frag");
+const BITMAP_FRAGMENT_GLSL: &str = include_str!("../shaders/bitmap.frag");
+
+pub struct WebGlRenderBackend {
+    gl: Gl,
+
+    vertex_position_location: u32,
+    vertex_color_location: u32,
+
+    color_program: ShaderProgram,
+    bitmap_program: ShaderProgram,
+    gradient_program: ShaderProgram,
+
+    textures: Vec<(swf::CharacterId, Texture)>,
+    meshes: Vec<Mesh>,
+
+    quad_shape: ShapeHandle,
+
+    num_masks: u32,
+    num_masks_active: u32,
+    write_stencil_mask: u32,
+    test_stencil_mask: u32,
+    next_stencil_mask: u32,
+    mask_stack: Vec<(u32, u32)>,
+    viewport_width: f32,
+    viewport_height: f32,
+    view_matrix: [[f32; 4]; 4],
+}
+
+impl WebGlRenderBackend {
+    pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, Error> {
+        // Create WebGL context.
+        let context_options = js_sys::Object::new();
+        js_sys::Reflect::set(
+            &context_options,
+            &"stencil".into(),
+            &wasm_bindgen::JsValue::TRUE,
+        )
+        .warn_on_error();
+        js_sys::Reflect::set(
+            &context_options,
+            &"alpha".into(),
+            &wasm_bindgen::JsValue::FALSE,
+        )
+        .warn_on_error();
+
+        let gl = canvas
+            .get_context_with_context_options("webgl", &context_options)
+            .into_js_result()?
+            .ok_or("No context returned")?
+            .dyn_into::<Gl>()
+            .map_err(|_| "Expected GL context")?;
+
+        let color_vertex = Self::compile_shader(&gl, Gl::VERTEX_SHADER, COLOR_VERTEX_GLSL)?;
+        let texture_vertex = Self::compile_shader(&gl, Gl::VERTEX_SHADER, TEXTURE_VERTEX_GLSL)?;
+        let color_fragment = Self::compile_shader(&gl, Gl::FRAGMENT_SHADER, COLOR_FRAGMENT_GLSL)?;
+        let bitmap_fragment = Self::compile_shader(&gl, Gl::FRAGMENT_SHADER, BITMAP_FRAGMENT_GLSL)?;
+        let gradient_fragment =
+            Self::compile_shader(&gl, Gl::FRAGMENT_SHADER, GRADIENT_FRAGMENT_GLSL)?;
+
+        let color_program = ShaderProgram::new(&gl, &color_vertex, &color_fragment)?;
+        let bitmap_program = ShaderProgram::new(&gl, &texture_vertex, &bitmap_fragment)?;
+        let gradient_program = ShaderProgram::new(&gl, &texture_vertex, &gradient_fragment)?;
+
+        // This assumes we are using the same vertex format for all shaders.
+        let vertex_position_location =
+            gl.get_attrib_location(&color_program.program, "position") as u32;
+        let vertex_color_location = gl.get_attrib_location(&color_program.program, "color") as u32;
+
+        let quad_mesh = Self::build_quad_mesh(&gl)?;
+        let quad_shape = ShapeHandle(0);
+
+        // Enable vertex attributes.
+        // Because we currently only use on vertex format, we can do this once on init.
+        gl.enable_vertex_attrib_array(vertex_position_location as u32);
+        gl.enable_vertex_attrib_array(vertex_color_location as u32);
+        gl.vertex_attrib_pointer_with_i32(
+            vertex_position_location,
+            2,
+            Gl::FLOAT,
+            false,
+            24, //std::mem::size_of::<Vertex>() as i32,
+            0,
+        );
+        gl.vertex_attrib_pointer_with_i32(
+            vertex_color_location,
+            4,
+            Gl::FLOAT,
+            false,
+            24, //std::mem::size_of::<Vertex>() as i32,
+            8,
+        );
+
+        gl.enable(Gl::BLEND);
+
+        // Necessary to load RGB textures (alignment defaults to 4).
+        gl.pixel_storei(Gl::UNPACK_ALIGNMENT, 1);
+
+        let mut renderer = Self {
+            gl,
+
+            color_program,
+            gradient_program,
+            bitmap_program,
+
+            meshes: vec![quad_mesh],
+            quad_shape,
+            textures: vec![],
+            viewport_width: 500.0,
+            viewport_height: 500.0,
+            view_matrix: [[0.0; 4]; 4],
+            num_masks: 0,
+            num_masks_active: 0,
+            write_stencil_mask: 0,
+            test_stencil_mask: 0,
+            next_stencil_mask: 1,
+            mask_stack: vec![],
+
+            vertex_position_location,
+            vertex_color_location,
+        };
+
+        renderer.build_matrices();
+        Ok(renderer)
+    }
+
+    // Builds the quad mesh that is used for rendering bitmap display objects.
+    fn build_quad_mesh(gl: &Gl) -> Result<Mesh, Error> {
+        let quad_mesh = unsafe {
+            let vertex_buffer = gl.create_buffer().unwrap();
+            gl.bind_buffer(Gl::ARRAY_BUFFER, Some(&vertex_buffer));
+
+            let verts = [
+                Vertex {
+                    position: [0.0, 0.0],
+                    color: [1.0, 1.0, 1.0, 1.0],
+                },
+                Vertex {
+                    position: [1.0, 0.0],
+                    color: [1.0, 1.0, 1.0, 1.0],
+                },
+                Vertex {
+                    position: [1.0, 1.0],
+                    color: [1.0, 1.0, 1.0, 1.0],
+                },
+                Vertex {
+                    position: [0.0, 1.0],
+                    color: [1.0, 1.0, 1.0, 1.0],
+                },
+            ];
+            let verts_bytes = std::slice::from_raw_parts(
+                verts.as_ptr() as *const u8,
+                std::mem::size_of_val(&verts),
+            );
+            gl.buffer_data_with_u8_array(Gl::ARRAY_BUFFER, verts_bytes, Gl::STATIC_DRAW);
+
+            let index_buffer = gl.create_buffer().unwrap();
+            gl.bind_buffer(Gl::ELEMENT_ARRAY_BUFFER, Some(&index_buffer));
+            let indices = [0u16, 1, 2, 0, 2, 3];
+            let indices_bytes = std::slice::from_raw_parts(
+                indices.as_ptr() as *const u8,
+                std::mem::size_of::<u16>() * indices.len(),
+            );
+            gl.buffer_data_with_u8_array(Gl::ELEMENT_ARRAY_BUFFER, indices_bytes, Gl::STATIC_DRAW);
+
+            Mesh {
+                draws: vec![Draw {
+                    draw_type: DrawType::Bitmap(Bitmap {
+                        matrix: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                        id: 0,
+
+                        is_smoothed: true,
+                        is_repeating: false,
+                    }),
+                    vertex_buffer,
+                    index_buffer,
+                    num_indices: 6,
+                }],
+            }
+        };
+
+        Ok(quad_mesh)
+    }
+
+    fn compile_shader(gl: &Gl, shader_type: u32, glsl_src: &str) -> Result<WebGlShader, Error> {
+        let shader = gl.create_shader(shader_type).unwrap();
+        gl.shader_source(&shader, glsl_src);
+        gl.compile_shader(&shader);
+        let log = gl.get_shader_info_log(&shader).unwrap_or_default();
+        if !log.is_empty() {
+            log::error!("{}", log);
+        }
+        Ok(shader)
+    }
+
+    fn register_shape_internal(&mut self, shape: &swf::Shape) -> ShapeHandle {
+        use ruffle_render_common_tess::DrawType as TessDrawType;
+
+        let handle = ShapeHandle(self.meshes.len());
+
+        let lyon_mesh = ruffle_render_common_tess::tessellate_shape(shape, |id| {
+            self.textures
+                .iter()
+                .find(|(other_id, _tex)| *other_id == id)
+                .map(|tex| (tex.1.width, tex.1.height))
+        });
+
+        let mut draws = Vec::with_capacity(lyon_mesh.len());
+
+        for draw in lyon_mesh {
+            let num_indices = draw.indices.len() as i32;
+
+            let (vertex_buffer, index_buffer) = unsafe {
+                let vertex_buffer = self.gl.create_buffer().unwrap();
+                self.gl.bind_buffer(Gl::ARRAY_BUFFER, Some(&vertex_buffer));
+
+                let verts_bytes = std::slice::from_raw_parts(
+                    draw.vertices.as_ptr() as *const u8,
+                    draw.vertices.len() * std::mem::size_of::<Vertex>(),
+                );
+                self.gl
+                    .buffer_data_with_u8_array(Gl::ARRAY_BUFFER, verts_bytes, Gl::STATIC_DRAW);
+
+                let indices: Vec<_> = draw.indices.into_iter().map(|n| n as u16).collect();
+                let index_buffer = self.gl.create_buffer().unwrap();
+                self.gl
+                    .bind_buffer(Gl::ELEMENT_ARRAY_BUFFER, Some(&index_buffer));
+                let indices_bytes = std::slice::from_raw_parts(
+                    indices.as_ptr() as *const u8,
+                    indices.len() * std::mem::size_of::<u16>(),
+                );
+                self.gl.buffer_data_with_u8_array(
+                    Gl::ELEMENT_ARRAY_BUFFER,
+                    indices_bytes,
+                    Gl::STATIC_DRAW,
+                );
+
+                (vertex_buffer, index_buffer)
+            };
+
+            let out_draw = match draw.draw_type {
+                TessDrawType::Color => Draw {
+                    draw_type: DrawType::Color,
+                    vertex_buffer,
+                    index_buffer,
+                    num_indices,
+                },
+                TessDrawType::Gradient(gradient) => {
+                    let mut ratios = [0.0; 8];
+                    let mut colors = [[0.0; 4]; 8];
+                    let num_colors = gradient.num_colors as usize;
+                    ratios[..num_colors].copy_from_slice(&gradient.ratios[..num_colors]);
+                    colors[..num_colors].copy_from_slice(&gradient.colors[..num_colors]);
+                    let out_gradient = Gradient {
+                        matrix: gradient.matrix,
+                        gradient_type: gradient.gradient_type,
+                        ratios,
+                        colors,
+                        num_colors: gradient.num_colors,
+                        repeat_mode: gradient.repeat_mode,
+                        focal_point: gradient.focal_point,
+                    };
+                    Draw {
+                        draw_type: DrawType::Gradient(Box::new(out_gradient)),
+                        vertex_buffer,
+                        index_buffer,
+                        num_indices,
+                    }
+                }
+                TessDrawType::Bitmap(bitmap) => Draw {
+                    draw_type: DrawType::Bitmap(Bitmap {
+                        matrix: bitmap.matrix,
+                        id: bitmap.id,
+                        is_smoothed: bitmap.is_smoothed,
+                        is_repeating: bitmap.is_repeating,
+                    }),
+                    vertex_buffer,
+                    index_buffer,
+                    num_indices,
+                },
+            };
+
+            draws.push(out_draw);
+        }
+
+        self.meshes.push(Mesh { draws });
+
+        handle
+    }
+
+    fn build_matrices(&mut self) {
+        self.view_matrix = [
+            [1.0 / (self.viewport_width as f32 / 2.0), 0.0, 0.0, 0.0],
+            [0.0, -1.0 / (self.viewport_height as f32 / 2.0), 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.0, 1.0],
+        ];
+    }
+}
+
+impl RenderBackend for WebGlRenderBackend {
+    fn set_viewport_dimensions(&mut self, width: u32, height: u32) {
+        self.viewport_width = width as f32;
+        self.viewport_height = height as f32;
+        self.gl.viewport(0, 0, width as i32, height as i32);
+        self.build_matrices();
+    }
+
+    fn register_shape(&mut self, shape: &swf::Shape) -> ShapeHandle {
+        self.register_shape_internal(shape)
+    }
+
+    fn register_glyph_shape(&mut self, glyph: &swf::Glyph) -> ShapeHandle {
+        let shape = swf::Shape {
+            version: 2,
+            id: 0,
+            shape_bounds: Default::default(),
+            edge_bounds: Default::default(),
+            has_fill_winding_rule: false,
+            has_non_scaling_strokes: false,
+            has_scaling_strokes: true,
+            styles: swf::ShapeStyles {
+                fill_styles: vec![FillStyle::Color(Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                })],
+                line_styles: vec![],
+            },
+            shape: glyph.shape_records.clone(),
+        };
+        self.register_shape_internal(&shape)
+    }
+
+    fn register_bitmap_jpeg(
+        &mut self,
+        id: swf::CharacterId,
+        data: &[u8],
+        jpeg_tables: Option<&[u8]>,
+    ) -> BitmapInfo {
+        let data = ruffle_core::backend::render::glue_tables_to_jpeg(data, jpeg_tables);
+        self.register_bitmap_jpeg_2(id, &data[..])
+    }
+
+    fn register_bitmap_jpeg_2(&mut self, id: swf::CharacterId, data: &[u8]) -> BitmapInfo {
+        let data = ruffle_core::backend::render::remove_invalid_jpeg_data(data);
+
+        let mut decoder = jpeg_decoder::Decoder::new(&data[..]);
+        decoder.read_info().unwrap();
+        let metadata = decoder.info().unwrap();
+        let decoded_data = decoder.decode().expect("failed to decode image");
+
+        let texture = self.gl.create_texture().unwrap();
+        self.gl.bind_texture(Gl::TEXTURE_2D, Some(&texture));
+        self.gl
+            .tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                0,
+                Gl::RGB as i32,
+                metadata.width.into(),
+                metadata.height.into(),
+                0,
+                Gl::RGB,
+                Gl::UNSIGNED_BYTE,
+                Some(&decoded_data),
+            )
+            .warn_on_error();
+
+        let handle = BitmapHandle(self.textures.len());
+        self.textures.push((
+            id,
+            Texture {
+                texture,
+                width: metadata.width.into(),
+                height: metadata.height.into(),
+            },
+        ));
+
+        BitmapInfo {
+            handle,
+            width: metadata.width,
+            height: metadata.height,
+        }
+    }
+
+    fn register_bitmap_jpeg_3(
+        &mut self,
+        id: swf::CharacterId,
+        jpeg_data: &[u8],
+        alpha_data: &[u8],
+    ) -> BitmapInfo {
+        let (width, height, rgba) =
+            ruffle_core::backend::render::define_bits_jpeg_to_rgba(jpeg_data, alpha_data)
+                .expect("Error decoding DefineBitsJPEG3");
+
+        let texture = self.gl.create_texture().unwrap();
+        self.gl.bind_texture(Gl::TEXTURE_2D, Some(&texture));
+        self.gl
+            .tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                0,
+                Gl::RGBA as i32,
+                width as i32,
+                height as i32,
+                0,
+                Gl::RGBA,
+                Gl::UNSIGNED_BYTE,
+                Some(&rgba),
+            )
+            .warn_on_error();
+
+        let handle = BitmapHandle(self.textures.len());
+        self.textures.push((
+            id,
+            Texture {
+                texture,
+                width,
+                height,
+            },
+        ));
+
+        BitmapInfo {
+            handle,
+            width: width.try_into().unwrap(),
+            height: height.try_into().unwrap(),
+        }
+    }
+
+    fn register_bitmap_png(&mut self, swf_tag: &swf::DefineBitsLossless) -> BitmapInfo {
+        let decoded_data = ruffle_core::backend::render::define_bits_lossless_to_rgba(swf_tag)
+            .expect("Error decoding DefineBitsLossless");
+
+        let texture = self.gl.create_texture().unwrap();
+        self.gl.bind_texture(Gl::TEXTURE_2D, Some(&texture));
+        self.gl
+            .tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+                Gl::TEXTURE_2D,
+                0,
+                Gl::RGBA as i32,
+                swf_tag.width.into(),
+                swf_tag.height.into(),
+                0,
+                Gl::RGBA,
+                Gl::UNSIGNED_BYTE,
+                Some(&decoded_data),
+            )
+            .warn_on_error();
+
+        // You must set the texture parameters for non-power-of-2 textures to function in WebGL.
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as i32);
+
+        let handle = BitmapHandle(self.textures.len());
+        self.textures.push((
+            swf_tag.id,
+            Texture {
+                texture,
+                width: swf_tag.width.into(),
+                height: swf_tag.height.into(),
+            },
+        ));
+
+        BitmapInfo {
+            handle,
+            width: swf_tag.width,
+            height: swf_tag.height,
+        }
+    }
+
+    fn begin_frame(&mut self) {
+        self.num_masks = 0;
+        self.num_masks_active = 0;
+        self.write_stencil_mask = 0;
+        self.test_stencil_mask = 0;
+        self.next_stencil_mask = 1;
+    }
+
+    fn end_frame(&mut self) {}
+
+    fn clear(&mut self, color: Color) {
+        self.gl.clear_color(
+            color.r as f32 / 255.0,
+            color.g as f32 / 255.0,
+            color.b as f32 / 255.0,
+            color.a as f32 / 255.0,
+        );
+        self.gl.clear(Gl::COLOR_BUFFER_BIT | Gl::STENCIL_BUFFER_BIT);
+    }
+
+    fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform) {
+        // TODO: Might be better to make this separate code to render the bitmap
+        // instead of going through render_shape. But render_shape already handles
+        // masking etc.
+        if let Some((id, bitmap)) = self.textures.get(bitmap.0) {
+            // Adjust the quad draw to use the target bitmap.
+            let mesh = &mut self.meshes[self.quad_shape.0];
+            let draw = &mut mesh.draws[0];
+            let width = bitmap.width as f32;
+            let height = bitmap.height as f32;
+            if let DrawType::Bitmap(Bitmap { id: draw_id, .. }) = &mut draw.draw_type {
+                *draw_id = *id;
+            }
+
+            // Scale the quad to the bitmap's dimensions.
+            use ruffle_core::matrix::Matrix;
+            let scale_transform = Transform {
+                matrix: transform.matrix
+                    * Matrix {
+                        a: width,
+                        d: height,
+                        ..Default::default()
+                    },
+                ..*transform
+            };
+
+            // Render the quad.
+            self.render_shape(self.quad_shape, &scale_transform);
+        }
+    }
+
+    fn render_shape(&mut self, shape: ShapeHandle, transform: &Transform) {
+        let mesh = &self.meshes[shape.0];
+
+        let world_matrix = [
+            [transform.matrix.a, transform.matrix.b, 0.0, 0.0],
+            [transform.matrix.c, transform.matrix.d, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [
+                transform.matrix.tx.to_pixels() as f32,
+                transform.matrix.ty.to_pixels() as f32,
+                0.0,
+                1.0,
+            ],
+        ];
+
+        let mult_color = [
+            transform.color_transform.r_mult,
+            transform.color_transform.g_mult,
+            transform.color_transform.b_mult,
+            transform.color_transform.a_mult,
+        ];
+
+        let add_color = [
+            transform.color_transform.r_add,
+            transform.color_transform.g_add,
+            transform.color_transform.b_add,
+            transform.color_transform.a_add,
+        ];
+
+        // Set masking state.
+        // TODO: Keep a dirty flag and minimize state changes.
+        if self.num_masks > 0 {
+            self.gl.enable(Gl::STENCIL_TEST);
+            if self.num_masks_active < self.num_masks {
+                self.gl.stencil_mask(self.write_stencil_mask);
+                self.gl
+                    .stencil_func(Gl::ALWAYS, self.write_stencil_mask as i32, 0xff);
+                self.gl.stencil_op(Gl::KEEP, Gl::KEEP, Gl::REPLACE);
+                self.gl.color_mask(false, false, false, false);
+            } else {
+                self.gl.stencil_mask(0);
+                self.gl.stencil_func(
+                    Gl::EQUAL,
+                    self.test_stencil_mask as i32,
+                    self.test_stencil_mask,
+                );
+                self.gl.stencil_op(Gl::KEEP, Gl::KEEP, Gl::KEEP);
+                self.gl.color_mask(true, true, true, true);
+            }
+        } else {
+            self.gl.disable(Gl::STENCIL_TEST);
+            self.gl.color_mask(true, true, true, true);
+        }
+
+        for draw in &mesh.draws {
+            self.gl
+                .bind_buffer(Gl::ARRAY_BUFFER, Some(&draw.vertex_buffer));
+            self.gl
+                .bind_buffer(Gl::ELEMENT_ARRAY_BUFFER, Some(&draw.index_buffer));
+            self.gl.vertex_attrib_pointer_with_i32(
+                self.vertex_position_location,
+                2,
+                Gl::FLOAT,
+                false,
+                24, //std::mem::size_of::<Vertex>() as i32,
+                0,
+            );
+            self.gl.vertex_attrib_pointer_with_i32(
+                self.vertex_color_location,
+                4,
+                Gl::FLOAT,
+                false,
+                24, //std::mem::size_of::<Vertex>() as i32,
+                8,
+            );
+
+            let program = match &draw.draw_type {
+                DrawType::Color => &self.color_program,
+                DrawType::Gradient(_) => &self.gradient_program,
+                DrawType::Bitmap { .. } => &self.bitmap_program,
+            };
+            self.gl.use_program(Some(&program.program));
+
+            // Set common uniforms.
+            program.uniform_matrix4fv(&self.gl, ShaderUniform::WorldMatrix, &world_matrix);
+            program.uniform_matrix4fv(&self.gl, ShaderUniform::ViewMatrix, &self.view_matrix);
+            program.uniform4fv(&self.gl, ShaderUniform::MultColor, &mult_color);
+            program.uniform4fv(&self.gl, ShaderUniform::AddColor, &add_color);
+
+            // Set shader specific uniforms.
+            match &draw.draw_type {
+                DrawType::Color => {
+                    self.gl.blend_func(Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA);
+                }
+                DrawType::Gradient(gradient) => {
+                    self.gl.blend_func(Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA);
+                    program.uniform_matrix3fv(
+                        &self.gl,
+                        ShaderUniform::TextureMatrix,
+                        &gradient.matrix,
+                    );
+                    program.uniform1i(
+                        &self.gl,
+                        ShaderUniform::GradientType,
+                        gradient.gradient_type,
+                    );
+                    program.uniform1fv(&self.gl, ShaderUniform::GradientRatios, &gradient.ratios);
+                    let colors =
+                        unsafe { std::slice::from_raw_parts(gradient.colors[0].as_ptr(), 32) };
+                    program.uniform4fv(&self.gl, ShaderUniform::GradientColors, &colors);
+                    program.uniform1i(
+                        &self.gl,
+                        ShaderUniform::GradientNumColors,
+                        gradient.num_colors as i32,
+                    );
+                    program.uniform1i(
+                        &self.gl,
+                        ShaderUniform::GradientRepeatMode,
+                        gradient.repeat_mode,
+                    );
+                    program.uniform1f(
+                        &self.gl,
+                        ShaderUniform::GradientFocalPoint,
+                        gradient.focal_point,
+                    );
+                }
+                DrawType::Bitmap(bitmap) => {
+                    // Bitmaps use pre-multiplied alpha.
+                    self.gl.blend_func(Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA);
+
+                    let texture = &self
+                        .textures
+                        .iter()
+                        .find(|(id, _tex)| *id == bitmap.id)
+                        .unwrap()
+                        .1;
+
+                    program.uniform_matrix3fv(
+                        &self.gl,
+                        ShaderUniform::TextureMatrix,
+                        &bitmap.matrix,
+                    );
+
+                    // Bind texture.
+                    self.gl.active_texture(Gl::TEXTURE0);
+                    self.gl.bind_texture(Gl::TEXTURE_2D, Some(&texture.texture));
+                    program.uniform1i(&self.gl, ShaderUniform::BitmapTexture, 0);
+
+                    // Set texture parameters.
+                    let filter = if bitmap.is_smoothed {
+                        Gl::LINEAR as i32
+                    } else {
+                        Gl::NEAREST as i32
+                    };
+                    self.gl
+                        .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, filter);
+                    self.gl
+                        .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, filter);
+                    let wrap = if bitmap.is_repeating {
+                        Gl::MIRRORED_REPEAT as i32
+                    } else {
+                        Gl::CLAMP_TO_EDGE as i32
+                    };
+                    self.gl
+                        .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, wrap);
+                    self.gl
+                        .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, wrap);
+                }
+            }
+
+            // Draw the triangles.
+            self.gl
+                .draw_elements_with_i32(Gl::TRIANGLES, draw.num_indices, Gl::UNSIGNED_SHORT, 0);
+        }
+    }
+
+    fn draw_letterbox(&mut self, letterbox: Letterbox) {
+        self.gl.clear_color(0.0, 0.0, 0.0, 0.0);
+
+        match letterbox {
+            Letterbox::None => (),
+            Letterbox::Letterbox(margin_height) => {
+                self.gl.enable(Gl::SCISSOR_TEST);
+                self.gl
+                    .scissor(0, 0, self.viewport_width as i32, margin_height as i32);
+                self.gl.clear(Gl::COLOR_BUFFER_BIT);
+                self.gl.scissor(
+                    0,
+                    (self.viewport_height - margin_height) as i32,
+                    self.viewport_width as i32,
+                    margin_height as i32 + 1,
+                );
+                self.gl.clear(Gl::COLOR_BUFFER_BIT);
+                self.gl.disable(Gl::SCISSOR_TEST);
+            }
+            Letterbox::Pillarbox(margin_width) => {
+                self.gl.enable(Gl::SCISSOR_TEST);
+                self.gl
+                    .scissor(0, 0, margin_width as i32, self.viewport_height as i32);
+                self.gl.clear(Gl::COLOR_BUFFER_BIT);
+                self.gl.scissor(
+                    (self.viewport_width - margin_width) as i32,
+                    0,
+                    margin_width as i32 + 1,
+                    self.viewport_height as i32,
+                );
+                self.gl.clear(Gl::COLOR_BUFFER_BIT);
+                self.gl.scissor(
+                    0,
+                    0,
+                    self.viewport_width as i32,
+                    self.viewport_height as i32,
+                );
+                self.gl.disable(Gl::SCISSOR_TEST);
+            }
+        }
+    }
+
+    fn push_mask(&mut self) {
+        // Desktop draws the masker to the stencil buffer, one bit per mask.
+        // Masks-within-masks are handled as a bitmask.
+        // This does unfortunately mean we are limited in the number of masks at once (usually 8 bits).
+        if self.next_stencil_mask >= 0x100 {
+            // If we've reached the limit of masks, clear the stencil buffer and start over.
+            // But this may not be correct if there is still a mask active (mask-within-mask).
+            if self.test_stencil_mask != 0 {
+                log::warn!(
+                    "Too many masks active for stencil buffer; possibly incorrect rendering"
+                );
+            }
+            self.next_stencil_mask = 1;
+            self.gl.clear_stencil(self.test_stencil_mask as i32);
+        }
+        self.num_masks += 1;
+        self.mask_stack
+            .push((self.write_stencil_mask, self.test_stencil_mask));
+        self.write_stencil_mask = self.next_stencil_mask;
+        self.test_stencil_mask |= self.next_stencil_mask;
+        self.next_stencil_mask <<= 1;
+    }
+
+    fn activate_mask(&mut self) {
+        self.num_masks_active += 1;
+    }
+
+    fn pop_mask(&mut self) {
+        if !self.mask_stack.is_empty() {
+            self.num_masks -= 1;
+            self.num_masks_active -= 1;
+            let (write, test) = self.mask_stack.pop().unwrap();
+            self.write_stencil_mask = write;
+            self.test_stencil_mask = test;
+        } else {
+            log::warn!("Mask stack underflow\n");
+        }
+    }
+}
+
+struct Texture {
+    width: u32,
+    height: u32,
+    texture: WebGlTexture,
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Vertex {
+    position: [f32; 2],
+    color: [f32; 4],
+}
+
+#[derive(Clone, Debug)]
+struct Gradient {
+    matrix: [[f32; 3]; 3],
+    gradient_type: i32,
+    ratios: [f32; 8],
+    colors: [[f32; 4]; 8],
+    num_colors: u32,
+    repeat_mode: i32,
+    focal_point: f32,
+}
+
+#[derive(Clone, Debug)]
+struct Bitmap {
+    matrix: [[f32; 3]; 3],
+    id: swf::CharacterId,
+    is_repeating: bool,
+    is_smoothed: bool,
+}
+
+struct Mesh {
+    draws: Vec<Draw>,
+}
+
+struct Draw {
+    draw_type: DrawType,
+    vertex_buffer: WebGlBuffer,
+    index_buffer: WebGlBuffer,
+    num_indices: i32,
+}
+
+enum DrawType {
+    Color,
+    Gradient(Box<Gradient>),
+    Bitmap(Bitmap),
+}
+
+// Because the shaders are currently simple and few in number, we are using a
+// straightforward shader model. We maintain an enum of every possible uniform,
+// and each shader tries to grab the location of each uniform.
+struct ShaderProgram {
+    program: WebGlProgram,
+    uniforms: [Option<WebGlUniformLocation>; NUM_UNIFORMS],
+}
+
+// These should match the uniform names in the shaders.
+const NUM_UNIFORMS: usize = 12;
+const UNIFORM_NAMES: [&str; NUM_UNIFORMS] = [
+    "world_matrix",
+    "view_matrix",
+    "mult_color",
+    "add_color",
+    "u_matrix",
+    "u_gradient_type",
+    "u_ratios",
+    "u_colors",
+    "u_num_colors",
+    "u_repeat_mode",
+    "u_focal_point",
+    "u_texture",
+];
+
+enum ShaderUniform {
+    WorldMatrix = 0,
+    ViewMatrix,
+    MultColor,
+    AddColor,
+    TextureMatrix,
+    GradientType,
+    GradientRatios,
+    GradientColors,
+    GradientNumColors,
+    GradientRepeatMode,
+    GradientFocalPoint,
+    BitmapTexture,
+}
+
+impl ShaderProgram {
+    fn new(
+        gl: &Gl,
+        vertex_shader: &WebGlShader,
+        fragment_shader: &WebGlShader,
+    ) -> Result<Self, Error> {
+        let program = gl.create_program().ok_or("Unable to create program")?;
+        gl.attach_shader(&program, &vertex_shader);
+        gl.attach_shader(&program, &fragment_shader);
+
+        gl.link_program(&program);
+        if !gl
+            .get_program_parameter(&program, Gl::LINK_STATUS)
+            .as_bool()
+            .unwrap_or(false)
+        {
+            let msg = format!(
+                "Error linking shader program: {:?}",
+                gl.get_program_info_log(&program)
+            );
+            log::error!("{}", msg);
+            return Err(msg.into());
+        }
+
+        // Find uniforms.
+        let mut uniforms: [Option<WebGlUniformLocation>; NUM_UNIFORMS] = Default::default();
+        for i in 0..NUM_UNIFORMS {
+            uniforms[i] = gl.get_uniform_location(&program, UNIFORM_NAMES[i]);
+        }
+
+        Ok(ShaderProgram { program, uniforms })
+    }
+
+    fn uniform1f(&self, gl: &Gl, uniform: ShaderUniform, value: f32) {
+        gl.uniform1f(self.uniforms[uniform as usize].as_ref(), value);
+    }
+
+    fn uniform1fv(&self, gl: &Gl, uniform: ShaderUniform, values: &[f32]) {
+        gl.uniform1fv_with_f32_array(self.uniforms[uniform as usize].as_ref(), values);
+    }
+
+    fn uniform1i(&self, gl: &Gl, uniform: ShaderUniform, value: i32) {
+        gl.uniform1i(self.uniforms[uniform as usize].as_ref(), value);
+    }
+
+    fn uniform4fv(&self, gl: &Gl, uniform: ShaderUniform, values: &[f32]) {
+        gl.uniform4fv_with_f32_array(self.uniforms[uniform as usize].as_ref(), values);
+    }
+
+    fn uniform_matrix3fv(&self, gl: &Gl, uniform: ShaderUniform, values: &[[f32; 3]; 3]) {
+        gl.uniform_matrix3fv_with_f32_array(
+            self.uniforms[uniform as usize].as_ref(),
+            false,
+            unsafe { std::slice::from_raw_parts(values[0].as_ptr(), 9) },
+        );
+    }
+
+    fn uniform_matrix4fv(&self, gl: &Gl, uniform: ShaderUniform, values: &[[f32; 4]; 4]) {
+        gl.uniform_matrix4fv_with_f32_array(
+            self.uniforms[uniform as usize].as_ref(),
+            false,
+            unsafe { std::slice::from_raw_parts(values[0].as_ptr(), 16) },
+        );
+    }
+}

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -112,22 +112,8 @@ impl WebGlRenderBackend {
         // Because we currently only use on vertex format, we can do this once on init.
         gl.enable_vertex_attrib_array(vertex_position_location as u32);
         gl.enable_vertex_attrib_array(vertex_color_location as u32);
-        gl.vertex_attrib_pointer_with_i32(
-            vertex_position_location,
-            2,
-            Gl::FLOAT,
-            false,
-            24, //std::mem::size_of::<Vertex>() as i32,
-            0,
-        );
-        gl.vertex_attrib_pointer_with_i32(
-            vertex_color_location,
-            4,
-            Gl::FLOAT,
-            false,
-            24, //std::mem::size_of::<Vertex>() as i32,
-            8,
-        );
+        gl.vertex_attrib_pointer_with_i32(vertex_position_location, 2, Gl::FLOAT, false, 12, 0);
+        gl.vertex_attrib_pointer_with_i32(vertex_color_location, 4, Gl::UNSIGNED_BYTE, true, 12, 8);
 
         gl.enable(Gl::BLEND);
         gl.blend_func(Gl::SRC_ALPHA, Gl::ONE_MINUS_SRC_ALPHA);
@@ -179,19 +165,19 @@ impl WebGlRenderBackend {
             let verts = [
                 Vertex {
                     position: [0.0, 0.0],
-                    color: [1.0, 1.0, 1.0, 1.0],
+                    color: 0xffffff,
                 },
                 Vertex {
                     position: [1.0, 0.0],
-                    color: [1.0, 1.0, 1.0, 1.0],
+                    color: 0xffffff,
                 },
                 Vertex {
                     position: [1.0, 1.0],
-                    color: [1.0, 1.0, 1.0, 1.0],
+                    color: 0xffffff,
                 },
                 Vertex {
                     position: [0.0, 1.0],
-                    color: [1.0, 1.0, 1.0, 1.0],
+                    color: 0xffffff,
                 },
             ];
             let verts_bytes = std::slice::from_raw_parts(
@@ -643,15 +629,15 @@ impl RenderBackend for WebGlRenderBackend {
                 2,
                 Gl::FLOAT,
                 false,
-                24, //std::mem::size_of::<Vertex>() as i32,
+                12,
                 0,
             );
             self.gl.vertex_attrib_pointer_with_i32(
                 self.vertex_color_location,
                 4,
-                Gl::FLOAT,
-                false,
-                24, //std::mem::size_of::<Vertex>() as i32,
+                Gl::UNSIGNED_BYTE,
+                true,
+                12,
                 8,
             );
 
@@ -866,10 +852,11 @@ struct Texture {
     texture: WebGlTexture,
 }
 
+#[repr(packed(1))]
 #[derive(Copy, Clone, Debug)]
 struct Vertex {
     position: [f32; 2],
-    color: [f32; 4],
+    color: u32,
 }
 
 #[derive(Clone, Debug)]

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -670,6 +670,16 @@ impl RenderBackend for WebGlRenderBackend {
             )
             .warn_on_error();
 
+        // You must set the texture parameters for non-power-of-2 textures to function in WebGL.
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as i32);
+
         let handle = BitmapHandle(self.textures.len());
         self.textures.push((
             id,
@@ -712,6 +722,16 @@ impl RenderBackend for WebGlRenderBackend {
                 Some(&rgba),
             )
             .warn_on_error();
+
+        // You must set the texture parameters for non-power-of-2 textures to function in WebGL.
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_S, Gl::CLAMP_TO_EDGE as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_WRAP_T, Gl::CLAMP_TO_EDGE as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, Gl::LINEAR as i32);
+        self.gl
+            .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as i32);
 
         let handle = BitmapHandle(self.textures.len());
         self.textures.push((
@@ -1053,7 +1073,8 @@ impl RenderBackend for WebGlRenderBackend {
                         .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, filter);
                     self.gl
                         .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, filter);
-                    let wrap = if bitmap.is_repeating {
+                    // On WebGL1, you are unable to change the wrapping parameter causes non-power-of-2 textures.
+                    let wrap = if self.gl2.is_some() && bitmap.is_repeating {
                         Gl::MIRRORED_REPEAT as i32
                     } else {
                         Gl::CLAMP_TO_EDGE as i32

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [features]
+default = ["console_error_panic_hook", "console_log", "webgl"]
 lzma = ["ruffle_core/lzma"]
-default = ["console_error_panic_hook", "console_log"]
+canvas = ["ruffle_render_canvas"]
+webgl = ["ruffle_render_webgl"]
 
 [dependencies]
 byteorder = "1.3.4"
@@ -19,9 +21,9 @@ fnv = "1.0.3"
 generational-arena = "0.2.7"
 js-sys = "0.3.25"
 log = "0.4"
-ruffle_render_canvas = { path = "../render/canvas" }
+ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
-ruffle_render_webgl = { path = "../render/webgl" }
+ruffle_render_webgl = { path = "../render/webgl", optional = true }
 url = "2.1.1"
 wasm-bindgen = "0.2.57"
 wasm-bindgen-futures = "0.4.4"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -21,6 +21,7 @@ js-sys = "0.3.25"
 log = "0.4"
 ruffle_render_canvas = { path = "../render/canvas" }
 ruffle_web_common = { path = "common" }
+ruffle_render_webgl = { path = "../render/webgl" }
 url = "2.1.1"
 wasm-bindgen = "0.2.57"
 wasm-bindgen-futures = "0.4.4"

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -5,5 +5,10 @@ authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+js-sys = "0.3.25"
 log = "0.4"
 wasm-bindgen = "0.2.57"
+
+[dependencies.web-sys]
+version = "0.3.34"
+features = ["Window"]

--- a/web/common/src/lib.rs
+++ b/web/common/src/lib.rs
@@ -33,3 +33,14 @@ impl<T> JsResult<T> for Result<T, JsValue> {
         self.map_err(|value| JsError { value })
     }
 }
+
+/// Very bad way to guess if we're running on a tablet/mobile.
+pub fn is_mobile_or_tablet() -> bool {
+    if let Some(window) = web_sys::window() {
+        if let Ok(val) = js_sys::Reflect::get(&window, &JsValue::from("orientation")) {
+            return !val.is_undefined();
+        }
+    }
+
+    false
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -8,6 +8,7 @@ use generational_arena::{Arena, Index};
 use js_sys::Uint8Array;
 use ruffle_core::PlayerEvent;
 use ruffle_render_canvas::WebCanvasRenderBackend;
+use ruffle_render_webgl::WebGlRenderBackend;
 use std::mem::drop;
 use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, error::Error, num::NonZeroI32};
@@ -101,7 +102,7 @@ impl Ruffle {
         swf_data.copy_to(&mut data[..]);
 
         let window = web_sys::window().ok_or_else(|| "Expected window")?;
-        let renderer = Box::new(WebCanvasRenderBackend::new(&canvas)?);
+        let renderer = Box::new(WebGlRenderBackend::new(&canvas)?);
         let audio = Box::new(WebAudioBackend::new()?);
         let navigator = Box::new(WebNavigatorBackend::new());
         let input = Box::new(WebInputBackend::new(&canvas));

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -6,9 +6,8 @@ mod navigator;
 use crate::{audio::WebAudioBackend, input::WebInputBackend, navigator::WebNavigatorBackend};
 use generational_arena::{Arena, Index};
 use js_sys::Uint8Array;
+use ruffle_core::backend::render::RenderBackend;
 use ruffle_core::PlayerEvent;
-use ruffle_render_canvas::WebCanvasRenderBackend;
-use ruffle_render_webgl::WebGlRenderBackend;
 use std::mem::drop;
 use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, error::Error, num::NonZeroI32};
@@ -102,7 +101,7 @@ impl Ruffle {
         swf_data.copy_to(&mut data[..]);
 
         let window = web_sys::window().ok_or_else(|| "Expected window")?;
-        let renderer = Box::new(WebGlRenderBackend::new(&canvas)?);
+        let renderer = create_renderer(&canvas)?;
         let audio = Box::new(WebAudioBackend::new()?);
         let navigator = Box::new(WebNavigatorBackend::new());
         let input = Box::new(WebInputBackend::new(&canvas));
@@ -468,4 +467,25 @@ impl Ruffle {
             }
         });
     }
+}
+
+fn create_renderer(canvas: &HtmlCanvasElement) -> Result<Box<dyn RenderBackend>, Box<dyn Error>> {
+    #[cfg(not(any(feature = "canvas", feature = "webgl")))]
+    std::compile_error!("You must enable one of the render backend features (e.g., webgl).");
+
+    #[cfg(feature = "webgl")]
+    {
+        if let Ok(renderer) = ruffle_render_webgl::WebGlRenderBackend::new(canvas) {
+            return Ok(Box::new(renderer));
+        }
+    }
+
+    #[cfg(feature = "canvas")]
+    {
+        if let Ok(renderer) = ruffle_render_canvas::WebCanvasRenderBackend::new(canvas) {
+            return Ok(Box::new(renderer));
+        }
+    }
+
+    Err("Unable to create renderer".into())
 }


### PR DESCRIPTION
This adds a WebGL1 rendering backend for use on web.
 * Moved render backends to subcrates in the top-level `render` directory because backends may share common code and potentially work on multiple platforms
 * `lyon` based tessellation code was moved to `render/common_tess` and is used by both the desktop and WebGL backends
 * This also paves the way for a WebGPU backend which could be used on both desktop and web (#14)
 * Opinions welcome (is this a good organization for the render backends? Should we do this for all backends? Should we just cram the tessellation stuff into `core`?)

Needs general testing, and still some TODOs:
 -  [x] No "Click to Play"/play button; will start with a blank screen, click on it to start the movie
 - [x] Allow choosing between the canvas and WebGL backends
 - [x] Minimize GL state change calls
 - [ ] Make `common_tess::tessellate_shape` return an `Iterator`
 - [x] WebGL2 support when available (VAO, MSAA settings, ...)