### PR TITLE
core: Support button event handlers on MovieClips

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -781,6 +781,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
                         .iter()
                         .cloned()
                         .map(|a| ClipAction::from_action_and_movie(a, clip.movie().unwrap()))
+                        .flatten()
                         .collect(),
                 );
             }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -20,7 +20,7 @@ mod morph_shape;
 mod movie_clip;
 mod text;
 
-use crate::events::{ButtonEvent, ButtonEventResult, ClipEvent};
+use crate::events::{ClipEvent, ClipEventResult};
 pub use bitmap::Bitmap;
 pub use button::Button;
 pub use edit_text::EditText;
@@ -720,26 +720,13 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     /// Executes and propagates the given clip event.
     /// Events execute inside-out; the deepest child will react first, followed by its parent, and
     /// so forth.
-    fn propagate_button_event(
+    fn handle_clip_event(
         &self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        event: ButtonEvent,
-    ) -> ButtonEventResult {
-        for child in self.children() {
-            if child.propagate_button_event(context, event) == ButtonEventResult::Handled {
-                return ButtonEventResult::Handled;
-            }
-        }
-        ButtonEventResult::NotHandled
-    }
-
-    /// Executes and propagates the given clip event.
-    /// Events execute inside-out; the deepest child will react first, followed by its parent, and
-    /// so forth.
-    fn propagate_clip_event(&self, context: &mut UpdateContext<'_, 'gc, '_>, event: ClipEvent) {
-        for child in self.children() {
-            child.propagate_clip_event(context, event);
-        }
+        _avm: &mut Avm1<'gc>,
+        _context: &mut UpdateContext<'_, 'gc, '_>,
+        _event: ClipEvent,
+    ) -> ClipEventResult {
+        ClipEventResult::NotHandled
     }
 
     fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext<'_, 'gc, '_>) {}

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -831,6 +831,8 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
 
     fn mouse_pick(
         &self,
+        _avm: &mut Avm1<'gc>,
+        _context: &mut UpdateContext<'_, 'gc, '_>,
         _self_node: DisplayObject<'gc>,
         _pos: (Twips, Twips),
     ) -> Option<DisplayObject<'gc>> {

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -247,6 +247,7 @@ impl<'gc> ButtonData<'gc> {
                     );
                     child.set_depth(context.gc_context, record.depth.into());
                     child.post_instantiation(avm, context, child, None);
+                    child.run_frame(avm, context);
                     self.children.insert(record.depth.into(), child);
                 }
             }
@@ -394,12 +395,8 @@ impl<'gc> ButtonData<'gc> {
                     && (action.condition != swf::ButtonActionCondition::KeyPress
                         || action.key_code == key_code)
                 {
-                    // KeyPress events are consumed when a button handles them.
-                    if action.condition == swf::ButtonActionCondition::KeyPress {
-                        handled = ClipEventResult::Handled;
-                    }
-
                     // Note that AVM1 buttons run actions relative to their parent, not themselves.
+                    handled = ClipEventResult::Handled;
                     context.action_queue.queue_actions(
                         parent,
                         ActionType::Normal {

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -176,6 +176,8 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
 
     fn mouse_pick(
         &self,
+        _avm: &mut Avm1<'gc>,
+        _context: &mut UpdateContext<'_, 'gc, '_>,
         self_node: DisplayObject<'gc>,
         point: (Twips, Twips),
     ) -> Option<DisplayObject<'gc>> {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -12,27 +12,9 @@ pub enum PlayerEvent {
     TextInput { codepoint: char },
 }
 
-/// The events that an AVM1 button can fire.
-///
-/// In Flash, these are created using `on` code on the button instance:
-/// ```ignore
-/// on(release) {
-///     trace("Button clicked");
-/// }
-/// ```
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[allow(dead_code)]
-pub enum ButtonEvent {
-    Press,
-    Release,
-    RollOut,
-    RollOver,
-    KeyPress { key_code: ButtonKeyCode },
-}
-
 /// Whether this button event was handled by some child.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum ButtonEventResult {
+pub enum ClipEventResult {
     NotHandled,
     Handled,
 }
@@ -61,6 +43,57 @@ pub enum ClipEvent {
     Release,
     ReleaseOutside,
     Unload,
+}
+
+impl ClipEvent {
+    /// Method names for button event handles.
+    pub const BUTTON_EVENT_METHODS: [&'static str; 7] = [
+        "onDragOver",
+        "onDragOut",
+        "onPress",
+        "onRelease",
+        "onReleaseOutside",
+        "onRollOut",
+        "onRollOver",
+    ];
+
+    /// Indicates that the event should be propagated down to children.
+    pub fn propagates(self) -> bool {
+        matches!(
+            self,
+            Self::MouseUp | Self::MouseDown | Self::MouseMove | Self::KeyPress { .. } | Self::KeyDown | Self::KeyUp
+        )
+    }
+
+    /// Indicates whether this is an event type used by Buttons (i.e., on that can be used in an `on` handler in Flash).
+    pub fn is_button_event(self) -> bool {
+        matches!(self, Self::DragOut | Self::DragOver | Self::KeyPress { .. } | Self::Press | Self::RollOut | Self::RollOver | Self::Release | Self::ReleaseOutside)
+    }
+
+    /// Returns the method name of the event handler for this event.
+    pub fn method_name(self) -> Option<&'static str> {
+        match self {
+            ClipEvent::Construct => None,
+            ClipEvent::Data => Some("onData"),
+            ClipEvent::DragOut => Some("onDragOut"),
+            ClipEvent::DragOver => Some("onDragOver"),
+            ClipEvent::EnterFrame => Some("onEnterFrame"),
+            ClipEvent::Initialize => None,
+            ClipEvent::KeyDown => Some("onKeyDown"),
+            ClipEvent::KeyPress { .. } => None,
+            ClipEvent::KeyUp => Some("onKeyUp"),
+            ClipEvent::Load => Some("onLoad"),
+            ClipEvent::MouseDown => Some("onMouseDown"),
+            ClipEvent::MouseMove => Some("onMouseMove"),
+            ClipEvent::MouseUp => Some("onMouseUp"),
+            ClipEvent::Press => Some("onPress"),
+            ClipEvent::RollOut => Some("onRollOut"),
+            ClipEvent::RollOver => Some("onRollOver"),
+            ClipEvent::Release => Some("onRelease"),
+            ClipEvent::ReleaseOutside => Some("onReleaseOutside"),
+            ClipEvent::Unload => Some("onUnload"),
+        }
+    }
 }
 
 /// Flash virtual keycode.


### PR DESCRIPTION
Adds support button-style event handlers (such as `onPress` and `onRelease`) to movie clips. This allows many more movies and games to advance beyond the preloader (for example, https://www.newgrounds.com/portal/view/592902), because putting onRelease handlers on a movie clip is common.

MovieClips support all button functionality and turn into "button mode" when a button event is added to them, either via `on(...)` or by setting a method property like `clip.onRelease`. When in button mode, they can grab mouse focus even when obscured and also show the hand cursor when hovered (by default). 

 * `ButtonEvent` is removed and replaced with `ClipEvent` (which also contains all button events)
 * Some cleanup of the clip event firing. There is still more work to do here, but this is allows a significant amount of content to start functioning.
 * Fixed a one-frame-delay bug where buttons would flicker when changing states.