### PR TITLE
Make RenderBack::register_bitmap* methods return a Result

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -13,15 +13,22 @@ pub trait RenderBackend: Downcast {
         id: swf::CharacterId,
         data: &[u8],
         jpeg_tables: Option<&[u8]>,
-    ) -> BitmapInfo;
-    fn register_bitmap_jpeg_2(&mut self, id: swf::CharacterId, data: &[u8]) -> BitmapInfo;
+    ) -> Result<BitmapInfo, Error>;
+    fn register_bitmap_jpeg_2(
+        &mut self,
+        id: swf::CharacterId,
+        data: &[u8],
+    ) -> Result<BitmapInfo, Error>;
     fn register_bitmap_jpeg_3(
         &mut self,
         id: swf::CharacterId,
         jpeg_data: &[u8],
         alpha_data: &[u8],
-    ) -> BitmapInfo;
-    fn register_bitmap_png(&mut self, swf_tag: &swf::DefineBitsLossless) -> BitmapInfo;
+    ) -> Result<BitmapInfo, Error>;
+    fn register_bitmap_png(
+        &mut self,
+        swf_tag: &swf::DefineBitsLossless,
+    ) -> Result<BitmapInfo, Error>;
 
     fn begin_frame(&mut self, clear: Color);
     fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform);
@@ -84,38 +91,45 @@ impl RenderBackend for NullRenderer {
         _id: swf::CharacterId,
         _data: &[u8],
         _jpeg_tables: Option<&[u8]>,
-    ) -> BitmapInfo {
-        BitmapInfo {
+    ) -> Result<BitmapInfo, Error> {
+        Ok(BitmapInfo {
             handle: BitmapHandle(0),
             width: 0,
             height: 0,
-        }
+        })
     }
-    fn register_bitmap_jpeg_2(&mut self, _id: swf::CharacterId, _data: &[u8]) -> BitmapInfo {
-        BitmapInfo {
+    fn register_bitmap_jpeg_2(
+        &mut self,
+        _id: swf::CharacterId,
+        _data: &[u8],
+    ) -> Result<BitmapInfo, Error> {
+        Ok(BitmapInfo {
             handle: BitmapHandle(0),
             width: 0,
             height: 0,
-        }
+        })
     }
     fn register_bitmap_jpeg_3(
         &mut self,
         _id: swf::CharacterId,
         _data: &[u8],
         _alpha_data: &[u8],
-    ) -> BitmapInfo {
-        BitmapInfo {
+    ) -> Result<BitmapInfo, Error> {
+        Ok(BitmapInfo {
             handle: BitmapHandle(0),
             width: 0,
             height: 0,
-        }
+        })
     }
-    fn register_bitmap_png(&mut self, _swf_tag: &swf::DefineBitsLossless) -> BitmapInfo {
-        BitmapInfo {
+    fn register_bitmap_png(
+        &mut self,
+        _swf_tag: &swf::DefineBitsLossless,
+    ) -> Result<BitmapInfo, Error> {
+        Ok(BitmapInfo {
             handle: BitmapHandle(0),
             width: 0,
             height: 0,
-        }
+        })
     }
     fn begin_frame(&mut self, _clear: Color) {}
     fn end_frame(&mut self) {}

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1367,7 +1367,9 @@ impl<'gc, 'a> MovieClipData<'gc> {
         version: u8,
     ) -> DecodeResult {
         let define_bits_lossless = reader.read_define_bits_lossless(version)?;
-        let bitmap_info = context.renderer.register_bitmap_png(&define_bits_lossless);
+        let bitmap_info = context
+            .renderer
+            .register_bitmap_png(&define_bits_lossless)?;
         let bitmap = crate::display_object::Bitmap::new(
             context,
             define_bits_lossless.id,
@@ -1523,7 +1525,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
                 .library
                 .library_for_movie_mut(self.movie())
                 .jpeg_tables(),
-        );
+        )?;
         let bitmap = crate::display_object::Bitmap::new(
             context,
             id,
@@ -1553,7 +1555,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .get_mut()
             .take(data_len as u64)
             .read_to_end(&mut jpeg_data)?;
-        let bitmap_info = context.renderer.register_bitmap_jpeg_2(id, &jpeg_data);
+        let bitmap_info = context.renderer.register_bitmap_jpeg_2(id, &jpeg_data)?;
         let bitmap = crate::display_object::Bitmap::new(
             context,
             id,
@@ -1591,7 +1593,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .read_to_end(&mut alpha_data)?;
         let bitmap_info = context
             .renderer
-            .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data);
+            .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data)?;
         let bitmap = Bitmap::new(
             context,
             id,
@@ -1630,7 +1632,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .read_to_end(&mut alpha_data)?;
         let bitmap_info = context
             .renderer
-            .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data);
+            .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data)?;
         let bitmap = Bitmap::new(
             context,
             id,

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -749,16 +749,18 @@ impl RenderBackend for WebGlRenderBackend {
         id: swf::CharacterId,
         data: &[u8],
         jpeg_tables: Option<&[u8]>,
-    ) -> BitmapInfo {
+    ) -> Result<BitmapInfo, Error> {
         let data = ruffle_core::backend::render::glue_tables_to_jpeg(data, jpeg_tables);
         self.register_bitmap_jpeg_2(id, &data[..])
     }
 
-    fn register_bitmap_jpeg_2(&mut self, id: swf::CharacterId, data: &[u8]) -> BitmapInfo {
-        let bitmap = ruffle_core::backend::render::decode_define_bits_jpeg(data, None)
-            .expect("Invalid DefineBitsJpeg2 data");
+    fn register_bitmap_jpeg_2(
+        &mut self,
+        id: swf::CharacterId,
+        data: &[u8],
+    ) -> Result<BitmapInfo, Error> {
+        let bitmap = ruffle_core::backend::render::decode_define_bits_jpeg(data, None)?;
         self.register_bitmap(id, bitmap)
-            .expect("Unable to register bitmap")
     }
 
     fn register_bitmap_jpeg_3(
@@ -766,19 +768,18 @@ impl RenderBackend for WebGlRenderBackend {
         id: swf::CharacterId,
         jpeg_data: &[u8],
         alpha_data: &[u8],
-    ) -> BitmapInfo {
+    ) -> Result<BitmapInfo, Error> {
         let bitmap =
-            ruffle_core::backend::render::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))
-                .expect("Invalid DefineBitsJpeg3 data");
+            ruffle_core::backend::render::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))?;
         self.register_bitmap(id, bitmap)
-            .expect("Unable to register bitmap")
     }
 
-    fn register_bitmap_png(&mut self, swf_tag: &swf::DefineBitsLossless) -> BitmapInfo {
-        let bitmap = ruffle_core::backend::render::decode_define_bits_lossless(swf_tag)
-            .expect("Error decoding DefineBitsLossless");
+    fn register_bitmap_png(
+        &mut self,
+        swf_tag: &swf::DefineBitsLossless,
+    ) -> Result<BitmapInfo, Error> {
+        let bitmap = ruffle_core::backend::render::decode_define_bits_lossless(swf_tag)?;
         self.register_bitmap(swf_tag.id, bitmap)
-            .expect("Unable to register bitmap")
     }
 
     fn begin_frame(&mut self, clear: Color) {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -959,16 +959,14 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         id: u16,
         data: &[u8],
         jpeg_tables: Option<&[u8]>,
-    ) -> BitmapInfo {
+    ) -> Result<BitmapInfo, Error> {
         let data = ruffle_core::backend::render::glue_tables_to_jpeg(data, jpeg_tables);
         self.register_bitmap_jpeg_2(id, &data[..])
     }
 
-    fn register_bitmap_jpeg_2(&mut self, id: u16, data: &[u8]) -> BitmapInfo {
-        let bitmap = ruffle_core::backend::render::decode_define_bits_jpeg(data, None)
-            .expect("Invalid DefineBitsJpeg2 data");
+    fn register_bitmap_jpeg_2(&mut self, id: u16, data: &[u8]) -> Result<BitmapInfo, Error> {
+        let bitmap = ruffle_core::backend::render::decode_define_bits_jpeg(data, None)?;
         self.register_bitmap(id, bitmap, "JPEG2")
-            .expect("Unable to register bitmap")
     }
 
     fn register_bitmap_jpeg_3(
@@ -976,19 +974,15 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         id: u16,
         jpeg_data: &[u8],
         alpha_data: &[u8],
-    ) -> BitmapInfo {
+    ) -> Result<BitmapInfo, Error> {
         let bitmap =
-            ruffle_core::backend::render::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))
-                .expect("Invalid DefineBitsJpeg3 data");
+            ruffle_core::backend::render::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))?;
         self.register_bitmap(id, bitmap, "JPEG3")
-            .expect("Unable to register bitmap")
     }
 
-    fn register_bitmap_png(&mut self, swf_tag: &DefineBitsLossless) -> BitmapInfo {
-        let bitmap = ruffle_core::backend::render::decode_define_bits_lossless(swf_tag)
-            .expect("Invalid DefineBitsJpeg2 data");
+    fn register_bitmap_png(&mut self, swf_tag: &DefineBitsLossless) -> Result<BitmapInfo, Error> {
+        let bitmap = ruffle_core::backend::render::decode_define_bits_lossless(swf_tag)?;
         self.register_bitmap(swf_tag.id, bitmap, "PNG")
-            .expect("Unable to register bitmap")
     }
 
     fn begin_frame(&mut self, clear: Color) {


### PR DESCRIPTION
I didn't do this for register_shape as I couldn't find a way that would fail today. We ignore broken segments but don't spoil the whole shape.