### PR TITLE
Small render API improvements

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -21,8 +21,7 @@ pub trait RenderBackend {
     ) -> BitmapInfo;
     fn register_bitmap_png(&mut self, swf_tag: &swf::DefineBitsLossless) -> BitmapInfo;
 
-    fn begin_frame(&mut self);
-    fn clear(&mut self, color: Color);
+    fn begin_frame(&mut self, clear: Color);
     fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform);
     fn render_shape(&mut self, shape: ShapeHandle, transform: &Transform);
     fn end_frame(&mut self);
@@ -113,9 +112,8 @@ impl RenderBackend for NullRenderer {
             height: 0,
         }
     }
-    fn begin_frame(&mut self) {}
+    fn begin_frame(&mut self, _clear: Color) {}
     fn end_frame(&mut self) {}
-    fn clear(&mut self, _color: Color) {}
     fn render_bitmap(&mut self, _bitmap: BitmapHandle, _transform: &Transform) {}
     fn render_shape(&mut self, _shape: ShapeHandle, _transform: &Transform) {}
     fn draw_letterbox(&mut self, _letterbox: Letterbox) {}

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -1,10 +1,11 @@
+use crate::shape_utils::DistilledShape;
 pub use crate::{transform::Transform, Color};
 use std::io::Read;
 pub use swf;
 
 pub trait RenderBackend {
     fn set_viewport_dimensions(&mut self, width: u32, height: u32);
-    fn register_shape(&mut self, shape: &swf::Shape) -> ShapeHandle;
+    fn register_shape(&mut self, shape: DistilledShape) -> ShapeHandle;
     fn register_glyph_shape(&mut self, shape: &swf::Glyph) -> ShapeHandle;
     fn register_bitmap_jpeg(
         &mut self,
@@ -68,7 +69,7 @@ impl Default for NullRenderer {
 
 impl RenderBackend for NullRenderer {
     fn set_viewport_dimensions(&mut self, _width: u32, _height: u32) {}
-    fn register_shape(&mut self, _shape: &swf::Shape) -> ShapeHandle {
+    fn register_shape(&mut self, _shape: DistilledShape) -> ShapeHandle {
         ShapeHandle(0)
     }
     fn register_glyph_shape(&mut self, _shape: &swf::Glyph) -> ShapeHandle {

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -19,7 +19,7 @@ impl<'gc> Graphic<'gc> {
     pub fn from_swf_tag(context: &mut UpdateContext<'_, 'gc, '_>, swf_shape: &swf::Shape) -> Self {
         let static_data = GraphicStatic {
             id: swf_shape.id,
-            render_handle: context.renderer.register_shape(swf_shape),
+            render_handle: context.renderer.register_shape(swf_shape.into()),
             bounds: swf_shape.shape_bounds.clone().into(),
         };
         Graphic(GcCell::allocate(

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -298,7 +298,7 @@ impl MorphShapeStatic {
         };
 
         let frame = Frame {
-            shape: renderer.register_shape(&shape),
+            shape: renderer.register_shape((&shape).into()),
             bounds: bounds.into(),
         };
         self.frames.insert(ratio, frame);

--- a/core/src/font/text_format.rs
+++ b/core/src/font/text_format.rs
@@ -109,12 +109,8 @@ impl TextFormat {
         Ok(Self {
             font: getstr_from_avm1_object(object1, "font", avm1, uc)?,
             size: getfloat_from_avm1_object(object1, "size", avm1, uc)?,
-            color: getfloat_from_avm1_object(object1, "color", avm1, uc)?.map(|v| swf::Color {
-                r: ((v as u32 & 0xFF_0000) >> 16) as u8,
-                g: ((v as u32 & 0x00_FF00) >> 8) as u8,
-                b: (v as u32 & 0x00_00FF) as u8,
-                a: 0xFF,
-            }),
+            color: getfloat_from_avm1_object(object1, "color", avm1, uc)?
+                .map(|v| swf::Color::from_rgb(v as u32, 0xFF)),
             align: getstr_from_avm1_object(object1, "align", avm1, uc)?.and_then(|v| {
                 match v.to_lowercase().as_str() {
                     "left" => Some(swf::TextAlign::Left),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -578,9 +578,7 @@ impl Player {
             valid: true,
         };
 
-        self.renderer.begin_frame();
-
-        self.renderer.clear(self.background_color.clone());
+        self.renderer.begin_frame(self.background_color.clone());
 
         let (renderer, transform_stack) = (&mut self.renderer, &mut self.transform_stack);
 

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -520,23 +520,21 @@ impl RenderBackend for WebCanvasRenderBackend {
         }
     }
 
-    fn begin_frame(&mut self) {
+    fn begin_frame(&mut self, clear: Color) {
         // Reset canvas transform in case it was left in a dirty state.
         self.context.reset_transform().unwrap();
+
+        let width = self.canvas.width();
+        let height = self.canvas.height();
+
+        let color = format!("rgb({}, {}, {})", clear.r, clear.g, clear.b);
+        self.context.set_fill_style(&color.into());
+        self.context
+            .fill_rect(0.0, 0.0, width.into(), height.into());
     }
 
     fn end_frame(&mut self) {
         // Noop
-    }
-
-    fn clear(&mut self, color: Color) {
-        let width = self.canvas.width();
-        let height = self.canvas.height();
-
-        let color = format!("rgb({}, {}, {})", color.r, color.g, color.b);
-        self.context.set_fill_style(&color.into());
-        self.context
-            .fill_rect(0.0, 0.0, width.into(), height.into());
     }
 
     fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform) {

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -6,7 +6,7 @@ use lyon::tessellation::{
 };
 use lyon::tessellation::{FillOptions, StrokeOptions};
 use ruffle_core::backend::render::swf::{self, FillStyle, Twips};
-use ruffle_core::shape_utils::{DrawCommand, DrawPath};
+use ruffle_core::shape_utils::{DistilledShape, DrawCommand, DrawPath};
 
 pub struct ShapeTessellator {
     fill_tess: FillTessellator,
@@ -21,11 +21,10 @@ impl ShapeTessellator {
         }
     }
 
-    pub fn tessellate_shape<F>(&mut self, shape: &swf::Shape, get_bitmap_dimensions: F) -> Mesh
+    pub fn tessellate_shape<F>(&mut self, shape: DistilledShape, get_bitmap_dimensions: F) -> Mesh
     where
         F: Fn(swf::CharacterId) -> Option<(u32, u32)>,
     {
-        let paths = ruffle_core::shape_utils::swf_shape_to_paths(shape);
         let mut mesh = Vec::new();
 
         let mut lyon_mesh: VertexBuffers<_, u32> = VertexBuffers::new();
@@ -43,7 +42,7 @@ impl ShapeTessellator {
             });
         }
 
-        for path in paths {
+        for path in shape.paths {
             match path {
                 DrawPath::Fill { style, commands } => match style {
                     FillStyle::Color(color) => {

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -839,7 +839,7 @@ impl RenderBackend for WebGlRenderBackend {
         }
     }
 
-    fn begin_frame(&mut self) {
+    fn begin_frame(&mut self, clear: Color) {
         self.num_masks = 0;
         self.num_masks_active = 0;
         self.write_stencil_mask = 0;
@@ -857,6 +857,16 @@ impl RenderBackend for WebGlRenderBackend {
             let gl = &self.gl;
             gl.bind_framebuffer(Gl::FRAMEBUFFER, Some(&msaa_buffers.render_framebuffer));
         }
+
+        self.set_stencil_state();
+        self.gl.clear_color(
+            clear.r as f32 / 255.0,
+            clear.g as f32 / 255.0,
+            clear.b as f32 / 255.0,
+            clear.a as f32 / 255.0,
+        );
+        self.gl.stencil_mask(0xff);
+        self.gl.clear(Gl::COLOR_BUFFER_BIT | Gl::STENCIL_BUFFER_BIT);
     }
 
     fn end_frame(&mut self) {
@@ -934,19 +944,6 @@ impl RenderBackend for WebGlRenderBackend {
                 0,
             );
         }
-    }
-
-    fn clear(&mut self, color: Color) {
-        self.set_stencil_state();
-
-        self.gl.clear_color(
-            color.r as f32 / 255.0,
-            color.g as f32 / 255.0,
-            color.b as f32 / 255.0,
-            color.a as f32 / 255.0,
-        );
-        self.gl.stencil_mask(0xff);
-        self.gl.clear(Gl::COLOR_BUFFER_BIT | Gl::STENCIL_BUFFER_BIT);
     }
 
     fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform) {

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -2,6 +2,7 @@ use ruffle_core::backend::render::swf::{self, FillStyle};
 use ruffle_core::backend::render::{
     BitmapHandle, BitmapInfo, Color, Letterbox, RenderBackend, ShapeHandle, Transform,
 };
+use ruffle_core::shape_utils::DistilledShape;
 use ruffle_render_common_tess::{GradientSpread, GradientType, ShapeTessellator, Vertex};
 use ruffle_web_common::JsResult;
 use std::convert::TryInto;
@@ -422,7 +423,7 @@ impl WebGlRenderBackend {
         Ok(())
     }
 
-    fn register_shape_internal(&mut self, shape: &swf::Shape) -> ShapeHandle {
+    fn register_shape_internal(&mut self, shape: DistilledShape) -> ShapeHandle {
         use ruffle_render_common_tess::DrawType as TessDrawType;
 
         let handle = ShapeHandle(self.meshes.len());
@@ -651,7 +652,7 @@ impl RenderBackend for WebGlRenderBackend {
         self.build_matrices();
     }
 
-    fn register_shape(&mut self, shape: &swf::Shape) -> ShapeHandle {
+    fn register_shape(&mut self, shape: DistilledShape) -> ShapeHandle {
         self.register_shape_internal(shape)
     }
 
@@ -675,7 +676,7 @@ impl RenderBackend for WebGlRenderBackend {
             },
             shape: glyph.shape_records.clone(),
         };
-        self.register_shape_internal(&shape)
+        self.register_shape_internal((&shape).into())
     }
 
     fn register_bitmap_jpeg(

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -1093,7 +1093,7 @@ impl RenderBackend for WgpuRenderBackend {
         }
     }
 
-    fn begin_frame(&mut self) {
+    fn begin_frame(&mut self, clear: Color) {
         assert!(self.current_frame.is_none());
         self.current_frame = match self.swap_chain.get_next_texture() {
             Ok(frame) => {
@@ -1116,9 +1116,7 @@ impl RenderBackend for WgpuRenderBackend {
         self.write_stencil_mask = 0;
         self.test_stencil_mask = 0;
         self.next_stencil_mask = 1;
-    }
 
-    fn clear(&mut self, color: Color) {
         if let Some((swap_chain_output, encoder)) = &mut self.current_frame {
             let (color_attachment, resolve_target) = if self.msaa_sample_count >= 2 {
                 (&self.frame_buffer_view, Some(&swap_chain_output.view))
@@ -1131,10 +1129,10 @@ impl RenderBackend for WgpuRenderBackend {
                     load_op: wgpu::LoadOp::Clear,
                     store_op: wgpu::StoreOp::Store,
                     clear_color: wgpu::Color {
-                        r: f64::from(color.r) / 255.0,
-                        g: f64::from(color.g) / 255.0,
-                        b: f64::from(color.b) / 255.0,
-                        a: f64::from(color.a) / 255.0,
+                        r: f64::from(clear.r) / 255.0,
+                        g: f64::from(clear.g) / 255.0,
+                        b: f64::from(clear.b) / 255.0,
+                        a: f64::from(clear.a) / 255.0,
                     },
                     resolve_target,
                 }],

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -162,6 +162,17 @@ pub struct Color {
     pub a: u8,
 }
 
+impl Color {
+    pub fn from_rgb(rgb: u32, alpha: u8) -> Self {
+        Self {
+            r: ((rgb & 0xFF_0000) >> 16) as u8,
+            g: ((rgb & 0x00_FF00) >> 8) as u8,
+            b: (rgb & 0x00_00FF) as u8,
+            a: alpha,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct ColorTransform {
     pub r_multiply: f32,


### PR DESCRIPTION
(+1 small core utility method)

The drawing API ultimately comes down to a DistilledShape, instead of a Shape, which is basically the output of the previous `swf_shape_to_paths` method. Shape was the swf-specific encoding of the same data, but drawing API is one layer of abstraction removed.

I've also merged begin_frame and clear because in wgpu, they're the same action - we ended up clearing twice.