### PR TITLE
web: Fix WebAudioBackend::stop_sounds_with_handle (fix #752)

### DIFF
--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -775,10 +775,14 @@ impl AudioBackend for WebAudioBackend {
             let mut instances = instances.borrow_mut();
             let handle = Some(handle);
             instances.retain(|_, instance| {
-                if let SoundInstanceType::AudioBuffer(ref node) = instance.instance_type {
-                    let _ = node.disconnect();
+                if instance.handle == handle {
+                    if let SoundInstanceType::AudioBuffer(ref node) = instance.instance_type {
+                        let _ = node.disconnect();
+                    }
+                    false
+                } else {
+                    true
                 }
-                instance.handle != handle
             });
         })
     }


### PR DESCRIPTION
This would incorrectly stop all audio nodes whenever a Stop sound
event was encountered.