### PR TITLE
Reduce amount of errors by coercing values instead of get-or-error

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -241,7 +241,7 @@ impl<'gc> Avm1<'gc> {
             action_context.gc_context,
             Scope::from_global_object(self.globals),
         );
-        let clip_obj = active_clip.object().as_object().unwrap();
+        let clip_obj = active_clip.object().as_object(self, action_context);
         let child_scope = GcCell::allocate(
             action_context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
@@ -272,7 +272,7 @@ impl<'gc> Avm1<'gc> {
             action_context.gc_context,
             Scope::from_global_object(self.globals),
         );
-        let clip_obj = active_clip.object().as_object().unwrap();
+        let clip_obj = active_clip.object().as_object(self, action_context);
         let child_scope = GcCell::allocate(
             action_context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
@@ -684,13 +684,10 @@ impl<'gc> Avm1<'gc> {
         // This means that values like `undefined` will resolve to clips with an instance name of
         // `"undefined"`, for example.
         let path = target.coerce_to_string(self, context)?;
+        let root = start.root();
+        let start = start.object().as_object(self, context);
         Ok(self
-            .resolve_target_path(
-                context,
-                start.root(),
-                start.object().as_object().unwrap(),
-                &path,
-            )?
+            .resolve_target_path(context, root, start, &path)?
             .and_then(|o| o.as_display_object()))
     }
 
@@ -720,7 +717,7 @@ impl<'gc> Avm1<'gc> {
         let mut path = path.as_bytes();
         let (mut object, mut is_slash_path) = if path[0] == b'/' {
             path = &path[1..];
-            (root.object().as_object().unwrap(), true)
+            (root.object().as_object(self, context), true)
         } else {
             (start, false)
         };
@@ -1236,7 +1233,7 @@ impl<'gc> Avm1<'gc> {
             .get_variable(context, &fn_name.as_string()?)?
             .resolve(self, context)?;
 
-        let this = self.target_clip_or_root().object().as_object()?;
+        let this = self.target_clip_or_root().object().as_object(self, context);
         let result = target_fn.call(self, context, this, None, &args)?;
         self.push(result);
 
@@ -1258,17 +1255,9 @@ impl<'gc> Avm1<'gc> {
 
         match method_name {
             Value::Undefined | Value::Null => {
-                let this = self.target_clip_or_root().object();
-                if let Ok(this) = this.as_object() {
-                    let result = object.call(self, context, this, None, &args)?;
-                    self.push(result);
-                } else {
-                    log::warn!(
-                        "Attempted to call constructor of {:?} (missing method name)",
-                        this
-                    );
-                    self.push(Value::Undefined);
-                }
+                let this = self.target_clip_or_root().object().as_object(self, context);
+                let result = object.call(self, context, this, None, &args)?;
+                self.push(result);
             }
             Value::String(name) => {
                 if name.is_empty() {
@@ -1292,10 +1281,12 @@ impl<'gc> Avm1<'gc> {
     }
 
     fn action_cast_op(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) -> Result<(), Error> {
-        let obj = self.pop().as_object()?;
-        let constr = self.pop().as_object()?;
+        let obj = self.pop().as_object(self, context);
+        let constr = self.pop().as_object(self, context);
 
-        let prototype = constr.get("prototype", self, context)?.as_object()?;
+        let prototype = constr
+            .get("prototype", self, context)?
+            .as_object(self, context);
 
         if obj.is_instance_of(self, context, constr, prototype)? {
             self.push(obj);
@@ -1572,15 +1563,14 @@ impl<'gc> Avm1<'gc> {
     }
 
     fn action_extends(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) -> Result<(), Error> {
-        let superclass = self.pop().as_object()?;
-        let subclass = self.pop().as_object()?;
+        let superclass = self.pop().as_object(self, context);
+        let subclass = self.pop().as_object(self, context);
 
         //TODO: What happens if we try to extend an object which has no `prototype`?
         //e.g. `class Whatever extends Object.prototype` or `class Whatever extends 5`
         let super_proto = superclass
             .get("prototype", self, context)?
-            .as_object()
-            .unwrap_or(self.prototypes.object);
+            .as_object(self, context);
 
         let sub_prototype: Object<'gc> =
             ScriptObject::object(context.gc_context, Some(super_proto)).into();
@@ -1738,8 +1728,7 @@ impl<'gc> Avm1<'gc> {
                     .as_movie_clip()
                     .unwrap()
                     .object()
-                    .as_object()
-                    .unwrap();
+                    .as_object(self, context);
                 let (url, opts) = self.locals_into_request_options(
                     context,
                     url,
@@ -1907,17 +1896,19 @@ impl<'gc> Avm1<'gc> {
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<(), Error> {
-        let constr = self.pop().as_object()?;
+        let constr = self.pop().as_object(self, context);
         let count = self.pop().as_i64()?; //TODO: Is this coercion actually performed by Flash?
         let mut interfaces = vec![];
 
         //TODO: If one of the interfaces is not an object, do we leave the
         //whole stack dirty, or...?
         for _ in 0..count {
-            interfaces.push(self.pop().as_object()?);
+            interfaces.push(self.pop().as_object(self, context));
         }
 
-        let mut prototype = constr.get("prototype", self, context)?.as_object()?;
+        let mut prototype = constr
+            .get("prototype", self, context)?
+            .as_object(self, context);
 
         prototype.set_interfaces(context.gc_context, interfaces);
 
@@ -1928,10 +1919,12 @@ impl<'gc> Avm1<'gc> {
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<(), Error> {
-        let constr = self.pop().as_object()?;
-        let obj = self.pop().as_object()?;
+        let constr = self.pop().as_object(self, context);
+        let obj = self.pop().as_object(self, context);
 
-        let prototype = constr.get("prototype", self, context)?.as_object()?;
+        let prototype = constr
+            .get("prototype", self, context)?
+            .as_object(self, context);
         let is_instance_of = obj.is_instance_of(self, context, constr, prototype)?;
 
         self.push(is_instance_of);
@@ -2060,7 +2053,9 @@ impl<'gc> Avm1<'gc> {
         let object = value_object::ValueObject::boxed(self, context, object_val);
         let constructor = object.get(&method_name.as_string()?, self, context)?;
         if let Value::Object(constructor) = constructor {
-            let prototype = constructor.get("prototype", self, context)?.as_object()?;
+            let prototype = constructor
+                .get("prototype", self, context)?
+                .as_object(self, context);
 
             let this = prototype.new(self, context, prototype, &args)?;
 
@@ -2095,7 +2090,7 @@ impl<'gc> Avm1<'gc> {
         let mut ret = Value::Undefined;
 
         if let Ok(fn_name) = fn_name.as_string() {
-            if let Ok(constructor) = self
+            let constructor = self
                 .stack_frames
                 .last()
                 .unwrap()
@@ -2103,24 +2098,19 @@ impl<'gc> Avm1<'gc> {
                 .read()
                 .resolve(fn_name, self, context)?
                 .resolve(self, context)?
-                .as_object()
-            {
-                if let Ok(prototype) = constructor.get("prototype", self, context)?.as_object() {
-                    let this = prototype.new(self, context, prototype, &args)?;
+                .as_object(self, context);
+            let prototype = constructor
+                .get("prototype", self, context)?
+                .as_object(self, context);
+            let this = prototype.new(self, context, prototype, &args)?;
 
-                    this.set("__constructor__", constructor.into(), self, context)?;
-                    if self.current_swf_version() < 7 {
-                        this.set("constructor", constructor.into(), self, context)?;
-                    }
-
-                    constructor.call(self, context, this, None, &args)?;
-                    ret = this.into();
-                } else {
-                    log::warn!("NewObject: Constructor has invalid prototype: {}", fn_name);
-                }
-            } else {
-                log::warn!("NewObject: Object is not a function: {}", fn_name);
+            this.set("__constructor__", constructor.into(), self, context)?;
+            if self.current_swf_version() < 7 {
+                this.set("constructor", constructor.into(), self, context)?;
             }
+
+            constructor.call(self, context, this, None, &args)?;
+            ret = this.into();
         } else {
             log::warn!("NewObject: Expected String for object name: {:?}", fn_name);
         }
@@ -2264,17 +2254,8 @@ impl<'gc> Avm1<'gc> {
         let name_val = self.pop();
         let name = name_val.coerce_to_string(self, context)?;
 
-        let object = self.pop();
-        if let Ok(object) = object.as_object() {
-            object.set(&name, value, self, context)?;
-        } else {
-            log::warn!(
-                "Attempted to set member {} of {:?} to {:?}",
-                name,
-                object,
-                value
-            );
-        }
+        let object = self.pop().as_object(self, context);
+        object.set(&name, value, self, context)?;
 
         Ok(())
     }
@@ -2329,15 +2310,12 @@ impl<'gc> Avm1<'gc> {
     ) -> Result<(), Error> {
         let base_clip = self.base_clip();
         let new_target_clip;
+        let root = base_clip.root();
+        let start = base_clip.object().as_object(self, context);
         if target.is_empty() {
             new_target_clip = Some(base_clip);
         } else if let Some(clip) = self
-            .resolve_target_path(
-                context,
-                base_clip.root(),
-                base_clip.object().as_object().unwrap(),
-                target,
-            )?
+            .resolve_target_path(context, root, start, target)?
             .and_then(|o| o.as_display_object())
         {
             new_target_clip = Some(clip);
@@ -2361,8 +2339,7 @@ impl<'gc> Avm1<'gc> {
             .target_clip()
             .unwrap_or_else(|| sf.base_clip().root())
             .object()
-            .as_object()
-            .unwrap();
+            .as_object(self, context);
 
         sf.set_scope(Scope::new_target_scope(scope, clip_obj, context.gc_context));
         Ok(())
@@ -2409,8 +2386,7 @@ impl<'gc> Avm1<'gc> {
             .target_clip()
             .unwrap_or_else(|| sf.base_clip().root())
             .object()
-            .as_object()
-            .unwrap();
+            .as_object(self, context);
         sf.set_scope(Scope::new_target_scope(scope, clip_obj, context.gc_context));
         Ok(())
     }
@@ -2575,10 +2551,10 @@ impl<'gc> Avm1<'gc> {
 
     fn action_target_path(
         &mut self,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<(), Error> {
         // TODO(Herschel)
-        let _clip = self.pop().as_object()?;
+        let _clip = self.pop().as_object(self, context);
         self.push(Value::Undefined);
         Err("Unimplemented action: TargetPath".into())
     }
@@ -2664,7 +2640,7 @@ impl<'gc> Avm1<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         actions: &[u8],
     ) -> Result<(), Error> {
-        let object = self.pop().as_object()?;
+        let object = self.pop().as_object(self, context);
         let block = self
             .current_stack_frame()
             .unwrap()

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -1233,7 +1233,10 @@ impl<'gc> Avm1<'gc> {
             .get_variable(context, &fn_name.as_string()?)?
             .resolve(self, context)?;
 
-        let this = self.target_clip_or_root().object().coerce_to_object(self, context);
+        let this = self
+            .target_clip_or_root()
+            .object()
+            .coerce_to_object(self, context);
         let result = target_fn.call(self, context, this, None, &args)?;
         self.push(result);
 
@@ -1255,7 +1258,10 @@ impl<'gc> Avm1<'gc> {
 
         match method_name {
             Value::Undefined | Value::Null => {
-                let this = self.target_clip_or_root().object().coerce_to_object(self, context);
+                let this = self
+                    .target_clip_or_root()
+                    .object()
+                    .coerce_to_object(self, context);
                 let result = object.call(self, context, this, None, &args)?;
                 self.push(result);
             }

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -11,6 +11,7 @@ use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::tag_utils::SwfSlice;
 use enumset::EnumSet;
 use gc_arena::{Collect, CollectionContext, GcCell, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 use swf::avm1::types::FunctionParam;
 
@@ -623,8 +624,8 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.base.get_keys(avm)
     }
 
-    fn as_string(&self) -> String {
-        "[type Function]".to_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Borrowed("[type Function]")
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -90,7 +90,7 @@ pub fn is_nan<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(val) = args.get(0) {
-        Ok(val.as_number(avm, action_context)?.is_nan().into())
+        Ok(val.coerce_to_f64(avm, action_context)?.is_nan().into())
     } else {
         Ok(true.into())
     }

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -45,14 +45,17 @@ pub fn getURL<'a, 'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     //TODO: Error behavior if no arguments are present
     if let Some(url_val) = args.get(0) {
-        let swf_version = avm.current_swf_version();
-        let url = url_val.clone().into_string(swf_version);
+        let url = url_val.coerce_to_string(avm, context)?;
         if let Some(fscommand) = fscommand::parse(&url) {
             fscommand::handle(fscommand, avm, context);
             return Ok(Value::Undefined.into());
         }
 
-        let window = args.get(1).map(|v| v.clone().into_string(swf_version));
+        let window = if let Some(window) = args.get(1) {
+            Some(window.coerce_to_string(avm, context)?.to_string())
+        } else {
+            None
+        };
         let method = match args.get(2) {
             Some(Value::String(s)) if s == "GET" => Some(NavigationMethod::GET),
             Some(Value::String(s)) if s == "POST" => Some(NavigationMethod::POST),
@@ -60,7 +63,9 @@ pub fn getURL<'a, 'gc>(
         };
         let vars_method = method.map(|m| (m, avm.locals_into_form_values(context)));
 
-        context.navigator.navigate_to_url(url, window, vars_method);
+        context
+            .navigator
+            .navigate_to_url(url.to_string(), window, vars_method);
     }
 
     Ok(Value::Undefined.into())

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -92,7 +92,7 @@ pub fn constructor<'gc>(
 
     if args.len() == 1 {
         let arg = args.get(0).unwrap();
-        if let Ok(length) = arg.as_number(avm, context) {
+        if let Ok(length) = arg.coerce_to_f64(avm, context) {
             if length >= 0.0 {
                 this.set_length(context.gc_context, length as usize);
                 consumed = true;
@@ -270,12 +270,12 @@ pub fn slice<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let start = args
         .get(0)
-        .and_then(|v| v.as_number(avm, context).ok())
+        .and_then(|v| v.coerce_to_f64(avm, context).ok())
         .map(|v| make_index_absolute(v as i32, this.length()))
         .unwrap_or(0);
     let end = args
         .get(1)
-        .and_then(|v| v.as_number(avm, context).ok())
+        .and_then(|v| v.coerce_to_f64(avm, context).ok())
         .map(|v| make_index_absolute(v as i32, this.length()))
         .unwrap_or_else(|| this.length());
 
@@ -306,12 +306,12 @@ pub fn splice<'gc>(
     let old_length = this.length();
     let start = args
         .get(0)
-        .and_then(|v| v.as_number(avm, context).ok())
+        .and_then(|v| v.coerce_to_f64(avm, context).ok())
         .map(|v| make_index_absolute(v as i32, old_length))
         .unwrap_or(0);
     let count = args
         .get(1)
-        .and_then(|v| v.as_number(avm, context).ok())
+        .and_then(|v| v.coerce_to_f64(avm, context).ok())
         .map(|v| v as i32)
         .unwrap_or(old_length as i32);
     if count < 0 {

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -205,7 +205,7 @@ fn set_transform<'gc>(
         let transform = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .as_object(avm, context);
+            .coerce_to_object(avm, context);
         set_color_mult(avm, context, transform, "ra", &mut color_transform.r_mult)?;
         set_color_mult(avm, context, transform, "ga", &mut color_transform.g_mult)?;
         set_color_mult(avm, context, transform, "ba", &mut color_transform.b_mult)?;

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -142,7 +142,7 @@ fn set_rgb<'gc>(
         let rgb = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .as_number(avm, context)? as i32;
+            .coerce_to_f64(avm, context)? as i32;
         let r = (((rgb >> 16) & 0xff) as f32) / 255.0;
         let g = (((rgb >> 8) & 0xff) as f32) / 255.0;
         let b = ((rgb & 0xff) as f32) / 255.0;
@@ -177,7 +177,7 @@ fn set_transform<'gc>(
         if transform.has_own_property(avm, context, property) {
             let n = transform
                 .get(property, avm, context)?
-                .as_number(avm, context)?;
+                .coerce_to_f64(avm, context)?;
             *out = f32::from(crate::avm1::value::f64_to_wrapping_i16(n * 2.56)) / 256.0
         }
         Ok(())
@@ -194,7 +194,7 @@ fn set_transform<'gc>(
         if transform.has_own_property(avm, context, property) {
             let n = transform
                 .get(property, avm, context)?
-                .as_number(avm, context)?;
+                .coerce_to_f64(avm, context)?;
             *out = f32::from(crate::avm1::value::f64_to_wrapping_i16(n)) / 255.0
         }
         Ok(())

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -202,16 +202,18 @@ fn set_transform<'gc>(
 
     if let Some(target) = target(avm, context, this)? {
         let mut color_transform = target.color_transform_mut(context.gc_context);
-        if let Ok(transform) = args.get(0).unwrap_or(&Value::Undefined).as_object() {
-            set_color_mult(avm, context, transform, "ra", &mut color_transform.r_mult)?;
-            set_color_mult(avm, context, transform, "ga", &mut color_transform.g_mult)?;
-            set_color_mult(avm, context, transform, "ba", &mut color_transform.b_mult)?;
-            set_color_mult(avm, context, transform, "aa", &mut color_transform.a_mult)?;
-            set_color_add(avm, context, transform, "rb", &mut color_transform.r_add)?;
-            set_color_add(avm, context, transform, "gb", &mut color_transform.g_add)?;
-            set_color_add(avm, context, transform, "bb", &mut color_transform.b_add)?;
-            set_color_add(avm, context, transform, "ab", &mut color_transform.a_add)?;
-        }
+        let transform = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .as_object(avm, context);
+        set_color_mult(avm, context, transform, "ra", &mut color_transform.r_mult)?;
+        set_color_mult(avm, context, transform, "ga", &mut color_transform.g_mult)?;
+        set_color_mult(avm, context, transform, "ba", &mut color_transform.b_mult)?;
+        set_color_mult(avm, context, transform, "aa", &mut color_transform.a_mult)?;
+        set_color_add(avm, context, transform, "rb", &mut color_transform.r_add)?;
+        set_color_add(avm, context, transform, "gb", &mut color_transform.g_add)?;
+        set_color_add(avm, context, transform, "bb", &mut color_transform.b_add)?;
+        set_color_add(avm, context, transform, "ab", &mut color_transform.a_add)?;
     }
 
     Ok(Value::Undefined.into())

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -69,18 +69,25 @@ pub fn define_display_object_proto<'gc>(
     object.add_property(
         gc_context,
         "_parent",
-        Executable::Native(|_avm, _context, this, _args| {
-            Ok(this
-                .as_display_object()
-                .and_then(|mc| mc.parent())
-                .and_then(|dn| dn.object().as_object().ok())
-                .map(Value::Object)
-                .unwrap_or(Value::Undefined)
-                .into())
-        }),
+        Executable::Native(get_parent),
         None,
         DontDelete | ReadOnly | DontEnum,
     );
+}
+
+pub fn get_parent<'gc>(
+    avm: &mut Avm1<'gc>,
+    context: &mut UpdateContext<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<ReturnValue<'gc>, Error> {
+    Ok(this
+        .as_display_object()
+        .and_then(|mc| mc.parent())
+        .map(|dn| dn.object().as_object(avm, context))
+        .map(Value::Object)
+        .unwrap_or(Value::Undefined)
+        .into())
 }
 
 pub fn get_depth<'gc>(

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -84,7 +84,7 @@ pub fn get_parent<'gc>(
     Ok(this
         .as_display_object()
         .and_then(|mc| mc.parent())
-        .map(|dn| dn.object().as_object(avm, context))
+        .map(|dn| dn.object().coerce_to_object(avm, context))
         .map(Value::Object)
         .unwrap_or(Value::Undefined)
         .into())

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -60,7 +60,7 @@ pub fn apply<'gc>(
     };
 
     while child_args.len() < length {
-        let args = args_object.as_object(avm, action_context);
+        let args = args_object.coerce_to_object(avm, action_context);
         let next_arg = args.get(&format!("{}", child_args.len()), avm, action_context)?;
 
         child_args.push(next_arg);

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -55,7 +55,7 @@ pub fn apply<'gc>(
     let length = match args_object {
         Value::Object(a) => a
             .get("length", avm, action_context)?
-            .as_number(avm, action_context)? as usize,
+            .coerce_to_f64(avm, action_context)? as usize,
         _ => 0,
     };
 

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -60,7 +60,7 @@ pub fn apply<'gc>(
     };
 
     while child_args.len() < length {
-        let args = args_object.as_object()?;
+        let args = args_object.as_object(avm, action_context);
         let next_arg = args.get(&format!("{}", child_args.len()), avm, action_context)?;
 
         child_args.push(next_arg);

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -14,7 +14,7 @@ pub fn is_down<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(key) = args
         .get(0)
-        .and_then(|v| v.as_number(avm, context).ok())
+        .and_then(|v| v.coerce_to_f64(avm, context).ok())
         .and_then(|k| KeyCode::try_from(k as u8).ok())
     {
         Ok(context.input.is_key_down(key).into())

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -13,7 +13,7 @@ macro_rules! wrap_std {
                 $name,
                 |avm, context, _this, args| -> Result<ReturnValue<'gc>, Error> {
                     if let Some(input) = args.get(0) {
-                        Ok($std(input.as_number(avm, context)?).into())
+                        Ok($std(input.coerce_to_f64(avm, context)?).into())
                     } else {
                         Ok(NAN.into())
                     }
@@ -35,11 +35,11 @@ fn atan2<'gc>(
     if let Some(y) = args.get(0) {
         if let Some(x) = args.get(1) {
             return Ok(y
-                .as_number(avm, context)?
-                .atan2(x.as_number(avm, context)?)
+                .coerce_to_f64(avm, context)?
+                .atan2(x.coerce_to_f64(avm, context)?)
                 .into());
         } else {
-            return Ok(y.as_number(avm, context)?.atan2(0.0).into());
+            return Ok(y.coerce_to_f64(avm, context)?.atan2(0.0).into());
         }
     }
     Ok(NAN.into())
@@ -53,11 +53,11 @@ fn pow<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(y) = args.get(0) {
         if let Some(x) = args.get(1) {
-            let x = x.as_number(avm, context)?;
+            let x = x.coerce_to_f64(avm, context)?;
             if x.is_nan() {
                 return Ok(NAN.into());
             }
-            return Ok(y.as_number(avm, context)?.powf(x).into());
+            return Ok(y.coerce_to_f64(avm, context)?.powf(x).into());
         }
     }
     Ok(NAN.into())
@@ -70,7 +70,7 @@ fn round<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(x) = args.get(0) {
-        let x = x.as_number(avm, context)?;
+        let x = x.coerce_to_f64(avm, context)?;
         // Note that Flash Math.round always rounds toward infinity,
         // unlike Rust f32::round which rounds away from zero.
         let ret = (x + 0.5).floor();
@@ -90,9 +90,9 @@ fn max<'gc>(
             match a.abstract_lt(b.to_owned(), avm, context)? {
                 Value::Bool(value) => {
                     if value {
-                        Ok(b.as_number(avm, context)?.into())
+                        Ok(b.coerce_to_f64(avm, context)?.into())
                     } else {
-                        Ok(a.as_number(avm, context)?.into())
+                        Ok(a.coerce_to_f64(avm, context)?.into())
                     }
                 }
                 _ => Ok(NAN.into()),
@@ -115,9 +115,9 @@ fn min<'gc>(
             match a.abstract_lt(b.to_owned(), avm, context)? {
                 Value::Bool(value) => {
                     if value {
-                        Ok(a.as_number(avm, context)?.into())
+                        Ok(a.coerce_to_f64(avm, context)?.into())
                     } else {
-                        Ok(b.as_number(avm, context)?.into())
+                        Ok(b.coerce_to_f64(avm, context)?.into())
                     }
                 }
                 _ => Ok(NAN.into()),

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -13,12 +13,34 @@ pub fn value_to_matrix<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Matrix, Error> {
-    let a = value.get("a", avm, context)?.as_number(avm, context)? as f32;
-    let b = value.get("b", avm, context)?.as_number(avm, context)? as f32;
-    let c = value.get("c", avm, context)?.as_number(avm, context)? as f32;
-    let d = value.get("d", avm, context)?.as_number(avm, context)? as f32;
-    let tx = Twips::from_pixels(value.get("tx", avm, context)?.as_number(avm, context)?);
-    let ty = Twips::from_pixels(value.get("ty", avm, context)?.as_number(avm, context)?);
+    let a = value
+        .coerce_to_object(avm, context)
+        .get("a", avm, context)?
+        .as_number(avm, context)? as f32;
+    let b = value
+        .coerce_to_object(avm, context)
+        .get("b", avm, context)?
+        .as_number(avm, context)? as f32;
+    let c = value
+        .coerce_to_object(avm, context)
+        .get("c", avm, context)?
+        .as_number(avm, context)? as f32;
+    let d = value
+        .coerce_to_object(avm, context)
+        .get("d", avm, context)?
+        .as_number(avm, context)? as f32;
+    let tx = Twips::from_pixels(
+        value
+            .coerce_to_object(avm, context)
+            .get("tx", avm, context)?
+            .as_number(avm, context)?,
+    );
+    let ty = Twips::from_pixels(
+        value
+            .coerce_to_object(avm, context)
+            .get("ty", avm, context)?
+            .as_number(avm, context)?,
+    );
 
     Ok(Matrix { a, b, c, d, tx, ty })
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -16,30 +16,30 @@ pub fn value_to_matrix<'gc>(
     let a = value
         .coerce_to_object(avm, context)
         .get("a", avm, context)?
-        .as_number(avm, context)? as f32;
+        .coerce_to_f64(avm, context)? as f32;
     let b = value
         .coerce_to_object(avm, context)
         .get("b", avm, context)?
-        .as_number(avm, context)? as f32;
+        .coerce_to_f64(avm, context)? as f32;
     let c = value
         .coerce_to_object(avm, context)
         .get("c", avm, context)?
-        .as_number(avm, context)? as f32;
+        .coerce_to_f64(avm, context)? as f32;
     let d = value
         .coerce_to_object(avm, context)
         .get("d", avm, context)?
-        .as_number(avm, context)? as f32;
+        .coerce_to_f64(avm, context)? as f32;
     let tx = Twips::from_pixels(
         value
             .coerce_to_object(avm, context)
             .get("tx", avm, context)?
-            .as_number(avm, context)?,
+            .coerce_to_f64(avm, context)?,
     );
     let ty = Twips::from_pixels(
         value
             .coerce_to_object(avm, context)
             .get("ty", avm, context)?
-            .as_number(avm, context)?,
+            .coerce_to_f64(avm, context)?,
     );
 
     Ok(Matrix { a, b, c, d, tx, ty })
@@ -55,11 +55,11 @@ pub fn gradient_object_to_matrix<'gc>(
         .coerce_to_string(avm, context)?
         == "box"
     {
-        let width = object.get("w", avm, context)?.as_number(avm, context)?;
-        let height = object.get("h", avm, context)?.as_number(avm, context)?;
-        let rotation = object.get("r", avm, context)?.as_number(avm, context)?;
-        let tx = object.get("x", avm, context)?.as_number(avm, context)?;
-        let ty = object.get("y", avm, context)?.as_number(avm, context)?;
+        let width = object.get("w", avm, context)?.coerce_to_f64(avm, context)?;
+        let height = object.get("h", avm, context)?.coerce_to_f64(avm, context)?;
+        let rotation = object.get("r", avm, context)?.coerce_to_f64(avm, context)?;
+        let tx = object.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+        let ty = object.get("y", avm, context)?.coerce_to_f64(avm, context)?;
         Ok(Matrix::create_gradient_box(
             width as f32,
             height as f32,
@@ -78,12 +78,20 @@ pub fn object_to_matrix<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<Matrix, Error> {
-    let a = object.get("a", avm, context)?.as_number(avm, context)? as f32;
-    let b = object.get("b", avm, context)?.as_number(avm, context)? as f32;
-    let c = object.get("c", avm, context)?.as_number(avm, context)? as f32;
-    let d = object.get("d", avm, context)?.as_number(avm, context)? as f32;
-    let tx = Twips::from_pixels(object.get("tx", avm, context)?.as_number(avm, context)?);
-    let ty = Twips::from_pixels(object.get("ty", avm, context)?.as_number(avm, context)?);
+    let a = object.get("a", avm, context)?.coerce_to_f64(avm, context)? as f32;
+    let b = object.get("b", avm, context)?.coerce_to_f64(avm, context)? as f32;
+    let c = object.get("c", avm, context)?.coerce_to_f64(avm, context)? as f32;
+    let d = object.get("d", avm, context)?.coerce_to_f64(avm, context)? as f32;
+    let tx = Twips::from_pixels(
+        object
+            .get("tx", avm, context)?
+            .coerce_to_f64(avm, context)?,
+    );
+    let ty = Twips::from_pixels(
+        object
+            .get("ty", avm, context)?
+            .coerce_to_f64(avm, context)?,
+    );
 
     Ok(Matrix { a, b, c, d, tx, ty })
 }
@@ -195,11 +203,11 @@ fn scale<'gc>(
     let scale_x = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let scale_y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let mut matrix = Matrix::scale(scale_x as f32, scale_y as f32);
     matrix *= object_to_matrix(this, avm, context)?;
     apply_matrix_to_object(matrix, this, avm, context)?;
@@ -216,7 +224,7 @@ fn rotate<'gc>(
     let angle = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let mut matrix = Matrix::rotate(angle as f32);
     matrix *= object_to_matrix(this, avm, context)?;
     apply_matrix_to_object(matrix, this, avm, context)?;
@@ -233,11 +241,11 @@ fn translate<'gc>(
     let translate_x = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let translate_y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let mut matrix = Matrix::translate(
         Twips::from_pixels(translate_x),
         Twips::from_pixels(translate_y),
@@ -288,23 +296,23 @@ fn create_box<'gc>(
     let scale_x = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let scale_y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     // [NA] Docs say rotation is optional and defaults to 0, but that's wrong?
     let rotation = args
         .get(2)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let translate_x = if let Some(value) = args.get(3) {
-        value.as_number(avm, context)?
+        value.coerce_to_f64(avm, context)?
     } else {
         0.0
     };
     let translate_y = if let Some(value) = args.get(4) {
-        value.as_number(avm, context)?
+        value.coerce_to_f64(avm, context)?
     } else {
         0.0
     };
@@ -330,23 +338,23 @@ fn create_gradient_box<'gc>(
     let width = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let height = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let rotation = if let Some(value) = args.get(2) {
-        value.as_number(avm, context)?
+        value.coerce_to_f64(avm, context)?
     } else {
         0.0
     };
     let translate_x = if let Some(value) = args.get(3) {
-        value.as_number(avm, context)?
+        value.coerce_to_f64(avm, context)?
     } else {
         0.0
     };
     let translate_y = if let Some(value) = args.get(4) {
-        value.as_number(avm, context)?
+        value.coerce_to_f64(avm, context)?
     } else {
         0.0
     };

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -369,26 +369,23 @@ fn to_string<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let a = this
-        .get("a", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let b = this
-        .get("b", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let c = this
-        .get("c", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let d = this
-        .get("d", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let tx = this
-        .get("tx", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let ty = this
-        .get("ty", avm, context)?
-        .coerce_to_string(avm, context)?;
+    let a = this.get("a", avm, context)?;
+    let b = this.get("b", avm, context)?;
+    let c = this.get("c", avm, context)?;
+    let d = this.get("d", avm, context)?;
+    let tx = this.get("tx", avm, context)?;
+    let ty = this.get("ty", avm, context)?;
 
-    Ok(format!("(a={}, b={}, c={}, d={}, tx={}, ty={})", a, b, c, d, tx, ty).into())
+    Ok(format!(
+        "(a={}, b={}, c={}, d={}, tx={}, ty={})",
+        a.coerce_to_string(avm, context)?,
+        b.coerce_to_string(avm, context)?,
+        c.coerce_to_string(avm, context)?,
+        d.coerce_to_string(avm, context)?,
+        tx.coerce_to_string(avm, context)?,
+        ty.coerce_to_string(avm, context)?
+    )
+    .into())
 }
 
 pub fn create_matrix_object<'gc>(

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -55,8 +55,8 @@ pub fn hit_test<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if args.len() > 1 {
-        let x = args.get(0).unwrap().as_number(avm, context)?;
-        let y = args.get(1).unwrap().as_number(avm, context)?;
+        let x = args.get(0).unwrap().coerce_to_f64(avm, context)?;
+        let y = args.get(1).unwrap().coerce_to_f64(avm, context)?;
         let shape = args
             .get(2)
             .map(|v| v.as_bool(avm.current_swf_version()))
@@ -148,11 +148,11 @@ fn line_style<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let Some(width) = args.get(0) {
-        let width = Twips::from_pixels(width.as_number(avm, context)?.min(255.0).max(0.0));
+        let width = Twips::from_pixels(width.coerce_to_f64(avm, context)?.min(255.0).max(0.0));
         let color = if let Some(rgb) = args.get(1) {
             let rgb = rgb.coerce_to_u32(avm, context)?;
             let alpha = if let Some(alpha) = args.get(2) {
-                alpha.as_number(avm, context)?.min(100.0).max(0.0)
+                alpha.coerce_to_f64(avm, context)?.min(100.0).max(0.0)
             } else {
                 100.0
             } as f32
@@ -191,7 +191,9 @@ fn line_style<'gc>(
         {
             Some("miter") => {
                 if let Some(limit) = args.get(7) {
-                    LineJoinStyle::Miter(limit.as_number(avm, context)?.max(0.0).min(255.0) as f32)
+                    LineJoinStyle::Miter(
+                        limit.coerce_to_f64(avm, context)?.max(0.0).min(255.0) as f32
+                    )
                 } else {
                     LineJoinStyle::Miter(3.0)
                 }
@@ -229,7 +231,7 @@ fn begin_fill<'gc>(
     if let Some(rgb) = args.get(0) {
         let rgb = rgb.coerce_to_u32(avm, context)?;
         let alpha = if let Some(alpha) = args.get(1) {
-            alpha.as_number(avm, context)?.min(100.0).max(0.0)
+            alpha.coerce_to_f64(avm, context)?.min(100.0).max(0.0)
         } else {
             100.0
         } as f32
@@ -271,9 +273,9 @@ fn begin_gradient_fill<'gc>(
         }
         let mut records = Vec::with_capacity(colors.len());
         for i in 0..colors.len() {
-            let ratio = ratios[i].as_number(avm, context)?.min(255.0).max(0.0);
+            let ratio = ratios[i].coerce_to_f64(avm, context)?.min(255.0).max(0.0);
             let rgb = colors[i].coerce_to_u32(avm, context)?;
-            let alpha = alphas[i].as_number(avm, context)?.min(100.0).max(0.0);
+            let alpha = alphas[i].coerce_to_f64(avm, context)?.min(100.0).max(0.0);
             records.push(GradientRecord {
                 ratio: ratio as u8,
                 color: Color::from_rgb(rgb, (alpha / 100.0 * 255.0) as u8),
@@ -310,7 +312,7 @@ fn begin_gradient_fill<'gc>(
                 if let Some(focal_point) = args.get(7) {
                     FillStyle::FocalGradient {
                         gradient,
-                        focal_point: focal_point.as_number(avm, context)? as f32,
+                        focal_point: focal_point.coerce_to_f64(avm, context)? as f32,
                     }
                 } else {
                     FillStyle::RadialGradient(gradient)
@@ -335,8 +337,8 @@ fn move_to<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let (Some(x), Some(y)) = (args.get(0), args.get(1)) {
-        let x = x.as_number(avm, context)?;
-        let y = y.as_number(avm, context)?;
+        let x = x.coerce_to_f64(avm, context)?;
+        let y = y.coerce_to_f64(avm, context)?;
         movie_clip.draw_command(
             context,
             DrawCommand::MoveTo {
@@ -355,8 +357,8 @@ fn line_to<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     if let (Some(x), Some(y)) = (args.get(0), args.get(1)) {
-        let x = x.as_number(avm, context)?;
-        let y = y.as_number(avm, context)?;
+        let x = x.coerce_to_f64(avm, context)?;
+        let y = y.coerce_to_f64(avm, context)?;
         movie_clip.draw_command(
             context,
             DrawCommand::LineTo {
@@ -377,10 +379,10 @@ fn curve_to<'gc>(
     if let (Some(x1), Some(y1), Some(x2), Some(y2)) =
         (args.get(0), args.get(1), args.get(2), args.get(3))
     {
-        let x1 = x1.as_number(avm, context)?;
-        let y1 = y1.as_number(avm, context)?;
-        let x2 = x2.as_number(avm, context)?;
-        let y2 = y2.as_number(avm, context)?;
+        let x1 = x1.coerce_to_f64(avm, context)?;
+        let y1 = y1.coerce_to_f64(avm, context)?;
+        let x2 = x2.coerce_to_f64(avm, context)?;
+        let y2 = y2.coerce_to_f64(avm, context)?;
         movie_clip.draw_command(
             context,
             DrawCommand::CurveTo {
@@ -508,27 +510,27 @@ fn create_text_field<'gc>(
         .get(1)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let x = args
         .get(2)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let y = args
         .get(3)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let width = args
         .get(4)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let height = args
         .get(5)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
 
     let mut text_field: DisplayObject<'gc> =
         EditText::new(context, movie, x, y, width, height).into();

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -76,7 +76,7 @@ pub fn hit_test<'gc>(
         let other = args
             .get(0)
             .unwrap()
-            .as_object(avm, context)
+            .coerce_to_object(avm, context)
             .as_display_object();
         if let Some(other) = other {
             return Ok(other
@@ -259,10 +259,10 @@ fn begin_gradient_fill<'gc>(
         args.get(4),
     ) {
         let method = method.clone().coerce_to_string(avm, context)?;
-        let colors = colors.as_object(avm, context).array();
-        let alphas = alphas.as_object(avm, context).array();
-        let ratios = ratios.as_object(avm, context).array();
-        let matrix_object = matrix.as_object(avm, context);
+        let colors = colors.coerce_to_object(avm, context).array();
+        let alphas = alphas.coerce_to_object(avm, context).array();
+        let ratios = ratios.coerce_to_object(avm, context).array();
+        let matrix_object = matrix.coerce_to_object(avm, context);
         if colors.len() != alphas.len() || colors.len() != ratios.len() {
             log::warn!(
                 "beginGradientFill() received different sized arrays for colors, alphas and ratios"
@@ -448,11 +448,11 @@ fn attach_movie<'gc>(
         // Set name and attach to parent.
         new_clip.set_name(context.gc_context, &new_instance_name);
         movie_clip.add_child_from_avm(context, new_clip, depth);
-        let init_object = init_object.map(|v| v.as_object(avm, context));
+        let init_object = init_object.map(|v| v.coerce_to_object(avm, context));
         new_clip.post_instantiation(avm, context, new_clip, init_object, true);
         new_clip.run_frame(avm, context);
 
-        Ok(new_clip.object().as_object(avm, context).into())
+        Ok(new_clip.object().coerce_to_object(avm, context).into())
     } else {
         log::warn!("Unable to attach '{}'", export_name);
         Ok(Value::Undefined.into())
@@ -602,11 +602,11 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
         // TODO: Any other properties we should copy...?
         // Definitely not ScriptObject properties.
 
-        let init_object = init_object.map(|v| v.as_object(avm, context));
+        let init_object = init_object.map(|v| v.coerce_to_object(avm, context));
         new_clip.post_instantiation(avm, context, new_clip, init_object, true);
         new_clip.run_frame(avm, context);
 
-        Ok(new_clip.object().as_object(avm, context).into())
+        Ok(new_clip.object().coerce_to_object(avm, context).into())
     } else {
         log::warn!("Unable to duplicate clip '{}'", movie_clip.name());
         Ok(Value::Undefined.into())
@@ -1008,7 +1008,7 @@ fn load_variables<'gc>(
     let method = NavigationMethod::from_method_str(&method.coerce_to_string(avm, context)?);
     let (url, opts) = avm.locals_into_request_options(context, url, method);
     let fetch = context.navigator.fetch(url, opts);
-    let target = target.object().as_object(avm, context);
+    let target = target.object().coerce_to_object(avm, context);
     let process =
         context
             .load_manager

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -424,7 +424,9 @@ fn attach_movie<'gc>(
         [export_name, new_instance_name, depth] => (
             export_name.coerce_to_string(avm, context)?,
             new_instance_name.coerce_to_string(avm, context)?,
-            depth.as_i32().unwrap_or(0).wrapping_add(AVM_DEPTH_BIAS),
+            depth
+                .coerce_to_i32(avm, context)?
+                .wrapping_add(AVM_DEPTH_BIAS),
         ),
         _ => {
             log::error!("MovieClip.attachMovie: Too few parameters");
@@ -468,7 +470,9 @@ fn create_empty_movie_clip<'gc>(
     let (new_instance_name, depth) = match &args[0..2] {
         [new_instance_name, depth] => (
             new_instance_name.coerce_to_string(avm, context)?,
-            depth.as_i32().unwrap_or(0).wrapping_add(AVM_DEPTH_BIAS),
+            depth
+                .coerce_to_i32(avm, context)?
+                .wrapping_add(AVM_DEPTH_BIAS),
         ),
         _ => {
             log::error!("MovieClip.attachMovie: Too few parameters");
@@ -563,7 +567,7 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
     let (new_instance_name, depth) = match &args[0..2] {
         [new_instance_name, depth] => (
             new_instance_name.coerce_to_string(avm, context)?,
-            depth.as_i32().unwrap_or(0).wrapping_add(depth_bias),
+            depth.coerce_to_i32(avm, context)?.wrapping_add(depth_bias),
         ),
         _ => {
             log::error!("MovieClip.attachMovie: Too few parameters");

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -95,11 +95,8 @@ pub fn broadcast_message<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let event_name = args
-        .get(0)
-        .cloned()
-        .unwrap_or(Value::Undefined)
-        .coerce_to_string(avm, context)?;
+    let event_name_val = args.get(0).cloned().unwrap_or(Value::Undefined);
+    let event_name = event_name_val.coerce_to_string(avm, context)?;
     let call_args = &args[0..];
 
     let listeners = this.get("_listeners", avm, context)?;
@@ -122,11 +119,8 @@ pub fn load_clip<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let url = args
-        .get(0)
-        .cloned()
-        .unwrap_or(Value::Undefined)
-        .coerce_to_string(avm, context)?;
+    let url_val = args.get(0).cloned().unwrap_or(Value::Undefined);
+    let url = url_val.coerce_to_string(avm, context)?;
     let target = args.get(1).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(target) = target {
@@ -134,7 +128,7 @@ pub fn load_clip<'gc>(
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
-            let fetch = context.navigator.fetch(url, RequestOptions::get());
+            let fetch = context.navigator.fetch(&url, RequestOptions::get());
             let process = context.load_manager.load_movie_into_clip(
                 context.player.clone().unwrap(),
                 DisplayObject::MovieClip(movieclip),

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -17,7 +17,7 @@ pub fn number<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let value = if let Some(val) = args.get(0) {
-        val.as_number(avm, context)?
+        val.coerce_to_f64(avm, context)?
     } else {
         0.0
     };
@@ -132,7 +132,7 @@ fn to_string<'gc>(
         let radix = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .as_number(avm, context)?;
+            .coerce_to_f64(avm, context)?;
         if radix >= 2.0 && radix <= 36.0 {
             radix as u32
         } else {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -243,7 +243,7 @@ pub fn as_set_prop_flags<'gc>(
             //Convert to native array.
             //TODO: Can we make this an iterator?
             let mut array = vec![];
-            let length = ob.get("length", avm, ac)?.as_number(avm, ac)? as usize;
+            let length = ob.get("length", avm, ac)?.coerce_to_f64(avm, ac)? as usize;
             for i in 0..length {
                 array.push(
                     ob.get(&format!("{}", i), avm, ac)?
@@ -261,13 +261,13 @@ pub fn as_set_prop_flags<'gc>(
     let set_attributes = EnumSet::<Attribute>::from_u128(
         args.get(2)
             .unwrap_or(&Value::Number(0.0))
-            .as_number(avm, ac)? as u128,
+            .coerce_to_f64(avm, ac)? as u128,
     );
 
     let clear_attributes = EnumSet::<Attribute>::from_u128(
         args.get(3)
             .unwrap_or(&Value::Number(0.0))
-            .as_number(avm, ac)? as u128,
+            .coerce_to_f64(avm, ac)? as u128,
     );
 
     match properties {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -114,7 +114,7 @@ fn is_prototype_of<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     match args.get(0) {
         Some(val) => {
-            let ob = val.as_object(avm, context);
+            let ob = val.coerce_to_object(avm, context);
             Ok(Value::Bool(this.is_prototype_of(ob)).into())
         }
         _ => Ok(Value::Bool(false).into()),
@@ -148,7 +148,7 @@ pub fn register_class<'gc>(
             if let Some(constructor) = args.get(1) {
                 movie_clip.set_avm1_constructor(
                     context.gc_context,
-                    Some(constructor.as_object(avm, context)),
+                    Some(constructor.coerce_to_object(avm, context)),
                 );
             } else {
                 movie_clip.set_avm1_constructor(context.gc_context, None);
@@ -236,7 +236,7 @@ pub fn as_set_prop_flags<'gc>(
     let mut object = args
         .get(0)
         .ok_or_else(|| my_error.unwrap_err())?
-        .as_object(avm, ac);
+        .coerce_to_object(avm, ac);
     let properties = match args.get(1).ok_or_else(|| my_error_2.unwrap_err())? {
         Value::Object(ob) => {
             //Convert to native array.

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -6,6 +6,7 @@ use crate::avm1::{Avm1, Error, Object, TObject, UpdateContext, Value};
 use crate::character::Character;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
+use std::borrow::Cow;
 
 /// Implements `Object`
 pub fn constructor<'gc>(
@@ -26,8 +27,8 @@ pub fn add_property<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let name = args
         .get(0)
-        .and_then(|v| v.to_owned().coerce_to_string(avm, context).ok())
-        .unwrap_or_else(|| "undefined".to_string());
+        .and_then(|v| v.coerce_to_string(avm, context).ok())
+        .unwrap_or_else(|| Cow::Borrowed("undefined"));
     let getter = args.get(1).unwrap_or(&Value::Undefined);
     let setter = args.get(2).unwrap_or(&Value::Undefined);
 
@@ -246,7 +247,8 @@ pub fn as_set_prop_flags<'gc>(
             for i in 0..length {
                 array.push(
                     ob.get(&format!("{}", i), avm, ac)?
-                        .coerce_to_string(avm, ac)?,
+                        .coerce_to_string(avm, ac)?
+                        .to_string(),
                 )
             }
 

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -211,14 +211,15 @@ fn to_string<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .coerce_to_string(avm, context)?;
+    let x = this.get("x", avm, context)?;
+    let y = this.get("y", avm, context)?;
 
-    Ok(format!("(x={}, y={})", x, y).into())
+    Ok(format!(
+        "(x={}, y={})",
+        x.coerce_to_string(avm, context)?,
+        y.coerce_to_string(avm, context)?
+    )
+    .into())
 }
 
 fn length<'gc>(

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -37,11 +37,11 @@ pub fn value_to_point<'gc>(
     let x = value
         .coerce_to_object(avm, context)
         .get("x", avm, context)?
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let y = value
         .coerce_to_object(avm, context)
         .get("y", avm, context)?
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     Ok((x, y))
 }
 
@@ -50,8 +50,8 @@ pub fn object_to_point<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error> {
-    let x = object.get("x", avm, context)?.as_number(avm, context)?;
-    let y = object.get("y", avm, context)?.as_number(avm, context)?;
+    let x = object.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let y = object.get("y", avm, context)?.coerce_to_f64(avm, context)?;
     Ok((x, y))
 }
 
@@ -120,8 +120,8 @@ fn add<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let this_y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let this_x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
     let other = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -137,8 +137,8 @@ fn subtract<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let this_y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let this_x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
     let other = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -179,11 +179,11 @@ fn polar<'gc>(
     let length = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let angle = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let point = point_to_object((length * angle.cos(), length * angle.sin()), avm, context)?;
     Ok(point.into())
 }
@@ -200,7 +200,7 @@ fn interpolate<'gc>(
 
     let a = value_to_point(args.get(0).unwrap().to_owned(), avm, context)?;
     let b = value_to_point(args.get(1).unwrap().to_owned(), avm, context)?;
-    let f = args.get(2).unwrap().as_number(avm, context)?;
+    let f = args.get(2).unwrap().coerce_to_f64(avm, context)?;
     let result = (b.0 - (b.0 - a.0) * f, b.1 - (b.1 - a.1) * f);
     Ok(point_to_object(result, avm, context)?.into())
 }
@@ -239,13 +239,15 @@ fn normalize<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let current_length = this.get("length", avm, context)?.as_number(avm, context)?;
+    let current_length = this
+        .get("length", avm, context)?
+        .coerce_to_f64(avm, context)?;
     if current_length.is_finite() {
         let point = object_to_point(this, avm, context)?;
         let new_length = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .as_number(avm, context)?;
+            .coerce_to_f64(avm, context)?;
         let (x, y) = if current_length == 0.0 {
             (point.0 * new_length, point.1 * new_length)
         } else {
@@ -272,11 +274,11 @@ fn offset<'gc>(
     let dx = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let dy = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
 
     this.set("x", (point.0 + dx).into(), avm, context)?;
     this.set("y", (point.1 + dy).into(), avm, context)?;

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -34,8 +34,14 @@ pub fn value_to_point<'gc>(
     avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error> {
-    let x = value.get("x", avm, context)?.as_number(avm, context)?;
-    let y = value.get("y", avm, context)?.as_number(avm, context)?;
+    let x = value
+        .coerce_to_object(avm, context)
+        .get("x", avm, context)?
+        .as_number(avm, context)?;
+    let y = value
+        .coerce_to_object(avm, context)
+        .get("y", avm, context)?
+        .as_number(avm, context)?;
     Ok((x, y))
 }
 
@@ -99,6 +105,7 @@ fn equals<'gc>(
     if let Some(other) = args.get(0) {
         let this_x = this.get("x", avm, context)?;
         let this_y = this.get("y", avm, context)?;
+        let other = other.coerce_to_object(avm, context);
         let other_x = other.get("x", avm, context)?;
         let other_y = other.get("y", avm, context)?;
         return Ok((this_x == other_x && this_y == other_y).into());
@@ -154,7 +161,10 @@ fn distance<'gc>(
     let a = args.get(0).unwrap_or(&Value::Undefined);
     let b = args.get(1).unwrap_or(&Value::Undefined);
     let delta = a.call_method("subtract", &[b.to_owned()], avm, context)?;
-    Ok(delta.get("length", avm, context)?.into())
+    Ok(delta
+        .coerce_to_object(avm, context)
+        .get("length", avm, context)?
+        .into())
 }
 
 fn polar<'gc>(

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -158,7 +158,10 @@ fn distance<'gc>(
         return Ok(NAN.into());
     }
 
-    let a = args.get(0).unwrap_or(&Value::Undefined);
+    let a = args
+        .get(0)
+        .unwrap_or(&Value::Undefined)
+        .coerce_to_object(avm, context);
     let b = args.get(1).unwrap_or(&Value::Undefined);
     let delta = a.call_method("subtract", &[b.to_owned()], avm, context)?;
     Ok(delta

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -91,8 +91,12 @@ fn is_empty<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
     Ok((width <= 0.0 || height <= 0.0 || width.is_nan() || height.is_nan()).into())
 }
 
@@ -139,20 +143,26 @@ fn contains<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     if x.is_nan() || y.is_nan() {
         return Ok(Value::Undefined.into());
     }
 
-    let left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let right = left + this.get("width", avm, context)?.as_number(avm, context)?;
-    let top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let bottom = top + this.get("height", avm, context)?.as_number(avm, context)?;
+    let left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let right = left
+        + this
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let bottom = top
+        + this
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
     Ok((x >= left && x < right && y >= top && y < bottom).into())
 }
@@ -172,10 +182,16 @@ fn contains_point<'gc>(
         return Ok(Value::Undefined.into());
     }
 
-    let left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let right = left + this.get("width", avm, context)?.as_number(avm, context)?;
-    let top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let bottom = top + this.get("height", avm, context)?.as_number(avm, context)?;
+    let left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let right = left
+        + this
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let bottom = top
+        + this
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
     Ok((x >= left && x < right && y >= top && y < bottom).into())
 }
@@ -192,15 +208,27 @@ fn contains_rectangle<'gc>(
         return Ok(Value::Undefined.into());
     };
 
-    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
-    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_right = this_left
+        + this
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let this_bottom = this_top
+        + this
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
-    let other_left = other.get("x", avm, context)?.as_number(avm, context)?;
-    let other_top = other.get("y", avm, context)?.as_number(avm, context)?;
-    let other_right = other_left + other.get("width", avm, context)?.as_number(avm, context)?;
-    let other_bottom = other_top + other.get("height", avm, context)?.as_number(avm, context)?;
+    let other_left = other.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let other_top = other.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let other_right = other_left
+        + other
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let other_bottom = other_top
+        + other
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
     if other_left.is_nan() || other_top.is_nan() || other_right.is_nan() || other_bottom.is_nan() {
         return Ok(Value::Undefined.into());
@@ -225,15 +253,27 @@ fn intersects<'gc>(
         return Ok(false.into());
     };
 
-    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
-    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_right = this_left
+        + this
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let this_bottom = this_top
+        + this
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
-    let other_left = other.get("x", avm, context)?.as_number(avm, context)?;
-    let other_top = other.get("y", avm, context)?.as_number(avm, context)?;
-    let other_right = other_left + other.get("width", avm, context)?.as_number(avm, context)?;
-    let other_bottom = other_top + other.get("height", avm, context)?.as_number(avm, context)?;
+    let other_left = other.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let other_top = other.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let other_right = other_left
+        + other
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let other_bottom = other_top
+        + other
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
     Ok((this_left < other_right
         && this_right > other_left
@@ -248,18 +288,28 @@ fn union<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
-    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_right = this_left
+        + this
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let this_bottom = this_top
+        + this
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
     let (other_left, other_top, other_width, other_height) =
         if let Some(Value::Object(other)) = args.get(0) {
             (
-                other.get("x", avm, context)?.as_number(avm, context)?,
-                other.get("y", avm, context)?.as_number(avm, context)?,
-                other.get("width", avm, context)?.as_number(avm, context)?,
-                other.get("height", avm, context)?.as_number(avm, context)?,
+                other.get("x", avm, context)?.coerce_to_f64(avm, context)?,
+                other.get("y", avm, context)?.coerce_to_f64(avm, context)?,
+                other
+                    .get("width", avm, context)?
+                    .coerce_to_f64(avm, context)?,
+                other
+                    .get("height", avm, context)?
+                    .coerce_to_f64(avm, context)?,
             )
         } else {
             (NAN, NAN, NAN, NAN)
@@ -314,20 +364,24 @@ fn inflate<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
     let horizontal = args
         .get(0)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let vertical = args
         .get(1)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
 
     this.set("x", Value::Number(x - horizontal), avm, context)?;
     this.set("y", Value::Number(y - vertical), avm, context)?;
@@ -353,10 +407,14 @@ fn inflate_point<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
     let (horizontal, vertical) = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -387,18 +445,18 @@ fn offset<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
     let horizontal = args
         .get(0)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let vertical = args
         .get(1)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
 
     this.set("x", Value::Number(x + horizontal), avm, context)?;
     this.set("y", Value::Number(y + vertical), avm, context)?;
@@ -412,8 +470,8 @@ fn offset_point<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
     let (horizontal, vertical) = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         avm,
@@ -432,18 +490,28 @@ fn intersection<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let this_left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let this_top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let this_right = this_left + this.get("width", avm, context)?.as_number(avm, context)?;
-    let this_bottom = this_top + this.get("height", avm, context)?.as_number(avm, context)?;
+    let this_left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let this_right = this_left
+        + this
+            .get("width", avm, context)?
+            .coerce_to_f64(avm, context)?;
+    let this_bottom = this_top
+        + this
+            .get("height", avm, context)?
+            .coerce_to_f64(avm, context)?;
 
     let (other_left, other_top, other_width, other_height) =
         if let Some(Value::Object(other)) = args.get(0) {
             (
-                other.get("x", avm, context)?.as_number(avm, context)?,
-                other.get("y", avm, context)?.as_number(avm, context)?,
-                other.get("width", avm, context)?.as_number(avm, context)?,
-                other.get("height", avm, context)?.as_number(avm, context)?,
+                other.get("x", avm, context)?.coerce_to_f64(avm, context)?,
+                other.get("y", avm, context)?.coerce_to_f64(avm, context)?,
+                other
+                    .get("width", avm, context)?
+                    .coerce_to_f64(avm, context)?,
+                other
+                    .get("height", avm, context)?
+                    .coerce_to_f64(avm, context)?,
             )
         } else {
             (NAN, NAN, NAN, NAN)
@@ -533,12 +601,14 @@ fn set_left<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let new_left = args.get(0).unwrap_or(&Value::Undefined).to_owned();
-    let old_left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let old_left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
     this.set("x", new_left.clone(), avm, context)?;
     this.set(
         "width",
-        Value::Number(width + (old_left - new_left.as_number(avm, context)?)),
+        Value::Number(width + (old_left - new_left.coerce_to_f64(avm, context)?)),
         avm,
         context,
     )?;
@@ -561,12 +631,14 @@ fn set_top<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let new_top = args.get(0).unwrap_or(&Value::Undefined).to_owned();
-    let old_top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let old_top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
     this.set("y", new_top.clone(), avm, context)?;
     this.set(
         "height",
-        Value::Number(height + (old_top - new_top.as_number(avm, context)?)),
+        Value::Number(height + (old_top - new_top.coerce_to_f64(avm, context)?)),
         avm,
         context,
     )?;
@@ -579,8 +651,10 @@ fn get_right<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
     Ok((x + width).into())
 }
 
@@ -591,11 +665,11 @@ fn set_right<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let right = if let Some(arg) = args.get(0) {
-        arg.as_number(avm, context)?
+        arg.coerce_to_f64(avm, context)?
     } else {
         NAN
     };
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
 
     this.set("width", Value::Number(right - x), avm, context)?;
 
@@ -608,8 +682,10 @@ fn get_bottom<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
     Ok((y + height).into())
 }
 
@@ -620,11 +696,11 @@ fn set_bottom<'gc>(
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
     let bottom = if let Some(arg) = args.get(0) {
-        arg.as_number(avm, context)?
+        arg.coerce_to_f64(avm, context)?
     } else {
         NAN
     };
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
 
     this.set("height", Value::Number(bottom - y), avm, context)?;
 
@@ -690,22 +766,26 @@ fn set_top_left<'gc>(
     } else {
         (Value::Undefined, Value::Undefined)
     };
-    let old_left = this.get("x", avm, context)?.as_number(avm, context)?;
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
-    let old_top = this.get("y", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let old_left = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
+    let old_top = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
 
     this.set("x", new_left.clone(), avm, context)?;
     this.set("y", new_top.clone(), avm, context)?;
     this.set(
         "width",
-        Value::Number(width + (old_left - new_left.as_number(avm, context)?)),
+        Value::Number(width + (old_left - new_left.coerce_to_f64(avm, context)?)),
         avm,
         context,
     )?;
     this.set(
         "height",
-        Value::Number(height + (old_top - new_top.as_number(avm, context)?)),
+        Value::Number(height + (old_top - new_top.coerce_to_f64(avm, context)?)),
         avm,
         context,
     )?;
@@ -719,10 +799,14 @@ fn get_bottom_right<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this.get("x", avm, context)?.as_number(avm, context)?;
-    let y = this.get("y", avm, context)?.as_number(avm, context)?;
-    let width = this.get("width", avm, context)?.as_number(avm, context)?;
-    let height = this.get("height", avm, context)?.as_number(avm, context)?;
+    let x = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let y = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
+    let width = this
+        .get("width", avm, context)?
+        .coerce_to_f64(avm, context)?;
+    let height = this
+        .get("height", avm, context)?
+        .coerce_to_f64(avm, context)?;
     let point = point_to_object((x + width, y + height), avm, context)?;
     Ok(point.into())
 }
@@ -738,8 +822,8 @@ fn set_bottom_right<'gc>(
         avm,
         context,
     )?;
-    let top = this.get("x", avm, context)?.as_number(avm, context)?;
-    let left = this.get("y", avm, context)?.as_number(avm, context)?;
+    let top = this.get("x", avm, context)?.coerce_to_f64(avm, context)?;
+    let left = this.get("y", avm, context)?.coerce_to_f64(avm, context)?;
 
     this.set("width", Value::Number(bottom - top), avm, context)?;
     this.set("height", Value::Number(right - left), avm, context)?;

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -57,20 +57,19 @@ fn to_string<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    let x = this
-        .get("x", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let y = this
-        .get("y", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let width = this
-        .get("width", avm, context)?
-        .coerce_to_string(avm, context)?;
-    let height = this
-        .get("height", avm, context)?
-        .coerce_to_string(avm, context)?;
+    let x = this.get("x", avm, context)?;
+    let y = this.get("y", avm, context)?;
+    let width = this.get("width", avm, context)?;
+    let height = this.get("height", avm, context)?;
 
-    Ok(format!("(x={}, y={}, w={}, h={})", x, y, width, height).into())
+    Ok(format!(
+        "(x={}, y={}, w={}, h={})",
+        x.coerce_to_string(avm, context)?,
+        y.coerce_to_string(avm, context)?,
+        width.coerce_to_string(avm, context)?,
+        height.coerce_to_string(avm, context)?
+    )
+    .into())
 }
 
 pub fn create_rectangle_object<'gc>(

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -11,7 +11,7 @@ use gc_arena::MutationContext;
 
 /// Implements `Sound`
 pub fn constructor<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     context: &mut UpdateContext<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -20,7 +20,7 @@ pub fn constructor<'gc>(
     // `Sound.setTransform`, `Sound.stop`, etc. will affect all sounds owned by this clip.
     let owner = args
         .get(0)
-        .and_then(|o| o.as_object().ok())
+        .map(|o| o.as_object(avm, context))
         .and_then(|o| o.as_display_object());
 
     let sound = this.as_sound_object().unwrap();

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -167,7 +167,7 @@ fn attach_sound<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     let name = args.get(0).unwrap_or(&Value::Undefined);
     if let Some(sound_object) = this.as_sound_object() {
-        let name = name.clone().coerce_to_string(avm, context)?;
+        let name = name.coerce_to_string(avm, context)?;
         let movie = sound_object
             .owner()
             .or_else(|| context.levels.get(&0).copied())
@@ -412,7 +412,7 @@ fn stop<'gc>(
     if let Some(sound) = this.as_sound_object() {
         if let Some(name) = args.get(0) {
             // Usage 1: Stop all instances of a particular sound, using the name parameter.
-            let name = name.clone().coerce_to_string(avm, context)?;
+            let name = name.coerce_to_string(avm, context)?;
             let movie = sound
                 .owner()
                 .or_else(|| context.levels.get(&0).copied())

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -20,7 +20,7 @@ pub fn constructor<'gc>(
     // `Sound.setTransform`, `Sound.stop`, etc. will affect all sounds owned by this clip.
     let owner = args
         .get(0)
-        .map(|o| o.as_object(avm, context))
+        .map(|o| o.coerce_to_object(avm, context))
         .and_then(|o| o.as_display_object());
 
     let sound = this.as_sound_object().unwrap();

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -361,11 +361,11 @@ fn start<'gc>(
     let start_offset = args
         .get(0)
         .unwrap_or(&Value::Number(0.0))
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
     let loops = args
         .get(1)
         .unwrap_or(&Value::Number(1.0))
-        .as_number(avm, context)?;
+        .coerce_to_f64(avm, context)?;
 
     let loops = if loops >= 1.0 && loops <= f64::from(std::i16::MAX) {
         loops as u16

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -406,8 +406,8 @@ pub fn set_clipboard<'gc>(
     let new_content = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .to_owned()
-        .coerce_to_string(avm, action_context)?;
+        .coerce_to_string(avm, action_context)?
+        .to_string();
 
     action_context.input.set_clipboard_content(new_content);
 

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -41,10 +41,7 @@ pub fn set_text<'gc>(
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
                 text_field.set_text(
-                    value
-                        .to_owned()
-                        .coerce_to_string(avm, context)
-                        .unwrap_or_else(|_| "undefined".to_string()),
+                    value.coerce_to_string(avm, context)?.to_string(),
                     context.gc_context,
                 )
             }

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -34,7 +34,7 @@ fn map_defined_to_number<'gc>(
         Some(Value::Undefined) => Value::Null,
         Some(Value::Null) => Value::Null,
         None => Value::Null,
-        Some(v) => v.as_number(avm, ac)?.into(),
+        Some(v) => v.coerce_to_f64(avm, ac)?.into(),
     };
 
     this.set(name, val, avm, ac)?;

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -77,7 +77,7 @@ pub fn xmlnode_append_child<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     if let (Some(mut xmlnode), Some(child_xmlnode)) = (
         this.as_xml_node(),
-        args.get(0).and_then(|n| n.as_object(avm, ac).as_xml_node()),
+        args.get(0).and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             let position = xmlnode.children_len();
@@ -96,8 +96,8 @@ pub fn xmlnode_insert_before<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     if let (Some(mut xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
         this.as_xml_node(),
-        args.get(0).and_then(|n| n.as_object(avm, ac).as_xml_node()),
-        args.get(1).and_then(|n| n.as_object(avm, ac).as_xml_node()),
+        args.get(0).and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
+        args.get(1).and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -77,7 +77,8 @@ pub fn xmlnode_append_child<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     if let (Some(mut xmlnode), Some(child_xmlnode)) = (
         this.as_xml_node(),
-        args.get(0).and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
+        args.get(0)
+            .and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             let position = xmlnode.children_len();
@@ -96,8 +97,10 @@ pub fn xmlnode_insert_before<'gc>(
 ) -> Result<ReturnValue<'gc>, Error> {
     if let (Some(mut xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
         this.as_xml_node(),
-        args.get(0).and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
-        args.get(1).and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
+        args.get(0)
+            .and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
+        args.get(1)
+            .and_then(|n| n.coerce_to_object(avm, ac).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -49,7 +49,8 @@ pub fn xmlnode_constructor<'gc>(
     let blank_document = XMLDocument::new(ac.gc_context);
 
     match (
-        args.get(0).map(|v| v.as_number(avm, ac).map(|v| v as u32)),
+        args.get(0)
+            .map(|v| v.coerce_to_f64(avm, ac).map(|v| v as u32)),
         args.get(1).map(|v| v.coerce_to_string(avm, ac)),
         this.as_xml_node(),
     ) {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -70,14 +70,14 @@ pub fn xmlnode_constructor<'gc>(
 }
 
 pub fn xmlnode_append_child<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     ac: &mut UpdateContext<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    if let (Some(mut xmlnode), Some(Ok(Some(child_xmlnode)))) = (
+    if let (Some(mut xmlnode), Some(child_xmlnode)) = (
         this.as_xml_node(),
-        args.get(0).map(|n| n.as_object().map(|n| n.as_xml_node())),
+        args.get(0).and_then(|n| n.as_object(avm, ac).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             let position = xmlnode.children_len();
@@ -89,15 +89,15 @@ pub fn xmlnode_append_child<'gc>(
 }
 
 pub fn xmlnode_insert_before<'gc>(
-    _avm: &mut Avm1<'gc>,
+    avm: &mut Avm1<'gc>,
     ac: &mut UpdateContext<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<ReturnValue<'gc>, Error> {
-    if let (Some(mut xmlnode), Some(Ok(Some(child_xmlnode))), Some(Ok(Some(insertpoint_xmlnode)))) = (
+    if let (Some(mut xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
         this.as_xml_node(),
-        args.get(0).map(|n| n.as_object().map(|n| n.as_xml_node())),
-        args.get(1).map(|n| n.as_object().map(|n| n.as_xml_node())),
+        args.get(0).and_then(|n| n.as_object(avm, ac).as_xml_node()),
+        args.get(1).and_then(|n| n.as_object(avm, ac).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {

--- a/core/src/avm1/listeners.rs
+++ b/core/src/avm1/listeners.rs
@@ -118,7 +118,7 @@ impl<'gc> Listeners<'gc> {
         let mut handlers = Vec::with_capacity(listeners.length());
 
         for i in 0..listeners.length() {
-            let listener = listeners.array_element(i).as_object(avm, context);
+            let listener = listeners.array_element(i).coerce_to_object(avm, context);
             if let Ok(handler) = listener.get(method, avm, context) {
                 handlers.push((listener, handler));
             }

--- a/core/src/avm1/listeners.rs
+++ b/core/src/avm1/listeners.rs
@@ -118,10 +118,9 @@ impl<'gc> Listeners<'gc> {
         let mut handlers = Vec::with_capacity(listeners.length());
 
         for i in 0..listeners.length() {
-            if let Ok(listener) = listeners.array_element(i).as_object() {
-                if let Ok(handler) = listener.get(method, avm, context) {
-                    handlers.push((listener, handler));
-                }
+            let listener = listeners.array_element(i).as_object(avm, context);
+            if let Ok(handler) = listener.get(method, avm, context) {
+                handlers.push((listener, handler));
             }
         }
 

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -14,6 +14,7 @@ use crate::xml::XMLNode;
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
 use ruffle_macros::enum_trait_object;
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 /// Represents an object that can be directly interacted with by the AVM
@@ -281,7 +282,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn get_keys(&self, avm: &mut Avm1<'gc>) -> Vec<String>;
 
     /// Coerce the object into a string.
-    fn as_string(&self) -> String;
+    fn as_string(&self) -> Cow<str>;
 
     /// Get the object's type string.
     fn type_of(&self) -> &'static str;

--- a/core/src/avm1/return_value.rs
+++ b/core/src/avm1/return_value.rs
@@ -4,6 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::{Avm1, Error, Object, Value};
 use crate::context::UpdateContext;
 use gc_arena::{Collect, GcCell};
+use std::borrow::Cow;
 use std::fmt;
 
 /// Represents the return value of a function call.
@@ -138,6 +139,12 @@ impl<'gc> From<String> for ReturnValue<'gc> {
 impl<'gc> From<&str> for ReturnValue<'gc> {
     fn from(string: &str) -> Self {
         ReturnValue::Immediate(Value::String(string.to_owned()))
+    }
+}
+
+impl<'gc> From<Cow<'_, str>> for ReturnValue<'gc> {
+    fn from(string: Cow<str>) -> Self {
+        ReturnValue::Immediate(Value::String(string.to_string()))
     }
 }
 

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -196,7 +196,7 @@ impl<'gc> ScriptObject<'gc> {
         base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error> {
         if name == "__proto__" {
-            self.0.write(context.gc_context).prototype = Some(value.as_object(avm, context));
+            self.0.write(context.gc_context).prototype = Some(value.coerce_to_object(avm, context));
         } else if let Ok(index) = name.parse::<usize>() {
             self.set_array_element(index, value.to_owned(), context.gc_context);
         } else {

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -203,7 +203,7 @@ impl<'gc> ScriptObject<'gc> {
         } else {
             if name == "length" {
                 let length = value
-                    .as_number(avm, context)
+                    .coerce_to_f64(avm, context)
                     .map(|v| v.abs() as i32)
                     .unwrap_or(0);
                 if length > 0 {

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -196,7 +196,7 @@ impl<'gc> ScriptObject<'gc> {
         base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error> {
         if name == "__proto__" {
-            self.0.write(context.gc_context).prototype = value.as_object().ok();
+            self.0.write(context.gc_context).prototype = Some(value.as_object(avm, context));
         } else if let Ok(index) = name.parse::<usize>() {
             self.set_array_element(index, value.to_owned(), context.gc_context);
         } else {

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -6,6 +6,7 @@ use crate::property_map::{Entry, PropertyMap};
 use core::fmt;
 use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
+use std::borrow::Cow;
 
 pub const TYPE_OF_OBJECT: &str = "object";
 
@@ -576,8 +577,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         out_keys
     }
 
-    fn as_string(&self) -> String {
-        "[object Object]".to_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Borrowed("[object Object]")
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/sound_object.rs
+++ b/core/src/avm1/sound_object.rs
@@ -9,6 +9,7 @@ use crate::context::UpdateContext;
 use crate::display_object::DisplayObject;
 use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 
 /// A SounObject that is tied to a sound from the AudioBackend.
@@ -285,8 +286,8 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
         self.base().get_keys(avm)
     }
 
-    fn as_string(&self) -> String {
-        self.base().as_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.base().as_string().into_owned())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/stage_object.rs
+++ b/core/src/avm1/stage_object.rs
@@ -10,6 +10,7 @@ use crate::display_object::{DisplayObject, MovieClip};
 use crate::property_map::PropertyMap;
 use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 
 /// The type string for MovieClip objects.
@@ -340,8 +341,8 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.base.set_interfaces(context, iface_list)
     }
 
-    fn as_string(&self) -> String {
-        self.display_object.path()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.display_object.path())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/stage_object.rs
+++ b/core/src/avm1/stage_object.rs
@@ -857,7 +857,7 @@ fn property_coerce_to_number<'gc>(
     value: Value<'gc>,
 ) -> Result<Option<f64>, Error> {
     if value != Value::Undefined && value != Value::Null {
-        let n = value.as_number(avm, context)?;
+        let n = value.coerce_to_f64(avm, context)?;
         if n.is_finite() {
             return Ok(Some(n));
         }

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -70,7 +70,7 @@ impl<'gc> SuperObject<'gc> {
             Ok(Some(
                 super_proto
                     .get("__constructor__", avm, context)?
-                    .as_object(avm, context),
+                    .coerce_to_object(avm, context),
             ))
         } else {
             Ok(None)

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -10,6 +10,7 @@ use crate::context::UpdateContext;
 use crate::display_object::DisplayObject;
 use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
+use std::borrow::Cow;
 
 /// Implementation of the `super` object in AS2.
 ///
@@ -268,8 +269,8 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         vec![]
     }
 
-    fn as_string(&self) -> String {
-        self.0.read().child.as_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.0.read().child.as_string().into_owned())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/super_object.rs
+++ b/core/src/avm1/super_object.rs
@@ -67,10 +67,11 @@ impl<'gc> SuperObject<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<Option<Object<'gc>>, Error> {
         if let Some(super_proto) = self.super_proto() {
-            Ok(super_proto
-                .get("__constructor__", avm, context)?
-                .as_object()
-                .ok())
+            Ok(Some(
+                super_proto
+                    .get("__constructor__", avm, context)?
+                    .as_object(avm, context),
+            ))
         } else {
             Ok(None)
         }

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -70,7 +70,7 @@ where
             Activation::from_nothing(swf_version, globals, gc_context, root),
         ));
 
-        let this = root.object().as_object(&mut avm, &mut context);
+        let this = root.object().coerce_to_object(&mut avm, &mut context);
 
         test(&mut avm, &mut context, this)
     }

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -70,7 +70,7 @@ where
             Activation::from_nothing(swf_version, globals, gc_context, root),
         ));
 
-        let this = root.object().as_object().unwrap();
+        let this = root.object().as_object(&mut avm, &mut context);
 
         test(&mut avm, &mut context, this)
     }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -542,13 +542,6 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn as_string(&self) -> Result<&String, Error> {
-        match self {
-            Value::String(s) => Ok(s),
-            _ => Err(format!("Expected String, found {:?}", self).into()),
-        }
-    }
-
     pub fn coerce_to_object(
         &self,
         avm: &mut Avm1<'gc>,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -557,19 +557,6 @@ impl<'gc> Value<'gc> {
         ValueObject::boxed(avm, context, self.to_owned())
     }
 
-    pub fn get(
-        &self,
-        name: &str,
-        avm: &mut Avm1<'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<Value<'gc>, Error> {
-        if let Value::Object(object) = self {
-            object.get(name, avm, context)
-        } else {
-            Ok(Value::Undefined)
-        }
-    }
-
     pub fn call(
         &self,
         avm: &mut Avm1<'gc>,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -506,42 +506,6 @@ impl<'gc> Value<'gc> {
         )
     }
 
-    /// Casts a Number into an `i32` following the ECMA-262 `ToInt32` specs.
-    /// The number will have 32-bit wrapping semantics if it is outside the range of an `i32`.
-    /// NaN and Infinities will return 0.
-    /// This is written to avoid undefined behavior when casting out-of-bounds floats to ints in Rust.
-    /// (see https://github.com/rust-lang/rust/issues/10184)
-    #[allow(clippy::unreadable_literal)]
-    pub fn as_i32(&self) -> Result<i32, Error> {
-        self.as_f64().map(f64_to_wrapping_i32)
-    }
-
-    /// Casts a Number into an `i32` following the ECMA-262 `ToUInt32` specs.
-    /// The number will have 32-bit wrapping semantics if it is outside the range of an `u32`.
-    /// NaN and Infinities will return 0.
-    /// This is written to avoid undefined behavior when casting out-of-bounds floats to ints in Rust.
-    /// (see https://github.com/rust-lang/rust/issues/10184)
-    #[allow(clippy::unreadable_literal)]
-    pub fn as_u32(&self) -> Result<u32, Error> {
-        self.as_f64().map(f64_to_wrapping_u32)
-    }
-
-    pub fn as_i64(&self) -> Result<i64, Error> {
-        self.as_f64().map(|n| n as i64)
-    }
-
-    #[allow(dead_code)]
-    pub fn as_usize(&self) -> Result<usize, Error> {
-        self.as_f64().map(|n| n as usize)
-    }
-
-    pub fn as_f64(&self) -> Result<f64, Error> {
-        match *self {
-            Value::Number(v) => Ok(v),
-            _ => Err(format!("Expected Number, found {:?}", self).into()),
-        }
-    }
-
     pub fn coerce_to_object(
         &self,
         avm: &mut Avm1<'gc>,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -220,7 +220,7 @@ impl<'gc> Value<'gc> {
     }
 
     /// ECMA-262 2nd edition s. 9.3 ToNumber
-    pub fn as_number(
+    pub fn coerce_to_f64(
         &self,
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
@@ -333,19 +333,19 @@ impl<'gc> Value<'gc> {
             (Value::Undefined, Value::Null) => Ok(true.into()),
             (Value::Null, Value::Undefined) => Ok(true.into()),
             (Value::Number(_), Value::String(_)) => Ok(self.abstract_eq(
-                Value::Number(other.as_number(avm, context)?),
+                Value::Number(other.coerce_to_f64(avm, context)?),
                 avm,
                 context,
                 true,
             )?),
             (Value::String(_), Value::Number(_)) => {
-                Ok(Value::Number(self.as_number(avm, context)?)
+                Ok(Value::Number(self.coerce_to_f64(avm, context)?)
                     .abstract_eq(other, avm, context, true)?)
             }
-            (Value::Bool(_), _) => Ok(Value::Number(self.as_number(avm, context)?)
+            (Value::Bool(_), _) => Ok(Value::Number(self.coerce_to_f64(avm, context)?)
                 .abstract_eq(other, avm, context, true)?),
             (_, Value::Bool(_)) => Ok(self.abstract_eq(
-                Value::Number(other.as_number(avm, context)?),
+                Value::Number(other.coerce_to_f64(avm, context)?),
                 avm,
                 context,
                 true,
@@ -409,7 +409,7 @@ impl<'gc> Value<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<u16, Error> {
-        self.as_number(avm, context).map(f64_to_wrapping_u16)
+        self.coerce_to_f64(avm, context).map(f64_to_wrapping_u16)
     }
 
     /// Coerce a number to an `i16` following the wrapping behavior ECMAScript specifications.
@@ -421,7 +421,7 @@ impl<'gc> Value<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<i16, Error> {
-        self.as_number(avm, context).map(f64_to_wrapping_i16)
+        self.coerce_to_f64(avm, context).map(f64_to_wrapping_i16)
     }
 
     /// Coerce a number to an `i32` following the ECMAScript specifications for `ToInt32`.
@@ -434,7 +434,7 @@ impl<'gc> Value<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<i32, Error> {
-        self.as_number(avm, context).map(f64_to_wrapping_i32)
+        self.coerce_to_f64(avm, context).map(f64_to_wrapping_i32)
     }
 
     /// Coerce a number to an `u32` following the ECMAScript specifications for `ToUInt32`.
@@ -446,7 +446,7 @@ impl<'gc> Value<'gc> {
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<u32, Error> {
-        self.as_number(avm, context).map(f64_to_wrapping_u32)
+        self.coerce_to_f64(avm, context).map(f64_to_wrapping_u32)
     }
 
     /// Coerce a value to a string.
@@ -666,14 +666,14 @@ mod test {
             let f = Value::Bool(false);
             let n = Value::Null;
 
-            assert_eq!(t.as_number(avm, context).unwrap(), 1.0);
-            assert!(u.as_number(avm, context).unwrap().is_nan());
-            assert_eq!(f.as_number(avm, context).unwrap(), 0.0);
-            assert!(n.as_number(avm, context).unwrap().is_nan());
+            assert_eq!(t.coerce_to_f64(avm, context).unwrap(), 1.0);
+            assert!(u.coerce_to_f64(avm, context).unwrap().is_nan());
+            assert_eq!(f.coerce_to_f64(avm, context).unwrap(), 0.0);
+            assert!(n.coerce_to_f64(avm, context).unwrap().is_nan());
 
             let bo = Value::Object(ScriptObject::bare_object(context.gc_context).into());
 
-            assert!(bo.as_number(avm, context).unwrap().is_nan());
+            assert!(bo.coerce_to_f64(avm, context).unwrap().is_nan());
         });
     }
 
@@ -686,14 +686,14 @@ mod test {
             let f = Value::Bool(false);
             let n = Value::Null;
 
-            assert_eq!(t.as_number(avm, context).unwrap(), 1.0);
-            assert_eq!(u.as_number(avm, context).unwrap(), 0.0);
-            assert_eq!(f.as_number(avm, context).unwrap(), 0.0);
-            assert_eq!(n.as_number(avm, context).unwrap(), 0.0);
+            assert_eq!(t.coerce_to_f64(avm, context).unwrap(), 1.0);
+            assert_eq!(u.coerce_to_f64(avm, context).unwrap(), 0.0);
+            assert_eq!(f.coerce_to_f64(avm, context).unwrap(), 0.0);
+            assert_eq!(n.coerce_to_f64(avm, context).unwrap(), 0.0);
 
             let bo = Value::Object(ScriptObject::bare_object(context.gc_context).into());
 
-            assert_eq!(bo.as_number(avm, context).unwrap(), 0.0);
+            assert_eq!(bo.coerce_to_f64(avm, context).unwrap(), 0.0);
         });
     }
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -549,7 +549,7 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn as_object(
+    pub fn coerce_to_object(
         &self,
         avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -1,3 +1,4 @@
+use crate::avm1::value_object::ValueObject;
 use crate::avm1::{Avm1, Error, Object, TObject, UpdateContext};
 use std::f64::NAN;
 
@@ -548,12 +549,12 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn as_object(&self) -> Result<Object<'gc>, Error> {
-        if let Value::Object(object) = self {
-            Ok(*object)
-        } else {
-            Err(format!("Expected Object, found {:?}", self).into())
-        }
+    pub fn as_object(
+        &self,
+        avm: &mut Avm1<'gc>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+    ) -> Object<'gc> {
+        ValueObject::boxed(avm, context, self.to_owned())
     }
 
     pub fn get(

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -571,20 +571,6 @@ impl<'gc> Value<'gc> {
             Ok(Value::Undefined)
         }
     }
-
-    pub fn call_method(
-        &self,
-        name: &str,
-        args: &[Value<'gc>],
-        avm: &mut Avm1<'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<Value<'gc>, Error> {
-        if let Value::Object(object) = self {
-            object.call_method(name, args, avm, context)
-        } else {
-            Ok(Value::Undefined)
-        }
-    }
 }
 
 /// Converts an `f64` to a String with (hopefully) the same output as Flash.

--- a/core/src/avm1/value_object.rs
+++ b/core/src/avm1/value_object.rs
@@ -7,6 +7,7 @@ use crate::avm1::return_value::ReturnValue;
 use crate::avm1::{Avm1, Error, Object, ScriptObject, UpdateContext, Value};
 use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 
 /// An Object that serves as a box for a primitive value.
@@ -293,8 +294,8 @@ impl<'gc> TObject<'gc> for ValueObject<'gc> {
         self.0.read().base.get_keys(avm)
     }
 
-    fn as_string(&self) -> String {
-        self.0.read().base.as_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.0.read().base.as_string().into_owned())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/xml_attributes_object.rs
+++ b/core/src/avm1/xml_attributes_object.rs
@@ -79,7 +79,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         self.node().set_attribute_value(
             context.gc_context,
             &XMLName::from_str(name),
-            &value.clone().coerce_to_string(avm, context)?,
+            &value.coerce_to_string(avm, context)?,
         );
         self.base().set(name, value, avm, context)
     }

--- a/core/src/avm1/xml_attributes_object.rs
+++ b/core/src/avm1/xml_attributes_object.rs
@@ -8,6 +8,7 @@ use crate::avm1::{Avm1, Error, Object, ScriptObject, UpdateContext, Value};
 use crate::xml::{XMLName, XMLNode};
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 
 /// A ScriptObject that is inherently tied to an XML node's attributes.
@@ -225,8 +226,8 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         self.base().get_keys(avm)
     }
 
-    fn as_string(&self) -> String {
-        self.base().as_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.base().as_string().into_owned())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/xml_idmap_object.rs
+++ b/core/src/avm1/xml_idmap_object.rs
@@ -8,6 +8,7 @@ use crate::avm1::{Avm1, Error, Object, ScriptObject, UpdateContext, Value};
 use crate::xml::{XMLDocument, XMLNode};
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 
 /// An Object that is inherently tied to an XML document's ID map.
@@ -221,8 +222,8 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         keys
     }
 
-    fn as_string(&self) -> String {
-        self.base().as_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.base().as_string().into_owned())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/avm1/xml_object.rs
+++ b/core/src/avm1/xml_object.rs
@@ -8,6 +8,7 @@ use crate::avm1::{Avm1, Error, Object, ScriptObject, UpdateContext, Value};
 use crate::xml::{XMLDocument, XMLNode};
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
+use std::borrow::Cow;
 use std::fmt;
 
 /// A ScriptObject that is inherently tied to an XML node.
@@ -212,8 +213,8 @@ impl<'gc> TObject<'gc> for XMLObject<'gc> {
         self.base().get_keys(avm)
     }
 
-    fn as_string(&self) -> String {
-        self.base().as_string()
+    fn as_string(&self) -> Cow<str> {
+        Cow::Owned(self.base().as_string().into_owned())
     }
 
     fn type_of(&self) -> &'static str {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -118,7 +118,7 @@ pub trait NavigatorBackend {
     );
 
     /// Fetch data at a given URL and return it some time in the future.
-    fn fetch(&self, url: String, request_options: RequestOptions) -> OwnedFuture<Vec<u8>, Error>;
+    fn fetch(&self, url: &str, request_options: RequestOptions) -> OwnedFuture<Vec<u8>, Error>;
 
     /// Get the amount of time since the SWF was launched.
     /// Used by the `getTimer` ActionScript call.
@@ -288,7 +288,7 @@ impl NavigatorBackend for NullNavigatorBackend {
     ) {
     }
 
-    fn fetch(&self, url: String, _opts: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
+    fn fetch(&self, url: &str, _opts: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
         let mut path = self.relative_base_path.clone();
         path.push(url);
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -882,10 +882,11 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
 
         parent
             .or_else(|| {
-                self.object()
-                    .as_object()
-                    .ok()
-                    .and_then(|o| o.as_display_object())
+                if let Value::Object(object) = self.object() {
+                    object.as_display_object()
+                } else {
+                    None
+                }
             })
             .expect("All objects must have root")
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -670,13 +670,12 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                     return Some(self_node);
                 }
 
-                if let Ok(object) = self.object().as_object() {
-                    if ClipEvent::BUTTON_EVENT_METHODS
-                        .iter()
-                        .any(|handler| object.has_property(avm, context, handler))
-                    {
-                        return Some(self_node);
-                    }
+                let object = self.object().as_object(avm, context);
+                if ClipEvent::BUTTON_EVENT_METHODS
+                    .iter()
+                    .any(|handler| object.has_property(avm, context, handler))
+                {
+                    return Some(self_node);
                 }
             }
 
@@ -732,7 +731,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
                 if let Ok(prototype) = constructor
                     .get("prototype", avm, context)
-                    .and_then(|v| v.as_object())
+                    .map(|v| v.as_object(avm, context))
                 {
                     let object: Object<'gc> = StageObject::for_display_object(
                         context.gc_context,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -670,7 +670,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                     return Some(self_node);
                 }
 
-                let object = self.object().as_object(avm, context);
+                let object = self.object().coerce_to_object(avm, context);
                 if ClipEvent::BUTTON_EVENT_METHODS
                     .iter()
                     .any(|handler| object.has_property(avm, context, handler))
@@ -731,7 +731,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
                 if let Ok(prototype) = constructor
                     .get("prototype", avm, context)
-                    .map(|v| v.as_object(avm, context))
+                    .map(|v| v.coerce_to_object(avm, context))
                 {
                     let object: Object<'gc> = StageObject::for_display_object(
                         context.gc_context,

--- a/core/src/font/text_format.rs
+++ b/core/src/font/text_format.rs
@@ -82,7 +82,7 @@ fn getfloat_from_avm1_object<'gc>(
     Ok(match object.get(name, avm1, uc)? {
         Value::Undefined => None,
         Value::Null => None,
-        v => Some(v.as_number(avm1, uc)?),
+        v => Some(v.coerce_to_f64(avm1, uc)?),
     })
 }
 

--- a/core/src/font/text_format.rs
+++ b/core/src/font/text_format.rs
@@ -69,7 +69,7 @@ fn getstr_from_avm1_object<'gc>(
     Ok(match object.get(name, avm1, uc)? {
         Value::Undefined => None,
         Value::Null => None,
-        v => Some(v.coerce_to_string(avm1, uc)?),
+        v => Some(v.coerce_to_string(avm1, uc)?.to_string()),
     })
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -252,7 +252,7 @@ impl Player {
             root.set_name(context.gc_context, "");
             context.levels.insert(0, root);
 
-            let object = root.object().as_object(avm, context);
+            let object = root.object().coerce_to_object(avm, context);
             object.define_value(
                 context.gc_context,
                 "$version",
@@ -369,7 +369,7 @@ impl Player {
                     );
                     let levels = context.levels.clone();
                     for (level, display_object) in levels {
-                        let object = display_object.object().as_object(avm, context);
+                        let object = display_object.object().coerce_to_object(avm, context);
                         dumper.print_variables(
                             &format!("Level #{}:", level),
                             &format!("_level{}", level),
@@ -713,7 +713,7 @@ impl Player {
                     ));
                     if let Ok(prototype) = constructor
                         .get("prototype", avm, context)
-                        .map(|v| v.as_object(avm, context))
+                        .map(|v| v.coerce_to_object(avm, context))
                     {
                         if let Value::Object(object) = actions.clip.object() {
                             object.set_proto(context.gc_context, Some(prototype));

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -252,14 +252,13 @@ impl Player {
             root.set_name(context.gc_context, "");
             context.levels.insert(0, root);
 
-            if let Ok(object) = root.object().as_object() {
-                object.define_value(
-                    context.gc_context,
-                    "$version",
-                    context.system.get_version_string(avm).into(),
-                    EnumSet::empty(),
-                );
-            }
+            let object = root.object().as_object(avm, context);
+            object.define_value(
+                context.gc_context,
+                "$version",
+                context.system.get_version_string(avm).into(),
+                EnumSet::empty(),
+            );
         });
 
         player.build_matrices();
@@ -370,15 +369,14 @@ impl Player {
                     );
                     let levels = context.levels.clone();
                     for (level, display_object) in levels {
-                        if let Ok(object) = display_object.object().as_object() {
-                            dumper.print_variables(
-                                &format!("Level #{}:", level),
-                                &format!("_level{}", level),
-                                &object,
-                                avm,
-                                context,
-                            );
-                        }
+                        let object = display_object.object().as_object(avm, context);
+                        dumper.print_variables(
+                            &format!("Level #{}:", level),
+                            &format!("_level{}", level),
+                            &object,
+                            avm,
+                            context,
+                        );
                     }
                     log::info!("Variable dump:\n{}", dumper.output());
                 });
@@ -715,7 +713,7 @@ impl Player {
                     ));
                     if let Ok(prototype) = constructor
                         .get("prototype", avm, context)
-                        .and_then(|v| v.as_object())
+                        .map(|v| v.as_object(avm, context))
                     {
                         if let Value::Object(object) = actions.clip.object() {
                             object.set_proto(context.gc_context, Some(prototype));

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -110,7 +110,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
         Instant::now().duration_since(self.start_time)
     }
 
-    fn fetch(&self, url: String, _options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
+    fn fetch(&self, url: &str, _options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
         // Load from local filesystem.
         // TODO: Support network loads, honor sandbox type (local-with-filesystem, local-with-network, remote, ...)
         let mut path = self.relative_base_path.clone();

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -92,7 +92,8 @@ impl NavigatorBackend for WebNavigatorBackend {
         Duration::from_millis(dt as u64)
     }
 
-    fn fetch(&self, url: String, options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
+    fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
+        let url = url.to_string();
         Box::pin(async move {
             let mut init = RequestInit::new();
 


### PR DESCRIPTION
In principle, I've removed most "as_foo" methods with "coerce_to_foo". Whenever we expect something to be a specific type "or else", we can manually pick it apart with something like `if let Value::Number(value) = value`. We should not be aborting the avm just because somebody passed in an incorrect type - Flash loves to fail silently.

This will help progress #731.

Along with this is an optimisation to reduce the amount of string allocations we do, by preferring `Cow<str>` for `coerce_to_string`.