### PR TITLE
Made Executable::Action take in a Gc to Avm1Function

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -12,7 +12,7 @@ use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject};
 use crate::tag_utils::SwfSlice;
 use enumset::EnumSet;
-use gc_arena::{Collect, GcCell, MutationContext};
+use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use rand::Rng;
 use smallvec::SmallVec;
 use std::borrow::Cow;
@@ -804,7 +804,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             ScriptObject::object(context.gc_context, Some(self.avm.prototypes.object)).into();
         let func_obj = FunctionObject::function(
             context.gc_context,
-            func,
+            Gc::allocate(context.gc_context, func),
             Some(self.avm.prototypes.function),
             Some(prototype),
         );
@@ -839,7 +839,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             ScriptObject::object(context.gc_context, Some(self.avm.prototypes.object)).into();
         let func_obj = FunctionObject::function(
             context.gc_context,
-            func,
+            Gc::allocate(context.gc_context, func),
             Some(self.avm.prototypes.function),
             Some(prototype),
         );

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -10,7 +10,7 @@ use crate::avm1::{Object, ObjectPtr, ScriptObject, TObject, UpdateContext};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::tag_utils::SwfSlice;
 use enumset::EnumSet;
-use gc_arena::{Collect, CollectionContext, GcCell, MutationContext};
+use gc_arena::{Collect, CollectionContext, Gc, GcCell, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
 use swf::avm1::types::FunctionParam;
@@ -189,7 +189,7 @@ pub enum Executable<'gc> {
 
     /// ActionScript data defined by a previous `DefineFunction` or
     /// `DefineFunction2` action.
-    Action(Avm1Function<'gc>),
+    Action(Gc<'gc, Avm1Function<'gc>>),
 }
 
 unsafe impl<'gc> Collect for Executable<'gc> {
@@ -367,8 +367,8 @@ impl<'gc> From<NativeFunction<'gc>> for Executable<'gc> {
     }
 }
 
-impl<'gc> From<Avm1Function<'gc>> for Executable<'gc> {
-    fn from(af: Avm1Function<'gc>) -> Self {
+impl<'gc> From<Gc<'gc, Avm1Function<'gc>>> for Executable<'gc> {
+    fn from(af: Gc<'gc, Avm1Function<'gc>>) -> Self {
         Executable::Action(af)
     }
 }


### PR DESCRIPTION
Per the comments in #767

This reduces the size of `Executable` to 16 bytes, down from 128. It is often cloned, such as once on every function call.