### PR TITLE
web: Fallback to canvas render backend in more cases (fix #545)

### DIFF
--- a/web/js-src/ruffle-player.js
+++ b/web/js-src/ruffle-player.js
@@ -18,7 +18,7 @@ export class RufflePlayer extends HTMLElement {
         self.shadow.appendChild(ruffle_shadow_template.content.cloneNode(true));
 
         self.dynamic_styles = self.shadow.getElementById("dynamic_styles");
-        self.canvas = self.shadow.getElementById("player");
+        self.container = self.shadow.getElementById("container");
         self.play_button = self.shadow.getElementById("play_button");
         if (self.play_button) {
             self.play_button.addEventListener("click", self.play_button_clicked.bind(self));
@@ -146,7 +146,7 @@ export class RufflePlayer extends HTMLElement {
                 throw e;
             });
 
-            this.instance = Ruffle.new(this.canvas, new Uint8Array(data));
+            this.instance = Ruffle.new(this.container, new Uint8Array(data));
             console.log("New Ruffle instance created.");
 
             if (this.play_button) {

--- a/web/js-src/shadow-template.js
+++ b/web/js-src/shadow-template.js
@@ -15,7 +15,7 @@ ruffle_shadow_tmpl.innerHTML = `
             overflow: hidden;
         }
 
-        #player {
+        #container canvas {
             width: 100%;
             height: 100%;
         }
@@ -47,7 +47,6 @@ ruffle_shadow_tmpl.innerHTML = `
 
     <div id="container">
         <div id="play_button"><div class="icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" viewBox="0 0 250 250" style="width:100%;height:100%;"><defs><linearGradient id="a" gradientUnits="userSpaceOnUse" x1="125" y1="0" x2="125" y2="250" spreadMethod="pad"><stop offset="0%" stop-color="#FDA138"/><stop offset="100%" stop-color="#FD3A40"/></linearGradient><g id="b"><path fill="url(#a)" d="M250 125q0-52-37-88-36-37-88-37T37 37Q0 73 0 125t37 88q36 37 88 37t88-37q37-36 37-88M87 195V55l100 70-100 70z"/><path fill="#FFF" d="M87 55v140l100-70L87 55z"/></g></defs><use xlink:href="#b"/></svg></div></div>
-        <canvas id="player"></canvas>
     </div>
 `;
 


### PR DESCRIPTION
If the WebGL renderer creation failed further along (after the `getContext` call), then Ruffle would not successfully fallback to the Canvas backend because only a single context may be created on a canvas, with no direct way to destroy a previous context.

This moves the HTML canvas from the HTML template to be created by the Rust code. Each backend will recreate the canvas when it tries to instantiate.
