### PR TITLE
READMEs and yak shaving

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,12 @@ jobs:
           name: Web Build
           command: |
             cd web
+
+            # Workaround for chrome not existing on circleCI.
+            # We aren't running tests, so we don't need to install chromedriver,
+            # and this file tells chromedriver to require existing chrome installation.
+            rm packages/selfhosted/.npmrc
+
             npm run bootstrap
             npm run buildProduction
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
           name: Web Build
           command: |
             cd web/packages/selfhosted/dist
-            cp ../../../../README.md .
-            cp ../../../../LICENSE_APACHE .
-            cp ../../../../LICENSE_MIT .
             zip -r web.zip .
             cd ../../../..
             mkdir -p workspace/web
@@ -92,9 +89,6 @@ jobs:
           name: Extension Build
           command: |
             cd web/packages/extension/build
-            cp ../../../../README.md .
-            cp ../../../../LICENSE_APACHE .
-            cp ../../../../LICENSE_MIT .
             zip -r extension.zip .
             cd ../../../..
             cp web/packages/extension/build/extension.zip workspace

--- a/README.md
+++ b/README.md
@@ -32,29 +32,9 @@ Ruffle is in the proof-of-concept stage and can currently run early Flash animat
 
 * `cargo run --package=ruffle_desktop -- test.swf`
 
-### Web
-
-* Install [Node.js](https://nodejs.org/en/)
-* Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/)
-
-#### Running the web demo
-
-* `cd web/demo`
-* `npm run bootstrap`
-* `npm run demo`
-* Load indicated page in browser (usually http://localhost:8080)
-
-#### Hosting on your own site
-
-* `cd web/selfhosted`
-* `npm run bootstrap`
-* `npm run build`
-* Follow the wiki instructions for [using Ruffle on your own site](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#web)
-
-#### Browser extension
-
-* Follow the wiki instructions for [building the Ruffle browser extension](https://github.com/ruffle-rs/ruffle/wiki/Building-Ruffle#building-the-web-extension)
-* Follow the wiki instructions for [using the Ruffle browser extension](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension)
+### Web or Extension
+Follow [the instructions in the web directory](web/README.md#building-from-source) for building
+either the web or browser extension version of Ruffle.
 
 ### Scanner
 
@@ -76,7 +56,7 @@ This currently requires hardware acceleration, but can be run headless (with no 
 
 - `core` contains the core emulator and common code
 - `desktop` contains the desktop client (uses `wgpu-rs`)
-- `web` contains the web client (uses `wasm-bindgen`)
+- [`web`](web) contains the web client and browser extension (uses `wasm-bindgen`)
 - `scanner` contains a utility to bulk parse swf files
 - `exporter` contains a utility to generate PNG screenshots of a swf file
 
@@ -99,7 +79,7 @@ Sincere thanks to the diamond level sponsors of Ruffle:
   <a href="https://www.crazygames.com">
     <img src="assets/crazygames_logo.png" alt="Crazy Games">
   </a>
-</a>
+</p>
 
 ## License
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_core"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitstream-io = "0.8.5"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
 default-run = "ruffle_desktop"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 cpal = "0.11.0"

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -3,6 +3,7 @@ name = "exporter"
 version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 ruffle_core = { path = "../core" }

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_render_canvas"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/render/common_tess/Cargo.toml
+++ b/render/common_tess/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_render_common_tess"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 log = "0.4"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_render_webgl"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 fnv = "1.0.7"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_render_wgpu"
 version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 wgpu = "0.5"

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_scanner"
 version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 ruffle_core = { path = "../core" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -3,6 +3,12 @@ name = "ruffle_web"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "Web (WASM) bindings to the Ruffle flash player"
+readme = "README.md"
+homepage = "https://ruffle.rs"
+repository = "https://github.com/ruffle-rs/ruffle/"
+publish = false # This crate is useless alone, people should use the npm package
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/web/LICENSE_APACHE
+++ b/web/LICENSE_APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/web/LICENSE_MIT
+++ b/web/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,95 @@
+# ruffle-web
+
+![Test Web](https://github.com/ruffle-rs/ruffle/workflows/Test%20Web/badge.svg)
+
+ruffle-web is a Wasm version of Ruffle, intended for use by either
+using the `ruffle-selfhosted` or `ruffle-extension` NPM packages.
+
+This project is split into two parts: The actual Flash player written in Rust,
+and a javascript interface to it. Most of the time, you will be building the
+actual rust part through the npm build scripts.
+
+## Using ruffle-web
+
+Please refer to our wiki for instructions on how to use Ruffle either
+[on your own website](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#web),
+or as a [browser extension](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension).
+
+## How it works
+
+We compile Ruffle down to a Wasm ([WebAssembly](https://webassembly.org/)) binary, which will be loaded
+into web pages either deliberately (installing the selfhosted package onto the website), or injected
+by users as a browser extension.
+
+By default we will detect and replace any embedded Flash content on websites with the Ruffle player
+(we call this "polyfilling"), but this can be configured by the website. This means that Ruffle is an
+"out of the box" solution for getting Flash to work again; include Ruffle and it should just work™.
+
+For rendering the content, we prefer to use [WebGL](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API).
+WebGL is very accurate, hardware-accelerated and very fast, but is not universally supported.
+Additionally, many privacy related browsers or extensions will disable WebGL by default.
+For this reason, we include a fallback using [the canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API).
+
+## Building from source
+
+### Requirements
+
+Before you are able to build this project, you must first install a few dependencies:
+
+#### Rust
+
+Follow the instructions [to install rust](https://www.rust-lang.org/tools/install) on your machine.
+
+We do not have a Minimum Supported Rust Version policy. If it fails to build, it's likely you may need
+to update to the latest stable version of rust. You may run `rustup update` to do this (if you installed
+rust using the above instructions).
+
+#### Node.js
+
+Follow the instructions [to install node.js](https://nodejs.org/en/) on your machine.
+
+We recommend using the currently active LTS 12, but we do also run tests with maintenance LTS 10.
+
+#### wasm-pack
+
+Follow the instructions [to install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) on your machine.
+
+### Building
+
+In this project, you may run the following commands to build all packages:
+
+-   `npm run bootstrap`
+    -   This will install every dependency for every package.
+    -   Run this every time you pull in new changes, otherwise you may be missing a package and the build will fail.
+-   `npm run build`
+    -   This will build the wasm binary and every node package (notably selfhosted and extension).
+    -   Output will be available in the `dist/` of each package (for example, `./packages/selfhosted/dist`),
+        save for the extension which is directory `build/`.
+
+From here, you may follow the instructions to [use Ruffle on your website](packages/selfhosted/README.md),
+or run a demo locally with `npm run demo`.
+
+### Testing
+
+To run all of the tests in this project, we currently require that you have [Chrome installed to its default location](https://www.google.com/chrome/).
+
+First, ensure you've build every package (see above), and then run `npm run test` to run the full suite of tests.
+
+## Structure
+
+-   This directory is a cargo crate which is the actual Flash player, and also a root node package.
+-   [packages/core](packages/core) is a node package which contains the core ruffle web API & wasm bindings.
+-   [packages/selfhosted](packages/selfhosted) is a node package intended for consumption by websites to include Ruffle on their site.
+-   [packages/extension](packages/extension) is a node package that turns Ruffle into a browser extension.
+-   [packages/demo](packages/demo) is an example node package of how to use self-hosted ruffle on your site, and testing it locally.
+
+## Contributing
+
+Please follow the [general contribution guidelines for Ruffle](../CONTRIBUTING.md).
+
+In addition to those, we ask that you ensure that you pass all tests with `npm run test`, and check the automatic code
+linting & styler by running `npm run format` before you commit.
+
+Where possible, please add tests to all new functionality or bug fixes that you contribute.
+
+Thank you!

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -3,6 +3,7 @@ name = "ruffle_web_common"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 js-sys = "0.3.25"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9750,13 +9750,22 @@
       "version": "file:packages/core"
     },
     "ruffle-demo": {
-      "version": "file:packages/demo"
+      "version": "file:packages/demo",
+      "requires": {
+        "ruffle-selfhosted": "file:packages/selfhosted"
+      }
     },
     "ruffle-extension": {
-      "version": "file:packages/extension"
+      "version": "file:packages/extension",
+      "requires": {
+        "ruffle-core": "file:packages/core"
+      }
     },
     "ruffle-selfhosted": {
-      "version": "file:packages/selfhosted"
+      "version": "file:packages/selfhosted",
+      "requires": {
+        "ruffle-core": "file:packages/core"
+      }
     },
     "run-async": {
       "version": "2.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
     "name": "ruffle",
     "version": "0.1.0",
     "description": "Root project of ruffle web",
+    "license": "(MIT OR Apache-2.0)",
     "private": true,
     "devDependencies": {
         "@wasm-tool/wasm-pack-plugin": "^1.3.1",

--- a/web/packages/core/README.md
+++ b/web/packages/core/README.md
@@ -1,0 +1,14 @@
+# ruffle-core
+
+ruffle-core is the core javascript bindings to the Wasm ruffle-web binary,
+and contains the bulk of the public API.
+
+## Using ruffle-core
+
+Please do not use this package directly, either use [ruffle-selfhosted](../selfhosted/) or
+[ruffle-extension](../extension). This page may be merged into ruffle-selfhosted at a later
+date.
+
+## Building, testing or contributing
+
+Please see [the ruffle-web README](../../README.md).

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -2,6 +2,7 @@
     "name": "ruffle-core",
     "version": "0.1.0",
     "description": "Core bindings for Ruffle",
+    "license": "(MIT OR Apache-2.0)",
     "private": true,
     "scripts": {
         "build": "webpack",

--- a/web/packages/demo/LICENSE_APACHE
+++ b/web/packages/demo/LICENSE_APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/web/packages/demo/LICENSE_MIT
+++ b/web/packages/demo/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/web/packages/demo/README.md
+++ b/web/packages/demo/README.md
@@ -1,0 +1,69 @@
+# ruffle-demo
+
+ruffle-demo is an example of how to include Ruffle in your website.
+It also serves as a nice local test to run Ruffle in the web locally, for developers.
+
+## Using ruffle-demo
+
+### Hosted demo
+
+To view this demo online right now, [check out the hosted demo](http://ruffle-rs.s3-website-us-west-1.amazonaws.com/builds/web-demo/index.html).
+
+It's exactly the same code as this directory, updated nightly.
+
+### Run your own demo
+
+After [building ruffle-web](../../README.md#building-from-source),
+you can run `npm run demo` in the `web` folder to launch the demo.
+
+It will start a local web server and print the address in the console.
+Navigate to that website (usually [http://localhost:8080](http://localhost:8080)) in your browser.
+
+### Configuring the demo
+
+The demo provides the ability to have a list of sample SWFs to choose from.
+This can be helpful if you have a list of useful SWFs to test through, and we use it ourselves
+to showcase Ruffle on various games or animations.
+
+To use this, add a new file `swfs.json` next to `index.html` in the demo. The contents should look like this:
+
+```json
+{
+    "swfs": [
+        {
+            "location": "swfs/alien_hominid.swf",
+            "title": "Alien Hominid",
+            "author": "Tom Fulp and Dan Paladin",
+            "authorLink": "https://www.newgrounds.com"
+        },
+        {
+            "location": "swfs/saturday_morning_watchmen.swf",
+            "title": "Saturday Morning Watchmen",
+            "author": "Harry Partridge",
+            "authorLink": "https://twitter.com/HappyHarryToons"
+        },
+        {
+            "location": "swfs/synj1.swf",
+            "title": "Synj vs. Horrid Part 1",
+            "author": "Dan Paladin",
+            "authorLink": "https://www.thebehemoth.com"
+        },
+        {
+            "location": "swfs/synj2.swf",
+            "title": "Synj vs. Horrid Part 2",
+            "author": "Dan Paladin",
+            "authorLink": "https://www.thebehemoth.com"
+        },
+        {
+            "location": "swfs/wasted_sky.swf",
+            "title": "Wasted Sky",
+            "author": "Tom Fulp",
+            "authorLink": "https://www.newgrounds.com"
+        }
+    ]
+}
+```
+
+## Building, testing or contributing
+
+Please see [the ruffle-web README](../../README.md).

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -2,6 +2,7 @@
     "name": "ruffle-demo",
     "version": "0.1.0",
     "description": "Demo of Ruffle Flash emulator",
+    "license": "(MIT OR Apache-2.0)",
     "scripts": {
         "build": "webpack",
         "serve": "webpack-dev-server"

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "description": "Demo of Ruffle Flash emulator",
     "license": "(MIT OR Apache-2.0)",
+    "private": true,
     "scripts": {
         "build": "webpack",
         "serve": "webpack-dev-server"

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -27,6 +27,12 @@ module.exports = (env, argv) => {
                         from: path.resolve(__dirname, "www/index.html"),
                         to: "index.html",
                     },
+                    {
+                        from: "LICENSE**",
+                    },
+                    {
+                        from: "README.md",
+                    },
                 ],
             }),
         ],

--- a/web/packages/demo/www/index.html
+++ b/web/packages/demo/www/index.html
@@ -1,175 +1,181 @@
 <!DOCTYPE html>
 <html data-ruffle-optout>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Ruffle Web Demo</title>
+        <link
+            href="https://fonts.googleapis.com/css?family=Lato"
+            rel="stylesheet"
+        />
+        <style>
+            body {
+                position: absolute;
+                top: 0;
+                left: 0;
+                margin: 0;
+                padding: 0;
+                width: 100%;
+                height: 100%;
+                font-family: "Lato", sans-serif;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                background-color: black;
+            }
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ruffle Web Demo</title>
-  <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
-  <style>
-    body {
-      position: absolute;
-      top: 0;
-      left: 0;
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-      font-family: 'Lato', sans-serif;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      background-color: black;
-    }
+            #main {
+                margin: 15px;
+                width: 100%;
+                height: 100%;
+                align-self: center;
+                max-height: calc(100vh - 70px);
+            }
 
-    #main {
-      margin: 15px;
-      width: 100%;
-      height: 100%;
-      align-self: center;
-      max-height: calc(100vh - 70px);
-    }
+            #container {
+                height: calc(100vh - 70px);
+                width: 100vw;
+            }
 
-    #container
-    {
-      height: calc(100vh - 70px);
-      width: 100vw;
-    }
+            #player {
+                width: 100vw;
+                height: calc(100vh - 70px);
+                display: block;
+            }
 
-    #player {
-      width: 100vw;
-      height: calc(100vh - 70px);
-      display: block;
-    }
+            #nav {
+                width: 100%;
+                background: #37528c;
+                border: 0;
+                border-color: darkgray;
+                border-bottom: 2px #37528c;
+                border-style: solid;
+                box-shadow: 0 5px 5px #37528c;
+                display: flex;
+                flex-direction: row;
+                justify-content: space-around;
+                align-items: center;
+                align-self: flex-start;
+                color: white;
+                min-height: 45px;
+            }
 
-    #nav {
-      width: 100%;
-      background: #37528C;
-      border: 0;
-      border-color: darkgray;
-      border-bottom: 2px #37528C;
-      border-style: solid;
-      box-shadow: 0 5px 5px #37528C;
-      display: flex;
-      flex-direction: row;
-      justify-content: space-around;
-      align-items: center;
-      align-self: flex-start;
-      color: white;
-      min-height: 45px;
-    }
+            #title:hover {
+                opacity: 0.5;
+                cursor: pointer;
+                transition-duration: 0.5s;
+            }
 
-    #title:hover {
-      opacity: 0.5;
-      cursor: pointer;
-      transition-duration: 0.5s;
-    }
+            #title img {
+                display: inline-block;
+                height: 32px;
+                margin-top: 5px;
+            }
 
-    #title img {
-      display: inline-block;
-      height: 32px;
-      margin-top: 5px;
-    }
+            #file-picker {
+                margin-top: 7px;
+            }
 
-    #file-picker {
-      margin-top: 7px;
-    }
+            #local-file-container {
+                display: inline-block;
+                vertical-align: middle;
+            }
 
-    #local-file-container {
-      display: inline-block;
-      vertical-align: middle;
-    }
+            #sample-swfs-container {
+                display: none;
+                vertical-align: middle;
+            }
 
-    #sample-swfs-container {
-      display: none;
-      vertical-align: middle;
-    }
+            #author-container {
+                display: none;
+                font-size: 13px;
+                text-align: left;
+            }
 
-    #author-container {
-      display: none;
-      font-size: 13px;
-      text-align: left;
-    }
+            #author {
+                padding-left: 5px;
+                color: #ffad33;
+            }
 
-    #author {
-      padding-left: 5px;
-      color: #ffad33;
-    }
+            @media only screen and (max-width: 800px) {
+                #local-file-container,
+                #sample-swfs-container {
+                    display: block;
+                }
 
-    @media only screen and (max-width: 800px) {
-      #local-file-container,#sample-swfs-container {
-        display: block;
-      }
+                #nav {
+                    min-height: 65px;
+                }
 
-      #nav {
-        min-height: 65px;
-      }
+                #player {
+                    height: calc(100vh - 90px) !important;
+                }
+            }
 
-      #player {
-        height: calc(100vh - 90px) !important;
-      }
-    }
+            @media only screen and (max-width: 600px) {
+                #local-file-container {
+                    display: none;
+                }
 
-    @media only screen and (max-width: 600px) {
-      #local-file-container {
-        display: none;
-      }
-      
-      #sample-swfs-label {
-        display: none;
-      }
+                #sample-swfs-label {
+                    display: none;
+                }
 
-      #author-container {
-        font-size: 12px;
-        text-align: center;
-      }
+                #author-container {
+                    font-size: 12px;
+                    text-align: center;
+                }
 
-      #nav {
-        min-height: 85px;
-        flex-direction: column;
-        padding-bottom: 2px;
-      }
-    }
+                #nav {
+                    min-height: 85px;
+                    flex-direction: column;
+                    padding-bottom: 2px;
+                }
+            }
 
-    select,
-    input {
-      margin: 0 5px;
-    }
+            select,
+            input {
+                margin: 0 5px;
+            }
 
-    #player {
-      width: 100%;
-      height: 100%;
-    }
-  </style>
-</head>
+            #player {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+    </head>
 
-<body>
-  <div id="nav">
-    <div id="title">
-      <a href="https://ruffle.rs" target="_blank">
-      <img src="https://ruffle.rs/assets/logo.png" alt="Ruffle" data-canonical-src="https://ruffle.rs/assets/logo.png">
-      </a>
-    </div>
-    <div id="file-picker">
-      <div id="local-file-container">
-        Local SWF: 
-        <input type="file" id="local-file">
-      </div>
-      <div id="sample-swfs-container">
-        <span id="sample-swfs-label">Sample SWF:</span>
-        <select id="sample-swfs">
-          <option value="none">None</option>
-          <optgroup id="anim-optgroup" label="Animations">
-          </optgroup>
-          <optgroup id="games-optgroup" label="Games">
-          </optgroup>
-        </select>
-        <span id="author-container">Author: <a href="#" target="_blank" id="author"></a></span>
-      </div>
-    </div>
-  </div>
-  <div id="main">
-  </div>
-  <script src="./index.js"></script>
-</body>
+    <body>
+        <div id="nav">
+            <div id="title">
+                <a href="https://ruffle.rs" target="_blank">
+                    <img
+                        src="https://ruffle.rs/assets/logo.png"
+                        alt="Ruffle"
+                        data-canonical-src="https://ruffle.rs/assets/logo.png"
+                    />
+                </a>
+            </div>
+            <div id="file-picker">
+                <div id="local-file-container">
+                    Local SWF:
+                    <input type="file" id="local-file" />
+                </div>
+                <div id="sample-swfs-container">
+                    <span id="sample-swfs-label">Sample SWF:</span>
+                    <select id="sample-swfs">
+                        <option value="none">None</option>
+                        <optgroup id="anim-optgroup" label="Animations">
+                        </optgroup>
+                        <optgroup id="games-optgroup" label="Games"> </optgroup>
+                    </select>
+                    <span id="author-container"
+                        >Author: <a href="#" target="_blank" id="author"></a
+                    ></span>
+                </div>
+            </div>
+        </div>
+        <div id="main"></div>
+        <script src="./index.js"></script>
+    </body>
 </html>

--- a/web/packages/extension/LICENSE_APACHE
+++ b/web/packages/extension/LICENSE_APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/web/packages/extension/LICENSE_MIT
+++ b/web/packages/extension/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/web/packages/extension/README.md
+++ b/web/packages/extension/README.md
@@ -1,0 +1,39 @@
+# ruffle-extension
+
+ruffle-extension is all of the power of Ruffle, in your browser.
+
+Without needing websites to do anything, the browser extension will automatically replace any Flash content on websites
+with the Ruffle player.
+
+The extension will automatically negotiate with websites that do have Ruffle installed, to ensure that there is no
+conflict between the versions. Newer version of ruffle, either from the website or extension,
+will always take precedence and disable the other.
+
+## Using ruffle-extension
+
+The browser extension is built to work in both Chrome and Firefox.
+
+We do not yet have a signed release of the extension, so you must load it as a temporary "unpacked" extension.
+
+Before you can install the extension, you must either download the
+[latest build](https://ruffle-rs.s3-us-west-1.amazonaws.com/builds/extension/ruffle_extension_latest.zip)
+or [build it yourself](../../README.md). For the purposes of these instructions, you want the extension as a loose
+folder and not a packed zip.
+
+### Chrome
+
+-   Navigate to chrome://extensions/
+-   Turn on Developer mode in the top right corner.
+-   Click Load unpacked.
+-   Select the extension folder.
+
+### Firefox
+
+-   Navigate to about:debugging
+-   Click on This Firefox.
+-   Click Load Temporary Add-on...
+-   Select manifest.json from your extension folder.
+
+## Building, testing or contributing
+
+Please see [the ruffle-web README](../../README.md).

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "description": "Extension packaging for Ruffle Flash Emulator",
     "license": "(MIT OR Apache-2.0)",
+    "private": true,
     "scripts": {
         "build": "webpack",
         "serve": "webpack-dev-server"

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -2,6 +2,7 @@
     "name": "ruffle-extension",
     "version": "0.1.0",
     "description": "Extension packaging for Ruffle Flash Emulator",
+    "license": "(MIT OR Apache-2.0)",
     "scripts": {
         "build": "webpack",
         "serve": "webpack-dev-server"

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
 const path = require("path");
 
 module.exports = (env, argv) => {
@@ -20,6 +21,11 @@ module.exports = (env, argv) => {
             jsonpFunction: "RufflePlayerExtensionLoader",
         },
         mode: mode,
-        plugins: [new CleanWebpackPlugin()],
+        plugins: [
+            new CleanWebpackPlugin(),
+            new CopyPlugin({
+                patterns: [{ from: "LICENSE*" }, { from: "README.md" }],
+            }),
+        ],
     };
 };

--- a/web/packages/selfhosted/LICENSE_APACHE
+++ b/web/packages/selfhosted/LICENSE_APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/web/packages/selfhosted/LICENSE_MIT
+++ b/web/packages/selfhosted/LICENSE_MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/web/packages/selfhosted/README.md
+++ b/web/packages/selfhosted/README.md
@@ -1,0 +1,53 @@
+# ruffle-selfhosted
+
+ruffle-selfhosted is the intended way to get Ruffle onto your website.
+
+You may either include it and forget about it, and we will polyfill existing Flash content,
+or use our APIs for custom configurations or more advanced usages of the Ruffle player.
+
+## Using ruffle-selfhosted
+
+For more examples and in-depth documentation on how to use Ruffle on your website, please
+[check out our wiki](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#web).
+
+### Host Ruffle
+
+Before you can get started with using Ruffle on your website, you must host its files yourself.
+Either take the [latest build](https://ruffle-rs.s3-us-west-1.amazonaws.com/builds/web/ruffle_web_latest.zip)
+or [build it yourself](../../README.md), and make these files accessible by your web server.
+
+Please note that the `.wasm` file must be served properly, and some web servers may not do that
+correctly out of the box. Please see [our wiki](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#configure-wasm-mime-type)
+for instructions on how to configure this, if you encounter a `Incorrect response MIME type` error.
+
+### "Plug and Play"
+
+If you have an existing website with flash content, you can simply include Ruffle as a script and
+our polyfill magic will replace everything for you. No fuss, no mess.
+
+```html
+<script src="path/to/ruffle/ruffle.js"></script>
+```
+
+### Javascript API
+
+If you want to control the Ruffle player, you may use our Javascript API.
+
+```html
+<script>
+    window.RufflePlayer = window.RufflePlayer || {};
+
+    window.addEventListener("DOMContentLoaded", () => {
+        let ruffle = window.RufflePlayer.newest();
+        let player = ruffle.create_player();
+        let container = document.getElementById("container");
+        container.appendChild(player);
+        player.stream_swf_url("movie.swf");
+    });
+</script>
+<script src="path/to/ruffle/ruffle.js"></script>
+```
+
+## Building, testing or contributing
+
+Please see [the ruffle-web README](../../README.md).

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -2,6 +2,7 @@
     "name": "ruffle-selfhosted",
     "version": "0.1.0",
     "description": "Put Flash back on the web with Ruffle on your own site",
+    "license": "(MIT OR Apache-2.0)",
     "scripts": {
         "build": "webpack",
         "serve": "webpack-dev-server",

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -1,8 +1,15 @@
 {
     "name": "ruffle-selfhosted",
     "version": "0.1.0",
-    "description": "Put Flash back on the web with Ruffle on your own site",
+    "description": "Putting Flash back on the web. Ruffle will polyfill all Flash content and replace it with the Ruffle flash player.",
     "license": "(MIT OR Apache-2.0)",
+    "keywords": [
+        "flash",
+        "swf"
+    ],
+    "homepage": "https://ruffle.rs",
+    "bugs": "https://github.com/ruffle-rs/ruffle/issues",
+    "repository": "github:ruffle-rs/ruffle",
     "scripts": {
         "build": "webpack",
         "serve": "webpack-dev-server",

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
 const path = require("path");
 
 module.exports = (env, argv) => {
@@ -20,6 +21,11 @@ module.exports = (env, argv) => {
             jsonpFunction: "RufflePlayerLoader",
         },
         mode: mode,
-        plugins: [new CleanWebpackPlugin()],
+        plugins: [
+            new CleanWebpackPlugin(),
+            new CopyPlugin({
+                patterns: [{ from: "LICENSE*" }, { from: "README.md" }],
+            }),
+        ],
     };
 };


### PR DESCRIPTION
I'm a believer in essential info living in the repo and not a wiki, so I've done a pass on our web crate and documented as much of it as possible in readmes, with callbacks to the wiki where appropriate.

We should be able to use this to judge when and how our structure/build setup changes, as every PR that changes something essential should include these files too.

I've also gone and touched up all the manifest files to clarify license and some other details.