### PR TITLE
Increase polyfill test timeout to 30 seconds

### DIFF
--- a/web/packages/selfhosted/test/polyfill/utils.js
+++ b/web/packages/selfhosted/test/polyfill/utils.js
@@ -11,7 +11,6 @@ function is_ruffle_loaded(browser) {
 
 function wait_for_ruffle(browser) {
     browser.waitUntil(() => is_ruffle_loaded(browser), {
-        timeout: 5000,
         timeoutMsg: "Expected Ruffle to load",
     });
 }

--- a/web/packages/selfhosted/wdio.conf.js
+++ b/web/packages/selfhosted/wdio.conf.js
@@ -94,7 +94,7 @@ exports.config = {
     baseUrl: "http://localhost",
     //
     // Default timeout for all waitFor* commands.
-    waitforTimeout: 10000,
+    waitforTimeout: 30000,
     //
     // Default timeout in milliseconds for request
     // if browser driver or grid doesn't send response


### PR DESCRIPTION
This will fix #657

After extensive research we eventually discovered that all of the time is being spent downloading ruffle.js from the local test server, not actually executing anything. We'll need to investigate that, but we can at least rest a little easy knowing that we're not doing anything crazy bad.