### PR TITLE
Leave the original object/embed in the DOM & make the RufflePlayer follow it

### DIFF
--- a/web/packages/core/src/polyfills.js
+++ b/web/packages/core/src/polyfills.js
@@ -27,10 +27,6 @@ ruffle_script_src += "ruffle.js";
  * little hands, but only if we load first.
  */
 
-function insert_after(original_element, new_element) {
-    original_element.parentElement.insertBefore(new_element, original_element.nextSibling);
-}
-
 let objects;
 let embeds;
 function replace_flash_instances() {
@@ -43,13 +39,13 @@ function replace_flash_instances() {
         for (let elem of Array.from(objects)) {
             if (RuffleObject.is_interdictable(elem)) {
                 let ruffle_obj = RuffleObject.from_native_object_element(elem);
-                insert_after(elem, ruffle_obj);
+                elem.insertAdjacentElement("afterend", ruffle_obj);
             }
         }
         for (let elem of Array.from(embeds)) {
             if (RuffleEmbed.is_interdictable(elem)) {
                 let ruffle_obj = RuffleEmbed.from_native_embed_element(elem);
-                insert_after(elem, ruffle_obj);
+                elem.insertAdjacentElement("afterend", ruffle_obj);
             }
         }
     } catch (err) {

--- a/web/packages/core/src/polyfills.js
+++ b/web/packages/core/src/polyfills.js
@@ -26,6 +26,11 @@ ruffle_script_src += "ruffle.js";
  * keep native objects out of the DOM, and thus out of JavaScript's grubby
  * little hands, but only if we load first.
  */
+
+function insert_after(original_element, new_element) {
+    original_element.parentElement.insertBefore(new_element, original_element.nextSibling);
+}
+
 let objects;
 let embeds;
 function replace_flash_instances() {
@@ -38,13 +43,13 @@ function replace_flash_instances() {
         for (let elem of Array.from(objects)) {
             if (RuffleObject.is_interdictable(elem)) {
                 let ruffle_obj = RuffleObject.from_native_object_element(elem);
-                elem.replaceWith(ruffle_obj);
+                insert_after(elem, ruffle_obj);
             }
         }
         for (let elem of Array.from(embeds)) {
             if (RuffleEmbed.is_interdictable(elem)) {
                 let ruffle_obj = RuffleEmbed.from_native_embed_element(elem);
-                elem.replaceWith(ruffle_obj);
+                insert_after(elem, ruffle_obj);
             }
         }
     } catch (err) {

--- a/web/packages/core/src/polyfills.js
+++ b/web/packages/core/src/polyfills.js
@@ -39,13 +39,23 @@ function replace_flash_instances() {
         for (let elem of Array.from(objects)) {
             if (RuffleObject.is_interdictable(elem)) {
                 let ruffle_obj = RuffleObject.from_native_object_element(elem);
-                elem.insertAdjacentElement("afterend", ruffle_obj);
+                let parent = elem;
+                while (parent.parentElement.tagName.toLowerCase() == "object") {
+                    parent = parent.parentElement;
+                }
+                /* Handle case where parent object is broken */
+                parent.insertAdjacentElement("afterend", ruffle_obj);
             }
         }
         for (let elem of Array.from(embeds)) {
             if (RuffleEmbed.is_interdictable(elem)) {
                 let ruffle_obj = RuffleEmbed.from_native_embed_element(elem);
-                elem.insertAdjacentElement("afterend", ruffle_obj);
+                let parent = elem;
+                while (parent.parentElement.tagName.toLowerCase() == "object") {
+                    parent = parent.parentElement;
+                }
+                /* Handle case where parent object is broken */
+                parent.insertAdjacentElement("afterend", ruffle_obj);
             }
         }
     } catch (err) {

--- a/web/packages/core/src/ruffle-embed.js
+++ b/web/packages/core/src/ruffle-embed.js
@@ -44,6 +44,12 @@ module.exports = class RuffleEmbed extends RufflePlayer {
         if (!elem.src) {
             return false;
         }
+        if (elem.parentElement && elem.parentElement.tagName == "object") {
+            /* Only polyfill top-level objects */
+            elem.src = "";
+            /* Set src to empty */
+            return false;
+        }
         if (
             elem.type.toLowerCase() === FLASH_MIMETYPE.toLowerCase() ||
             elem.type.toLowerCase() === FUTURESPLASH_MIMETYPE.toLowerCase() ||

--- a/web/packages/core/src/ruffle-embed.js
+++ b/web/packages/core/src/ruffle-embed.js
@@ -44,10 +44,19 @@ module.exports = class RuffleEmbed extends RufflePlayer {
         if (!elem.src) {
             return false;
         }
-        if (elem.parentElement && elem.parentElement.tagName == "object") {
-            /* Only polyfill top-level objects */
-            elem.src = "";
-            /* Set src to empty */
+        if (
+            elem.parentElement &&
+            elem.parentElement.tagName.toLowerCase() == "object"
+        ) {
+        /* Only polyfill top-level objects */
+            if (elem.hasAttribute("src")) {
+                elem.removeAttribute("src");
+            }
+            elem.height = 0;
+            elem.width = 0;
+            /* Turn element into dummy */
+            /* setting it to 0 width & height prevents it from *
+             * messing up display Netscape 4 style             */
             return false;
         }
         if (
@@ -68,6 +77,14 @@ module.exports = class RuffleEmbed extends RufflePlayer {
         let external_name = register_element("ruffle-embed", RuffleEmbed);
         let ruffle_obj = document.createElement(external_name);
         ruffle_obj.copy_element(elem);
+        ruffle_obj.original = elem;
+        /* Set original for detecting if original is (re)moved */
+        if (elem.hasAttribute("src")) {
+            elem.removeAttribute("src");
+        }
+        elem.width = 0;
+        elem.height = 0;
+        /* Turn the original embed into a dummy element */
 
         return ruffle_obj;
     }

--- a/web/packages/core/src/ruffle-embed.js
+++ b/web/packages/core/src/ruffle-embed.js
@@ -10,9 +10,11 @@ const { register_element } = require("./register-element");
 
 module.exports = class RuffleEmbed extends RufflePlayer {
     constructor(...args) {
-        const observer = new MutationObserver(function (mutationsList, observer) {
+        const observer = new MutationObserver(function () {
             /* handle if original object is (re)moved */
-            RufflePlayer.handle_player_changes(document.getElementsByTagName("ruffle-embed"));
+            RufflePlayer.handle_player_changes(
+                document.getElementsByTagName("ruffle-embed")
+            );
         });
         observer.observe(document, { childList: true, subtree: true });
         let self = super(...args);
@@ -57,7 +59,7 @@ module.exports = class RuffleEmbed extends RufflePlayer {
             elem.parentElement.tagName.toLowerCase() == "object" &&
             !elem.parentElement.hasAttribute("data-broken")
         ) {
-        /* Only polyfill top-level objects */
+            /* Only polyfill top-level objects */
             if (elem.hasAttribute("src")) {
                 elem.removeAttribute("src");
             }
@@ -84,7 +86,9 @@ module.exports = class RuffleEmbed extends RufflePlayer {
     static from_native_embed_element(elem) {
         let external_name = register_element("ruffle-embed", RuffleEmbed);
         let ruffle_obj = document.createElement(external_name);
-        const observer = new MutationObserver(RufflePlayer.handleOriginalAttributeChanges);
+        const observer = new MutationObserver(
+            RufflePlayer.handleOriginalAttributeChanges
+        );
         ruffle_obj.copy_element(elem);
         ruffle_obj.original = elem;
         /* Set original for detecting if original is (re)moved */

--- a/web/packages/core/src/ruffle-embed.js
+++ b/web/packages/core/src/ruffle-embed.js
@@ -46,18 +46,22 @@ module.exports = class RuffleEmbed extends RufflePlayer {
     }
 
     static is_interdictable(elem) {
+        if (elem.hasAttribute("data-polyfilled")) {
+            return false;
+        }
         if (!elem.src) {
             return false;
         }
         if (
             elem.parentElement &&
-            elem.parentElement.tagName.toLowerCase() == "object"
+            elem.parentElement.tagName.toLowerCase() == "object" &&
+            !elem.parentElement.hasAttribute("data-broken")
         ) {
         /* Only polyfill top-level objects */
             if (elem.hasAttribute("src")) {
                 elem.removeAttribute("src");
             }
-            elem.style.display = "none";
+            elem.style.setProperty("display", "none", "important");
             /* Turn element into dummy */
             /* setting it to 0 width & height prevents it from *
              * messing up display Netscape 4 style             */
@@ -80,14 +84,23 @@ module.exports = class RuffleEmbed extends RufflePlayer {
     static from_native_embed_element(elem) {
         let external_name = register_element("ruffle-embed", RuffleEmbed);
         let ruffle_obj = document.createElement(external_name);
+        const observer = new MutationObserver(RufflePlayer.handleOriginalAttributeChanges);
         ruffle_obj.copy_element(elem);
         ruffle_obj.original = elem;
         /* Set original for detecting if original is (re)moved */
         if (elem.hasAttribute("src")) {
             elem.removeAttribute("src");
         }
-        elem.style.display = "none";
+        if (elem.hasAttribute("id")) {
+            elem.removeAttribute("id");
+        }
+        if (elem.hasAttribute("name")) {
+            elem.removeAttribute("name");
+        }
+        elem.setAttribute("data-polyfilled", "polyfilled");
+        elem.style.setProperty("display", "none", "important");
         /* Turn the original embed into a dummy element */
+        observer.observe(elem, { attributes: true });
 
         return ruffle_obj;
     }

--- a/web/packages/core/src/ruffle-embed.js
+++ b/web/packages/core/src/ruffle-embed.js
@@ -10,6 +10,11 @@ const { register_element } = require("./register-element");
 
 module.exports = class RuffleEmbed extends RufflePlayer {
     constructor(...args) {
+        const observer = new MutationObserver(function (mutationsList, observer) {
+            /* handle if original object is (re)moved */
+            RufflePlayer.handle_player_changes(document.getElementsByTagName("ruffle-embed"));
+        });
+        observer.observe(document, { childList: true, subtree: true });
         let self = super(...args);
 
         return self;
@@ -52,8 +57,7 @@ module.exports = class RuffleEmbed extends RufflePlayer {
             if (elem.hasAttribute("src")) {
                 elem.removeAttribute("src");
             }
-            elem.height = 0;
-            elem.width = 0;
+            elem.style.display = "none";
             /* Turn element into dummy */
             /* setting it to 0 width & height prevents it from *
              * messing up display Netscape 4 style             */
@@ -82,8 +86,7 @@ module.exports = class RuffleEmbed extends RufflePlayer {
         if (elem.hasAttribute("src")) {
             elem.removeAttribute("src");
         }
-        elem.width = 0;
-        elem.height = 0;
+        elem.style.display = "none";
         /* Turn the original embed into a dummy element */
 
         return ruffle_obj;

--- a/web/packages/core/src/ruffle-object.js
+++ b/web/packages/core/src/ruffle-object.js
@@ -48,6 +48,19 @@ module.exports = class RuffleObject extends RufflePlayer {
                 return false;
             }
         }
+        if (elem.parentElement && elem.parentElement.tagName == "object") {
+            /* Only polyfill top-level objects */
+            let params = elem.getElementsByTagName("param");
+            for (let i = 0; i < params.length; i++) {
+                if (params[i].name == "movie") {
+                    params[i].parentElement.removeChild(params[i]);
+                }
+                /* Remove movie param */
+            }
+            elem.data = "";
+            /* Set data to empty */
+            return false;
+        }
         if (
             elem.type.toLowerCase() === FLASH_MIMETYPE.toLowerCase() ||
             elem.type.toLowerCase() === FUTURESPLASH_MIMETYPE.toLowerCase() ||

--- a/web/packages/core/src/ruffle-object.js
+++ b/web/packages/core/src/ruffle-object.js
@@ -11,9 +11,11 @@ const { register_element } = require("./register-element");
 
 module.exports = class RuffleObject extends RufflePlayer {
     constructor(...args) {
-        const observer = new MutationObserver(function (mutationsList, observer) {
+        const observer = new MutationObserver(function () {
             /* handle if original object is (re)moved */
-            RufflePlayer.handle_player_changes(document.getElementsByTagName("ruffle-object"));
+            RufflePlayer.handle_player_changes(
+                document.getElementsByTagName("ruffle-object")
+            );
         });
         observer.observe(document, { childList: true, subtree: true });
         super(...args);
@@ -46,7 +48,7 @@ module.exports = class RuffleObject extends RufflePlayer {
 
     static is_interdictable(elem) {
         if (elem.hasAttribute("data-polyfilled")) {
-        /* Don't polyfill an element twice */
+            /* Don't polyfill an element twice */
             return false;
         }
         if (
@@ -54,19 +56,22 @@ module.exports = class RuffleObject extends RufflePlayer {
             elem.parentElement.tagName.toLowerCase() == "object" &&
             !elem.parentElement.hasAttribute("data-broken")
         ) {
-        /* Only polyfill top-level objects */
+            /* Only polyfill top-level objects */
             let children = elem.getElementsByTagName("*");
-            for (let i = 0;i < children.length;i ++) {
+            for (let i = 0; i < children.length; i++) {
                 if (
                     children[i].tagName.toLowerCase() == "param" &&
                     children[i].name == "movie"
                 ) {
+                    /* Remove movie param */
                     children[i].parentElement.removeChild(children[i]);
-                }
-                /* Remove movie param */
-                else if (children[i].tagName.toLowerCase() != "param") {
+                } else if (children[i].tagName.toLowerCase() != "param") {
                     /* Hide fallback content */
-                    children[i].style.setProperty("display", "none", "important");
+                    children[i].style.setProperty(
+                        "display",
+                        "none",
+                        "important"
+                    );
                 }
             }
             if (elem.hasAttribute("data")) {
@@ -117,8 +122,7 @@ module.exports = class RuffleObject extends RufflePlayer {
                 return true;
             }
         }
-        /* Note: flash fallbacks inside of non-flash objects don't work
-*/
+        /* Note: flash fallbacks inside of non-flash objects don't work */
         return false;
     }
 
@@ -138,11 +142,13 @@ module.exports = class RuffleObject extends RufflePlayer {
         let external_name = register_element("ruffle-object", RuffleObject);
         let ruffle_obj = document.createElement(external_name);
         let params = elem.getElementsByTagName("param");
-        const observer = new MutationObserver(RufflePlayer.handleOriginalAttributeChanges);
+        const observer = new MutationObserver(
+            RufflePlayer.handleOriginalAttributeChanges
+        );
         ruffle_obj.copy_element(elem);
         ruffle_obj.original = elem;
         /* Set original for detecting if original is (re)moved */
-        for (let i = 0;i < params.length;i ++) {
+        for (let i = 0; i < params.length; i++) {
             if (params[i].name == "movie") {
                 params[i].parentElement.removeChild(params[i]);
             }

--- a/web/packages/core/src/ruffle-object.js
+++ b/web/packages/core/src/ruffle-object.js
@@ -48,8 +48,11 @@ module.exports = class RuffleObject extends RufflePlayer {
                 return false;
             }
         }
-        if (elem.parentElement && elem.parentElement.tagName == "object") {
-            /* Only polyfill top-level objects */
+        if (
+            elem.parentElement && 
+            elem.parentElement.tagName.toLowerCase() == "object"
+        ) {
+        /* Only polyfill top-level objects */
             let params = elem.getElementsByTagName("param");
             for (let i = 0; i < params.length; i++) {
                 if (params[i].name == "movie") {
@@ -57,8 +60,11 @@ module.exports = class RuffleObject extends RufflePlayer {
                 }
                 /* Remove movie param */
             }
-            elem.data = "";
-            /* Set data to empty */
+            if (elem.hasAttribute("data")) {
+                elem.removeAttribute("data");
+            }
+            elem.width = 0;
+            elem.height = 0;
             return false;
         }
         if (
@@ -109,7 +115,22 @@ module.exports = class RuffleObject extends RufflePlayer {
     static from_native_object_element(elem) {
         let external_name = register_element("ruffle-object", RuffleObject);
         let ruffle_obj = document.createElement(external_name);
+        let params = elem.getElementsByTagName("param");
         ruffle_obj.copy_element(elem);
+        ruffle_obj.original = elem;
+        /* Set original for detecting if original is (re)moved */
+        for (let i = 0;i < params.length;i ++) {
+            if (params[i].name == "movie") {
+                params[i].parentElement.removeChild(params[i]);
+            }
+            /* Remove movie param */
+        }
+        if (elem.hasAttribute("data")) {
+            elem.removeAttribute("data");
+        }
+        elem.height = 0;
+        elem.width = 0;
+        /* Turn original object into dummy element */
 
         return ruffle_obj;
     }

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -29,6 +29,8 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
 
         self.instance = null;
 
+        self.original = null;
+
         self.Ruffle = load_ruffle();
 
         return self;
@@ -215,7 +217,12 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
             }
 
             for (let node of Array.from(elem.children)) {
-                this.appendChild(node);
+                if (node.tagName.toLowerCase() != "object" && node.tagName.toLowerCase() != "embed" && node.parentElement.parentElement.tagName.toLowerCase() != "object") {
+                    this.appendChild(node);
+                }
+                else {
+                    console.log(node.tagName.toLowerCase() + " skipped");
+                }
             }
         }
     }

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -217,10 +217,14 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
             }
 
             for (let node of Array.from(elem.children)) {
-                if (node.tagName.toLowerCase() != "object" && node.tagName.toLowerCase() != "embed" && node.parentElement.parentElement.tagName.toLowerCase() != "object") {
+                if (
+                    node.tagName.toLowerCase() != "object" &&
+                    node.tagName.toLowerCase() != "embed" &&
+                    node.parentElement.parentElement.tagName.toLowerCase() !=
+                        "object"
+                ) {
                     this.appendChild(node);
-                }
-                else {
+                } else {
                     console.log(node.tagName.toLowerCase() + " skipped");
                 }
             }
@@ -249,16 +253,18 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
     }
 
     static handle_player_changes(players) {
-        for (let i = 0;i < players.length;i ++) {
+        for (let i = 0; i < players.length; i++) {
             if (players[i].parentElement.contains(players[i].original)) {
-            /* Original is still there */
+                /* Original is still there */
                 continue;
             }
             /*else*/ if (document.body.contains(players[i].original)) {
                 console.log("Player moved");
-                players[i].original.insertAdjacentElement("beforebegin", players[i]);
-            }
-            else {
+                players[i].original.insertAdjacentElement(
+                    "afterend",
+                    players[i]
+                );
+            } else {
                 console.log("Player removed");
                 players[i].parentElement.removeChild(players[i]);
             }
@@ -268,7 +274,11 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
     static handleOriginalAttributeChanges(mutationsList) {
         for (let i = 0; i < mutationsList.length; i++) {
             if (mutationsList[i].target.style.display != "none") {
-                mutationsList[i].target.style.setProperty("display", "none", "important");
+                mutationsList[i].target.style.setProperty(
+                    "display",
+                    "none",
+                    "important"
+                );
             }
         }
     }

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -29,7 +29,7 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
 
         self.instance = null;
 
-        self.original = null;
+        self.original = self;
 
         self.Ruffle = load_ruffle();
 
@@ -246,6 +246,23 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
             }
         }
         return null;
+    }
+
+    static handle_player_changes(players) {
+        for (let i = 0;i < players.length;i ++) {
+            if (players[i].parentElement.contains(players[i].original)) {
+            /* Original is still there */
+                continue;
+            }
+            /*else*/ if (document.body.contains(players[i].original)) {
+                console.log("Player moved");
+                players[i].original.insertAdjacentElement("beforebegin", players[i]);
+            }
+            else {
+                console.log("Player removed");
+                players[i].parentElement.removeChild(players[i]);
+            }
+        }
     }
 };
 

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -262,6 +262,14 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
                 console.log("Player removed");
                 players[i].parentElement.removeChild(players[i]);
             }
+            /* Todo: use players[i].original.style somehow(#502) */
+        }
+    }
+    static handleOriginalAttributeChanges(mutationsList) {
+        for (let i = 0; i < mutationsList.length; i++) {
+            if (mutationsList[i].target.style.display != "none") {
+                mutationsList[i].target.style.setProperty("display", "none", "important");
+            }
         }
     }
 };

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -51,6 +51,9 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
     }
 
     disconnectedCallback() {
+        if (this.original != this) {
+            this.original.parentElement.removeChild(this.original);
+        }
         if (this.instance) {
             this.instance.destroy();
             this.instance = null;

--- a/web/packages/selfhosted/test/polyfill/classic_frames_injected/expected.html
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_injected/expected.html
@@ -1,9 +1,4 @@
-<ruffle-object
-    type="application/x-shockwave-flash"
-    data="/test_assets/example.swf"
-    width="550"
-    height="400"
->
-    <param name="movie" value="/test_assets/example.swf" />
-    <param name="quality" value="high" />
-</ruffle-object>
+<object type="application/x-shockwave-flash" width="550" height="400" data-polyfilled="polyfilled" style="display: none !important;">
+                
+                
+            </object><ruffle-object type="application/x-shockwave-flash" data="/test_assets/example.swf" width="550" height="400"><param name="movie" value="/test_assets/example.swf"><param name="quality" value="high"></ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/classic_frames_provided/expected.html
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_provided/expected.html
@@ -1,9 +1,4 @@
-<ruffle-object
-    type="application/x-shockwave-flash"
-    data="/test_assets/example.swf"
-    width="550"
-    height="400"
->
-    <param name="movie" value="/test_assets/example.swf" />
-    <param name="quality" value="high" />
-</ruffle-object>
+<object type="application/x-shockwave-flash" width="550" height="400" data-polyfilled="polyfilled" style="display: none !important;">
+                
+                
+            </object><ruffle-object type="application/x-shockwave-flash" data="/test_assets/example.swf" width="550" height="400"><param name="movie" value="/test_assets/example.swf"><param name="quality" value="high"></ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/iframes_injected/expected.html
+++ b/web/packages/selfhosted/test/polyfill/iframes_injected/expected.html
@@ -1,9 +1,4 @@
-<ruffle-object
-    type="application/x-shockwave-flash"
-    data="/test_assets/example.swf"
-    width="550"
-    height="400"
->
-    <param name="movie" value="/test_assets/example.swf" />
-    <param name="quality" value="high" />
-</ruffle-object>
+<object type="application/x-shockwave-flash" width="550" height="400" data-polyfilled="polyfilled" style="display: none !important;">
+                
+                
+            </object><ruffle-object type="application/x-shockwave-flash" data="/test_assets/example.swf" width="550" height="400"><param name="movie" value="/test_assets/example.swf"><param name="quality" value="high"></ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/iframes_provided/expected.html
+++ b/web/packages/selfhosted/test/polyfill/iframes_provided/expected.html
@@ -1,9 +1,4 @@
-<ruffle-object
-    type="application/x-shockwave-flash"
-    data="/test_assets/example.swf"
-    width="550"
-    height="400"
->
-    <param name="movie" value="/test_assets/example.swf" />
-    <param name="quality" value="high" />
-</ruffle-object>
+<object type="application/x-shockwave-flash" width="550" height="400" data-polyfilled="polyfilled" style="display: none !important;">
+                
+                
+            </object><ruffle-object type="application/x-shockwave-flash" data="/test_assets/example.swf" width="550" height="400"><param name="movie" value="/test_assets/example.swf"><param name="quality" value="high"></ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/object_and_embed/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_and_embed/expected.html
@@ -1,18 +1,6 @@
-<ruffle-object
-    classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
-    width="550"
-    height="400"
-    codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"
->
-    <param name="movie" value="/test_assets/example.swf" />
-    <param name="quality" value="high" />
-    <param name="menu" value="false" />
-    <ruffle-embed
-        src="/test_assets/example.swf"
-        width="550"
-        height="400"
-        quality="high"
-        menu="false"
-        pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
-    />
-</ruffle-object>
+<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="550" height="400" codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0" data-polyfilled="polyfilled" style="display: none !important;">
+                
+                
+                
+                <embed width="550" height="400" quality="high" menu="false" pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash" style="display: none !important;">
+            </object><ruffle-object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="550" height="400" codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"><param name="movie" value="/test_assets/example.swf"><param name="quality" value="high"><param name="menu" value="false"></ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/pdf/test.js
+++ b/web/packages/selfhosted/test/polyfill/pdf/test.js
@@ -11,7 +11,7 @@ describe("PDF object", () => {
     });
 
     // TODO: This is broken today.
-    it.skip("doesn't polyfill with ruffle", () => {
+    it("doesn't polyfill with ruffle", () => {
         inject_ruffle_and_wait(browser);
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");

--- a/web/packages/selfhosted/test/polyfill/remove_object/expected.html
+++ b/web/packages/selfhosted/test/polyfill/remove_object/expected.html
@@ -1,9 +1,5 @@
-<ruffle-object
-    width="550"
-    height="400"
-    codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"
-    id="foo"
-    ><param name="movie" value="/test_assets/example.swf" /><param
-        name="quality"
-        value="high" /><param name="menu" value="false"
-/></ruffle-object>
+<object width="550" height="400" codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0" data-polyfilled="polyfilled" style="display: none !important;">
+                
+                
+                
+            </object><ruffle-object width="550" height="400" codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0" id="foo"><param name="movie" value="/test_assets/example.swf"><param name="quality" value="high"><param name="menu" value="false"></ruffle-object>


### PR DESCRIPTION
This completely fixes #542 and allows polyfilling the flash interface for the object/embeds using `RufflePlayer.original`. This handles both the object/embed being removed & it being moved to a different place in the DOM.