### PR TITLE
Switch PR & commit testing to use Github Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,11 +311,6 @@ jobs:
 workflows:
   version: 2
 
-  # Basic linux build on each push or pull request to the repo
-  commit_build:
-    jobs:
-      - build
-
   # Nightly builds
   nightly_build:
     triggers:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,77 @@
+name: Test Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Test rust ${{ matrix.rust_version }} / node ${{ matrix.node_version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.rust_version == 'nightly' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: ['10', '12']
+        rust_version: ['stable', 'beta', 'nightly']
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Use Node.js ${{ matrix.node_version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node_version }}
+
+    - name: Use stable rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust_version }}
+        override: true
+        components: rustfmt, clippy
+
+    - name: Install linux depencencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get -y install libasound2-dev 
+
+    - name: Install wasm-pack
+      run: cargo install wasm-pack 
+
+    - name: Run all rust tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+
+    - name: Check clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all --tests -- -D warnings
+
+    - name: Check rust formatting
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
+    - name: Build web self-hosted
+      working-directory: web/selfhosted
+      run: |
+        npm ci
+        npm run build -- --mode=production
+
+    - name: Build web demo
+      working-directory: web/demo
+      run: |
+        npm ci
+        npm run build -- --mode=production
+
+    - name: Build browser extension
+      working-directory: web/extension
+      run: |
+        npm ci
+        npm run build -- --mode=production


### PR DESCRIPTION
This also increases the test coverage away from just Ubuntu / Node 10 / Rust Stable, to a matrix of:

- OS: Ubuntu, Mac, Windows
- Node: 10 LTS, 12 LTS
- Rust: Stable, Beta, Nightly

It seems that a full test suite takes about 10 minutes, as opposed to the 60 minutes today with the circleci setup.

Rust nightly builds are setup to not fail the overall workflow, however betas will. Today, it seems we are failing beta Clippy checks - I'll submit a separate PR for that.

I left the existing publish steps on circleci for now. We can change that over later.