### PR TITLE
Added Opt-Groups for Web Demo

### DIFF
--- a/web/packages/demo/www/index.html
+++ b/web/packages/demo/www/index.html
@@ -62,6 +62,7 @@
     #title:hover {
       opacity: 0.5;
       cursor: pointer;
+      transition-duration: 0.5s;
     }
 
     #title img {
@@ -109,7 +110,7 @@
       }
     }
 
-    @media only screen and (max-device-width: 600px) {
+    @media only screen and (max-width: 600px) {
       #local-file-container {
         display: none;
       }
@@ -158,6 +159,10 @@
         <span id="sample-swfs-label">Sample SWF:</span>
         <select id="sample-swfs">
           <option value="none">None</option>
+          <optgroup id="anim-optgroup" label="Animations">
+          </optgroup>
+          <optgroup id="games-optgroup" label="Games">
+          </optgroup>
         </select>
         <span id="author-container">Author: <a href="#" target="_blank" id="author"></a></span>
       </div>

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -16,6 +16,8 @@ let author = document.getElementById("author");
 let sampleFileInputContainer = document.getElementById("sample-swfs-container");
 let sampleFileInput = document.getElementById("sample-swfs");
 let localFileInput = document.getElementById("local-file");
+let animOptGroup = document.getElementById("anim-optgroup");
+let gamesOptGroup = document.getElementById("games-optgroup");
 
 window.addEventListener("DOMContentLoaded", () => {
     ruffle = window.RufflePlayer.newest();
@@ -25,19 +27,20 @@ window.addEventListener("DOMContentLoaded", () => {
     fetch("swfs.json").then((response) => {
         if (response.ok) {
             response.json().then((data) => {
-                const list = document.getElementById("sample-swfs");
                 jsonData = data;
                 jsonData.swfs.forEach((item) => {
                     let temp = document.createElement("option");
                     temp.innerHTML = item.title;
                     temp.setAttribute("value", item.location);
-                    list.appendChild(temp);
+                    if (item.type == "Animation") {
+                        animOptGroup.append(temp);
+                    } else if (item.type == "Game") {
+                        gamesOptGroup.appendChild(temp);
+                    }
                 });
-                document.getElementById("sample-swfs-container").style.display =
-                    "inline-block";
+                sampleFileInputContainer.style.display = "inline-block";
                 let rn = Math.floor(
-                    Math.random() *
-                        Math.floor(sampleFileInput.children.length - 1)
+                    Math.random() * Math.floor(jsonData.swfs.length)
                 );
                 sampleFileInput.selectedIndex = rn + 1;
                 loadRemoteFile(jsonData.swfs[rn].location);
@@ -69,16 +72,13 @@ if (window.location.search && window.location.search != "") {
 }
 
 function sampleFileSelected() {
-    let selected_value =
-        sampleFileInput.children[sampleFileInput.selectedIndex].value;
     let selected_index = sampleFileInput.selectedIndex - 1; //We subtract 1 here because the dropdown menu inlcudes a "None" option.
-    if (selected_value != "none") {
+    if (selected_index != -1) {
         author_container.style.display = "block";
         author.innerHTML = jsonData.swfs[selected_index].author;
         author.href = jsonData.swfs[selected_index].authorLink;
-
         localFileInput.value = null;
-        loadRemoteFile(selected_value);
+        loadRemoteFile(jsonData.swfs[selected_index].location);
     } else {
         replacePlayer();
     }


### PR DESCRIPTION
This commit adds HTML Opt-Groups separating Games and Animations on the web demo sample dropdown menu. There are also a few tiny styling changes. Mainly the addition of a transition duration to the logo image, as well as changing "max-device-width" to "max-width" on a media query so that the "mobile" view is shown if you scale down the window on desktop browsers.