### PR TITLE
wgpu: Hook up gradient spread mode and focal point

### DIFF
--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -20,8 +20,8 @@ use crate::pipelines::Pipelines;
 use crate::shapes::{Draw, DrawType, GradientUniforms, IncompleteDrawType, Mesh};
 use crate::target::{RenderTarget, RenderTargetFrame, SwapChainTarget};
 use crate::utils::{
-    build_view_matrix, create_buffer_with_data, ruffle_path_to_lyon_path, swf_bitmap_to_gl_matrix,
-    swf_to_gl_matrix,
+    build_view_matrix, create_buffer_with_data, gradient_spread_mode_index,
+    ruffle_path_to_lyon_path, swf_bitmap_to_gl_matrix, swf_to_gl_matrix,
 };
 use ruffle_core::color_transform::ColorTransform;
 use std::mem::replace;
@@ -374,7 +374,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                             ratios,
                             colors,
                             num_colors: gradient.records.len() as u32,
-                            repeat_mode: 0,
+                            repeat_mode: gradient_spread_mode_index(gradient.spread),
                             focal_point: 0.0,
                         };
                         let matrix = swf_to_gl_matrix(gradient.matrix.clone());
@@ -443,7 +443,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                             ratios,
                             colors,
                             num_colors: gradient.records.len() as u32,
-                            repeat_mode: 0,
+                            repeat_mode: gradient_spread_mode_index(gradient.spread),
                             focal_point: 0.0,
                         };
                         let matrix = swf_to_gl_matrix(gradient.matrix.clone());
@@ -511,11 +511,11 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                         }
 
                         let uniforms = GradientUniforms {
-                            gradient_type: 1,
+                            gradient_type: 2,
                             ratios,
                             colors,
                             num_colors: gradient.records.len() as u32,
-                            repeat_mode: 0,
+                            repeat_mode: gradient_spread_mode_index(gradient.spread),
                             focal_point: *focal_point,
                         };
                         let matrix = swf_to_gl_matrix(gradient.matrix.clone());

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -1,7 +1,7 @@
 use lyon::lyon_algorithms::path::Path;
 use ruffle_core::shape_utils::DrawCommand;
 use ruffle_core::swf;
-use swf::Twips;
+use swf::{GradientSpread, Twips};
 macro_rules! create_debug_label {
     ($($arg:tt)*) => (
         if cfg!(feature = "render_debug_labels") {
@@ -125,4 +125,13 @@ pub fn build_view_matrix(viewport_width: u32, viewport_height: u32) -> [[f32; 4]
         [0.0, 0.0, 1.0, 0.0],
         [-1.0, 1.0, 0.0, 1.0],
     ]
+}
+
+/// Map for SWF gradient spread mode to the uniform value used by the gradient shader.
+pub fn gradient_spread_mode_index(spread: GradientSpread) -> i32 {
+    match spread {
+        GradientSpread::Pad => 0,
+        GradientSpread::Repeat => 1,
+        GradientSpread::Reflect => 2,
+    }
 }


### PR DESCRIPTION
Gradient spread modes and focal point were implemented in the shader, but the uniforms were not hooked up. Now these should function as expected.