### PR TITLE
audio: Don't panic on unimplemented codecs

### DIFF
--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -390,7 +390,9 @@ fn start<'gc>(
                     envelope: None,
                 },
             );
-            sound_object.set_sound_instance(context.gc_context, Some(sound_instance));
+            if let Ok(sound_instance) = sound_instance {
+                sound_object.set_sound_instance(context.gc_context, Some(sound_instance));
+            }
         } else {
             log::warn!("Sound.start: No sound is attached");
         }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -35,8 +35,11 @@ pub trait AudioBackend {
 
     /// Starts playing a sound instance that is not tied to a MovieClip timeline.
     /// In Flash, this is known as an "Event" sound.
-    fn start_sound(&mut self, sound: SoundHandle, settings: &swf::SoundInfo)
-        -> SoundInstanceHandle;
+    fn start_sound(
+        &mut self,
+        sound: SoundHandle,
+        settings: &swf::SoundInfo,
+    ) -> Result<SoundInstanceHandle, Error>;
 
     fn start_stream(
         &mut self,
@@ -44,7 +47,7 @@ pub trait AudioBackend {
         clip_frame: u16,
         clip_data: crate::tag_utils::SwfSlice,
         handle: &swf::SoundStreamHead,
-    ) -> AudioStreamHandle;
+    ) -> Result<AudioStreamHandle, Error>;
 
     /// Stops a playing sound instance.
     /// No-op if the sound is not playing.
@@ -108,8 +111,8 @@ impl AudioBackend for NullAudioBackend {
         &mut self,
         _sound: SoundHandle,
         _sound_info: &swf::SoundInfo,
-    ) -> SoundInstanceHandle {
-        SoundInstanceHandle::from_raw_parts(0, 0)
+    ) -> Result<SoundInstanceHandle, Error> {
+        Ok(SoundInstanceHandle::from_raw_parts(0, 0))
     }
 
     fn start_stream(
@@ -118,8 +121,8 @@ impl AudioBackend for NullAudioBackend {
         _stream_start_frame: u16,
         _clip_data: crate::tag_utils::SwfSlice,
         _handle: &swf::SoundStreamHead,
-    ) -> AudioStreamHandle {
-        self.streams.insert(())
+    ) -> Result<AudioStreamHandle, Error> {
+        Ok(self.streams.insert(()))
     }
 
     fn stop_sound(&mut self, _sound: SoundInstanceHandle) {}

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -379,7 +379,7 @@ impl<'gc> ButtonData<'gc> {
                 .library_for_movie_mut(self.movie())
                 .get_sound(*id)
             {
-                context.audio.start_sound(sound_handle, sound_info);
+                let _ = context.audio.start_sound(sound_handle, sound_info);
             }
         }
     }


### PR DESCRIPTION
Remove `unimplemented` calls when encountring unsupported codecs
such as Nellymoser. Instead, return an Error that can be
gracefully handled.

Fixes #549. Allows Nanaca Crash to progress further in-game.