### PR TITLE
Fix frame polyfill

### DIFF
--- a/web/packages/selfhosted/test/polyfill/classic_frames_injected/test.js
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_injected/test.js
@@ -5,8 +5,7 @@ const fs = require("fs");
 
 use(chaiHtml);
 
-// TODO: Injected is broken today
-describe.skip("Flash inside frame with injected ruffle", () => {
+describe("Flash inside frame with injected ruffle", () => {
     it("loads the test", () => {
         open_test(browser, __dirname);
     });

--- a/web/packages/selfhosted/test/polyfill/iframes_injected/test.js
+++ b/web/packages/selfhosted/test/polyfill/iframes_injected/test.js
@@ -5,8 +5,7 @@ const fs = require("fs");
 
 use(chaiHtml);
 
-// TODO: Injected is broken today
-describe.skip("Flash inside iframe with injected ruffle", () => {
+describe("Flash inside iframe with injected ruffle", () => {
     it("loads the test", () => {
         open_test(browser, __dirname);
     });


### PR DESCRIPTION
The frame polyfill wasn't working if the ruffle script was loaded after the frame & it wouldn't call the original `onload` handler if one was set.