### PR TITLE
Don't polyfill elements with no src or data attributes

### DIFF
--- a/web/js-src/ruffle-embed.js
+++ b/web/js-src/ruffle-embed.js
@@ -34,6 +34,9 @@ export default class RuffleEmbed extends RufflePlayer {
     }
 
     static is_interdictable(elem) {
+        if (!elem.src) {
+		return false;
+        }
         if (elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE || elem.type == FLASH7_AND_8_MIMETYPE || elem.type == FLASH_MOVIE_MIMETYPE) {
             return true;
         } else if (elem.type === undefined || elem.type === "") {

--- a/web/js-src/ruffle-object.js
+++ b/web/js-src/ruffle-object.js
@@ -28,6 +28,9 @@ export default class RuffleObject extends RufflePlayer {
     }
 
     static is_interdictable(elem) {
+        if (!elem.src && !elem.data) {
+            return false;
+        }
         if (elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE || elem.type == FLASH7_AND_8_MIMETYPE || elem.type == FLASH_MOVIE_MIMETYPE) {
             return true;
         } else if (elem.attributes && elem.attributes.classid && elem.attributes.classid.value === FLASH_ACTIVEX_CLASSID) {

--- a/web/js-src/ruffle-object.js
+++ b/web/js-src/ruffle-object.js
@@ -28,8 +28,17 @@ export default class RuffleObject extends RufflePlayer {
     }
 
     static is_interdictable(elem) {
-        if (!elem.src && !elem.data) {
-            return false;
+        if (!elem.data) {
+            let has_movie = false;
+            let params = elem.getElementsByTagName("param");
+            for (let i = 0;i < params.length;i ++) {
+                if (params[i].name == "movie" && params[i].value) {
+                    has_movie = true;
+                }
+            }
+            if (!has_movie) {
+                return false;
+            }
         }
         if (elem.type === FLASH_MIMETYPE || elem.type === FUTURESPLASH_MIMETYPE || elem.type == FLASH7_AND_8_MIMETYPE || elem.type == FLASH_MOVIE_MIMETYPE) {
             return true;


### PR DESCRIPTION
This addresses #542 in some cases(with SWFObject). Also, I found that this unbreaks Google Docs, Sheets, &c. because they have a momentarily inserted flash object with no src or data attribute.