### PR TITLE
Debugging improvements - warnings, errors, documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,23 @@ Ruffle is a young project, and there is still much Flash functionality that is u
 ## Debugging ActionScript Content
 
 If you build Ruffle with `--features avm_debug` and enable debug logging (`RUST_LOG=warn,ruffle_core=debug`) then you will
-be able to follow the flow of ActionScript inside of a SWF movie. Please note that this will likely slow down Ruffle,
-and it may spam quite a lot of output.
+activate a few built-in debugging utilities inside Ruffle, listed below.
+ 
+### Warnings and Errors
+All AVM errors and warnings will print their stack trace so that you can view where they are in relation to the 
+ActionScript inside the movie. This requires no extra configuration and will be visible by default.
+
+### Step-By-Step Output
+If you use the hotkey `CTRL + ALT + D` you will toggle verbose AVM debugging output on and off (default off). 
+You will be able to follow the flow of ActionScript inside of a SWF movie, as each action is performed.
+Please note that this will likely slow down Ruffle, and it may significantly spam output. Please use sparingly.
 
 When paired with a tool such as [JPEXS](https://github.com/jindrapetrik/jpexs-decompiler), you can compare the ActionScript
 you see being executed in Ruffle with the actual ActionScript inside of the game, and attempt to find whatever problem
 it is that you're looking for.
 
-In addition to this, the hotkey `CTRL + ALT + V` will dump every variable inside the AVM at the moment you press it.
+### Complete Variable Dumping
+The hotkey `CTRL + ALT + V` will dump every variable inside the AVM at the moment you press it.
 This can be very useful to inspect the internal state of games and see, for example, if a coordinate is NaN, your lives
 are negative, or maybe an important object just didn't get initialized.
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -54,6 +54,26 @@ macro_rules! avm_debug {
     )
 }
 
+macro_rules! avm_warn {
+    ($activation: ident, $($arg:tt)*) => (
+        if cfg!(feature = "avm_debug") {
+            log::warn!("{} -- in {}", format!($($arg)*), $activation.id())
+        } else {
+            log::warn!($($arg)*)
+        }
+    )
+}
+
+macro_rules! avm_error {
+    ($activation: ident, $($arg:tt)*) => (
+        if cfg!(feature = "avm_debug") {
+            log::error!("{} -- in {}", format!($($arg)*), $activation.id())
+        } else {
+            log::error!($($arg)*)
+        }
+    )
+}
+
 pub struct Avm1<'gc> {
     /// The Flash Player version we're emulating.
     player_version: u8,

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -54,20 +54,22 @@ macro_rules! avm_debug {
     )
 }
 
+#[macro_export]
 macro_rules! avm_warn {
     ($activation: ident, $($arg:tt)*) => (
         if cfg!(feature = "avm_debug") {
-            log::warn!("{} -- in {}", format!($($arg)*), $activation.id())
+            log::warn!("{} -- in {}", format!($($arg)*), $activation.id)
         } else {
             log::warn!($($arg)*)
         }
     )
 }
 
+#[macro_export]
 macro_rules! avm_error {
     ($activation: ident, $($arg:tt)*) => (
         if cfg!(feature = "avm_debug") {
-            log::error!("{} -- in {}", format!($($arg)*), $activation.id())
+            log::error!("{} -- in {}", format!($($arg)*), $activation.id)
         } else {
             log::error!($($arg)*)
         }

--- a/core/src/avm1/fscommand.rs
+++ b/core/src/avm1/fscommand.rs
@@ -3,6 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::UpdateContext;
+use crate::avm_warn;
 /// Parse an FSCommand URL.
 pub fn parse(url: &str) -> Option<&str> {
     log::info!("Checking {}", url);
@@ -16,10 +17,10 @@ pub fn parse(url: &str) -> Option<&str> {
 /// TODO: FSCommand URL handling
 pub fn handle<'gc>(
     fscommand: &str,
-    _activation: &mut Activation,
+    activation: &mut Activation,
     _ac: &mut UpdateContext,
 ) -> Result<(), Error<'gc>> {
-    log::warn!("Unhandled FSCommand: {}", fscommand);
+    avm_warn!(activation, "Unhandled FSCommand: {}", fscommand);
 
     //This should be an error.
     Ok(())

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -282,7 +282,7 @@ impl<'gc> Executable<'gc> {
                         .unwrap_or(ac.player_version)
                 };
 
-                let name = if activation.avm.show_debug_output() {
+                let name = if cfg!(feature = "avm_debug") {
                     let mut result = match &af.name {
                         None => name.to_string(),
                         Some(name) => name.to_string(),

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -5,6 +5,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm_warn;
 use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use gc_arena::MutationContext;
 use std::borrow::Cow;
@@ -120,12 +121,12 @@ pub fn create_proto<'gc>(
 }
 
 fn add_request_header<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("LoadVars.addRequestHeader: Unimplemented");
+    avm_warn!(activation, "LoadVars.addRequestHeader: Unimplemented");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -4,6 +4,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute::{self, *};
 use crate::avm1::{Object, TObject, UpdateContext, Value};
+use crate::avm_warn;
 use crate::character::Character;
 use crate::display_object::TDisplayObject;
 use enumset::EnumSet;
@@ -304,7 +305,10 @@ pub fn as_set_prop_flags<'gc>(
     let mut object = if let Some(object) = args.get(0).map(|v| v.coerce_to_object(activation, ac)) {
         object
     } else {
-        log::warn!("ASSetPropFlags called without object to apply to!");
+        avm_warn!(
+            activation,
+            "ASSetPropFlags called without object to apply to!"
+        );
         return Ok(Value::Undefined);
     };
 
@@ -329,7 +333,7 @@ pub fn as_set_prop_flags<'gc>(
         Some(Value::String(s)) => Some(s.split(',').map(String::from).collect()),
         Some(_) => None,
         None => {
-            log::warn!("ASSetPropFlags called without object list!");
+            avm_warn!(activation, "ASSetPropFlags called without object list!");
             return Ok(Value::Undefined);
         }
     };

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -2,6 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::{AvmString, Object, TObject, Value};
+use crate::avm_warn;
 use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
@@ -11,22 +12,22 @@ use crate::avm1::object::shared_object::SharedObject;
 use json::JsonValue;
 
 pub fn delete_all<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.deleteAll() not implemented");
+    avm_warn!(activation, "SharedObject.deleteAll() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn get_disk_usage<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.getDiskUsage() not implemented");
+    avm_warn!(activation, "SharedObject.getDiskUsage() not implemented");
     Ok(Value::Undefined)
 }
 
@@ -150,7 +151,10 @@ pub fn get_local<'gc>(
     }
 
     if args.len() > 1 {
-        log::warn!("SharedObject.getLocal() doesn't support localPath or secure yet");
+        avm_warn!(
+            activation,
+            "SharedObject.getLocal() doesn't support localPath or secure yet"
+        );
     }
 
     // Data property only should exist when created with getLocal/Remote
@@ -187,42 +191,42 @@ pub fn get_local<'gc>(
 }
 
 pub fn get_remote<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.getRemote() not implemented");
+    avm_warn!(activation, "SharedObject.getRemote() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn get_max_size<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.getMaxSize() not implemented");
+    avm_warn!(activation, "SharedObject.getMaxSize() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn add_listener<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.addListener() not implemented");
+    avm_warn!(activation, "SharedObject.addListener() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn remove_listener<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.removeListener() not implemented");
+    avm_warn!(activation, "SharedObject.removeListener() not implemented");
     Ok(Value::Undefined)
 }
 
@@ -321,22 +325,22 @@ pub fn clear<'gc>(
 }
 
 pub fn close<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.close() not implemented");
+    avm_warn!(activation, "SharedObject.close() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn connect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.connect() not implemented");
+    avm_warn!(activation, "SharedObject.connect() not implemented");
     Ok(Value::Undefined)
 }
 
@@ -363,52 +367,52 @@ pub fn flush<'gc>(
 }
 
 pub fn get_size<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.getSize() not implemented");
+    avm_warn!(activation, "SharedObject.getSize() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn send<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.send() not implemented");
+    avm_warn!(activation, "SharedObject.send() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn set_fps<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.setFps() not implemented");
+    avm_warn!(activation, "SharedObject.setFps() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn on_status<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.onStatus() not implemented");
+    avm_warn!(activation, "SharedObject.onStatus() not implemented");
     Ok(Value::Undefined)
 }
 
 pub fn on_sync<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("SharedObject.onSync() not implemented");
+    avm_warn!(activation, "SharedObject.onSync() not implemented");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -6,6 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute::*;
 use crate::avm1::{Object, SoundObject, TObject, UpdateContext, Value};
+use crate::avm_warn;
 use crate::character::Character;
 use crate::display_object::TDisplayObject;
 use gc_arena::MutationContext;
@@ -201,16 +202,17 @@ fn attach_sound<'gc>(
                 );
                 sound_object.set_position(context.gc_context, 0);
             } else {
-                log::warn!("Sound.attachSound: Sound '{}' not found", name);
+                avm_warn!(activation, "Sound.attachSound: Sound '{}' not found", name);
             }
         } else {
-            log::warn!(
+            avm_warn!(
+                activation,
                 "Sound.attachSound: Cannot attach Sound '{}' without a library to reference",
                 name
             );
         }
     } else {
-        log::warn!("Sound.attachSound: this is not a Sound");
+        avm_warn!(activation, "Sound.attachSound: this is not a Sound");
     }
     Ok(Value::Undefined)
 }
@@ -225,7 +227,7 @@ fn duration<'gc>(
         if let Some(sound_object) = this.as_sound_object() {
             return Ok(sound_object.duration().into());
         } else {
-            log::warn!("Sound.duration: this is not a Sound");
+            avm_warn!(activation, "Sound.duration: this is not a Sound");
         }
     }
 
@@ -239,7 +241,7 @@ fn get_bytes_loaded<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.current_swf_version() >= 6 {
-        log::warn!("Sound.getBytesLoaded: Unimplemented");
+        avm_warn!(activation, "Sound.getBytesLoaded: Unimplemented");
         Ok(1.into())
     } else {
         Ok(Value::Undefined)
@@ -253,7 +255,7 @@ fn get_bytes_total<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.current_swf_version() >= 6 {
-        log::warn!("Sound.getBytesTotal: Unimplemented");
+        avm_warn!(activation, "Sound.getBytesTotal: Unimplemented");
         Ok(1.into())
     } else {
         Ok(Value::Undefined)
@@ -261,32 +263,32 @@ fn get_bytes_total<'gc>(
 }
 
 fn get_pan<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Sound.getPan: Unimplemented");
+    avm_warn!(activation, "Sound.getPan: Unimplemented");
     Ok(0.into())
 }
 
 fn get_transform<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Sound.getTransform: Unimplemented");
+    avm_warn!(activation, "Sound.getTransform: Unimplemented");
     Ok(Value::Undefined)
 }
 
 fn get_volume<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Sound.getVolume: Unimplemented");
+    avm_warn!(activation, "Sound.getVolume: Unimplemented");
     Ok(100.into())
 }
 
@@ -297,7 +299,7 @@ fn id3<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.current_swf_version() >= 6 {
-        log::warn!("Sound.id3: Unimplemented");
+        avm_warn!(activation, "Sound.id3: Unimplemented");
     }
     Ok(Value::Undefined)
 }
@@ -309,7 +311,7 @@ fn load_sound<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.current_swf_version() >= 6 {
-        log::warn!("Sound.loadSound: Unimplemented");
+        avm_warn!(activation, "Sound.loadSound: Unimplemented");
     }
     Ok(Value::Undefined)
 }
@@ -327,44 +329,44 @@ fn position<'gc>(
             // Needs some audio backend work for this.
             if sound_object.sound().is_some() {
                 if let Some(_sound_instance) = sound_object.sound_instance() {
-                    log::warn!("Sound.position: Unimplemented");
+                    avm_warn!(activation, "Sound.position: Unimplemented");
                 }
                 return Ok(sound_object.position().into());
             }
         } else {
-            log::warn!("Sound.position: this is not a Sound");
+            avm_warn!(activation, "Sound.position: this is not a Sound");
         }
     }
     Ok(Value::Undefined)
 }
 
 fn set_pan<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Sound.setPan: Unimplemented");
+    avm_warn!(activation, "Sound.setPan: Unimplemented");
     Ok(Value::Undefined)
 }
 
 fn set_transform<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Sound.setTransform: Unimplemented");
+    avm_warn!(activation, "Sound.setTransform: Unimplemented");
     Ok(Value::Undefined)
 }
 
 fn set_volume<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Sound.setVolume: Unimplemented");
+    avm_warn!(activation, "Sound.setVolume: Unimplemented");
     Ok(Value::Undefined)
 }
 
@@ -410,10 +412,10 @@ fn start<'gc>(
                 sound_object.set_sound_instance(context.gc_context, Some(sound_instance));
             }
         } else {
-            log::warn!("Sound.start: No sound is attached");
+            avm_warn!(activation, "Sound.start: No sound is attached");
         }
     } else {
-        log::warn!("Sound.start: Invalid sound");
+        avm_warn!(activation, "Sound.start: Invalid sound");
     }
 
     Ok(Value::Undefined)
@@ -442,10 +444,11 @@ fn stop<'gc>(
                     // Stop all sounds with the given name.
                     context.audio.stop_sounds_with_handle(*sound);
                 } else {
-                    log::warn!("Sound.stop: Sound '{}' not found", name);
+                    avm_warn!(activation, "Sound.stop: Sound '{}' not found", name);
                 }
             } else {
-                log::warn!(
+                avm_warn!(
+                    activation,
                     "Sound.stop: Cannot stop Sound '{}' without a library to reference",
                     name
                 )
@@ -461,7 +464,7 @@ fn stop<'gc>(
             context.audio.stop_all_sounds();
         }
     } else {
-        log::warn!("Sound.stop: this is not a Sound");
+        avm_warn!(activation, "Sound.stop: this is not a Sound");
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -6,6 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm_warn;
 use gc_arena::MutationContext;
 
 pub fn create_stage_object<'gc>(
@@ -101,32 +102,32 @@ pub fn create_stage_object<'gc>(
 }
 
 fn add_listener<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.addListener: unimplemented");
+    avm_warn!(activation, "Stage.addListener: unimplemented");
     Ok(Value::Undefined)
 }
 
 fn align<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.align: unimplemented");
+    avm_warn!(activation, "Stage.align: unimplemented");
     Ok("".into())
 }
 
 fn set_align<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.align: unimplemented");
+    avm_warn!(activation, "Stage.align: unimplemented");
     Ok(Value::Undefined)
 }
 
@@ -140,52 +141,52 @@ fn height<'gc>(
 }
 
 fn remove_listener<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.removeListener: unimplemented");
+    avm_warn!(activation, "Stage.removeListener: unimplemented");
     Ok("".into())
 }
 
 fn scale_mode<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.scaleMode: unimplemented");
+    avm_warn!(activation, "Stage.scaleMode: unimplemented");
     Ok("noScale".into())
 }
 
 fn set_scale_mode<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.scaleMode: unimplemented");
+    avm_warn!(activation, "Stage.scaleMode: unimplemented");
     Ok(Value::Undefined)
 }
 
 fn show_menu<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.showMenu: unimplemented");
+    avm_warn!(activation, "Stage.showMenu: unimplemented");
     Ok(true.into())
 }
 
 fn set_show_menu<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Stage.showMenu: unimplemented");
+    avm_warn!(activation, "Stage.showMenu: unimplemented");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -3,6 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::Object;
 use crate::avm1::{ScriptObject, TObject, Value};
+use crate::avm_warn;
 use crate::context::UpdateContext;
 use core::fmt;
 use enumset::{EnumSet, EnumSetType};
@@ -435,7 +436,11 @@ pub fn show_settings<'gc>(
 
     let panel = SettingsPanel::try_from(panel_pos as u8).unwrap_or(SettingsPanel::Privacy);
 
-    log::warn!("System.showSettings({:?}) not not implemented", panel);
+    avm_warn!(
+        activation,
+        "System.showSettings({:?}) not not implemented",
+        panel
+    );
     Ok(Value::Undefined)
 }
 
@@ -492,12 +497,12 @@ pub fn get_exact_settings<'gc>(
 }
 
 pub fn on_status<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _action_context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.onStatus() not implemented");
+    avm_warn!(activation, "System.onStatus() not implemented");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -3,48 +3,55 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::Object;
 use crate::avm1::{AvmString, ScriptObject, TObject, Value};
+use crate::avm_warn;
 use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::convert::Into;
 
 fn allow_domain<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.security.allowDomain() not implemented");
+    avm_warn!(activation, "System.security.allowDomain() not implemented");
     Ok(Value::Undefined)
 }
 
 fn allow_insecure_domain<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.security.allowInsecureDomain() not implemented");
+    avm_warn!(
+        activation,
+        "System.security.allowInsecureDomain() not implemented"
+    );
     Ok(Value::Undefined)
 }
 
 fn load_policy_file<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.security.allowInsecureDomain() not implemented");
+    avm_warn!(
+        activation,
+        "System.security.allowInsecureDomain() not implemented"
+    );
     Ok(Value::Undefined)
 }
 
 fn escape_domain<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.security.escapeDomain() not implemented");
+    avm_warn!(activation, "System.security.escapeDomain() not implemented");
     Ok(Value::Undefined)
 }
 
@@ -58,22 +65,28 @@ fn get_sandbox_type<'gc>(
 }
 
 fn get_choose_local_swf_path<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.security.chooseLocalSwfPath() not implemented");
+    avm_warn!(
+        activation,
+        "System.security.chooseLocalSwfPath() not implemented"
+    );
     Ok(Value::Undefined)
 }
 
 fn policy_file_resolver<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("System.security.chooseLocalSwfPath() not implemented");
+    avm_warn!(
+        activation,
+        "System.security.chooseLocalSwfPath() not implemented"
+    );
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -4,6 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::display_object;
 use crate::avm1::property::Attribute::*;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm_error;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::html::TextFormat;
 use gc_arena::MutationContext;
@@ -45,7 +46,7 @@ pub fn set_text<'gc>(
                     value.coerce_to_string(activation, context)?.to_string(),
                     context,
                 ) {
-                    log::error!("Error when setting TextField.text: {}", err);
+                    avm_error!(activation, "Error when setting TextField.text: {}", err);
                 }
                 text_field.propagate_text_binding(activation, context);
             }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -13,6 +13,7 @@ use crate::avm1::object::xml_attributes_object::XMLAttributesObject;
 use crate::avm1::object::xml_idmap_object::XMLIDMapObject;
 use crate::avm1::object::xml_object::XMLObject;
 use crate::avm1::{ScriptObject, SoundObject, StageObject, UpdateContext, Value};
+use crate::avm_warn;
 use crate::display_object::DisplayObject;
 use crate::xml::XMLNode;
 use enumset::EnumSet;
@@ -132,7 +133,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
         if let Value::Object(_) = method {
         } else {
-            log::warn!("Object method {} is not callable", name);
+            avm_warn!(activation, "Object method {} is not callable", name);
         }
 
         method.call(name, activation, context, (*self).into(), base_proto, args)

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -6,6 +6,7 @@ use crate::avm1::function::Executable;
 use crate::avm1::object::search_prototype;
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ObjectPtr, ScriptObject, TDisplayObject, TObject, Value};
+use crate::avm_warn;
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, EditText, MovieClip};
 use crate::property_map::PropertyMap;
@@ -888,11 +889,11 @@ fn set_name<'gc>(
 }
 
 fn drop_target<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Unimplemented property _droptarget");
+    avm_warn!(activation, "Unimplemented property _droptarget");
     Ok("".into())
 }
 
@@ -910,78 +911,78 @@ fn url<'gc>(
 }
 
 fn high_quality<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Unimplemented property _highquality");
+    avm_warn!(activation, "Unimplemented property _highquality");
     Ok(1.into())
 }
 
 fn set_high_quality<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    log::warn!("Unimplemented property _highquality");
+    avm_warn!(activation, "Unimplemented property _highquality");
     Ok(())
 }
 
 fn focus_rect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Unimplemented property _focusrect");
+    avm_warn!(activation, "Unimplemented property _focusrect");
     Ok(Value::Null)
 }
 
 fn set_focus_rect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    log::warn!("Unimplemented property _focusrect");
+    avm_warn!(activation, "Unimplemented property _focusrect");
     Ok(())
 }
 
 fn sound_buf_time<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Unimplemented property _soundbuftime");
+    avm_warn!(activation, "Unimplemented property _soundbuftime");
     Ok(5.into())
 }
 
 fn set_sound_buf_time<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    log::warn!("Unimplemented property _soundbuftime");
+    avm_warn!(activation, "Unimplemented property _soundbuftime");
     Ok(())
 }
 
 fn quality<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    log::warn!("Unimplemented property _quality");
+    avm_warn!(activation, "Unimplemented property _quality");
     Ok("HIGH".into())
 }
 
 fn set_quality<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _context: &mut UpdateContext<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    log::warn!("Unimplemented property _quality");
+    avm_warn!(activation, "Unimplemented property _quality");
     Ok(())
 }
 

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -7,6 +7,7 @@ use crate::avm1::object::script_object::TYPE_OF_OBJECT;
 use crate::avm1::object::search_prototype;
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ObjectPtr, ScriptObject, TObject, Value};
+use crate::avm_warn;
 use crate::context::UpdateContext;
 use crate::display_object::DisplayObject;
 use enumset::EnumSet;
@@ -138,7 +139,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
         if let Value::Object(_) = method {
         } else {
-            log::warn!("Super method {} is not callable", name);
+            avm_warn!(activation, "Super method {} is not callable", name);
         }
 
         method.call(name, activation, context, child, base_proto, args)

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -11,6 +11,7 @@ use gc_arena::{Collect, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
 
+use crate::avm_warn;
 /// A ScriptObject that is inherently tied to an XML node's attributes.
 ///
 /// Note that this is *not* the same as the XMLNode object itself; for example,
@@ -116,7 +117,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         _args: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error<'gc>> {
         //TODO: `new xmlnode.attributes()` returns undefined, not an object
-        log::warn!("Cannot create new XML Attributes object");
+        avm_warn!(activation, "Cannot create new XML Attributes object");
         Ok(Value::Undefined.coerce_to_object(activation, context))
     }
 

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -5,6 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::{ObjectPtr, TObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, UpdateContext, Value};
+use crate::avm_warn;
 use crate::xml::{XMLDocument, XMLNode};
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
@@ -116,7 +117,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         _args: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error<'gc>> {
         //TODO: `new xmlnode.attributes()` returns undefined, not an object
-        log::warn!("Cannot create new XML Attributes object");
+        avm_warn!(activation, "Cannot create new XML Attributes object");
         Ok(Value::Undefined.coerce_to_object(activation, context))
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ extern crate smallvec;
 #[macro_use]
 extern crate downcast_rs;
 
+#[macro_use]
 mod avm1;
 mod avm2;
 mod bounding_box;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -441,49 +441,50 @@ impl Player {
     pub fn handle_event(&mut self, event: PlayerEvent) {
         let mut needs_render = self.needs_render;
 
-        if let PlayerEvent::KeyDown {
-            key_code: KeyCode::V,
-        } = event
-        {
-            if self.input.is_key_down(KeyCode::Control) && self.input.is_key_down(KeyCode::Alt) {
-                self.mutate_with_update_context(|avm1, _avm2, context| {
-                    let mut dumper = VariableDumper::new("  ");
+        if cfg!(feature = "avm_debug") {
+            if let PlayerEvent::KeyDown {
+                key_code: KeyCode::V,
+            } = event
+            {
+                if self.input.is_key_down(KeyCode::Control) && self.input.is_key_down(KeyCode::Alt)
+                {
+                    self.mutate_with_update_context(|avm1, _avm2, context| {
+                        let mut dumper = VariableDumper::new("  ");
 
-                    let mut activation = Activation::from_nothing(
-                        avm1,
-                        ActivationIdentifier::root("[Variable Dumper]"),
-                        context.swf.version(),
-                        avm1.global_object_cell(),
-                        context.gc_context,
-                        *context.levels.get(&0).unwrap(),
-                    );
+                        let mut activation = Activation::from_nothing(
+                            avm1,
+                            ActivationIdentifier::root("[Variable Dumper]"),
+                            context.swf.version(),
+                            avm1.global_object_cell(),
+                            context.gc_context,
+                            *context.levels.get(&0).unwrap(),
+                        );
 
-                    dumper.print_variables(
-                        "Global Variables:",
-                        "_global",
-                        &activation.avm.global_object_cell(),
-                        &mut activation,
-                        context,
-                    );
-                    let levels = context.levels.clone();
-                    for (level, display_object) in levels {
-                        let object = display_object
-                            .object()
-                            .coerce_to_object(&mut activation, context);
                         dumper.print_variables(
-                            &format!("Level #{}:", level),
-                            &format!("_level{}", level),
-                            &object,
+                            "Global Variables:",
+                            "_global",
+                            &activation.avm.global_object_cell(),
                             &mut activation,
                             context,
                         );
-                    }
-                    log::info!("Variable dump:\n{}", dumper.output());
-                });
+                        let levels = context.levels.clone();
+                        for (level, display_object) in levels {
+                            let object = display_object
+                                .object()
+                                .coerce_to_object(&mut activation, context);
+                            dumper.print_variables(
+                                &format!("Level #{}:", level),
+                                &format!("_level{}", level),
+                                &object,
+                                &mut activation,
+                                context,
+                            );
+                        }
+                        log::info!("Variable dump:\n{}", dumper.output());
+                    });
+                }
             }
-        }
 
-        if cfg!(feature = "avm_debug") {
             if let PlayerEvent::KeyDown {
                 key_code: KeyCode::D,
             } = event


### PR DESCRIPTION
Changes:
- Variable dumping is now locked behind `avm_debug` as the cost of `avm_debug` isn't as high anymore
- New error/warn printing when `avm_debug` is enabled, to show where the error/warn happened
- Updated instructions for debugging ActionScript in documentation



Example of new errors/warnings:

>Object method onLoadInitHandler is not callable -- in broadcastMessage / onLoadInit(string, movieclip) / [Anonymous](string, movieclip) / dispatchEvent(object) core.ruffle.js:1:36557
>
>Cannot enumerate Undefined -- in broadcastMessage / onLoadInit(string, movieclip) / [Anonymous](string, movieclip) / dispatchEvent(object) / dispatchQueue(object, object) / [Anonymous](object) / onGlobalCrumbsLoaded(object) / setWorldCrumbs(undefined)