### PR TITLE
core: Fix incorrect String.charCodeAt bounds check (close #633)

### DIFF
--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -204,7 +204,7 @@ fn char_code_at<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .coerce_to_i32(avm, context)?;
-    let ret = if i > 0 {
+    let ret = if i >= 0 {
         this.encode_utf16()
             .nth(i as usize)
             .map(f64::from)


### PR DESCRIPTION
Fixes #633 
Changed ```>``` to ```>=``` so 0 is considered a valid index