### PR TITLE
Fix clippy on nightly

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -288,6 +288,7 @@ impl<'gc> Value<'gc> {
     }
 
     /// ECMA-262 2nd edition s. 11.9.3 Abstract equality comparison algorithm
+    #[allow(clippy::unknown_clippy_lints, clippy::unnested_or_patterns)]
     pub fn abstract_eq(
         &self,
         other: Value<'gc>,


### PR DESCRIPTION
Clippy added a new lint that we can't actually fix until the 'or_patterns' syntax is stabilized. Let's just ignore it. And also ignore the fact that we can't ignore it on stable. 👀 