### PR TITLE
web: Made VersionRange actually work, and add tests for it

### DIFF
--- a/web/packages/core/src/version-range.js
+++ b/web/packages/core/src/version-range.js
@@ -18,7 +18,7 @@ exports.VersionRange = class VersionRange {
         for (let i = 0; i < this.requirements.length; i += 1) {
             let matches = true;
 
-            for (let j = 0; i < this.requirements[i].length; j += 1) {
+            for (let j = 0; j < this.requirements[i].length; j += 1) {
                 let comparator = this.requirements[i][j][0];
                 let version = this.requirements[i][j][1];
 
@@ -28,22 +28,26 @@ exports.VersionRange = class VersionRange {
                 if (comparator === "" || comparator === "=") {
                     matches = matches && version.is_equal(fver);
                 } else if (comparator === ">") {
-                    matches = matches && version.has_precedence_over(fver);
-                } else if (comparator === ">=") {
-                    matches =
-                        matches &&
-                        (version.has_precedence_over(fver) ||
-                            version.is_equal(fver));
-                } else if (comparator === "<") {
                     matches = matches && fver.has_precedence_over(version);
-                } else if (comparator === "<=") {
+                } else if (comparator === ">=") {
                     matches =
                         matches &&
                         (fver.has_precedence_over(version) ||
                             version.is_equal(fver));
+                } else if (comparator === "<") {
+                    matches = matches && version.has_precedence_over(fver);
+                } else if (comparator === "<=") {
+                    matches =
+                        matches &&
+                        (version.has_precedence_over(fver) ||
+                            version.is_equal(fver));
                 } else if (comparator === "^") {
                     matches = matches && version.is_compatible_with(fver);
                 }
+            }
+
+            if (matches) {
+                return true;
             }
         }
 
@@ -70,7 +74,7 @@ exports.VersionRange = class VersionRange {
                     requirements.push(requirement_set);
                     requirement_set = [];
                 }
-            } else {
+            } else if (components[i].length > 0) {
                 let match = /[0-9]/.exec(components[i]);
                 let comparator = components[i].slice(0, match.index).trim();
                 let version = Version.from_semver(
@@ -83,9 +87,8 @@ exports.VersionRange = class VersionRange {
 
         if (requirement_set.length > 0) {
             requirements.push(requirement_set);
-            requirement_set = [];
         }
 
-        return new VersionRange(requirement_set);
+        return new VersionRange(requirements);
     }
 };

--- a/web/packages/core/test/version-range.js
+++ b/web/packages/core/test/version-range.js
@@ -1,0 +1,156 @@
+const { assert } = require("chai");
+const { VersionRange } = require("../src/version-range");
+const { Version } = require("../src/version");
+
+describe("VersionRange", function () {
+    describe("#from_requirement_string()", function () {
+        it("should accept a specific version without an equals sign", function () {
+            const range = VersionRange.from_requirement_string("1.2.3");
+            assert.deepEqual(range.requirements, [
+                [["", Version.from_semver("1.2.3")]],
+            ]);
+        });
+
+        it("should accept two different versions without equals signs", function () {
+            const range = VersionRange.from_requirement_string(
+                "1.2.3 || 1.2.4"
+            );
+            assert.deepEqual(range.requirements, [
+                [["", Version.from_semver("1.2.3")]],
+                [["", Version.from_semver("1.2.4")]],
+            ]);
+        });
+
+        it("should accept a specific version with an equals sign", function () {
+            const range = VersionRange.from_requirement_string("=1.2.3");
+            assert.deepEqual(range.requirements, [
+                [["=", Version.from_semver("1.2.3")]],
+            ]);
+        });
+
+        it("should accept a specific version with an equals sign", function () {
+            const range = VersionRange.from_requirement_string(
+                "=1.2.3 || =1.2.4"
+            );
+            assert.deepEqual(range.requirements, [
+                [["=", Version.from_semver("1.2.3")]],
+                [["=", Version.from_semver("1.2.4")]],
+            ]);
+        });
+
+        it("should accept a min and max range", function () {
+            const range = VersionRange.from_requirement_string(">1.2.3 <1.2.5");
+            assert.deepEqual(range.requirements, [
+                [
+                    [">", Version.from_semver("1.2.3")],
+                    ["<", Version.from_semver("1.2.5")],
+                ],
+            ]);
+        });
+
+        it("should allow inclusive range", function () {
+            const range = VersionRange.from_requirement_string(
+                ">=1-test <=2-test"
+            );
+            assert.deepEqual(range.requirements, [
+                [
+                    [">=", Version.from_semver("1-test")],
+                    ["<=", Version.from_semver("2-test")],
+                ],
+            ]);
+        });
+
+        it("should ignore extra whitespace within a range", function () {
+            const range = VersionRange.from_requirement_string("^1.2   <1.3");
+            assert.deepEqual(range.requirements, [
+                [
+                    ["^", Version.from_semver("1.2")],
+                    ["<", Version.from_semver("1.3")],
+                ],
+            ]);
+        });
+
+        it("should ignore empty ranges", function () {
+            const range = VersionRange.from_requirement_string(
+                "|| || 1.2.4 || || 1.2.5 ||"
+            );
+            assert.deepEqual(range.requirements, [
+                [["", Version.from_semver("1.2.4")]],
+                [["", Version.from_semver("1.2.5")]],
+            ]);
+        });
+    });
+
+    describe("#satisfied_by()", function () {
+        const groups = [
+            {
+                requirements: "1.2.3",
+                tests: [
+                    { version: "1.2.3", expected: true },
+                    { version: "1.2.4", expected: false },
+                    { version: "1.2.2", expected: false },
+                    { version: "1.2.3-test", expected: true },
+                ],
+            },
+            {
+                requirements: "1.2.3 || 1.2.4",
+                tests: [
+                    { version: "1.2.3", expected: true },
+                    { version: "1.2.4", expected: true },
+                    { version: "1.2.2", expected: false },
+                    { version: "1.2.3-test", expected: true },
+                    { version: "1.2.4+build", expected: true },
+                ],
+            },
+            {
+                requirements: "^1.2",
+                tests: [
+                    { version: "1.2", expected: true },
+                    { version: "1.2.5", expected: true },
+                    { version: "1.2.6-pre", expected: false },
+                    { version: "1.3", expected: true },
+                    { version: "2.0", expected: false },
+                ],
+            },
+            {
+                requirements: ">=1.2.3 <=1.3.2",
+                tests: [
+                    { version: "1.2", expected: false },
+                    { version: "1.2.3", expected: true },
+                    { version: "1.2.5", expected: true },
+                    { version: "1.2.6+build", expected: true },
+                    { version: "1.3.2", expected: true },
+                    { version: "1.3.3", expected: false },
+                ],
+            },
+            {
+                requirements: ">1.2.3 <1.3.2",
+                tests: [
+                    { version: "1.2", expected: false },
+                    { version: "1.2.3", expected: false },
+                    { version: "1.2.5", expected: true },
+                    { version: "1.2.6+build", expected: true },
+                    { version: "1.3.2", expected: false },
+                    { version: "1.3.3", expected: false },
+                ],
+            },
+        ];
+
+        groups.forEach(function (group) {
+            const range = VersionRange.from_requirement_string(
+                group.requirements
+            );
+            describe(`with requirements '${group.requirements}'`, function () {
+                group.tests.forEach(function (test) {
+                    it(`returns ${test.expected} for '${test.version}'`, function () {
+                        const version = Version.from_semver(test.version);
+                        const result = range.satisfied_by.apply(range, [
+                            version,
+                        ]);
+                        assert.equal(result, test.expected);
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Neither of the methods worked before, which means all of our version negotiations would have always failed. Not sure how having both the extension & selfhosted works today, with that in mind.