### PR TITLE
Reduce String allocations

### DIFF
--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -428,7 +428,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         attributes: EnumSet<Attribute>,
     ) {
         self.0.write(gc_context).values.insert(
-            name.to_owned(),
+            name,
             Property::Virtual {
                 get,
                 set,
@@ -448,7 +448,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         attributes: EnumSet<Attribute>,
     ) {
         self.0.write(gc_context).values.insert(
-            name.to_owned(),
+            name,
             Property::Virtual {
                 get,
                 set,
@@ -465,11 +465,10 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         value: Value<'gc>,
         attributes: EnumSet<Attribute>,
     ) {
-        self.0.write(gc_context).values.insert(
-            name.to_string(),
-            Property::Stored { value, attributes },
-            false,
-        );
+        self.0
+            .write(gc_context)
+            .values
+            .insert(name, Property::Stored { value, attributes }, false);
     }
 
     fn set_attributes(

--- a/core/src/avm1/script_object.rs
+++ b/core/src/avm1/script_object.rs
@@ -159,12 +159,7 @@ impl<'gc> ScriptObject<'gc> {
         native_value: Option<Value<'gc>>,
         is_enumerable: bool,
     ) {
-        match self
-            .0
-            .write(gc_context)
-            .values
-            .entry(name.to_string(), false)
-        {
+        match self.0.write(gc_context).values.entry(name, false) {
             Entry::Occupied(mut entry) => {
                 if let Property::Stored { value, .. } = entry.get_mut() {
                     match native_value {
@@ -266,7 +261,7 @@ impl<'gc> ScriptObject<'gc> {
                     .0
                     .write(context.gc_context)
                     .values
-                    .entry(name.to_owned(), activation.is_case_sensitive())
+                    .entry(name, activation.is_case_sensitive())
                 {
                     Entry::Occupied(mut entry) => entry.get_mut().set(value.clone()),
                     Entry::Vacant(entry) => {

--- a/core/src/avm1/stage_object.rs
+++ b/core/src/avm1/stage_object.rs
@@ -598,7 +598,7 @@ impl<'gc> DisplayPropertyMap<'gc> {
         set: Option<DisplaySetter<'gc>>,
     ) {
         let prop = DisplayProperty { get, set };
-        self.0.insert(name.to_string(), prop, false);
+        self.0.insert(name, prop, false);
     }
 }
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -479,7 +479,7 @@ impl<'gc> Value<'gc> {
             Value::Null => Cow::Borrowed("null"),
             Value::Bool(true) => Cow::Borrowed("true"),
             Value::Bool(false) => Cow::Borrowed("false"),
-            Value::Number(v) => Cow::Owned(f64_to_string(*v)),
+            Value::Number(v) => f64_to_string(*v),
             Value::String(v) => Cow::Borrowed(v),
         })
     }
@@ -541,13 +541,13 @@ impl<'gc> Value<'gc> {
 
 /// Converts an `f64` to a String with (hopefully) the same output as Flash.
 /// For example, NAN returns `"NaN"`, and infinity returns `"Infinity"`.
-pub fn f64_to_string(n: f64) -> String {
+pub fn f64_to_string(n: f64) -> Cow<'static, str> {
     if n.is_nan() {
-        "NaN".to_string()
+        Cow::Borrowed("NaN")
     } else if n == std::f64::INFINITY {
-        "Infinity".to_string()
+        Cow::Borrowed("Infinity")
     } else if n == std::f64::NEG_INFINITY {
-        "-Infinity".to_string()
+        Cow::Borrowed("-Infinity")
     } else if n != 0.0 && (n.abs() >= 1e15 || n.abs() < 1e-5) {
         // Exponential notation.
         // Cheating a bit here; Flash always put a sign in front of the exponent, e.g. 1e+15.
@@ -558,10 +558,10 @@ pub fn f64_to_string(n: f64) -> String {
                 s.insert(i + 1, '+');
             }
         }
-        s
+        Cow::Owned(s)
     } else {
         // Normal number.
-        n.to_string()
+        Cow::Owned(n.to_string())
     }
 }
 

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -1193,14 +1193,14 @@ impl FormatSpans {
         for step in tree.as_node().walk().unwrap() {
             match step {
                 Step::In(node)
-                    if node.tag_name().unwrap().node_name().as_str() == "sbr"
-                        || node.tag_name().unwrap().node_name().as_str() == "br" =>
+                    if node.tag_name().unwrap().node_name() == "sbr"
+                        || node.tag_name().unwrap().node_name() == "br" =>
                 {
                     self.replace_text(self.text.len(), self.text.len(), "\n", format_stack.last());
                 }
                 Step::Out(node)
-                    if node.tag_name().unwrap().node_name().as_str() == "sbr"
-                        || node.tag_name().unwrap().node_name().as_str() == "br" => {}
+                    if node.tag_name().unwrap().node_name() == "sbr"
+                        || node.tag_name().unwrap().node_name() == "br" => {}
                 Step::In(node) => format_stack.push(TextFormat::from_presentational_markup(
                     node,
                     format_stack
@@ -1218,8 +1218,8 @@ impl FormatSpans {
                     last_successful_format = format_stack.last().cloned();
                 }
                 Step::Out(node)
-                    if node.tag_name().unwrap().node_name().as_str() == "p"
-                        || node.tag_name().unwrap().node_name().as_str() == "li" =>
+                    if node.tag_name().unwrap().node_name() == "p"
+                        || node.tag_name().unwrap().node_name() == "li" =>
                 {
                     self.replace_text(
                         self.text.len(),

--- a/core/src/property_map.rs
+++ b/core/src/property_map.rs
@@ -76,8 +76,8 @@ impl<V> PropertyMap<V> {
         self.0.get_index(index).map(|(_, v)| v)
     }
 
-    pub fn insert(&mut self, key: String, value: V, case_sensitive: bool) -> Option<V> {
-        match self.entry(&key, case_sensitive) {
+    pub fn insert(&mut self, key: &str, value: V, case_sensitive: bool) -> Option<V> {
+        match self.entry(key, case_sensitive) {
             Entry::Occupied(entry) => Some(entry.insert(value)),
             Entry::Vacant(entry) => {
                 entry.insert(value);

--- a/core/src/property_map.rs
+++ b/core/src/property_map.rs
@@ -26,7 +26,7 @@ impl<V> PropertyMap<V> {
         }
     }
 
-    pub fn entry(&mut self, key: &str, case_sensitive: bool) -> Entry<V> {
+    pub fn entry<'a>(&'a mut self, key: &'a str, case_sensitive: bool) -> Entry<'a, V> {
         if case_sensitive {
             match self.0.get_full_mut(&CaseSensitiveStr(&key)) {
                 Some((index, _, _)) => Entry::Occupied(OccupiedEntry {
@@ -35,7 +35,7 @@ impl<V> PropertyMap<V> {
                 }),
                 None => Entry::Vacant(VacantEntry {
                     map: &mut self.0,
-                    key: key.to_string(),
+                    key,
                 }),
             }
         } else {
@@ -46,7 +46,7 @@ impl<V> PropertyMap<V> {
                 }),
                 None => Entry::Vacant(VacantEntry {
                     map: &mut self.0,
-                    key: key.to_string(),
+                    key,
                 }),
             }
         }
@@ -141,12 +141,12 @@ impl<'a, V> OccupiedEntry<'a, V> {
 
 pub struct VacantEntry<'a, V> {
     map: &'a mut IndexMap<PropertyName, V>,
-    key: String,
+    key: &'a str,
 }
 
 impl<'a, V> VacantEntry<'a, V> {
     pub fn insert(self, value: V) {
-        self.map.insert(PropertyName(self.key), value);
+        self.map.insert(PropertyName(self.key.to_string()), value);
     }
 }
 

--- a/core/src/property_map.rs
+++ b/core/src/property_map.rs
@@ -26,7 +26,7 @@ impl<V> PropertyMap<V> {
         }
     }
 
-    pub fn entry(&mut self, key: String, case_sensitive: bool) -> Entry<V> {
+    pub fn entry(&mut self, key: &str, case_sensitive: bool) -> Entry<V> {
         if case_sensitive {
             match self.0.get_full_mut(&CaseSensitiveStr(&key)) {
                 Some((index, _, _)) => Entry::Occupied(OccupiedEntry {
@@ -35,7 +35,7 @@ impl<V> PropertyMap<V> {
                 }),
                 None => Entry::Vacant(VacantEntry {
                     map: &mut self.0,
-                    key,
+                    key: key.to_string(),
                 }),
             }
         } else {
@@ -46,7 +46,7 @@ impl<V> PropertyMap<V> {
                 }),
                 None => Entry::Vacant(VacantEntry {
                     map: &mut self.0,
-                    key,
+                    key: key.to_string(),
                 }),
             }
         }
@@ -77,7 +77,7 @@ impl<V> PropertyMap<V> {
     }
 
     pub fn insert(&mut self, key: String, value: V, case_sensitive: bool) -> Option<V> {
-        match self.entry(key, case_sensitive) {
+        match self.entry(&key, case_sensitive) {
             Entry::Occupied(entry) => Some(entry.insert(value)),
             Entry::Vacant(entry) => {
                 entry.insert(value);

--- a/core/src/xml/namespace.rs
+++ b/core/src/xml/namespace.rs
@@ -78,11 +78,11 @@ impl XMLName {
     /// Return the fully qualified part of the name.
     ///
     /// This consists of the namespace, if present, plus a colon and local name.
-    pub fn node_name(&self) -> String {
+    pub fn node_name(&self) -> Cow<str> {
         if let Some(ref ns) = self.namespace {
-            format!("{}:{}", ns, self.name)
+            Cow::Owned(format!("{}:{}", ns, self.name))
         } else {
-            self.name.to_string()
+            Cow::Borrowed(&self.name)
         }
     }
 }


### PR DESCRIPTION
Nothing incredible, but there's a few places we're allocating Strings and we don't need to be. PropertyMap, for example, very rarely needs ownership of Strings so everything passing in an allocated new String is just a waste.