### PR TITLE
Allow toggling avm_debug output on and off with ctrl+alt+d

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -282,7 +282,7 @@ impl<'gc> Executable<'gc> {
                         .unwrap_or(ac.player_version)
                 };
 
-                let name = if cfg!(feature = "avm_debug") {
+                let name = if activation.avm.show_debug_output() {
                     let mut result = match &af.name {
                         None => name.to_string(),
                         Some(name) => name.to_string(),

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -415,7 +415,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error> {
         let op = reader.read_op();
         if let Ok(Some(op)) = op {
-            avm_debug!("Opcode: {:?}", op);
+            avm_debug!(self.avm2, "Opcode: {:?}", op);
 
             let result = match op {
                 Op::PushByte { value } => self.op_push_byte(value),
@@ -1093,7 +1093,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         index: Index<AbcMultiname>,
     ) -> Result<FrameControl<'gc>, Error> {
         let multiname = self.pool_multiname(method, index, context.gc_context)?;
-        avm_debug!("Resolving {:?}", multiname);
+        avm_debug!(self.avm2, "Resolving {:?}", multiname);
         let result = if let Some(scope) = self.scope() {
             scope.read().find(&multiname, self, context)?
         } else {
@@ -1113,7 +1113,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         index: Index<AbcMultiname>,
     ) -> Result<FrameControl<'gc>, Error> {
         let multiname = self.pool_multiname(method, index, context.gc_context)?;
-        avm_debug!("Resolving {:?}", multiname);
+        avm_debug!(self.avm2, "Resolving {:?}", multiname);
         let found: Result<Object<'gc>, Error> = if let Some(scope) = self.scope() {
             scope.read().find(&multiname, self, context)?
         } else {
@@ -1134,7 +1134,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         index: Index<AbcMultiname>,
     ) -> Result<FrameControl<'gc>, Error> {
         let multiname = self.pool_multiname_static(method, index, context.gc_context)?;
-        avm_debug!("Resolving {:?}", multiname);
+        avm_debug!(self.avm2, "Resolving {:?}", multiname);
         let found: Result<Value<'gc>, Error> = if let Some(scope) = self.scope() {
             scope
                 .write(context.gc_context)
@@ -1607,9 +1607,9 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             let register_name = self.pool_string(method, register_name)?;
             let value = self.local_register(register as u32)?;
 
-            avm_debug!("Debug: {} = {:?}", register_name, value);
+            avm_debug!(self.avm2, "Debug: {} = {:?}", register_name, value);
         } else {
-            avm_debug!("Unknown debugging mode!");
+            avm_debug!(self.avm2, "Unknown debugging mode!");
         }
 
         Ok(FrameControl::Continue)
@@ -1636,7 +1636,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error> {
         let file_name = self.pool_string(method, file_name)?;
 
-        avm_debug!("File: {}", file_name);
+        avm_debug!(self.avm2, "File: {}", file_name);
 
         Ok(FrameControl::Continue)
     }
@@ -1653,7 +1653,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     #[allow(unused_variables)]
     fn op_debug_line(&mut self, line_num: u32) -> Result<FrameControl<'gc>, Error> {
-        avm_debug!("Line: {}", line_num);
+        avm_debug!(self.avm2, "Line: {}", line_num);
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -431,6 +431,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         let fn_proto = activation.avm2().prototypes().function;
         let trait_name = trait_entry.name().clone();
         avm_debug!(
+            activation.avm2(),
             "Installing trait {:?} of kind {:?}",
             trait_name,
             trait_entry.kind()

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -451,6 +451,32 @@ impl Player {
             }
         }
 
+        if cfg!(feature = "avm_debug") {
+            if let PlayerEvent::KeyDown {
+                key_code: KeyCode::D,
+            } = event
+            {
+                if self.input.is_key_down(KeyCode::Control) && self.input.is_key_down(KeyCode::Alt)
+                {
+                    self.mutate_with_update_context(|avm1, avm2, _context| {
+                        if avm1.show_debug_output() {
+                            log::info!(
+                                "AVM Debugging turned off! Press CTRL+ALT+D to turn off again."
+                            );
+                            avm1.set_show_debug_output(false);
+                            avm2.set_show_debug_output(false);
+                        } else {
+                            log::info!(
+                                "AVM Debugging turned on! Press CTRL+ALT+D to turn on again."
+                            );
+                            avm1.set_show_debug_output(true);
+                            avm2.set_show_debug_output(true);
+                        }
+                    });
+                }
+            }
+        }
+
         // Update mouse position from mouse events.
         if let PlayerEvent::MouseMove { x, y }
         | PlayerEvent::MouseDown { x, y }


### PR DESCRIPTION
Defaults to off, but I figure this should probably be a command-line argument or API argument later.

This (ab)uses constant functions to make sure that code is compiled out when the feature is turned off.