### PR TITLE
Remove unnecessary command line window on Windows

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,3 +1,4 @@
+#![windows_subsystem = "windows"]
 #![allow(clippy::unneeded_field_pattern)]
 
 mod audio;


### PR DESCRIPTION
When opening a `.swf` file through a file association (open with), an unnecessary command line window is shown. This removes that extraneous window.