### PR TITLE
chore: Mark .as files as ActionScript on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
 # Enforce LF line endings for text files
 *      text=auto eol=lf
 
+# Set *.as files as ActionScript on Github, vs github's guess of AngelScript
+*.as linguist-language=ActionScript
+
 # Binary files
 *.png  binary
 *.fla  binary


### PR DESCRIPTION
Right now it thinks we're part AngelScript, and gives incorrect syntax highlighting