### PR TITLE
core: Fix undefined wrapping behavior triggered by Rust nightly (fix #579)

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -623,10 +623,8 @@ pub fn f64_to_string(n: f64) -> String {
 pub fn f64_to_wrapping_u16(n: f64) -> u16 {
     if !n.is_finite() {
         0
-    } else if n >= 0.0 {
-        (n % 65536.0) as u16
     } else {
-        ((n.trunc() % 65536.0) + 65536.0) as u16
+        n.trunc().rem_euclid(65536.0) as u16
     }
 }
 
@@ -642,10 +640,8 @@ pub fn f64_to_wrapping_i16(n: f64) -> i16 {
 pub fn f64_to_wrapping_u32(n: f64) -> u32 {
     if !n.is_finite() {
         0
-    } else if n >= 0.0 {
-        (n % 4294967296.0) as u32
     } else {
-        ((n.trunc() % 4294967296.0) + 4294967296.0) as u32
+        n.trunc().rem_euclid(4294967296.0) as u32
     }
 }
 

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -303,7 +303,7 @@ impl<W: Write> Writer<W> {
     }
 
     fn write_fbits(&mut self, num_bits: u8, n: f32) -> Result<()> {
-        self.write_ubits(num_bits, (n * 65536f32) as u32)
+        self.write_sbits(num_bits, (n * 65536f32) as i32)
     }
 
     fn write_encoded_u32(&mut self, mut n: u32) -> Result<()> {


### PR DESCRIPTION
Casting floats-to-int could be treacherous in Rust, and it is currently undefined behavior on stable if the value wasn't representable in the target type. A PR just landed in nightly that defines these to saturate. This broke a few things in our code that were incorrectly relying on this undefined behavior.

Fix these methods to avoid undefined behavior and properly handle the edge cases. Fixes #579.

See:
https://doc.rust-lang.org/1.22.1/book/first-edition/casting-between-types.html#numeric-casts (old behavior)
https://github.com/rust-lang/rust/pull/71269
https://github.com/rust-lang/rust/issues/10184