### PR TITLE
Exporter: Add support to skip ahead n-frames for screen capture

### DIFF
--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -8,6 +8,7 @@ use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::Player;
 use ruffle_render_wgpu::target::TextureTarget;
 use ruffle_render_wgpu::WgpuRenderBackend;
+use std::cmp;
 use std::error::Error;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
@@ -62,7 +63,8 @@ fn take_screenshot(
     )?;
 
     let mut result = Vec::new();
-    for i in 0..frames {
+
+    for i in 0..cmp::max(frames,skipframes) {
         if let Some(progress) = &progress {
             progress.set_message(&format!(
                 "{} frame {}",
@@ -72,10 +74,7 @@ fn take_screenshot(
         }
 
         player.lock().unwrap().run_frame();
-        
-
-      
-        if i > skipframes-frames{
+        if skipframes == 0 || i >= cmp::max(skipframes-frames , 0) {
             player.lock().unwrap().render();
             let mut player = player.lock().unwrap();
             let renderer = player
@@ -89,6 +88,7 @@ fn take_screenshot(
                 return Err(format!("Unable to capture frame {} of {:?}", i, swf_path).into());
             }
         }
+
         if let Some(progress) = &progress {
             progress.inc(1);
         }

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -33,6 +33,10 @@ struct Opt {
     #[structopt(short = "f", long = "frames", default_value = "1")]
     frames: u32,
 
+    /// Number of frames to skip
+    #[structopt(long = "skipframes", default_value = "0")]
+    skipframes: u32,
+
     /// Don't show a progress bar
     #[structopt(short, long)]
     silent: bool,
@@ -43,6 +47,7 @@ fn take_screenshot(
     queue: Rc<wgpu::Queue>,
     swf_path: &Path,
     frames: u32,
+    skipframes: u32,
     progress: &Option<ProgressBar>,
 ) -> Result<Vec<RgbaImage>, Box<dyn std::error::Error>> {
     let movie = SwfMovie::from_path(&swf_path)?;
@@ -67,20 +72,23 @@ fn take_screenshot(
         }
 
         player.lock().unwrap().run_frame();
-        player.lock().unwrap().render();
+        
 
-        let mut player = player.lock().unwrap();
-        let renderer = player
-            .renderer_mut()
-            .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
-            .unwrap();
-        let target = renderer.target();
-        if let Some(image) = target.capture(renderer.device()) {
-            result.push(image);
-        } else {
-            return Err(format!("Unable to capture frame {} of {:?}", i, swf_path).into());
+      
+        if i > skipframes-frames{
+            player.lock().unwrap().render();
+            let mut player = player.lock().unwrap();
+            let renderer = player
+                .renderer_mut()
+                .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
+                .unwrap();
+            let target = renderer.target();
+            if let Some(image) = target.capture(renderer.device()) {
+                result.push(image);
+            } else {
+                return Err(format!("Unable to capture frame {} of {:?}", i, swf_path).into());
+            }
         }
-
         if let Some(progress) = &progress {
             progress.inc(1);
         }
@@ -124,6 +132,7 @@ fn capture_single_swf(
     queue: Rc<wgpu::Queue>,
     swf: &Path,
     frames: u32,
+    skipframes: u32,
     output: Option<PathBuf>,
     with_progress: bool,
 ) -> Result<(), Box<dyn Error>> {
@@ -156,7 +165,7 @@ fn capture_single_swf(
         None
     };
 
-    let frames = take_screenshot(device, queue, &swf, frames, &progress)?;
+    let frames = take_screenshot(device, queue, &swf, frames, skipframes, &progress)?;
 
     if let Some(progress) = &progress {
         progress.set_message(&swf.file_stem().unwrap().to_string_lossy());
@@ -201,6 +210,7 @@ fn capture_multiple_swfs(
     queue: Rc<wgpu::Queue>,
     directory: &Path,
     frames: u32,
+    skipframes: u32,
     output: &Path,
     with_progress: bool,
 ) -> Result<(), Box<dyn Error>> {
@@ -226,6 +236,7 @@ fn capture_multiple_swfs(
             queue.clone(),
             &file.path(),
             frames,
+            skipframes,
             &progress,
         )?;
 
@@ -310,6 +321,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             Rc::new(queue),
             &opt.swf,
             opt.frames,
+            opt.skipframes,
             opt.output_path,
             !opt.silent,
         )?;
@@ -319,6 +331,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             Rc::new(queue),
             &opt.swf,
             opt.frames,
+            opt.skipframes,
             &output,
             !opt.silent,
         )?;


### PR DESCRIPTION
I added a new parameter --skipframes that accepts an integer. This will allow you to skip ahead n-number of frames in order to skip things like animation intro. 

Example usage for a single screenshot:
`cargo run --package=exporter -- ~/path/to/example.swf --skipframes 100`


Example usage for multiple screenshots. Here we grab the last 3 frames after skipping 100 frames:
`cargo run --package=exporter -- ~/path/to/example.swf  ~/path/to/screenshots/folder/output --frames 3 --skipframes 100`