### PR TITLE
core: Limit tag parsing to slice of tag data

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -248,7 +248,7 @@ impl<'gc> MovieClip<'gc> {
                 TagCode::DefineSound => self
                     .0
                     .write(context.gc_context)
-                    .define_sound(context, reader, tag_len),
+                    .define_sound(context, reader),
                 TagCode::DefineSprite => self.0.write(context.gc_context).define_sprite(
                     avm,
                     context,
@@ -1678,10 +1678,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let id = reader.read_u16()?;
         let data_len = tag_len - 2;
         let mut jpeg_data = Vec::with_capacity(data_len);
-        reader
-            .get_mut()
-            .take(data_len as u64)
-            .read_to_end(&mut jpeg_data)?;
+        reader.get_mut().read_to_end(&mut jpeg_data)?;
         let bitmap_info = context.renderer.register_bitmap_jpeg(
             id,
             &jpeg_data,
@@ -1715,10 +1712,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let id = reader.read_u16()?;
         let data_len = tag_len - 2;
         let mut jpeg_data = Vec::with_capacity(data_len);
-        reader
-            .get_mut()
-            .take(data_len as u64)
-            .read_to_end(&mut jpeg_data)?;
+        reader.get_mut().read_to_end(&mut jpeg_data)?;
         let bitmap_info = context.renderer.register_bitmap_jpeg_2(id, &jpeg_data)?;
         let bitmap = crate::display_object::Bitmap::new(
             context,
@@ -2001,14 +1995,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
-        tag_len: usize,
     ) -> DecodeResult {
-        // TODO(Herschel): Can we use a slice of the sound data instead of copying the data?
-        use std::io::Read;
-        let mut reader = swf::read::Reader::new(
-            reader.get_mut().take(tag_len as u64),
-            self.static_data.swf.version(),
-        );
         let sound = reader.read_define_sound()?;
         if let Ok(handle) = context.audio.register_sound(&sound) {
             context
@@ -2123,10 +2110,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         use std::io::Read;
         // TODO(Herschel): Can we use a slice instead of copying?
         let mut jpeg_data = Vec::with_capacity(tag_len);
-        reader
-            .get_mut()
-            .take(tag_len as u64)
-            .read_to_end(&mut jpeg_data)?;
+        reader.get_mut().read_to_end(&mut jpeg_data)?;
         context
             .library
             .library_for_movie_mut(self.movie())

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -342,6 +342,10 @@ impl<R: Read> Reader<R> {
         }
     }
 
+    pub fn version(&self) -> u8 {
+        self.version
+    }
+
     /// Returns a reference to the underlying `Reader`.
     pub fn get_ref(&self) -> &R {
         &self.input


### PR DESCRIPTION
The tag parsing code in `core` vs. the parsing code in `swf` has gotten a little muddled about who is responsible for slicing the tag data when parsing the SWF. The `swf` functions expect the underlying reader to contain the tag data only, but `core` will often call the `swf` functions with a reader containing the entire SWF data. This can cause huge memory usage as many tags without an explicit length would read data to the end of the SWF instead of the end of the tag (see #808).

As a stop-gap, this adjusts the tag parsing in `MovieClip` to make a sub-reader with a slice of the tag data, avoiding unbounded reads. TODO: The next task will be to go through `swf` and change it to operate on [u8] slices instead of arbitrary streams, which should clean this up better.