### PR TITLE
core: Print swf version on startup, and warn when we run into avm2

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -145,7 +145,14 @@ impl<'gc> MovieClip<'gc> {
         let mut reader = data.read_from(self.0.read().tag_stream_pos);
         let mut cur_frame = 1;
         let mut ids = fnv::FnvHashMap::default();
-        let tag_callback = |reader: &mut _, tag_code, tag_len| match tag_code {
+        let tag_callback = |reader: &mut SwfStream<&[u8]>, tag_code, tag_len| match tag_code {
+            TagCode::FileAttributes => {
+                let attributes = reader.read_file_attributes()?;
+                if attributes.is_action_script_3 {
+                    log::warn!("This SWF contains ActionScript 3 which is not yet supported by Ruffle. The movie may not work as intended.");
+                }
+                Ok(())
+            }
             TagCode::DefineBits => self
                 .0
                 .write(context.gc_context)

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -154,7 +154,8 @@ impl Player {
         let movie = Arc::new(movie);
 
         info!(
-            "{}x{}",
+            "Loaded SWF version {}, with a resolution of {}x{}",
+            movie.header().version,
             movie.header().stage_size.x_max,
             movie.header().stage_size.y_max
         );

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -595,14 +595,7 @@ impl<R: Read> Reader<R> {
             Some(TagCode::ExportAssets) => Tag::ExportAssets(tag_reader.read_export_assets()?),
 
             Some(TagCode::FileAttributes) => {
-                let flags = tag_reader.read_u32()?;
-                Tag::FileAttributes(FileAttributes {
-                    use_direct_blit: (flags & 0b01000000) != 0,
-                    use_gpu: (flags & 0b00100000) != 0,
-                    has_metadata: (flags & 0b00010000) != 0,
-                    is_action_script_3: (flags & 0b00001000) != 0,
-                    use_network_sandbox: (flags & 0b00000001) != 0,
-                })
+                Tag::FileAttributes(tag_reader.read_file_attributes()?)
             }
 
             Some(TagCode::Protect) => {
@@ -2044,6 +2037,17 @@ impl<R: Read> Reader<R> {
             num_frames: self.read_u16()?,
             tags: self.read_tag_list()?,
         }))
+    }
+
+    pub fn read_file_attributes(&mut self) -> Result<FileAttributes> {
+        let flags = self.read_u32()?;
+        Ok(FileAttributes {
+            use_direct_blit: (flags & 0b01000000) != 0,
+            use_gpu: (flags & 0b00100000) != 0,
+            has_metadata: (flags & 0b00010000) != 0,
+            is_action_script_3: (flags & 0b00001000) != 0,
+            use_network_sandbox: (flags & 0b00000001) != 0,
+        })
     }
 
     pub fn read_export_assets(&mut self) -> Result<ExportAssets> {


### PR DESCRIPTION
This should help with the occasional issue we get about avm2 content.