### PR TITLE
Load ruffle extension at start of page load(fixes #501 & #448 with extension)

### DIFF
--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -14,7 +14,16 @@
  *    unintentionally.
  * 2. The ability to load extension resources such as .wasm files
  */
-let page_optout = document.getElementsByTagName("html")[0].dataset.ruffleOptout !== undefined;
+let page_optout = document.documentElement.hasAttribute("data-ruffle-optout");
+try {
+    if ((!page_optout)&&window.top&&window.top.document&&window.top.document.documentElement) {
+        /* In case the opting out page uses iframes */
+        page_optout = window.top.document.documentElement.hasAttribute("data-ruffle-optout");
+    }
+}
+catch (e) {
+    console.log("Unable to check top-level optout: " + e.message);
+}
 let obfuscated_event_prefix = "rufEvent" + Math.floor(Math.random() * 100000000000);
 let ext_path = "";
 if (chrome && chrome.extension && chrome.extension.getURL) {
@@ -30,11 +39,17 @@ if (!(page_optout||window.RufflePlayer)) {
     '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){console.log("installing polyfill");navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
     let scriptelem = document.createElement("script");
     setup_scriptelem.innerHTML = setup_src;
+    /* The setup_scriptelem sets runtime_path & obfusticated_event_prefix *
+     * and runs the plugin polyfill, which must run before any flash      *
+     * detection scripts.                                                 */
     (document.head || document.documentElement).appendChild(setup_scriptelem);
     window.RufflePlayer = {};
     window.RufflePlayer.config = {
         "public_path": ext_path + "dist/",
         "polyfills": ["static-content", "dynamic-content"]
+        /* We only want "static-content" & "dynamic-content" because we *
+         * inject the plugin polyfill above & use all_frames in         *
+         * manifest.json for (i)frames.                                 */
     };
     scriptelem.src = ext_path + "dist/ruffle.js";
     (document.head || document.documentElement).appendChild(scriptelem);

--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -14,18 +14,20 @@
  *    unintentionally.
  * 2. The ability to load extension resources such as .wasm files
  */
+function insert_script() {
+    let setup_scriptelem = document.createElement("script");
+    let setup_src = "var runtime_path = \"" +
+        ext_path + "\";\nvar obfuscated_event_prefix = \"" +
+        obfuscated_event_prefix + "\";";
+    let scriptelem = document.createElement("script");
+    setup_scriptelem.appendChild(document.createTextNode(setup_src));
+    document.head.appendChild(setup_scriptelem);
+    scriptelem.src=ext_path + "dist/ruffle.js";
+    document.head.appendChild(scriptelem);
+}
 function insert_ruffle(mutationsList,observer) {
-    let nodesAdded = mutationsList.some(mutation => mutation.addedNodes.length > 0);
-    if (nodesAdded&&document.head) {
-        let setup_scriptelem = document.createElement("script");
-        let setup_src = "var runtime_path = \"" +
-            ext_path + "\";\nvar obfuscated_event_prefix = \"" +
-            obfuscated_event_prefix + "\";";
-        let scriptelem = document.createElement("script");
-        setup_scriptelem.appendChild(document.createTextNode(setup_src));
-        document.head.appendChild(setup_scriptelem);
-        scriptelem.src=ext_path + "dist/ruffle.js";
-        document.head.appendChild(scriptelem);
+    if (document.head) {
+        insert_script();
         observer.disconnect();
     }
 }
@@ -39,6 +41,11 @@ if (chrome && chrome.extension && chrome.extension.getURL) {
     ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
 }
 if (!(page_optout||window.RufflePlayer)) {
-    const observer = new MutationObserver(insert_ruffle);
-    observer.observe(document, {childList: true, subtree: true});
+    if (document.head) {
+        insert_script();
+    }
+    else {
+        const observer = new MutationObserver(insert_ruffle);
+        observer.observe(document, {childList: true, subtree: true});
+    }
 }

--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -26,10 +26,16 @@ if (!(page_optout||window.RufflePlayer)) {
     let setup_scriptelem = document.createElement("script");
     let setup_src = "var runtime_path = \"" +
         ext_path + "\";\nvar obfuscated_event_prefix = \"" +
-        obfuscated_event_prefix + "\";";
+        obfuscated_event_prefix + "\";" +
+    '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){console.log("installing polyfill");navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
     let scriptelem = document.createElement("script");
-    setup_scriptelem.appendChild(document.createTextNode(setup_src));
+    setup_scriptelem.innerHTML = setup_src;
     (document.head || document.documentElement).appendChild(setup_scriptelem);
-    scriptelem.src=ext_path + "dist/ruffle.js";
+    window.RufflePlayer = {};
+    window.RufflePlayer.config = {
+        "public_path": ext_path + "dist/",
+        "polyfills": ["static-content", "dynamic-content"]
+    };
+    scriptelem.src = ext_path + "dist/ruffle.js";
     (document.head || document.documentElement).appendChild(scriptelem);
 }

--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -16,7 +16,7 @@
  */
 let page_optout = document.documentElement.hasAttribute("data-ruffle-optout");
 try {
-    if ((!page_optout)&&window.top&&window.top.document&&window.top.document.documentElement) {
+    if ((!page_optout) && window.top && window.top.document && window.top.document.documentElement) {
         /* In case the opting out page uses iframes */
         page_optout = window.top.document.documentElement.hasAttribute("data-ruffle-optout");
     }
@@ -31,15 +31,15 @@ if (chrome && chrome.extension && chrome.extension.getURL) {
 } else if (browser && browser.runtime && browser.runtime.getURL) {
     ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
 }
-if (!(page_optout||window.RufflePlayer)) {
+if (!(page_optout || window.RufflePlayer)) {
     let setup_scriptelem = document.createElement("script");
     let setup_src = "var runtime_path = \"" +
         ext_path + "\";\nvar obfuscated_event_prefix = \"" +
         obfuscated_event_prefix + "\";" +
-    '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){console.log("installing polyfill");navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
+        '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
     let scriptelem = document.createElement("script");
     setup_scriptelem.innerHTML = setup_src;
-    /* The setup_scriptelem sets runtime_path & obfusticated_event_prefix *
+    /* The setup_scriptelem sets runtime_path & obfuscated_event_prefix *
      * and runs the plugin polyfill, which must run before any flash      *
      * detection scripts.                                                 */
     (document.head || document.documentElement).appendChild(setup_scriptelem);

--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -14,24 +14,6 @@
  *    unintentionally.
  * 2. The ability to load extension resources such as .wasm files
  */
-function insert_script() {
-    let setup_scriptelem = document.createElement("script");
-    let setup_src = "var runtime_path = \"" +
-        ext_path + "\";\nvar obfuscated_event_prefix = \"" +
-        obfuscated_event_prefix + "\";";
-    let scriptelem = document.createElement("script");
-    setup_scriptelem.appendChild(document.createTextNode(setup_src));
-    document.head.appendChild(setup_scriptelem);
-    scriptelem.src=ext_path + "dist/ruffle.js";
-    document.head.appendChild(scriptelem);
-}
-function insert_ruffle(mutationsList,observer) {
-    if (document.head) {
-        insert_script();
-        observer.disconnect();
-    }
-}
-
 let page_optout = document.getElementsByTagName("html")[0].dataset.ruffleOptout !== undefined;
 let obfuscated_event_prefix = "rufEvent" + Math.floor(Math.random() * 100000000000);
 let ext_path = "";
@@ -41,11 +23,13 @@ if (chrome && chrome.extension && chrome.extension.getURL) {
     ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
 }
 if (!(page_optout||window.RufflePlayer)) {
-    if (document.head) {
-        insert_script();
-    }
-    else {
-        const observer = new MutationObserver(insert_ruffle);
-        observer.observe(document, {childList: true, subtree: true});
-    }
+    let setup_scriptelem = document.createElement("script");
+    let setup_src = "var runtime_path = \"" +
+        ext_path + "\";\nvar obfuscated_event_prefix = \"" +
+        obfuscated_event_prefix + "\";";
+    let scriptelem = document.createElement("script");
+    setup_scriptelem.appendChild(document.createTextNode(setup_src));
+    (document.head || document.documentElement).appendChild(setup_scriptelem);
+    scriptelem.src=ext_path + "dist/ruffle.js";
+    (document.head || document.documentElement).appendChild(scriptelem);
 }

--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -16,13 +16,7 @@
  */
 function insert_ruffle(mutationsList,observer) {
     let nodesAdded = mutationsList.some(mutation => mutation.addedNodes.length > 0);
-    let ext_path = "";
     if (nodesAdded&&document.head) {
-        if (chrome && chrome.extension && chrome.extension.getURL) {
-            ext_path = chrome.extension.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
-        } else if (browser && browser.runtime && browser.runtime.getURL) {
-            ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
-        }
         let setup_scriptelem = document.createElement("script");
         let setup_src = "var runtime_path = \"" +
             ext_path + "\";\nvar obfuscated_event_prefix = \"" +
@@ -36,9 +30,14 @@ function insert_ruffle(mutationsList,observer) {
     }
 }
 
-
 let page_optout = document.getElementsByTagName("html")[0].dataset.ruffleOptout !== undefined;
 let obfuscated_event_prefix = "rufEvent" + Math.floor(Math.random() * 100000000000);
+let ext_path = "";
+if (chrome && chrome.extension && chrome.extension.getURL) {
+    ext_path = chrome.extension.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
+} else if (browser && browser.runtime && browser.runtime.getURL) {
+    ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
+}
 if (!(page_optout||window.RufflePlayer)) {
     const observer = new MutationObserver(insert_ruffle);
     observer.observe(document, {childList: true, subtree: true});

--- a/web/extension/build/js/lv0.js
+++ b/web/extension/build/js/lv0.js
@@ -1,4 +1,4 @@
-(/**
+/**
  * Pierce the extension sandbox by copying our code into window space.
  * 
  * The isolation extension content scripts get is neat, but it causes problems
@@ -14,29 +14,32 @@
  *    unintentionally.
  * 2. The ability to load extension resources such as .wasm files
  */
-    async function () {
-        let page_optout = document.getElementsByTagName("html")[0].dataset.ruffleOptout !== undefined;
-        let obfuscated_event_prefix = "rufEvent" + Math.floor(Math.random() * 100000000000);
-
-        if (!page_optout) {
-            let ext_path = "";
-            if (chrome && chrome.extension && chrome.extension.getURL) {
-                ext_path = chrome.extension.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
-            } else if (browser && browser.runtime && browser.runtime.getURL) {
-                ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
-            }
-
-            let ruffle_src_resp = await fetch(ext_path + "dist/ruffle.js");
-            if (ruffle_src_resp.ok) {
-                let ruffle_src = "(function () { var runtime_path = \"" +
-                    ext_path + "\";\nvar obfuscated_event_prefix = \"" +
-                    obfuscated_event_prefix + "\";\n" +
-                    await ruffle_src_resp.text() + "}())";
-                let scriptelem = document.createElement("script");
-                scriptelem.appendChild(document.createTextNode(ruffle_src));
-                document.head.appendChild(scriptelem);
-            } else {
-                console.error("Critical error loading Ruffle into page")
-            }
+function insert_ruffle(mutationsList,observer) {
+    let nodesAdded = mutationsList.some(mutation => mutation.addedNodes.length > 0);
+    let ext_path = "";
+    if (nodesAdded&&document.head) {
+        if (chrome && chrome.extension && chrome.extension.getURL) {
+            ext_path = chrome.extension.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
+        } else if (browser && browser.runtime && browser.runtime.getURL) {
+            ext_path = browser.runtime.getURL("dist/ruffle.js").replace("dist/ruffle.js", "");
         }
-    }());
+        let setup_scriptelem = document.createElement("script");
+        let setup_src = "var runtime_path = \"" +
+            ext_path + "\";\nvar obfuscated_event_prefix = \"" +
+            obfuscated_event_prefix + "\";";
+        let scriptelem = document.createElement("script");
+        setup_scriptelem.appendChild(document.createTextNode(setup_src));
+        document.head.appendChild(setup_scriptelem);
+        scriptelem.src=ext_path + "dist/ruffle.js";
+        document.head.appendChild(scriptelem);
+        observer.disconnect();
+    }
+}
+
+
+let page_optout = document.getElementsByTagName("html")[0].dataset.ruffleOptout !== undefined;
+let obfuscated_event_prefix = "rufEvent" + Math.floor(Math.random() * 100000000000);
+if (!(page_optout||window.RufflePlayer)) {
+    const observer = new MutationObserver(insert_ruffle);
+    observer.observe(document, {childList: true, subtree: true});
+}

--- a/web/extension/build/manifest.json
+++ b/web/extension/build/manifest.json
@@ -14,7 +14,8 @@
         {
             "matches": ["<all_urls>"],
             "js": ["js/lv0.js"],
-            "all_frames": true
+            "all_frames": true,
+            "run_at": "document_start"
         }
     ],
     "web_accessible_resources": ["dist/*"]


### PR DESCRIPTION
In my testing, this causes the extension to load ruffle somewhere in the middle of the head as the document is being loaded, rather than at the end of the head after the document is finished loading, which seems to be enough to fix this issue. This fix adds `"load_at": "document_start"` to the `manifest.json`, which makes `lv0.js` run as soon as the page starts loading. `lv0.js` was modified to use a `MutationObserver` & insert the extension setup code & ruffle.js in 2 script tags, 1 after the other. The `MutationObserver` was necessary because, on Chrome, Chromium, & Chromium-based browsers, scripts loaded at `document_start` run before the head element is loaded, causing script insertions to either fail when trying to insert into the head or not work when inserted directly into the `document` object(above the head). The `MutationObserver` is `disconnect`ed as soon as the script is inserted, to avoid inserting it every time a new tag is loaded, which would freeze the browser.

fixes #501