### PR TITLE
Handle ReturnValue silently in most APIs

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1241,7 +1241,8 @@ impl<'gc> Avm1<'gc> {
             .resolve(fn_name.as_string()?, self, context)?
             .resolve(self, context)?;
         let this = self.target_clip_or_root().object().as_object()?;
-        target_fn.call(self, context, this, None, &args)?.push(self);
+        let result = target_fn.call(self, context, this, None, &args)?;
+        self.push(result);
 
         Ok(())
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1263,7 +1263,8 @@ impl<'gc> Avm1<'gc> {
             Value::Undefined | Value::Null => {
                 let this = self.target_clip_or_root().object();
                 if let Ok(this) = this.as_object() {
-                    object.call(self, context, this, None, &args)?.push(self);
+                    let result = object.call(self, context, this, None, &args)?;
+                    self.push(result);
                 } else {
                     log::warn!(
                         "Attempted to call constructor of {:?} (missing method name)",
@@ -1274,7 +1275,8 @@ impl<'gc> Avm1<'gc> {
             }
             Value::String(name) => {
                 if name.is_empty() {
-                    object.call(self, context, object, None, &args)?.push(self);
+                    let result = object.call(self, context, object, None, &args)?;
+                    self.push(result);
                 } else {
                     object.call_method(&name, &args, self, context)?.push(self);
                 }
@@ -2070,9 +2072,7 @@ impl<'gc> Avm1<'gc> {
             }
 
             //TODO: What happens if you `ActionNewMethod` without a method name?
-            constructor
-                .call(self, context, this, None, &args)?
-                .resolve(self, context)?;
+            constructor.call(self, context, this, None, &args)?;
 
             self.push(this);
         } else {
@@ -2115,9 +2115,7 @@ impl<'gc> Avm1<'gc> {
                         this.set("constructor", constructor.into(), self, context)?;
                     }
 
-                    constructor
-                        .call(self, context, this, None, &args)?
-                        .resolve(self, context)?;
+                    constructor.call(self, context, this, None, &args)?;
                     ret = this.into();
                 } else {
                     log::warn!("NewObject: Constructor has invalid prototype: {}", fn_name);

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1278,7 +1278,8 @@ impl<'gc> Avm1<'gc> {
                     let result = object.call(self, context, object, None, &args)?;
                     self.push(result);
                 } else {
-                    object.call_method(&name, &args, self, context)?.push(self);
+                    let result = object.call_method(&name, &args, self, context)?;
+                    self.push(result);
                 }
             }
             _ => {

--- a/core/src/avm1/debug.rs
+++ b/core/src/avm1/debug.rs
@@ -104,10 +104,7 @@ impl<'a> VariableDumper<'a> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) {
-        match object
-            .get(&key, avm, context)
-            .and_then(|v| v.resolve(avm, context))
-        {
+        match object.get(&key, avm, context) {
             Ok(value) => {
                 self.print_value(&value, avm, context);
             }

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -478,11 +478,12 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         if let Some(exec) = self.as_executable() {
-            exec.exec(avm, context, this, base_proto, args)
+            exec.exec(avm, context, this, base_proto, args)?
+                .resolve(avm, context)
         } else {
-            Ok(Value::Undefined.into())
+            Ok(Value::Undefined)
         }
     }
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -457,7 +457,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base.get_local(name, avm, context, this)
     }
 

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -794,7 +794,6 @@ fn sort_compare_custom<'gc>(
     let args = [a.clone(), b.clone()];
     let ret = compare_fn
         .call(avm, context, this, None, &args)
-        .and_then(|v| v.resolve(avm, context))
         .unwrap_or(Value::Undefined);
     match ret {
         Value::Number(n) if n > 0.0 => Ordering::Greater,

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -377,7 +377,6 @@ pub fn concat<'gc>(
     for i in 0..this.length() {
         let old = this
             .get(&i.to_string(), avm, context)
-            .and_then(|v| v.resolve(avm, context))
             .unwrap_or(Value::Undefined);
         array.define_value(
             context.gc_context,
@@ -398,7 +397,6 @@ pub fn concat<'gc>(
                 for i in 0..object.length() {
                     let old = object
                         .get(&i.to_string(), avm, context)
-                        .and_then(|v| v.resolve(avm, context))
                         .unwrap_or(Value::Undefined);
                     array.define_value(
                         context.gc_context,
@@ -770,16 +768,8 @@ fn sort_compare_fields<'a, 'gc: 'a>(
         for (field_name, compare_fn) in field_names.iter().zip(compare_fns.iter_mut()) {
             let a_object = ValueObject::boxed(avm, context, a.clone());
             let b_object = ValueObject::boxed(avm, context, b.clone());
-            let a_prop = a_object
-                .get(field_name, avm, context)
-                .unwrap()
-                .resolve(avm, context)
-                .unwrap();
-            let b_prop = b_object
-                .get(field_name, avm, context)
-                .unwrap()
-                .resolve(avm, context)
-                .unwrap();
+            let a_prop = a_object.get(field_name, avm, context).unwrap();
+            let b_prop = b_object.get(field_name, avm, context).unwrap();
 
             let result = compare_fn(avm, context, &a_prop, &b_prop);
             if result != Ordering::Equal {

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -81,7 +81,7 @@ fn target<'gc>(
     // The target path resolves based on the active tellTarget clip of the stack frame.
     // This means calls on the same `Color` object could set the color of different clips
     // depending on which timeline its called from!
-    let target = this.get("target", avm, context)?.resolve(avm, context)?;
+    let target = this.get("target", avm, context)?;
     // Undefined or empty target is no-op.
     if target != Value::Undefined && !matches!(&target, &Value::String(ref s) if s.is_empty()) {
         let start_clip = avm.target_clip_or_root();
@@ -177,7 +177,6 @@ fn set_transform<'gc>(
         if transform.has_own_property(avm, context, property) {
             let n = transform
                 .get(property, avm, context)?
-                .resolve(avm, context)?
                 .as_number(avm, context)?;
             *out = f32::from(crate::avm1::value::f64_to_wrapping_i16(n * 2.56)) / 256.0
         }
@@ -195,7 +194,6 @@ fn set_transform<'gc>(
         if transform.has_own_property(avm, context, property) {
             let n = transform
                 .get(property, avm, context)?
-                .resolve(avm, context)?
                 .as_number(avm, context)?;
             *out = f32::from(crate::avm1::value::f64_to_wrapping_i16(n)) / 255.0
         }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -55,16 +55,13 @@ pub fn apply<'gc>(
     let length = match args_object {
         Value::Object(a) => a
             .get("length", avm, action_context)?
-            .resolve(avm, action_context)?
             .as_number(avm, action_context)? as usize,
         _ => 0,
     };
 
     while child_args.len() < length {
         let args = args_object.as_object()?;
-        let next_arg = args
-            .get(&format!("{}", child_args.len()), avm, action_context)?
-            .resolve(avm, action_context)?;
+        let next_arg = args.get(&format!("{}", child_args.len()), avm, action_context)?;
 
         child_args.push(next_arg);
     }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -13,7 +13,14 @@ pub fn value_to_matrix<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Matrix, Error> {
-    object_to_matrix(value.as_object()?, avm, context)
+    let a = value.get("a", avm, context)?.as_number(avm, context)? as f32;
+    let b = value.get("b", avm, context)?.as_number(avm, context)? as f32;
+    let c = value.get("c", avm, context)?.as_number(avm, context)? as f32;
+    let d = value.get("d", avm, context)?.as_number(avm, context)? as f32;
+    let tx = Twips::from_pixels(value.get("tx", avm, context)?.as_number(avm, context)?);
+    let ty = Twips::from_pixels(value.get("ty", avm, context)?.as_number(avm, context)?);
+
+    Ok(Matrix { a, b, c, d, tx, ty })
 }
 
 pub fn gradient_object_to_matrix<'gc>(

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -23,30 +23,14 @@ pub fn gradient_object_to_matrix<'gc>(
 ) -> Result<Matrix, Error> {
     if object
         .get("matrixType", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?
         == "box"
     {
-        let width = object
-            .get("w", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-        let height = object
-            .get("h", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-        let rotation = object
-            .get("r", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-        let tx = object
-            .get("x", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-        let ty = object
-            .get("y", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+        let width = object.get("w", avm, context)?.as_number(avm, context)?;
+        let height = object.get("h", avm, context)?.as_number(avm, context)?;
+        let rotation = object.get("r", avm, context)?.as_number(avm, context)?;
+        let tx = object.get("x", avm, context)?.as_number(avm, context)?;
+        let ty = object.get("y", avm, context)?.as_number(avm, context)?;
         Ok(Matrix::create_gradient_box(
             width as f32,
             height as f32,
@@ -65,34 +49,12 @@ pub fn object_to_matrix<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Matrix, Error> {
-    let a = object
-        .get("a", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)? as f32;
-    let b = object
-        .get("b", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)? as f32;
-    let c = object
-        .get("c", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)? as f32;
-    let d = object
-        .get("d", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)? as f32;
-    let tx = Twips::from_pixels(
-        object
-            .get("tx", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?,
-    );
-    let ty = Twips::from_pixels(
-        object
-            .get("ty", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?,
-    );
+    let a = object.get("a", avm, context)?.as_number(avm, context)? as f32;
+    let b = object.get("b", avm, context)?.as_number(avm, context)? as f32;
+    let c = object.get("c", avm, context)?.as_number(avm, context)? as f32;
+    let d = object.get("d", avm, context)?.as_number(avm, context)? as f32;
+    let tx = Twips::from_pixels(object.get("tx", avm, context)?.as_number(avm, context)?);
+    let ty = Twips::from_pixels(object.get("ty", avm, context)?.as_number(avm, context)?);
 
     Ok(Matrix { a, b, c, d, tx, ty })
 }
@@ -183,12 +145,12 @@ fn clone<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let proto = context.system_prototypes.matrix;
     let args = [
-        this.get("a", avm, context)?.resolve(avm, context)?,
-        this.get("b", avm, context)?.resolve(avm, context)?,
-        this.get("c", avm, context)?.resolve(avm, context)?,
-        this.get("d", avm, context)?.resolve(avm, context)?,
-        this.get("tx", avm, context)?.resolve(avm, context)?,
-        this.get("ty", avm, context)?.resolve(avm, context)?,
+        this.get("a", avm, context)?,
+        this.get("b", avm, context)?,
+        this.get("c", avm, context)?,
+        this.get("d", avm, context)?,
+        this.get("tx", avm, context)?,
+        this.get("ty", avm, context)?,
     ];
     let cloned = proto.new(avm, context, proto, &args)?;
     let _ = constructor(avm, context, cloned, &args)?;
@@ -380,27 +342,21 @@ fn to_string<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let a = this
         .get("a", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let b = this
         .get("b", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let c = this
         .get("c", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let d = this
         .get("d", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let tx = this
         .get("tx", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let ty = this
         .get("ty", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
 
     Ok(format!("(a={}, b={}, c={}, d={}, tx={}, ty={})", a, b, c, d, tx, ty).into())

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -875,12 +875,8 @@ fn local_to_global<'gc>(
         // localToGlobal does no coercion; it fails if the properties are not numbers.
         // It does not search the prototype chain.
         if let (Value::Number(x), Value::Number(y)) = (
-            point
-                .get_local("x", avm, context, *point)?
-                .resolve(avm, context)?,
-            point
-                .get_local("y", avm, context, *point)?
-                .resolve(avm, context)?,
+            point.get_local("x", avm, context, *point)?,
+            point.get_local("y", avm, context, *point)?,
         ) {
             let x = Twips::from_pixels(x);
             let y = Twips::from_pixels(y);
@@ -961,12 +957,8 @@ fn global_to_local<'gc>(
         // globalToLocal does no coercion; it fails if the properties are not numbers.
         // It does not search the prototype chain.
         if let (Value::Number(x), Value::Number(y)) = (
-            point
-                .get_local("x", avm, context, *point)?
-                .resolve(avm, context)?,
-            point
-                .get_local("y", avm, context, *point)?
-                .resolve(avm, context)?,
+            point.get_local("x", avm, context, *point)?,
+            point.get_local("y", avm, context, *point)?,
         ) {
             let x = Twips::from_pixels(x);
             let y = Twips::from_pixels(y);

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -35,9 +35,7 @@ pub fn add_listener<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let new_listener = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let listeners = this
-        .get("_listeners", avm, context)?
-        .resolve(avm, context)?;
+    let listeners = this.get("_listeners", avm, context)?;
 
     if let Value::Object(listeners) = listeners {
         let length = listeners.length();
@@ -55,18 +53,14 @@ pub fn remove_listener<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let old_listener = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let listeners = this
-        .get("_listeners", avm, context)?
-        .resolve(avm, context)?;
+    let listeners = this.get("_listeners", avm, context)?;
 
     if let Value::Object(listeners) = listeners {
         let length = listeners.length();
         let mut position = None;
 
         for i in 0..length {
-            let other_listener = listeners
-                .get(&format!("{}", i), avm, context)?
-                .resolve(avm, context)?;
+            let other_listener = listeners.get(&format!("{}", i), avm, context)?;
             if old_listener == other_listener {
                 position = Some(i);
                 break;
@@ -108,14 +102,10 @@ pub fn broadcast_message<'gc>(
         .coerce_to_string(avm, context)?;
     let call_args = &args[0..];
 
-    let listeners = this
-        .get("_listeners", avm, context)?
-        .resolve(avm, context)?;
+    let listeners = this.get("_listeners", avm, context)?;
     if let Value::Object(listeners) = listeners {
         for i in 0..listeners.length() {
-            let listener = listeners
-                .get(&format!("{}", i), avm, context)?
-                .resolve(avm, context)?;
+            let listener = listeners.get(&format!("{}", i), avm, context)?;
 
             if let Value::Object(listener) = listener {
                 listener

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -108,9 +108,7 @@ pub fn broadcast_message<'gc>(
             let listener = listeners.get(&format!("{}", i), avm, context)?;
 
             if let Value::Object(listener) = listener {
-                listener
-                    .call_method(&event_name, call_args, avm, context)?
-                    .resolve(avm, context)?;
+                listener.call_method(&event_name, call_args, avm, context)?;
             }
         }
     }

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -243,14 +243,10 @@ pub fn as_set_prop_flags<'gc>(
             //Convert to native array.
             //TODO: Can we make this an iterator?
             let mut array = vec![];
-            let length = ob
-                .get("length", avm, ac)?
-                .resolve(avm, ac)?
-                .as_number(avm, ac)? as usize;
+            let length = ob.get("length", avm, ac)?.as_number(avm, ac)? as usize;
             for i in 0..length {
                 array.push(
                     ob.get(&format!("{}", i), avm, ac)?
-                        .resolve(avm, ac)?
                         .coerce_to_string(avm, ac)?,
                 )
             }

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -46,14 +46,8 @@ pub fn object_to_point<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error> {
-    let x = object
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let y = object
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = object.get("x", avm, context)?.as_number(avm, context)?;
+    let y = object.get("y", avm, context)?.as_number(avm, context)?;
     Ok((x, y))
 }
 
@@ -91,10 +85,7 @@ fn clone<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let proto = context.system_prototypes.point;
-    let args = [
-        this.get("x", avm, context)?.resolve(avm, context)?,
-        this.get("y", avm, context)?.resolve(avm, context)?,
-    ];
+    let args = [this.get("x", avm, context)?, this.get("y", avm, context)?];
     let cloned = proto.new(avm, context, proto, &args)?;
     let _ = constructor(avm, context, cloned, &args)?;
 
@@ -108,10 +99,10 @@ fn equals<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(Value::Object(other)) = args.get(0) {
-        let this_x = this.get("x", avm, context)?.resolve(avm, context)?;
-        let this_y = this.get("y", avm, context)?.resolve(avm, context)?;
-        let other_x = other.get("x", avm, context)?.resolve(avm, context)?;
-        let other_y = other.get("y", avm, context)?.resolve(avm, context)?;
+        let this_x = this.get("x", avm, context)?;
+        let this_y = this.get("y", avm, context)?;
+        let other_x = other.get("x", avm, context)?;
+        let other_y = other.get("y", avm, context)?;
         return Ok((this_x == other_x && this_y == other_y).into());
     }
 
@@ -124,14 +115,8 @@ fn add<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let this_x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let this_y = this.get("y", avm, context)?.as_number(avm, context)?;
     let other = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -147,14 +132,8 @@ fn subtract<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let this_x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let this_y = this.get("y", avm, context)?.as_number(avm, context)?;
     let other = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -180,7 +159,7 @@ fn distance<'gc>(
         .call_method("subtract", &[b.to_owned()], avm, context)?
         .resolve(avm, context)?;
     if let Value::Object(object) = delta {
-        let length = object.get("length", avm, context)?.resolve(avm, context)?;
+        let length = object.get("length", avm, context)?;
         Ok(length.into())
     } else {
         Ok(Value::Undefined.into())
@@ -230,11 +209,9 @@ fn to_string<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let x = this
         .get("x", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let y = this
         .get("y", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
 
     Ok(format!("(x={}, y={})", x, y).into())
@@ -257,10 +234,7 @@ fn normalize<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let current_length = this
-        .get("length", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let current_length = this.get("length", avm, context)?.as_number(avm, context)?;
     if current_length.is_finite() {
         let point = object_to_point(this, avm, context)?;
         let new_length = args

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -34,11 +34,9 @@ pub fn value_to_point<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error> {
-    if let Value::Object(object) = value {
-        object_to_point(object, avm, context)
-    } else {
-        Ok((NAN, NAN))
-    }
+    let x = value.get("x", avm, context)?.as_number(avm, context)?;
+    let y = value.get("y", avm, context)?.as_number(avm, context)?;
+    Ok((x, y))
 }
 
 pub fn object_to_point<'gc>(
@@ -98,7 +96,7 @@ fn equals<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    if let Some(Value::Object(other)) = args.get(0) {
+    if let Some(other) = args.get(0) {
         let this_x = this.get("x", avm, context)?;
         let this_y = this.get("y", avm, context)?;
         let other_x = other.get("x", avm, context)?;
@@ -155,14 +153,8 @@ fn distance<'gc>(
 
     let a = args.get(0).unwrap_or(&Value::Undefined);
     let b = args.get(1).unwrap_or(&Value::Undefined);
-    let delta = a
-        .call_method("subtract", &[b.to_owned()], avm, context)?;
-    if let Value::Object(object) = delta {
-        let length = object.get("length", avm, context)?;
-        Ok(length.into())
-    } else {
-        Ok(Value::Undefined.into())
-    }
+    let delta = a.call_method("subtract", &[b.to_owned()], avm, context)?;
+    Ok(delta.get("length", avm, context)?.into())
 }
 
 fn polar<'gc>(

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -156,8 +156,7 @@ fn distance<'gc>(
     let a = args.get(0).unwrap_or(&Value::Undefined);
     let b = args.get(1).unwrap_or(&Value::Undefined);
     let delta = a
-        .call_method("subtract", &[b.to_owned()], avm, context)?
-        .resolve(avm, context)?;
+        .call_method("subtract", &[b.to_owned()], avm, context)?;
     if let Value::Object(object) = delta {
         let length = object.get("length", avm, context)?;
         Ok(length.into())

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -59,19 +59,15 @@ fn to_string<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let x = this
         .get("x", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let y = this
         .get("y", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let width = this
         .get("width", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
     let height = this
         .get("height", avm, context)?
-        .resolve(avm, context)?
         .coerce_to_string(avm, context)?;
 
     Ok(format!("(x={}, y={}, w={}, h={})", x, y, width, height).into())
@@ -96,14 +92,8 @@ fn is_empty<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
     Ok((width <= 0.0 || height <= 0.0 || width.is_nan() || height.is_nan()).into())
 }
 
@@ -128,10 +118,10 @@ fn clone<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let proto = context.system_prototypes.rectangle;
     let args = [
-        this.get("x", avm, context)?.resolve(avm, context)?,
-        this.get("y", avm, context)?.resolve(avm, context)?,
-        this.get("width", avm, context)?.resolve(avm, context)?,
-        this.get("height", avm, context)?.resolve(avm, context)?,
+        this.get("x", avm, context)?,
+        this.get("y", avm, context)?,
+        this.get("width", avm, context)?,
+        this.get("height", avm, context)?,
     ];
     let cloned = proto.new(avm, context, proto, &args)?;
     let _ = constructor(avm, context, cloned, &args)?;
@@ -160,24 +150,10 @@ fn contains<'gc>(
         return Ok(Value::Undefined.into());
     }
 
-    let left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let right = left
-        + this
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let bottom = top
-        + this
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let right = left + this.get("width", avm, context)?.as_number(avm, context)?;
+    let top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let bottom = top + this.get("height", avm, context)?.as_number(avm, context)?;
 
     Ok((x >= left && x < right && y >= top && y < bottom).into())
 }
@@ -197,24 +173,10 @@ fn contains_point<'gc>(
         return Ok(Value::Undefined.into());
     }
 
-    let left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let right = left
-        + this
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let bottom = top
-        + this
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let right = left + this.get("width", avm, context)?.as_number(avm, context)?;
+    let top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let bottom = top + this.get("height", avm, context)?.as_number(avm, context)?;
 
     Ok((x >= left && x < right && y >= top && y < bottom).into())
 }
@@ -231,43 +193,15 @@ fn contains_rectangle<'gc>(
         return Ok(Value::Undefined.into());
     };
 
-    let this_left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_right = this_left
-        + this
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let this_bottom = this_top
-        + this
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
+    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
 
-    let other_left = other
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let other_top = other
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let other_right = other_left
-        + other
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let other_bottom = other_top
-        + other
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let other_left = other.get("x", avm, context)?.as_number(avm, context)?;
+    let other_top = other.get("y", avm, context)?.as_number(avm, context)?;
+    let other_right = other_left + other.get("width", avm, context)?.as_number(avm, context)?;
+    let other_bottom = other_top + other.get("height", avm, context)?.as_number(avm, context)?;
 
     if other_left.is_nan() || other_top.is_nan() || other_right.is_nan() || other_bottom.is_nan() {
         return Ok(Value::Undefined.into());
@@ -292,43 +226,15 @@ fn intersects<'gc>(
         return Ok(false.into());
     };
 
-    let this_left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_right = this_left
-        + this
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let this_bottom = this_top
-        + this
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
+    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
 
-    let other_left = other
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let other_top = other
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let other_right = other_left
-        + other
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let other_bottom = other_top
-        + other
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let other_left = other.get("x", avm, context)?.as_number(avm, context)?;
+    let other_top = other.get("y", avm, context)?.as_number(avm, context)?;
+    let other_right = other_left + other.get("width", avm, context)?.as_number(avm, context)?;
+    let other_bottom = other_top + other.get("height", avm, context)?.as_number(avm, context)?;
 
     Ok((this_left < other_right
         && this_right > other_left
@@ -343,44 +249,18 @@ fn union<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_right = this_left
-        + this
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let this_bottom = this_top
-        + this
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
+    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
 
     let (other_left, other_top, other_width, other_height) =
         if let Some(Value::Object(other)) = args.get(0) {
             (
-                other
-                    .get("x", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
-                other
-                    .get("y", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
-                other
-                    .get("width", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
-                other
-                    .get("height", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
+                other.get("x", avm, context)?.as_number(avm, context)?,
+                other.get("y", avm, context)?.as_number(avm, context)?,
+                other.get("width", avm, context)?.as_number(avm, context)?,
+                other.get("height", avm, context)?.as_number(avm, context)?,
             )
         } else {
             (NAN, NAN, NAN, NAN)
@@ -435,22 +315,10 @@ fn inflate<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
     let horizontal = args
         .get(0)
         .unwrap_or(&Value::Undefined)
@@ -486,22 +354,10 @@ fn inflate_point<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
     let (horizontal, vertical) = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -532,14 +388,8 @@ fn offset<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
     let horizontal = args
         .get(0)
         .unwrap_or(&Value::Undefined)
@@ -563,14 +413,8 @@ fn offset_point<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
     let (horizontal, vertical) = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -589,44 +433,18 @@ fn intersection<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let this_right = this_left
-        + this
-            .get("width", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
-    let this_bottom = this_top
-        + this
-            .get("height", avm, context)?
-            .resolve(avm, context)?
-            .as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
+    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
 
     let (other_left, other_top, other_width, other_height) =
         if let Some(Value::Object(other)) = args.get(0) {
             (
-                other
-                    .get("x", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
-                other
-                    .get("y", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
-                other
-                    .get("width", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
-                other
-                    .get("height", avm, context)?
-                    .resolve(avm, context)?
-                    .as_number(avm, context)?,
+                other.get("x", avm, context)?.as_number(avm, context)?,
+                other.get("y", avm, context)?.as_number(avm, context)?,
+                other.get("width", avm, context)?.as_number(avm, context)?,
+                other.get("height", avm, context)?.as_number(avm, context)?,
             )
         } else {
             (NAN, NAN, NAN, NAN)
@@ -679,14 +497,14 @@ fn equals<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(Value::Object(other)) = args.get(0) {
-        let this_x = this.get("x", avm, context)?.resolve(avm, context)?;
-        let this_y = this.get("y", avm, context)?.resolve(avm, context)?;
-        let this_width = this.get("width", avm, context)?.resolve(avm, context)?;
-        let this_height = this.get("height", avm, context)?.resolve(avm, context)?;
-        let other_x = other.get("x", avm, context)?.resolve(avm, context)?;
-        let other_y = other.get("y", avm, context)?.resolve(avm, context)?;
-        let other_width = other.get("width", avm, context)?.resolve(avm, context)?;
-        let other_height = other.get("height", avm, context)?.resolve(avm, context)?;
+        let this_x = this.get("x", avm, context)?;
+        let this_y = this.get("y", avm, context)?;
+        let this_width = this.get("width", avm, context)?;
+        let this_height = this.get("height", avm, context)?;
+        let other_x = other.get("x", avm, context)?;
+        let other_y = other.get("y", avm, context)?;
+        let other_width = other.get("width", avm, context)?;
+        let other_height = other.get("height", avm, context)?;
         let proto = context.system_prototypes.rectangle;
         let constructor = context.system_prototypes.rectangle_constructor;
         return Ok((this_x == other_x
@@ -706,7 +524,7 @@ fn get_left<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    Ok(this.get("x", avm, context)?.resolve(avm, context)?.into())
+    Ok(this.get("x", avm, context)?.into())
 }
 
 fn set_left<'gc>(
@@ -716,14 +534,8 @@ fn set_left<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let new_left = args.get(0).unwrap_or(&Value::Undefined).to_owned();
-    let old_left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let old_left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
     this.set("x", new_left.clone(), avm, context)?;
     this.set(
         "width",
@@ -740,7 +552,7 @@ fn get_top<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    Ok(this.get("y", avm, context)?.resolve(avm, context)?.into())
+    Ok(this.get("y", avm, context)?.into())
 }
 
 fn set_top<'gc>(
@@ -750,14 +562,8 @@ fn set_top<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let new_top = args.get(0).unwrap_or(&Value::Undefined).to_owned();
-    let old_top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let old_top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
     this.set("y", new_top.clone(), avm, context)?;
     this.set(
         "height",
@@ -774,14 +580,8 @@ fn get_right<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
     Ok((x + width).into())
 }
 
@@ -796,10 +596,7 @@ fn set_right<'gc>(
     } else {
         NAN
     };
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
 
     this.set("width", Value::Number(right - x), avm, context)?;
 
@@ -812,14 +609,8 @@ fn get_bottom<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
     Ok((y + height).into())
 }
 
@@ -834,10 +625,7 @@ fn set_bottom<'gc>(
     } else {
         NAN
     };
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
 
     this.set("height", Value::Number(bottom - y), avm, context)?;
 
@@ -850,8 +638,8 @@ fn get_size<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let width = this.get("width", avm, context)?.resolve(avm, context)?;
-    let height = this.get("height", avm, context)?.resolve(avm, context)?;
+    let width = this.get("width", avm, context)?;
+    let height = this.get("height", avm, context)?;
     let point = construct_new_point(&[width, height], avm, context)?;
     Ok(point.into())
 }
@@ -864,8 +652,8 @@ fn set_size<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let (width, height) = if let Some(Value::Object(object)) = args.get(0) {
         (
-            object.get("x", avm, context)?.resolve(avm, context)?,
-            object.get("y", avm, context)?.resolve(avm, context)?,
+            object.get("x", avm, context)?,
+            object.get("y", avm, context)?,
         )
     } else {
         (Value::Undefined, Value::Undefined)
@@ -883,8 +671,8 @@ fn get_top_left<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.resolve(avm, context)?;
-    let y = this.get("y", avm, context)?.resolve(avm, context)?;
+    let x = this.get("x", avm, context)?;
+    let y = this.get("y", avm, context)?;
     let point = construct_new_point(&[x, y], avm, context)?;
     Ok(point.into())
 }
@@ -897,28 +685,16 @@ fn set_top_left<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let (new_left, new_top) = if let Some(Value::Object(object)) = args.get(0) {
         (
-            object.get("x", avm, context)?.resolve(avm, context)?,
-            object.get("y", avm, context)?.resolve(avm, context)?,
+            object.get("x", avm, context)?,
+            object.get("y", avm, context)?,
         )
     } else {
         (Value::Undefined, Value::Undefined)
     };
-    let old_left = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let old_top = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let old_left = this.get("x", avm, context)?.as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let old_top = this.get("y", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
 
     this.set("x", new_left.clone(), avm, context)?;
     this.set("y", new_top.clone(), avm, context)?;
@@ -944,22 +720,10 @@ fn get_bottom_right<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let height = this.get("height", avm, context)?.as_number(avm, context)?;
     let point = point_to_object((x + width, y + height), avm, context)?;
     Ok(point.into())
 }
@@ -975,14 +739,8 @@ fn set_bottom_right<'gc>(
         avm,
         context,
     )?;
-    let top = this
-        .get("x", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
-    let left = this
-        .get("y", avm, context)?
-        .resolve(avm, context)?
-        .as_number(avm, context)?;
+    let top = this.get("x", avm, context)?.as_number(avm, context)?;
+    let left = this.get("y", avm, context)?.as_number(avm, context)?;
 
     this.set("width", Value::Number(bottom - top), avm, context)?;
     this.set("height", Value::Number(right - left), avm, context)?;

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -825,17 +825,14 @@ pub fn xml_on_data<'gc>(
     let src = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Undefined = src {
-        this.call_method("onLoad", &[false.into()], avm, ac)?
-            .resolve(avm, ac)?;
+        this.call_method("onLoad", &[false.into()], avm, ac)?;
     } else {
         let src = src.coerce_to_string(avm, ac)?;
-        this.call_method("parseXML", &[src.into()], avm, ac)?
-            .resolve(avm, ac)?;
+        this.call_method("parseXML", &[src.into()], avm, ac)?;
 
         this.set("loaded", true.into(), avm, ac)?;
 
-        this.call_method("onLoad", &[true.into()], avm, ac)?
-            .resolve(avm, ac)?;
+        this.call_method("onLoad", &[true.into()], avm, ac)?;
     }
 
     Ok(Value::Undefined.into())

--- a/core/src/avm1/listeners.rs
+++ b/core/src/avm1/listeners.rs
@@ -119,10 +119,7 @@ impl<'gc> Listeners<'gc> {
 
         for i in 0..listeners.length() {
             if let Ok(listener) = listeners.array_element(i).as_object() {
-                if let Ok(handler) = listener
-                    .get(method, avm, context)
-                    .and_then(|v| v.resolve(avm, context))
-                {
+                if let Ok(handler) = listener.get(method, avm, context) {
                     handlers.push((listener, handler));
                 }
             }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -87,7 +87,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error>;
+    ) -> Result<Value<'gc>, Error>;
 
     /// Call a method on the object.
     ///

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -102,7 +102,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         args: &[Value<'gc>],
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         let (method, base_proto) =
             search_prototype(Some((*self).into()), name, avm, context, (*self).into())?;
         let method = method.resolve(avm, context)?;
@@ -112,7 +112,9 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             log::warn!("Object method {} is not callable", name);
         }
 
-        method.call(avm, context, (*self).into(), base_proto, args)
+        method
+            .call(avm, context, (*self).into(), base_proto, args)?
+            .resolve(avm, context)
     }
 
     /// Call a setter defined in this object.

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -48,7 +48,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error>;
+    ) -> Result<Value<'gc>, Error>;
 
     /// Retrieve a named property from the object, or it's prototype.
     fn get(
@@ -58,8 +58,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         if self.has_own_property(avm, context, name) {
-            self.get_local(name, avm, context, (*self).into())?
-                .resolve(avm, context)
+            self.get_local(name, avm, context, (*self).into())
         } else {
             search_prototype(self.proto(), name, avm, context, (*self).into())?
                 .0
@@ -462,7 +461,10 @@ pub fn search_prototype<'gc>(
         }
 
         if proto.unwrap().has_own_property(avm, context, name) {
-            return Ok((proto.unwrap().get_local(name, avm, context, this)?, proto));
+            return Ok((
+                proto.unwrap().get_local(name, avm, context, this)?.into(),
+                proto,
+            ));
         }
 
         proto = proto.unwrap().proto();

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -112,9 +112,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             log::warn!("Object method {} is not callable", name);
         }
 
-        method
-            .call(avm, context, (*self).into(), base_proto, args)?
-            .resolve(avm, context)
+        method.call(avm, context, (*self).into(), base_proto, args)
     }
 
     /// Call a setter defined in this object.

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -238,7 +238,7 @@ impl<'gc> Scope<'gc> {
         this: Object<'gc>,
     ) -> Result<ReturnValue<'gc>, Error> {
         if self.locals().has_property(avm, context, name) {
-            return self.locals().get(name, avm, context);
+            return Ok(self.locals().get(name, avm, context)?.into());
         }
         if let Some(scope) = self.parent() {
             return scope.resolve(name, avm, context, this);

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -341,8 +341,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         _this: Object<'gc>,
         _base_proto: Option<Object<'gc>>,
         _args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
-        Ok(Value::Undefined.into())
+    ) -> Result<Value<'gc>, Error> {
+        Ok(Value::Undefined)
     }
 
     fn call_setter(

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -777,7 +777,7 @@ mod tests {
         with_object(0, |avm, context, object| {
             assert_eq!(
                 object.get("not_defined", avm, context).unwrap(),
-                ReturnValue::Immediate(Value::Undefined)
+                Value::Undefined
             );
         })
     }
@@ -795,13 +795,10 @@ mod tests {
                 .set("natural", "natural".into(), avm, context)
                 .unwrap();
 
-            assert_eq!(
-                object.get("forced", avm, context).unwrap(),
-                ReturnValue::Immediate("forced".into())
-            );
+            assert_eq!(object.get("forced", avm, context).unwrap(), "forced".into());
             assert_eq!(
                 object.get("natural", avm, context).unwrap(),
-                ReturnValue::Immediate("natural".into())
+                "natural".into()
             );
         })
     }
@@ -831,11 +828,11 @@ mod tests {
 
             assert_eq!(
                 object.get("normal", avm, context).unwrap(),
-                ReturnValue::Immediate("replaced".into())
+                "replaced".into()
             );
             assert_eq!(
                 object.get("readonly", avm, context).unwrap(),
-                ReturnValue::Immediate("initial".into())
+                "initial".into()
             );
         })
     }
@@ -851,10 +848,7 @@ mod tests {
             );
 
             assert_eq!(object.delete(avm, context.gc_context, "test"), false);
-            assert_eq!(
-                object.get("test", avm, context).unwrap(),
-                ReturnValue::Immediate("initial".into())
-            );
+            assert_eq!(object.get("test", avm, context).unwrap(), "initial".into());
 
             object
                 .as_script_object()
@@ -863,10 +857,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(object.delete(avm, context.gc_context, "test"), false);
-            assert_eq!(
-                object.get("test", avm, context).unwrap(),
-                ReturnValue::Immediate("replaced".into())
-            );
+            assert_eq!(object.get("test", avm, context).unwrap(), "replaced".into());
         })
     }
 
@@ -885,17 +876,11 @@ mod tests {
                 EnumSet::empty(),
             );
 
-            assert_eq!(
-                object.get("test", avm, context).unwrap(),
-                ReturnValue::Immediate("Virtual!".into())
-            );
+            assert_eq!(object.get("test", avm, context).unwrap(), "Virtual!".into());
 
             // This set should do nothing
             object.set("test", "Ignored!".into(), avm, context).unwrap();
-            assert_eq!(
-                object.get("test", avm, context).unwrap(),
-                ReturnValue::Immediate("Virtual!".into())
-            );
+            assert_eq!(object.get("test", avm, context).unwrap(), "Virtual!".into());
         })
     }
 
@@ -944,19 +929,19 @@ mod tests {
 
             assert_eq!(
                 object.get("virtual", avm, context).unwrap(),
-                ReturnValue::Immediate(Value::Undefined)
+                Value::Undefined
             );
             assert_eq!(
                 object.get("virtual_un", avm, context).unwrap(),
-                ReturnValue::Immediate("Virtual!".into())
+                "Virtual!".into()
             );
             assert_eq!(
                 object.get("stored", avm, context).unwrap(),
-                ReturnValue::Immediate(Value::Undefined)
+                Value::Undefined
             );
             assert_eq!(
                 object.get("stored_un", avm, context).unwrap(),
-                ReturnValue::Immediate("Stored!".into())
+                "Stored!".into()
             );
         })
     }

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -293,16 +293,18 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         if name == "__proto__" {
-            return Ok(self.proto().map_or(Value::Undefined, Value::Object).into());
+            return Ok(self.proto().map_or(Value::Undefined, Value::Object));
         }
 
         if let Some(value) = self.0.read().values.get(name, avm.is_case_sensitive()) {
-            return value.get(avm, context, this, Some((*self).into()));
+            return value
+                .get(avm, context, this, Some((*self).into()))?
+                .resolve(avm, context);
         }
 
-        Ok(Value::Undefined.into())
+        Ok(Value::Undefined)
     }
 
     /// Set a named property on the object.

--- a/core/src/avm1/sound_object.rs
+++ b/core/src/avm1/sound_object.rs
@@ -135,7 +135,7 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base().get_local(name, avm, context, this)
     }
 

--- a/core/src/avm1/sound_object.rs
+++ b/core/src/avm1/sound_object.rs
@@ -156,7 +156,7 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base().call(avm, context, this, base_proto, args)
     }
 

--- a/core/src/avm1/stage_object.rs
+++ b/core/src/avm1/stage_object.rs
@@ -144,7 +144,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base.call(avm, context, this, base_proto, args)
     }
 

--- a/core/src/avm1/stage_object.rs
+++ b/core/src/avm1/stage_object.rs
@@ -69,8 +69,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         // Property search order for DisplayObjects:
         if self.has_own_property(avm, context, name) {
             // 1) Actual properties on the underlying object
-            self.get_local(name, avm, context, (*self).into())?
-                .resolve(avm, context)
+            self.get_local(name, avm, context, (*self).into())
         } else if let Some(property) = props.read().get_by_name(&name) {
             // 2) Display object properties such as _x, _y
             let val = property.get(avm, context, self.display_object)?;
@@ -99,7 +98,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base.get_local(name, avm, context, this)
     }
 

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -131,9 +131,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
             log::warn!("Super method {} is not callable", name);
         }
 
-        method
-            .call(avm, context, child, base_proto, args)?
-            .resolve(avm, context)
+        method.call(avm, context, child, base_proto, args)
     }
 
     fn call_setter(

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -84,8 +84,8 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         _avm: &mut Avm1<'gc>,
         _context: &mut UpdateContext<'_, 'gc, '_>,
         _this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
-        Ok(Value::Undefined.into())
+    ) -> Result<Value<'gc>, Error> {
+        Ok(Value::Undefined)
     }
 
     fn set(

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -106,11 +106,11 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         _this: Object<'gc>,
         _base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         if let Some(constr) = self.super_constr(avm, context)? {
             constr.call(avm, context, self.0.read().child, self.super_proto(), args)
         } else {
-            Ok(Value::Undefined.into())
+            Ok(Value::Undefined)
         }
     }
 

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -120,7 +120,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         args: &[Value<'gc>],
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         let child = self.0.read().child;
         let super_proto = self.super_proto();
         let (method, base_proto) = search_prototype(super_proto, name, avm, context, child)?;
@@ -131,7 +131,9 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
             log::warn!("Super method {} is not callable", name);
         }
 
-        method.call(avm, context, child, base_proto, args)
+        method
+            .call(avm, context, child, base_proto, args)?
+            .resolve(avm, context)
     }
 
     fn call_setter(

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -69,7 +69,6 @@ impl<'gc> SuperObject<'gc> {
         if let Some(super_proto) = self.super_proto() {
             Ok(super_proto
                 .get("__constructor__", avm, context)?
-                .resolve(avm, context)?
                 .as_object()
                 .ok())
         } else {

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -91,7 +91,7 @@ macro_rules! test_method {
                             $(
                                 args.push($arg.into());
                             )*
-                            assert_eq!(function.call(avm, context, object, None, &args)?, ReturnValue::Immediate($out.into()), "{:?} => {:?} in swf {}", args, $out, version);
+                            assert_eq!(function.call(avm, context, object, None, &args)?, $out.into(), "{:?} => {:?} in swf {}", args, $out, version);
                         )*
 
                         Ok(())

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -83,7 +83,7 @@ macro_rules! test_method {
                 for version in &$versions {
                     let _ = with_avm(*version, |avm, context, _root| -> Result<(), Error> {
                         let object = $object(avm, context);
-                        let function = object.get($name, avm, context)?.unwrap_immediate();
+                        let function = object.get($name, avm, context)?;
 
                         $(
                             #[allow(unused_mut)]

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -556,6 +556,19 @@ impl<'gc> Value<'gc> {
         }
     }
 
+    pub fn get(
+        &self,
+        name: &str,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+    ) -> Result<Value<'gc>, Error> {
+        if let Value::Object(object) = self {
+            object.get(name, avm, context)
+        } else {
+            Ok(Value::Undefined)
+        }
+    }
+
     pub fn call(
         &self,
         avm: &mut Avm1<'gc>,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -599,7 +599,7 @@ impl<'gc> Value<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<ReturnValue<'gc>, Error> {
         if let Value::Object(object) = self {
-            object.call_method(name, args, avm, context)
+            Ok(object.call_method(name, args, avm, context)?.into())
         } else {
             Ok(Value::Undefined.into())
         }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -1,5 +1,4 @@
 use crate::avm1::object::search_prototype;
-use crate::avm1::return_value::ReturnValue;
 use crate::avm1::{Avm1, Error, Object, TObject, UpdateContext};
 use std::f64::NAN;
 
@@ -595,11 +594,11 @@ impl<'gc> Value<'gc> {
         args: &[Value<'gc>],
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         if let Value::Object(object) = self {
-            Ok(object.call_method(name, args, avm, context)?.into())
+            object.call_method(name, args, avm, context)
         } else {
-            Ok(Value::Undefined.into())
+            Ok(Value::Undefined)
         }
     }
 }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -585,7 +585,7 @@ impl<'gc> Value<'gc> {
         args: &[Value<'gc>],
     ) -> Result<ReturnValue<'gc>, Error> {
         if let Value::Object(object) = self {
-            object.call(avm, context, this, base_proto, args)
+            Ok(object.call(avm, context, this, base_proto, args)?.into())
         } else {
             Ok(Value::Undefined.into())
         }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -252,7 +252,6 @@ impl<'gc> Value<'gc> {
                 value_of_impl
                     .resolve(avm, context)?
                     .call(avm, context, *object, base_proto, &fake_args)?
-                    .resolve(avm, context)?
             }
             val => val.to_owned(),
         })
@@ -484,7 +483,6 @@ impl<'gc> Value<'gc> {
                 match to_string_impl
                     .resolve(avm, context)?
                     .call(avm, context, object, base_proto, &fake_args)?
-                    .resolve(avm, context)?
                 {
                     Value::String(s) => s,
                     _ => "[type Object]".to_string(),
@@ -583,11 +581,11 @@ impl<'gc> Value<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         if let Value::Object(object) = self {
-            Ok(object.call(avm, context, this, base_proto, args)?.into())
+            object.call(avm, context, this, base_proto, args)
         } else {
-            Ok(Value::Undefined.into())
+            Ok(Value::Undefined)
         }
     }
 

--- a/core/src/avm1/value_object.rs
+++ b/core/src/avm1/value_object.rs
@@ -124,7 +124,7 @@ impl<'gc> TObject<'gc> for ValueObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.0.read().base.get_local(name, avm, context, this)
     }
 

--- a/core/src/avm1/value_object.rs
+++ b/core/src/avm1/value_object.rs
@@ -145,7 +145,7 @@ impl<'gc> TObject<'gc> for ValueObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.0
             .read()
             .base

--- a/core/src/avm1/xml_attributes_object.rs
+++ b/core/src/avm1/xml_attributes_object.rs
@@ -61,13 +61,12 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         _avm: &mut Avm1<'gc>,
         _context: &mut UpdateContext<'_, 'gc, '_>,
         _this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         Ok(self
             .node()
             .attribute_value(&XMLName::from_str(name))
             .map(|s| s.into())
-            .unwrap_or_else(|| Value::Undefined)
-            .into())
+            .unwrap_or_else(|| Value::Undefined))
     }
 
     fn set(

--- a/core/src/avm1/xml_attributes_object.rs
+++ b/core/src/avm1/xml_attributes_object.rs
@@ -91,7 +91,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base().call(avm, context, this, base_proto, args)
     }
 

--- a/core/src/avm1/xml_idmap_object.rs
+++ b/core/src/avm1/xml_idmap_object.rs
@@ -88,7 +88,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base().call(avm, context, this, base_proto, args)
     }
 

--- a/core/src/avm1/xml_idmap_object.rs
+++ b/core/src/avm1/xml_idmap_object.rs
@@ -61,7 +61,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         if let Some(mut node) = self.document().get_node_by_id(name) {
             Ok(node
                 .script_object(context.gc_context, Some(avm.prototypes().xml_node))

--- a/core/src/avm1/xml_object.rs
+++ b/core/src/avm1/xml_object.rs
@@ -62,7 +62,7 @@ impl<'gc> TObject<'gc> for XMLObject<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base().get_local(name, avm, context, this)
     }
 

--- a/core/src/avm1/xml_object.rs
+++ b/core/src/avm1/xml_object.rs
@@ -83,7 +83,7 @@ impl<'gc> TObject<'gc> for XMLObject<'gc> {
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
-    ) -> Result<ReturnValue<'gc>, Error> {
+    ) -> Result<Value<'gc>, Error> {
         self.base().call(avm, context, this, base_proto, args)
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -745,9 +745,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                         }
                     }
                     self.0.write(context.gc_context).object = Some(object);
-                    if let Ok(result) = constructor.call(avm, context, object, None, &[]) {
-                        let _ = result.resolve(avm, context);
-                    }
+                    let _ = constructor.call(avm, context, object, None, &[]);
                     return;
                 }
             }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -729,7 +729,6 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
                 if let Ok(prototype) = constructor
                     .get("prototype", avm, context)
-                    .and_then(|v| v.resolve(avm, context))
                     .and_then(|v| v.as_object())
                 {
                     let object: Object<'gc> = StageObject::for_display_object(
@@ -740,10 +739,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                     .into();
                     if let Some(init_object) = init_object {
                         for key in init_object.get_keys(avm) {
-                            if let Ok(value) = init_object
-                                .get(&key, avm, context)
-                                .and_then(|v| v.resolve(avm, context))
-                            {
+                            if let Ok(value) = init_object.get(&key, avm, context) {
                                 let _ = object.set(&key, value, avm, context);
                             }
                         }
@@ -763,10 +759,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             );
             if let Some(init_object) = init_object {
                 for key in init_object.get_keys(avm) {
-                    if let Ok(value) = init_object
-                        .get(&key, avm, context)
-                        .and_then(|v| v.resolve(avm, context))
-                    {
+                    if let Ok(value) = init_object.get(&key, avm, context) {
                         let _ = object.set(&key, value, avm, context);
                     }
                 }

--- a/core/src/font/text_format.rs
+++ b/core/src/font/text_format.rs
@@ -66,7 +66,7 @@ fn getstr_from_avm1_object<'gc>(
     avm1: &mut Avm1<'gc>,
     uc: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Option<String>, Error> {
-    Ok(match object.get(name, avm1, uc)?.resolve(avm1, uc)? {
+    Ok(match object.get(name, avm1, uc)? {
         Value::Undefined => None,
         Value::Null => None,
         v => Some(v.coerce_to_string(avm1, uc)?),
@@ -79,7 +79,7 @@ fn getfloat_from_avm1_object<'gc>(
     avm1: &mut Avm1<'gc>,
     uc: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Option<f64>, Error> {
-    Ok(match object.get(name, avm1, uc)?.resolve(avm1, uc)? {
+    Ok(match object.get(name, avm1, uc)? {
         Value::Undefined => None,
         Value::Null => None,
         v => Some(v.as_number(avm1, uc)?),
@@ -92,7 +92,7 @@ fn getbool_from_avm1_object<'gc>(
     avm1: &mut Avm1<'gc>,
     uc: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Option<bool>, Error> {
-    Ok(match object.get(name, avm1, uc)?.resolve(avm1, uc)? {
+    Ok(match object.get(name, avm1, uc)? {
         Value::Undefined => None,
         Value::Null => None,
         v => Some(v.as_bool(avm1.current_swf_version())),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -719,9 +719,7 @@ impl Player {
                                     actions.clip,
                                 ),
                             ));
-                            if let Ok(result) = constructor.call(avm, context, object, None, &[]) {
-                                let _ = result.resolve(avm, context);
-                            }
+                            let _ = constructor.call(avm, context, object, None, &[]);
                         }
                     }
                 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -696,7 +696,6 @@ impl Player {
                     ));
                     if let Ok(prototype) = constructor
                         .get("prototype", avm, context)
-                        .and_then(|v| v.resolve(avm, context))
                         .and_then(|v| v.as_object())
                     {
                         if let Value::Object(object) = actions.clip.object() {


### PR DESCRIPTION
This reduces the boilerplate of simply accessing values quite a lot.

This will totally merge conflict with #670 - I'll rebase whichever one comes second :)