### PR TITLE
Activation & UpdateContext reshuffling

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -172,7 +172,7 @@ impl<'gc> Avm1<'gc> {
         }
 
         let mut parent_activation = Activation::from_nothing(
-            context,
+            context.reborrow(),
             ActivationIdentifier::root("[Actions Parent]"),
             swf_version,
             self.global_object_cell(),
@@ -217,7 +217,7 @@ impl<'gc> Avm1<'gc> {
         function: F,
     ) -> R
     where
-        for<'c> F: FnOnce(&mut Activation<'c, '_, 'gc, '_>) -> R,
+        for<'b> F: FnOnce(&mut Activation<'b, 'gc, '_>) -> R,
     {
         let clip_obj = match active_clip.object() {
             Value::Object(o) => o,
@@ -232,7 +232,7 @@ impl<'gc> Avm1<'gc> {
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
         );
         let mut activation = Activation::from_action(
-            action_context,
+            action_context.reborrow(),
             ActivationIdentifier::root("[Display Object]"),
             swf_version,
             child_scope,
@@ -260,7 +260,7 @@ impl<'gc> Avm1<'gc> {
         }
 
         let mut parent_activation = Activation::from_nothing(
-            context,
+            context.reborrow(),
             ActivationIdentifier::root("[Init Parent]"),
             swf_version,
             self.global_object_cell(),
@@ -314,7 +314,7 @@ impl<'gc> Avm1<'gc> {
         }
 
         let mut activation = Activation::from_nothing(
-            context,
+            context.reborrow(),
             ActivationIdentifier::root(name.to_owned()),
             swf_version,
             self.global_object_cell(),
@@ -341,7 +341,7 @@ impl<'gc> Avm1<'gc> {
         let global = self.global_object();
 
         let mut activation = Activation::from_nothing(
-            context,
+            context.reborrow(),
             ActivationIdentifier::root("[System Listeners]"),
             swf_version,
             self.global_object_cell(),
@@ -431,7 +431,7 @@ impl<'gc> Avm1<'gc> {
     pub const fn set_show_debug_output(&self, _visible: bool) {}
 }
 
-pub fn root_error_handler<'gc>(activation: &mut Activation<'_, '_, 'gc, '_>, error: Error<'gc>) {
+pub fn root_error_handler<'gc>(activation: &mut Activation<'_, 'gc, '_>, error: Error<'gc>) {
     if let Error::ThrownValue(error) = &error {
         let string = error
             .coerce_to_string(activation)
@@ -459,7 +459,7 @@ fn skip_actions(reader: &mut Reader<'_>, num_actions_to_skip: u8) {
 /// Runs via the `startDrag` method or `StartDrag` AVM1 action.
 pub fn start_drag<'gc>(
     display_object: DisplayObject<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     args: &[Value<'gc>],
 ) {
     let lock_center = args

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -172,7 +172,6 @@ impl<'gc> Avm1<'gc> {
         }
 
         let mut parent_activation = Activation::from_nothing(
-            self,
             context,
             ActivationIdentifier::root("[Actions Parent]"),
             swf_version,
@@ -191,9 +190,8 @@ impl<'gc> Avm1<'gc> {
                 clip_obj,
             ),
         );
-        let constant_pool = parent_activation.avm.constant_pool;
+        let constant_pool = parent_activation.context.avm1.constant_pool;
         let mut child_activation = Activation::from_action(
-            parent_activation.avm,
             parent_activation.context,
             parent_activation.id.child(name),
             swf_version,
@@ -234,7 +232,6 @@ impl<'gc> Avm1<'gc> {
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
         );
         let mut activation = Activation::from_action(
-            self,
             action_context,
             ActivationIdentifier::root("[Display Object]"),
             swf_version,
@@ -263,7 +260,6 @@ impl<'gc> Avm1<'gc> {
         }
 
         let mut parent_activation = Activation::from_nothing(
-            self,
             context,
             ActivationIdentifier::root("[Init Parent]"),
             swf_version,
@@ -282,10 +278,9 @@ impl<'gc> Avm1<'gc> {
                 clip_obj,
             ),
         );
-        parent_activation.avm.push(Value::Undefined);
-        let constant_pool = parent_activation.avm.constant_pool;
+        parent_activation.context.avm1.push(Value::Undefined);
+        let constant_pool = parent_activation.context.avm1.constant_pool;
         let mut child_activation = Activation::from_action(
-            parent_activation.avm,
             parent_activation.context,
             parent_activation.id.child("[Init]"),
             swf_version,
@@ -319,7 +314,6 @@ impl<'gc> Avm1<'gc> {
         }
 
         let mut activation = Activation::from_nothing(
-            self,
             context,
             ActivationIdentifier::root(name.to_owned()),
             swf_version,
@@ -347,7 +341,6 @@ impl<'gc> Avm1<'gc> {
         let global = self.global_object();
 
         let mut activation = Activation::from_nothing(
-            self,
             context,
             ActivationIdentifier::root("[System Listeners]"),
             swf_version,
@@ -448,7 +441,7 @@ pub fn root_error_handler<'gc>(activation: &mut Activation<'_, '_, 'gc, '_>, err
         log::error!("{}", error);
     }
     if error.is_halting() {
-        activation.avm.halt();
+        activation.context.avm1.halt();
     }
 }
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -334,7 +334,7 @@ impl<'gc> Avm1<'gc> {
         }
     }
 
-    pub fn notify_system_listeners<'a>(
+    pub fn notify_system_listeners(
         active_clip: DisplayObject<'gc>,
         swf_version: u8,
         context: &mut UpdateContext<'_, 'gc, '_>,

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -178,7 +178,7 @@ unsafe impl<'gc> gc_arena::Collect for ActivationIdentifier<'gc> {
 
 #[derive(Collect)]
 #[collect(unsafe_drop)]
-pub struct Activation<'a, 'gc: 'a> {
+pub struct Activation<'a, 'b: 'a, 'gc: 'b, 'gc_context: 'a> {
     pub avm: &'a mut Avm1<'gc>,
 
     /// Represents the SWF version of a given function.
@@ -221,22 +221,25 @@ pub struct Activation<'a, 'gc: 'a> {
     /// This can be changed with `tellTarget` (via `ActionSetTarget` and `ActionSetTarget2`).
     target_clip: Option<DisplayObject<'gc>>,
 
+    pub context: &'a mut UpdateContext<'b, 'gc, 'gc_context>,
+
     /// An identifier to refer to this activation by, when debugging.
     /// This is often the name of a function (if known), or some static name to indicate where
     /// in the code it is (for example, a with{} block).
     pub id: ActivationIdentifier<'a>,
 }
 
-impl Drop for Activation<'_, '_> {
+impl Drop for Activation<'_, '_, '_, '_> {
     fn drop(&mut self) {
         avm_debug!(self.avm, "END {}", self.id);
     }
 }
 
-impl<'a, 'gc: 'a> Activation<'a, 'gc> {
+impl<'a, 'b: 'a, 'gc: 'b, 'gc_context: 'a> Activation<'a, 'b, 'gc, 'gc_context> {
     #[allow(clippy::too_many_arguments)]
     pub fn from_action(
         avm: &'a mut Avm1<'gc>,
+        context: &'a mut UpdateContext<'b, 'gc, 'gc_context>,
         id: ActivationIdentifier<'a>,
         swf_version: u8,
         scope: GcCell<'gc, Scope<'gc>>,
@@ -248,6 +251,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         avm_debug!(avm, "START {}", id);
         Self {
             avm,
+            context,
             id,
             swf_version,
             scope,
@@ -261,16 +265,17 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     /// Create a new activation to run a block of code with a given scope.
-    pub fn with_new_scope<'b, S: Into<Cow<'static, str>>>(
-        &'b mut self,
+    pub fn with_new_scope<'c, S: Into<Cow<'static, str>>>(
+        &'c mut self,
         name: S,
         scope: GcCell<'gc, Scope<'gc>>,
-    ) -> Activation<'b, 'gc> {
+    ) -> Activation<'c, 'b, 'gc, 'gc_context> {
         let id = self.id.child(name);
         avm_debug!(self.avm, "START {}", id);
         Activation {
             avm: self.avm,
             id,
+            context: self.context,
             swf_version: self.swf_version,
             scope,
             constant_pool: self.constant_pool,
@@ -288,19 +293,23 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// activation frame with access to the global context.
     pub fn from_nothing(
         avm: &'a mut Avm1<'gc>,
+        context: &'a mut UpdateContext<'b, 'gc, 'gc_context>,
         id: ActivationIdentifier<'a>,
         swf_version: u8,
         globals: Object<'gc>,
-        mc: MutationContext<'gc, '_>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
-        let global_scope = GcCell::allocate(mc, Scope::from_global_object(globals));
-        let child_scope = GcCell::allocate(mc, Scope::new_local_scope(global_scope, mc));
-        let empty_constant_pool = GcCell::allocate(mc, Vec::new());
+        let global_scope = GcCell::allocate(context.gc_context, Scope::from_global_object(globals));
+        let child_scope = GcCell::allocate(
+            context.gc_context,
+            Scope::new_local_scope(global_scope, context.gc_context),
+        );
+        let empty_constant_pool = GcCell::allocate(context.gc_context, Vec::new());
         avm_debug!(avm, "START {}", id);
 
         Self {
             avm,
+            context,
             id,
             swf_version,
             scope: child_scope,
@@ -320,21 +329,20 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         active_clip: DisplayObject<'gc>,
         swf_version: u8,
         code: SwfSlice,
-        context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<ReturnType<'gc>, Error<'gc>> {
         let mut parent_activation = Activation::from_nothing(
             self.avm,
+            self.context,
             self.id.child("[Actions Parent]"),
             swf_version,
             self.avm.globals,
-            context.gc_context,
             active_clip,
         );
         let clip_obj = active_clip
             .object()
-            .coerce_to_object(&mut parent_activation, context);
+            .coerce_to_object(&mut parent_activation);
         let child_scope = GcCell::allocate(
-            context.gc_context,
+            parent_activation.context.gc_context,
             Scope::new(
                 parent_activation.scope_cell(),
                 scope::ScopeClass::Target,
@@ -344,6 +352,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         let constant_pool = parent_activation.avm.constant_pool;
         let mut child_activation = Activation::from_action(
             parent_activation.avm,
+            parent_activation.context,
             parent_activation.id.child(name),
             swf_version,
             child_scope,
@@ -352,36 +361,36 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             clip_obj,
             None,
         );
-        child_activation.run_actions(context, code)
+        child_activation.run_actions(code)
     }
 
     /// Add a stack frame that executes code in initializer scope.
-    pub fn run_with_child_frame_for_display_object<'c, F, R, S: Into<Cow<'static, str>>>(
+    pub fn run_with_child_frame_for_display_object<F, R, S: Into<Cow<'static, str>>>(
         &mut self,
         name: S,
         active_clip: DisplayObject<'gc>,
         swf_version: u8,
-        action_context: &mut UpdateContext<'c, 'gc, '_>,
         function: F,
     ) -> R
     where
-        for<'b> F: FnOnce(&mut Activation<'b, 'gc>, &mut UpdateContext<'c, 'gc, '_>) -> R,
+        for<'c> F: FnOnce(&mut Activation<'c, '_, 'gc, '_>) -> R,
     {
         let clip_obj = match active_clip.object() {
             Value::Object(o) => o,
             _ => panic!("No script object for display object"),
         };
         let global_scope = GcCell::allocate(
-            action_context.gc_context,
+            self.context.gc_context,
             Scope::from_global_object(self.avm.globals),
         );
         let child_scope = GcCell::allocate(
-            action_context.gc_context,
+            self.context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
         );
         let constant_pool = self.avm.constant_pool;
         let mut activation = Activation::from_action(
             self.avm,
+            self.context,
             self.id.child(name),
             swf_version,
             child_scope,
@@ -390,18 +399,14 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             clip_obj,
             None,
         );
-        function(&mut activation, action_context)
+        function(&mut activation)
     }
 
-    pub fn run_actions(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        code: SwfSlice,
-    ) -> Result<ReturnType<'gc>, Error<'gc>> {
+    pub fn run_actions(&mut self, code: SwfSlice) -> Result<ReturnType<'gc>, Error<'gc>> {
         let mut read = Reader::new(code.as_ref(), self.swf_version());
 
         loop {
-            let result = self.do_action(&code, context, &mut read);
+            let result = self.do_action(&code, &mut read);
             match result {
                 Ok(FrameControl::Return(return_type)) => break Ok(return_type),
                 Ok(FrameControl::Continue) => {}
@@ -414,7 +419,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     fn do_action(
         &mut self,
         data: &SwfSlice,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut Reader<'_>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         if reader.pos() >= (data.end - data.start) {
@@ -424,135 +428,128 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             avm_debug!(self.avm, "({}) Action: {:?}", self.id.depth(), action);
 
             match action {
-                Action::Add => self.action_add(context),
-                Action::Add2 => self.action_add_2(context),
-                Action::And => self.action_and(context),
-                Action::AsciiToChar => self.action_ascii_to_char(context),
-                Action::BitAnd => self.action_bit_and(context),
-                Action::BitLShift => self.action_bit_lshift(context),
-                Action::BitOr => self.action_bit_or(context),
-                Action::BitRShift => self.action_bit_rshift(context),
-                Action::BitURShift => self.action_bit_urshift(context),
-                Action::BitXor => self.action_bit_xor(context),
-                Action::Call => self.action_call(context),
-                Action::CallFunction => self.action_call_function(context),
-                Action::CallMethod => self.action_call_method(context),
-                Action::CastOp => self.action_cast_op(context),
-                Action::CharToAscii => self.action_char_to_ascii(context),
-                Action::CloneSprite => self.action_clone_sprite(context),
+                Action::Add => self.action_add(),
+                Action::Add2 => self.action_add_2(),
+                Action::And => self.action_and(),
+                Action::AsciiToChar => self.action_ascii_to_char(),
+                Action::BitAnd => self.action_bit_and(),
+                Action::BitLShift => self.action_bit_lshift(),
+                Action::BitOr => self.action_bit_or(),
+                Action::BitRShift => self.action_bit_rshift(),
+                Action::BitURShift => self.action_bit_urshift(),
+                Action::BitXor => self.action_bit_xor(),
+                Action::Call => self.action_call(),
+                Action::CallFunction => self.action_call_function(),
+                Action::CallMethod => self.action_call_method(),
+                Action::CastOp => self.action_cast_op(),
+                Action::CharToAscii => self.action_char_to_ascii(),
+                Action::CloneSprite => self.action_clone_sprite(),
                 Action::ConstantPool(constant_pool) => {
-                    self.action_constant_pool(context, &constant_pool[..])
+                    self.action_constant_pool(&constant_pool[..])
                 }
-                Action::Decrement => self.action_decrement(context),
+                Action::Decrement => self.action_decrement(),
                 Action::DefineFunction {
                     name,
                     params,
                     actions,
                 } => self.action_define_function(
-                    context,
                     &name,
                     &params[..],
                     data.to_subslice(actions).unwrap(),
                 ),
-                Action::DefineFunction2(func) => {
-                    self.action_define_function_2(context, &func, &data)
-                }
-                Action::DefineLocal => self.action_define_local(context),
-                Action::DefineLocal2 => self.action_define_local_2(context),
-                Action::Delete => self.action_delete(context),
-                Action::Delete2 => self.action_delete_2(context),
-                Action::Divide => self.action_divide(context),
-                Action::EndDrag => self.action_end_drag(context),
-                Action::Enumerate => self.action_enumerate(context),
-                Action::Enumerate2 => self.action_enumerate_2(context),
-                Action::Equals => self.action_equals(context),
-                Action::Equals2 => self.action_equals_2(context),
-                Action::Extends => self.action_extends(context),
-                Action::GetMember => self.action_get_member(context),
-                Action::GetProperty => self.action_get_property(context),
-                Action::GetTime => self.action_get_time(context),
-                Action::GetVariable => self.action_get_variable(context),
-                Action::GetUrl { url, target } => self.action_get_url(context, &url, &target),
+                Action::DefineFunction2(func) => self.action_define_function_2(&func, &data),
+                Action::DefineLocal => self.action_define_local(),
+                Action::DefineLocal2 => self.action_define_local_2(),
+                Action::Delete => self.action_delete(),
+                Action::Delete2 => self.action_delete_2(),
+                Action::Divide => self.action_divide(),
+                Action::EndDrag => self.action_end_drag(),
+                Action::Enumerate => self.action_enumerate(),
+                Action::Enumerate2 => self.action_enumerate_2(),
+                Action::Equals => self.action_equals(),
+                Action::Equals2 => self.action_equals_2(),
+                Action::Extends => self.action_extends(),
+                Action::GetMember => self.action_get_member(),
+                Action::GetProperty => self.action_get_property(),
+                Action::GetTime => self.action_get_time(),
+                Action::GetVariable => self.action_get_variable(),
+                Action::GetUrl { url, target } => self.action_get_url(&url, &target),
                 Action::GetUrl2 {
                     send_vars_method,
                     is_target_sprite,
                     is_load_vars,
-                } => {
-                    self.action_get_url_2(context, send_vars_method, is_target_sprite, is_load_vars)
-                }
-                Action::GotoFrame(frame) => self.action_goto_frame(context, frame),
+                } => self.action_get_url_2(send_vars_method, is_target_sprite, is_load_vars),
+                Action::GotoFrame(frame) => self.action_goto_frame(frame),
                 Action::GotoFrame2 {
                     set_playing,
                     scene_offset,
-                } => self.action_goto_frame_2(context, set_playing, scene_offset),
-                Action::Greater => self.action_greater(context),
-                Action::GotoLabel(label) => self.action_goto_label(context, &label),
-                Action::If { offset } => self.action_if(context, offset, reader),
-                Action::Increment => self.action_increment(context),
-                Action::InitArray => self.action_init_array(context),
-                Action::InitObject => self.action_init_object(context),
-                Action::ImplementsOp => self.action_implements_op(context),
-                Action::InstanceOf => self.action_instance_of(context),
-                Action::Jump { offset } => self.action_jump(context, offset, reader),
-                Action::Less => self.action_less(context),
-                Action::Less2 => self.action_less_2(context),
-                Action::MBAsciiToChar => self.action_mb_ascii_to_char(context),
-                Action::MBCharToAscii => self.action_mb_char_to_ascii(context),
-                Action::MBStringLength => self.action_mb_string_length(context),
-                Action::MBStringExtract => self.action_mb_string_extract(context),
-                Action::Modulo => self.action_modulo(context),
-                Action::Multiply => self.action_multiply(context),
-                Action::NextFrame => self.action_next_frame(context),
-                Action::NewMethod => self.action_new_method(context),
-                Action::NewObject => self.action_new_object(context),
-                Action::Not => self.action_not(context),
-                Action::Or => self.action_or(context),
-                Action::Play => self.action_play(context),
-                Action::Pop => self.action_pop(context),
-                Action::PreviousFrame => self.action_prev_frame(context),
-                Action::Push(values) => self.action_push(context, &values[..]),
-                Action::PushDuplicate => self.action_push_duplicate(context),
-                Action::RandomNumber => self.action_random_number(context),
-                Action::RemoveSprite => self.action_remove_sprite(context),
+                } => self.action_goto_frame_2(set_playing, scene_offset),
+                Action::Greater => self.action_greater(),
+                Action::GotoLabel(label) => self.action_goto_label(&label),
+                Action::If { offset } => self.action_if(offset, reader),
+                Action::Increment => self.action_increment(),
+                Action::InitArray => self.action_init_array(),
+                Action::InitObject => self.action_init_object(),
+                Action::ImplementsOp => self.action_implements_op(),
+                Action::InstanceOf => self.action_instance_of(),
+                Action::Jump { offset } => self.action_jump(offset, reader),
+                Action::Less => self.action_less(),
+                Action::Less2 => self.action_less_2(),
+                Action::MBAsciiToChar => self.action_mb_ascii_to_char(),
+                Action::MBCharToAscii => self.action_mb_char_to_ascii(),
+                Action::MBStringLength => self.action_mb_string_length(),
+                Action::MBStringExtract => self.action_mb_string_extract(),
+                Action::Modulo => self.action_modulo(),
+                Action::Multiply => self.action_multiply(),
+                Action::NextFrame => self.action_next_frame(),
+                Action::NewMethod => self.action_new_method(),
+                Action::NewObject => self.action_new_object(),
+                Action::Not => self.action_not(),
+                Action::Or => self.action_or(),
+                Action::Play => self.action_play(),
+                Action::Pop => self.action_pop(),
+                Action::PreviousFrame => self.action_prev_frame(),
+                Action::Push(values) => self.action_push(&values[..]),
+                Action::PushDuplicate => self.action_push_duplicate(),
+                Action::RandomNumber => self.action_random_number(),
+                Action::RemoveSprite => self.action_remove_sprite(),
                 Action::Return => self.action_return(),
-                Action::SetMember => self.action_set_member(context),
-                Action::SetProperty => self.action_set_property(context),
-                Action::SetTarget(target) => self.action_set_target(context, &target),
-                Action::SetTarget2 => self.action_set_target2(context),
-                Action::SetVariable => self.action_set_variable(context),
-                Action::StackSwap => self.action_stack_swap(context),
-                Action::StartDrag => self.action_start_drag(context),
-                Action::Stop => self.action_stop(context),
-                Action::StopSounds => self.action_stop_sounds(context),
-                Action::StoreRegister(register) => self.action_store_register(context, register),
-                Action::StrictEquals => self.action_strict_equals(context),
-                Action::StringAdd => self.action_string_add(context),
-                Action::StringEquals => self.action_string_equals(context),
-                Action::StringExtract => self.action_string_extract(context),
-                Action::StringGreater => self.action_string_greater(context),
-                Action::StringLength => self.action_string_length(context),
-                Action::StringLess => self.action_string_less(context),
-                Action::Subtract => self.action_subtract(context),
-                Action::TargetPath => self.action_target_path(context),
-                Action::ToggleQuality => self.toggle_quality(context),
-                Action::ToInteger => self.action_to_integer(context),
-                Action::ToNumber => self.action_to_number(context),
-                Action::ToString => self.action_to_string(context),
-                Action::Trace => self.action_trace(context),
-                Action::TypeOf => self.action_type_of(context),
+                Action::SetMember => self.action_set_member(),
+                Action::SetProperty => self.action_set_property(),
+                Action::SetTarget(target) => self.action_set_target(&target),
+                Action::SetTarget2 => self.action_set_target2(),
+                Action::SetVariable => self.action_set_variable(),
+                Action::StackSwap => self.action_stack_swap(),
+                Action::StartDrag => self.action_start_drag(),
+                Action::Stop => self.action_stop(),
+                Action::StopSounds => self.action_stop_sounds(),
+                Action::StoreRegister(register) => self.action_store_register(register),
+                Action::StrictEquals => self.action_strict_equals(),
+                Action::StringAdd => self.action_string_add(),
+                Action::StringEquals => self.action_string_equals(),
+                Action::StringExtract => self.action_string_extract(),
+                Action::StringGreater => self.action_string_greater(),
+                Action::StringLength => self.action_string_length(),
+                Action::StringLess => self.action_string_less(),
+                Action::Subtract => self.action_subtract(),
+                Action::TargetPath => self.action_target_path(),
+                Action::ToggleQuality => self.toggle_quality(),
+                Action::ToInteger => self.action_to_integer(),
+                Action::ToNumber => self.action_to_number(),
+                Action::ToString => self.action_to_string(),
+                Action::Trace => self.action_trace(),
+                Action::TypeOf => self.action_type_of(),
                 Action::WaitForFrame {
                     frame,
                     num_actions_to_skip,
-                } => self.action_wait_for_frame(context, frame, num_actions_to_skip, reader),
+                } => self.action_wait_for_frame(frame, num_actions_to_skip, reader),
                 Action::WaitForFrame2 {
                     num_actions_to_skip,
-                } => self.action_wait_for_frame_2(context, num_actions_to_skip, reader),
-                Action::With { actions } => {
-                    self.action_with(context, data.to_subslice(actions).unwrap())
-                }
-                Action::Throw => self.action_throw(context),
-                Action::Try(try_block) => self.action_try(context, &try_block, &data),
-                _ => self.unknown_op(context, action),
+                } => self.action_wait_for_frame_2(num_actions_to_skip, reader),
+                Action::With { actions } => self.action_with(data.to_subslice(actions).unwrap()),
+                Action::Throw => self.action_throw(),
+                Action::Try(try_block) => self.action_try(&try_block, &data),
+                _ => self.unknown_op(action),
             }
         } else {
             //The explicit end opcode was encountered so return here
@@ -562,51 +559,41 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn unknown_op(
         &mut self,
-        _context: &mut UpdateContext,
         action: swf::avm1::types::Action,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         avm_error!(self, "Unknown AVM1 opcode: {:?}", action);
         Ok(FrameControl::Continue)
     }
 
-    fn action_add(
-        &mut self,
-        _context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_add(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let a = self.avm.pop();
         let b = self.avm.pop();
         self.avm.push(b.into_number_v1() + a.into_number_v1());
         Ok(FrameControl::Continue)
     }
 
-    fn action_add_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_add_2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // ECMA-262 s. 11.6.1
         let a = self.avm.pop();
         let b = self.avm.pop();
 
         // TODO(Herschel):
         if let Value::String(a) = a {
-            let mut s = b.coerce_to_string(self, context)?.to_string();
+            let mut s = b.coerce_to_string(self)?.to_string();
             s.push_str(&a);
-            self.avm.push(AvmString::new(context.gc_context, s));
+            self.avm.push(AvmString::new(self.context.gc_context, s));
         } else if let Value::String(b) = b {
             let mut b = b.to_string();
-            b.push_str(&a.coerce_to_string(self, context)?);
-            self.avm.push(AvmString::new(context.gc_context, b));
+            b.push_str(&a.coerce_to_string(self)?);
+            self.avm.push(AvmString::new(self.context.gc_context, b));
         } else {
-            let result = b.coerce_to_f64(self, context)? + a.coerce_to_f64(self, context)?;
+            let result = b.coerce_to_f64(self)? + a.coerce_to_f64(self)?;
             self.avm.push(result);
         }
         Ok(FrameControl::Continue)
     }
 
-    fn action_and(
-        &mut self,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_and(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 logical and
         let a = self.avm.pop();
         let b = self.avm.pop();
@@ -617,44 +604,34 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_ascii_to_char(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_ascii_to_char(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Results on incorrect operands?
-        let val = (self.avm.pop().coerce_to_f64(self, context)? as u8) as char;
+        let val = (self.avm.pop().coerce_to_f64(self)? as u8) as char;
         self.avm
-            .push(AvmString::new(context.gc_context, val.to_string()));
+            .push(AvmString::new(self.context.gc_context, val.to_string()));
         Ok(FrameControl::Continue)
     }
 
-    fn action_char_to_ascii(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_char_to_ascii(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Results on incorrect operands?
         let val = self.avm.pop();
-        let string = val.coerce_to_string(self, context)?;
+        let string = val.coerce_to_string(self)?;
         let result = string.bytes().next().unwrap_or(0);
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_clone_sprite(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_clone_sprite(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let depth = self.avm.pop();
         let target = self.avm.pop();
         let source = self.avm.pop();
         let start_clip = self.target_clip_or_root();
-        let source_clip = self.resolve_target_display_object(context, start_clip, source)?;
+        let source_clip = self.resolve_target_display_object(start_clip, source)?;
 
         if let Some(movie_clip) = source_clip.and_then(|o| o.as_movie_clip()) {
             let _ = globals::movie_clip::duplicate_movie_clip_with_bias(
                 movie_clip,
                 self,
-                context,
                 &[target, depth],
                 0,
             );
@@ -665,76 +642,55 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_bit_and(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_u32(self, context)?;
-        let b = self.avm.pop().coerce_to_u32(self, context)?;
+    fn action_bit_and(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_u32(self)?;
+        let b = self.avm.pop().coerce_to_u32(self)?;
         let result = a & b;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_bit_lshift(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_i32(self, context)? & 0b11111; // Only 5 bits used for shift count
-        let b = self.avm.pop().coerce_to_i32(self, context)?;
+    fn action_bit_lshift(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_i32(self)? & 0b11111; // Only 5 bits used for shift count
+        let b = self.avm.pop().coerce_to_i32(self)?;
         let result = b << a;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_bit_or(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_u32(self, context)?;
-        let b = self.avm.pop().coerce_to_u32(self, context)?;
+    fn action_bit_or(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_u32(self)?;
+        let b = self.avm.pop().coerce_to_u32(self)?;
         let result = a | b;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_bit_rshift(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_i32(self, context)? & 0b11111; // Only 5 bits used for shift count
-        let b = self.avm.pop().coerce_to_i32(self, context)?;
+    fn action_bit_rshift(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_i32(self)? & 0b11111; // Only 5 bits used for shift count
+        let b = self.avm.pop().coerce_to_i32(self)?;
         let result = b >> a;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_bit_urshift(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_u32(self, context)? & 0b11111; // Only 5 bits used for shift count
-        let b = self.avm.pop().coerce_to_u32(self, context)?;
+    fn action_bit_urshift(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_u32(self)? & 0b11111; // Only 5 bits used for shift count
+        let b = self.avm.pop().coerce_to_u32(self)?;
         let result = b >> a;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_bit_xor(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_u32(self, context)?;
-        let b = self.avm.pop().coerce_to_u32(self, context)?;
+    fn action_bit_xor(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_u32(self)?;
+        let b = self.avm.pop().coerce_to_u32(self)?;
         let result = b ^ a;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_call(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_call(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // Runs any actions on the given frame.
         let arg = self.avm.pop();
         let target = self.target_clip_or_root();
@@ -748,8 +704,8 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             }
         } else {
             // An optional path to a movieclip and a frame #/label, such as "/clip:framelabel".
-            let frame_path = arg.coerce_to_string(self, context)?;
-            if let Some((clip, frame)) = self.resolve_variable_path(context, target, &frame_path)? {
+            let frame_path = arg.coerce_to_string(self)?;
+            if let Some((clip, frame)) = self.resolve_variable_path(target, &frame_path)? {
                 if let Some(clip) = clip.as_display_object().and_then(|o| o.as_movie_clip()) {
                     if let Ok(frame) = frame.parse().map(f64_to_wrapping_u32) {
                         // First try to parse as a frame number.
@@ -764,13 +720,12 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
         if let Some((clip, frame)) = call_frame {
             if frame <= u32::from(std::u16::MAX) {
-                for action in clip.actions_on_frame(context, frame as u16) {
+                for action in clip.actions_on_frame(self.context, frame as u16) {
                     let _ = self.run_child_frame_for_action(
                         "[Frame Call]",
                         clip.into(),
                         self.current_swf_version(),
                         action,
-                        context,
                     )?;
                 }
             }
@@ -781,38 +736,29 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_call_function(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_call_function(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let fn_name_value = self.avm.pop();
-        let fn_name = fn_name_value.coerce_to_string(self, context)?;
+        let fn_name = fn_name_value.coerce_to_string(self)?;
         let mut args = Vec::new();
-        let num_args = self.avm.pop().coerce_to_f64(self, context)? as i64; // TODO(Herschel): max arg count?
+        let num_args = self.avm.pop().coerce_to_f64(self)? as i64; // TODO(Herschel): max arg count?
         for _ in 0..num_args {
             args.push(self.avm.pop());
         }
 
-        let target_fn = self.get_variable(context, &fn_name)?;
+        let target_fn = self.get_variable(&fn_name)?;
 
-        let this = self
-            .target_clip_or_root()
-            .object()
-            .coerce_to_object(self, context);
-        let result = target_fn.call(&fn_name, self, context, this, None, &args)?;
+        let this = self.target_clip_or_root().object().coerce_to_object(self);
+        let result = target_fn.call(&fn_name, self, this, None, &args)?;
         self.avm.push(result);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_call_method(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_call_method(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let method_name = self.avm.pop();
         let object_val = self.avm.pop();
-        let object = value_object::ValueObject::boxed(self, context, object_val);
-        let num_args = self.avm.pop().coerce_to_f64(self, context)? as i64; // TODO(Herschel): max arg count?
+        let object = value_object::ValueObject::boxed(self, object_val);
+        let num_args = self.avm.pop().coerce_to_f64(self)? as i64; // TODO(Herschel): max arg count?
         let mut args = Vec::new();
         for _ in 0..num_args {
             args.push(self.avm.pop());
@@ -820,19 +766,16 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
         match method_name {
             Value::Undefined | Value::Null => {
-                let this = self
-                    .target_clip_or_root()
-                    .object()
-                    .coerce_to_object(self, context);
-                let result = object.call("[Anonymous]", self, context, this, None, &args)?;
+                let this = self.target_clip_or_root().object().coerce_to_object(self);
+                let result = object.call("[Anonymous]", self, this, None, &args)?;
                 self.avm.push(result);
             }
             Value::String(name) => {
                 if name.is_empty() {
-                    let result = object.call("[Anonymous]", self, context, object, None, &args)?;
+                    let result = object.call("[Anonymous]", self, object, None, &args)?;
                     self.avm.push(result);
                 } else {
-                    let result = object.call_method(&name, &args, self, context)?;
+                    let result = object.call_method(&name, &args, self)?;
                     self.avm.push(result);
                 }
             }
@@ -849,18 +792,13 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_cast_op(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_cast_op(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let obj = self.avm.pop();
-        let constr = self.avm.pop().coerce_to_object(self, context);
+        let constr = self.avm.pop().coerce_to_object(self);
 
         let is_instance_of = if let Value::Object(obj) = obj {
-            let prototype = constr
-                .get("prototype", self, context)?
-                .coerce_to_object(self, context);
-            obj.is_instance_of(self, context, constr, prototype)?
+            let prototype = constr.get("prototype", self)?.coerce_to_object(self);
+            obj.is_instance_of(self, constr, prototype)?
         } else {
             false
         };
@@ -873,11 +811,10 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_constant_pool(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         constant_pool: &[&str],
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         self.avm.constant_pool = GcCell::allocate(
-            context.gc_context,
+            self.context.gc_context,
             constant_pool.iter().map(|s| (*s).to_string()).collect(),
         );
         self.set_constant_pool(self.avm.constant_pool);
@@ -885,24 +822,20 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_decrement(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_f64(self, context)?;
+    fn action_decrement(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(a - 1.0);
         Ok(FrameControl::Continue)
     }
 
     fn action_define_function(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         name: &str,
         params: &[&str],
         actions: SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let swf_version = self.swf_version();
-        let scope = Scope::new_closure_scope(self.scope_cell(), context.gc_context);
+        let scope = Scope::new_closure_scope(self.scope_cell(), self.context.gc_context);
         let constant_pool = self.constant_pool();
         let func = Avm1Function::from_df1(
             swf_version,
@@ -914,17 +847,17 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             self.target_clip_or_root(),
         );
         let prototype =
-            ScriptObject::object(context.gc_context, Some(self.avm.prototypes.object)).into();
+            ScriptObject::object(self.context.gc_context, Some(self.avm.prototypes.object)).into();
         let func_obj = FunctionObject::function(
-            context.gc_context,
-            Gc::allocate(context.gc_context, func),
+            self.context.gc_context,
+            Gc::allocate(self.context.gc_context, func),
             Some(self.avm.prototypes.function),
             prototype,
         );
         if name == "" {
             self.avm.push(func_obj);
         } else {
-            self.define(name, func_obj, context.gc_context);
+            self.define(name, func_obj);
         }
 
         Ok(FrameControl::Continue)
@@ -932,13 +865,12 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_define_function_2(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         action_func: &Function,
         parent_data: &SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let swf_version = self.swf_version();
         let func_data = parent_data.to_subslice(action_func.actions).unwrap();
-        let scope = Scope::new_closure_scope(self.scope_cell(), context.gc_context);
+        let scope = Scope::new_closure_scope(self.scope_cell(), self.context.gc_context);
         let constant_pool = self.constant_pool();
         let func = Avm1Function::from_df2(
             swf_version,
@@ -949,67 +881,58 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             self.base_clip(),
         );
         let prototype =
-            ScriptObject::object(context.gc_context, Some(self.avm.prototypes.object)).into();
+            ScriptObject::object(self.context.gc_context, Some(self.avm.prototypes.object)).into();
         let func_obj = FunctionObject::function(
-            context.gc_context,
-            Gc::allocate(context.gc_context, func),
+            self.context.gc_context,
+            Gc::allocate(self.context.gc_context, func),
             Some(self.avm.prototypes.function),
             prototype,
         );
         if action_func.name == "" {
             self.avm.push(func_obj);
         } else {
-            self.define(action_func.name, func_obj, context.gc_context);
+            self.define(action_func.name, func_obj);
         }
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_define_local(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_define_local(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // If the property does not exist on the local object's prototype chain, it is created on the local object.
         // Otherwise, the property is set (including calling virtual setters).
         let value = self.avm.pop();
         let name_val = self.avm.pop();
-        let name = name_val.coerce_to_string(self, context)?;
+        let name = name_val.coerce_to_string(self)?;
         let scope = self.scope_cell();
         scope
-            .write(context.gc_context)
+            .write(self.context.gc_context)
             .locals()
-            .set(&name, value, self, context)?;
+            .set(&name, value, self)?;
         Ok(FrameControl::Continue)
     }
 
-    fn action_define_local_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_define_local_2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // If the property does not exist on the local object's prototype chain, it is created on the local object.
         // Otherwise, the property is unchanged.
         let name_val = self.avm.pop();
-        let name = name_val.coerce_to_string(self, context)?;
+        let name = name_val.coerce_to_string(self)?;
         let scope = self.scope_cell();
-        if !scope.read().locals().has_property(self, context, &name) {
+        if !scope.read().locals().has_property(self, &name) {
             scope
-                .write(context.gc_context)
+                .write(self.context.gc_context)
                 .locals()
-                .set(&name, Value::Undefined, self, context)?;
+                .set(&name, Value::Undefined, self)?;
         }
         Ok(FrameControl::Continue)
     }
 
-    fn action_delete(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_delete(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let name_val = self.avm.pop();
-        let name = name_val.coerce_to_string(self, context)?;
+        let name = name_val.coerce_to_string(self)?;
         let object = self.avm.pop();
 
         if let Value::Object(object) = object {
-            let success = object.delete(self, context.gc_context, &name);
+            let success = object.delete(self, &name);
             self.avm.push(success);
         } else {
             avm_warn!(self, "Cannot delete property {} from {:?}", name, object);
@@ -1019,32 +942,24 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_delete_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_delete_2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let name_val = self.avm.pop();
-        let name = name_val.coerce_to_string(self, context)?;
+        let name = name_val.coerce_to_string(self)?;
 
         //Fun fact: This isn't in the Adobe SWF19 spec, but this opcode returns
         //a boolean based on if the delete actually deleted something.
-        let did_exist = self.is_defined(context, &name);
+        let did_exist = self.is_defined(&name);
 
-        self.scope_cell()
-            .read()
-            .delete(self, context, &name, context.gc_context);
+        self.scope_cell().read().delete(self, &name);
         self.avm.push(did_exist);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_divide(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_divide(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 divide
-        let a = self.avm.pop().coerce_to_f64(self, context)?;
-        let b = self.avm.pop().coerce_to_f64(self, context)?;
+        let a = self.avm.pop().coerce_to_f64(self)?;
+        let b = self.avm.pop().coerce_to_f64(self)?;
 
         // TODO(Herschel): SWF19: "If A is zero, the result NaN, Infinity, or -Infinity is pushed to the in SWF 5 and later.
         // In SWF 4, the result is the string #ERROR#.""
@@ -1054,27 +969,21 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_end_drag(
-        &mut self,
-        context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        *context.drag_object = None;
+    fn action_end_drag(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        *self.context.drag_object = None;
         Ok(FrameControl::Continue)
     }
 
-    fn action_enumerate(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_enumerate(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let name_value = self.avm.pop();
-        let name = name_value.coerce_to_string(self, context)?;
+        let name = name_value.coerce_to_string(self)?;
         self.avm.push(Value::Null); // Sentinel that indicates end of enumeration
-        let object = self.resolve(&name, context)?;
+        let object = self.resolve(&name)?;
 
         match object {
             Value::Object(ob) => {
                 for k in ob.get_keys(self).into_iter().rev() {
-                    self.avm.push(AvmString::new(context.gc_context, k));
+                    self.avm.push(AvmString::new(self.context.gc_context, k));
                 }
             }
             _ => avm_error!(self, "Cannot enumerate properties of {}", name),
@@ -1083,17 +992,14 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_enumerate_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_enumerate_2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.avm.pop();
 
         self.avm.push(Value::Null); // Sentinel that indicates end of enumeration
 
         if let Value::Object(object) = value {
             for k in object.get_keys(self).into_iter().rev() {
-                self.avm.push(AvmString::new(context.gc_context, k));
+                self.avm.push(AvmString::new(self.context.gc_context, k));
             }
         } else {
             avm_warn!(self, "Cannot enumerate {:?}", value);
@@ -1103,10 +1009,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     #[allow(clippy::float_cmp)]
-    fn action_equals(
-        &mut self,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_equals(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 equality
         let a = self.avm.pop();
         let b = self.avm.pop();
@@ -1117,82 +1020,68 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     #[allow(clippy::float_cmp)]
-    fn action_equals_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_equals_2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // Version >=5 equality
         let a = self.avm.pop();
         let b = self.avm.pop();
-        let result = b.abstract_eq(a, self, context, false)?;
+        let result = b.abstract_eq(a, self, false)?;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_extends(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let superclass = self.avm.pop().coerce_to_object(self, context);
-        let subclass = self.avm.pop().coerce_to_object(self, context);
+    fn action_extends(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let superclass = self.avm.pop().coerce_to_object(self);
+        let subclass = self.avm.pop().coerce_to_object(self);
 
         //TODO: What happens if we try to extend an object which has no `prototype`?
         //e.g. `class Whatever extends Object.prototype` or `class Whatever extends 5`
-        let super_proto = superclass
-            .get("prototype", self, context)?
-            .coerce_to_object(self, context);
+        let super_proto = superclass.get("prototype", self)?.coerce_to_object(self);
 
         let mut sub_prototype: Object<'gc> =
-            ScriptObject::object(context.gc_context, Some(super_proto)).into();
+            ScriptObject::object(self.context.gc_context, Some(super_proto)).into();
 
-        sub_prototype.set("constructor", superclass.into(), self, context)?;
+        sub_prototype.set("constructor", superclass.into(), self)?;
         sub_prototype.set_attributes(
-            context.gc_context,
+            self.context.gc_context,
             Some("constructor"),
             Attribute::DontEnum.into(),
             EnumSet::empty(),
         );
 
-        sub_prototype.set("__constructor__", superclass.into(), self, context)?;
+        sub_prototype.set("__constructor__", superclass.into(), self)?;
         sub_prototype.set_attributes(
-            context.gc_context,
+            self.context.gc_context,
             Some("__constructor__"),
             Attribute::DontEnum.into(),
             EnumSet::empty(),
         );
 
-        subclass.set("prototype", sub_prototype.into(), self, context)?;
+        subclass.set("prototype", sub_prototype.into(), self)?;
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_get_member(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_get_member(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let name_val = self.avm.pop();
-        let name = name_val.coerce_to_string(self, context)?;
+        let name = name_val.coerce_to_string(self)?;
         let object_val = self.avm.pop();
-        let object = value_object::ValueObject::boxed(self, context, object_val);
+        let object = value_object::ValueObject::boxed(self, object_val);
 
-        let result = object.get(&name, self, context)?;
+        let result = object.get(&name, self)?;
         self.avm.push(result);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_get_property(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_get_property(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let prop_index = self.avm.pop().into_number_v1() as usize;
         let path = self.avm.pop();
         let ret = if let Some(target) = self.target_clip() {
-            if let Some(clip) = self.resolve_target_display_object(context, target, path)? {
+            if let Some(clip) = self.resolve_target_display_object(target, path)? {
                 let display_properties = self.avm.display_properties;
-                let props = display_properties.write(context.gc_context);
+                let props = display_properties.write(self.context.gc_context);
                 if let Some(property) = props.get_by_index(prop_index) {
-                    property.get(self, context, clip)?
+                    property.get(self, clip)?
                 } else {
                     avm_warn!(self, "GetProperty: Invalid property index {}", prop_index);
                     Value::Undefined
@@ -1209,49 +1098,38 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_get_time(
-        &mut self,
-        context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let time = context.navigator.time_since_launch().as_millis() as u32;
+    fn action_get_time(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let time = self.context.navigator.time_since_launch().as_millis() as u32;
         self.avm.push(time);
         Ok(FrameControl::Continue)
     }
 
-    fn action_get_variable(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_get_variable(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let var_path = self.avm.pop();
-        let path = var_path.coerce_to_string(self, context)?;
+        let path = var_path.coerce_to_string(self)?;
 
-        let value = self.get_variable(context, &path)?;
+        let value = self.get_variable(&path)?;
         self.avm.push(value);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_get_url(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        url: &str,
-        target: &str,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_get_url(&mut self, url: &str, target: &str) -> Result<FrameControl<'gc>, Error<'gc>> {
         if target.starts_with("_level") && target.len() > 6 {
             let url = url.to_string();
             match target[6..].parse::<u32>() {
                 Ok(level_id) => {
-                    let fetch = context.navigator.fetch(&url, RequestOptions::get());
-                    let level = self.resolve_level(level_id, context);
+                    let fetch = self.context.navigator.fetch(&url, RequestOptions::get());
+                    let level = self.resolve_level(level_id);
 
-                    let process = context.load_manager.load_movie_into_clip(
-                        context.player.clone().unwrap(),
+                    let process = self.context.load_manager.load_movie_into_clip(
+                        self.context.player.clone().unwrap(),
                         level,
                         fetch,
                         url,
                         None,
                     );
-                    context.navigator.spawn_future(process);
+                    self.context.navigator.spawn_future(process);
                 }
                 Err(e) => avm_warn!(
                     self,
@@ -1265,9 +1143,9 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         }
 
         if let Some(fscommand) = fscommand::parse(url) {
-            fscommand::handle(fscommand, self, context)?;
+            fscommand::handle(fscommand, self)?;
         } else {
-            context
+            self.context
                 .navigator
                 .navigate_to_url(url.to_owned(), Some(target.to_owned()), None);
         }
@@ -1277,7 +1155,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_get_url_2(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         swf_method: swf::avm1::types::SendVarsMethod,
         is_target_sprite: bool,
         is_load_vars: bool,
@@ -1286,20 +1163,20 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         // TODO: What happens if there's only one string?
         let target = self.avm.pop();
         let url_val = self.avm.pop();
-        let url = url_val.coerce_to_string(self, context)?;
+        let url = url_val.coerce_to_string(self)?;
 
         if let Some(fscommand) = fscommand::parse(&url) {
-            fscommand::handle(fscommand, self, context)?;
+            fscommand::handle(fscommand, self)?;
             return Ok(FrameControl::Continue);
         }
 
-        let window_target = target.coerce_to_string(self, context)?;
+        let window_target = target.coerce_to_string(self)?;
         let clip_target: Option<DisplayObject<'gc>> = if is_target_sprite {
             if let Value::Object(target) = target {
                 target.as_display_object()
             } else {
                 let start = self.target_clip_or_root();
-                self.resolve_target_display_object(context, start, target.clone())?
+                self.resolve_target_display_object(start, target.clone())?
             }
         } else {
             Some(self.target_clip_or_root())
@@ -1311,39 +1188,37 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                     .as_movie_clip()
                     .unwrap()
                     .object()
-                    .coerce_to_object(self, context);
+                    .coerce_to_object(self);
                 let (url, opts) = self.locals_into_request_options(
-                    context,
                     Cow::Borrowed(&url),
                     NavigationMethod::from_send_vars_method(swf_method),
                 );
-                let fetch = context.navigator.fetch(&url, opts);
-                let process = context.load_manager.load_form_into_object(
-                    context.player.clone().unwrap(),
+                let fetch = self.context.navigator.fetch(&url, opts);
+                let process = self.context.load_manager.load_form_into_object(
+                    self.context.player.clone().unwrap(),
                     target_obj,
                     fetch,
                 );
 
-                context.navigator.spawn_future(process);
+                self.context.navigator.spawn_future(process);
             }
 
             return Ok(FrameControl::Continue);
         } else if is_target_sprite {
             if let Some(clip_target) = clip_target {
                 let (url, opts) = self.locals_into_request_options(
-                    context,
                     Cow::Borrowed(&url),
                     NavigationMethod::from_send_vars_method(swf_method),
                 );
-                let fetch = context.navigator.fetch(&url, opts);
-                let process = context.load_manager.load_movie_into_clip(
-                    context.player.clone().unwrap(),
+                let fetch = self.context.navigator.fetch(&url, opts);
+                let process = self.context.load_manager.load_movie_into_clip(
+                    self.context.player.clone().unwrap(),
                     clip_target,
                     fetch,
                     url.to_string(),
                     None,
                 );
-                context.navigator.spawn_future(process);
+                self.context.navigator.spawn_future(process);
             }
 
             return Ok(FrameControl::Continue);
@@ -1351,17 +1226,17 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             // target of `_level#` indicates a `loadMovieNum` call.
             match window_target[6..].parse::<u32>() {
                 Ok(level_id) => {
-                    let fetch = context.navigator.fetch(&url, RequestOptions::get());
-                    let level = self.resolve_level(level_id, context);
+                    let fetch = self.context.navigator.fetch(&url, RequestOptions::get());
+                    let level = self.resolve_level(level_id);
 
-                    let process = context.load_manager.load_movie_into_clip(
-                        context.player.clone().unwrap(),
+                    let process = self.context.load_manager.load_movie_into_clip(
+                        self.context.player.clone().unwrap(),
                         level,
                         fetch,
                         url.to_string(),
                         None,
                     );
-                    context.navigator.spawn_future(process);
+                    self.context.navigator.spawn_future(process);
                 }
                 Err(e) => avm_warn!(
                     self,
@@ -1374,11 +1249,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             return Ok(FrameControl::Continue);
         } else {
             let vars = match NavigationMethod::from_send_vars_method(swf_method) {
-                Some(method) => Some((method, self.locals_into_form_values(context))),
+                Some(method) => Some((method, self.locals_into_form_values())),
                 None => None,
             };
 
-            context.navigator.navigate_to_url(
+            self.context.navigator.navigate_to_url(
                 url.to_string(),
                 Some(window_target.to_string()),
                 vars,
@@ -1387,15 +1262,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_goto_frame(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        frame: u16,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_goto_frame(&mut self, frame: u16) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
                 // The frame on the stack is 0-based, not 1-based.
-                clip.goto_frame(self.avm, context, frame + 1, true);
+                clip.goto_frame(self.avm, self.context, frame + 1, true);
             } else {
                 avm_error!(self, "GotoFrame failed: Target is not a MovieClip");
             }
@@ -1407,7 +1278,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_goto_frame_2(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         set_playing: bool,
         scene_offset: u16,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
@@ -1419,7 +1289,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                 let _ = globals::movie_clip::goto_frame(
                     clip,
                     self,
-                    context,
                     &[frame],
                     !set_playing,
                     scene_offset,
@@ -1433,15 +1302,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_goto_label(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        label: &str,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_goto_label(&mut self, label: &str) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
                 if let Some(frame) = clip.frame_label_to_number(label) {
-                    clip.goto_frame(self.avm, context, frame, true);
+                    clip.goto_frame(self.avm, self.context, frame, true);
                 } else {
                     avm_warn!(self, "GoToLabel: Frame label '{}' not found", label);
                 }
@@ -1456,7 +1321,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_if(
         &mut self,
-        _context: &mut UpdateContext,
         jump_offset: i16,
         reader: &mut Reader<'_>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
@@ -1467,41 +1331,33 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_increment(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_f64(self, context)?;
+    fn action_increment(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(a + 1.0);
         Ok(FrameControl::Continue)
     }
 
-    fn action_init_array(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let num_elements = self.avm.pop().coerce_to_f64(self, context)? as i64;
-        let array = ScriptObject::array(context.gc_context, Some(self.avm.prototypes.array));
+    fn action_init_array(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let num_elements = self.avm.pop().coerce_to_f64(self)? as i64;
+        let array = ScriptObject::array(self.context.gc_context, Some(self.avm.prototypes.array));
 
         for i in 0..num_elements {
-            array.set_array_element(i as usize, self.avm.pop(), context.gc_context);
+            array.set_array_element(i as usize, self.avm.pop(), self.context.gc_context);
         }
 
         self.avm.push(Value::Object(array.into()));
         Ok(FrameControl::Continue)
     }
 
-    fn action_init_object(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let num_props = self.avm.pop().coerce_to_f64(self, context)? as i64;
-        let object = ScriptObject::object(context.gc_context, Some(self.avm.prototypes.object));
+    fn action_init_object(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let num_props = self.avm.pop().coerce_to_f64(self)? as i64;
+        let object =
+            ScriptObject::object(self.context.gc_context, Some(self.avm.prototypes.object));
         for _ in 0..num_props {
             let value = self.avm.pop();
             let name_val = self.avm.pop();
-            let name = name_val.coerce_to_string(self, context)?;
-            object.set(&name, value, self, context)?;
+            let name = name_val.coerce_to_string(self)?;
+            object.set(&name, value, self)?;
         }
 
         self.avm.push(Value::Object(object.into()));
@@ -1509,41 +1365,31 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_implements_op(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let constr = self.avm.pop().coerce_to_object(self, context);
-        let count = self.avm.pop().coerce_to_f64(self, context)? as i64; //TODO: Is this coercion actually performed by Flash?
+    fn action_implements_op(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let constr = self.avm.pop().coerce_to_object(self);
+        let count = self.avm.pop().coerce_to_f64(self)? as i64; //TODO: Is this coercion actually performed by Flash?
         let mut interfaces = vec![];
 
         //TODO: If one of the interfaces is not an object, do we leave the
         //whole stack dirty, or...?
         for _ in 0..count {
-            interfaces.push(self.avm.pop().coerce_to_object(self, context));
+            interfaces.push(self.avm.pop().coerce_to_object(self));
         }
 
-        let mut prototype = constr
-            .get("prototype", self, context)?
-            .coerce_to_object(self, context);
+        let mut prototype = constr.get("prototype", self)?.coerce_to_object(self);
 
-        prototype.set_interfaces(context.gc_context, interfaces);
+        prototype.set_interfaces(self.context.gc_context, interfaces);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_instance_of(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let constr = self.avm.pop().coerce_to_object(self, context);
+    fn action_instance_of(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let constr = self.avm.pop().coerce_to_object(self);
         let obj = self.avm.pop();
 
         let is_instance_of = if let Value::Object(obj) = obj {
-            let prototype = constr
-                .get("prototype", self, context)?
-                .coerce_to_object(self, context);
-            obj.is_instance_of(self, context, constr, prototype)?
+            let prototype = constr.get("prototype", self)?.coerce_to_object(self);
+            obj.is_instance_of(self, constr, prototype)?
         } else {
             false
         };
@@ -1554,7 +1400,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_jump(
         &mut self,
-        _context: &mut UpdateContext,
         jump_offset: i16,
         reader: &mut Reader<'_>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
@@ -1563,10 +1408,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_less(
-        &mut self,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_less(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 less than
         let a = self.avm.pop();
         let b = self.avm.pop();
@@ -1576,45 +1418,36 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_less_2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_less_2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // ECMA-262 s. 11.8.1
         let a = self.avm.pop();
         let b = self.avm.pop();
 
-        let result = b.abstract_lt(a, self, context)?;
+        let result = b.abstract_lt(a, self)?;
 
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_greater(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_greater(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // ECMA-262 s. 11.8.2
         let a = self.avm.pop();
         let b = self.avm.pop();
 
-        let result = a.abstract_lt(b, self, context)?;
+        let result = a.abstract_lt(b, self)?;
 
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_mb_ascii_to_char(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_mb_ascii_to_char(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Results on incorrect operands?
         use std::convert::TryFrom;
-        let result = char::try_from(self.avm.pop().coerce_to_f64(self, context)? as u32);
+        let result = char::try_from(self.avm.pop().coerce_to_f64(self)? as u32);
         match result {
             Ok(val) => self
                 .avm
-                .push(AvmString::new(context.gc_context, val.to_string())),
+                .push(AvmString::new(self.context.gc_context, val.to_string())),
             Err(e) => avm_warn!(
                 self,
                 "Couldn't parse char for action_mb_ascii_to_char: {}",
@@ -1624,81 +1457,61 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_mb_char_to_ascii(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_mb_char_to_ascii(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Results on incorrect operands?
         let val = self.avm.pop();
-        let s = val.coerce_to_string(self, context)?;
+        let s = val.coerce_to_string(self)?;
         let result = s.chars().next().unwrap_or('\0') as u32;
         self.avm.push(result);
         Ok(FrameControl::Continue)
     }
 
-    fn action_mb_string_extract(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_mb_string_extract(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Result with incorrect operands?
-        let len = self.avm.pop().coerce_to_f64(self, context)? as usize;
-        let start = self.avm.pop().coerce_to_f64(self, context)? as usize;
+        let len = self.avm.pop().coerce_to_f64(self)? as usize;
+        let start = self.avm.pop().coerce_to_f64(self)? as usize;
         let val = self.avm.pop();
-        let s = val.coerce_to_string(self, context)?;
+        let s = val.coerce_to_string(self)?;
         let result = s[len..len + start].to_string(); // TODO(Herschel): Flash uses UTF-16 internally.
-        self.avm.push(AvmString::new(context.gc_context, result));
+        self.avm
+            .push(AvmString::new(self.context.gc_context, result));
         Ok(FrameControl::Continue)
     }
 
-    fn action_mb_string_length(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_mb_string_length(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Result with non-string operands?
         let val = self.avm.pop();
-        let len = val.coerce_to_string(self, context)?.len();
+        let len = val.coerce_to_string(self)?.len();
         self.avm.push(len as f64);
         Ok(FrameControl::Continue)
     }
 
-    fn action_multiply(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_f64(self, context)?;
-        let b = self.avm.pop().coerce_to_f64(self, context)?;
+    fn action_multiply(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_f64(self)?;
+        let b = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(a * b);
         Ok(FrameControl::Continue)
     }
 
-    fn action_modulo(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_modulo(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO: Wrong operands?
-        let a = self.avm.pop().coerce_to_f64(self, context)?;
-        let b = self.avm.pop().coerce_to_f64(self, context)?;
+        let a = self.avm.pop().coerce_to_f64(self)?;
+        let b = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(b % a);
         Ok(FrameControl::Continue)
     }
 
-    fn action_not(
-        &mut self,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_not(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let version = self.current_swf_version();
         let val = !self.avm.pop().as_bool(version);
         self.avm.push(Value::from_bool(val, version));
         Ok(FrameControl::Continue)
     }
 
-    fn action_next_frame(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_next_frame(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
-                clip.next_frame(self.avm, context);
+                clip.next_frame(self.avm, self.context);
             } else {
                 avm_warn!(self, "NextFrame: Target is not a MovieClip");
             }
@@ -1708,24 +1521,20 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_new_method(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_new_method(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let method_name = self.avm.pop();
         let object_val = self.avm.pop();
-        let num_args = self.avm.pop().coerce_to_f64(self, context)? as i64;
+        let num_args = self.avm.pop().coerce_to_f64(self)? as i64;
         let mut args = Vec::new();
         for _ in 0..num_args {
             args.push(self.avm.pop());
         }
 
-        let object = value_object::ValueObject::boxed(self, context, object_val);
-        let constructor =
-            object.get(&method_name.coerce_to_string(self, context)?, self, context)?;
+        let object = value_object::ValueObject::boxed(self, object_val);
+        let constructor = object.get(&method_name.coerce_to_string(self)?, self)?;
         if let Value::Object(constructor) = constructor {
             //TODO: What happens if you `ActionNewMethod` without a method name?
-            let this = constructor.construct(self, context, &args)?;
+            let this = constructor.construct(self, &args)?;
 
             self.avm.push(this);
         } else {
@@ -1740,33 +1549,25 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_new_object(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_new_object(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let fn_name_val = self.avm.pop();
-        let fn_name = fn_name_val.coerce_to_string(self, context)?;
-        let num_args = self.avm.pop().coerce_to_f64(self, context)? as i64;
+        let fn_name = fn_name_val.coerce_to_string(self)?;
+        let num_args = self.avm.pop().coerce_to_f64(self)? as i64;
         let mut args = Vec::new();
         for _ in 0..num_args {
             args.push(self.avm.pop());
         }
 
-        let constructor = self
-            .resolve(&fn_name, context)?
-            .coerce_to_object(self, context);
+        let constructor = self.resolve(&fn_name)?.coerce_to_object(self);
 
-        let this = constructor.construct(self, context, &args)?;
+        let this = constructor.construct(self, &args)?;
 
         self.avm.push(this);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_or(
-        &mut self,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_or(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 logical or
         let a = self.avm.pop();
         let b = self.avm.pop();
@@ -1776,13 +1577,10 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_play(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_play(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
-                clip.play(context)
+                clip.play(self.context)
             } else {
                 avm_warn!(self, "Play: Target is not a MovieClip");
             }
@@ -1792,13 +1590,10 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_prev_frame(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_prev_frame(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
-                clip.prev_frame(self.avm, context);
+                clip.prev_frame(self.avm, self.context);
             } else {
                 avm_warn!(self, "PrevFrame: Target is not a MovieClip");
             }
@@ -1808,17 +1603,13 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_pop(
-        &mut self,
-        _context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_pop(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         self.avm.pop();
         Ok(FrameControl::Continue)
     }
 
     fn action_push(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         values: &[swf::avm1::types::Value],
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         for value in values {
@@ -1830,11 +1621,13 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                 SwfValue::Int(v) => f64::from(*v).into(),
                 SwfValue::Float(v) => f64::from(*v).into(),
                 SwfValue::Double(v) => (*v).into(),
-                SwfValue::Str(v) => AvmString::new(context.gc_context, (*v).to_string()).into(),
+                SwfValue::Str(v) => {
+                    AvmString::new(self.context.gc_context, (*v).to_string()).into()
+                }
                 SwfValue::Register(v) => self.current_register(*v),
                 SwfValue::ConstantPool(i) => {
                     if let Some(value) = self.constant_pool().read().get(*i as usize) {
-                        AvmString::new(context.gc_context, value.to_string()).into()
+                        AvmString::new(self.context.gc_context, value.to_string()).into()
                     } else {
                         avm_warn!(
                             self,
@@ -1851,25 +1644,19 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_push_duplicate(
-        &mut self,
-        _context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_push_duplicate(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let val = self.avm.pop();
         self.avm.push(val.clone());
         self.avm.push(val);
         Ok(FrameControl::Continue)
     }
 
-    fn action_random_number(
-        &mut self,
-        context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_random_number(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // A max value < 0 will always return 0,
         // and the max value gets converted into an i32, so any number > 2^31 - 1 will return 0.
         let max = self.avm.pop().into_number_v1() as i32;
         let val = if max > 0 {
-            context.rng.gen_range(0, max)
+            self.context.rng.gen_range(0, max)
         } else {
             0
         };
@@ -1877,16 +1664,13 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_remove_sprite(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_remove_sprite(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let target = self.avm.pop();
         let start_clip = self.target_clip_or_root();
-        let target_clip = self.resolve_target_display_object(context, start_clip, target)?;
+        let target_clip = self.resolve_target_display_object(start_clip, target)?;
 
         if let Some(target_clip) = target_clip.and_then(|o| o.as_movie_clip()) {
-            let _ = globals::movie_clip::remove_movie_clip_with_bias(target_clip, context, 0);
+            let _ = globals::movie_clip::remove_movie_clip_with_bias(target_clip, self.context, 0);
         } else {
             avm_warn!(self, "RemoveSprite: Source is not a movie clip");
         }
@@ -1899,33 +1683,27 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Return(ReturnType::Explicit(return_value)))
     }
 
-    fn action_set_member(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_set_member(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.avm.pop();
         let name_val = self.avm.pop();
-        let name = name_val.coerce_to_string(self, context)?;
+        let name = name_val.coerce_to_string(self)?;
 
-        let object = self.avm.pop().coerce_to_object(self, context);
-        object.set(&name, value, self, context)?;
+        let object = self.avm.pop().coerce_to_object(self);
+        object.set(&name, value, self)?;
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_set_property(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_set_property(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.avm.pop();
-        let prop_index = self.avm.pop().coerce_to_u32(self, context)? as usize;
+        let prop_index = self.avm.pop().coerce_to_u32(self)? as usize;
         let path = self.avm.pop();
         if let Some(target) = self.target_clip() {
-            if let Some(clip) = self.resolve_target_display_object(context, target, path)? {
+            if let Some(clip) = self.resolve_target_display_object(target, path)? {
                 let display_properties = self.avm.display_properties;
                 let props = display_properties.read();
                 if let Some(property) = props.get_by_index(prop_index) {
-                    property.set(self, context, clip, value)?;
+                    property.set(self, clip, value)?;
                 }
             } else {
                 avm_warn!(self, "SetProperty: Invalid target");
@@ -1936,23 +1714,17 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_set_variable(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_set_variable(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // Flash 4-style variable
         let value = self.avm.pop();
         let var_path_val = self.avm.pop();
-        let var_path = var_path_val.coerce_to_string(self, context)?;
-        self.set_variable(context, &var_path, value)?;
+        let var_path = var_path_val.coerce_to_string(self)?;
+        self.set_variable(&var_path, value)?;
         Ok(FrameControl::Continue)
     }
 
     #[allow(clippy::float_cmp)]
-    fn action_strict_equals(
-        &mut self,
-        _context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_strict_equals(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // The same as normal equality but types must match
         let a = self.avm.pop();
         let b = self.avm.pop();
@@ -1961,19 +1733,15 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_set_target(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        target: &str,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_set_target(&mut self, target: &str) -> Result<FrameControl<'gc>, Error<'gc>> {
         let base_clip = self.base_clip();
         let new_target_clip;
         let root = base_clip.root();
-        let start = base_clip.object().coerce_to_object(self, context);
+        let start = base_clip.object().coerce_to_object(self);
         if target.is_empty() {
             new_target_clip = Some(base_clip);
         } else if let Some(clip) = self
-            .resolve_target_path(context, root, start, target)?
+            .resolve_target_path(root, start, target)?
             .and_then(|o| o.as_display_object())
         {
             new_target_clip = Some(clip);
@@ -1995,20 +1763,21 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             .target_clip()
             .unwrap_or_else(|| self.base_clip().root())
             .object()
-            .coerce_to_object(self, context);
+            .coerce_to_object(self);
 
-        self.set_scope(Scope::new_target_scope(scope, clip_obj, context.gc_context));
+        self.set_scope(Scope::new_target_scope(
+            scope,
+            clip_obj,
+            self.context.gc_context,
+        ));
         Ok(FrameControl::Continue)
     }
 
-    fn action_set_target2(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_set_target2(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let target = self.avm.pop();
         match target {
             Value::String(target) => {
-                return self.action_set_target(context, &target);
+                return self.action_set_target(&target);
             }
             Value::Undefined => {
                 // Reset
@@ -2021,13 +1790,13 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                     self.set_target_clip(Some(clip));
                 } else {
                     // Other objects get coerced to string
-                    let target = target.coerce_to_string(self, context)?;
-                    return self.action_set_target(context, &target);
+                    let target = target.coerce_to_string(self)?;
+                    return self.action_set_target(&target);
                 }
             }
             _ => {
-                let target = target.coerce_to_string(self, context)?;
-                return self.action_set_target(context, &target);
+                let target = target.coerce_to_string(self)?;
+                return self.action_set_target(&target);
             }
         };
 
@@ -2036,15 +1805,16 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             .target_clip()
             .unwrap_or_else(|| self.base_clip().root())
             .object()
-            .coerce_to_object(self, context);
-        self.set_scope(Scope::new_target_scope(scope, clip_obj, context.gc_context));
+            .coerce_to_object(self);
+        self.set_scope(Scope::new_target_scope(
+            scope,
+            clip_obj,
+            self.context.gc_context,
+        ));
         Ok(FrameControl::Continue)
     }
 
-    fn action_stack_swap(
-        &mut self,
-        _context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_stack_swap(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let a = self.avm.pop();
         let b = self.avm.pop();
         self.avm.push(a);
@@ -2052,13 +1822,10 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_start_drag(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_start_drag(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let target = self.avm.pop();
         let start_clip = self.target_clip_or_root();
-        let display_object = self.resolve_target_display_object(context, start_clip, target)?;
+        let display_object = self.resolve_target_display_object(start_clip, target)?;
         if let Some(display_object) = display_object {
             let lock_center = self.avm.pop();
             let constrain = self.avm.pop().as_bool(self.current_swf_version());
@@ -2067,14 +1834,9 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                 let x2 = self.avm.pop();
                 let y1 = self.avm.pop();
                 let x1 = self.avm.pop();
-                start_drag(
-                    display_object,
-                    self,
-                    context,
-                    &[lock_center, x1, y1, x2, y2],
-                );
+                start_drag(display_object, self, &[lock_center, x1, y1, x2, y2]);
             } else {
-                start_drag(display_object, self, context, &[lock_center]);
+                start_drag(display_object, self, &[lock_center]);
             };
         } else {
             avm_warn!(self, "StartDrag: Invalid target");
@@ -2082,13 +1844,10 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_stop(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_stop(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         if let Some(clip) = self.target_clip() {
             if let Some(clip) = clip.as_movie_clip() {
-                clip.stop(context);
+                clip.stop(self.context);
             } else {
                 avm_warn!(self, "Stop: Target is not a MovieClip");
             }
@@ -2098,63 +1857,47 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn action_stop_sounds(
-        &mut self,
-        context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        context.audio.stop_all_sounds();
+    fn action_stop_sounds(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        self.context.audio.stop_all_sounds();
         Ok(FrameControl::Continue)
     }
 
-    fn action_store_register(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        register: u8,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_store_register(&mut self, register: u8) -> Result<FrameControl<'gc>, Error<'gc>> {
         // The value must remain on the stack.
         let val = self.avm.pop();
         self.avm.push(val.clone());
-        self.set_current_register(register, val, context);
+        self.set_current_register(register, val);
 
         Ok(FrameControl::Continue)
     }
 
-    fn action_string_add(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_string_add(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // SWFv4 string concatenation
         // TODO(Herschel): Result with non-string operands?
         let a = self.avm.pop();
-        let mut b = self.avm.pop().coerce_to_string(self, context)?.to_string();
-        b.push_str(&a.coerce_to_string(self, context)?);
-        self.avm.push(AvmString::new(context.gc_context, b));
+        let mut b = self.avm.pop().coerce_to_string(self)?.to_string();
+        b.push_str(&a.coerce_to_string(self)?);
+        self.avm.push(AvmString::new(self.context.gc_context, b));
         Ok(FrameControl::Continue)
     }
 
-    fn action_string_equals(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_string_equals(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 strcmp
         let a = self.avm.pop();
         let b = self.avm.pop();
-        let result = b.coerce_to_string(self, context)? == a.coerce_to_string(self, context)?;
+        let result = b.coerce_to_string(self)? == a.coerce_to_string(self)?;
         self.avm
             .push(Value::from_bool(result, self.current_swf_version()));
         Ok(FrameControl::Continue)
     }
 
-    fn action_string_extract(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_string_extract(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // SWFv4 substring
         // TODO(Herschel): Result with incorrect operands?
-        let len = self.avm.pop().coerce_to_f64(self, context)? as usize;
-        let start = self.avm.pop().coerce_to_f64(self, context)? as usize;
+        let len = self.avm.pop().coerce_to_f64(self)? as usize;
+        let start = self.avm.pop().coerce_to_f64(self)? as usize;
         let val = self.avm.pop();
-        let s = val.coerce_to_string(self, context)?;
+        let s = val.coerce_to_string(self)?;
         // This is specifically a non-UTF8 aware substring.
         // SWFv4 only used ANSI strings.
         let result = s
@@ -2163,144 +1906,111 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             .take(len)
             .map(|c| c as char)
             .collect::<String>();
-        self.avm.push(AvmString::new(context.gc_context, result));
+        self.avm
+            .push(AvmString::new(self.context.gc_context, result));
         Ok(FrameControl::Continue)
     }
 
-    fn action_string_greater(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_string_greater(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 strcmp
         let a = self.avm.pop();
         let b = self.avm.pop();
         // This is specifically a non-UTF8 aware comparison.
         let result = b
-            .coerce_to_string(self, context)?
+            .coerce_to_string(self)?
             .bytes()
-            .gt(a.coerce_to_string(self, context)?.bytes());
+            .gt(a.coerce_to_string(self)?.bytes());
         self.avm
             .push(Value::from_bool(result, self.current_swf_version()));
         Ok(FrameControl::Continue)
     }
 
-    fn action_string_length(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_string_length(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 strlen
         // Only returns byte length.
         // TODO(Herschel): Result with non-string operands?
         let val = self.avm.pop();
-        let len = val.coerce_to_string(self, context)?.bytes().len() as f64;
+        let len = val.coerce_to_string(self)?.bytes().len() as f64;
         self.avm.push(len);
         Ok(FrameControl::Continue)
     }
 
-    fn action_string_less(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_string_less(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // AS1 strcmp
         let a = self.avm.pop();
         let b = self.avm.pop();
         // This is specifically a non-UTF8 aware comparison.
         let result = b
-            .coerce_to_string(self, context)?
+            .coerce_to_string(self)?
             .bytes()
-            .lt(a.coerce_to_string(self, context)?.bytes());
+            .lt(a.coerce_to_string(self)?.bytes());
         self.avm
             .push(Value::from_bool(result, self.current_swf_version()));
         Ok(FrameControl::Continue)
     }
 
-    fn action_subtract(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let a = self.avm.pop().coerce_to_f64(self, context)?;
-        let b = self.avm.pop().coerce_to_f64(self, context)?;
+    fn action_subtract(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let a = self.avm.pop().coerce_to_f64(self)?;
+        let b = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(b - a);
         Ok(FrameControl::Continue)
     }
 
-    fn action_target_path(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_target_path(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel)
-        let _clip = self.avm.pop().coerce_to_object(self, context);
+        let _clip = self.avm.pop().coerce_to_object(self);
         self.avm.push(Value::Undefined);
         avm_warn!(self, "Unimplemented action: TargetPath");
         Ok(FrameControl::Continue)
     }
 
-    fn toggle_quality(
-        &mut self,
-        _context: &mut UpdateContext,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn toggle_quality(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Noop for now? Could chang anti-aliasing on render backend.
         Ok(FrameControl::Continue)
     }
 
-    fn action_to_integer(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let val = self.avm.pop().coerce_to_f64(self, context)?;
+    fn action_to_integer(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let val = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(val.trunc());
         Ok(FrameControl::Continue)
     }
 
-    fn action_to_number(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let val = self.avm.pop().coerce_to_f64(self, context)?;
+    fn action_to_number(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let val = self.avm.pop().coerce_to_f64(self)?;
         self.avm.push(val);
         Ok(FrameControl::Continue)
     }
 
-    fn action_to_string(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_to_string(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let val = self.avm.pop();
-        let string = val.coerce_to_string(self, context)?;
+        let string = val.coerce_to_string(self)?;
         self.avm
-            .push(AvmString::new(context.gc_context, string.to_string()));
+            .push(AvmString::new(self.context.gc_context, string.to_string()));
         Ok(FrameControl::Continue)
     }
 
-    fn action_trace(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_trace(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let val = self.avm.pop();
         // trace always prints "undefined" even though SWF6 and below normally
         // coerce undefined to "".
         let out = if val == Value::Undefined {
             "undefined".into()
         } else {
-            val.coerce_to_string(self, context)?
+            val.coerce_to_string(self)?
         };
         log::info!(target: "avm_trace", "{}", out);
         Ok(FrameControl::Continue)
     }
 
-    fn action_type_of(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_type_of(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let type_of = self.avm.pop().type_of();
         self.avm
-            .push(AvmString::new(context.gc_context, type_of.to_string()));
+            .push(AvmString::new(self.context.gc_context, type_of.to_string()));
         Ok(FrameControl::Continue)
     }
 
     fn action_wait_for_frame(
         &mut self,
-        _context: &mut UpdateContext,
         _frame: u16,
         num_actions_to_skip: u8,
         r: &mut Reader<'_>,
@@ -2317,12 +2027,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_wait_for_frame_2(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         num_actions_to_skip: u8,
         r: &mut Reader<'_>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         // TODO(Herschel): Always true for now.
-        let _frame_num = self.avm.pop().coerce_to_f64(self, context)? as u16;
+        let _frame_num = self.avm.pop().coerce_to_f64(self)? as u16;
         let loaded = true;
         if !loaded {
             // Note that the offset is given in # of actions, NOT in bytes.
@@ -2333,26 +2042,19 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     #[allow(unused_variables)]
-    fn action_throw(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_throw(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.avm.pop();
         avm_debug!(
             self.avm,
             "Thrown exception: {}",
             value
-                .coerce_to_string(self, context)
+                .coerce_to_string(self)
                 .unwrap_or_else(|_| "undefined".into())
         );
         Err(Error::ThrownValue(value))
     }
 
-    fn action_with(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        code: SwfSlice,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_with(&mut self, code: SwfSlice) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.avm.pop();
         match value {
             // Undefined/null with is ignored.
@@ -2364,11 +2066,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
             value => {
                 // Note that primitives get boxed at this point.
-                let object = value.coerce_to_object(self, context);
+                let object = value.coerce_to_object(self);
                 let with_scope =
-                    Scope::new_with_scope(self.scope_cell(), object, context.gc_context);
+                    Scope::new_with_scope(self.scope_cell(), object, self.context.gc_context);
                 let mut new_activation = self.with_new_scope("[With]", with_scope);
-                if let ReturnType::Explicit(value) = new_activation.run_actions(context, code)? {
+                if let ReturnType::Explicit(value) = new_activation.run_actions(code)? {
                     Ok(FrameControl::Return(ReturnType::Explicit(value)))
                 } else {
                     Ok(FrameControl::Continue)
@@ -2379,19 +2081,16 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     fn action_try(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         try_block: &TryBlock,
         parent_data: &SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let mut result = self.run_actions(
-            context,
-            parent_data.to_subslice(try_block.try_actions).unwrap(),
-        );
+        let mut result = self.run_actions(parent_data.to_subslice(try_block.try_actions).unwrap());
 
         if let Some((catch_vars, actions)) = &try_block.catch {
             if let Err(Error::ThrownValue(value)) = &result {
                 let mut activation = Activation::from_action(
                     self.avm,
+                    self.context,
                     self.id.child("[Catch]"),
                     self.swf_version,
                     self.scope,
@@ -2402,21 +2101,19 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                 );
 
                 match catch_vars {
-                    CatchVar::Var(name) => {
-                        activation.set_variable(context, name, value.to_owned())?
-                    }
+                    CatchVar::Var(name) => activation.set_variable(name, value.to_owned())?,
                     CatchVar::Register(id) => {
-                        activation.set_current_register(*id, value.to_owned(), context)
+                        activation.set_current_register(*id, value.to_owned())
                     }
                 }
 
-                result = activation.run_actions(context, parent_data.to_subslice(actions).unwrap());
+                result = activation.run_actions(parent_data.to_subslice(actions).unwrap());
             }
         }
 
         if let Some(actions) = try_block.finally {
             if let ReturnType::Explicit(value) =
-                self.run_actions(context, parent_data.to_subslice(actions).unwrap())?
+                self.run_actions(parent_data.to_subslice(actions).unwrap())?
             {
                 return Ok(FrameControl::Return(ReturnType::Explicit(value)));
             }
@@ -2447,14 +2144,9 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// Set a register to a given value.
     ///
     /// If a given register does not exist, this function does nothing.
-    pub fn set_current_register(
-        &mut self,
-        id: u8,
-        value: Value<'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) {
+    pub fn set_current_register(&mut self, id: u8, value: Value<'gc>) {
         if self.has_local_register(id) {
-            self.set_local_register(id, value, context.gc_context);
+            self.set_local_register(id, value);
         } else if let Some(v) = self.avm.registers.get_mut(id as usize) {
             *v = value;
         }
@@ -2466,23 +2158,19 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// legacy methods, such as the `ActionGetURL2` opcode or `getURL` function.
     ///
     /// WARNING: This does not support user defined virtual properties!
-    pub fn object_into_form_values(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        object: Object<'gc>,
-    ) -> HashMap<String, String> {
+    pub fn object_into_form_values(&mut self, object: Object<'gc>) -> HashMap<String, String> {
         let mut form_values = HashMap::new();
         let keys = object.get_keys(self);
 
         for k in keys {
-            let v = object.get(&k, self, context);
+            let v = object.get(&k, self);
 
             //TODO: What happens if an error occurs inside a virtual property?
             form_values.insert(
                 k,
                 v.ok()
                     .unwrap_or_else(|| Value::Undefined)
-                    .coerce_to_string(self, context)
+                    .coerce_to_string(self)
                     .unwrap_or_else(|_| "undefined".into())
                     .to_string(),
             );
@@ -2493,16 +2181,15 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
     /// Construct request options for a fetch operation that may sends object properties as
     /// form data in the request body or URL.
-    pub fn object_into_request_options<'b>(
+    pub fn object_into_request_options<'c>(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         object: Object<'gc>,
-        url: Cow<'b, str>,
+        url: Cow<'c, str>,
         method: Option<NavigationMethod>,
-    ) -> (Cow<'b, str>, RequestOptions) {
+    ) -> (Cow<'c, str>, RequestOptions) {
         match method {
             Some(method) => {
-                let vars = self.object_into_form_values(context, object);
+                let vars = self.object_into_form_values(object);
                 let qstring = form_urlencoded::Serializer::new(String::new())
                     .extend_pairs(vars.iter())
                     .finish();
@@ -2535,26 +2222,22 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// legacy methods, such as the `ActionGetURL2` opcode or `getURL` function.
     ///
     /// WARNING: This does not support user defined virtual properties!
-    pub fn locals_into_form_values(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> HashMap<String, String> {
+    pub fn locals_into_form_values(&mut self) -> HashMap<String, String> {
         let scope = self.scope_cell();
         let locals = scope.read().locals_cell();
-        self.object_into_form_values(context, locals)
+        self.object_into_form_values(locals)
     }
 
     /// Construct request options for a fetch operation that may send locals as
     /// form data in the request body or URL.
-    pub fn locals_into_request_options<'b>(
+    pub fn locals_into_request_options<'c>(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        url: Cow<'b, str>,
+        url: Cow<'c, str>,
         method: Option<NavigationMethod>,
-    ) -> (Cow<'b, str>, RequestOptions) {
+    ) -> (Cow<'c, str>, RequestOptions) {
         let scope = self.scope_cell();
         let locals = scope.read().locals_cell();
-        self.object_into_request_options(context, locals, url, method)
+        self.object_into_request_options(locals, url, method)
     }
 
     /// Resolves a target value to a display object, relative to a starting display object.
@@ -2571,7 +2254,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// at the prototype chain, but not the scope chain.
     pub fn resolve_target_display_object(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         start: DisplayObject<'gc>,
         target: Value<'gc>,
     ) -> Result<Option<DisplayObject<'gc>>, Error<'gc>> {
@@ -2585,11 +2267,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         // Otherwise, we coerce it into a string and try to resolve it as a path.
         // This means that values like `undefined` will resolve to clips with an instance name of
         // `"undefined"`, for example.
-        let path = target.coerce_to_string(self, context)?;
+        let path = target.coerce_to_string(self)?;
         let root = start.root();
-        let start = start.object().coerce_to_object(self, context);
+        let start = start.object().coerce_to_object(self);
         Ok(self
-            .resolve_target_path(context, root, start, &path)?
+            .resolve_target_path(root, start, &path)?
             .and_then(|o| o.as_display_object()))
     }
 
@@ -2604,7 +2286,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// at the prototype chain, but not the scope chain.
     pub fn resolve_target_path(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         root: DisplayObject<'gc>,
         start: Object<'gc>,
         path: &str,
@@ -2619,7 +2300,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         let mut path = path.as_bytes();
         let (mut object, mut is_slash_path) = if path[0] == b'/' {
             path = &path[1..];
-            (root.object().coerce_to_object(self, context), true)
+            (root.object().coerce_to_object(self), true)
         } else {
             (start, false)
         };
@@ -2683,7 +2364,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
                 {
                     child.object()
                 } else {
-                    object.get(&name, self, context).unwrap()
+                    object.get(&name, self).unwrap()
                 }
             };
 
@@ -2704,7 +2385,6 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     /// TODO: This can probably be merged with some of the above `resolve_target_path` methods.
     pub fn resolve_variable_path<'s>(
         &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
         start: DisplayObject<'gc>,
         path: &'s str,
     ) -> Result<Option<(Object<'gc>, &'s str)>, Error<'gc>> {
@@ -2732,7 +2412,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             let mut current_scope = Some(self.scope_cell());
             while let Some(scope) = current_scope {
                 if let Some(object) =
-                    self.resolve_target_path(context, start.root(), *scope.read().locals(), path)?
+                    self.resolve_target_path(start.root(), *scope.read().locals(), path)?
                 {
                     return Ok(Some((object, var_name)));
                 }
@@ -2772,11 +2452,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     ///
     /// Finally, if none of the above applies, it is a normal variable name resovled via the
     /// scope chain.
-    pub fn get_variable<'s>(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        path: &'s str,
-    ) -> Result<Value<'gc>, Error<'gc>> {
+    pub fn get_variable<'s>(&mut self, path: &'s str) -> Result<Value<'gc>, Error<'gc>> {
         // Resolve a variable path for a GetVariable action.
         let start = self.target_clip_or_root();
 
@@ -2804,10 +2480,10 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             let mut current_scope = Some(self.scope_cell());
             while let Some(scope) = current_scope {
                 if let Some(object) =
-                    self.resolve_target_path(context, start.root(), *scope.read().locals(), path)?
+                    self.resolve_target_path(start.root(), *scope.read().locals(), path)?
                 {
-                    if object.has_property(self, context, var_name) {
-                        return Ok(object.get(var_name, self, context)?);
+                    if object.has_property(self, var_name) {
+                        return Ok(object.get(var_name, self)?);
                     }
                 }
                 current_scope = scope.read().parent_cell();
@@ -2822,7 +2498,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             let mut current_scope = Some(self.scope_cell());
             while let Some(scope) = current_scope {
                 if let Some(object) =
-                    self.resolve_target_path(context, start.root(), *scope.read().locals(), path)?
+                    self.resolve_target_path(start.root(), *scope.read().locals(), path)?
                 {
                     return Ok(object.into());
                 }
@@ -2832,7 +2508,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
         // Finally! It's a plain old variable name.
         // Resolve using scope chain, as normal.
-        self.resolve(&path, context)
+        self.resolve(&path)
     }
 
     /// Sets the value referenced by a target path string.
@@ -2857,12 +2533,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     ///
     /// If the string does not resolve as a path, the path is considered a normal variable
     /// name and is set on the scope chain as usual.
-    pub fn set_variable<'s>(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        path: &'s str,
-        value: Value<'gc>,
-    ) -> Result<(), Error<'gc>> {
+    pub fn set_variable<'s>(&mut self, path: &'s str, value: Value<'gc>) -> Result<(), Error<'gc>> {
         // Resolve a variable path for a GetVariable action.
         let start = self.target_clip_or_root();
 
@@ -2886,9 +2557,9 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             let mut current_scope = Some(self.scope_cell());
             while let Some(scope) = current_scope {
                 if let Some(object) =
-                    self.resolve_target_path(context, start.root(), *scope.read().locals(), path)?
+                    self.resolve_target_path(start.root(), *scope.read().locals(), path)?
                 {
-                    object.set(var_name, value, self, context)?;
+                    object.set(var_name, value, self)?;
                     return Ok(());
                 }
                 current_scope = scope.read().parent_cell();
@@ -2903,7 +2574,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
         // in the scope chain, otherwise it is created on the top-level object.
         let this = self.this_cell();
         let scope = self.scope_cell();
-        scope.read().set(path, value, self, context, this)?;
+        scope.read().set(path, value, self, this)?;
         Ok(())
     }
 
@@ -2911,23 +2582,19 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     ///
     /// If the level does not exist, then it will be created and instantiated
     /// with a script object.
-    pub fn resolve_level(
-        &mut self,
-        level_id: u32,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> DisplayObject<'gc> {
-        if let Some(level) = context.levels.get(&level_id) {
+    pub fn resolve_level(&mut self, level_id: u32) -> DisplayObject<'gc> {
+        if let Some(level) = self.context.levels.get(&level_id) {
             *level
         } else {
             let mut level: DisplayObject<'_> = MovieClip::new(
                 SwfSlice::empty(self.base_clip().movie().unwrap()),
-                context.gc_context,
+                self.context.gc_context,
             )
             .into();
 
-            level.set_depth(context.gc_context, level_id as i32);
-            context.levels.insert(level_id, level);
-            level.post_instantiation(self.avm, context, level, None, false);
+            level.set_depth(self.context.gc_context, level_id as i32);
+            self.context.levels.insert(level_id, level);
+            level.post_instantiation(self.avm, self.context, level, None, false);
 
             level
         }
@@ -2943,7 +2610,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     /// Obtain the value of `_root`.
-    pub fn root_object(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> Value<'gc> {
+    pub fn root_object(&self) -> Value<'gc> {
         self.base_clip().root().object()
     }
 
@@ -2961,11 +2628,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     ///
     /// Because scopes are object chains, the same rules for `Object::get`
     /// still apply here.
-    pub fn resolve(
-        &mut self,
-        name: &str,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<Value<'gc>, Error<'gc>> {
+    pub fn resolve(&mut self, name: &str) -> Result<Value<'gc>, Error<'gc>> {
         if name == "this" {
             return Ok(Value::Object(self.this_cell()));
         }
@@ -2976,11 +2639,11 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
 
         self.scope_cell()
             .read()
-            .resolve(name, self, context, self.this_cell())
+            .resolve(name, self, self.this_cell())
     }
 
     /// Check if a particular property in the scope chain is defined.
-    pub fn is_defined(&mut self, context: &mut UpdateContext<'_, 'gc, '_>, name: &str) -> bool {
+    pub fn is_defined(&mut self, name: &str) -> bool {
         if name == "this" {
             return true;
         }
@@ -2989,7 +2652,7 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
             return true;
         }
 
-        self.scope_cell().read().is_defined(self, context, name)
+        self.scope_cell().read().is_defined(self, name)
     }
 
     /// Returns the SWF version of the action or function being executed.
@@ -3037,8 +2700,8 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     /// Define a named local variable within this activation.
-    pub fn define(&self, name: &str, value: impl Into<Value<'gc>>, mc: MutationContext<'gc, '_>) {
-        self.scope().define(name, value, mc)
+    pub fn define(&self, name: &str, value: impl Into<Value<'gc>>) {
+        self.scope().define(name, value, self.context.gc_context)
     }
 
     /// Returns value of `this` as a reference.
@@ -3070,14 +2733,9 @@ impl<'a, 'gc: 'a> Activation<'a, 'gc> {
     }
 
     /// Set a local register.
-    pub fn set_local_register(
-        &mut self,
-        id: u8,
-        value: impl Into<Value<'gc>>,
-        mc: MutationContext<'gc, '_>,
-    ) {
+    pub fn set_local_register(&mut self, id: u8, value: impl Into<Value<'gc>>) {
         if let Some(ref mut local_registers) = self.local_registers {
-            if let Some(r) = local_registers.write(mc).get_mut(id) {
+            if let Some(r) = local_registers.write(self.context.gc_context).get_mut(id) {
                 *r = value.into();
             }
         }

--- a/core/src/avm1/debug.rs
+++ b/core/src/avm1/debug.rs
@@ -23,7 +23,7 @@ impl<'a> VariableDumper<'a> {
     pub fn dump<'gc>(
         value: &Value<'gc>,
         indent: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> String {
         let mut dumper = VariableDumper::new(indent);
         dumper.print_value(value, activation);
@@ -83,7 +83,7 @@ impl<'a> VariableDumper<'a> {
     pub fn print_object<'gc>(
         &mut self,
         object: &Object<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) {
         let (id, new) = self.object_id(object);
         self.output.push_str("[object #");
@@ -99,7 +99,7 @@ impl<'a> VariableDumper<'a> {
         &mut self,
         object: &Object<'gc>,
         key: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) {
         match object.get(&key, activation) {
             Ok(value) => {
@@ -116,7 +116,7 @@ impl<'a> VariableDumper<'a> {
     pub fn print_properties<'gc>(
         &mut self,
         object: &Object<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) {
         let keys = object.get_keys(activation);
         if keys.is_empty() {
@@ -142,7 +142,7 @@ impl<'a> VariableDumper<'a> {
     pub fn print_value<'gc>(
         &mut self,
         value: &Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) {
         match value {
             Value::Undefined => self.output.push_str("undefined"),
@@ -163,7 +163,7 @@ impl<'a> VariableDumper<'a> {
         header: &str,
         name: &str,
         object: &Object<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) {
         let keys = object.get_keys(activation);
         if keys.is_empty() {

--- a/core/src/avm1/fscommand.rs
+++ b/core/src/avm1/fscommand.rs
@@ -2,8 +2,8 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::UpdateContext;
 use crate::avm_warn;
+
 /// Parse an FSCommand URL.
 pub fn parse(url: &str) -> Option<&str> {
     log::info!("Checking {}", url);
@@ -17,8 +17,7 @@ pub fn parse(url: &str) -> Option<&str> {
 /// TODO: FSCommand URL handling
 pub fn handle<'gc>(
     fscommand: &str,
-    activation: &mut Activation,
-    _ac: &mut UpdateContext,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<(), Error<'gc>> {
     avm_warn!(activation, "Unhandled FSCommand: {}", fscommand);
 

--- a/core/src/avm1/fscommand.rs
+++ b/core/src/avm1/fscommand.rs
@@ -17,7 +17,7 @@ pub fn parse(url: &str) -> Option<&str> {
 /// TODO: FSCommand URL handling
 pub fn handle<'gc>(
     fscommand: &str,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<(), Error<'gc>> {
     avm_warn!(activation, "Unhandled FSCommand: {}", fscommand);
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -307,13 +307,10 @@ impl<'gc> Executable<'gc> {
                     Cow::Borrowed("[Anonymous]")
                 };
 
+                let max_recursion_depth = activation.context.avm1.max_recursion_depth();
                 let mut frame = Activation::from_action(
                     activation.context.reborrow(),
-                    activation.id.function(
-                        name,
-                        reason,
-                        activation.context.avm1.max_recursion_depth(),
-                    )?,
+                    activation.id.function(name, reason, max_recursion_depth)?,
                     effective_ver,
                     child_scope,
                     af.constant_pool,

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -249,7 +249,7 @@ impl<'gc> Executable<'gc> {
                 );
                 let arguments = ScriptObject::array(
                     activation.context.gc_context,
-                    Some(activation.avm.prototypes().array),
+                    Some(activation.context.avm1.prototypes().array),
                 );
                 arguments.define_value(
                     activation.context.gc_context,
@@ -311,11 +311,12 @@ impl<'gc> Executable<'gc> {
                 };
 
                 let mut frame = Activation::from_action(
-                    activation.avm,
                     activation.context,
-                    activation
-                        .id
-                        .function(name, reason, activation.avm.max_recursion_depth())?,
+                    activation.id.function(
+                        name,
+                        reason,
+                        activation.context.avm1.max_recursion_depth(),
+                    )?,
                     effective_ver,
                     child_scope,
                     af.constant_pool,
@@ -369,7 +370,7 @@ impl<'gc> Executable<'gc> {
                 }
 
                 if af.preload_global {
-                    let global = frame.avm.global_object();
+                    let global = frame.context.avm1.global_object();
                     frame.set_local_register(preload_r, global);
                 }
 

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -44,7 +44,7 @@ mod text_format;
 mod xml;
 
 pub fn random<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -57,7 +57,7 @@ pub fn random<'gc>(
 }
 
 pub fn is_finite<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -70,7 +70,7 @@ pub fn is_finite<'gc>(
 }
 
 pub fn is_nan<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -82,7 +82,7 @@ pub fn is_nan<'gc>(
 }
 
 pub fn get_infinity<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -94,7 +94,7 @@ pub fn get_infinity<'gc>(
 }
 
 pub fn get_nan<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -106,7 +106,7 @@ pub fn get_nan<'gc>(
 }
 
 pub fn set_interval<'a, 'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -115,7 +115,7 @@ pub fn set_interval<'a, 'gc>(
 }
 
 pub fn set_timeout<'a, 'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -124,7 +124,7 @@ pub fn set_timeout<'a, 'gc>(
 }
 
 pub fn create_timer<'a, 'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     _this: Object<'gc>,
     args: &[Value<'gc>],
@@ -167,7 +167,7 @@ pub fn create_timer<'a, 'gc>(
 }
 
 pub fn clear_interval<'a, 'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     _this: Object<'gc>,
     args: &[Value<'gc>],
@@ -184,7 +184,7 @@ pub fn clear_interval<'a, 'gc>(
 }
 
 pub fn update_after_event<'a, 'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -645,7 +645,7 @@ pub fn create_globals<'gc>(
 mod tests {
     use super::*;
 
-    fn setup<'gc>(activation: &mut Activation<'_, '_, 'gc, '_>) -> Object<'gc> {
+    fn setup<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Object<'gc> {
         create_globals(activation.context.gc_context).1
     }
 

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -105,7 +105,7 @@ pub fn get_nan<'gc>(
     }
 }
 
-pub fn set_interval<'a, 'gc>(
+pub fn set_interval<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
@@ -114,7 +114,7 @@ pub fn set_interval<'a, 'gc>(
     create_timer(activation, this, args, false)
 }
 
-pub fn set_timeout<'a, 'gc>(
+pub fn set_timeout<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
@@ -123,7 +123,7 @@ pub fn set_timeout<'a, 'gc>(
     create_timer(activation, this, args, true)
 }
 
-pub fn create_timer<'a, 'gc>(
+pub fn create_timer<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
 
     _this: Object<'gc>,
@@ -166,7 +166,7 @@ pub fn create_timer<'a, 'gc>(
     Ok(id.into())
 }
 
-pub fn clear_interval<'a, 'gc>(
+pub fn clear_interval<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
 
     _this: Object<'gc>,
@@ -183,7 +183,7 @@ pub fn clear_interval<'a, 'gc>(
     Ok(Value::Undefined)
 }
 
-pub fn update_after_event<'a, 'gc>(
+pub fn update_after_event<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use enumset::EnumSet;
 use gc_arena::Collect;
 use gc_arena::MutationContext;
@@ -44,50 +44,45 @@ mod text_format;
 mod xml;
 
 pub fn random<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args.get(0) {
-        Some(Value::Number(max)) => Ok(action_context.rng.gen_range(0.0f64, max).floor().into()),
+        Some(Value::Number(max)) => {
+            Ok(activation.context.rng.gen_range(0.0f64, max).floor().into())
+        }
         _ => Ok(Value::Undefined), //TODO: Shouldn't this be an error condition?
     }
 }
 
 pub fn is_finite<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let ret = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, action_context)?
+        .coerce_to_f64(activation)?
         .is_finite();
     Ok(ret.into())
 }
 
 pub fn is_nan<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(val) = args.get(0) {
-        Ok(val
-            .coerce_to_f64(activation, action_context)?
-            .is_nan()
-            .into())
+        Ok(val.coerce_to_f64(activation)?.is_nan().into())
     } else {
         Ok(true.into())
     }
 }
 
 pub fn get_infinity<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -99,8 +94,7 @@ pub fn get_infinity<'gc>(
 }
 
 pub fn get_nan<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -112,26 +106,26 @@ pub fn get_nan<'gc>(
 }
 
 pub fn set_interval<'a, 'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'a, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    create_timer(activation, context, this, args, false)
+    create_timer(activation, this, args, false)
 }
 
 pub fn set_timeout<'a, 'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'a, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    create_timer(activation, context, this, args, true)
+    create_timer(activation, this, args, true)
 }
 
 pub fn create_timer<'a, 'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'a, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     _this: Object<'gc>,
     args: &[Value<'gc>],
     is_timeout: bool,
@@ -146,7 +140,7 @@ pub fn create_timer<'a, 'gc>(
                 method_name: args
                     .get(1)
                     .unwrap_or(&Value::Undefined)
-                    .coerce_to_string(activation, context)?
+                    .coerce_to_string(activation)?
                     .to_string(),
             },
             2,
@@ -156,7 +150,7 @@ pub fn create_timer<'a, 'gc>(
 
     let interval = match args.get(i) {
         Some(Value::Undefined) | None => return Ok(Value::Undefined),
-        Some(value) => value.coerce_to_i32(activation, context)?,
+        Some(value) => value.coerce_to_i32(activation)?,
     };
     let params = if let Some(params) = args.get(i + 1..) {
         params.to_vec()
@@ -164,7 +158,8 @@ pub fn create_timer<'a, 'gc>(
         vec![]
     };
 
-    let id = context
+    let id = activation
+        .context
         .timers
         .add_timer(callback, interval, params, is_timeout);
 
@@ -172,16 +167,16 @@ pub fn create_timer<'a, 'gc>(
 }
 
 pub fn clear_interval<'a, 'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'a, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let id = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_i32(activation, context)?;
-    if !context.timers.remove(id) {
+        .coerce_to_i32(activation)?;
+    if !activation.context.timers.remove(id) {
         log::info!("clearInterval: Timer {} does not exist", id);
     }
 
@@ -189,12 +184,11 @@ pub fn clear_interval<'a, 'gc>(
 }
 
 pub fn update_after_event<'a, 'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'a, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    *context.needs_render = true;
+    *activation.context.needs_render = true;
 
     Ok(Value::Undefined)
 }
@@ -651,11 +645,8 @@ pub fn create_globals<'gc>(
 mod tests {
     use super::*;
 
-    fn setup<'gc>(
-        _activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Object<'gc> {
-        create_globals(context.gc_context).1
+    fn setup<'gc>(activation: &mut Activation<'_, '_, 'gc, '_>) -> Object<'gc> {
+        create_globals(activation.context.gc_context).1
     }
 
     test_method!(boolean_function, "Boolean", setup,

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -127,7 +127,7 @@ pub fn array_function<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut consumed = false;
 
-    let prototype = activation.avm.prototypes.array;
+    let prototype = activation.context.avm1.prototypes.array;
     let array_obj = prototype.create_bare_object(activation, prototype)?;
 
     if args.len() == 1 {
@@ -324,7 +324,7 @@ pub fn slice<'gc>(
 
     let array = ScriptObject::array(
         activation.context.gc_context,
-        Some(activation.avm.prototypes.array),
+        Some(activation.context.avm1.prototypes.array),
     );
 
     if start < end {
@@ -369,7 +369,7 @@ pub fn splice<'gc>(
 
     let removed = ScriptObject::array(
         activation.context.gc_context,
-        Some(activation.avm.prototypes.array),
+        Some(activation.context.avm1.prototypes.array),
     );
     let to_remove = count.min(old_length as i32 - start as i32).max(0) as usize;
     let to_add = if args.len() > 2 { &args[2..] } else { &[] };
@@ -428,7 +428,7 @@ pub fn concat<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let array = ScriptObject::array(
         activation.context.gc_context,
-        Some(activation.avm.prototypes.array),
+        Some(activation.context.avm1.prototypes.array),
     );
     let mut length = 0;
 
@@ -450,7 +450,13 @@ pub fn concat<'gc>(
 
         if let Value::Object(object) = arg {
             let object = *object;
-            if activation.avm.prototypes.array.is_prototype_of(object) {
+            if activation
+                .context
+                .avm1
+                .prototypes
+                .array
+                .is_prototype_of(object)
+            {
                 added = true;
                 for i in 0..object.length() {
                     let old = object
@@ -623,7 +629,7 @@ fn sort_with_function<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let length = this.length();
     let mut values: Vec<(usize, Value<'gc>)> = this.array().into_iter().enumerate().collect();
-    let array_proto = activation.avm.prototypes.array;
+    let array_proto = activation.context.avm1.prototypes.array;
 
     let descending = (flags & DESCENDING) != 0;
     let unique_sort = (flags & UNIQUE_SORT) != 0;

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object;
 use crate::avm1::property::Attribute;
-use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::cmp::Ordering;
@@ -23,15 +23,8 @@ const NUMERIC: i32 = 16;
 const DEFAULT_ORDERING: Ordering = Ordering::Equal;
 
 // Compare function used by sort and sortOn.
-type CompareFn<'a, 'gc> = Box<
-    dyn 'a
-        + FnMut(
-            &mut Activation<'_, 'gc>,
-            &mut UpdateContext<'_, 'gc, '_>,
-            &Value<'gc>,
-            &Value<'gc>,
-        ) -> Ordering,
->;
+type CompareFn<'a, 'gc> =
+    Box<dyn 'a + FnMut(&mut Activation<'_, '_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering>;
 
 pub fn create_array_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
@@ -90,8 +83,7 @@ pub fn create_array_object<'gc>(
 
 /// Implements `Array` constructor
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -99,12 +91,12 @@ pub fn constructor<'gc>(
 
     if args.len() == 1 {
         let arg = args.get(0).unwrap();
-        if let Ok(length) = arg.coerce_to_f64(activation, context) {
+        if let Ok(length) = arg.coerce_to_f64(activation) {
             if length >= 0.0 {
-                this.set_length(context.gc_context, length as usize);
+                this.set_length(activation.context.gc_context, length as usize);
                 consumed = true;
             } else if !length.is_nan() {
-                this.set_length(context.gc_context, 0);
+                this.set_length(activation.context.gc_context, 0);
                 consumed = true;
             }
         }
@@ -114,14 +106,14 @@ pub fn constructor<'gc>(
         let mut length = 0;
         for arg in args {
             this.define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 &length.to_string(),
                 arg.to_owned(),
                 EnumSet::empty(),
             );
             length += 1;
         }
-        this.set_length(context.gc_context, length);
+        this.set_length(activation.context.gc_context, length);
     }
 
     Ok(Value::Undefined)
@@ -129,24 +121,23 @@ pub fn constructor<'gc>(
 
 /// Implements `Array` function
 pub fn array_function<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut consumed = false;
 
     let prototype = activation.avm.prototypes.array;
-    let array_obj = prototype.create_bare_object(activation, context, prototype)?;
+    let array_obj = prototype.create_bare_object(activation, prototype)?;
 
     if args.len() == 1 {
         let arg = args.get(0).unwrap();
-        if let Ok(length) = arg.coerce_to_f64(activation, context) {
+        if let Ok(length) = arg.coerce_to_f64(activation) {
             if length >= 0.0 {
-                array_obj.set_length(context.gc_context, length as usize);
+                array_obj.set_length(activation.context.gc_context, length as usize);
                 consumed = true;
             } else if !length.is_nan() {
-                array_obj.set_length(context.gc_context, 0);
+                array_obj.set_length(activation.context.gc_context, 0);
                 consumed = true;
             }
         }
@@ -155,30 +146,29 @@ pub fn array_function<'gc>(
     if !consumed {
         let mut length = 0;
         for arg in args {
-            array_obj.set_array_element(length, arg.to_owned(), context.gc_context);
+            array_obj.set_array_element(length, arg.to_owned(), activation.context.gc_context);
             length += 1;
         }
-        array_obj.set_length(context.gc_context, length);
+        array_obj.set_length(activation.context.gc_context, length);
     }
 
     Ok(array_obj.into())
 }
 
 pub fn push<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let old_length = this.length();
     let new_length = old_length + args.len();
-    this.set_length(context.gc_context, new_length);
+    this.set_length(activation.context.gc_context, new_length);
 
     for i in 0..args.len() {
         this.set_array_element(
             old_length + i,
             args.get(i).unwrap().to_owned(),
-            context.gc_context,
+            activation.context.gc_context,
         );
     }
 
@@ -186,8 +176,7 @@ pub fn push<'gc>(
 }
 
 pub fn unshift<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -197,22 +186,29 @@ pub fn unshift<'gc>(
 
     if old_length > 0 {
         for i in (old_length - 1..new_length).rev() {
-            this.set_array_element(i, this.array_element(i - offset), context.gc_context);
+            this.set_array_element(
+                i,
+                this.array_element(i - offset),
+                activation.context.gc_context,
+            );
         }
     }
 
     for i in 0..args.len() {
-        this.set_array_element(i, args.get(i).unwrap().to_owned(), context.gc_context);
+        this.set_array_element(
+            i,
+            args.get(i).unwrap().to_owned(),
+            activation.context.gc_context,
+        );
     }
 
-    this.set_length(context.gc_context, new_length);
+    this.set_length(activation.context.gc_context, new_length);
 
     Ok((new_length as f64).into())
 }
 
 pub fn shift<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -226,20 +222,19 @@ pub fn shift<'gc>(
     let removed = this.array_element(0);
 
     for i in 0..new_length {
-        this.set_array_element(i, this.array_element(i + 1), context.gc_context);
+        this.set_array_element(i, this.array_element(i + 1), activation.context.gc_context);
     }
 
-    this.delete_array_element(new_length, context.gc_context);
-    this.delete(activation, context.gc_context, &new_length.to_string());
+    this.delete_array_element(new_length, activation.context.gc_context);
+    this.delete(activation, &new_length.to_string());
 
-    this.set_length(context.gc_context, new_length);
+    this.set_length(activation.context.gc_context, new_length);
 
     Ok(removed)
 }
 
 pub fn pop<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -251,17 +246,16 @@ pub fn pop<'gc>(
     let new_length = old_length - 1;
 
     let removed = this.array_element(new_length);
-    this.delete_array_element(new_length, context.gc_context);
-    this.delete(activation, context.gc_context, &new_length.to_string());
+    this.delete_array_element(new_length, activation.context.gc_context);
+    this.delete(activation, &new_length.to_string());
 
-    this.set_length(context.gc_context, new_length);
+    this.set_length(activation.context.gc_context, new_length);
 
     Ok(removed)
 }
 
 pub fn reverse<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -269,30 +263,29 @@ pub fn reverse<'gc>(
     let mut values = this.array().to_vec();
 
     for i in 0..length {
-        this.set_array_element(i, values.pop().unwrap(), context.gc_context);
+        this.set_array_element(i, values.pop().unwrap(), activation.context.gc_context);
     }
 
     Ok(Value::Undefined)
 }
 
 pub fn join<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let separator = args
         .get(0)
-        .and_then(|v| v.coerce_to_string(activation, context).ok())
+        .and_then(|v| v.coerce_to_string(activation).ok())
         .unwrap_or_else(|| ",".into());
     let values: Vec<Value<'gc>> = this.array();
 
     Ok(AvmString::new(
-        context.gc_context,
+        activation.context.gc_context,
         values
             .iter()
             .map(|v| {
-                v.coerce_to_string(activation, context)
+                v.coerce_to_string(activation)
                     .unwrap_or_else(|_| "undefined".into())
                     .to_string()
             })
@@ -314,30 +307,36 @@ fn make_index_absolute(mut index: i32, length: usize) -> usize {
 }
 
 pub fn slice<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let start = args
         .get(0)
-        .and_then(|v| v.coerce_to_f64(activation, context).ok())
+        .and_then(|v| v.coerce_to_f64(activation).ok())
         .map(|v| make_index_absolute(v as i32, this.length()))
         .unwrap_or(0);
     let end = args
         .get(1)
-        .and_then(|v| v.coerce_to_f64(activation, context).ok())
+        .and_then(|v| v.coerce_to_f64(activation).ok())
         .map(|v| make_index_absolute(v as i32, this.length()))
         .unwrap_or_else(|| this.length());
 
-    let array = ScriptObject::array(context.gc_context, Some(activation.avm.prototypes.array));
+    let array = ScriptObject::array(
+        activation.context.gc_context,
+        Some(activation.avm.prototypes.array),
+    );
 
     if start < end {
         let length = end - start;
-        array.set_length(context.gc_context, length);
+        array.set_length(activation.context.gc_context, length);
 
         for i in 0..length {
-            array.set_array_element(i, this.array_element(start + i), context.gc_context);
+            array.set_array_element(
+                i,
+                this.array_element(start + i),
+                activation.context.gc_context,
+            );
         }
     }
 
@@ -345,8 +344,7 @@ pub fn slice<'gc>(
 }
 
 pub fn splice<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -357,35 +355,42 @@ pub fn splice<'gc>(
     let old_length = this.length();
     let start = args
         .get(0)
-        .and_then(|v| v.coerce_to_f64(activation, context).ok())
+        .and_then(|v| v.coerce_to_f64(activation).ok())
         .map(|v| make_index_absolute(v as i32, old_length))
         .unwrap_or(0);
     let count = args
         .get(1)
-        .and_then(|v| v.coerce_to_f64(activation, context).ok())
+        .and_then(|v| v.coerce_to_f64(activation).ok())
         .map(|v| v as i32)
         .unwrap_or(old_length as i32);
     if count < 0 {
         return Ok(Value::Undefined);
     }
 
-    let removed = ScriptObject::array(context.gc_context, Some(activation.avm.prototypes.array));
+    let removed = ScriptObject::array(
+        activation.context.gc_context,
+        Some(activation.avm.prototypes.array),
+    );
     let to_remove = count.min(old_length as i32 - start as i32).max(0) as usize;
     let to_add = if args.len() > 2 { &args[2..] } else { &[] };
     let offset = to_remove as i32 - to_add.len() as i32;
     let new_length = old_length + to_add.len() - to_remove;
 
     for i in start..start + to_remove {
-        removed.set_array_element(i - start, this.array_element(i), context.gc_context);
+        removed.set_array_element(
+            i - start,
+            this.array_element(i),
+            activation.context.gc_context,
+        );
     }
-    removed.set_length(context.gc_context, to_remove);
+    removed.set_length(activation.context.gc_context, to_remove);
 
     if offset < 0 {
         for i in (start + to_add.len()..new_length).rev() {
             this.set_array_element(
                 i,
                 this.array_element((i as i32 + offset) as usize),
-                context.gc_context,
+                activation.context.gc_context,
             );
         }
     } else {
@@ -393,7 +398,7 @@ pub fn splice<'gc>(
             this.set_array_element(
                 i,
                 this.array_element((i as i32 + offset) as usize),
-                context.gc_context,
+                activation.context.gc_context,
             );
         }
     }
@@ -402,35 +407,37 @@ pub fn splice<'gc>(
         this.set_array_element(
             start + i,
             to_add.get(i).unwrap().to_owned(),
-            context.gc_context,
+            activation.context.gc_context,
         );
     }
 
     for i in new_length..old_length {
-        this.delete_array_element(i, context.gc_context);
-        this.delete(activation, context.gc_context, &i.to_string());
+        this.delete_array_element(i, activation.context.gc_context);
+        this.delete(activation, &i.to_string());
     }
 
-    this.set_length(context.gc_context, new_length);
+    this.set_length(activation.context.gc_context, new_length);
 
     Ok(removed.into())
 }
 
 pub fn concat<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let array = ScriptObject::array(context.gc_context, Some(activation.avm.prototypes.array));
+    let array = ScriptObject::array(
+        activation.context.gc_context,
+        Some(activation.avm.prototypes.array),
+    );
     let mut length = 0;
 
     for i in 0..this.length() {
         let old = this
-            .get(&i.to_string(), activation, context)
+            .get(&i.to_string(), activation)
             .unwrap_or(Value::Undefined);
         array.define_value(
-            context.gc_context,
+            activation.context.gc_context,
             &length.to_string(),
             old,
             EnumSet::empty(),
@@ -447,10 +454,10 @@ pub fn concat<'gc>(
                 added = true;
                 for i in 0..object.length() {
                     let old = object
-                        .get(&i.to_string(), activation, context)
+                        .get(&i.to_string(), activation)
                         .unwrap_or(Value::Undefined);
                     array.define_value(
-                        context.gc_context,
+                        activation.context.gc_context,
                         &length.to_string(),
                         old,
                         EnumSet::empty(),
@@ -462,7 +469,7 @@ pub fn concat<'gc>(
 
         if !added {
             array.define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 &length.to_string(),
                 arg.clone(),
                 EnumSet::empty(),
@@ -471,23 +478,21 @@ pub fn concat<'gc>(
         }
     }
 
-    array.set_length(context.gc_context, length);
+    array.set_length(activation.context.gc_context, length);
 
     Ok(array.into())
 }
 
 pub fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    join(activation, context, this, &[])
+    join(activation, this, &[])
 }
 
 fn sort<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -516,10 +521,10 @@ fn sort<'gc>(
     };
 
     let compare_fn: CompareFn<'_, 'gc> = if let Some(f) = compare_fn {
-        let this = value_object::ValueObject::boxed(activation, context, Value::Undefined);
+        let this = value_object::ValueObject::boxed(activation, Value::Undefined);
         // this is undefined in the compare function
-        Box::new(move |activation, context, a: &Value<'gc>, b: &Value<'gc>| {
-            sort_compare_custom(activation, context, this, a, b, &f)
+        Box::new(move |activation, a: &Value<'gc>, b: &Value<'gc>| {
+            sort_compare_custom(activation, this, a, b, &f)
         })
     } else if numeric {
         Box::new(sort_compare_numeric(string_compare_fn))
@@ -527,12 +532,11 @@ fn sort<'gc>(
         Box::new(string_compare_fn)
     };
 
-    sort_with_function(activation, context, this, compare_fn, flags)
+    sort_with_function(activation, this, compare_fn, flags)
 }
 
 fn sort_on<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -544,15 +548,13 @@ fn sort_on<'gc>(
             // Array of field names.
             let mut field_names = vec![];
             for name in array.array() {
-                field_names.push(name.coerce_to_string(activation, context)?.to_string());
+                field_names.push(name.coerce_to_string(activation)?.to_string());
             }
             field_names
         }
         Some(field_name) => {
             // Single field.
-            vec![field_name
-                .coerce_to_string(activation, context)?
-                .to_string()]
+            vec![field_name.coerce_to_string(activation)?.to_string()]
         }
         None => return Ok(Value::Undefined),
     };
@@ -568,7 +570,7 @@ fn sort_on<'gc>(
             if array.length() == fields.len() {
                 let mut flags = vec![];
                 for flag in array.array() {
-                    flags.push(flag.coerce_to_i32(activation, context)?);
+                    flags.push(flag.coerce_to_i32(activation)?);
                 }
                 flags
             } else {
@@ -578,7 +580,7 @@ fn sort_on<'gc>(
         }
         Some(flags) => {
             // Single field.
-            let flags = flags.coerce_to_i32(activation, context)?;
+            let flags = flags.coerce_to_i32(activation)?;
             std::iter::repeat(flags).take(fields.len()).collect()
         }
         None => std::iter::repeat(0).take(fields.len()).collect(),
@@ -610,19 +612,13 @@ fn sort_on<'gc>(
 
     let compare_fn = sort_compare_fields(fields, field_compare_fns);
 
-    sort_with_function(activation, context, this, compare_fn, main_flags)
+    sort_with_function(activation, this, compare_fn, main_flags)
 }
 
 fn sort_with_function<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
-    mut compare_fn: impl FnMut(
-        &mut Activation<'_, 'gc>,
-        &mut UpdateContext<'_, 'gc, '_>,
-        &Value<'gc>,
-        &Value<'gc>,
-    ) -> Ordering,
+    mut compare_fn: impl FnMut(&mut Activation<'_, '_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering,
     flags: i32,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let length = this.length();
@@ -635,7 +631,7 @@ fn sort_with_function<'gc>(
 
     let mut is_unique = true;
     values.sort_unstable_by(|a, b| {
-        let mut ret = compare_fn(activation, context, &a.1, &b.1);
+        let mut ret = compare_fn(activation, &a.1, &b.1);
         if descending {
             ret = ret.reverse();
         }
@@ -655,17 +651,21 @@ fn sort_with_function<'gc>(
     if return_indexed_array {
         // Array.RETURNINDEXEDARRAY returns an array containing the sorted indices, and does not modify
         // the original array.
-        let array = ScriptObject::array(context.gc_context, Some(array_proto));
-        array.set_length(context.gc_context, length);
+        let array = ScriptObject::array(activation.context.gc_context, Some(array_proto));
+        array.set_length(activation.context.gc_context, length);
         for (i, value) in values.into_iter().enumerate() {
-            array.set_array_element(i, Value::Number(value.0 as f64), context.gc_context);
+            array.set_array_element(
+                i,
+                Value::Number(value.0 as f64),
+                activation.context.gc_context,
+            );
         }
         Ok(array.into())
     } else {
         // Standard sort modifies the original array, and returns it.
         // AS2 reference incorrectly states this returns nothing, but it returns the original array, sorted.
         for (i, value) in values.into_iter().enumerate() {
-            this.set_array_element(i, value.1, context.gc_context);
+            this.set_array_element(i, value.1, activation.context.gc_context);
         }
         Ok(this.into())
     }
@@ -762,13 +762,12 @@ pub fn create_proto<'gc>(
 }
 
 fn sort_compare_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     a: &Value<'gc>,
     b: &Value<'gc>,
 ) -> Ordering {
-    let a_str = a.coerce_to_string(activation, context);
-    let b_str = b.coerce_to_string(activation, context);
+    let a_str = a.coerce_to_string(activation);
+    let b_str = b.coerce_to_string(activation);
     // TODO: Handle errors.
     if let (Ok(a_str), Ok(b_str)) = (a_str, b_str) {
         a_str.cmp(&b_str)
@@ -778,13 +777,12 @@ fn sort_compare_string<'gc>(
 }
 
 fn sort_compare_string_ignore_case<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     a: &Value<'gc>,
     b: &Value<'gc>,
 ) -> Ordering {
-    let a_str = a.coerce_to_string(activation, context);
-    let b_str = b.coerce_to_string(activation, context);
+    let a_str = a.coerce_to_string(activation);
+    let b_str = b.coerce_to_string(activation);
     // TODO: Handle errors.
     if let (Ok(a_str), Ok(b_str)) = (a_str, b_str) {
         crate::string_utils::swf_string_cmp_ignore_case(&a_str, &b_str)
@@ -793,24 +791,14 @@ fn sort_compare_string_ignore_case<'gc>(
     }
 }
 
-fn sort_compare_numeric<'gc>(
-    mut string_compare_fn: impl FnMut(
-        &mut Activation<'_, 'gc>,
-        &mut UpdateContext<'_, 'gc, '_>,
-        &Value<'gc>,
-        &Value<'gc>,
-    ) -> Ordering,
-) -> impl FnMut(
-    &mut Activation<'_, 'gc>,
-    &mut UpdateContext<'_, 'gc, '_>,
-    &Value<'gc>,
-    &Value<'gc>,
-) -> Ordering {
-    move |activation, context, a, b| {
+fn sort_compare_numeric(
+    mut string_compare_fn: impl FnMut(&mut Activation, &Value, &Value) -> Ordering,
+) -> impl FnMut(&mut Activation, &Value, &Value) -> Ordering {
+    move |activation, a, b| {
         if let (Value::Number(a), Value::Number(b)) = (a, b) {
             a.partial_cmp(b).unwrap_or(DEFAULT_ORDERING)
         } else {
-            string_compare_fn(activation, context, a, b)
+            string_compare_fn(activation, a, b)
         }
     }
 }
@@ -818,22 +806,16 @@ fn sort_compare_numeric<'gc>(
 fn sort_compare_fields<'a, 'gc: 'a>(
     field_names: Vec<String>,
     mut compare_fns: Vec<CompareFn<'a, 'gc>>,
-) -> impl 'a
-       + FnMut(
-    &mut Activation<'_, 'gc>,
-    &mut UpdateContext<'_, 'gc, '_>,
-    &Value<'gc>,
-    &Value<'gc>,
-) -> Ordering {
+) -> impl 'a + FnMut(&mut Activation<'_, '_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering {
     use crate::avm1::object::value_object::ValueObject;
-    move |activation, context, a, b| {
+    move |activation, a, b| {
         for (field_name, compare_fn) in field_names.iter().zip(compare_fns.iter_mut()) {
-            let a_object = ValueObject::boxed(activation, context, a.clone());
-            let b_object = ValueObject::boxed(activation, context, b.clone());
-            let a_prop = a_object.get(field_name, activation, context).unwrap();
-            let b_prop = b_object.get(field_name, activation, context).unwrap();
+            let a_object = ValueObject::boxed(activation, a.clone());
+            let b_object = ValueObject::boxed(activation, b.clone());
+            let a_prop = a_object.get(field_name, activation).unwrap();
+            let b_prop = b_object.get(field_name, activation).unwrap();
 
-            let result = compare_fn(activation, context, &a_prop, &b_prop);
+            let result = compare_fn(activation, &a_prop, &b_prop);
             if result != Ordering::Equal {
                 return result;
             }
@@ -845,8 +827,7 @@ fn sort_compare_fields<'a, 'gc: 'a>(
 
 // Returning an impl Trait here doesn't work yet because of https://github.com/rust-lang/rust/issues/65805 (?)
 fn sort_compare_custom<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     a: &Value<'gc>,
     b: &Value<'gc>,
@@ -855,7 +836,7 @@ fn sort_compare_custom<'gc>(
     // TODO: Handle errors.
     let args = [a.clone(), b.clone()];
     let ret = compare_fn
-        .call("[Compare]", activation, context, this, None, &args)
+        .call("[Compare]", activation, this, None, &args)
         .unwrap_or(Value::Undefined);
     match ret {
         Value::Number(n) if n > 0.0 => Ordering::Greater,

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -24,7 +24,7 @@ const DEFAULT_ORDERING: Ordering = Ordering::Equal;
 
 // Compare function used by sort and sortOn.
 type CompareFn<'a, 'gc> =
-    Box<dyn 'a + FnMut(&mut Activation<'_, '_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering>;
+    Box<dyn 'a + FnMut(&mut Activation<'_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering>;
 
 pub fn create_array_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
@@ -83,7 +83,7 @@ pub fn create_array_object<'gc>(
 
 /// Implements `Array` constructor
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -121,7 +121,7 @@ pub fn constructor<'gc>(
 
 /// Implements `Array` function
 pub fn array_function<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -156,7 +156,7 @@ pub fn array_function<'gc>(
 }
 
 pub fn push<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -176,7 +176,7 @@ pub fn push<'gc>(
 }
 
 pub fn unshift<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -208,7 +208,7 @@ pub fn unshift<'gc>(
 }
 
 pub fn shift<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -234,7 +234,7 @@ pub fn shift<'gc>(
 }
 
 pub fn pop<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -255,7 +255,7 @@ pub fn pop<'gc>(
 }
 
 pub fn reverse<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -270,7 +270,7 @@ pub fn reverse<'gc>(
 }
 
 pub fn join<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -307,7 +307,7 @@ fn make_index_absolute(mut index: i32, length: usize) -> usize {
 }
 
 pub fn slice<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -344,7 +344,7 @@ pub fn slice<'gc>(
 }
 
 pub fn splice<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -422,7 +422,7 @@ pub fn splice<'gc>(
 }
 
 pub fn concat<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -490,7 +490,7 @@ pub fn concat<'gc>(
 }
 
 pub fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -498,7 +498,7 @@ pub fn to_string<'gc>(
 }
 
 fn sort<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -542,7 +542,7 @@ fn sort<'gc>(
 }
 
 fn sort_on<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -622,9 +622,9 @@ fn sort_on<'gc>(
 }
 
 fn sort_with_function<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
-    mut compare_fn: impl FnMut(&mut Activation<'_, '_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering,
+    mut compare_fn: impl FnMut(&mut Activation<'_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering,
     flags: i32,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let length = this.length();
@@ -768,7 +768,7 @@ pub fn create_proto<'gc>(
 }
 
 fn sort_compare_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     a: &Value<'gc>,
     b: &Value<'gc>,
 ) -> Ordering {
@@ -783,7 +783,7 @@ fn sort_compare_string<'gc>(
 }
 
 fn sort_compare_string_ignore_case<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     a: &Value<'gc>,
     b: &Value<'gc>,
 ) -> Ordering {
@@ -812,7 +812,7 @@ fn sort_compare_numeric(
 fn sort_compare_fields<'a, 'gc: 'a>(
     field_names: Vec<String>,
     mut compare_fns: Vec<CompareFn<'a, 'gc>>,
-) -> impl 'a + FnMut(&mut Activation<'_, '_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering {
+) -> impl 'a + FnMut(&mut Activation<'_, 'gc, '_>, &Value<'gc>, &Value<'gc>) -> Ordering {
     use crate::avm1::object::value_object::ValueObject;
     move |activation, a, b| {
         for (field_name, compare_fn) in field_names.iter().zip(compare_fns.iter_mut()) {
@@ -833,7 +833,7 @@ fn sort_compare_fields<'a, 'gc: 'a>(
 
 // Returning an impl Trait here doesn't work yet because of https://github.com/rust-lang/rust/issues/65805 (?)
 fn sort_compare_custom<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     a: &Value<'gc>,
     b: &Value<'gc>,

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -28,7 +28,7 @@ impl<'gc> BroadcasterFunctions<'gc> {
 }
 
 pub fn add_listener<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -57,7 +57,7 @@ pub fn add_listener<'gc>(
 }
 
 pub fn remove_listener<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -102,7 +102,7 @@ pub fn remove_listener<'gc>(
 }
 
 pub fn broadcast_message<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -117,7 +117,7 @@ pub fn broadcast_message<'gc>(
 }
 
 pub fn broadcast_internal<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     call_args: &[Value<'gc>],
     method_name: &str,
@@ -138,7 +138,7 @@ pub fn broadcast_internal<'gc>(
 }
 
 pub fn initialize<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -147,8 +147,8 @@ pub fn initialize<'gc>(
         initialize_internal(
             activation.context.gc_context,
             broadcaster,
-            activation.avm.broadcaster_functions,
-            activation.avm.prototypes().array,
+            activation.context.avm1.broadcaster_functions,
+            activation.context.avm1.prototypes().array,
         );
     }
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -10,7 +10,7 @@ use gc_arena::MutationContext;
 
 /// `Boolean` constructor
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -30,7 +30,7 @@ pub fn constructor<'gc>(
 
 /// `Boolean` function
 pub fn boolean_function<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -87,7 +87,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -103,7 +103,7 @@ pub fn to_string<'gc>(
 }
 
 pub fn value_of<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -5,14 +5,12 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// `Boolean` constructor
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -24,7 +22,7 @@ pub fn constructor<'gc>(
 
     // Called from a constructor, populate `this`.
     if let Some(mut vbox) = this.as_value_object() {
-        vbox.replace_value(context.gc_context, cons_value);
+        vbox.replace_value(activation.context.gc_context, cons_value);
     }
 
     Ok(Value::Undefined)
@@ -32,8 +30,7 @@ pub fn constructor<'gc>(
 
 /// `Boolean` function
 pub fn boolean_function<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -90,8 +87,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn to_string<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -99,7 +95,7 @@ pub fn to_string<'gc>(
         // Must be a bool.
         // Boolean.prototype.toString.call(x) returns undefined for non-bools.
         if let Value::Bool(b) = vbox.unbox() {
-            return Ok(AvmString::new(context.gc_context, b.to_string()).into());
+            return Ok(AvmString::new(activation.context.gc_context, b.to_string()).into());
         }
     }
 
@@ -107,8 +103,7 @@ pub fn to_string<'gc>(
 }
 
 pub fn value_of<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -20,7 +20,7 @@ pub fn create_proto<'gc>(
 
 /// Implements `Button` constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::display_object;
-use crate::avm1::{Object, ScriptObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use gc_arena::MutationContext;
 
 pub fn create_proto<'gc>(
@@ -20,8 +20,7 @@ pub fn create_proto<'gc>(
 
 /// Implements `Button` constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -115,7 +115,7 @@ fn get_transform<'gc>(
         let color_transform = target.color_transform();
         let out = ScriptObject::object(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.object),
+            Some(activation.context.avm1.prototypes.object),
         );
         out.set("ra", (color_transform.r_mult * 100.0).into(), activation)?;
         out.set("ga", (color_transform.g_mult * 100.0).into(), activation)?;

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -12,7 +12,7 @@ use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     mut this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -74,7 +74,7 @@ pub fn create_proto<'gc>(
 
 /// Gets the target display object of this color transform.
 fn target<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
 ) -> Result<Option<DisplayObject<'gc>>, Error<'gc>> {
     // The target path resolves based on the active tellTarget clip of the stack frame.
@@ -91,7 +91,7 @@ fn target<'gc>(
 }
 
 fn get_rgb<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -107,7 +107,7 @@ fn get_rgb<'gc>(
 }
 
 fn get_transform<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -132,7 +132,7 @@ fn get_transform<'gc>(
 }
 
 fn set_rgb<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -157,7 +157,7 @@ fn set_rgb<'gc>(
 }
 
 fn set_transform<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -165,7 +165,7 @@ fn set_transform<'gc>(
     // to the 16-bit range used by the internal representations of the Flash Player.
     // This will get slightly simpler when we change ColorTransform to the proper representation (see #193).
     fn set_color_mult<'gc>(
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         transform: Object<'gc>,
         property: &str,
         out: &mut f32,
@@ -181,7 +181,7 @@ fn set_transform<'gc>(
     }
 
     fn set_color_add<'gc>(
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         transform: Object<'gc>,
         property: &str,
         out: &mut f32,

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -6,23 +6,22 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // The target display object that this color will modify.
     let target = args.get(0).cloned().unwrap_or(Value::Undefined);
     // Set undocumented `target` property
-    this.set("target", target, activation, context)?;
+    this.set("target", target, activation)?;
     this.set_attributes(
-        context.gc_context,
+        activation.context.gc_context,
         Some("target"),
         DontDelete | ReadOnly | DontEnum,
         EnumSet::empty(),
@@ -75,30 +74,28 @@ pub fn create_proto<'gc>(
 
 /// Gets the target display object of this color transform.
 fn target<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
 ) -> Result<Option<DisplayObject<'gc>>, Error<'gc>> {
     // The target path resolves based on the active tellTarget clip of the stack frame.
     // This means calls on the same `Color` object could set the color of different clips
     // depending on which timeline its called from!
-    let target = this.get("target", activation, context)?;
+    let target = this.get("target", activation)?;
     // Undefined or empty target is no-op.
     if target != Value::Undefined && !matches!(&target, &Value::String(ref s) if s.is_empty()) {
         let start_clip = activation.target_clip_or_root();
-        activation.resolve_target_display_object(context, start_clip, target)
+        activation.resolve_target_display_object(start_clip, target)
     } else {
         Ok(None)
     }
 }
 
 fn get_rgb<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(target) = target(activation, context, this)? {
+    if let Some(target) = target(activation, this)? {
         let color_transform = target.color_transform();
         let r = ((color_transform.r_add * 255.0) as i32) << 16;
         let g = ((color_transform.g_add * 255.0) as i32) << 8;
@@ -110,62 +107,24 @@ fn get_rgb<'gc>(
 }
 
 fn get_transform<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(target) = target(activation, context, this)? {
+    if let Some(target) = target(activation, this)? {
         let color_transform = target.color_transform();
-        let out = ScriptObject::object(context.gc_context, Some(activation.avm.prototypes.object));
-        out.set(
-            "ra",
-            (color_transform.r_mult * 100.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "ga",
-            (color_transform.g_mult * 100.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "ba",
-            (color_transform.b_mult * 100.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "aa",
-            (color_transform.a_mult * 100.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "rb",
-            (color_transform.r_add * 255.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "gb",
-            (color_transform.g_add * 255.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "bb",
-            (color_transform.b_add * 255.0).into(),
-            activation,
-            context,
-        )?;
-        out.set(
-            "ab",
-            (color_transform.a_add * 255.0).into(),
-            activation,
-            context,
-        )?;
+        let out = ScriptObject::object(
+            activation.context.gc_context,
+            Some(activation.avm.prototypes.object),
+        );
+        out.set("ra", (color_transform.r_mult * 100.0).into(), activation)?;
+        out.set("ga", (color_transform.g_mult * 100.0).into(), activation)?;
+        out.set("ba", (color_transform.b_mult * 100.0).into(), activation)?;
+        out.set("aa", (color_transform.a_mult * 100.0).into(), activation)?;
+        out.set("rb", (color_transform.r_add * 255.0).into(), activation)?;
+        out.set("gb", (color_transform.g_add * 255.0).into(), activation)?;
+        out.set("bb", (color_transform.b_add * 255.0).into(), activation)?;
+        out.set("ab", (color_transform.a_add * 255.0).into(), activation)?;
         Ok(out.into())
     } else {
         Ok(Value::Undefined)
@@ -173,17 +132,16 @@ fn get_transform<'gc>(
 }
 
 fn set_rgb<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(target) = target(activation, context, this)? {
-        let mut color_transform = target.color_transform_mut(context.gc_context);
+    if let Some(target) = target(activation, this)? {
+        let mut color_transform = target.color_transform_mut(activation.context.gc_context);
         let rgb = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .coerce_to_f64(activation, context)? as i32;
+            .coerce_to_f64(activation)? as i32;
         let r = (((rgb >> 16) & 0xff) as f32) / 255.0;
         let g = (((rgb >> 8) & 0xff) as f32) / 255.0;
         let b = ((rgb & 0xff) as f32) / 255.0;
@@ -199,8 +157,7 @@ fn set_rgb<'gc>(
 }
 
 fn set_transform<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -208,101 +165,51 @@ fn set_transform<'gc>(
     // to the 16-bit range used by the internal representations of the Flash Player.
     // This will get slightly simpler when we change ColorTransform to the proper representation (see #193).
     fn set_color_mult<'gc>(
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         transform: Object<'gc>,
         property: &str,
         out: &mut f32,
     ) -> Result<(), Error<'gc>> {
         // The parameters are set only if the property exists on the object itself (prototype excluded).
-        if transform.has_own_property(activation, context, property) {
+        if transform.has_own_property(activation, property) {
             let n = transform
-                .get(property, activation, context)?
-                .coerce_to_f64(activation, context)?;
+                .get(property, activation)?
+                .coerce_to_f64(activation)?;
             *out = f32::from(crate::avm1::value::f64_to_wrapping_i16(n * 2.56)) / 256.0
         }
         Ok(())
     }
 
     fn set_color_add<'gc>(
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         transform: Object<'gc>,
         property: &str,
         out: &mut f32,
     ) -> Result<(), Error<'gc>> {
         // The parameters are set only if the property exists on the object itself (prototype excluded).
-        if transform.has_own_property(activation, context, property) {
+        if transform.has_own_property(activation, property) {
             let n = transform
-                .get(property, activation, context)?
-                .coerce_to_f64(activation, context)?;
+                .get(property, activation)?
+                .coerce_to_f64(activation)?;
             *out = f32::from(crate::avm1::value::f64_to_wrapping_i16(n)) / 255.0
         }
         Ok(())
     }
 
-    if let Some(target) = target(activation, context, this)? {
-        let mut color_transform = target.color_transform_mut(context.gc_context);
+    if let Some(target) = target(activation, this)? {
+        let mut color_transform = target.color_transform_mut(activation.context.gc_context);
         let transform = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .coerce_to_object(activation, context);
-        set_color_mult(
-            activation,
-            context,
-            transform,
-            "ra",
-            &mut color_transform.r_mult,
-        )?;
-        set_color_mult(
-            activation,
-            context,
-            transform,
-            "ga",
-            &mut color_transform.g_mult,
-        )?;
-        set_color_mult(
-            activation,
-            context,
-            transform,
-            "ba",
-            &mut color_transform.b_mult,
-        )?;
-        set_color_mult(
-            activation,
-            context,
-            transform,
-            "aa",
-            &mut color_transform.a_mult,
-        )?;
-        set_color_add(
-            activation,
-            context,
-            transform,
-            "rb",
-            &mut color_transform.r_add,
-        )?;
-        set_color_add(
-            activation,
-            context,
-            transform,
-            "gb",
-            &mut color_transform.g_add,
-        )?;
-        set_color_add(
-            activation,
-            context,
-            transform,
-            "bb",
-            &mut color_transform.b_add,
-        )?;
-        set_color_add(
-            activation,
-            context,
-            transform,
-            "ab",
-            &mut color_transform.a_add,
-        )?;
+            .coerce_to_object(activation);
+        set_color_mult(activation, transform, "ra", &mut color_transform.r_mult)?;
+        set_color_mult(activation, transform, "ga", &mut color_transform.g_mult)?;
+        set_color_mult(activation, transform, "ba", &mut color_transform.b_mult)?;
+        set_color_mult(activation, transform, "aa", &mut color_transform.a_mult)?;
+        set_color_add(activation, transform, "rb", &mut color_transform.r_add)?;
+        set_color_add(activation, transform, "gb", &mut color_transform.g_add)?;
+        set_color_add(activation, transform, "bb", &mut color_transform.b_add)?;
+        set_color_add(activation, transform, "ab", &mut color_transform.a_add)?;
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -26,7 +26,7 @@ macro_rules! with_color_transform {
 }
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -81,7 +81,7 @@ pub fn constructor<'gc>(
 #[allow(dead_code)]
 pub fn object_to_color_transform<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<ColorTransform, Error<'gc>> {
     let red_multiplier = object
         .get("redMultiplier", activation)?
@@ -121,7 +121,7 @@ pub fn object_to_color_transform<'gc>(
 }
 
 pub fn get_rgb<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -134,7 +134,7 @@ pub fn get_rgb<'gc>(
 }
 
 pub fn set_rgb<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -165,7 +165,7 @@ macro_rules! color_transform_value_accessor {
     ($([$get_ident: ident, $set_ident: ident],)*) => {
         $(
             pub fn $set_ident<'gc>(
-                activation: &mut Activation<'_, '_, 'gc, '_>,
+                activation: &mut Activation<'_, 'gc, '_>,
 
                 this: Object<'gc>,
                 args: &[Value<'gc>],
@@ -181,7 +181,7 @@ macro_rules! color_transform_value_accessor {
             }
 
             pub fn $get_ident<'gc>(
-                _activation: &mut Activation<'_, '_, 'gc, '_>,
+                _activation: &mut Activation<'_, 'gc, '_>,
                 this: Object<'gc>,
                 _args: &[Value<'gc>],
             ) -> Result<Value<'gc>, Error<'gc>> {
@@ -244,7 +244,7 @@ pub fn create_proto<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     _args: &[Value<'gc>],
@@ -267,7 +267,7 @@ fn to_string<'gc>(
 }
 
 fn concat<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     _args: &[Value<'gc>],

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -4,7 +4,6 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::{AvmString, Object, TObject, Value};
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
@@ -27,53 +26,53 @@ macro_rules! with_color_transform {
 }
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let red_multiplier = args
         .get(0)
         .unwrap_or(&Value::Number(1.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let green_multiplier = args
         .get(1)
         .unwrap_or(&Value::Number(1.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let blue_multiplier = args
         .get(2)
         .unwrap_or(&Value::Number(1.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let alpha_multiplier = args
         .get(3)
         .unwrap_or(&Value::Number(1.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let red_offset = args
         .get(4)
         .unwrap_or(&Value::Number(0.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let green_offset = args
         .get(5)
         .unwrap_or(&Value::Number(0.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let blue_offset = args
         .get(6)
         .unwrap_or(&Value::Number(0.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let alpha_offset = args
         .get(7)
         .unwrap_or(&Value::Number(0.into()))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
 
     let ct = this.as_color_transform_object().unwrap();
-    ct.set_red_multiplier(context.gc_context, red_multiplier);
-    ct.set_green_multiplier(context.gc_context, green_multiplier);
-    ct.set_blue_multiplier(context.gc_context, blue_multiplier);
-    ct.set_alpha_multiplier(context.gc_context, alpha_multiplier);
-    ct.set_red_offset(context.gc_context, red_offset);
-    ct.set_green_offset(context.gc_context, green_offset);
-    ct.set_blue_offset(context.gc_context, blue_offset);
-    ct.set_alpha_offset(context.gc_context, alpha_offset);
+    ct.set_red_multiplier(activation.context.gc_context, red_multiplier);
+    ct.set_green_multiplier(activation.context.gc_context, green_multiplier);
+    ct.set_blue_multiplier(activation.context.gc_context, blue_multiplier);
+    ct.set_alpha_multiplier(activation.context.gc_context, alpha_multiplier);
+    ct.set_red_offset(activation.context.gc_context, red_offset);
+    ct.set_green_offset(activation.context.gc_context, green_offset);
+    ct.set_blue_offset(activation.context.gc_context, blue_offset);
+    ct.set_alpha_offset(activation.context.gc_context, alpha_offset);
 
     Ok(Value::Undefined)
 }
@@ -82,33 +81,32 @@ pub fn constructor<'gc>(
 #[allow(dead_code)]
 pub fn object_to_color_transform<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<ColorTransform, Error<'gc>> {
     let red_multiplier = object
-        .get("redMultiplier", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("redMultiplier", activation)?
+        .coerce_to_f64(activation)? as f32;
     let green_multiplier = object
-        .get("greenMultiplier", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("greenMultiplier", activation)?
+        .coerce_to_f64(activation)? as f32;
     let blue_multiplier = object
-        .get("blueMultiplier", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("blueMultiplier", activation)?
+        .coerce_to_f64(activation)? as f32;
     let alpha_multiplier = object
-        .get("alphaMultiplier", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("alphaMultiplier", activation)?
+        .coerce_to_f64(activation)? as f32;
     let red_offset = object
-        .get("redOffset", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("redOffset", activation)?
+        .coerce_to_f64(activation)? as f32;
     let green_offset = object
-        .get("greenOffset", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("greenOffset", activation)?
+        .coerce_to_f64(activation)? as f32;
     let blue_offset = object
-        .get("blueOffset", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("blueOffset", activation)?
+        .coerce_to_f64(activation)? as f32;
     let alpha_offset = object
-        .get("alphaOffset", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .get("alphaOffset", activation)?
+        .coerce_to_f64(activation)? as f32;
 
     Ok(ColorTransform {
         r_mult: red_multiplier,
@@ -123,8 +121,7 @@ pub fn object_to_color_transform<'gc>(
 }
 
 pub fn get_rgb<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -137,15 +134,15 @@ pub fn get_rgb<'gc>(
 }
 
 pub fn set_rgb<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let new_rgb = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_u32(activation, context)?;
+        .coerce_to_u32(activation)?;
 
     let red = ((new_rgb >> 16) & 0xFF) as f64;
     let green = ((new_rgb >> 8) & 0xFF) as f64;
@@ -153,13 +150,13 @@ pub fn set_rgb<'gc>(
 
     let ct = this.as_color_transform_object().unwrap();
 
-    ct.set_red_offset(context.gc_context, red);
-    ct.set_green_offset(context.gc_context, green);
-    ct.set_blue_offset(context.gc_context, blue);
+    ct.set_red_offset(activation.context.gc_context, red);
+    ct.set_green_offset(activation.context.gc_context, green);
+    ct.set_blue_offset(activation.context.gc_context, blue);
 
-    ct.set_red_multiplier(context.gc_context, 0.0);
-    ct.set_green_multiplier(context.gc_context, 0.0);
-    ct.set_blue_multiplier(context.gc_context, 0.0);
+    ct.set_red_multiplier(activation.context.gc_context, 0.0);
+    ct.set_green_multiplier(activation.context.gc_context, 0.0);
+    ct.set_blue_multiplier(activation.context.gc_context, 0.0);
 
     Ok(Value::Undefined)
 }
@@ -168,24 +165,23 @@ macro_rules! color_transform_value_accessor {
     ($([$get_ident: ident, $set_ident: ident],)*) => {
         $(
             pub fn $set_ident<'gc>(
-                activation: &mut Activation<'_, 'gc>,
-                context: &mut UpdateContext<'_, 'gc, '_>,
+                activation: &mut Activation<'_, '_, 'gc, '_>,
+
                 this: Object<'gc>,
                 args: &[Value<'gc>],
             ) -> Result<Value<'gc>, Error<'gc>> {
                 let new_val = args
                     .get(0)
                     .unwrap_or(&Value::Undefined)
-                    .coerce_to_f64(activation, context)?;
+                    .coerce_to_f64(activation)?;
 
                 let ct = this.as_color_transform_object().unwrap();
-                ct.$set_ident(context.gc_context, new_val);
+                ct.$set_ident(activation.context.gc_context, new_val);
                 Ok(Value::Undefined.into())
             }
 
             pub fn $get_ident<'gc>(
-                _activation: &mut Activation<'_, 'gc>,
-                _context: &mut UpdateContext<'_, 'gc, '_>,
+                _activation: &mut Activation<'_, '_, 'gc, '_>,
                 this: Object<'gc>,
                 _args: &[Value<'gc>],
             ) -> Result<Value<'gc>, Error<'gc>> {
@@ -248,28 +244,31 @@ pub fn create_proto<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let formatted = format!("(redMultiplier={}, greenMultiplier={}, blueMultiplier={}, alphaMultiplier={}, redOffset={}, greenOffset={}, blueOffset={}, alphaOffset={})",
-            this.get("redMultiplier", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("greenMultiplier", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("blueMultiplier", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("alphaMultiplier", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("redOffset", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("greenOffset", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("blueOffset", activation, context)?.coerce_to_string(activation, context)?,
-            this.get("alphaOffset", activation, context)?.coerce_to_string(activation, context)?
+            this.get("redMultiplier", activation)?.coerce_to_string(activation)?,
+            this.get("greenMultiplier", activation)?.coerce_to_string(activation)?,
+            this.get("blueMultiplier", activation)?.coerce_to_string(activation)?,
+            this.get("alphaMultiplier", activation)?.coerce_to_string(activation)?,
+            this.get("redOffset", activation)?.coerce_to_string(activation)?,
+            this.get("greenOffset", activation)?.coerce_to_string(activation)?,
+            this.get("blueOffset", activation)?.coerce_to_string(activation)?,
+            this.get("alphaOffset", activation)?.coerce_to_string(activation)?
     );
 
-    Ok(Value::String(AvmString::new(context.gc_context, formatted)))
+    Ok(Value::String(AvmString::new(
+        activation.context.gc_context,
+        formatted,
+    )))
 }
 
 fn concat<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -279,7 +278,7 @@ fn concat<'gc>(
         if arg == &Value::Undefined {
             return Ok(Value::Undefined);
         }
-        let other = arg.coerce_to_object(activation, context);
+        let other = arg.coerce_to_object(activation);
 
         let other_ct = other.as_color_transform_object().unwrap();
         let this_ct = this.as_color_transform_object().unwrap();
@@ -297,14 +296,14 @@ fn concat<'gc>(
         let alpha_offset = (other_ct.get_alpha_offset() * this_ct.get_alpha_multiplier())
             + this_ct.get_alpha_offset();
 
-        this_ct.set_red_multiplier(context.gc_context, red_multiplier);
-        this_ct.set_green_multiplier(context.gc_context, green_multiplier);
-        this_ct.set_blue_multiplier(context.gc_context, blue_multiplier);
-        this_ct.set_alpha_multiplier(context.gc_context, alpha_multiplier);
-        this_ct.set_red_offset(context.gc_context, red_offset);
-        this_ct.set_green_offset(context.gc_context, green_offset);
-        this_ct.set_blue_offset(context.gc_context, blue_offset);
-        this_ct.set_alpha_offset(context.gc_context, alpha_offset);
+        this_ct.set_red_multiplier(activation.context.gc_context, red_multiplier);
+        this_ct.set_green_multiplier(activation.context.gc_context, green_multiplier);
+        this_ct.set_blue_multiplier(activation.context.gc_context, blue_multiplier);
+        this_ct.set_alpha_multiplier(activation.context.gc_context, alpha_multiplier);
+        this_ct.set_red_offset(activation.context.gc_context, red_offset);
+        this_ct.set_green_offset(activation.context.gc_context, green_offset);
+        this_ct.set_blue_offset(activation.context.gc_context, blue_offset);
+        this_ct.set_alpha_offset(activation.context.gc_context, alpha_offset);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -18,7 +18,7 @@ pub fn constructor<'gc>(
 
     this.set("onSelect", callback.into(), activation)?;
 
-    let prototype = activation.avm.prototypes.object;
+    let prototype = activation.context.avm1.prototypes.object;
     let built_in_items = prototype.create_bare_object(activation, prototype)?;
 
     built_in_items.set("print", true.into(), activation)?;
@@ -32,7 +32,7 @@ pub fn constructor<'gc>(
 
     this.set("builtInItems", built_in_items.into(), activation)?;
 
-    let constructor = activation.avm.prototypes.array_constructor;
+    let constructor = activation.context.avm1.prototypes.array_constructor;
     let custom_items = constructor.construct(activation, &[])?;
 
     this.set("customItems", custom_items.into(), activation)?;
@@ -49,7 +49,7 @@ pub fn copy<'gc>(
         .get("onSelect", activation)?
         .coerce_to_object(activation);
 
-    let constructor = activation.avm.prototypes.context_menu_constructor;
+    let constructor = activation.context.avm1.prototypes.context_menu_constructor;
     let copy = constructor.construct(activation, &[callback.into()])?;
 
     let built_in = this

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -7,7 +7,7 @@ use crate::avm1::{ScriptObject, Value};
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -41,7 +41,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn copy<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -112,7 +112,7 @@ pub fn copy<'gc>(
 }
 
 pub fn hide_builtin_items<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     _args: &[Value<'gc>],

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -4,128 +4,129 @@ use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let callback = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_object(activation, context);
+        .coerce_to_object(activation);
 
-    this.set("onSelect", callback.into(), activation, context)?;
+    this.set("onSelect", callback.into(), activation)?;
 
     let prototype = activation.avm.prototypes.object;
-    let built_in_items = prototype.create_bare_object(activation, context, prototype)?;
+    let built_in_items = prototype.create_bare_object(activation, prototype)?;
 
-    built_in_items.set("print", true.into(), activation, context)?;
-    built_in_items.set("forward_back", true.into(), activation, context)?;
-    built_in_items.set("rewind", true.into(), activation, context)?;
-    built_in_items.set("loop", true.into(), activation, context)?;
-    built_in_items.set("play", true.into(), activation, context)?;
-    built_in_items.set("quality", true.into(), activation, context)?;
-    built_in_items.set("zoom", true.into(), activation, context)?;
-    built_in_items.set("save", true.into(), activation, context)?;
+    built_in_items.set("print", true.into(), activation)?;
+    built_in_items.set("forward_back", true.into(), activation)?;
+    built_in_items.set("rewind", true.into(), activation)?;
+    built_in_items.set("loop", true.into(), activation)?;
+    built_in_items.set("play", true.into(), activation)?;
+    built_in_items.set("quality", true.into(), activation)?;
+    built_in_items.set("zoom", true.into(), activation)?;
+    built_in_items.set("save", true.into(), activation)?;
 
-    this.set("builtInItems", built_in_items.into(), activation, context)?;
+    this.set("builtInItems", built_in_items.into(), activation)?;
 
     let constructor = activation.avm.prototypes.array_constructor;
-    let custom_items = constructor.construct(activation, context, &[])?;
+    let custom_items = constructor.construct(activation, &[])?;
 
-    this.set("customItems", custom_items.into(), activation, context)?;
+    this.set("customItems", custom_items.into(), activation)?;
 
     Ok(Value::Undefined)
 }
 
 pub fn copy<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let callback = this
-        .get("onSelect", activation, context)?
-        .coerce_to_object(activation, context);
+        .get("onSelect", activation)?
+        .coerce_to_object(activation);
 
     let constructor = activation.avm.prototypes.context_menu_constructor;
-    let copy = constructor.construct(activation, context, &[callback.into()])?;
+    let copy = constructor.construct(activation, &[callback.into()])?;
 
     let built_in = this
-        .get("builtInItems", activation, context)?
-        .coerce_to_object(activation, context);
+        .get("builtInItems", activation)?
+        .coerce_to_object(activation);
     let copy_built_in = copy
-        .get("builtInItems", activation, context)?
-        .coerce_to_object(activation, context);
+        .get("builtInItems", activation)?
+        .coerce_to_object(activation);
 
     let save = built_in
-        .get("save", activation, context)?
+        .get("save", activation)?
         .as_bool(activation.current_swf_version());
     let zoom = built_in
-        .get("zoom", activation, context)?
+        .get("zoom", activation)?
         .as_bool(activation.current_swf_version());
     let quality = built_in
-        .get("quality", activation, context)?
+        .get("quality", activation)?
         .as_bool(activation.current_swf_version());
     let play = built_in
-        .get("play", activation, context)?
+        .get("play", activation)?
         .as_bool(activation.current_swf_version());
     let loop_ = built_in
-        .get("loop", activation, context)?
+        .get("loop", activation)?
         .as_bool(activation.current_swf_version());
     let rewind = built_in
-        .get("rewind", activation, context)?
+        .get("rewind", activation)?
         .as_bool(activation.current_swf_version());
     let forward_back = built_in
-        .get("forward_back", activation, context)?
+        .get("forward_back", activation)?
         .as_bool(activation.current_swf_version());
     let print = built_in
-        .get("print", activation, context)?
+        .get("print", activation)?
         .as_bool(activation.current_swf_version());
 
-    copy_built_in.set("save", save.into(), activation, context)?;
-    copy_built_in.set("zoom", zoom.into(), activation, context)?;
-    copy_built_in.set("quality", quality.into(), activation, context)?;
-    copy_built_in.set("play", play.into(), activation, context)?;
-    copy_built_in.set("loop", loop_.into(), activation, context)?;
-    copy_built_in.set("rewind", rewind.into(), activation, context)?;
-    copy_built_in.set("forward_back", forward_back.into(), activation, context)?;
-    copy_built_in.set("print", print.into(), activation, context)?;
+    copy_built_in.set("save", save.into(), activation)?;
+    copy_built_in.set("zoom", zoom.into(), activation)?;
+    copy_built_in.set("quality", quality.into(), activation)?;
+    copy_built_in.set("play", play.into(), activation)?;
+    copy_built_in.set("loop", loop_.into(), activation)?;
+    copy_built_in.set("rewind", rewind.into(), activation)?;
+    copy_built_in.set("forward_back", forward_back.into(), activation)?;
+    copy_built_in.set("print", print.into(), activation)?;
 
     let custom_items = this
-        .get("customItems", activation, context)?
-        .coerce_to_object(activation, context);
+        .get("customItems", activation)?
+        .coerce_to_object(activation);
     let custom_items_copy = copy
-        .get("customItems", activation, context)?
-        .coerce_to_object(activation, context);
+        .get("customItems", activation)?
+        .coerce_to_object(activation);
 
     for i in 0..custom_items.length() {
-        custom_items_copy.set_array_element(i, custom_items.array_element(i), context.gc_context);
+        custom_items_copy.set_array_element(
+            i,
+            custom_items.array_element(i),
+            activation.context.gc_context,
+        );
     }
 
     Ok(copy.into())
 }
 
 pub fn hide_builtin_items<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let built_in_items = this
-        .get("builtInItems", activation, context)?
-        .coerce_to_object(activation, context);
-    built_in_items.set("zoom", false.into(), activation, context)?;
-    built_in_items.set("quality", false.into(), activation, context)?;
-    built_in_items.set("play", false.into(), activation, context)?;
-    built_in_items.set("loop", false.into(), activation, context)?;
-    built_in_items.set("rewind", false.into(), activation, context)?;
-    built_in_items.set("forward_back", false.into(), activation, context)?;
-    built_in_items.set("print", false.into(), activation, context)?;
+        .get("builtInItems", activation)?
+        .coerce_to_object(activation);
+    built_in_items.set("zoom", false.into(), activation)?;
+    built_in_items.set("quality", false.into(), activation)?;
+    built_in_items.set("play", false.into(), activation)?;
+    built_in_items.set("loop", false.into(), activation)?;
+    built_in_items.set("rewind", false.into(), activation)?;
+    built_in_items.set("forward_back", false.into(), activation)?;
+    built_in_items.set("print", false.into(), activation)?;
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -78,7 +78,11 @@ pub fn copy<'gc>(
         .get("visible", activation)?
         .as_bool(activation.swf_version());
 
-    let constructor = activation.avm.prototypes.context_menu_item_constructor;
+    let constructor = activation
+        .context
+        .avm1
+        .prototypes
+        .context_menu_item_constructor;
     let copy = constructor.construct(
         activation,
         &[

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -7,7 +7,7 @@ use crate::avm1::{ScriptObject, Value};
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -55,7 +55,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn copy<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     _args: &[Value<'gc>],

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -4,12 +4,11 @@ use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object};
 use crate::avm1::{ScriptObject, Value};
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -17,11 +16,11 @@ pub fn constructor<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .coerce_to_string(activation, context)?
+        .coerce_to_string(activation)?
         .to_string();
     let callback = args
         .get(1)
-        .map(|v| v.to_owned().coerce_to_object(activation, context));
+        .map(|v| v.to_owned().coerce_to_object(activation));
     let separator_before = args
         .get(2)
         .unwrap_or(&Value::Bool(false))
@@ -40,57 +39,50 @@ pub fn constructor<'gc>(
 
     this.set(
         "caption",
-        AvmString::new(context.gc_context, caption).into(),
+        AvmString::new(activation.context.gc_context, caption).into(),
         activation,
-        context,
     )?;
 
     if let Some(callback) = callback {
-        this.set("onSelect", callback.into(), activation, context)?;
+        this.set("onSelect", callback.into(), activation)?;
     }
 
-    this.set(
-        "separatorBefore",
-        separator_before.into(),
-        activation,
-        context,
-    )?;
-    this.set("enabled", enabled.into(), activation, context)?;
-    this.set("visible", visible.into(), activation, context)?;
+    this.set("separatorBefore", separator_before.into(), activation)?;
+    this.set("enabled", enabled.into(), activation)?;
+    this.set("visible", visible.into(), activation)?;
 
     Ok(Value::Undefined)
 }
 
 pub fn copy<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let caption = this
-        .get("caption", activation, context)?
-        .coerce_to_string(activation, context)?
+        .get("caption", activation)?
+        .coerce_to_string(activation)?
         .to_string();
     let callback = this
-        .get("onSelect", activation, context)?
-        .coerce_to_object(activation, context);
+        .get("onSelect", activation)?
+        .coerce_to_object(activation);
 
     let enabled = this
-        .get("enabled", activation, context)?
+        .get("enabled", activation)?
         .as_bool(activation.swf_version());
     let separator_before = this
-        .get("separator_before", activation, context)?
+        .get("separator_before", activation)?
         .as_bool(activation.swf_version());
     let visible = this
-        .get("visible", activation, context)?
+        .get("visible", activation)?
         .as_bool(activation.swf_version());
 
     let constructor = activation.avm.prototypes.context_menu_item_constructor;
     let copy = constructor.construct(
         activation,
-        context,
         &[
-            AvmString::new(context.gc_context, caption).into(),
+            AvmString::new(activation.context.gc_context, caption).into(),
             callback.into(),
             separator_before.into(),
             enabled.into(),

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -56,7 +56,9 @@ pub fn define_display_object_proto<'gc>(
         "_global",
         FunctionObject::function(
             gc_context,
-            Executable::Native(|activation, _this, _args| Ok(activation.avm.global_object())),
+            Executable::Native(|activation, _this, _args| {
+                Ok(activation.context.avm1.global_object())
+            }),
             Some(fn_proto),
             fn_proto,
         ),

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -24,7 +24,7 @@ macro_rules! with_display_object {
         $(
             $object.force_set_function(
                 $name,
-                |activation: &mut Activation<'_, '_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
+                |activation: &mut Activation<'_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
                     if let Some(display_object) = this.as_display_object() {
                         return $fn(display_object, activation, args);
                     }
@@ -109,7 +109,7 @@ pub fn define_display_object_proto<'gc>(
 }
 
 pub fn get_parent<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -123,7 +123,7 @@ pub fn get_parent<'gc>(
 
 pub fn get_depth<'gc>(
     display_object: DisplayObject<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.current_swf_version() >= 6 {
@@ -135,7 +135,7 @@ pub fn get_depth<'gc>(
 }
 
 pub fn overwrite_root<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -154,7 +154,7 @@ pub fn overwrite_root<'gc>(
 }
 
 pub fn overwrite_global<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -173,7 +173,7 @@ pub fn overwrite_global<'gc>(
 }
 
 pub fn overwrite_parent<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
@@ -24,9 +24,9 @@ macro_rules! with_display_object {
         $(
             $object.force_set_function(
                 $name,
-                |activation, context: &mut UpdateContext<'_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
+                |activation: &mut Activation<'_, '_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
                     if let Some(display_object) = this.as_display_object() {
-                        return $fn(display_object, activation, context, args);
+                        return $fn(display_object, activation, args);
                     }
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
@@ -56,9 +56,7 @@ pub fn define_display_object_proto<'gc>(
         "_global",
         FunctionObject::function(
             gc_context,
-            Executable::Native(|activation, context, _this, _args| {
-                Ok(activation.avm.global_object(context))
-            }),
+            Executable::Native(|activation, _this, _args| Ok(activation.avm.global_object())),
             Some(fn_proto),
             fn_proto,
         ),
@@ -76,9 +74,7 @@ pub fn define_display_object_proto<'gc>(
         "_root",
         FunctionObject::function(
             gc_context,
-            Executable::Native(|activation, context, _this, _args| {
-                Ok(activation.root_object(context))
-            }),
+            Executable::Native(|activation, _this, _args| Ok(activation.root_object())),
             Some(fn_proto),
             fn_proto,
         ),
@@ -111,23 +107,21 @@ pub fn define_display_object_proto<'gc>(
 }
 
 pub fn get_parent<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_display_object()
         .and_then(|mc| mc.parent())
-        .map(|dn| dn.object().coerce_to_object(activation, context))
+        .map(|dn| dn.object().coerce_to_object(activation))
         .map(Value::Object)
         .unwrap_or(Value::Undefined))
 }
 
 pub fn get_depth<'gc>(
     display_object: DisplayObject<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.current_swf_version() >= 6 {
@@ -139,8 +133,7 @@ pub fn get_depth<'gc>(
 }
 
 pub fn overwrite_root<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -148,14 +141,18 @@ pub fn overwrite_root<'gc>(
         .get(0)
         .map(|v| v.to_owned())
         .unwrap_or(Value::Undefined);
-    this.define_value(ac.gc_context, "_root", new_val, EnumSet::new());
+    this.define_value(
+        activation.context.gc_context,
+        "_root",
+        new_val,
+        EnumSet::new(),
+    );
 
     Ok(Value::Undefined)
 }
 
 pub fn overwrite_global<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -163,14 +160,18 @@ pub fn overwrite_global<'gc>(
         .get(0)
         .map(|v| v.to_owned())
         .unwrap_or(Value::Undefined);
-    this.define_value(ac.gc_context, "_global", new_val, EnumSet::new());
+    this.define_value(
+        activation.context.gc_context,
+        "_global",
+        new_val,
+        EnumSet::new(),
+    );
 
     Ok(Value::Undefined)
 }
 
 pub fn overwrite_parent<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -178,7 +179,12 @@ pub fn overwrite_parent<'gc>(
         .get(0)
         .map(|v| v.to_owned())
         .unwrap_or(Value::Undefined);
-    this.define_value(ac.gc_context, "_parent", new_val, EnumSet::new());
+    this.define_value(
+        activation.context.gc_context,
+        "_parent",
+        new_val,
+        EnumSet::new(),
+    );
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -3,20 +3,20 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let message: Value<'gc> = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if message != Value::Undefined {
-        this.set("message", message, activation, context)?;
+        this.set("message", message, activation)?;
     }
 
     Ok(Value::Undefined)
@@ -44,15 +44,15 @@ pub fn create_proto<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let message = this.get("message", activation, context)?;
+    let message = this.get("message", activation)?;
     Ok(AvmString::new(
-        context.gc_context,
-        message.coerce_to_string(activation, context)?.to_string(),
+        activation.context.gc_context,
+        message.coerce_to_string(activation)?.to_string(),
     )
     .into())
 }

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -8,7 +8,7 @@ use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -44,7 +44,7 @@ pub fn create_proto<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     _args: &[Value<'gc>],

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -9,7 +9,7 @@ use gc_arena::MutationContext;
 
 /// Implements `Function`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -18,7 +18,7 @@ pub fn constructor<'gc>(
 
 /// Implements `Function.prototype.call`
 pub fn call<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     func: Object<'gc>,
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -49,7 +49,7 @@ pub fn call<'gc>(
 
 /// Implements `Function.prototype.apply`
 pub fn apply<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     func: Object<'gc>,
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -87,7 +87,7 @@ pub fn apply<'gc>(
 
 /// Implements `Function.prototype.toString`
 fn to_string<'gc>(
-    _: &mut Activation<'_, '_, 'gc, '_>,
+    _: &mut Activation<'_, 'gc, '_>,
     _: Object<'gc>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -24,7 +24,7 @@ pub fn call<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = match myargs.get(0) {
         Some(Value::Object(this)) => *this,
-        _ => activation.avm.globals,
+        _ => activation.context.avm1.globals,
     };
     let empty = [];
     let args = match myargs.len() {
@@ -55,7 +55,7 @@ pub fn apply<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = match myargs.get(0) {
         Some(Value::Object(this)) => *this,
-        _ => activation.avm.globals,
+        _ => activation.context.avm1.globals,
     };
     let mut child_args = Vec::new();
     let args_object = myargs.get(1).cloned().unwrap_or(Value::Undefined);

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -3,14 +3,13 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// Implements `Function`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -19,8 +18,7 @@ pub fn constructor<'gc>(
 
 /// Implements `Function.prototype.call`
 pub fn call<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     func: Object<'gc>,
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -39,7 +37,6 @@ pub fn call<'gc>(
         Some(exec) => exec.exec(
             "[Anonymous]",
             activation,
-            action_context,
             this,
             None,
             args,
@@ -52,8 +49,7 @@ pub fn call<'gc>(
 
 /// Implements `Function.prototype.apply`
 pub fn apply<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     func: Object<'gc>,
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -64,15 +60,13 @@ pub fn apply<'gc>(
     let mut child_args = Vec::new();
     let args_object = myargs.get(1).cloned().unwrap_or(Value::Undefined);
     let length = match args_object {
-        Value::Object(a) => a
-            .get("length", activation, action_context)?
-            .coerce_to_f64(activation, action_context)? as usize,
+        Value::Object(a) => a.get("length", activation)?.coerce_to_f64(activation)? as usize,
         _ => 0,
     };
 
     while child_args.len() < length {
-        let args = args_object.coerce_to_object(activation, action_context);
-        let next_arg = args.get(&format!("{}", child_args.len()), activation, action_context)?;
+        let args = args_object.coerce_to_object(activation);
+        let next_arg = args.get(&format!("{}", child_args.len()), activation)?;
 
         child_args.push(next_arg);
     }
@@ -81,7 +75,6 @@ pub fn apply<'gc>(
         Some(exec) => exec.exec(
             "[Anonymous]",
             activation,
-            action_context,
             this,
             None,
             &child_args,
@@ -94,8 +87,7 @@ pub fn apply<'gc>(
 
 /// Implements `Function.prototype.toString`
 fn to_string<'gc>(
-    _: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _: &mut Activation<'_, '_, 'gc, '_>,
     _: Object<'gc>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -8,7 +8,7 @@ use gc_arena::MutationContext;
 use std::convert::TryFrom;
 
 pub fn is_down<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -24,7 +24,7 @@ pub fn is_down<'gc>(
 }
 
 pub fn get_code<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -2,35 +2,33 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::events::KeyCode;
 use gc_arena::MutationContext;
 use std::convert::TryFrom;
 
 pub fn is_down<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(key) = args
         .get(0)
-        .and_then(|v| v.coerce_to_f64(activation, context).ok())
+        .and_then(|v| v.coerce_to_f64(activation).ok())
         .and_then(|k| KeyCode::try_from(k as u8).ok())
     {
-        Ok(context.input.is_key_down(key).into())
+        Ok(activation.context.input.is_key_down(key).into())
     } else {
         Ok(false.into())
     }
 }
 
 pub fn get_code<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let code: u8 = context.input.get_last_key_code().into();
+    let code: u8 = activation.context.input.get_last_key_code().into();
     Ok(code.into())
 }
 

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 
 /// Implements `LoadVars`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -120,7 +120,7 @@ pub fn create_proto<'gc>(
 }
 
 fn add_request_header<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -129,7 +129,7 @@ fn add_request_header<'gc>(
 }
 
 fn decode<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -150,7 +150,7 @@ fn decode<'gc>(
 }
 
 fn get_bytes_loaded<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -159,7 +159,7 @@ fn get_bytes_loaded<'gc>(
 }
 
 fn get_bytes_total<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -168,7 +168,7 @@ fn get_bytes_total<'gc>(
 }
 
 fn load<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -183,7 +183,7 @@ fn load<'gc>(
 }
 
 fn on_data<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -203,7 +203,7 @@ fn on_data<'gc>(
 }
 
 fn on_load<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -212,7 +212,7 @@ fn on_load<'gc>(
 }
 
 fn send<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -263,7 +263,7 @@ fn send<'gc>(
 }
 
 fn send_and_load<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -286,7 +286,7 @@ fn send_and_load<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -317,7 +317,7 @@ fn to_string<'gc>(
 }
 
 fn spawn_load_var_fetch<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     loader_object: Object<'gc>,
     url: &AvmString,
     send_object: Option<(Object<'gc>, NavigationMethod)>,

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -4,7 +4,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
-use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use gc_arena::MutationContext;
@@ -12,8 +12,7 @@ use std::borrow::Cow;
 
 /// Implements `LoadVars`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -121,8 +120,7 @@ pub fn create_proto<'gc>(
 }
 
 fn add_request_header<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -131,21 +129,19 @@ fn add_request_header<'gc>(
 }
 
 fn decode<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // Spec says added in SWF 7, but not version gated.
     // Decode the query string into properties on this object.
     if let Some(data) = args.get(0) {
-        let data = data.coerce_to_string(activation, context)?;
+        let data = data.coerce_to_string(activation)?;
         for (k, v) in url::form_urlencoded::parse(data.as_bytes()) {
             this.set(
                 &k,
-                crate::avm1::AvmString::new(context.gc_context, v.into_owned()).into(),
+                crate::avm1::AvmString::new(activation.context.gc_context, v.into_owned()).into(),
                 activation,
-                context,
             )?;
         }
     }
@@ -154,44 +150,40 @@ fn decode<'gc>(
 }
 
 fn get_bytes_loaded<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // Forwards to undocumented property on the object.
-    this.get("_bytesLoaded", activation, context)
+    this.get("_bytesLoaded", activation)
 }
 
 fn get_bytes_total<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // Forwards to undocumented property on the object.
-    this.get("_bytesTotal", activation, context)
+    this.get("_bytesTotal", activation)
 }
 
 fn load<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let url = match args.get(0) {
-        Some(val) => val.coerce_to_string(activation, context)?,
+        Some(val) => val.coerce_to_string(activation)?,
         None => return Ok(false.into()),
     };
 
-    spawn_load_var_fetch(activation, context, this, &url, None)?;
+    spawn_load_var_fetch(activation, this, &url, None)?;
 
     Ok(true.into())
 }
 
 fn on_data<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -199,20 +191,19 @@ fn on_data<'gc>(
     let success = match args.get(0) {
         None | Some(Value::Undefined) | Some(Value::Null) => false,
         Some(val) => {
-            this.call_method(&"decode", &[val.clone()], activation, context)?;
-            this.set("loaded", true.into(), activation, context)?;
+            this.call_method(&"decode", &[val.clone()], activation)?;
+            this.set("loaded", true.into(), activation)?;
             true
         }
     };
 
-    this.call_method(&"onLoad", &[success.into()], activation, context)?;
+    this.call_method(&"onLoad", &[success.into()], activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn on_load<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -221,26 +212,25 @@ fn on_load<'gc>(
 }
 
 fn send<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // `send` navigates the browser to a URL with the given query parameter.
     let url = match args.get(0) {
-        Some(url) => url.coerce_to_string(activation, context)?,
+        Some(url) => url.coerce_to_string(activation)?,
         None => return Ok(false.into()),
     };
 
     let window = match args.get(1) {
-        Some(v) => Some(v.coerce_to_string(activation, context)?),
+        Some(v) => Some(v.coerce_to_string(activation)?),
         None => None,
     };
 
     let method_name = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_string(activation, context)?;
+        .coerce_to_string(activation)?;
     let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::POST);
 
     use std::collections::HashMap;
@@ -249,20 +239,20 @@ fn send<'gc>(
     let keys = this.get_keys(activation);
 
     for k in keys {
-        let v = this.get(&k, activation, context);
+        let v = this.get(&k, activation);
 
         form_values.insert(
             k,
             v.ok()
                 .unwrap_or_else(|| Value::Undefined)
-                .coerce_to_string(activation, context)
+                .coerce_to_string(activation)
                 .unwrap_or_else(|_| "undefined".into())
                 .to_string(),
         );
     }
 
     if let Some(window) = window {
-        context.navigator.navigate_to_url(
+        activation.context.navigator.navigate_to_url(
             url.to_string(),
             Some(window.to_string()),
             Some((method, form_values)),
@@ -273,13 +263,12 @@ fn send<'gc>(
 }
 
 fn send_and_load<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let url_val = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let url = url_val.coerce_to_string(activation, context)?;
+    let url = url_val.coerce_to_string(activation)?;
     let target = match args.get(1) {
         Some(&Value::Object(o)) => o,
         _ => return Ok(false.into()),
@@ -288,17 +277,16 @@ fn send_and_load<'gc>(
     let method_name = args
         .get(2)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_string(activation, context)?;
+        .coerce_to_string(activation)?;
     let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::POST);
 
-    spawn_load_var_fetch(activation, context, target, &url, Some((this, method)))?;
+    spawn_load_var_fetch(activation, target, &url, Some((this, method)))?;
 
     Ok(true.into())
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -308,14 +296,14 @@ fn to_string<'gc>(
     let keys = this.get_keys(activation);
 
     for k in keys {
-        let v = this.get(&k, activation, context);
+        let v = this.get(&k, activation);
 
         //TODO: What happens if an error occurs inside a virtual property?
         form_values.insert(
             k,
             v.ok()
                 .unwrap_or_else(|| Value::Undefined)
-                .coerce_to_string(activation, context)
+                .coerce_to_string(activation)
                 .unwrap_or_else(|_| "undefined".into())
                 .to_string(),
         );
@@ -325,60 +313,54 @@ fn to_string<'gc>(
         .extend_pairs(form_values.iter())
         .finish();
 
-    Ok(crate::avm1::AvmString::new(context.gc_context, query_string).into())
+    Ok(crate::avm1::AvmString::new(activation.context.gc_context, query_string).into())
 }
 
 fn spawn_load_var_fetch<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     loader_object: Object<'gc>,
     url: &AvmString,
     send_object: Option<(Object<'gc>, NavigationMethod)>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let (url, request_options) = if let Some((send_object, method)) = send_object {
         // Send properties from `send_object`.
-        activation.object_into_request_options(
-            context,
-            send_object,
-            Cow::Borrowed(&url),
-            Some(method),
-        )
+        activation.object_into_request_options(send_object, Cow::Borrowed(&url), Some(method))
     } else {
         // Not sending any parameters.
         (Cow::Borrowed(url.as_str()), RequestOptions::get())
     };
 
-    let fetch = context.navigator.fetch(&url, request_options);
-    let process = context.load_manager.load_form_into_load_vars(
-        context.player.clone().unwrap(),
+    let fetch = activation.context.navigator.fetch(&url, request_options);
+    let process = activation.context.load_manager.load_form_into_load_vars(
+        activation.context.player.clone().unwrap(),
         loader_object,
         fetch,
     );
 
     // Create hidden properties on object.
-    if !loader_object.has_property(activation, context, "_bytesLoaded") {
+    if !loader_object.has_property(activation, "_bytesLoaded") {
         loader_object.define_value(
-            context.gc_context,
+            activation.context.gc_context,
             "_bytesLoaded",
             0.into(),
             Attribute::DontDelete | Attribute::DontEnum,
         );
     } else {
-        loader_object.set("_bytesLoaded", 0.into(), activation, context)?;
+        loader_object.set("_bytesLoaded", 0.into(), activation)?;
     }
 
-    if !loader_object.has_property(activation, context, "loaded") {
+    if !loader_object.has_property(activation, "loaded") {
         loader_object.define_value(
-            context.gc_context,
+            activation.context.gc_context,
             "loaded",
             false.into(),
             Attribute::DontDelete | Attribute::DontEnum,
         );
     } else {
-        loader_object.set("loaded", false.into(), activation, context)?;
+        loader_object.set("loaded", false.into(), activation)?;
     }
 
-    context.navigator.spawn_future(process);
+    activation.context.navigator.spawn_future(process);
 
     Ok(true.into())
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -28,7 +28,7 @@ macro_rules! wrap_std {
 }
 
 fn atan2<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -46,7 +46,7 @@ fn atan2<'gc>(
 }
 
 fn pow<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -63,7 +63,7 @@ fn pow<'gc>(
 }
 
 fn round<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -78,7 +78,7 @@ fn round<'gc>(
 }
 
 fn max<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -102,7 +102,7 @@ fn max<'gc>(
 }
 
 fn min<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -126,7 +126,7 @@ fn min<'gc>(
 }
 
 pub fn random<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -255,7 +255,7 @@ mod tests {
     use super::*;
     use crate::avm1::test_utils::with_avm;
 
-    fn setup<'gc>(activation: &mut Activation<'_, '_, 'gc, '_>) -> Object<'gc> {
+    fn setup<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Object<'gc> {
         create(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes().object),

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -258,8 +258,8 @@ mod tests {
     fn setup<'gc>(activation: &mut Activation<'_, '_, 'gc, '_>) -> Object<'gc> {
         create(
             activation.context.gc_context,
-            Some(activation.avm.prototypes().object),
-            Some(activation.avm.prototypes().function),
+            Some(activation.context.avm1.prototypes().object),
+            Some(activation.context.avm1.prototypes().function),
         )
     }
 
@@ -476,8 +476,8 @@ mod tests {
         with_avm(19, |activation, _root| -> Result<(), Error> {
             let math = create(
                 activation.context.gc_context,
-                Some(activation.avm.prototypes().object),
-                Some(activation.avm.prototypes().function),
+                Some(activation.context.avm1.prototypes().object),
+                Some(activation.context.avm1.prototypes().function),
             );
 
             assert_eq!(atan2(activation, math, &[]).unwrap(), NAN.into());
@@ -502,8 +502,8 @@ mod tests {
         with_avm(19, |activation, _root| -> Result<(), Error> {
             let math = create(
                 activation.context.gc_context,
-                Some(activation.avm.prototypes().object),
-                Some(activation.avm.prototypes().function),
+                Some(activation.context.avm1.prototypes().object),
+                Some(activation.context.avm1.prototypes().function),
             );
 
             assert_eq!(

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -4,43 +4,41 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 use swf::{Matrix, Twips};
 
 pub fn value_to_matrix<'gc>(
     value: Value<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
     let a = value
-        .coerce_to_object(activation, context)
-        .get("a", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .coerce_to_object(activation)
+        .get("a", activation)?
+        .coerce_to_f64(activation)? as f32;
     let b = value
-        .coerce_to_object(activation, context)
-        .get("b", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .coerce_to_object(activation)
+        .get("b", activation)?
+        .coerce_to_f64(activation)? as f32;
     let c = value
-        .coerce_to_object(activation, context)
-        .get("c", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .coerce_to_object(activation)
+        .get("c", activation)?
+        .coerce_to_f64(activation)? as f32;
     let d = value
-        .coerce_to_object(activation, context)
-        .get("d", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
+        .coerce_to_object(activation)
+        .get("d", activation)?
+        .coerce_to_f64(activation)? as f32;
     let tx = Twips::from_pixels(
         value
-            .coerce_to_object(activation, context)
-            .get("tx", activation, context)?
-            .coerce_to_f64(activation, context)?,
+            .coerce_to_object(activation)
+            .get("tx", activation)?
+            .coerce_to_f64(activation)?,
     );
     let ty = Twips::from_pixels(
         value
-            .coerce_to_object(activation, context)
-            .get("ty", activation, context)?
-            .coerce_to_f64(activation, context)?,
+            .coerce_to_object(activation)
+            .get("ty", activation)?
+            .coerce_to_f64(activation)?,
     );
 
     Ok(Matrix { a, b, c, d, tx, ty })
@@ -48,29 +46,18 @@ pub fn value_to_matrix<'gc>(
 
 pub fn gradient_object_to_matrix<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
     if object
-        .get("matrixType", activation, context)?
-        .coerce_to_string(activation, context)?
+        .get("matrixType", activation)?
+        .coerce_to_string(activation)?
         == "box"
     {
-        let width = object
-            .get("w", activation, context)?
-            .coerce_to_f64(activation, context)?;
-        let height = object
-            .get("h", activation, context)?
-            .coerce_to_f64(activation, context)?;
-        let rotation = object
-            .get("r", activation, context)?
-            .coerce_to_f64(activation, context)?;
-        let tx = object
-            .get("x", activation, context)?
-            .coerce_to_f64(activation, context)?;
-        let ty = object
-            .get("y", activation, context)?
-            .coerce_to_f64(activation, context)?;
+        let width = object.get("w", activation)?.coerce_to_f64(activation)?;
+        let height = object.get("h", activation)?.coerce_to_f64(activation)?;
+        let rotation = object.get("r", activation)?.coerce_to_f64(activation)?;
+        let tx = object.get("x", activation)?.coerce_to_f64(activation)?;
+        let ty = object.get("y", activation)?.coerce_to_f64(activation)?;
         Ok(Matrix::create_gradient_box(
             width as f32,
             height as f32,
@@ -80,37 +67,20 @@ pub fn gradient_object_to_matrix<'gc>(
         ))
     } else {
         // TODO: You can apparently pass a 3x3 matrix here. Did anybody actually? How does it work?
-        object_to_matrix(object, activation, context)
+        object_to_matrix(object, activation)
     }
 }
 
 pub fn object_to_matrix<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
-    let a = object
-        .get("a", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
-    let b = object
-        .get("b", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
-    let c = object
-        .get("c", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
-    let d = object
-        .get("d", activation, context)?
-        .coerce_to_f64(activation, context)? as f32;
-    let tx = Twips::from_pixels(
-        object
-            .get("tx", activation, context)?
-            .coerce_to_f64(activation, context)?,
-    );
-    let ty = Twips::from_pixels(
-        object
-            .get("ty", activation, context)?
-            .coerce_to_f64(activation, context)?,
-    );
+    let a = object.get("a", activation)?.coerce_to_f64(activation)? as f32;
+    let b = object.get("b", activation)?.coerce_to_f64(activation)? as f32;
+    let c = object.get("c", activation)?.coerce_to_f64(activation)? as f32;
+    let d = object.get("d", activation)?.coerce_to_f64(activation)? as f32;
+    let tx = Twips::from_pixels(object.get("tx", activation)?.coerce_to_f64(activation)?);
+    let ty = Twips::from_pixels(object.get("ty", activation)?.coerce_to_f64(activation)?);
 
     Ok(Matrix { a, b, c, d, tx, ty })
 }
@@ -119,8 +89,7 @@ pub fn object_to_matrix<'gc>(
 #[allow(dead_code)]
 pub fn matrix_to_object<'gc>(
     matrix: Matrix,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let args = [
         matrix.a.into(),
@@ -131,51 +100,49 @@ pub fn matrix_to_object<'gc>(
         matrix.ty.to_pixels().into(),
     ];
     let constructor = activation.avm.prototypes.matrix_constructor;
-    let object = constructor.construct(activation, context, &args)?;
+    let object = constructor.construct(activation, &args)?;
     Ok(object)
 }
 
 pub fn apply_matrix_to_object<'gc>(
     matrix: Matrix,
     object: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<(), Error<'gc>> {
-    object.set("a", matrix.a.into(), activation, context)?;
-    object.set("b", matrix.b.into(), activation, context)?;
-    object.set("c", matrix.c.into(), activation, context)?;
-    object.set("d", matrix.d.into(), activation, context)?;
-    object.set("tx", matrix.tx.to_pixels().into(), activation, context)?;
-    object.set("ty", matrix.ty.to_pixels().into(), activation, context)?;
+    object.set("a", matrix.a.into(), activation)?;
+    object.set("b", matrix.b.into(), activation)?;
+    object.set("c", matrix.c.into(), activation)?;
+    object.set("d", matrix.d.into(), activation)?;
+    object.set("tx", matrix.tx.to_pixels().into(), activation)?;
+    object.set("ty", matrix.ty.to_pixels().into(), activation)?;
     Ok(())
 }
 
 fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.is_empty() {
-        apply_matrix_to_object(Matrix::identity(), this, activation, context)?;
+        apply_matrix_to_object(Matrix::identity(), this, activation)?;
     } else {
         if let Some(a) = args.get(0) {
-            this.set("a", a.clone(), activation, context)?;
+            this.set("a", a.clone(), activation)?;
         }
         if let Some(b) = args.get(1) {
-            this.set("b", b.clone(), activation, context)?;
+            this.set("b", b.clone(), activation)?;
         }
         if let Some(c) = args.get(2) {
-            this.set("c", c.clone(), activation, context)?;
+            this.set("c", c.clone(), activation)?;
         }
         if let Some(d) = args.get(3) {
-            this.set("d", d.clone(), activation, context)?;
+            this.set("d", d.clone(), activation)?;
         }
         if let Some(tx) = args.get(4) {
-            this.set("tx", tx.clone(), activation, context)?;
+            this.set("tx", tx.clone(), activation)?;
         }
         if let Some(ty) = args.get(5) {
-            this.set("ty", ty.clone(), activation, context)?;
+            this.set("ty", ty.clone(), activation)?;
         }
     }
 
@@ -183,153 +150,141 @@ fn constructor<'gc>(
 }
 
 fn identity<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    apply_matrix_to_object(Matrix::identity(), this, activation, context)?;
+    apply_matrix_to_object(Matrix::identity(), this, activation)?;
     Ok(Value::Undefined)
 }
 
 fn clone<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let args = [
-        this.get("a", activation, context)?,
-        this.get("b", activation, context)?,
-        this.get("c", activation, context)?,
-        this.get("d", activation, context)?,
-        this.get("tx", activation, context)?,
-        this.get("ty", activation, context)?,
+        this.get("a", activation)?,
+        this.get("b", activation)?,
+        this.get("c", activation)?,
+        this.get("d", activation)?,
+        this.get("tx", activation)?,
+        this.get("ty", activation)?,
     ];
     let constructor = activation.avm.prototypes.matrix_constructor;
-    let cloned = constructor.construct(activation, context, &args)?;
+    let cloned = constructor.construct(activation, &args)?;
     Ok(cloned.into())
 }
 
 fn scale<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_x = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let scale_y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let mut matrix = Matrix::scale(scale_x as f32, scale_y as f32);
-    matrix *= object_to_matrix(this, activation, context)?;
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    matrix *= object_to_matrix(this, activation)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn rotate<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let angle = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let mut matrix = Matrix::rotate(angle as f32);
-    matrix *= object_to_matrix(this, activation, context)?;
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    matrix *= object_to_matrix(this, activation)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn translate<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let translate_x = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let translate_y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let mut matrix = Matrix::translate(
         Twips::from_pixels(translate_x),
         Twips::from_pixels(translate_y),
     );
-    matrix *= object_to_matrix(this, activation, context)?;
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    matrix *= object_to_matrix(this, activation)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn concat<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut matrix = object_to_matrix(this, activation, context)?;
-    let other = value_to_matrix(
-        args.get(0).unwrap_or(&Value::Undefined).clone(),
-        activation,
-        context,
-    )?;
+    let mut matrix = object_to_matrix(this, activation)?;
+    let other = value_to_matrix(args.get(0).unwrap_or(&Value::Undefined).clone(), activation)?;
     matrix = other * matrix;
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn invert<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut matrix = object_to_matrix(this, activation, context)?;
+    let mut matrix = object_to_matrix(this, activation)?;
     matrix.invert();
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn create_box<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_x = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let scale_y = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     // [NA] Docs say rotation is optional and defaults to 0, but that's wrong?
     let rotation = args
         .get(2)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let translate_x = if let Some(value) = args.get(3) {
-        value.coerce_to_f64(activation, context)?
+        value.coerce_to_f64(activation)?
     } else {
         0.0
     };
     let translate_y = if let Some(value) = args.get(4) {
-        value.coerce_to_f64(activation, context)?
+        value.coerce_to_f64(activation)?
     } else {
         0.0
     };
@@ -341,37 +296,36 @@ fn create_box<'gc>(
         Twips::from_pixels(translate_x),
         Twips::from_pixels(translate_y),
     );
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn create_gradient_box<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let width = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let height = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let rotation = if let Some(value) = args.get(2) {
-        value.coerce_to_f64(activation, context)?
+        value.coerce_to_f64(activation)?
     } else {
         0.0
     };
     let translate_x = if let Some(value) = args.get(3) {
-        value.coerce_to_f64(activation, context)?
+        value.coerce_to_f64(activation)?
     } else {
         0.0
     };
     let translate_y = if let Some(value) = args.get(4) {
-        value.coerce_to_f64(activation, context)?
+        value.coerce_to_f64(activation)?
     } else {
         0.0
     };
@@ -383,34 +337,33 @@ fn create_gradient_box<'gc>(
         Twips::from_pixels(translate_x),
         Twips::from_pixels(translate_y),
     );
-    apply_matrix_to_object(matrix, this, activation, context)?;
+    apply_matrix_to_object(matrix, this, activation)?;
 
     Ok(Value::Undefined)
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let a = this.get("a", activation, context)?;
-    let b = this.get("b", activation, context)?;
-    let c = this.get("c", activation, context)?;
-    let d = this.get("d", activation, context)?;
-    let tx = this.get("tx", activation, context)?;
-    let ty = this.get("ty", activation, context)?;
+    let a = this.get("a", activation)?;
+    let b = this.get("b", activation)?;
+    let c = this.get("c", activation)?;
+    let d = this.get("d", activation)?;
+    let tx = this.get("tx", activation)?;
+    let ty = this.get("ty", activation)?;
 
     Ok(AvmString::new(
-        context.gc_context,
+        activation.context.gc_context,
         format!(
             "(a={}, b={}, c={}, d={}, tx={}, ty={})",
-            a.coerce_to_string(activation, context)?,
-            b.coerce_to_string(activation, context)?,
-            c.coerce_to_string(activation, context)?,
-            d.coerce_to_string(activation, context)?,
-            tx.coerce_to_string(activation, context)?,
-            ty.coerce_to_string(activation, context)?
+            a.coerce_to_string(activation)?,
+            b.coerce_to_string(activation)?,
+            c.coerce_to_string(activation)?,
+            d.coerce_to_string(activation)?,
+            tx.coerce_to_string(activation)?,
+            ty.coerce_to_string(activation)?
         ),
     )
     .into())

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -99,7 +99,7 @@ pub fn matrix_to_object<'gc>(
         matrix.tx.to_pixels().into(),
         matrix.ty.to_pixels().into(),
     ];
-    let constructor = activation.avm.prototypes.matrix_constructor;
+    let constructor = activation.context.avm1.prototypes.matrix_constructor;
     let object = constructor.construct(activation, &args)?;
     Ok(object)
 }
@@ -171,7 +171,7 @@ fn clone<'gc>(
         this.get("tx", activation)?,
         this.get("ty", activation)?,
     ];
-    let constructor = activation.avm.prototypes.matrix_constructor;
+    let constructor = activation.context.avm1.prototypes.matrix_constructor;
     let cloned = constructor.construct(activation, &args)?;
     Ok(cloned.into())
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -10,7 +10,7 @@ use swf::{Matrix, Twips};
 
 pub fn value_to_matrix<'gc>(
     value: Value<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
     let a = value
         .coerce_to_object(activation)
@@ -46,7 +46,7 @@ pub fn value_to_matrix<'gc>(
 
 pub fn gradient_object_to_matrix<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
     if object
         .get("matrixType", activation)?
@@ -73,7 +73,7 @@ pub fn gradient_object_to_matrix<'gc>(
 
 pub fn object_to_matrix<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
     let a = object.get("a", activation)?.coerce_to_f64(activation)? as f32;
     let b = object.get("b", activation)?.coerce_to_f64(activation)? as f32;
@@ -89,7 +89,7 @@ pub fn object_to_matrix<'gc>(
 #[allow(dead_code)]
 pub fn matrix_to_object<'gc>(
     matrix: Matrix,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let args = [
         matrix.a.into(),
@@ -107,7 +107,7 @@ pub fn matrix_to_object<'gc>(
 pub fn apply_matrix_to_object<'gc>(
     matrix: Matrix,
     object: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<(), Error<'gc>> {
     object.set("a", matrix.a.into(), activation)?;
     object.set("b", matrix.b.into(), activation)?;
@@ -119,7 +119,7 @@ pub fn apply_matrix_to_object<'gc>(
 }
 
 fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -150,7 +150,7 @@ fn constructor<'gc>(
 }
 
 fn identity<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -159,7 +159,7 @@ fn identity<'gc>(
 }
 
 fn clone<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -177,7 +177,7 @@ fn clone<'gc>(
 }
 
 fn scale<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -197,7 +197,7 @@ fn scale<'gc>(
 }
 
 fn rotate<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -213,7 +213,7 @@ fn rotate<'gc>(
 }
 
 fn translate<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -236,7 +236,7 @@ fn translate<'gc>(
 }
 
 fn concat<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -249,7 +249,7 @@ fn concat<'gc>(
 }
 
 fn invert<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -261,7 +261,7 @@ fn invert<'gc>(
 }
 
 fn create_box<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -302,7 +302,7 @@ fn create_box<'gc>(
 }
 
 fn create_gradient_box<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -343,7 +343,7 @@ fn create_gradient_box<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -2,17 +2,16 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use gc_arena::MutationContext;
 
 pub fn show_mouse<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let was_visible = context.input.mouse_visible();
-    context.input.show_mouse();
+    let was_visible = activation.context.input.mouse_visible();
+    activation.context.input.show_mouse();
     if was_visible {
         Ok(0.into())
     } else {
@@ -21,13 +20,12 @@ pub fn show_mouse<'gc>(
 }
 
 pub fn hide_mouse<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let was_visible = context.input.mouse_visible();
-    context.input.hide_mouse();
+    let was_visible = activation.context.input.mouse_visible();
+    activation.context.input.hide_mouse();
     if was_visible {
         Ok(0.into())
     } else {

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -6,7 +6,7 @@ use crate::avm1::{Object, ScriptObject, Value};
 use gc_arena::MutationContext;
 
 pub fn show_mouse<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -20,7 +20,7 @@ pub fn show_mouse<'gc>(
 }
 
 pub fn hide_mouse<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -970,7 +970,7 @@ fn get_rect<'gc>(
 }
 
 #[allow(unused_must_use)] //can't use errors yet
-pub fn get_url<'a, 'gc>(
+pub fn get_url<'gc>(
     _movie_clip: MovieClip<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -456,14 +456,8 @@ fn attach_movie<'gc>(
         } else {
             None
         };
-        new_clip.post_instantiation(
-            activation.avm,
-            activation.context,
-            new_clip,
-            init_object,
-            true,
-        );
-        new_clip.run_frame(activation.avm, activation.context);
+        new_clip.post_instantiation(activation.context, new_clip, init_object, true);
+        new_clip.run_frame(activation.context);
 
         Ok(new_clip.object().coerce_to_object(activation).into())
     } else {
@@ -500,14 +494,8 @@ fn create_empty_movie_clip<'gc>(
     // Set name and attach to parent.
     new_clip.set_name(activation.context.gc_context, &new_instance_name);
     movie_clip.add_child_from_avm(activation.context, new_clip.into(), depth);
-    new_clip.post_instantiation(
-        activation.avm,
-        activation.context,
-        new_clip.into(),
-        None,
-        true,
-    );
-    new_clip.run_frame(activation.avm, activation.context);
+    new_clip.post_instantiation(activation.context, new_clip.into(), None, true);
+    new_clip.run_frame(activation.context);
 
     Ok(new_clip.object())
 }
@@ -556,7 +544,7 @@ fn create_text_field<'gc>(
         text_field,
         (depth as Depth).wrapping_add(AVM_DEPTH_BIAS),
     );
-    text_field.post_instantiation(activation.avm, activation.context, text_field, None, true);
+    text_field.post_instantiation(activation.context, text_field, None, true);
 
     if activation.current_swf_version() >= 8 {
         //SWF8+ returns the `TextField` instance here
@@ -631,14 +619,8 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
         // Definitely not ScriptObject properties.
 
         let init_object = init_object.map(|v| v.coerce_to_object(activation));
-        new_clip.post_instantiation(
-            activation.avm,
-            activation.context,
-            new_clip,
-            init_object,
-            true,
-        );
-        new_clip.run_frame(activation.avm, activation.context);
+        new_clip.post_instantiation(activation.context, new_clip, init_object, true);
+        new_clip.run_frame(activation.context);
 
         Ok(new_clip.object().coerce_to_object(activation).into())
     } else {
@@ -750,7 +732,7 @@ pub fn goto_frame<'gc>(
         frame = frame.wrapping_add(i32::from(scene_offset));
         frame = frame.saturating_add(1);
         if frame > 0 {
-            clip.goto_frame(activation.avm, activation.context, frame as u16, stop);
+            clip.goto_frame(activation.context, frame as u16, stop);
         }
     }
     Ok(Value::Undefined)
@@ -761,7 +743,7 @@ fn next_frame<'gc>(
     activation: &mut Activation<'_, '_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    movie_clip.next_frame(activation.avm, activation.context);
+    movie_clip.next_frame(activation.context);
     Ok(Value::Undefined)
 }
 
@@ -779,7 +761,7 @@ fn prev_frame<'gc>(
     activation: &mut Activation<'_, '_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    movie_clip.prev_frame(activation.avm, activation.context);
+    movie_clip.prev_frame(activation.context);
     Ok(Value::Undefined)
 }
 
@@ -965,7 +947,7 @@ fn get_bounds<'gc>(
 
         let out = ScriptObject::object(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.object),
+            Some(activation.context.avm1.prototypes.object),
         );
         out.set("xMin", out_bounds.x_min.to_pixels().into(), activation)?;
         out.set("yMin", out_bounds.y_min.to_pixels().into(), activation)?;

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -18,7 +18,7 @@ pub fn constructor<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let listeners = ScriptObject::array(
         activation.context.gc_context,
-        Some(activation.avm.prototypes().array),
+        Some(activation.context.avm1.prototypes().array),
     );
     this.define_value(
         activation.context.gc_context,

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -12,7 +12,7 @@ use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -32,7 +32,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn add_listener<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -49,7 +49,7 @@ pub fn add_listener<'gc>(
 }
 
 pub fn remove_listener<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -91,7 +91,7 @@ pub fn remove_listener<'gc>(
 }
 
 pub fn broadcast_message<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -114,7 +114,7 @@ pub fn broadcast_message<'gc>(
 }
 
 pub fn load_clip<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -149,7 +149,7 @@ pub fn load_clip<'gc>(
 }
 
 pub fn unload_clip<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -160,7 +160,7 @@ pub fn unload_clip<'gc>(
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
-            movieclip.unload(activation.context);
+            movieclip.unload(&mut activation.context);
             movieclip.replace_with_movie(activation.context.gc_context, None);
 
             return Ok(true.into());
@@ -171,7 +171,7 @@ pub fn unload_clip<'gc>(
 }
 
 pub fn get_progress<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -5,57 +5,56 @@ use crate::avm1::error::Error;
 use crate::avm1::object::script_object::ScriptObject;
 use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, UpdateContext, Value};
+use crate::avm1::{Object, Value};
 use crate::backend::navigator::RequestOptions;
 use crate::display_object::{DisplayObject, TDisplayObject};
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let listeners =
-        ScriptObject::array(context.gc_context, Some(activation.avm.prototypes().array));
+    let listeners = ScriptObject::array(
+        activation.context.gc_context,
+        Some(activation.avm.prototypes().array),
+    );
     this.define_value(
-        context.gc_context,
+        activation.context.gc_context,
         "_listeners",
         Value::Object(listeners.into()),
         Attribute::DontEnum.into(),
     );
-    listeners.set_array_element(0, Value::Object(this), context.gc_context);
+    listeners.set_array_element(0, Value::Object(this), activation.context.gc_context);
 
     Ok(Value::Undefined)
 }
 
 pub fn add_listener<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let new_listener = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let listeners = this.get("_listeners", activation, context)?;
+    let listeners = this.get("_listeners", activation)?;
 
     if let Value::Object(listeners) = listeners {
         let length = listeners.length();
-        listeners.set_length(context.gc_context, length + 1);
-        listeners.set_array_element(length, new_listener, context.gc_context);
+        listeners.set_length(activation.context.gc_context, length + 1);
+        listeners.set_array_element(length, new_listener, activation.context.gc_context);
     }
 
     Ok(true.into())
 }
 
 pub fn remove_listener<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let old_listener = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let listeners = this.get("_listeners", activation, context)?;
+    let listeners = this.get("_listeners", activation)?;
 
     if let Value::Object(listeners) = listeners {
         let length = listeners.length();
@@ -76,14 +75,14 @@ pub fn remove_listener<'gc>(
                     listeners.set_array_element(
                         i,
                         listeners.array_element(i + 1),
-                        context.gc_context,
+                        activation.context.gc_context,
                     );
                 }
 
-                listeners.delete_array_element(new_length, context.gc_context);
-                listeners.delete(activation, context.gc_context, &new_length.to_string());
+                listeners.delete_array_element(new_length, activation.context.gc_context);
+                listeners.delete(activation, &new_length.to_string());
 
-                listeners.set_length(context.gc_context, new_length);
+                listeners.set_length(activation.context.gc_context, new_length);
             }
         }
     }
@@ -92,22 +91,21 @@ pub fn remove_listener<'gc>(
 }
 
 pub fn broadcast_message<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let event_name_val = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let event_name = event_name_val.coerce_to_string(activation, context)?;
+    let event_name = event_name_val.coerce_to_string(activation)?;
     let call_args = &args[0..];
 
-    let listeners = this.get("_listeners", activation, context)?;
+    let listeners = this.get("_listeners", activation)?;
     if let Value::Object(listeners) = listeners {
         for i in 0..listeners.length() {
             let listener = listeners.array_element(i);
 
             if let Value::Object(listener) = listener {
-                listener.call_method(&event_name, call_args, activation, context)?;
+                listener.call_method(&event_name, call_args, activation)?;
             }
         }
     }
@@ -116,13 +114,12 @@ pub fn broadcast_message<'gc>(
 }
 
 pub fn load_clip<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let url_val = args.get(0).cloned().unwrap_or(Value::Undefined);
-    let url = url_val.coerce_to_string(activation, context)?;
+    let url = url_val.coerce_to_string(activation)?;
     let target = args.get(1).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(target) = target {
@@ -130,16 +127,19 @@ pub fn load_clip<'gc>(
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
-            let fetch = context.navigator.fetch(&url, RequestOptions::get());
-            let process = context.load_manager.load_movie_into_clip(
-                context.player.clone().unwrap(),
+            let fetch = activation
+                .context
+                .navigator
+                .fetch(&url, RequestOptions::get());
+            let process = activation.context.load_manager.load_movie_into_clip(
+                activation.context.player.clone().unwrap(),
                 DisplayObject::MovieClip(movieclip),
                 fetch,
                 url.to_string(),
                 Some(this),
             );
 
-            context.navigator.spawn_future(process);
+            activation.context.navigator.spawn_future(process);
         }
 
         Ok(true.into())
@@ -149,8 +149,7 @@ pub fn load_clip<'gc>(
 }
 
 pub fn unload_clip<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -161,8 +160,8 @@ pub fn unload_clip<'gc>(
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
-            movieclip.unload(context);
-            movieclip.replace_with_movie(context.gc_context, None);
+            movieclip.unload(activation.context);
+            movieclip.replace_with_movie(activation.context.gc_context, None);
 
             return Ok(true.into());
         }
@@ -172,8 +171,7 @@ pub fn unload_clip<'gc>(
 }
 
 pub fn get_progress<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -184,9 +182,9 @@ pub fn get_progress<'gc>(
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
-            let ret_obj = ScriptObject::object(context.gc_context, None);
+            let ret_obj = ScriptObject::object(activation.context.gc_context, None);
             ret_obj.define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "bytesLoaded",
                 movieclip
                     .movie()
@@ -195,7 +193,7 @@ pub fn get_progress<'gc>(
                 EnumSet::empty(),
             );
             ret_obj.define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "bytesTotal",
                 movieclip
                     .movie()

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -11,7 +11,7 @@ use gc_arena::MutationContext;
 
 /// `Number` constructor
 pub fn number<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -31,7 +31,7 @@ pub fn number<'gc>(
 
 /// `Number` function
 pub fn number_function<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -127,7 +127,7 @@ pub fn create_proto<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -201,7 +201,7 @@ fn to_string<'gc>(
 }
 
 fn value_of<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -6,26 +6,24 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property::Attribute::*;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// `Number` constructor
 pub fn number<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = if let Some(val) = args.get(0) {
-        val.coerce_to_f64(activation, context)?
+        val.coerce_to_f64(activation)?
     } else {
         0.0
     };
 
     // If called from a constructor, populate `this`.
     if let Some(mut vbox) = this.as_value_object() {
-        vbox.replace_value(context.gc_context, value.into());
+        vbox.replace_value(activation.context.gc_context, value.into());
     }
 
     Ok(Value::Undefined)
@@ -33,13 +31,12 @@ pub fn number<'gc>(
 
 /// `Number` function
 pub fn number_function<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = if let Some(val) = args.get(0) {
-        val.coerce_to_f64(activation, context)?
+        val.coerce_to_f64(activation)?
     } else {
         0.0
     };
@@ -130,8 +127,7 @@ pub fn create_proto<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -150,7 +146,7 @@ fn to_string<'gc>(
         let radix = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .coerce_to_f64(activation, context)?;
+            .coerce_to_f64(activation)?;
         if radix >= 2.0 && radix <= 36.0 {
             radix as u32
         } else {
@@ -161,10 +157,8 @@ fn to_string<'gc>(
     if radix == 10 {
         // Output number as floating-point decimal.
         Ok(AvmString::new(
-            context.gc_context,
-            Value::from(this)
-                .coerce_to_string(activation, context)?
-                .to_string(),
+            activation.context.gc_context,
+            Value::from(this).coerce_to_string(activation)?.to_string(),
         )
         .into())
     } else if this > -2_147_483_648.0 && this < 2_147_483_648.0 {
@@ -194,7 +188,7 @@ fn to_string<'gc>(
             i += 1;
         }
         let out: String = digits[..i].iter().rev().collect();
-        Ok(AvmString::new(context.gc_context, out).into())
+        Ok(AvmString::new(activation.context.gc_context, out).into())
     } else {
         // NaN or large numbers.
         // Player version specific behavior:
@@ -207,8 +201,7 @@ fn to_string<'gc>(
 }
 
 fn value_of<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -230,7 +223,7 @@ fn value_of<'gc>(
 //     "-/0000000000000000000000000000000",
 //     "-/.//./..././/0.0./0.",
 //     "-.000000000000000",
-//     "-/--,,..-,-,0,-",
+//     "-/--,..-,-,0,-",
 //     "-++-0-.00++-.",
 //     "-/0,/-,.///*.",
 //     "-.0000000000",

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 
 /// Implements `Object` constructor
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -22,7 +22,7 @@ pub fn constructor<'gc>(
 
 /// Implements `Object` function
 pub fn object_function<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -35,7 +35,7 @@ pub fn object_function<'gc>(
 
 /// Implements `Object.prototype.addProperty`
 pub fn add_property<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -78,7 +78,7 @@ pub fn add_property<'gc>(
 
 /// Implements `Object.prototype.hasOwnProperty`
 pub fn has_own_property<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -92,7 +92,7 @@ pub fn has_own_property<'gc>(
 
 /// Implements `Object.prototype.toString`
 fn to_string<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _: Object<'gc>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -101,7 +101,7 @@ fn to_string<'gc>(
 
 /// Implements `Object.prototype.isPropertyEnumerable`
 fn is_property_enumerable<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -113,7 +113,7 @@ fn is_property_enumerable<'gc>(
 
 /// Implements `Object.prototype.isPrototypeOf`
 fn is_prototype_of<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -128,7 +128,7 @@ fn is_prototype_of<'gc>(
 
 /// Implements `Object.prototype.valueOf`
 fn value_of<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -137,7 +137,7 @@ fn value_of<'gc>(
 
 /// Implements `Object.registerClass`
 pub fn register_class<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -175,7 +175,7 @@ pub fn register_class<'gc>(
 
 /// Implements `Object.prototype.watch`
 fn watch<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -206,7 +206,7 @@ fn watch<'gc>(
 
 /// Implements `Object.prototype.unmwatch`
 fn unwatch<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -304,7 +304,7 @@ pub fn fill_proto<'gc>(
 /// declare the property flags of a given property. It's not part of
 /// `Object.prototype`, and I suspect that's a deliberate omission.
 pub fn as_set_prop_flags<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -11,7 +11,7 @@ use std::f64::NAN;
 
 pub fn point_to_object<'gc>(
     point: (f64, f64),
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let args = [point.0.into(), point.1.into()];
     construct_new_point(&args, activation)
@@ -19,7 +19,7 @@ pub fn point_to_object<'gc>(
 
 pub fn construct_new_point<'gc>(
     args: &[Value<'gc>],
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let constructor = activation.context.avm1.prototypes.point_constructor;
     let object = constructor.construct(activation, &args)?;
@@ -28,7 +28,7 @@ pub fn construct_new_point<'gc>(
 
 pub fn value_to_point<'gc>(
     value: Value<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error<'gc>> {
     let x = value
         .coerce_to_object(activation)
@@ -43,7 +43,7 @@ pub fn value_to_point<'gc>(
 
 pub fn object_to_point<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error<'gc>> {
     let x = object.get("x", activation)?.coerce_to_f64(activation)?;
     let y = object.get("y", activation)?.coerce_to_f64(activation)?;
@@ -51,7 +51,7 @@ pub fn object_to_point<'gc>(
 }
 
 fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -75,7 +75,7 @@ fn constructor<'gc>(
 }
 
 fn clone<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -87,7 +87,7 @@ fn clone<'gc>(
 }
 
 fn equals<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -104,7 +104,7 @@ fn equals<'gc>(
 }
 
 fn add<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -119,7 +119,7 @@ fn add<'gc>(
 }
 
 fn subtract<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -134,7 +134,7 @@ fn subtract<'gc>(
 }
 
 fn distance<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -154,7 +154,7 @@ fn distance<'gc>(
 }
 
 fn polar<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -171,7 +171,7 @@ fn polar<'gc>(
 }
 
 fn interpolate<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -187,7 +187,7 @@ fn interpolate<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -206,7 +206,7 @@ fn to_string<'gc>(
 }
 
 fn length<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -216,7 +216,7 @@ fn length<'gc>(
 }
 
 fn normalize<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -244,7 +244,7 @@ fn normalize<'gc>(
 }
 
 fn offset<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -5,81 +5,69 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::f64::NAN;
 
 pub fn point_to_object<'gc>(
     point: (f64, f64),
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let args = [point.0.into(), point.1.into()];
-    construct_new_point(&args, activation, context)
+    construct_new_point(&args, activation)
 }
 
 pub fn construct_new_point<'gc>(
     args: &[Value<'gc>],
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
     let constructor = activation.avm.prototypes.point_constructor;
-    let object = constructor.construct(activation, context, &args)?;
+    let object = constructor.construct(activation, &args)?;
     Ok(object)
 }
 
 pub fn value_to_point<'gc>(
     value: Value<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<(f64, f64), Error<'gc>> {
     let x = value
-        .coerce_to_object(activation, context)
-        .get("x", activation, context)?
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_object(activation)
+        .get("x", activation)?
+        .coerce_to_f64(activation)?;
     let y = value
-        .coerce_to_object(activation, context)
-        .get("y", activation, context)?
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_object(activation)
+        .get("y", activation)?
+        .coerce_to_f64(activation)?;
     Ok((x, y))
 }
 
 pub fn object_to_point<'gc>(
     object: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<(f64, f64), Error<'gc>> {
-    let x = object
-        .get("x", activation, context)?
-        .coerce_to_f64(activation, context)?;
-    let y = object
-        .get("y", activation, context)?
-        .coerce_to_f64(activation, context)?;
+    let x = object.get("x", activation)?.coerce_to_f64(activation)?;
+    let y = object.get("y", activation)?.coerce_to_f64(activation)?;
     Ok((x, y))
 }
 
 fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.is_empty() {
-        this.set("x", 0.into(), activation, context)?;
-        this.set("y", 0.into(), activation, context)?;
+        this.set("x", 0.into(), activation)?;
+        this.set("y", 0.into(), activation)?;
     } else {
         this.set(
             "x",
             args.get(0).unwrap_or(&Value::Undefined).to_owned(),
             activation,
-            context,
         )?;
         this.set(
             "y",
             args.get(1).unwrap_or(&Value::Undefined).to_owned(),
             activation,
-            context,
         )?;
     }
 
@@ -87,33 +75,28 @@ fn constructor<'gc>(
 }
 
 fn clone<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let args = [
-        this.get("x", activation, context)?,
-        this.get("y", activation, context)?,
-    ];
+    let args = [this.get("x", activation)?, this.get("y", activation)?];
     let constructor = activation.avm.prototypes.point_constructor;
-    let cloned = constructor.construct(activation, context, &args)?;
+    let cloned = constructor.construct(activation, &args)?;
 
     Ok(cloned.into())
 }
 
 fn equals<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(other) = args.get(0) {
-        let this_x = this.get("x", activation, context)?;
-        let this_y = this.get("y", activation, context)?;
-        let other = other.coerce_to_object(activation, context);
-        let other_x = other.get("x", activation, context)?;
-        let other_y = other.get("y", activation, context)?;
+        let this_x = this.get("x", activation)?;
+        let this_y = this.get("y", activation)?;
+        let other = other.coerce_to_object(activation);
+        let other_x = other.get("x", activation)?;
+        let other_y = other.get("y", activation)?;
         return Ok((this_x == other_x && this_y == other_y).into());
     }
 
@@ -121,50 +104,37 @@ fn equals<'gc>(
 }
 
 fn add<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this_x = this
-        .get("x", activation, context)?
-        .coerce_to_f64(activation, context)?;
-    let this_y = this
-        .get("y", activation, context)?
-        .coerce_to_f64(activation, context)?;
+    let this_x = this.get("x", activation)?.coerce_to_f64(activation)?;
+    let this_y = this.get("y", activation)?.coerce_to_f64(activation)?;
     let other = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         activation,
-        context,
     )?;
-    let object = point_to_object((this_x + other.0, this_y + other.1), activation, context)?;
+    let object = point_to_object((this_x + other.0, this_y + other.1), activation)?;
     Ok(object.into())
 }
 
 fn subtract<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this_x = this
-        .get("x", activation, context)?
-        .coerce_to_f64(activation, context)?;
-    let this_y = this
-        .get("y", activation, context)?
-        .coerce_to_f64(activation, context)?;
+    let this_x = this.get("x", activation)?.coerce_to_f64(activation)?;
+    let this_y = this.get("y", activation)?.coerce_to_f64(activation)?;
     let other = value_to_point(
         args.get(0).unwrap_or(&Value::Undefined).to_owned(),
         activation,
-        context,
     )?;
-    let object = point_to_object((this_x - other.0, this_y - other.1), activation, context)?;
+    let object = point_to_object((this_x - other.0, this_y - other.1), activation)?;
     Ok(object.into())
 }
 
 fn distance<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -175,99 +145,88 @@ fn distance<'gc>(
     let a = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_object(activation, context);
+        .coerce_to_object(activation);
     let b = args.get(1).unwrap_or(&Value::Undefined);
-    let delta = a.call_method("subtract", &[b.to_owned()], activation, context)?;
+    let delta = a.call_method("subtract", &[b.to_owned()], activation)?;
     Ok(delta
-        .coerce_to_object(activation, context)
-        .get("length", activation, context)?)
+        .coerce_to_object(activation)
+        .get("length", activation)?)
 }
 
 fn polar<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let length = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let angle = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
-    let point = point_to_object(
-        (length * angle.cos(), length * angle.sin()),
-        activation,
-        context,
-    )?;
+        .coerce_to_f64(activation)?;
+    let point = point_to_object((length * angle.cos(), length * angle.sin()), activation)?;
     Ok(point.into())
 }
 
 fn interpolate<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.len() < 3 {
-        return Ok(point_to_object((NAN, NAN), activation, context)?.into());
+        return Ok(point_to_object((NAN, NAN), activation)?.into());
     }
 
-    let a = value_to_point(args.get(0).unwrap().to_owned(), activation, context)?;
-    let b = value_to_point(args.get(1).unwrap().to_owned(), activation, context)?;
-    let f = args.get(2).unwrap().coerce_to_f64(activation, context)?;
+    let a = value_to_point(args.get(0).unwrap().to_owned(), activation)?;
+    let b = value_to_point(args.get(1).unwrap().to_owned(), activation)?;
+    let f = args.get(2).unwrap().coerce_to_f64(activation)?;
     let result = (b.0 - (b.0 - a.0) * f, b.1 - (b.1 - a.1) * f);
-    Ok(point_to_object(result, activation, context)?.into())
+    Ok(point_to_object(result, activation)?.into())
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let x = this.get("x", activation, context)?;
-    let y = this.get("y", activation, context)?;
+    let x = this.get("x", activation)?;
+    let y = this.get("y", activation)?;
 
     Ok(AvmString::new(
-        context.gc_context,
+        activation.context.gc_context,
         format!(
             "(x={}, y={})",
-            x.coerce_to_string(activation, context)?,
-            y.coerce_to_string(activation, context)?
+            x.coerce_to_string(activation)?,
+            y.coerce_to_string(activation)?
         ),
     )
     .into())
 }
 
 fn length<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let point = value_to_point(this.into(), activation, context)?;
+    let point = value_to_point(this.into(), activation)?;
     let length = (point.0 * point.0 + point.1 * point.1).sqrt();
     Ok(length.into())
 }
 
 fn normalize<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let current_length = this
-        .get("length", activation, context)?
-        .coerce_to_f64(activation, context)?;
+    let current_length = this.get("length", activation)?.coerce_to_f64(activation)?;
     if current_length.is_finite() {
-        let point = object_to_point(this, activation, context)?;
+        let point = object_to_point(this, activation)?;
         let new_length = args
             .get(0)
             .unwrap_or(&Value::Undefined)
-            .coerce_to_f64(activation, context)?;
+            .coerce_to_f64(activation)?;
         let (x, y) = if current_length == 0.0 {
             (point.0 * new_length, point.1 * new_length)
         } else {
@@ -277,31 +236,30 @@ fn normalize<'gc>(
             )
         };
 
-        this.set("x", x.into(), activation, context)?;
-        this.set("y", y.into(), activation, context)?;
+        this.set("x", x.into(), activation)?;
+        this.set("y", y.into(), activation)?;
     }
 
     Ok(Value::Undefined)
 }
 
 fn offset<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let point = value_to_point(this.into(), activation, context)?;
+    let point = value_to_point(this.into(), activation)?;
     let dx = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let dy = args
         .get(1)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
 
-    this.set("x", (point.0 + dx).into(), activation, context)?;
-    this.set("y", (point.1 + dy).into(), activation, context)?;
+    this.set("x", (point.0 + dx).into(), activation)?;
+    this.set("y", (point.1 + dy).into(), activation)?;
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -21,7 +21,7 @@ pub fn construct_new_point<'gc>(
     args: &[Value<'gc>],
     activation: &mut Activation<'_, '_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let constructor = activation.avm.prototypes.point_constructor;
+    let constructor = activation.context.avm1.prototypes.point_constructor;
     let object = constructor.construct(activation, &args)?;
     Ok(object)
 }
@@ -80,7 +80,7 @@ fn clone<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let args = [this.get("x", activation)?, this.get("y", activation)?];
-    let constructor = activation.avm.prototypes.point_constructor;
+    let constructor = activation.context.avm1.prototypes.point_constructor;
     let cloned = constructor.construct(activation, &args)?;
 
     Ok(cloned.into())

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -11,7 +11,7 @@ use gc_arena::MutationContext;
 use std::f64::NAN;
 
 fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -47,7 +47,7 @@ fn constructor<'gc>(
 }
 
 fn to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -83,7 +83,7 @@ pub fn create_rectangle_object<'gc>(
 }
 
 fn is_empty<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -93,7 +93,7 @@ fn is_empty<'gc>(
 }
 
 fn set_empty<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -105,7 +105,7 @@ fn set_empty<'gc>(
 }
 
 fn clone<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -121,7 +121,7 @@ fn clone<'gc>(
 }
 
 fn contains<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -150,7 +150,7 @@ fn contains<'gc>(
 }
 
 fn contains_point<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -171,7 +171,7 @@ fn contains_point<'gc>(
 }
 
 fn contains_rectangle<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -203,7 +203,7 @@ fn contains_rectangle<'gc>(
 }
 
 fn intersects<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -231,7 +231,7 @@ fn intersects<'gc>(
 }
 
 fn union<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -295,7 +295,7 @@ fn union<'gc>(
 }
 
 fn inflate<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -323,7 +323,7 @@ fn inflate<'gc>(
 }
 
 fn inflate_point<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -345,7 +345,7 @@ fn inflate_point<'gc>(
 }
 
 fn offset<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -369,7 +369,7 @@ fn offset<'gc>(
 }
 
 fn offset_point<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -387,7 +387,7 @@ fn offset_point<'gc>(
 }
 
 fn intersection<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -448,7 +448,7 @@ fn intersection<'gc>(
 }
 
 fn equals<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -475,7 +475,7 @@ fn equals<'gc>(
 }
 
 fn get_left<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -483,7 +483,7 @@ fn get_left<'gc>(
 }
 
 fn set_left<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -500,7 +500,7 @@ fn set_left<'gc>(
 }
 
 fn get_top<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -508,7 +508,7 @@ fn get_top<'gc>(
 }
 
 fn set_top<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -525,7 +525,7 @@ fn set_top<'gc>(
 }
 
 fn get_right<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -535,7 +535,7 @@ fn get_right<'gc>(
 }
 
 fn set_right<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -552,7 +552,7 @@ fn set_right<'gc>(
 }
 
 fn get_bottom<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -562,7 +562,7 @@ fn get_bottom<'gc>(
 }
 
 fn set_bottom<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -579,7 +579,7 @@ fn set_bottom<'gc>(
 }
 
 fn get_size<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -590,7 +590,7 @@ fn get_size<'gc>(
 }
 
 fn set_size<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -607,7 +607,7 @@ fn set_size<'gc>(
 }
 
 fn get_top_left<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -618,7 +618,7 @@ fn get_top_left<'gc>(
 }
 
 fn set_top_left<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -649,7 +649,7 @@ fn set_top_left<'gc>(
 }
 
 fn get_bottom_right<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -662,7 +662,7 @@ fn get_bottom_right<'gc>(
 }
 
 fn set_bottom_right<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -115,7 +115,7 @@ fn clone<'gc>(
         this.get("width", activation)?,
         this.get("height", activation)?,
     ];
-    let constructor = activation.avm.prototypes.rectangle_constructor;
+    let constructor = activation.context.avm1.prototypes.rectangle_constructor;
     let cloned = constructor.construct(activation, &args)?;
     Ok(cloned.into())
 }
@@ -289,7 +289,7 @@ fn union<'gc>(
         Value::Number(width),
         Value::Number(height),
     ];
-    let constructor = activation.avm.prototypes.rectangle_constructor;
+    let constructor = activation.context.avm1.prototypes.rectangle_constructor;
     let result = constructor.construct(activation, &args)?;
     Ok(result.into())
 }
@@ -442,7 +442,7 @@ fn intersection<'gc>(
         Value::Number(right - left),
         Value::Number(bottom - top),
     ];
-    let constructor = activation.avm.prototypes.rectangle_constructor;
+    let constructor = activation.context.avm1.prototypes.rectangle_constructor;
     let result = constructor.construct(activation, &args)?;
     Ok(result.into())
 }

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -101,7 +101,7 @@ fn set_empty<'gc>(
     this.set("y", 0.into(), activation)?;
     this.set("width", 0.into(), activation)?;
     this.set("height", 0.into(), activation)?;
-    Ok(Value::Undefined.into())
+    Ok(Value::Undefined)
 }
 
 fn clone<'gc>(
@@ -479,7 +479,7 @@ fn get_left<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(this.get("x", activation)?.into())
+    this.get("x", activation)
 }
 
 fn set_left<'gc>(
@@ -504,7 +504,7 @@ fn get_top<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(this.get("y", activation)?.into())
+    this.get("y", activation)
 }
 
 fn set_top<'gc>(

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -46,7 +46,7 @@ fn recursive_serialize<'gc>(
                 Value::String(s) => json_obj[k] = s.to_string().into(),
                 Value::Object(o) => {
                     // Don't attempt to serialize functions
-                    let function = activation.avm.prototypes.function;
+                    let function = activation.context.avm1.prototypes.function;
                     if !o
                         .is_instance_of(activation, o, function)
                         .unwrap_or_default()
@@ -114,7 +114,7 @@ fn recursive_deserialize<'gc>(
                 );
             }
             JsonValue::Object(o) => {
-                let prototype = activation.avm.prototypes.object;
+                let prototype = activation.context.avm1.prototypes.object;
                 if let Ok(obj) = prototype.create_bare_object(activation, prototype) {
                     recursive_deserialize(JsonValue::Object(o.clone()), activation, obj);
 
@@ -156,7 +156,7 @@ pub fn get_local<'gc>(
     }
 
     // Data property only should exist when created with getLocal/Remote
-    let constructor = activation.avm.prototypes.shared_object_constructor;
+    let constructor = activation.context.avm1.prototypes.shared_object_constructor;
     let this = constructor.construct(activation, &[])?;
 
     // Set the internal name
@@ -164,7 +164,7 @@ pub fn get_local<'gc>(
     obj_so.set_name(activation.context.gc_context, name.to_string());
 
     // Create the data object
-    let prototype = activation.avm.prototypes.object;
+    let prototype = activation.context.avm1.prototypes.object;
     let data = prototype.create_bare_object(activation, prototype)?;
 
     // Load the data object from storage if it existed prior

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -3,7 +3,6 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::{AvmString, Object, TObject, Value};
 use crate::avm_warn;
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
@@ -12,8 +11,7 @@ use crate::avm1::object::shared_object::SharedObject;
 use json::JsonValue;
 
 pub fn delete_all<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -22,8 +20,7 @@ pub fn delete_all<'gc>(
 }
 
 pub fn get_disk_usage<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -35,13 +32,12 @@ pub fn get_disk_usage<'gc>(
 /// It would be best if this was implemented via serde but due to avm and context it can't
 /// Undefined fields aren't serialized
 fn recursive_serialize<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     obj: Object<'gc>,
     json_obj: &mut JsonValue,
 ) {
     for k in &obj.get_keys(activation) {
-        if let Ok(elem) = obj.get(k, activation, action_context) {
+        if let Ok(elem) = obj.get(k, activation) {
             match elem {
                 Value::Undefined => {}
                 Value::Null => json_obj[k] = JsonValue::Null,
@@ -52,11 +48,11 @@ fn recursive_serialize<'gc>(
                     // Don't attempt to serialize functions
                     let function = activation.avm.prototypes.function;
                     if !o
-                        .is_instance_of(activation, action_context, o, function)
+                        .is_instance_of(activation, o, function)
                         .unwrap_or_default()
                     {
                         let mut sub_data_json = JsonValue::new_object();
-                        recursive_serialize(activation, action_context, o, &mut sub_data_json);
+                        recursive_serialize(activation, o, &mut sub_data_json);
                         json_obj[k] = sub_data_json;
                     }
                 }
@@ -70,36 +66,40 @@ fn recursive_serialize<'gc>(
 /// Undefined fields aren't deserialized
 fn recursive_deserialize<'gc>(
     json_obj: JsonValue,
-    activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     object: Object<'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
 ) {
     for entry in json_obj.entries() {
         match entry.1 {
             JsonValue::Null => {
-                object.define_value(context.gc_context, entry.0, Value::Null, EnumSet::empty());
+                object.define_value(
+                    activation.context.gc_context,
+                    entry.0,
+                    Value::Null,
+                    EnumSet::empty(),
+                );
             }
             JsonValue::Short(s) => {
                 let val: String = s.as_str().to_string();
                 object.define_value(
-                    context.gc_context,
+                    activation.context.gc_context,
                     entry.0,
-                    Value::String(AvmString::new(context.gc_context, val)),
+                    Value::String(AvmString::new(activation.context.gc_context, val)),
                     EnumSet::empty(),
                 );
             }
             JsonValue::String(s) => {
                 object.define_value(
-                    context.gc_context,
+                    activation.context.gc_context,
                     entry.0,
-                    Value::String(AvmString::new(context.gc_context, s.clone())),
+                    Value::String(AvmString::new(activation.context.gc_context, s.clone())),
                     EnumSet::empty(),
                 );
             }
             JsonValue::Number(f) => {
                 let val: f64 = f.clone().into();
                 object.define_value(
-                    context.gc_context,
+                    activation.context.gc_context,
                     entry.0,
                     Value::Number(val),
                     EnumSet::empty(),
@@ -107,7 +107,7 @@ fn recursive_deserialize<'gc>(
             }
             JsonValue::Boolean(b) => {
                 object.define_value(
-                    context.gc_context,
+                    activation.context.gc_context,
                     entry.0,
                     Value::Bool(*b),
                     EnumSet::empty(),
@@ -115,11 +115,11 @@ fn recursive_deserialize<'gc>(
             }
             JsonValue::Object(o) => {
                 let prototype = activation.avm.prototypes.object;
-                if let Ok(obj) = prototype.create_bare_object(activation, context, prototype) {
-                    recursive_deserialize(JsonValue::Object(o.clone()), activation, obj, context);
+                if let Ok(obj) = prototype.create_bare_object(activation, prototype) {
+                    recursive_deserialize(JsonValue::Object(o.clone()), activation, obj);
 
                     object.define_value(
-                        context.gc_context,
+                        activation.context.gc_context,
                         entry.0,
                         Value::Object(obj),
                         EnumSet::empty(),
@@ -132,8 +132,7 @@ fn recursive_deserialize<'gc>(
 }
 
 pub fn get_local<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -141,11 +140,11 @@ pub fn get_local<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .to_owned()
-        .coerce_to_string(activation, action_context)?
+        .coerce_to_string(activation)?
         .to_string();
 
     //Check if this is referencing an existing shared object
-    if let Some(so) = action_context.shared_objects.get(&name) {
+    if let Some(so) = activation.context.shared_objects.get(&name) {
         return Ok(Value::Object(*so));
     }
 
@@ -158,38 +157,37 @@ pub fn get_local<'gc>(
 
     // Data property only should exist when created with getLocal/Remote
     let constructor = activation.avm.prototypes.shared_object_constructor;
-    let this = constructor.construct(activation, action_context, &[])?;
+    let this = constructor.construct(activation, &[])?;
 
     // Set the internal name
     let obj_so = this.as_shared_object().unwrap();
-    obj_so.set_name(action_context.gc_context, name.to_string());
+    obj_so.set_name(activation.context.gc_context, name.to_string());
 
     // Create the data object
     let prototype = activation.avm.prototypes.object;
-    let data = prototype.create_bare_object(activation, action_context, prototype)?;
+    let data = prototype.create_bare_object(activation, prototype)?;
 
     // Load the data object from storage if it existed prior
-    if let Some(saved) = action_context.storage.get_string(&name) {
+    if let Some(saved) = activation.context.storage.get_string(&name) {
         if let Ok(json_data) = json::parse(&saved) {
-            recursive_deserialize(json_data, activation, data, action_context);
+            recursive_deserialize(json_data, activation, data);
         }
     }
 
     this.define_value(
-        action_context.gc_context,
+        activation.context.gc_context,
         "data",
         data.into(),
         EnumSet::empty(),
     );
 
-    action_context.shared_objects.insert(name, this);
+    activation.context.shared_objects.insert(name, this);
 
     Ok(this.into())
 }
 
 pub fn get_remote<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -198,8 +196,7 @@ pub fn get_remote<'gc>(
 }
 
 pub fn get_max_size<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -208,8 +205,7 @@ pub fn get_max_size<'gc>(
 }
 
 pub fn add_listener<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -218,8 +214,7 @@ pub fn add_listener<'gc>(
 }
 
 pub fn remove_listener<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -300,30 +295,26 @@ pub fn create_shared_object_object<'gc>(
 }
 
 pub fn clear<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let data = this
-        .get("data", activation, action_context)?
-        .coerce_to_object(activation, action_context);
+    let data = this.get("data", activation)?.coerce_to_object(activation);
 
     for k in &data.get_keys(activation) {
-        data.delete(activation, action_context.gc_context, k);
+        data.delete(activation, k);
     }
 
     let so = this.as_shared_object().unwrap();
     let name = so.get_name();
 
-    action_context.storage.remove_key(&name);
+    activation.context.storage.remove_key(&name);
 
     Ok(Value::Undefined)
 }
 
 pub fn close<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -332,8 +323,7 @@ pub fn close<'gc>(
 }
 
 pub fn connect<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -342,30 +332,27 @@ pub fn connect<'gc>(
 }
 
 pub fn flush<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let data = this
-        .get("data", activation, action_context)?
-        .coerce_to_object(activation, action_context);
+    let data = this.get("data", activation)?.coerce_to_object(activation);
 
     let mut data_json = JsonValue::new_object();
-    recursive_serialize(activation, action_context, data, &mut data_json);
+    recursive_serialize(activation, data, &mut data_json);
 
     let this_obj = this.as_shared_object().unwrap();
     let name = this_obj.get_name();
 
-    Ok(action_context
+    Ok(activation
+        .context
         .storage
         .put_string(&name, data_json.dump())
         .into())
 }
 
 pub fn get_size<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -374,8 +361,7 @@ pub fn get_size<'gc>(
 }
 
 pub fn send<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -384,8 +370,7 @@ pub fn send<'gc>(
 }
 
 pub fn set_fps<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -394,8 +379,7 @@ pub fn set_fps<'gc>(
 }
 
 pub fn on_status<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -404,8 +388,7 @@ pub fn on_status<'gc>(
 }
 
 pub fn on_sync<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -473,8 +456,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -11,7 +11,7 @@ use crate::avm1::object::shared_object::SharedObject;
 use json::JsonValue;
 
 pub fn delete_all<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -20,7 +20,7 @@ pub fn delete_all<'gc>(
 }
 
 pub fn get_disk_usage<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -32,7 +32,7 @@ pub fn get_disk_usage<'gc>(
 /// It would be best if this was implemented via serde but due to avm and context it can't
 /// Undefined fields aren't serialized
 fn recursive_serialize<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     obj: Object<'gc>,
     json_obj: &mut JsonValue,
 ) {
@@ -66,7 +66,7 @@ fn recursive_serialize<'gc>(
 /// Undefined fields aren't deserialized
 fn recursive_deserialize<'gc>(
     json_obj: JsonValue,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     object: Object<'gc>,
 ) {
     for entry in json_obj.entries() {
@@ -132,7 +132,7 @@ fn recursive_deserialize<'gc>(
 }
 
 pub fn get_local<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -187,7 +187,7 @@ pub fn get_local<'gc>(
 }
 
 pub fn get_remote<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -196,7 +196,7 @@ pub fn get_remote<'gc>(
 }
 
 pub fn get_max_size<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -205,7 +205,7 @@ pub fn get_max_size<'gc>(
 }
 
 pub fn add_listener<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -214,7 +214,7 @@ pub fn add_listener<'gc>(
 }
 
 pub fn remove_listener<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -295,7 +295,7 @@ pub fn create_shared_object_object<'gc>(
 }
 
 pub fn clear<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -314,7 +314,7 @@ pub fn clear<'gc>(
 }
 
 pub fn close<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -323,7 +323,7 @@ pub fn close<'gc>(
 }
 
 pub fn connect<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -332,7 +332,7 @@ pub fn connect<'gc>(
 }
 
 pub fn flush<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -352,7 +352,7 @@ pub fn flush<'gc>(
 }
 
 pub fn get_size<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -361,7 +361,7 @@ pub fn get_size<'gc>(
 }
 
 pub fn send<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -370,7 +370,7 @@ pub fn send<'gc>(
 }
 
 pub fn set_fps<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -379,7 +379,7 @@ pub fn set_fps<'gc>(
 }
 
 pub fn on_status<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -388,7 +388,7 @@ pub fn on_status<'gc>(
 }
 
 pub fn on_sync<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -456,7 +456,7 @@ pub fn create_proto<'gc>(
 }
 
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -13,7 +13,7 @@ use gc_arena::MutationContext;
 
 /// Implements `Sound`
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -176,7 +176,7 @@ pub fn create_proto<'gc>(
 }
 
 fn attach_sound<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -221,7 +221,7 @@ fn attach_sound<'gc>(
 }
 
 fn duration<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -237,7 +237,7 @@ fn duration<'gc>(
 }
 
 fn get_bytes_loaded<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -250,7 +250,7 @@ fn get_bytes_loaded<'gc>(
 }
 
 fn get_bytes_total<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -263,7 +263,7 @@ fn get_bytes_total<'gc>(
 }
 
 fn get_pan<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -272,7 +272,7 @@ fn get_pan<'gc>(
 }
 
 fn get_transform<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -281,7 +281,7 @@ fn get_transform<'gc>(
 }
 
 fn get_volume<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -290,7 +290,7 @@ fn get_volume<'gc>(
 }
 
 fn id3<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -301,7 +301,7 @@ fn id3<'gc>(
 }
 
 fn load_sound<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -312,7 +312,7 @@ fn load_sound<'gc>(
 }
 
 fn position<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -335,7 +335,7 @@ fn position<'gc>(
 }
 
 fn set_pan<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -344,7 +344,7 @@ fn set_pan<'gc>(
 }
 
 fn set_transform<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -353,7 +353,7 @@ fn set_transform<'gc>(
 }
 
 fn set_volume<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -362,7 +362,7 @@ fn set_volume<'gc>(
 }
 
 fn start<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -413,7 +413,7 @@ fn start<'gc>(
 }
 
 fn stop<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -5,7 +5,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{Object, SoundObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, SoundObject, TObject, Value};
 use crate::avm_warn;
 use crate::character::Character;
 use crate::display_object::TDisplayObject;
@@ -13,8 +13,7 @@ use gc_arena::MutationContext;
 
 /// Implements `Sound`
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -22,11 +21,11 @@ pub fn constructor<'gc>(
     // `Sound.setTransform`, `Sound.stop`, etc. will affect all sounds owned by this clip.
     let owner = args
         .get(0)
-        .map(|o| o.coerce_to_object(activation, context))
+        .map(|o| o.coerce_to_object(activation))
         .and_then(|o| o.as_display_object());
 
     let sound = this.as_sound_object().unwrap();
-    sound.set_owner(context.gc_context, owner);
+    sound.set_owner(activation.context.gc_context, owner);
 
     Ok(this.into())
 }
@@ -177,30 +176,34 @@ pub fn create_proto<'gc>(
 }
 
 fn attach_sound<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let name = args.get(0).unwrap_or(&Value::Undefined);
     if let Some(sound_object) = this.as_sound_object() {
-        let name = name.coerce_to_string(activation, context)?;
+        let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| context.levels.get(&0).copied())
+            .or_else(|| activation.context.levels.get(&0).copied())
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
-            if let Some(Character::Sound(sound)) = context
+            if let Some(Character::Sound(sound)) = activation
+                .context
                 .library
                 .library_for_movie_mut(movie)
                 .get_character_by_export_name(&name)
             {
-                sound_object.set_sound(context.gc_context, Some(*sound));
+                sound_object.set_sound(activation.context.gc_context, Some(*sound));
                 sound_object.set_duration(
-                    context.gc_context,
-                    context.audio.get_sound_duration(*sound).unwrap_or(0),
+                    activation.context.gc_context,
+                    activation
+                        .context
+                        .audio
+                        .get_sound_duration(*sound)
+                        .unwrap_or(0),
                 );
-                sound_object.set_position(context.gc_context, 0);
+                sound_object.set_position(activation.context.gc_context, 0);
             } else {
                 avm_warn!(activation, "Sound.attachSound: Sound '{}' not found", name);
             }
@@ -218,8 +221,7 @@ fn attach_sound<'gc>(
 }
 
 fn duration<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -235,8 +237,7 @@ fn duration<'gc>(
 }
 
 fn get_bytes_loaded<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -249,8 +250,7 @@ fn get_bytes_loaded<'gc>(
 }
 
 fn get_bytes_total<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -263,8 +263,7 @@ fn get_bytes_total<'gc>(
 }
 
 fn get_pan<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -273,8 +272,7 @@ fn get_pan<'gc>(
 }
 
 fn get_transform<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -283,8 +281,7 @@ fn get_transform<'gc>(
 }
 
 fn get_volume<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -293,8 +290,7 @@ fn get_volume<'gc>(
 }
 
 fn id3<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -305,8 +301,7 @@ fn id3<'gc>(
 }
 
 fn load_sound<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -317,8 +312,7 @@ fn load_sound<'gc>(
 }
 
 fn position<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -341,8 +335,7 @@ fn position<'gc>(
 }
 
 fn set_pan<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -351,8 +344,7 @@ fn set_pan<'gc>(
 }
 
 fn set_transform<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -361,8 +353,7 @@ fn set_transform<'gc>(
 }
 
 fn set_volume<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -371,19 +362,18 @@ fn set_volume<'gc>(
 }
 
 fn start<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let start_offset = args
         .get(0)
         .unwrap_or(&Value::Number(0.0))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let loops = args
         .get(1)
         .unwrap_or(&Value::Number(1.0))
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
 
     let loops = if loops >= 1.0 && loops <= f64::from(std::i16::MAX) {
         loops as u16
@@ -394,7 +384,7 @@ fn start<'gc>(
     use swf::{SoundEvent, SoundInfo};
     if let Some(sound_object) = this.as_sound_object() {
         if let Some(sound) = sound_object.sound() {
-            let sound_instance = context.audio.start_sound(
+            let sound_instance = activation.context.audio.start_sound(
                 sound,
                 &SoundInfo {
                     event: SoundEvent::Start,
@@ -409,7 +399,8 @@ fn start<'gc>(
                 },
             );
             if let Ok(sound_instance) = sound_instance {
-                sound_object.set_sound_instance(context.gc_context, Some(sound_instance));
+                sound_object
+                    .set_sound_instance(activation.context.gc_context, Some(sound_instance));
             }
         } else {
             avm_warn!(activation, "Sound.start: No sound is attached");
@@ -422,27 +413,27 @@ fn start<'gc>(
 }
 
 fn stop<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(sound) = this.as_sound_object() {
         if let Some(name) = args.get(0) {
             // Usage 1: Stop all instances of a particular sound, using the name parameter.
-            let name = name.coerce_to_string(activation, context)?;
+            let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| context.levels.get(&0).copied())
+                .or_else(|| activation.context.levels.get(&0).copied())
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
-                if let Some(Character::Sound(sound)) = context
+                if let Some(Character::Sound(sound)) = activation
+                    .context
                     .library
                     .library_for_movie_mut(movie)
                     .get_character_by_export_name(&name)
                 {
                     // Stop all sounds with the given name.
-                    context.audio.stop_sounds_with_handle(*sound);
+                    activation.context.audio.stop_sounds_with_handle(*sound);
                 } else {
                     avm_warn!(activation, "Sound.stop: Sound '{}' not found", name);
                 }
@@ -457,11 +448,11 @@ fn stop<'gc>(
             // Usage 2: Stop all sound running within a given clip.
             // TODO: We just stop the last played sound for now.
             if let Some(sound_instance) = sound.sound_instance() {
-                context.audio.stop_sound(sound_instance);
+                activation.context.audio.stop_sound(sound_instance);
             }
         } else {
             // Usage 3: If there is no owner and no name, this call acts like `stopAllSounds()`.
-            context.audio.stop_all_sounds();
+            activation.context.audio.stop_all_sounds();
         }
     } else {
         avm_warn!(activation, "Sound.stop: this is not a Sound");

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -105,7 +105,7 @@ pub fn create_stage_object<'gc>(
 }
 
 fn align<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -114,7 +114,7 @@ fn align<'gc>(
 }
 
 fn set_align<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -123,7 +123,7 @@ fn set_align<'gc>(
 }
 
 fn height<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -131,7 +131,7 @@ fn height<'gc>(
 }
 
 fn scale_mode<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -140,7 +140,7 @@ fn scale_mode<'gc>(
 }
 
 fn set_scale_mode<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -149,7 +149,7 @@ fn set_scale_mode<'gc>(
 }
 
 fn show_menu<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -158,7 +158,7 @@ fn show_menu<'gc>(
 }
 
 fn set_show_menu<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -167,7 +167,7 @@ fn set_show_menu<'gc>(
 }
 
 fn width<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -6,7 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
 use gc_arena::MutationContext;
 
@@ -105,8 +105,7 @@ pub fn create_stage_object<'gc>(
 }
 
 fn align<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -115,8 +114,7 @@ fn align<'gc>(
 }
 
 fn set_align<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -125,17 +123,15 @@ fn set_align<'gc>(
 }
 
 fn height<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(context.stage_size.1.to_pixels().into())
+    Ok(activation.context.stage_size.1.to_pixels().into())
 }
 
 fn scale_mode<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -144,8 +140,7 @@ fn scale_mode<'gc>(
 }
 
 fn set_scale_mode<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -154,8 +149,7 @@ fn set_scale_mode<'gc>(
 }
 
 fn show_menu<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -164,8 +158,7 @@ fn show_menu<'gc>(
 }
 
 fn set_show_menu<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -174,10 +167,9 @@ fn set_show_menu<'gc>(
 }
 
 fn width<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(context.stage_size.0.to_pixels().into())
+    Ok(activation.context.stage_size.0.to_pixels().into())
 }

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -6,28 +6,26 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property::Attribute::*;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use crate::string_utils;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// `String` constructor
 pub fn string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = match args.get(0).cloned() {
         Some(Value::String(s)) => s,
-        Some(v) => v.coerce_to_string(activation, ac)?,
-        _ => AvmString::new(ac.gc_context, String::new()),
+        Some(v) => v.coerce_to_string(activation)?,
+        _ => AvmString::new(activation.context.gc_context, String::new()),
     };
 
     if let Some(mut vbox) = this.as_value_object() {
         let len = value.encode_utf16().count();
-        vbox.set_length(ac.gc_context, len);
-        vbox.replace_value(ac.gc_context, value.clone().into());
+        vbox.set_length(activation.context.gc_context, len);
+        vbox.replace_value(activation.context.gc_context, value.clone().into());
     }
 
     Ok(Value::Undefined)
@@ -35,15 +33,14 @@ pub fn string<'gc>(
 
 /// `String` function
 pub fn string_function<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = match args.get(0).cloned() {
         Some(Value::String(s)) => s,
-        Some(v) => v.coerce_to_string(activation, ac)?,
-        _ => AvmString::new(ac.gc_context, String::new()),
+        Some(v) => v.coerce_to_string(activation)?,
+        _ => AvmString::new(activation.context.gc_context, String::new()),
     };
 
     Ok(value.into())
@@ -188,19 +185,18 @@ pub fn create_proto<'gc>(
 }
 
 fn char_at<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: Will return REPLACEMENT_CHAR if this indexes a character outside the BMP, losing info about the surrogate.
     // When we improve our string representation, the unpaired surrogate should be returned.
     let this_val = Value::from(this);
-    let string = this_val.coerce_to_string(activation, context)?;
+    let string = this_val.coerce_to_string(activation)?;
     let i = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_i32(activation, context)?;
+        .coerce_to_i32(activation)?;
     let ret = if i >= 0 {
         string
             .encode_utf16()
@@ -210,21 +206,20 @@ fn char_at<'gc>(
     } else {
         "".into()
     };
-    Ok(AvmString::new(context.gc_context, ret).into())
+    Ok(AvmString::new(activation.context.gc_context, ret).into())
 }
 
 fn char_code_at<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     let i = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_i32(activation, context)?;
+        .coerce_to_i32(activation)?;
     let ret = if i >= 0 {
         this.encode_utf16()
             .nth(i as usize)
@@ -237,55 +232,50 @@ fn char_code_at<'gc>(
 }
 
 fn concat<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut ret = Value::from(this)
-        .coerce_to_string(activation, context)?
-        .to_string();
+    let mut ret = Value::from(this).coerce_to_string(activation)?.to_string();
     for arg in args {
-        let s = arg.coerce_to_string(activation, context)?;
+        let s = arg.coerce_to_string(activation)?;
         ret.push_str(&s)
     }
-    Ok(AvmString::new(context.gc_context, ret).into())
+    Ok(AvmString::new(activation.context.gc_context, ret).into())
 }
 
 fn from_char_code<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: Unpaired surrogates will be replace with Unicode replacement char.
     let mut out = String::with_capacity(args.len());
     for arg in args {
-        let i = arg.coerce_to_u16(activation, context)?;
+        let i = arg.coerce_to_u16(activation)?;
         if i == 0 {
             // Stop at a null-terminator.
             break;
         }
         out.push(utf16_code_unit_to_char(i));
     }
-    Ok(AvmString::new(context.gc_context, out).into())
+    Ok(AvmString::new(activation.context.gc_context, out).into())
 }
 
 fn index_of<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = Value::from(this)
-        .coerce_to_string(activation, context)?
+        .coerce_to_string(activation)?
         .encode_utf16()
         .collect::<Vec<u16>>();
     let pattern = match args.get(0) {
         None | Some(Value::Undefined) => return Ok(Value::Undefined),
         Some(s) => s
             .clone()
-            .coerce_to_string(activation, context)?
+            .coerce_to_string(activation)?
             .encode_utf16()
             .collect::<Vec<_>>(),
     };
@@ -293,7 +283,7 @@ fn index_of<'gc>(
         let n = args
             .get(1)
             .unwrap_or(&Value::Undefined)
-            .coerce_to_i32(activation, context)?;
+            .coerce_to_i32(activation)?;
         if n >= 0 {
             n as usize
         } else {
@@ -320,27 +310,26 @@ fn index_of<'gc>(
 }
 
 fn last_index_of<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = Value::from(this)
-        .coerce_to_string(activation, context)?
+        .coerce_to_string(activation)?
         .encode_utf16()
         .collect::<Vec<u16>>();
     let pattern = match args.get(0) {
         None | Some(Value::Undefined) => return Ok(Value::Undefined),
         Some(s) => s
             .clone()
-            .coerce_to_string(activation, context)?
+            .coerce_to_string(activation)?
             .encode_utf16()
             .collect::<Vec<_>>(),
     };
     let start_index = match args.get(1) {
         None | Some(Value::Undefined) => this.len(),
         Some(n) => {
-            let n = n.coerce_to_i32(activation, context)?;
+            let n = n.coerce_to_i32(activation)?;
             if n >= 0 {
                 let n = n as usize;
                 if n <= this.len() {
@@ -372,8 +361,7 @@ fn last_index_of<'gc>(
 }
 
 fn slice<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -383,17 +371,17 @@ fn slice<'gc>(
     }
 
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     let this_len = this.encode_utf16().count();
     let start_index = string_wrapping_index(
         args.get(0)
             .unwrap_or(&Value::Undefined)
-            .coerce_to_i32(activation, context)?,
+            .coerce_to_i32(activation)?,
         this_len,
     );
     let end_index = match args.get(1) {
         None | Some(Value::Undefined) => this_len,
-        Some(n) => string_wrapping_index(n.coerce_to_i32(activation, context)?, this_len),
+        Some(n) => string_wrapping_index(n.coerce_to_i32(activation)?, this_len),
     };
     if start_index < end_index {
         let ret = utf16_iter_to_string(
@@ -401,33 +389,35 @@ fn slice<'gc>(
                 .skip(start_index)
                 .take(end_index - start_index),
         );
-        Ok(AvmString::new(context.gc_context, ret).into())
+        Ok(AvmString::new(activation.context.gc_context, ret).into())
     } else {
         Ok("".into())
     }
 }
 
 fn split<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     let delimiter_val = args.get(0).unwrap_or(&Value::Undefined);
-    let delimiter = delimiter_val.coerce_to_string(activation, context)?;
+    let delimiter = delimiter_val.coerce_to_string(activation)?;
     let limit = match args.get(1) {
         None | Some(Value::Undefined) => std::usize::MAX,
-        Some(n) => std::cmp::max(0, n.coerce_to_i32(activation, context)?) as usize,
+        Some(n) => std::cmp::max(0, n.coerce_to_i32(activation)?) as usize,
     };
-    let array = ScriptObject::array(context.gc_context, Some(activation.avm.prototypes.array));
+    let array = ScriptObject::array(
+        activation.context.gc_context,
+        Some(activation.avm.prototypes.array),
+    );
     if !delimiter.is_empty() {
         for (i, token) in this.split(delimiter.as_ref()).take(limit).enumerate() {
             array.set_array_element(
                 i,
-                AvmString::new(context.gc_context, token.to_string()).into(),
-                context.gc_context,
+                AvmString::new(activation.context.gc_context, token.to_string()).into(),
+                activation.context.gc_context,
             );
         }
     } else {
@@ -437,8 +427,8 @@ fn split<'gc>(
         for (i, token) in this.chars().take(limit).enumerate() {
             array.set_array_element(
                 i,
-                AvmString::new(context.gc_context, token.to_string()).into(),
-                context.gc_context,
+                AvmString::new(activation.context.gc_context, token.to_string()).into(),
+                activation.context.gc_context,
             );
         }
     }
@@ -446,8 +436,7 @@ fn split<'gc>(
 }
 
 fn substr<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -456,25 +445,22 @@ fn substr<'gc>(
     }
 
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     let this_len = this.encode_utf16().count();
-    let start_index = string_wrapping_index(
-        args.get(0).unwrap().coerce_to_i32(activation, context)?,
-        this_len,
-    );
+    let start_index =
+        string_wrapping_index(args.get(0).unwrap().coerce_to_i32(activation)?, this_len);
 
     let len = match args.get(1) {
         None | Some(Value::Undefined) => this_len,
-        Some(n) => string_index(n.coerce_to_i32(activation, context)?, this_len),
+        Some(n) => string_index(n.coerce_to_i32(activation)?, this_len),
     };
 
     let ret = utf16_iter_to_string(this.encode_utf16().skip(start_index).take(len));
-    Ok(AvmString::new(context.gc_context, ret).into())
+    Ok(AvmString::new(activation.context.gc_context, ret).into())
 }
 
 fn substring<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -483,16 +469,13 @@ fn substring<'gc>(
     }
 
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     let this_len = this.encode_utf16().count();
-    let mut start_index = string_index(
-        args.get(0).unwrap().coerce_to_i32(activation, context)?,
-        this_len,
-    );
+    let mut start_index = string_index(args.get(0).unwrap().coerce_to_i32(activation)?, this_len);
 
     let mut end_index = match args.get(1) {
         None | Some(Value::Undefined) => this_len,
-        Some(n) => string_index(n.coerce_to_i32(activation, context)?, this_len),
+        Some(n) => string_index(n.coerce_to_i32(activation)?, this_len),
     };
 
     // substring automatically swaps the start/end if they are flipped.
@@ -504,19 +487,18 @@ fn substring<'gc>(
             .skip(start_index)
             .take(end_index - start_index),
     );
-    Ok(AvmString::new(context.gc_context, ret).into())
+    Ok(AvmString::new(activation.context.gc_context, ret).into())
 }
 
 fn to_lower_case<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     Ok(AvmString::new(
-        context.gc_context,
+        activation.context.gc_context,
         this.chars()
             .map(string_utils::swf_char_to_lowercase)
             .collect::<String>(),
@@ -526,8 +508,7 @@ fn to_lower_case<'gc>(
 
 /// `String.toString` / `String.valueOf` impl
 pub fn to_string_value_of<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -544,15 +525,14 @@ pub fn to_string_value_of<'gc>(
 }
 
 fn to_upper_case<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this_val = Value::from(this);
-    let this = this_val.coerce_to_string(activation, context)?;
+    let this = this_val.coerce_to_string(activation)?;
     Ok(AvmString::new(
-        context.gc_context,
+        activation.context.gc_context,
         this.chars()
             .map(string_utils::swf_char_to_uppercase)
             .collect::<String>(),

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -410,7 +410,7 @@ fn split<'gc>(
     };
     let array = ScriptObject::array(
         activation.context.gc_context,
-        Some(activation.avm.prototypes.array),
+        Some(activation.context.avm1.prototypes.array),
     );
     if !delimiter.is_empty() {
         for (i, token) in this.split(delimiter.as_ref()).take(limit).enumerate() {

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -12,7 +12,7 @@ use gc_arena::MutationContext;
 
 /// `String` constructor
 pub fn string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -33,7 +33,7 @@ pub fn string<'gc>(
 
 /// `String` function
 pub fn string_function<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -185,7 +185,7 @@ pub fn create_proto<'gc>(
 }
 
 fn char_at<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -210,7 +210,7 @@ fn char_at<'gc>(
 }
 
 fn char_code_at<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -232,7 +232,7 @@ fn char_code_at<'gc>(
 }
 
 fn concat<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -245,7 +245,7 @@ fn concat<'gc>(
 }
 
 fn from_char_code<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -263,7 +263,7 @@ fn from_char_code<'gc>(
 }
 
 fn index_of<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -310,7 +310,7 @@ fn index_of<'gc>(
 }
 
 fn last_index_of<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -361,7 +361,7 @@ fn last_index_of<'gc>(
 }
 
 fn slice<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -396,7 +396,7 @@ fn slice<'gc>(
 }
 
 fn split<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -436,7 +436,7 @@ fn split<'gc>(
 }
 
 fn substr<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -460,7 +460,7 @@ fn substr<'gc>(
 }
 
 fn substring<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -491,7 +491,7 @@ fn substring<'gc>(
 }
 
 fn to_lower_case<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -508,7 +508,7 @@ fn to_lower_case<'gc>(
 
 /// `String.toString` / `String.valueOf` impl
 pub fn to_string_value_of<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -525,7 +525,7 @@ pub fn to_string_value_of<'gc>(
 }
 
 fn to_upper_case<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -2,9 +2,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::Object;
-use crate::avm1::{ScriptObject, TObject, Value};
+use crate::avm1::{Avm1, ScriptObject, TObject, Value};
 use crate::avm_warn;
-use crate::context::UpdateContext;
 use core::fmt;
 use enumset::{EnumSet, EnumSetType};
 use gc_arena::MutationContext;
@@ -274,11 +273,11 @@ pub struct SystemProperties {
 }
 
 impl SystemProperties {
-    pub fn get_version_string(&self, activation: &mut Activation) -> String {
+    pub fn get_version_string(&self, avm: &mut Avm1) -> String {
         format!(
             "{} {},0,0,0",
             self.manufacturer.get_platform_name(),
-            activation.avm.player_version
+            avm.player_version
         )
     }
 
@@ -306,7 +305,7 @@ impl SystemProperties {
         percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).to_string()
     }
 
-    pub fn get_server_string(&self, activation: &mut Activation) -> String {
+    pub fn get_server_string(&self, avm: &mut Avm1) -> String {
         url::form_urlencoded::Serializer::new(String::new())
             .append_pair("A", self.encode_capability(SystemCapabilities::Audio))
             .append_pair(
@@ -348,7 +347,7 @@ impl SystemProperties {
                 "M",
                 &self.encode_string(
                     self.manufacturer
-                        .get_manufacturer_string(activation.avm.player_version)
+                        .get_manufacturer_string(avm.player_version)
                         .as_str(),
                 ),
             )
@@ -359,11 +358,7 @@ impl SystemProperties {
             .append_pair("COL", &self.screen_color.to_string())
             .append_pair("AR", &self.aspect_ratio.to_string())
             .append_pair("OS", &self.encode_string(&self.os.to_string()))
-            .append_pair(
-                "L",
-                self.language
-                    .get_language_code(activation.avm.player_version),
-            )
+            .append_pair("L", self.language.get_language_code(avm.player_version))
             .append_pair("IME", self.encode_capability(SystemCapabilities::IME))
             .append_pair("PT", &self.player_type.to_string())
             .append_pair(
@@ -404,25 +399,23 @@ impl Default for SystemProperties {
 }
 
 pub fn set_clipboard<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let new_content = args
         .get(0)
         .unwrap_or(&Value::Undefined)
-        .coerce_to_string(activation, action_context)?
+        .coerce_to_string(activation)?
         .to_string();
 
-    action_context.input.set_clipboard_content(new_content);
+    activation.context.input.set_clipboard_content(new_content);
 
     Ok(Value::Undefined)
 }
 
 pub fn show_settings<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -432,7 +425,7 @@ pub fn show_settings<'gc>(
     let panel_pos = args
         .get(0)
         .unwrap_or(&Value::Number(last_panel_pos as f64))
-        .coerce_to_i32(activation, action_context)?;
+        .coerce_to_i32(activation)?;
 
     let panel = SettingsPanel::try_from(panel_pos as u8).unwrap_or(SettingsPanel::Privacy);
 
@@ -445,8 +438,7 @@ pub fn show_settings<'gc>(
 }
 
 pub fn set_use_code_page<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -456,23 +448,21 @@ pub fn set_use_code_page<'gc>(
         .to_owned()
         .as_bool(activation.current_swf_version());
 
-    action_context.system.use_codepage = value;
+    activation.context.system.use_codepage = value;
 
     Ok(Value::Undefined)
 }
 
 pub fn get_use_code_page<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(action_context.system.use_codepage.into())
+    Ok(activation.context.system.use_codepage.into())
 }
 
 pub fn set_exact_settings<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -482,23 +472,21 @@ pub fn set_exact_settings<'gc>(
         .to_owned()
         .as_bool(activation.current_swf_version());
 
-    action_context.system.exact_settings = value;
+    activation.context.system.exact_settings = value;
 
     Ok(Value::Undefined)
 }
 
 pub fn get_exact_settings<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(action_context.system.exact_settings.into())
+    Ok(activation.context.system.exact_settings.into())
 }
 
 pub fn on_status<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -399,7 +399,7 @@ impl Default for SystemProperties {
 }
 
 pub fn set_clipboard<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -415,7 +415,7 @@ pub fn set_clipboard<'gc>(
 }
 
 pub fn show_settings<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -438,7 +438,7 @@ pub fn show_settings<'gc>(
 }
 
 pub fn set_use_code_page<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -454,7 +454,7 @@ pub fn set_use_code_page<'gc>(
 }
 
 pub fn get_use_code_page<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -462,7 +462,7 @@ pub fn get_use_code_page<'gc>(
 }
 
 pub fn set_exact_settings<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -478,7 +478,7 @@ pub fn set_exact_settings<'gc>(
 }
 
 pub fn get_exact_settings<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -486,7 +486,7 @@ pub fn get_exact_settings<'gc>(
 }
 
 pub fn on_status<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -4,19 +4,17 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::system::SystemCapabilities;
 use crate::avm1::object::Object;
 use crate::avm1::{AvmString, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 macro_rules! capabilities_func {
     ($func_name: ident, $capability: expr) => {
         pub fn $func_name<'gc>(
-            _activation: &mut Activation<'_, 'gc>,
-            context: &mut UpdateContext<'_, 'gc, '_>,
+            activation: &mut Activation<'_, '_, 'gc, '_>,
             _this: Object<'gc>,
             _args: &[Value<'gc>],
         ) -> Result<Value<'gc>, Error<'gc>> {
-            Ok(context.system.has_capability($capability).into())
+            Ok(activation.context.system.has_capability($capability).into())
         }
     };
 }
@@ -24,12 +22,11 @@ macro_rules! capabilities_func {
 macro_rules! inverse_capabilities_func {
     ($func_name: ident, $capability: expr) => {
         pub fn $func_name<'gc>(
-            _activation: &mut Activation<'_, 'gc>,
-            context: &mut UpdateContext<'_, 'gc, '_>,
+            activation: &mut Activation<'_, '_, 'gc, '_>,
             _this: Object<'gc>,
             _args: &[Value<'gc>],
         ) -> Result<Value<'gc>, Error<'gc>> {
-            Ok((!context.system.has_capability($capability)).into())
+            Ok((!activation.context.system.has_capability($capability)).into())
         }
     };
 }
@@ -77,32 +74,38 @@ inverse_capabilities_func!(get_is_av_hardware_disabled, SystemCapabilities::AvHa
 inverse_capabilities_func!(get_is_windowless_disabled, SystemCapabilities::WindowLess);
 
 pub fn get_player_type<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: Object<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, context.system.player_type.to_string()).into())
-}
-
-pub fn get_screen_color<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: Object<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, context.system.screen_color.to_string()).into())
-}
-
-pub fn get_language<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new(
-        context.gc_context,
-        context
+        activation.context.gc_context,
+        activation.context.system.player_type.to_string(),
+    )
+    .into())
+}
+
+pub fn get_screen_color<'gc>(
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        activation.context.system.screen_color.to_string(),
+    )
+    .into())
+}
+
+pub fn get_language<'gc>(
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        activation
+            .context
             .system
             .language
             .get_language_code(activation.avm.player_version)
@@ -112,50 +115,46 @@ pub fn get_language<'gc>(
 }
 
 pub fn get_screen_resolution_x<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(context.system.screen_resolution.0.into())
+    Ok(activation.context.system.screen_resolution.0.into())
 }
 
 pub fn get_screen_resolution_y<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(context.system.screen_resolution.1.into())
+    Ok(activation.context.system.screen_resolution.1.into())
 }
 
 pub fn get_pixel_aspect_ratio<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(context.system.aspect_ratio.into())
+    Ok(activation.context.system.aspect_ratio.into())
 }
 
 pub fn get_screen_dpi<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(context.system.dpi.into())
+    Ok(activation.context.system.dpi.into())
 }
 
 pub fn get_manufacturer<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new(
-        context.gc_context,
-        context
+        activation.context.gc_context,
+        activation
+            .context
             .system
             .manufacturer
             .get_manufacturer_string(activation.avm.player_version),
@@ -164,60 +163,60 @@ pub fn get_manufacturer<'gc>(
 }
 
 pub fn get_os_name<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
-    _this: Object<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, context.system.os.to_string()).into())
-}
-
-pub fn get_version<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new(
-        context.gc_context,
-        context.system.get_version_string(activation),
+        activation.context.gc_context,
+        activation.context.system.os.to_string(),
+    )
+    .into())
+}
+
+pub fn get_version<'gc>(
+    activation: &mut Activation<'_, '_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        activation.context.system.get_version_string(activation.avm),
     )
     .into())
 }
 
 pub fn get_server_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(
-        context.gc_context,
-        context.system.get_server_string(activation),
-    )
-    .into())
+    let server_string = activation.context.system.get_server_string(activation.avm);
+    Ok(AvmString::new(activation.context.gc_context, server_string).into())
 }
 
 pub fn get_cpu_architecture<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new(
-        context.gc_context,
-        context.system.cpu_architecture.to_string(),
+        activation.context.gc_context,
+        activation.context.system.cpu_architecture.to_string(),
     )
     .into())
 }
 
 pub fn get_max_idc_level<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, context.system.idc_level.clone()).into())
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        activation.context.system.idc_level.clone(),
+    )
+    .into())
 }
 
 pub fn create<'gc>(

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -108,7 +108,7 @@ pub fn get_language<'gc>(
             .context
             .system
             .language
-            .get_language_code(activation.avm.player_version)
+            .get_language_code(activation.context.avm1.player_version)
             .to_string(),
     )
     .into())
@@ -157,7 +157,7 @@ pub fn get_manufacturer<'gc>(
             .context
             .system
             .manufacturer
-            .get_manufacturer_string(activation.avm.player_version),
+            .get_manufacturer_string(activation.context.avm1.player_version),
     )
     .into())
 }
@@ -181,7 +181,10 @@ pub fn get_version<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new(
         activation.context.gc_context,
-        activation.context.system.get_version_string(activation.avm),
+        activation
+            .context
+            .system
+            .get_version_string(activation.context.avm1),
     )
     .into())
 }
@@ -191,7 +194,10 @@ pub fn get_server_string<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let server_string = activation.context.system.get_server_string(activation.avm);
+    let server_string = activation
+        .context
+        .system
+        .get_server_string(activation.context.avm1);
     Ok(AvmString::new(activation.context.gc_context, server_string).into())
 }
 

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -10,7 +10,7 @@ use gc_arena::MutationContext;
 macro_rules! capabilities_func {
     ($func_name: ident, $capability: expr) => {
         pub fn $func_name<'gc>(
-            activation: &mut Activation<'_, '_, 'gc, '_>,
+            activation: &mut Activation<'_, 'gc, '_>,
             _this: Object<'gc>,
             _args: &[Value<'gc>],
         ) -> Result<Value<'gc>, Error<'gc>> {
@@ -22,7 +22,7 @@ macro_rules! capabilities_func {
 macro_rules! inverse_capabilities_func {
     ($func_name: ident, $capability: expr) => {
         pub fn $func_name<'gc>(
-            activation: &mut Activation<'_, '_, 'gc, '_>,
+            activation: &mut Activation<'_, 'gc, '_>,
             _this: Object<'gc>,
             _args: &[Value<'gc>],
         ) -> Result<Value<'gc>, Error<'gc>> {
@@ -74,7 +74,7 @@ inverse_capabilities_func!(get_is_av_hardware_disabled, SystemCapabilities::AvHa
 inverse_capabilities_func!(get_is_windowless_disabled, SystemCapabilities::WindowLess);
 
 pub fn get_player_type<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -86,7 +86,7 @@ pub fn get_player_type<'gc>(
 }
 
 pub fn get_screen_color<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -98,7 +98,7 @@ pub fn get_screen_color<'gc>(
 }
 
 pub fn get_language<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -115,7 +115,7 @@ pub fn get_language<'gc>(
 }
 
 pub fn get_screen_resolution_x<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -123,7 +123,7 @@ pub fn get_screen_resolution_x<'gc>(
 }
 
 pub fn get_screen_resolution_y<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -131,7 +131,7 @@ pub fn get_screen_resolution_y<'gc>(
 }
 
 pub fn get_pixel_aspect_ratio<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -139,7 +139,7 @@ pub fn get_pixel_aspect_ratio<'gc>(
 }
 
 pub fn get_screen_dpi<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -147,7 +147,7 @@ pub fn get_screen_dpi<'gc>(
 }
 
 pub fn get_manufacturer<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -163,7 +163,7 @@ pub fn get_manufacturer<'gc>(
 }
 
 pub fn get_os_name<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -175,7 +175,7 @@ pub fn get_os_name<'gc>(
 }
 
 pub fn get_version<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -190,7 +190,7 @@ pub fn get_version<'gc>(
 }
 
 pub fn get_server_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -202,7 +202,7 @@ pub fn get_server_string<'gc>(
 }
 
 pub fn get_cpu_architecture<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -214,7 +214,7 @@ pub fn get_cpu_architecture<'gc>(
 }
 
 pub fn get_max_idc_level<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -5,13 +5,11 @@ use crate::avm1::object::Object;
 use crate::avm1::property::Attribute;
 use crate::avm1::property::Attribute::{DontDelete, DontEnum, ReadOnly};
 use crate::avm1::{ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 use std::convert::Into;
 
 fn on_ime_composition<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -19,8 +17,7 @@ fn on_ime_composition<'gc>(
 }
 
 fn do_conversion<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -28,8 +25,7 @@ fn do_conversion<'gc>(
 }
 
 fn get_conversion_mode<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -37,8 +33,7 @@ fn get_conversion_mode<'gc>(
 }
 
 fn get_enabled<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -46,8 +41,7 @@ fn get_enabled<'gc>(
 }
 
 fn set_composition_string<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -55,8 +49,7 @@ fn set_composition_string<'gc>(
 }
 
 fn set_conversion_mode<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -64,8 +57,7 @@ fn set_conversion_mode<'gc>(
 }
 
 fn set_enabled<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -9,7 +9,7 @@ use gc_arena::MutationContext;
 use std::convert::Into;
 
 fn on_ime_composition<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -17,7 +17,7 @@ fn on_ime_composition<'gc>(
 }
 
 fn do_conversion<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -25,7 +25,7 @@ fn do_conversion<'gc>(
 }
 
 fn get_conversion_mode<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -33,7 +33,7 @@ fn get_conversion_mode<'gc>(
 }
 
 fn get_enabled<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -41,7 +41,7 @@ fn get_enabled<'gc>(
 }
 
 fn set_composition_string<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -49,7 +49,7 @@ fn set_composition_string<'gc>(
 }
 
 fn set_conversion_mode<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -57,7 +57,7 @@ fn set_conversion_mode<'gc>(
 }
 
 fn set_enabled<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -9,7 +9,7 @@ use gc_arena::MutationContext;
 use std::convert::Into;
 
 fn allow_domain<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -18,7 +18,7 @@ fn allow_domain<'gc>(
 }
 
 fn allow_insecure_domain<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -30,7 +30,7 @@ fn allow_insecure_domain<'gc>(
 }
 
 fn load_policy_file<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -42,7 +42,7 @@ fn load_policy_file<'gc>(
 }
 
 fn escape_domain<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -51,7 +51,7 @@ fn escape_domain<'gc>(
 }
 
 fn get_sandbox_type<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -63,7 +63,7 @@ fn get_sandbox_type<'gc>(
 }
 
 fn get_choose_local_swf_path<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -75,7 +75,7 @@ fn get_choose_local_swf_path<'gc>(
 }
 
 fn policy_file_resolver<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -4,14 +4,12 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::Object;
 use crate::avm1::{AvmString, ScriptObject, TObject, Value};
 use crate::avm_warn;
-use crate::context::UpdateContext;
 use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::convert::Into;
 
 fn allow_domain<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -20,8 +18,7 @@ fn allow_domain<'gc>(
 }
 
 fn allow_insecure_domain<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -33,8 +30,7 @@ fn allow_insecure_domain<'gc>(
 }
 
 fn load_policy_file<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -46,8 +42,7 @@ fn load_policy_file<'gc>(
 }
 
 fn escape_domain<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -56,17 +51,19 @@ fn escape_domain<'gc>(
 }
 
 fn get_sandbox_type<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, context.system.sandbox_type.to_string()).into())
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        activation.context.system.sandbox_type.to_string(),
+    )
+    .into())
 }
 
 fn get_choose_local_swf_path<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -78,8 +75,7 @@ fn get_choose_local_swf_path<'gc>(
 }
 
 fn policy_file_resolver<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::display_object;
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::avm_error;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::html::TextFormat;
@@ -11,8 +11,7 @@ use gc_arena::MutationContext;
 
 /// Implements `TextField`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -20,22 +19,20 @@ pub fn constructor<'gc>(
 }
 
 pub fn get_text<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(display_object) = this.as_display_object() {
         if let Some(text_field) = display_object.as_edit_text() {
-            return Ok(AvmString::new(context.gc_context, text_field.text()).into());
+            return Ok(AvmString::new(activation.context.gc_context, text_field.text()).into());
         }
     }
     Ok(Value::Undefined)
 }
 
 pub fn set_text<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -43,12 +40,12 @@ pub fn set_text<'gc>(
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
                 if let Err(err) = text_field.set_text(
-                    value.coerce_to_string(activation, context)?.to_string(),
-                    context,
+                    value.coerce_to_string(activation)?.to_string(),
+                    activation.context,
                 ) {
                     avm_error!(activation, "Error when setting TextField.text: {}", err);
                 }
-                text_field.propagate_text_binding(activation, context);
+                text_field.propagate_text_binding(activation);
             }
         }
     }
@@ -56,8 +53,7 @@ pub fn set_text<'gc>(
 }
 
 pub fn get_html<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -70,15 +66,17 @@ pub fn get_html<'gc>(
 }
 
 pub fn set_html<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(display_object) = this.as_display_object() {
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
-                text_field.set_is_html(context, value.as_bool(activation.current_swf_version()));
+                text_field.set_is_html(
+                    activation.context,
+                    value.as_bool(activation.current_swf_version()),
+                );
             }
         }
     }
@@ -86,15 +84,14 @@ pub fn set_html<'gc>(
 }
 
 pub fn get_html_text<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(display_object) = this.as_display_object() {
         if let Some(text_field) = display_object.as_edit_text() {
-            if let Ok(text) = text_field.html_text(context) {
-                return Ok(AvmString::new(context.gc_context, text).into());
+            if let Ok(text) = text_field.html_text(activation.context) {
+                return Ok(AvmString::new(activation.context.gc_context, text).into());
             }
         }
     }
@@ -102,8 +99,7 @@ pub fn get_html_text<'gc>(
 }
 
 pub fn set_html_text<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -112,8 +108,8 @@ pub fn set_html_text<'gc>(
             let text = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
-                .coerce_to_string(activation, context)?;
-            let _ = text_field.set_html_text(text.to_string(), context);
+                .coerce_to_string(activation)?;
+            let _ = text_field.set_html_text(text.to_string(), activation.context);
             // Changing the htmlText does NOT update variable bindings (does not call EditText::propagate_text_binding).
         }
     }
@@ -121,8 +117,7 @@ pub fn set_html_text<'gc>(
 }
 
 pub fn get_border<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -136,8 +131,7 @@ pub fn get_border<'gc>(
 }
 
 pub fn set_border<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -145,7 +139,7 @@ pub fn set_border<'gc>(
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
                 let has_border = value.as_bool(activation.current_swf_version());
-                text_field.set_has_border(context.gc_context, has_border);
+                text_field.set_has_border(activation.context.gc_context, has_border);
             }
         }
     }
@@ -153,8 +147,7 @@ pub fn set_border<'gc>(
 }
 
 pub fn get_embed_fonts<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -168,8 +161,7 @@ pub fn get_embed_fonts<'gc>(
 }
 
 pub fn set_embed_fonts<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -177,7 +169,7 @@ pub fn set_embed_fonts<'gc>(
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
                 let embed_fonts = value.as_bool(activation.current_swf_version());
-                text_field.set_is_device_font(context, !embed_fonts);
+                text_field.set_is_device_font(activation.context, !embed_fonts);
             }
         }
     }
@@ -185,8 +177,7 @@ pub fn set_embed_fonts<'gc>(
 }
 
 pub fn get_length<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -203,10 +194,10 @@ macro_rules! with_text_field {
         $(
             $object.force_set_function(
                 $name,
-                |activation, context: &mut UpdateContext<'_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
+                |activation: &mut Activation<'_, '_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
                     if let Some(display_object) = this.as_display_object() {
                         if let Some(text_field) = display_object.as_edit_text() {
-                            return $fn(text_field, activation, context, args);
+                            return $fn(text_field, activation, args);
                         }
                     }
                     Ok(Value::Undefined)
@@ -220,8 +211,7 @@ macro_rules! with_text_field {
 }
 
 pub fn text_width<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -229,7 +219,7 @@ pub fn text_width<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        let metrics = etext.measure_text(context);
+        let metrics = etext.measure_text(activation.context);
 
         return Ok(metrics.0.to_pixels().into());
     }
@@ -238,8 +228,7 @@ pub fn text_width<'gc>(
 }
 
 pub fn text_height<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -247,7 +236,7 @@ pub fn text_height<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        let metrics = etext.measure_text(context);
+        let metrics = etext.measure_text(activation.context);
 
         return Ok(metrics.1.to_pixels().into());
     }
@@ -256,8 +245,7 @@ pub fn text_height<'gc>(
 }
 
 pub fn multiline<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -272,8 +260,7 @@ pub fn multiline<'gc>(
 }
 
 pub fn set_multiline<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -287,15 +274,14 @@ pub fn set_multiline<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        etext.set_multiline(is_multiline, context);
+        etext.set_multiline(is_multiline, activation.context);
     }
 
     Ok(Value::Undefined)
 }
 
 fn variable<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -304,7 +290,7 @@ fn variable<'gc>(
         .and_then(|dobj| dobj.as_edit_text())
     {
         if let Some(variable) = etext.variable() {
-            return Ok(AvmString::new(context.gc_context, variable.to_string()).into());
+            return Ok(AvmString::new(activation.context.gc_context, variable.to_string()).into());
         }
     }
 
@@ -313,29 +299,27 @@ fn variable<'gc>(
 }
 
 fn set_variable<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let variable = match args.get(0) {
         None | Some(Value::Undefined) | Some(Value::Null) => None,
-        Some(v) => Some(v.coerce_to_string(activation, context)?),
+        Some(v) => Some(v.coerce_to_string(activation)?),
     };
 
     if let Some(etext) = this
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        etext.set_variable(variable.map(|v| v.to_string()), activation, context);
+        etext.set_variable(variable.map(|v| v.to_string()), activation);
     }
 
     Ok(Value::Undefined)
 }
 
 pub fn word_wrap<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -350,8 +334,7 @@ pub fn word_wrap<'gc>(
 }
 
 pub fn set_word_wrap<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -365,15 +348,14 @@ pub fn set_word_wrap<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        etext.set_word_wrap(is_word_wrap, context);
+        etext.set_word_wrap(is_word_wrap, activation.context);
     }
 
     Ok(Value::Undefined)
 }
 
 pub fn auto_size<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -393,8 +375,7 @@ pub fn auto_size<'gc>(
 }
 
 pub fn set_auto_size<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -410,7 +391,7 @@ pub fn set_auto_size<'gc>(
                 Value::Bool(true) => AutoSizeMode::Left,
                 _ => AutoSizeMode::None,
             },
-            context,
+            activation.context,
         );
     }
 
@@ -638,26 +619,24 @@ pub fn attach_virtual_properties<'gc>(
 
 fn get_new_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let tf = text_field.new_text_format();
 
-    Ok(tf.as_avm1_object(activation, context)?.into())
+    Ok(tf.as_avm1_object(activation)?.into())
 }
 
 fn set_new_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let tf = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(tf) = tf {
-        let tf_parsed = TextFormat::from_avm1_object(tf, activation, context)?;
-        text_field.set_new_text_format(tf_parsed, context);
+        let tf_parsed = TextFormat::from_avm1_object(tf, activation)?;
+        text_field.set_new_text_format(tf_parsed, activation.context);
     }
 
     Ok(Value::Undefined)
@@ -665,17 +644,16 @@ fn set_new_text_format<'gc>(
 
 fn get_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let (from, to) = match (args.get(0), args.get(1)) {
         (Some(f), Some(t)) => (
-            f.coerce_to_f64(activation, context)? as usize,
-            t.coerce_to_f64(activation, context)? as usize,
+            f.coerce_to_f64(activation)? as usize,
+            t.coerce_to_f64(activation)? as usize,
         ),
         (Some(f), None) => {
-            let v = f.coerce_to_f64(activation, context)? as usize;
+            let v = f.coerce_to_f64(activation)? as usize;
             (v, v.saturating_add(1))
         }
         _ => (0, text_field.text_length()),
@@ -683,34 +661,33 @@ fn get_text_format<'gc>(
 
     Ok(text_field
         .text_format(from, to)
-        .as_avm1_object(activation, context)?
+        .as_avm1_object(activation)?
         .into())
 }
 
 fn set_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let tf = args.last().cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(tf) = tf {
-        let tf_parsed = TextFormat::from_avm1_object(tf, activation, context)?;
+        let tf_parsed = TextFormat::from_avm1_object(tf, activation)?;
 
         let (from, to) = match (args.get(0), args.get(1)) {
             (Some(f), Some(t)) if args.len() > 2 => (
-                f.coerce_to_f64(activation, context)? as usize,
-                t.coerce_to_f64(activation, context)? as usize,
+                f.coerce_to_f64(activation)? as usize,
+                t.coerce_to_f64(activation)? as usize,
             ),
             (Some(f), _) if args.len() > 1 => {
-                let v = f.coerce_to_f64(activation, context)? as usize;
+                let v = f.coerce_to_f64(activation)? as usize;
                 (v, v.saturating_add(1))
             }
             _ => (0, text_field.text_length()),
         };
 
-        text_field.set_text_format(from, to, tf_parsed, context);
+        text_field.set_text_format(from, to, tf_parsed, activation.context);
     }
 
     Ok(Value::Undefined)
@@ -718,28 +695,27 @@ fn set_text_format<'gc>(
 
 fn replace_text<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let from = args
         .get(0)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let to = args
         .get(1)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .coerce_to_f64(activation, context)?;
+        .coerce_to_f64(activation)?;
     let text = args
         .get(2)
         .cloned()
         .unwrap_or(Value::Undefined)
-        .coerce_to_string(activation, context)?
+        .coerce_to_string(activation)?
         .to_string();
 
-    text_field.replace_text(from as usize, to as usize, &text, context);
+    text_field.replace_text(from as usize, to as usize, &text, activation.context);
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -11,7 +11,7 @@ use gc_arena::MutationContext;
 
 /// Implements `TextField`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -19,7 +19,7 @@ pub fn constructor<'gc>(
 }
 
 pub fn get_text<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -32,7 +32,7 @@ pub fn get_text<'gc>(
 }
 
 pub fn set_text<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -41,7 +41,7 @@ pub fn set_text<'gc>(
             if let Some(value) = args.get(0) {
                 if let Err(err) = text_field.set_text(
                     value.coerce_to_string(activation)?.to_string(),
-                    activation.context,
+                    &mut activation.context,
                 ) {
                     avm_error!(activation, "Error when setting TextField.text: {}", err);
                 }
@@ -53,7 +53,7 @@ pub fn set_text<'gc>(
 }
 
 pub fn get_html<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -66,7 +66,7 @@ pub fn get_html<'gc>(
 }
 
 pub fn set_html<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -74,7 +74,7 @@ pub fn set_html<'gc>(
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
                 text_field.set_is_html(
-                    activation.context,
+                    &mut activation.context,
                     value.as_bool(activation.current_swf_version()),
                 );
             }
@@ -84,13 +84,13 @@ pub fn set_html<'gc>(
 }
 
 pub fn get_html_text<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(display_object) = this.as_display_object() {
         if let Some(text_field) = display_object.as_edit_text() {
-            if let Ok(text) = text_field.html_text(activation.context) {
+            if let Ok(text) = text_field.html_text(&mut activation.context) {
                 return Ok(AvmString::new(activation.context.gc_context, text).into());
             }
         }
@@ -99,7 +99,7 @@ pub fn get_html_text<'gc>(
 }
 
 pub fn set_html_text<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -109,7 +109,7 @@ pub fn set_html_text<'gc>(
                 .get(0)
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_string(activation)?;
-            let _ = text_field.set_html_text(text.to_string(), activation.context);
+            let _ = text_field.set_html_text(text.to_string(), &mut activation.context);
             // Changing the htmlText does NOT update variable bindings (does not call EditText::propagate_text_binding).
         }
     }
@@ -117,7 +117,7 @@ pub fn set_html_text<'gc>(
 }
 
 pub fn get_border<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -131,7 +131,7 @@ pub fn get_border<'gc>(
 }
 
 pub fn set_border<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -147,7 +147,7 @@ pub fn set_border<'gc>(
 }
 
 pub fn get_embed_fonts<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -161,7 +161,7 @@ pub fn get_embed_fonts<'gc>(
 }
 
 pub fn set_embed_fonts<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -169,7 +169,7 @@ pub fn set_embed_fonts<'gc>(
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
                 let embed_fonts = value.as_bool(activation.current_swf_version());
-                text_field.set_is_device_font(activation.context, !embed_fonts);
+                text_field.set_is_device_font(&mut activation.context, !embed_fonts);
             }
         }
     }
@@ -177,7 +177,7 @@ pub fn set_embed_fonts<'gc>(
 }
 
 pub fn get_length<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -194,7 +194,7 @@ macro_rules! with_text_field {
         $(
             $object.force_set_function(
                 $name,
-                |activation: &mut Activation<'_, '_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
+                |activation: &mut Activation<'_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
                     if let Some(display_object) = this.as_display_object() {
                         if let Some(text_field) = display_object.as_edit_text() {
                             return $fn(text_field, activation, args);
@@ -211,7 +211,7 @@ macro_rules! with_text_field {
 }
 
 pub fn text_width<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -219,7 +219,7 @@ pub fn text_width<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        let metrics = etext.measure_text(activation.context);
+        let metrics = etext.measure_text(&mut activation.context);
 
         return Ok(metrics.0.to_pixels().into());
     }
@@ -228,7 +228,7 @@ pub fn text_width<'gc>(
 }
 
 pub fn text_height<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -236,7 +236,7 @@ pub fn text_height<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        let metrics = etext.measure_text(activation.context);
+        let metrics = etext.measure_text(&mut activation.context);
 
         return Ok(metrics.1.to_pixels().into());
     }
@@ -245,7 +245,7 @@ pub fn text_height<'gc>(
 }
 
 pub fn multiline<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -260,7 +260,7 @@ pub fn multiline<'gc>(
 }
 
 pub fn set_multiline<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -274,14 +274,14 @@ pub fn set_multiline<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        etext.set_multiline(is_multiline, activation.context);
+        etext.set_multiline(is_multiline, &mut activation.context);
     }
 
     Ok(Value::Undefined)
 }
 
 fn variable<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -299,7 +299,7 @@ fn variable<'gc>(
 }
 
 fn set_variable<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -319,7 +319,7 @@ fn set_variable<'gc>(
 }
 
 pub fn word_wrap<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -334,7 +334,7 @@ pub fn word_wrap<'gc>(
 }
 
 pub fn set_word_wrap<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -348,14 +348,14 @@ pub fn set_word_wrap<'gc>(
         .as_display_object()
         .and_then(|dobj| dobj.as_edit_text())
     {
-        etext.set_word_wrap(is_word_wrap, activation.context);
+        etext.set_word_wrap(is_word_wrap, &mut activation.context);
     }
 
     Ok(Value::Undefined)
 }
 
 pub fn auto_size<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -375,7 +375,7 @@ pub fn auto_size<'gc>(
 }
 
 pub fn set_auto_size<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -391,7 +391,7 @@ pub fn set_auto_size<'gc>(
                 Value::Bool(true) => AutoSizeMode::Left,
                 _ => AutoSizeMode::None,
             },
-            activation.context,
+            &mut activation.context,
         );
     }
 
@@ -619,7 +619,7 @@ pub fn attach_virtual_properties<'gc>(
 
 fn get_new_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let tf = text_field.new_text_format();
@@ -629,14 +629,14 @@ fn get_new_text_format<'gc>(
 
 fn set_new_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let tf = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(tf) = tf {
         let tf_parsed = TextFormat::from_avm1_object(tf, activation)?;
-        text_field.set_new_text_format(tf_parsed, activation.context);
+        text_field.set_new_text_format(tf_parsed, &mut activation.context);
     }
 
     Ok(Value::Undefined)
@@ -644,7 +644,7 @@ fn set_new_text_format<'gc>(
 
 fn get_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let (from, to) = match (args.get(0), args.get(1)) {
@@ -667,7 +667,7 @@ fn get_text_format<'gc>(
 
 fn set_text_format<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let tf = args.last().cloned().unwrap_or(Value::Undefined);
@@ -687,7 +687,7 @@ fn set_text_format<'gc>(
             _ => (0, text_field.text_length()),
         };
 
-        text_field.set_text_format(from, to, tf_parsed, activation.context);
+        text_field.set_text_format(from, to, tf_parsed, &mut activation.context);
     }
 
     Ok(Value::Undefined)
@@ -695,7 +695,7 @@ fn set_text_format<'gc>(
 
 fn replace_text<'gc>(
     text_field: EditText<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let from = args
@@ -715,7 +715,7 @@ fn replace_text<'gc>(
         .coerce_to_string(activation)?
         .to_string();
 
-    text_field.replace_text(from as usize, to as usize, &text, activation.context);
+    text_field.replace_text(from as usize, to as usize, &text, &mut activation.context);
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -73,10 +73,8 @@ pub fn set_html<'gc>(
     if let Some(display_object) = this.as_display_object() {
         if let Some(text_field) = display_object.as_edit_text() {
             if let Some(value) = args.get(0) {
-                text_field.set_is_html(
-                    &mut activation.context,
-                    value.as_bool(activation.current_swf_version()),
-                );
+                let current_swf_version = activation.current_swf_version();
+                text_field.set_is_html(&mut activation.context, value.as_bool(current_swf_version));
             }
         }
     }

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -2,14 +2,13 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::{AvmString, Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
 
 fn map_defined_to_string<'gc>(
     name: &str,
     this: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     val: Option<Value<'gc>>,
 ) -> Result<(), Error<'gc>> {
     let val = match val {
@@ -17,13 +16,13 @@ fn map_defined_to_string<'gc>(
         Some(Value::Null) => Value::Null,
         None => Value::Null,
         Some(v) => AvmString::new(
-            ac.gc_context,
-            v.coerce_to_string(activation, ac)?.to_string(),
+            activation.context.gc_context,
+            v.coerce_to_string(activation)?.to_string(),
         )
         .into(),
     };
 
-    this.set(name, val, activation, ac)?;
+    this.set(name, val, activation)?;
 
     Ok(())
 }
@@ -31,18 +30,17 @@ fn map_defined_to_string<'gc>(
 fn map_defined_to_number<'gc>(
     name: &str,
     this: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     val: Option<Value<'gc>>,
 ) -> Result<(), Error<'gc>> {
     let val = match val {
         Some(Value::Undefined) => Value::Null,
         Some(Value::Null) => Value::Null,
         None => Value::Null,
-        Some(v) => v.coerce_to_f64(activation, ac)?.into(),
+        Some(v) => v.coerce_to_f64(activation)?.into(),
     };
 
-    this.set(name, val, activation, ac)?;
+    this.set(name, val, activation)?;
 
     Ok(())
 }
@@ -50,8 +48,7 @@ fn map_defined_to_number<'gc>(
 fn map_defined_to_bool<'gc>(
     name: &str,
     this: Object<'gc>,
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     val: Option<Value<'gc>>,
 ) -> Result<(), Error<'gc>> {
     let val = match val {
@@ -61,31 +58,30 @@ fn map_defined_to_bool<'gc>(
         Some(v) => v.as_bool(activation.current_swf_version()).into(),
     };
 
-    this.set(name, val, activation, ac)?;
+    this.set(name, val, activation)?;
 
     Ok(())
 }
 
 /// `TextFormat` constructor
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    map_defined_to_string("font", this, activation, ac, args.get(0).cloned())?;
-    map_defined_to_number("size", this, activation, ac, args.get(1).cloned())?;
-    map_defined_to_number("color", this, activation, ac, args.get(2).cloned())?;
-    map_defined_to_bool("bold", this, activation, ac, args.get(3).cloned())?;
-    map_defined_to_bool("italic", this, activation, ac, args.get(4).cloned())?;
-    map_defined_to_bool("underline", this, activation, ac, args.get(5).cloned())?;
-    map_defined_to_string("url", this, activation, ac, args.get(6).cloned())?;
-    map_defined_to_string("target", this, activation, ac, args.get(7).cloned())?;
-    map_defined_to_string("align", this, activation, ac, args.get(8).cloned())?;
-    map_defined_to_number("leftMargin", this, activation, ac, args.get(9).cloned())?;
-    map_defined_to_number("rightMargin", this, activation, ac, args.get(10).cloned())?;
-    map_defined_to_number("indent", this, activation, ac, args.get(11).cloned())?;
-    map_defined_to_number("leading", this, activation, ac, args.get(12).cloned())?;
+    map_defined_to_string("font", this, activation, args.get(0).cloned())?;
+    map_defined_to_number("size", this, activation, args.get(1).cloned())?;
+    map_defined_to_number("color", this, activation, args.get(2).cloned())?;
+    map_defined_to_bool("bold", this, activation, args.get(3).cloned())?;
+    map_defined_to_bool("italic", this, activation, args.get(4).cloned())?;
+    map_defined_to_bool("underline", this, activation, args.get(5).cloned())?;
+    map_defined_to_string("url", this, activation, args.get(6).cloned())?;
+    map_defined_to_string("target", this, activation, args.get(7).cloned())?;
+    map_defined_to_string("align", this, activation, args.get(8).cloned())?;
+    map_defined_to_number("leftMargin", this, activation, args.get(9).cloned())?;
+    map_defined_to_number("rightMargin", this, activation, args.get(10).cloned())?;
+    map_defined_to_number("indent", this, activation, args.get(11).cloned())?;
+    map_defined_to_number("leading", this, activation, args.get(12).cloned())?;
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -8,7 +8,7 @@ use gc_arena::MutationContext;
 fn map_defined_to_string<'gc>(
     name: &str,
     this: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     val: Option<Value<'gc>>,
 ) -> Result<(), Error<'gc>> {
     let val = match val {
@@ -30,7 +30,7 @@ fn map_defined_to_string<'gc>(
 fn map_defined_to_number<'gc>(
     name: &str,
     this: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     val: Option<Value<'gc>>,
 ) -> Result<(), Error<'gc>> {
     let val = match val {
@@ -48,7 +48,7 @@ fn map_defined_to_number<'gc>(
 fn map_defined_to_bool<'gc>(
     name: &str,
     this: Object<'gc>,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     val: Option<Value<'gc>>,
 ) -> Result<(), Error<'gc>> {
     let val = match val {
@@ -65,7 +65,7 @@ fn map_defined_to_bool<'gc>(
 
 /// `TextFormat` constructor
 pub fn constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -145,7 +145,7 @@ pub fn xmlnode_clone_node<'gc>(
 
         return Ok(Value::Object(clone_node.script_object(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.xml_node),
+            Some(activation.context.avm1.prototypes.xml_node),
         )));
     }
 
@@ -322,7 +322,7 @@ pub fn xmlnode_child_nodes<'gc>(
     if let Some(node) = this.as_xml_node() {
         let array = ScriptObject::array(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.array),
+            Some(activation.context.avm1.prototypes.array),
         );
         if let Some(children) = node.children() {
             let mut compatible_nodes = 0;
@@ -336,7 +336,7 @@ pub fn xmlnode_child_nodes<'gc>(
                     child
                         .script_object(
                             activation.context.gc_context,
-                            Some(activation.avm.prototypes.xml_node),
+                            Some(activation.context.avm1.prototypes.xml_node),
                         )
                         .into(),
                     activation.context.gc_context,
@@ -365,7 +365,7 @@ pub fn xmlnode_first_child<'gc>(
                     child
                         .script_object(
                             activation.context.gc_context,
-                            Some(activation.avm.prototypes.xml_node),
+                            Some(activation.context.avm1.prototypes.xml_node),
                         )
                         .into()
                 })
@@ -389,7 +389,7 @@ pub fn xmlnode_last_child<'gc>(
                     child
                         .script_object(
                             activation.context.gc_context,
-                            Some(activation.avm.prototypes.xml_node),
+                            Some(activation.context.avm1.prototypes.xml_node),
                         )
                         .into()
                 })
@@ -413,7 +413,7 @@ pub fn xmlnode_parent_node<'gc>(
                 parent
                     .script_object(
                         activation.context.gc_context,
-                        Some(activation.avm.prototypes.xml_node),
+                        Some(activation.context.avm1.prototypes.xml_node),
                     )
                     .into()
             })
@@ -442,7 +442,7 @@ pub fn xmlnode_previous_sibling<'gc>(
             .map(|mut prev| {
                 prev.script_object(
                     activation.context.gc_context,
-                    Some(activation.avm.prototypes.xml_node),
+                    Some(activation.context.avm1.prototypes.xml_node),
                 )
                 .into()
             })
@@ -471,7 +471,7 @@ pub fn xmlnode_next_sibling<'gc>(
             .map(|mut next| {
                 next.script_object(
                     activation.context.gc_context,
-                    Some(activation.avm.prototypes.xml_node),
+                    Some(activation.context.avm1.prototypes.xml_node),
                 )
                 .into()
             })
@@ -822,7 +822,7 @@ pub fn xml_create_element<'gc>(
     let object = XMLObject::from_xml_node(
         activation.context.gc_context,
         xml_node,
-        Some(activation.avm.prototypes().xml_node),
+        Some(activation.context.avm1.prototypes().xml_node),
     );
 
     xml_node.introduce_script_object(activation.context.gc_context, object);
@@ -849,7 +849,7 @@ pub fn xml_create_text_node<'gc>(
     let object = XMLObject::from_xml_node(
         activation.context.gc_context,
         xml_node,
-        Some(activation.avm.prototypes().xml_node),
+        Some(activation.context.avm1.prototypes().xml_node),
     );
 
     xml_node.introduce_script_object(activation.context.gc_context, object);

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -6,7 +6,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::script_object::ScriptObject;
 use crate::avm1::object::xml_object::XMLObject;
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{AvmString, Object, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::RequestOptions;
 use crate::xml;
@@ -42,28 +42,29 @@ fn is_as2_compatible(node: XMLNode<'_>) -> bool {
 
 /// XMLNode constructor
 pub fn xmlnode_constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let blank_document = XMLDocument::new(ac.gc_context);
+    let blank_document = XMLDocument::new(activation.context.gc_context);
 
     match (
         args.get(0)
-            .map(|v| v.coerce_to_f64(activation, ac).map(|v| v as u32)),
-        args.get(1).map(|v| v.coerce_to_string(activation, ac)),
+            .map(|v| v.coerce_to_f64(activation).map(|v| v as u32)),
+        args.get(1).map(|v| v.coerce_to_string(activation)),
         this.as_xml_node(),
     ) {
         (Some(Ok(1)), Some(Ok(ref strval)), Some(ref mut this_node)) => {
-            let mut xmlelement = XMLNode::new_element(ac.gc_context, strval, blank_document);
-            xmlelement.introduce_script_object(ac.gc_context, this);
-            this_node.swap(ac.gc_context, xmlelement);
+            let mut xmlelement =
+                XMLNode::new_element(activation.context.gc_context, strval, blank_document);
+            xmlelement.introduce_script_object(activation.context.gc_context, this);
+            this_node.swap(activation.context.gc_context, xmlelement);
         }
         (Some(Ok(3)), Some(Ok(ref strval)), Some(ref mut this_node)) => {
-            let mut xmlelement = XMLNode::new_text(ac.gc_context, strval, blank_document);
-            xmlelement.introduce_script_object(ac.gc_context, this);
-            this_node.swap(ac.gc_context, xmlelement);
+            let mut xmlelement =
+                XMLNode::new_text(activation.context.gc_context, strval, blank_document);
+            xmlelement.introduce_script_object(activation.context.gc_context, this);
+            this_node.swap(activation.context.gc_context, xmlelement);
         }
         //Invalid nodetype ID, string value missing, or not an XMLElement
         _ => {}
@@ -73,19 +74,20 @@ pub fn xmlnode_constructor<'gc>(
 }
 
 pub fn xmlnode_append_child<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (Some(mut xmlnode), Some(child_xmlnode)) = (
         this.as_xml_node(),
         args.get(0)
-            .and_then(|n| n.coerce_to_object(activation, ac).as_xml_node()),
+            .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             let position = xmlnode.children_len();
-            if let Err(e) = xmlnode.insert_child(ac.gc_context, position, child_xmlnode) {
+            if let Err(e) =
+                xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode)
+            {
                 avm_warn!(
                     activation,
                     "Couldn't insert_child inside of XMLNode.appendChild: {}",
@@ -99,21 +101,22 @@ pub fn xmlnode_append_child<'gc>(
 }
 
 pub fn xmlnode_insert_before<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (Some(mut xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
         this.as_xml_node(),
         args.get(0)
-            .and_then(|n| n.coerce_to_object(activation, ac).as_xml_node()),
+            .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
         args.get(1)
-            .and_then(|n| n.coerce_to_object(activation, ac).as_xml_node()),
+            .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
     ) {
         if let Ok(None) = child_xmlnode.parent() {
             if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {
-                if let Err(e) = xmlnode.insert_child(ac.gc_context, position, child_xmlnode) {
+                if let Err(e) =
+                    xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode)
+                {
                     avm_warn!(
                         activation,
                         "Couldn't insert_child inside of XMLNode.insertBefore: {}",
@@ -128,8 +131,7 @@ pub fn xmlnode_insert_before<'gc>(
 }
 
 pub fn xmlnode_clone_node<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -139,10 +141,10 @@ pub fn xmlnode_clone_node<'gc>(
             .map(|v| v.as_bool(activation.current_swf_version()))
             .unwrap_or(false),
     ) {
-        let mut clone_node = xmlnode.duplicate(ac.gc_context, deep);
+        let mut clone_node = xmlnode.duplicate(activation.context.gc_context, deep);
 
         return Ok(Value::Object(clone_node.script_object(
-            ac.gc_context,
+            activation.context.gc_context,
             Some(activation.avm.prototypes.xml_node),
         )));
     }
@@ -151,17 +153,16 @@ pub fn xmlnode_clone_node<'gc>(
 }
 
 pub fn xmlnode_get_namespace_for_prefix<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (Some(xmlnode), Some(prefix_string)) = (
         this.as_xml_node(),
-        args.get(0).map(|v| v.coerce_to_string(activation, ac)),
+        args.get(0).map(|v| v.coerce_to_string(activation)),
     ) {
         if let Some(uri) = xmlnode.lookup_uri_for_namespace(&prefix_string?) {
-            Ok(AvmString::new(ac.gc_context, uri).into())
+            Ok(AvmString::new(activation.context.gc_context, uri).into())
         } else {
             Ok(Value::Null)
         }
@@ -171,17 +172,16 @@ pub fn xmlnode_get_namespace_for_prefix<'gc>(
 }
 
 pub fn xmlnode_get_prefix_for_namespace<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let (Some(xmlnode), Some(uri_string)) = (
         this.as_xml_node(),
-        args.get(0).map(|v| v.coerce_to_string(activation, ac)),
+        args.get(0).map(|v| v.coerce_to_string(activation)),
     ) {
         if let Some(prefix) = xmlnode.lookup_namespace_for_uri(&uri_string?) {
-            Ok(AvmString::new(ac.gc_context, prefix).into())
+            Ok(AvmString::new(activation.context.gc_context, prefix).into())
         } else {
             Ok(Value::Null)
         }
@@ -191,8 +191,7 @@ pub fn xmlnode_get_prefix_for_namespace<'gc>(
 }
 
 pub fn xmlnode_has_child_nodes<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _ac: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -204,14 +203,13 @@ pub fn xmlnode_has_child_nodes<'gc>(
 }
 
 pub fn xmlnode_remove_node<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
         if let Ok(Some(mut parent)) = node.parent() {
-            if let Err(e) = parent.remove_child(ac.gc_context, node) {
+            if let Err(e) = parent.remove_child(activation.context.gc_context, node) {
                 avm_warn!(activation, "Error in XML.removeNode: {}", e);
             }
         }
@@ -221,8 +219,7 @@ pub fn xmlnode_remove_node<'gc>(
 }
 
 pub fn xmlnode_to_string<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -230,7 +227,7 @@ pub fn xmlnode_to_string<'gc>(
         let result = node.into_string(&mut is_as2_compatible);
 
         return Ok(AvmString::new(
-            ac.gc_context,
+            activation.context.gc_context,
             result.unwrap_or_else(|e| {
                 avm_warn!(activation, "XMLNode toString failed: {}", e);
                 "".to_string()
@@ -243,34 +240,31 @@ pub fn xmlnode_to_string<'gc>(
 }
 
 pub fn xmlnode_local_name<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_xml_node()
         .and_then(|n| n.tag_name())
-        .map(|n| AvmString::new(ac.gc_context, n.local_name().to_string()).into())
+        .map(|n| AvmString::new(activation.context.gc_context, n.local_name().to_string()).into())
         .unwrap_or_else(|| Value::Null))
 }
 
 pub fn xmlnode_node_name<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_xml_node()
         .and_then(|n| n.tag_name())
-        .map(|n| AvmString::new(ac.gc_context, n.node_name().to_string()).into())
+        .map(|n| AvmString::new(activation.context.gc_context, n.node_name().to_string()).into())
         .unwrap_or_else(|| Value::Null))
 }
 
 pub fn xmlnode_node_type<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _ac: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -289,21 +283,19 @@ pub fn xmlnode_node_type<'gc>(
 }
 
 pub fn xmlnode_node_value<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_xml_node()
         .and_then(|n| n.node_value())
-        .map(|n| AvmString::new(ac.gc_context, n).into())
+        .map(|n| AvmString::new(activation.context.gc_context, n).into())
         .unwrap_or_else(|| Value::Null))
 }
 
 pub fn xmlnode_prefix<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -312,7 +304,7 @@ pub fn xmlnode_prefix<'gc>(
         .and_then(|n| n.tag_name())
         .map(|n| {
             AvmString::new(
-                ac.gc_context,
+                activation.context.gc_context,
                 n.prefix()
                     .map(|n| n.to_string())
                     .unwrap_or_else(|| "".to_string()),
@@ -323,13 +315,15 @@ pub fn xmlnode_prefix<'gc>(
 }
 
 pub fn xmlnode_child_nodes<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let array = ScriptObject::array(ac.gc_context, Some(activation.avm.prototypes.array));
+        let array = ScriptObject::array(
+            activation.context.gc_context,
+            Some(activation.avm.prototypes.array),
+        );
         if let Some(children) = node.children() {
             let mut compatible_nodes = 0;
             for mut child in children {
@@ -340,9 +334,12 @@ pub fn xmlnode_child_nodes<'gc>(
                 array.set_array_element(
                     compatible_nodes as usize,
                     child
-                        .script_object(ac.gc_context, Some(activation.avm.prototypes.xml_node))
+                        .script_object(
+                            activation.context.gc_context,
+                            Some(activation.avm.prototypes.xml_node),
+                        )
                         .into(),
-                    ac.gc_context,
+                    activation.context.gc_context,
                 );
 
                 compatible_nodes += 1;
@@ -356,8 +353,7 @@ pub fn xmlnode_child_nodes<'gc>(
 }
 
 pub fn xmlnode_first_child<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -367,7 +363,10 @@ pub fn xmlnode_first_child<'gc>(
                 .next()
                 .map(|mut child| {
                     child
-                        .script_object(ac.gc_context, Some(activation.avm.prototypes.xml_node))
+                        .script_object(
+                            activation.context.gc_context,
+                            Some(activation.avm.prototypes.xml_node),
+                        )
                         .into()
                 })
                 .unwrap_or_else(|| Value::Null));
@@ -378,8 +377,7 @@ pub fn xmlnode_first_child<'gc>(
 }
 
 pub fn xmlnode_last_child<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -389,7 +387,10 @@ pub fn xmlnode_last_child<'gc>(
                 .next_back()
                 .map(|mut child| {
                     child
-                        .script_object(ac.gc_context, Some(activation.avm.prototypes.xml_node))
+                        .script_object(
+                            activation.context.gc_context,
+                            Some(activation.avm.prototypes.xml_node),
+                        )
                         .into()
                 })
                 .unwrap_or_else(|| Value::Null));
@@ -400,8 +401,7 @@ pub fn xmlnode_last_child<'gc>(
 }
 
 pub fn xmlnode_parent_node<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -411,7 +411,10 @@ pub fn xmlnode_parent_node<'gc>(
             .unwrap_or(None)
             .map(|mut parent| {
                 parent
-                    .script_object(ac.gc_context, Some(activation.avm.prototypes.xml_node))
+                    .script_object(
+                        activation.context.gc_context,
+                        Some(activation.avm.prototypes.xml_node),
+                    )
                     .into()
             })
             .unwrap_or_else(|| Value::Null));
@@ -421,8 +424,7 @@ pub fn xmlnode_parent_node<'gc>(
 }
 
 pub fn xmlnode_previous_sibling<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -438,8 +440,11 @@ pub fn xmlnode_previous_sibling<'gc>(
 
         return Ok(prev
             .map(|mut prev| {
-                prev.script_object(ac.gc_context, Some(activation.avm.prototypes.xml_node))
-                    .into()
+                prev.script_object(
+                    activation.context.gc_context,
+                    Some(activation.avm.prototypes.xml_node),
+                )
+                .into()
             })
             .unwrap_or_else(|| Value::Null));
     }
@@ -448,8 +453,7 @@ pub fn xmlnode_previous_sibling<'gc>(
 }
 
 pub fn xmlnode_next_sibling<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -465,8 +469,11 @@ pub fn xmlnode_next_sibling<'gc>(
 
         return Ok(next
             .map(|mut next| {
-                next.script_object(ac.gc_context, Some(activation.avm.prototypes.xml_node))
-                    .into()
+                next.script_object(
+                    activation.context.gc_context,
+                    Some(activation.avm.prototypes.xml_node),
+                )
+                .into()
             })
             .unwrap_or_else(|| Value::Null));
     }
@@ -475,14 +482,13 @@ pub fn xmlnode_next_sibling<'gc>(
 }
 
 pub fn xmlnode_attributes<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mut node) = this.as_xml_node() {
         return Ok(node
-            .attribute_script_object(ac.gc_context)
+            .attribute_script_object(activation.context.gc_context)
             .map(|o| o.into())
             .unwrap_or_else(|| Value::Undefined));
     }
@@ -491,15 +497,14 @@ pub fn xmlnode_attributes<'gc>(
 }
 
 pub fn xmlnode_namespace_uri<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
         if let Some(name) = node.tag_name() {
             return Ok(AvmString::new(
-                ac.gc_context,
+                activation.context.gc_context,
                 node.lookup_uri_for_namespace(name.prefix().unwrap_or(""))
                     .unwrap_or_else(|| "".to_string()),
             )
@@ -762,22 +767,22 @@ pub fn create_xmlnode_proto<'gc>(
 
 /// XML (document) constructor
 pub fn xml_constructor<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match (
-        args.get(0).map(|v| v.coerce_to_string(activation, ac)),
+        args.get(0).map(|v| v.coerce_to_string(activation)),
         this.as_xml_node(),
     ) {
         (Some(Ok(ref string)), Some(ref mut this_node)) => {
-            let xmldoc = XMLDocument::new(ac.gc_context);
+            let xmldoc = XMLDocument::new(activation.context.gc_context);
             let mut xmlnode = xmldoc.as_node();
-            xmlnode.introduce_script_object(ac.gc_context, this);
-            this_node.swap(ac.gc_context, xmlnode);
+            xmlnode.introduce_script_object(activation.context.gc_context, this);
+            this_node.swap(activation.context.gc_context, xmlnode);
 
-            if let Err(e) = this_node.replace_with_str(ac.gc_context, string, true) {
+            if let Err(e) = this_node.replace_with_str(activation.context.gc_context, string, true)
+            {
                 avm_warn!(
                     activation,
                     "Couldn't replace_with_str inside of XML constructor: {}",
@@ -786,10 +791,10 @@ pub fn xml_constructor<'gc>(
             }
         }
         (None, Some(ref mut this_node)) => {
-            let xmldoc = XMLDocument::new(ac.gc_context);
+            let xmldoc = XMLDocument::new(activation.context.gc_context);
             let mut xmlnode = xmldoc.as_node();
-            xmlnode.introduce_script_object(ac.gc_context, this);
-            this_node.swap(ac.gc_context, xmlnode);
+            xmlnode.introduce_script_object(activation.context.gc_context, this);
+            this_node.swap(activation.context.gc_context, xmlnode);
         }
         //Non-string argument or not an XML document
         _ => {}
@@ -799,70 +804,67 @@ pub fn xml_constructor<'gc>(
 }
 
 pub fn xml_create_element<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let document = if let Some(node) = this.as_xml_node() {
         node.document()
     } else {
-        XMLDocument::new(ac.gc_context)
+        XMLDocument::new(activation.context.gc_context)
     };
 
     let nodename = args
         .get(0)
-        .map(|v| v.coerce_to_string(activation, ac).unwrap_or_default())
+        .map(|v| v.coerce_to_string(activation).unwrap_or_default())
         .unwrap_or_default();
-    let mut xml_node = XMLNode::new_element(ac.gc_context, &nodename, document);
+    let mut xml_node = XMLNode::new_element(activation.context.gc_context, &nodename, document);
     let object = XMLObject::from_xml_node(
-        ac.gc_context,
+        activation.context.gc_context,
         xml_node,
         Some(activation.avm.prototypes().xml_node),
     );
 
-    xml_node.introduce_script_object(ac.gc_context, object);
+    xml_node.introduce_script_object(activation.context.gc_context, object);
 
     Ok(object.into())
 }
 
 pub fn xml_create_text_node<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let document = if let Some(node) = this.as_xml_node() {
         node.document()
     } else {
-        XMLDocument::new(ac.gc_context)
+        XMLDocument::new(activation.context.gc_context)
     };
 
     let text_node = args
         .get(0)
-        .map(|v| v.coerce_to_string(activation, ac).unwrap_or_default())
+        .map(|v| v.coerce_to_string(activation).unwrap_or_default())
         .unwrap_or_default();
-    let mut xml_node = XMLNode::new_text(ac.gc_context, &text_node, document);
+    let mut xml_node = XMLNode::new_text(activation.context.gc_context, &text_node, document);
     let object = XMLObject::from_xml_node(
-        ac.gc_context,
+        activation.context.gc_context,
         xml_node,
         Some(activation.avm.prototypes().xml_node),
     );
 
-    xml_node.introduce_script_object(ac.gc_context, object);
+    xml_node.introduce_script_object(activation.context.gc_context, object);
 
     Ok(object.into())
 }
 
 pub fn xml_parse_xml<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mut node) = this.as_xml_node() {
         let xmlstring =
-            if let Some(Ok(xmlstring)) = args.get(0).map(|s| s.coerce_to_string(activation, ac)) {
+            if let Some(Ok(xmlstring)) = args.get(0).map(|s| s.coerce_to_string(activation)) {
                 xmlstring
             } else {
                 "".into()
@@ -870,7 +872,7 @@ pub fn xml_parse_xml<'gc>(
 
         if let Some(children) = node.children() {
             for child in children.rev() {
-                let result = node.remove_child(ac.gc_context, child);
+                let result = node.remove_child(activation.context.gc_context, child);
                 if let Err(e) = result {
                     avm_warn!(
                         activation,
@@ -882,7 +884,7 @@ pub fn xml_parse_xml<'gc>(
             }
         }
 
-        let result = node.replace_with_str(ac.gc_context, &xmlstring, true);
+        let result = node.replace_with_str(activation.context.gc_context, &xmlstring, true);
         if let Err(e) = result {
             avm_warn!(activation, "XML parsing error: {}", e);
         }
@@ -892,8 +894,7 @@ pub fn xml_parse_xml<'gc>(
 }
 
 pub fn xml_load<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -904,20 +905,23 @@ pub fn xml_load<'gc>(
     }
 
     if let Some(node) = this.as_xml_node() {
-        let url = url.coerce_to_string(activation, ac)?;
+        let url = url.coerce_to_string(activation)?;
 
-        this.set("loaded", false.into(), activation, ac)?;
+        this.set("loaded", false.into(), activation)?;
 
-        let fetch = ac.navigator.fetch(&url, RequestOptions::get());
+        let fetch = activation
+            .context
+            .navigator
+            .fetch(&url, RequestOptions::get());
         let target_clip = activation.target_clip_or_root();
-        let process = ac.load_manager.load_xml_into_node(
-            ac.player.clone().unwrap(),
+        let process = activation.context.load_manager.load_xml_into_node(
+            activation.context.player.clone().unwrap(),
             node,
             target_clip,
             fetch,
         );
 
-        ac.navigator.spawn_future(process);
+        activation.context.navigator.spawn_future(process);
 
         Ok(true.into())
     } else {
@@ -926,35 +930,32 @@ pub fn xml_load<'gc>(
 }
 
 pub fn xml_on_data<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let src = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Undefined = src {
-        this.call_method("onLoad", &[false.into()], activation, ac)?;
+        this.call_method("onLoad", &[false.into()], activation)?;
     } else {
-        let src = src.coerce_to_string(activation, ac)?;
+        let src = src.coerce_to_string(activation)?;
         this.call_method(
             "parseXML",
-            &[AvmString::new(ac.gc_context, src.to_string()).into()],
+            &[AvmString::new(activation.context.gc_context, src.to_string()).into()],
             activation,
-            ac,
         )?;
 
-        this.set("loaded", true.into(), activation, ac)?;
+        this.set("loaded", true.into(), activation)?;
 
-        this.call_method("onLoad", &[true.into()], activation, ac)?;
+        this.call_method("onLoad", &[true.into()], activation)?;
     }
 
     Ok(Value::Undefined)
 }
 
 pub fn xml_doc_type_decl<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -963,7 +964,7 @@ pub fn xml_doc_type_decl<'gc>(
             let result = doctype.into_string(&mut |_| true);
 
             return Ok(AvmString::new(
-                ac.gc_context,
+                activation.context.gc_context,
                 result.unwrap_or_else(|e| {
                     avm_warn!(activation, "Error occured when serializing DOCTYPE: {}", e);
                     "".to_string()
@@ -977,8 +978,7 @@ pub fn xml_doc_type_decl<'gc>(
 }
 
 pub fn xml_xml_decl<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -992,7 +992,7 @@ pub fn xml_xml_decl<'gc>(
                 e
             );
         } else if let Ok(Some(result_str)) = result {
-            return Ok(AvmString::new(ac.gc_context, result_str).into());
+            return Ok(AvmString::new(activation.context.gc_context, result_str).into());
         }
     }
 
@@ -1000,21 +1000,22 @@ pub fn xml_xml_decl<'gc>(
 }
 
 pub fn xml_id_map<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    ac: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        return Ok(node.document().idmap_script_object(ac.gc_context).into());
+        return Ok(node
+            .document()
+            .idmap_script_object(activation.context.gc_context)
+            .into());
     }
 
     Ok(Value::Undefined)
 }
 
 pub fn xml_status<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _ac: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -42,7 +42,7 @@ fn is_as2_compatible(node: XMLNode<'_>) -> bool {
 
 /// XMLNode constructor
 pub fn xmlnode_constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -74,7 +74,7 @@ pub fn xmlnode_constructor<'gc>(
 }
 
 pub fn xmlnode_append_child<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -101,7 +101,7 @@ pub fn xmlnode_append_child<'gc>(
 }
 
 pub fn xmlnode_insert_before<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -131,7 +131,7 @@ pub fn xmlnode_insert_before<'gc>(
 }
 
 pub fn xmlnode_clone_node<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -153,7 +153,7 @@ pub fn xmlnode_clone_node<'gc>(
 }
 
 pub fn xmlnode_get_namespace_for_prefix<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -172,7 +172,7 @@ pub fn xmlnode_get_namespace_for_prefix<'gc>(
 }
 
 pub fn xmlnode_get_prefix_for_namespace<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -191,7 +191,7 @@ pub fn xmlnode_get_prefix_for_namespace<'gc>(
 }
 
 pub fn xmlnode_has_child_nodes<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -203,7 +203,7 @@ pub fn xmlnode_has_child_nodes<'gc>(
 }
 
 pub fn xmlnode_remove_node<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -219,7 +219,7 @@ pub fn xmlnode_remove_node<'gc>(
 }
 
 pub fn xmlnode_to_string<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -240,7 +240,7 @@ pub fn xmlnode_to_string<'gc>(
 }
 
 pub fn xmlnode_local_name<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -252,7 +252,7 @@ pub fn xmlnode_local_name<'gc>(
 }
 
 pub fn xmlnode_node_name<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -264,7 +264,7 @@ pub fn xmlnode_node_name<'gc>(
 }
 
 pub fn xmlnode_node_type<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -283,7 +283,7 @@ pub fn xmlnode_node_type<'gc>(
 }
 
 pub fn xmlnode_node_value<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -295,7 +295,7 @@ pub fn xmlnode_node_value<'gc>(
 }
 
 pub fn xmlnode_prefix<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -315,7 +315,7 @@ pub fn xmlnode_prefix<'gc>(
 }
 
 pub fn xmlnode_child_nodes<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -353,7 +353,7 @@ pub fn xmlnode_child_nodes<'gc>(
 }
 
 pub fn xmlnode_first_child<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -377,7 +377,7 @@ pub fn xmlnode_first_child<'gc>(
 }
 
 pub fn xmlnode_last_child<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -401,7 +401,7 @@ pub fn xmlnode_last_child<'gc>(
 }
 
 pub fn xmlnode_parent_node<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -424,7 +424,7 @@ pub fn xmlnode_parent_node<'gc>(
 }
 
 pub fn xmlnode_previous_sibling<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -453,7 +453,7 @@ pub fn xmlnode_previous_sibling<'gc>(
 }
 
 pub fn xmlnode_next_sibling<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -482,7 +482,7 @@ pub fn xmlnode_next_sibling<'gc>(
 }
 
 pub fn xmlnode_attributes<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -497,7 +497,7 @@ pub fn xmlnode_attributes<'gc>(
 }
 
 pub fn xmlnode_namespace_uri<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -767,7 +767,7 @@ pub fn create_xmlnode_proto<'gc>(
 
 /// XML (document) constructor
 pub fn xml_constructor<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -804,7 +804,7 @@ pub fn xml_constructor<'gc>(
 }
 
 pub fn xml_create_element<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -831,7 +831,7 @@ pub fn xml_create_element<'gc>(
 }
 
 pub fn xml_create_text_node<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -858,7 +858,7 @@ pub fn xml_create_text_node<'gc>(
 }
 
 pub fn xml_parse_xml<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -894,7 +894,7 @@ pub fn xml_parse_xml<'gc>(
 }
 
 pub fn xml_load<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -930,7 +930,7 @@ pub fn xml_load<'gc>(
 }
 
 pub fn xml_on_data<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -955,7 +955,7 @@ pub fn xml_on_data<'gc>(
 }
 
 pub fn xml_doc_type_decl<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -978,7 +978,7 @@ pub fn xml_doc_type_decl<'gc>(
 }
 
 pub fn xml_xml_decl<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -1000,7 +1000,7 @@ pub fn xml_xml_decl<'gc>(
 }
 
 pub fn xml_id_map<'gc>(
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -1015,7 +1015,7 @@ pub fn xml_id_map<'gc>(
 }
 
 pub fn xml_status<'gc>(
-    _activation: &mut Activation<'_, '_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -117,7 +117,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Takes an already existing object and performs this constructor (if valid) on it.
     fn construct_on_existing(
         &self,
-        activation: &mut Activation<'_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
         mut _this: Object<'gc>,
         _args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -12,7 +12,7 @@ use crate::avm1::object::color_transform_object::ColorTransformObject;
 use crate::avm1::object::xml_attributes_object::XMLAttributesObject;
 use crate::avm1::object::xml_idmap_object::XMLIDMapObject;
 use crate::avm1::object::xml_object::XMLObject;
-use crate::avm1::{ScriptObject, SoundObject, StageObject, UpdateContext, Value};
+use crate::avm1::{ScriptObject, SoundObject, StageObject, Value};
 use crate::avm_warn;
 use crate::display_object::DisplayObject;
 use crate::xml::XMLNode;
@@ -65,8 +65,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>>;
 
@@ -74,13 +73,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn get(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        if self.has_own_property(activation, context, name) {
-            self.get_local(name, activation, context, (*self).into())
+        if self.has_own_property(activation, name) {
+            self.get_local(name, activation, (*self).into())
         } else {
-            Ok(search_prototype(self.proto(), name, activation, context, (*self).into())?.0)
+            Ok(search_prototype(self.proto(), name, activation, (*self).into())?.0)
         }
     }
 
@@ -89,8 +87,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>>;
 
     /// Call the underlying object.
@@ -101,8 +98,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -112,18 +108,16 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Calling this on something other than a constructor will return a new Undefined object.
     fn construct(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         _args: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(Value::Undefined.coerce_to_object(activation, context))
+        Ok(Value::Undefined.coerce_to_object(activation))
     }
 
     /// Takes an already existing object and performs this constructor (if valid) on it.
     fn construct_on_existing(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         mut _this: Object<'gc>,
         _args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
@@ -141,16 +135,10 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         name: &str,
         args: &[Value<'gc>],
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        let (method, base_proto) = search_prototype(
-            Some((*self).into()),
-            name,
-            activation,
-            context,
-            (*self).into(),
-        )?;
+        let (method, base_proto) =
+            search_prototype(Some((*self).into()), name, activation, (*self).into())?;
         let method = method;
 
         if let Value::Object(_) = method {
@@ -158,7 +146,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             avm_warn!(activation, "Object method {} is not callable", name);
         }
 
-        method.call(name, activation, context, (*self).into(), base_proto, args)
+        method.call(name, activation, (*self).into(), base_proto, args)
     }
 
     /// Call a setter defined in this object.
@@ -174,8 +162,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Option<Object<'gc>>;
 
     /// Construct a host object of some kind and return it's cell.
@@ -187,20 +174,14 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// initialize the object.
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>>;
 
     /// Delete a named property from the object.
     ///
     /// Returns false if the property cannot be deleted.
-    fn delete(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        gc_context: MutationContext<'gc, '_>,
-        name: &str,
-    ) -> bool;
+    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
 
     /// Retrieve the `__proto__` of a given object.
     ///
@@ -281,7 +262,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// as `__proto__`.
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -294,7 +275,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// The property does not need to exist at the time of this being called.
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -307,42 +288,31 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// called.
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool;
 
     /// Checks if the object has a given named property.
-    fn has_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool;
+    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
 
     /// Checks if the object has a given named property on itself (and not,
     /// say, the object's prototype or superclass)
-    fn has_own_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool;
+    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
 
     /// Checks if the object has a given named property on itself that is
     /// virtual.
-    fn has_own_virtual(
+    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
+
+    /// Checks if a named property appears when enumerating the object.
+    fn is_property_enumerable(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         name: &str,
     ) -> bool;
 
-    /// Checks if a named property appears when enumerating the object.
-    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc>, name: &str) -> bool;
-
     /// Enumerate the object.
-    fn get_keys(&self, activation: &mut Activation<'_, 'gc>) -> Vec<String>;
+    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String>;
 
     /// Coerce the object into a string.
     fn as_string(&self) -> Cow<str>;
@@ -373,8 +343,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// somehow could this would support that, too.
     fn is_instance_of(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         constructor: Object<'gc>,
         prototype: Object<'gc>,
     ) -> Result<bool, Error<'gc>> {
@@ -398,7 +367,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                         return Ok(true);
                     }
 
-                    if let Value::Object(o) = interface.get("prototype", activation, context)? {
+                    if let Value::Object(o) = interface.get("prototype", activation)? {
                         proto_stack.push(o);
                     }
                 }
@@ -528,8 +497,7 @@ impl<'gc> Object<'gc> {
 pub fn search_prototype<'gc>(
     mut proto: Option<Object<'gc>>,
     name: &str,
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: Object<'gc>,
 ) -> Result<(Value<'gc>, Option<Object<'gc>>), Error<'gc>> {
     let mut depth = 0;
@@ -539,11 +507,8 @@ pub fn search_prototype<'gc>(
             return Err(Error::PrototypeRecursionLimit);
         }
 
-        if proto.unwrap().has_own_property(activation, context, name) {
-            return Ok((
-                proto.unwrap().get_local(name, activation, context, this)?,
-                proto,
-            ));
+        if proto.unwrap().has_own_property(activation, name) {
+            return Ok((proto.unwrap().get_local(name, activation, this)?, proto));
         }
 
         proto = proto.unwrap().proto();

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -65,7 +65,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>>;
 
@@ -73,7 +73,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn get(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if self.has_own_property(activation, name) {
             self.get_local(name, activation, (*self).into())
@@ -87,7 +87,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error<'gc>>;
 
     /// Call the underlying object.
@@ -98,7 +98,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -108,7 +108,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Calling this on something other than a constructor will return a new Undefined object.
     fn construct(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _args: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(Value::Undefined.coerce_to_object(activation))
@@ -117,7 +117,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Takes an already existing object and performs this constructor (if valid) on it.
     fn construct_on_existing(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         mut _this: Object<'gc>,
         _args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
@@ -135,7 +135,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         name: &str,
         args: &[Value<'gc>],
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let (method, base_proto) =
             search_prototype(Some((*self).into()), name, activation, (*self).into())?;
@@ -162,7 +162,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Option<Object<'gc>>;
 
     /// Construct a host object of some kind and return it's cell.
@@ -174,14 +174,14 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// initialize the object.
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>>;
 
     /// Delete a named property from the object.
     ///
     /// Returns false if the property cannot be deleted.
-    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
+    fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool;
 
     /// Retrieve the `__proto__` of a given object.
     ///
@@ -262,7 +262,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// as `__proto__`.
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -275,7 +275,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// The property does not need to exist at the time of this being called.
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -288,31 +288,27 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// called.
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool;
 
     /// Checks if the object has a given named property.
-    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
+    fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool;
 
     /// Checks if the object has a given named property on itself (and not,
     /// say, the object's prototype or superclass)
-    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
+    fn has_own_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool;
 
     /// Checks if the object has a given named property on itself that is
     /// virtual.
-    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool;
+    fn has_own_virtual(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool;
 
     /// Checks if a named property appears when enumerating the object.
-    fn is_property_enumerable(
-        &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
-        name: &str,
-    ) -> bool;
+    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool;
 
     /// Enumerate the object.
-    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String>;
+    fn get_keys(&self, activation: &mut Activation<'_, 'gc, '_>) -> Vec<String>;
 
     /// Coerce the object into a string.
     fn as_string(&self) -> Cow<str>;
@@ -343,7 +339,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// somehow could this would support that, too.
     fn is_instance_of(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         constructor: Object<'gc>,
         prototype: Object<'gc>,
     ) -> Result<bool, Error<'gc>> {
@@ -497,7 +493,7 @@ impl<'gc> Object<'gc> {
 pub fn search_prototype<'gc>(
     mut proto: Option<Object<'gc>>,
     name: &str,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
 ) -> Result<(Value<'gc>, Option<Object<'gc>>), Error<'gc>> {
     let mut depth = 0;

--- a/core/src/avm1/object/color_transform_object.rs
+++ b/core/src/avm1/object/color_transform_object.rs
@@ -106,7 +106,7 @@ impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
             value,
             activation,
             (*self).into(),
-            Some(activation.avm.prototypes.color_transform),
+            Some(activation.context.avm1.prototypes.color_transform),
         )
     }
 
@@ -118,12 +118,11 @@ impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
     fn create_bare_object(
         &self,
         activation: &mut Activation<'_, '_, 'gc, '_>,
-
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(ColorTransformObject::empty_color_transform_object(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.color_transform),
+            Some(activation.context.avm1.prototypes.color_transform),
         )
         .into())
     }

--- a/core/src/avm1/object/color_transform_object.rs
+++ b/core/src/avm1/object/color_transform_object.rs
@@ -98,7 +98,7 @@ impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         let base = self.0.read().base;
         base.internal_set(
@@ -117,7 +117,7 @@ impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(ColorTransformObject::empty_color_transform_object(

--- a/core/src/avm1/object/color_transform_object.rs
+++ b/core/src/avm1/object/color_transform_object.rs
@@ -1,6 +1,5 @@
 use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::context::UpdateContext;
 use crate::impl_custom_object_without_set;
 use gc_arena::{Collect, GcCell, MutationContext};
 
@@ -99,15 +98,13 @@ impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         let base = self.0.read().base;
         base.internal_set(
             name,
             value,
             activation,
-            context,
             (*self).into(),
             Some(activation.avm.prototypes.color_transform),
         )
@@ -120,12 +117,12 @@ impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
+
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(ColorTransformObject::empty_color_transform_object(
-            context.gc_context,
+            activation.context.gc_context,
             Some(activation.avm.prototypes.color_transform),
         )
         .into())

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -4,21 +4,16 @@ macro_rules! impl_custom_object_without_set {
         fn get_local(
             &self,
             name: &str,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             this: crate::avm1::Object<'gc>,
         ) -> Result<crate::avm1::Value<'gc>, crate::avm1::Error<'gc>> {
-            self.0
-                .read()
-                .$field
-                .get_local(name, activation, context, this)
+            self.0.read().$field.get_local(name, activation, this)
         }
 
         fn call(
             &self,
             name: &str,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             this: crate::avm1::Object<'gc>,
             base_proto: Option<crate::avm1::Object<'gc>>,
             args: &[crate::avm1::Value<'gc>],
@@ -26,29 +21,24 @@ macro_rules! impl_custom_object_without_set {
             self.0
                 .read()
                 .$field
-                .call(name, activation, context, this, base_proto, args)
+                .call(name, activation, this, base_proto, args)
         }
 
         fn call_setter(
             &self,
             name: &str,
             value: crate::avm1::Value<'gc>,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
         ) -> Option<crate::avm1::object::Object<'gc>> {
-            self.0
-                .read()
-                .$field
-                .call_setter(name, value, activation, context)
+            self.0.read().$field.call_setter(name, value, activation)
         }
 
         fn delete(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            gc_context: gc_arena::MutationContext<'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             name: &str,
         ) -> bool {
-            self.0.read().$field.delete(activation, gc_context, name)
+            self.0.read().$field.delete(activation, name)
         }
 
         fn proto(&self) -> Option<crate::avm1::Object<'gc>> {
@@ -107,7 +97,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn add_property_with_case(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: &str,
             get: crate::avm1::object::Object<'gc>,
@@ -122,40 +112,31 @@ macro_rules! impl_custom_object_without_set {
 
         fn has_property(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             name: &str,
         ) -> bool {
-            self.0.read().$field.has_property(activation, context, name)
+            self.0.read().$field.has_property(activation, name)
         }
 
         fn has_own_property(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             name: &str,
         ) -> bool {
-            self.0
-                .read()
-                .$field
-                .has_own_property(activation, context, name)
+            self.0.read().$field.has_own_property(activation, name)
         }
 
         fn has_own_virtual(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             name: &str,
         ) -> bool {
-            self.0
-                .read()
-                .$field
-                .has_own_virtual(activation, context, name)
+            self.0.read().$field.has_own_virtual(activation, name)
         }
 
         fn is_property_enumerable(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             name: &str,
         ) -> bool {
             self.0
@@ -164,7 +145,10 @@ macro_rules! impl_custom_object_without_set {
                 .is_property_enumerable(activation, name)
         }
 
-        fn get_keys(&self, activation: &mut crate::avm1::Activation<'_, 'gc>) -> Vec<String> {
+        fn get_keys(
+            &self,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+        ) -> Vec<String> {
             self.0.read().$field.get_keys(activation)
         }
 
@@ -237,7 +221,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn set_watcher(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: std::borrow::Cow<str>,
             callback: crate::avm1::object::Object<'gc>,
@@ -251,7 +235,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn remove_watcher(
             &self,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: std::borrow::Cow<str>,
         ) -> bool {
@@ -272,10 +256,9 @@ macro_rules! impl_custom_object {
             &self,
             name: &str,
             value: crate::avm1::Value<'gc>,
-            activation: &mut crate::avm1::Activation<'_, 'gc>,
-            context: &mut crate::context::UpdateContext<'_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
         ) -> Result<(), crate::avm1::Error<'gc>> {
-            self.0.read().$field.set(name, value, activation, context)
+            self.0.read().$field.set(name, value, activation)
         }
     };
 }

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -4,7 +4,7 @@ macro_rules! impl_custom_object_without_set {
         fn get_local(
             &self,
             name: &str,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             this: crate::avm1::Object<'gc>,
         ) -> Result<crate::avm1::Value<'gc>, crate::avm1::Error<'gc>> {
             self.0.read().$field.get_local(name, activation, this)
@@ -13,7 +13,7 @@ macro_rules! impl_custom_object_without_set {
         fn call(
             &self,
             name: &str,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             this: crate::avm1::Object<'gc>,
             base_proto: Option<crate::avm1::Object<'gc>>,
             args: &[crate::avm1::Value<'gc>],
@@ -28,14 +28,14 @@ macro_rules! impl_custom_object_without_set {
             &self,
             name: &str,
             value: crate::avm1::Value<'gc>,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
         ) -> Option<crate::avm1::object::Object<'gc>> {
             self.0.read().$field.call_setter(name, value, activation)
         }
 
         fn delete(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             name: &str,
         ) -> bool {
             self.0.read().$field.delete(activation, name)
@@ -97,7 +97,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn add_property_with_case(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: &str,
             get: crate::avm1::object::Object<'gc>,
@@ -112,7 +112,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn has_property(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             name: &str,
         ) -> bool {
             self.0.read().$field.has_property(activation, name)
@@ -120,7 +120,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn has_own_property(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             name: &str,
         ) -> bool {
             self.0.read().$field.has_own_property(activation, name)
@@ -128,7 +128,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn has_own_virtual(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             name: &str,
         ) -> bool {
             self.0.read().$field.has_own_virtual(activation, name)
@@ -136,7 +136,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn is_property_enumerable(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             name: &str,
         ) -> bool {
             self.0
@@ -145,10 +145,7 @@ macro_rules! impl_custom_object_without_set {
                 .is_property_enumerable(activation, name)
         }
 
-        fn get_keys(
-            &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
-        ) -> Vec<String> {
+        fn get_keys(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>) -> Vec<String> {
             self.0.read().$field.get_keys(activation)
         }
 
@@ -221,7 +218,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn set_watcher(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: std::borrow::Cow<str>,
             callback: crate::avm1::object::Object<'gc>,
@@ -235,7 +232,7 @@ macro_rules! impl_custom_object_without_set {
 
         fn remove_watcher(
             &self,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: std::borrow::Cow<str>,
         ) -> bool {
@@ -256,7 +253,7 @@ macro_rules! impl_custom_object {
             &self,
             name: &str,
             value: crate::avm1::Value<'gc>,
-            activation: &mut crate::avm1::Activation<'_, '_, 'gc, '_>,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
         ) -> Result<(), crate::avm1::Error<'gc>> {
             self.0.read().$field.set(name, value, activation)
         }

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, ExecutionReason, FunctionObject, NativeFunction};
 use crate::avm1::property::{Attribute, Property};
-use crate::avm1::{AvmString, Object, ObjectPtr, TObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ObjectPtr, TObject, Value};
 use crate::property_map::{Entry, PropertyMap};
 use core::fmt;
 use enumset::EnumSet;
@@ -36,8 +36,8 @@ impl<'gc> Watcher<'gc> {
     #[allow(clippy::too_many_arguments)]
     pub fn call(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
+
         name: &str,
         old_value: Value<'gc>,
         new_value: Value<'gc>,
@@ -45,7 +45,10 @@ impl<'gc> Watcher<'gc> {
         base_proto: Option<Object<'gc>>,
     ) -> Result<Value<'gc>, crate::avm1::error::Error<'gc>> {
         let args = [
-            Value::String(AvmString::new(context.gc_context, name.to_string())),
+            Value::String(AvmString::new(
+                activation.context.gc_context,
+                name.to_string(),
+            )),
             old_value,
             new_value,
             self.user_data.clone(),
@@ -54,7 +57,6 @@ impl<'gc> Watcher<'gc> {
             executable.exec(
                 name,
                 activation,
-                context,
                 this,
                 base_proto,
                 &args,
@@ -252,26 +254,25 @@ impl<'gc> ScriptObject<'gc> {
         &self,
         name: &str,
         mut value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if name == "__proto__" {
-            self.0.write(context.gc_context).prototype =
-                Some(value.coerce_to_object(activation, context));
+            self.0.write(activation.context.gc_context).prototype =
+                Some(value.coerce_to_object(activation));
         } else if let Ok(index) = name.parse::<usize>() {
-            self.set_array_element(index, value.to_owned(), context.gc_context);
+            self.set_array_element(index, value.to_owned(), activation.context.gc_context);
         } else if !name.is_empty() {
             if name == "length" {
                 let length = value
-                    .coerce_to_f64(activation, context)
+                    .coerce_to_f64(activation)
                     .map(|v| v.abs() as i32)
                     .unwrap_or(0);
                 if length > 0 {
-                    self.set_length(context.gc_context, length as usize);
+                    self.set_length(activation.context.gc_context, length as usize);
                 } else {
-                    self.set_length(context.gc_context, 0);
+                    self.set_length(activation.context.gc_context, 0);
                 }
             }
 
@@ -288,7 +289,7 @@ impl<'gc> ScriptObject<'gc> {
             if is_vacant {
                 let mut proto: Option<Object<'gc>> = Some((*self).into());
                 while let Some(this_proto) = proto {
-                    if this_proto.has_own_virtual(activation, context, name) {
+                    if this_proto.has_own_virtual(activation, name) {
                         break;
                     }
 
@@ -297,14 +298,11 @@ impl<'gc> ScriptObject<'gc> {
 
                 if let Some(this_proto) = proto {
                     worked = true;
-                    if let Some(rval) =
-                        this_proto.call_setter(name, value.clone(), activation, context)
-                    {
+                    if let Some(rval) = this_proto.call_setter(name, value.clone(), activation) {
                         if let Some(exec) = rval.as_executable() {
                             let _ = exec.exec(
                                 "[Setter]",
                                 activation,
-                                context,
                                 this,
                                 Some(this_proto),
                                 &[value.clone()],
@@ -328,10 +326,9 @@ impl<'gc> ScriptObject<'gc> {
                     .cloned();
                 let mut return_value = Ok(());
                 if let Some(watcher) = watcher {
-                    let old_value = self.get(name, activation, context)?;
+                    let old_value = self.get(name, activation)?;
                     value = match watcher.call(
                         activation,
-                        context,
                         name,
                         old_value,
                         value.clone(),
@@ -349,7 +346,7 @@ impl<'gc> ScriptObject<'gc> {
 
                 let rval = match self
                     .0
-                    .write(context.gc_context)
+                    .write(activation.context.gc_context)
                     .values
                     .entry(name, activation.is_case_sensitive())
                 {
@@ -369,7 +366,6 @@ impl<'gc> ScriptObject<'gc> {
                         let _ = exec.exec(
                             "[Setter]",
                             activation,
-                            context,
                             this,
                             base_proto,
                             &[value],
@@ -399,8 +395,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if name == "__proto__" {
@@ -427,7 +422,6 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
                 match exec.exec(
                     "[Getter]",
                     activation,
-                    context,
                     this,
                     Some((*self).into()),
                     &[],
@@ -454,14 +448,12 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         self.internal_set(
             name,
             value,
             activation,
-            context,
             (*self).into(),
             Some((*self).into()),
         )
@@ -475,8 +467,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn call(
         &self,
         _name: &str,
-        _activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
+        _activation: &mut Activation<'_, '_, 'gc, '_>,
         _this: Object<'gc>,
         _base_proto: Option<Object<'gc>>,
         _args: &[Value<'gc>],
@@ -488,12 +479,11 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
         match self
             .0
-            .write(context.gc_context)
+            .write(activation.context.gc_context)
             .values
             .get_mut(name, activation.is_case_sensitive())
         {
@@ -505,16 +495,15 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         match self.0.read().array {
             ArrayStorage::Vector(_) => {
-                Ok(ScriptObject::array(context.gc_context, Some(this)).into())
+                Ok(ScriptObject::array(activation.context.gc_context, Some(this)).into())
             }
             ArrayStorage::Properties { .. } => {
-                Ok(ScriptObject::object(context.gc_context, Some(this)).into())
+                Ok(ScriptObject::object(activation.context.gc_context, Some(this)).into())
             }
         }
     }
@@ -522,13 +511,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     /// Delete a named property from the object.
     ///
     /// Returns false if the property cannot be deleted.
-    fn delete(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        gc_context: MutationContext<'gc, '_>,
-        name: &str,
-    ) -> bool {
-        let mut object = self.0.write(gc_context);
+    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        let mut object = self.0.write(activation.context.gc_context);
         if let Some(prop) = object.values.get(name, activation.is_case_sensitive()) {
             if prop.can_delete() {
                 object.values.remove(name, activation.is_case_sensitive());
@@ -560,7 +544,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -580,7 +564,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -595,7 +579,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool {
@@ -653,27 +637,17 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     /// Checks if the object has a given named property.
-    fn has_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.has_own_property(activation, context, name)
+    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.has_own_property(activation, name)
             || self
                 .proto()
                 .as_ref()
-                .map_or(false, |p| p.has_property(activation, context, name))
+                .map_or(false, |p| p.has_property(activation, name))
     }
 
     /// Checks if the object has a given named property on itself (and not,
     /// say, the object's prototype or superclass)
-    fn has_own_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
         if name == "__proto__" {
             return true;
         }
@@ -683,12 +657,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
             .contains_key(name, activation.is_case_sensitive())
     }
 
-    fn has_own_virtual(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
         if let Some(slot) = self
             .0
             .read()
@@ -702,7 +671,11 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     /// Checks if a named property appears when enumerating the object.
-    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc>, name: &str) -> bool {
+    fn is_property_enumerable(
+        &self,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
+        name: &str,
+    ) -> bool {
         if let Some(prop) = self
             .0
             .read()
@@ -716,7 +689,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     /// Enumerate the object.
-    fn get_keys(&self, activation: &mut Activation<'_, 'gc>) -> Vec<String> {
+    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
         let proto_keys = self
             .proto()
             .map_or_else(Vec::new, |p| p.get_keys(activation));
@@ -879,6 +852,7 @@ mod tests {
     use crate::backend::navigator::NullNavigatorBackend;
     use crate::backend::render::NullRenderer;
     use crate::backend::storage::MemoryStorageBackend;
+    use crate::context::UpdateContext;
     use crate::display_object::MovieClip;
     use crate::library::Library;
     use crate::loader::LoadManager;
@@ -891,11 +865,7 @@ mod tests {
 
     fn with_object<F, R>(swf_version: u8, test: F) -> R
     where
-        F: for<'a, 'gc> FnOnce(
-            &mut Activation<'_, 'gc>,
-            &mut UpdateContext<'a, 'gc, '_>,
-            Object<'gc>,
-        ) -> R,
+        F: for<'a, 'gc> FnOnce(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> R,
     {
         rootless_arena(|gc_context| {
             let mut avm = Avm1::new(gc_context, swf_version);
@@ -946,24 +916,26 @@ mod tests {
             let object = ScriptObject::object(gc_context, Some(avm.prototypes().object)).into();
 
             let globals = avm.global_object_cell();
+            let base_clip = *context.levels.get(&0).unwrap();
+            let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
                 &mut avm,
+                &mut context,
                 ActivationIdentifier::root("[Test]"),
-                context.swf.version(),
+                swf_version,
                 globals,
-                context.gc_context,
-                *context.levels.get(&0).unwrap(),
+                base_clip,
             );
 
-            test(&mut activation, &mut context, object)
+            test(&mut activation, object)
         })
     }
 
     #[test]
     fn test_get_undefined() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             assert_eq!(
-                object.get("not_defined", activation, context).unwrap(),
+                object.get("not_defined", activation).unwrap(),
                 Value::Undefined
             );
         })
@@ -971,57 +943,44 @@ mod tests {
 
     #[test]
     fn test_set_get() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "forced",
                 "forced".into(),
                 EnumSet::empty(),
             );
-            object
-                .set("natural", "natural".into(), activation, context)
-                .unwrap();
+            object.set("natural", "natural".into(), activation).unwrap();
 
-            assert_eq!(
-                object.get("forced", activation, context).unwrap(),
-                "forced".into()
-            );
-            assert_eq!(
-                object.get("natural", activation, context).unwrap(),
-                "natural".into()
-            );
+            assert_eq!(object.get("forced", activation).unwrap(), "forced".into());
+            assert_eq!(object.get("natural", activation).unwrap(), "natural".into());
         })
     }
 
     #[test]
     fn test_set_readonly() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "normal",
                 "initial".into(),
                 EnumSet::empty(),
             );
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "readonly",
                 "initial".into(),
                 ReadOnly.into(),
             );
 
+            object.set("normal", "replaced".into(), activation).unwrap();
             object
-                .set("normal", "replaced".into(), activation, context)
-                .unwrap();
-            object
-                .set("readonly", "replaced".into(), activation, context)
+                .set("readonly", "replaced".into(), activation)
                 .unwrap();
 
+            assert_eq!(object.get("normal", activation).unwrap(), "replaced".into());
             assert_eq!(
-                object.get("normal", activation, context).unwrap(),
-                "replaced".into()
-            );
-            assert_eq!(
-                object.get("readonly", activation, context).unwrap(),
+                object.get("readonly", activation).unwrap(),
                 "initial".into()
             );
         })
@@ -1029,140 +988,105 @@ mod tests {
 
     #[test]
     fn test_deletable_not_readonly() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "test",
                 "initial".into(),
                 DontDelete.into(),
             );
 
-            assert_eq!(object.delete(activation, context.gc_context, "test"), false);
-            assert_eq!(
-                object.get("test", activation, context).unwrap(),
-                "initial".into()
-            );
+            assert_eq!(object.delete(activation, "test"), false);
+            assert_eq!(object.get("test", activation).unwrap(), "initial".into());
 
             object
                 .as_script_object()
                 .unwrap()
-                .set("test", "replaced".into(), activation, context)
+                .set("test", "replaced".into(), activation)
                 .unwrap();
 
-            assert_eq!(object.delete(activation, context.gc_context, "test"), false);
-            assert_eq!(
-                object.get("test", activation, context).unwrap(),
-                "replaced".into()
-            );
+            assert_eq!(object.delete(activation, "test"), false);
+            assert_eq!(object.get("test", activation).unwrap(), "replaced".into());
         })
     }
 
     #[test]
     fn test_virtual_get() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             let getter = FunctionObject::function(
-                context.gc_context,
-                Executable::Native(|_avm, _context, _this, _args| Ok("Virtual!".into())),
+                activation.context.gc_context,
+                Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
                 None,
                 activation.avm.prototypes.function,
             );
 
             object.as_script_object().unwrap().add_property(
-                context.gc_context,
+                activation.context.gc_context,
                 "test",
                 getter,
                 None,
                 EnumSet::empty(),
             );
 
-            assert_eq!(
-                object.get("test", activation, context).unwrap(),
-                "Virtual!".into()
-            );
+            assert_eq!(object.get("test", activation).unwrap(), "Virtual!".into());
 
             // This set should do nothing
-            object
-                .set("test", "Ignored!".into(), activation, context)
-                .unwrap();
-            assert_eq!(
-                object.get("test", activation, context).unwrap(),
-                "Virtual!".into()
-            );
+            object.set("test", "Ignored!".into(), activation).unwrap();
+            assert_eq!(object.get("test", activation).unwrap(), "Virtual!".into());
         })
     }
 
     #[test]
     fn test_delete() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             let getter = FunctionObject::function(
-                context.gc_context,
-                Executable::Native(|_avm, _context, _this, _args| Ok("Virtual!".into())),
+                activation.context.gc_context,
+                Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
                 None,
                 activation.avm.prototypes.function,
             );
 
             object.as_script_object().unwrap().add_property(
-                context.gc_context,
+                activation.context.gc_context,
                 "virtual",
                 getter,
                 None,
                 EnumSet::empty(),
             );
             object.as_script_object().unwrap().add_property(
-                context.gc_context,
+                activation.context.gc_context,
                 "virtual_un",
                 getter,
                 None,
                 DontDelete.into(),
             );
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "stored",
                 "Stored!".into(),
                 EnumSet::empty(),
             );
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "stored_un",
                 "Stored!".into(),
                 DontDelete.into(),
             );
 
-            assert_eq!(
-                object.delete(activation, context.gc_context, "virtual"),
-                true
-            );
-            assert_eq!(
-                object.delete(activation, context.gc_context, "virtual_un"),
-                false
-            );
-            assert_eq!(
-                object.delete(activation, context.gc_context, "stored"),
-                true
-            );
-            assert_eq!(
-                object.delete(activation, context.gc_context, "stored_un"),
-                false
-            );
-            assert_eq!(
-                object.delete(activation, context.gc_context, "non_existent"),
-                false
-            );
+            assert_eq!(object.delete(activation, "virtual"), true);
+            assert_eq!(object.delete(activation, "virtual_un"), false);
+            assert_eq!(object.delete(activation, "stored"), true);
+            assert_eq!(object.delete(activation, "stored_un"), false);
+            assert_eq!(object.delete(activation, "non_existent"), false);
 
+            assert_eq!(object.get("virtual", activation).unwrap(), Value::Undefined);
             assert_eq!(
-                object.get("virtual", activation, context).unwrap(),
-                Value::Undefined
-            );
-            assert_eq!(
-                object.get("virtual_un", activation, context).unwrap(),
+                object.get("virtual_un", activation).unwrap(),
                 "Virtual!".into()
             );
+            assert_eq!(object.get("stored", activation).unwrap(), Value::Undefined);
             assert_eq!(
-                object.get("stored", activation, context).unwrap(),
-                Value::Undefined
-            );
-            assert_eq!(
-                object.get("stored_un", activation, context).unwrap(),
+                object.get("stored_un", activation).unwrap(),
                 "Stored!".into()
             );
         })
@@ -1170,35 +1094,35 @@ mod tests {
 
     #[test]
     fn test_iter_values() {
-        with_object(0, |activation, context, object| {
+        with_object(0, |activation, object| {
             let getter = FunctionObject::function(
-                context.gc_context,
-                Executable::Native(|_avm, _context, _this, _args| Ok(Value::Null)),
+                activation.context.gc_context,
+                Executable::Native(|_avm, _this, _args| Ok(Value::Null)),
                 None,
                 activation.avm.prototypes.function,
             );
 
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "stored",
                 Value::Null,
                 EnumSet::empty(),
             );
             object.as_script_object().unwrap().define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "stored_hidden",
                 Value::Null,
                 DontEnum.into(),
             );
             object.as_script_object().unwrap().add_property(
-                context.gc_context,
+                activation.context.gc_context,
                 "virtual",
                 getter,
                 None,
                 EnumSet::empty(),
             );
             object.as_script_object().unwrap().add_property(
-                context.gc_context,
+                activation.context.gc_context,
                 "virtual_hidden",
                 getter,
                 None,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -36,7 +36,7 @@ impl<'gc> Watcher<'gc> {
     #[allow(clippy::too_many_arguments)]
     pub fn call(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
 
         name: &str,
         old_value: Value<'gc>,
@@ -254,7 +254,7 @@ impl<'gc> ScriptObject<'gc> {
         &self,
         name: &str,
         mut value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
@@ -395,7 +395,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if name == "__proto__" {
@@ -448,7 +448,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         self.internal_set(
             name,
@@ -467,7 +467,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn call(
         &self,
         _name: &str,
-        _activation: &mut Activation<'_, '_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
         _base_proto: Option<Object<'gc>>,
         _args: &[Value<'gc>],
@@ -479,7 +479,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
         match self
             .0
@@ -495,7 +495,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         match self.0.read().array {
@@ -511,7 +511,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     /// Delete a named property from the object.
     ///
     /// Returns false if the property cannot be deleted.
-    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         let mut object = self.0.write(activation.context.gc_context);
         if let Some(prop) = object.values.get(name, activation.is_case_sensitive()) {
             if prop.can_delete() {
@@ -544,7 +544,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -564,7 +564,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -579,7 +579,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool {
@@ -637,7 +637,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     /// Checks if the object has a given named property.
-    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.has_own_property(activation, name)
             || self
                 .proto()
@@ -647,7 +647,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     /// Checks if the object has a given named property on itself (and not,
     /// say, the object's prototype or superclass)
-    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         if name == "__proto__" {
             return true;
         }
@@ -657,7 +657,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
             .contains_key(name, activation.is_case_sensitive())
     }
 
-    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_virtual(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         if let Some(slot) = self
             .0
             .read()
@@ -671,11 +671,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     /// Checks if a named property appears when enumerating the object.
-    fn is_property_enumerable(
-        &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         if let Some(prop) = self
             .0
             .read()
@@ -689,7 +685,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     /// Enumerate the object.
-    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
+    fn get_keys(&self, activation: &mut Activation<'_, 'gc, '_>) -> Vec<String> {
         let proto_keys = self
             .proto()
             .map_or_else(Vec::new, |p| p.get_keys(activation));
@@ -865,7 +861,7 @@ mod tests {
 
     fn with_object<F, R>(swf_version: u8, test: F) -> R
     where
-        F: for<'a, 'gc> FnOnce(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> R,
+        F: for<'a, 'gc> FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> R,
     {
         rootless_arena(|gc_context| {
             let mut avm = Avm1::new(gc_context, swf_version);
@@ -920,7 +916,7 @@ mod tests {
             let base_clip = *context.levels.get(&0).unwrap();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
-                &mut context,
+                context,
                 ActivationIdentifier::root("[Test]"),
                 swf_version,
                 globals,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -872,6 +872,9 @@ mod tests {
             let mut levels = BTreeMap::new();
             levels.insert(0, root);
 
+            let object = ScriptObject::object(gc_context, Some(avm.prototypes().object)).into();
+            let globals = avm.global_object_cell();
+
             let mut context = UpdateContext {
                 gc_context,
                 player_version: 32,
@@ -910,9 +913,6 @@ mod tests {
             root.post_instantiation(&mut context, root, None, false);
             root.set_name(context.gc_context, "");
 
-            let object = ScriptObject::object(gc_context, Some(avm.prototypes().object)).into();
-
-            let globals = avm.global_object_cell();
             let base_clip = *context.levels.get(&0).unwrap();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -908,9 +908,10 @@ mod tests {
                 unbound_text_fields: &mut Vec::new(),
                 timers: &mut Timers::new(),
                 needs_render: &mut false,
+                avm1: &mut avm,
             };
 
-            root.post_instantiation(&mut avm, &mut context, root, None, false);
+            root.post_instantiation(&mut context, root, None, false);
             root.set_name(context.gc_context, "");
 
             let object = ScriptObject::object(gc_context, Some(avm.prototypes().object)).into();
@@ -919,7 +920,6 @@ mod tests {
             let base_clip = *context.levels.get(&0).unwrap();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
-                &mut avm,
                 &mut context,
                 ActivationIdentifier::root("[Test]"),
                 swf_version,
@@ -1017,7 +1017,7 @@ mod tests {
                 activation.context.gc_context,
                 Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
                 None,
-                activation.avm.prototypes.function,
+                activation.context.avm1.prototypes.function,
             );
 
             object.as_script_object().unwrap().add_property(
@@ -1043,7 +1043,7 @@ mod tests {
                 activation.context.gc_context,
                 Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
                 None,
-                activation.avm.prototypes.function,
+                activation.context.avm1.prototypes.function,
             );
 
             object.as_script_object().unwrap().add_property(
@@ -1099,7 +1099,7 @@ mod tests {
                 activation.context.gc_context,
                 Executable::Native(|_avm, _this, _args| Ok(Value::Null)),
                 None,
-                activation.avm.prototypes.function,
+                activation.context.avm1.prototypes.function,
             );
 
             object.as_script_object().unwrap().define_value(

--- a/core/src/avm1/object/shared_object.rs
+++ b/core/src/avm1/object/shared_object.rs
@@ -65,7 +65,7 @@ impl<'gc> TObject<'gc> for SharedObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(SharedObject::empty_shared_obj(

--- a/core/src/avm1/object/shared_object.rs
+++ b/core/src/avm1/object/shared_object.rs
@@ -70,7 +70,7 @@ impl<'gc> TObject<'gc> for SharedObject<'gc> {
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(SharedObject::empty_shared_obj(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.shared_object),
+            Some(activation.context.avm1.prototypes.shared_object),
         )
         .into())
     }

--- a/core/src/avm1/object/shared_object.rs
+++ b/core/src/avm1/object/shared_object.rs
@@ -4,7 +4,6 @@ use gc_arena::{Collect, GcCell, MutationContext};
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TObject};
-use crate::context::UpdateContext;
 use std::fmt;
 
 /// A SharedObject
@@ -66,12 +65,11 @@ impl<'gc> TObject<'gc> for SharedObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(SharedObject::empty_shared_obj(
-            context.gc_context,
+            activation.context.gc_context,
             Some(activation.avm.prototypes.shared_object),
         )
         .into())

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -128,7 +128,7 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
 
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -4,7 +4,6 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TObject};
 use crate::backend::audio::{SoundHandle, SoundInstanceHandle};
-use crate::context::UpdateContext;
 use crate::display_object::DisplayObject;
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -129,14 +128,15 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
+
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(
-            SoundObject::empty_sound(context.gc_context, Some(activation.avm.prototypes.sound))
-                .into(),
+        Ok(SoundObject::empty_sound(
+            activation.context.gc_context,
+            Some(activation.avm.prototypes.sound),
         )
+        .into())
     }
 
     fn as_sound_object(&self) -> Option<SoundObject<'gc>> {

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -134,7 +134,7 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(SoundObject::empty_sound(
             activation.context.gc_context,
-            Some(activation.avm.prototypes.sound),
+            Some(activation.context.avm1.prototypes.sound),
         )
         .into())
     }

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -131,7 +131,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let obj = self.0.read();
-        let props = activation.avm.display_properties;
+        let props = activation.context.avm1.display_properties;
         let case_sensitive = activation.is_case_sensitive();
         // Property search order for DisplayObjects:
         if self.has_own_property(activation, name) {
@@ -173,7 +173,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         let obj = self.0.read();
-        let props = activation.avm.display_properties;
+        let props = activation.context.avm1.display_properties;
 
         // Check if a text field is bound to this property and update the text if so.
         for binding in obj
@@ -346,7 +346,8 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         }
 
         if activation
-            .avm
+            .context
+            .avm1
             .display_properties
             .read()
             .get_by_name(&name)

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -128,32 +128,31 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
     fn get(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let obj = self.0.read();
         let props = activation.avm.display_properties;
         let case_sensitive = activation.is_case_sensitive();
         // Property search order for DisplayObjects:
-        if self.has_own_property(activation, context, name) {
+        if self.has_own_property(activation, name) {
             // 1) Actual properties on the underlying object
-            self.get_local(name, activation, context, (*self).into())
+            self.get_local(name, activation, (*self).into())
         } else if let Some(property) = props.read().get_by_name(&name) {
             // 2) Display object properties such as _x, _y
-            let val = property.get(activation, context, obj.display_object)?;
+            let val = property.get(activation, obj.display_object)?;
             Ok(val)
         } else if let Some(child) = obj.display_object.get_child_by_name(name, case_sensitive) {
             // 3) Child display objects with the given instance name
             Ok(child.object())
         } else if let Some(level) =
             obj.display_object
-                .get_level_by_path(name, context, case_sensitive)
+                .get_level_by_path(name, activation.context, case_sensitive)
         {
             // 4) _levelN
             Ok(level.object())
         } else {
             // 5) Prototype
-            Ok(search_prototype(self.proto(), name, activation, context, (*self).into())?.0)
+            Ok(search_prototype(self.proto(), name, activation, (*self).into())?.0)
         }
         // 6) TODO: __resolve?
     }
@@ -161,22 +160,17 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        self.0
-            .read()
-            .base
-            .get_local(name, activation, context, this)
+        self.0.read().base.get_local(name, activation, this)
     }
 
     fn set(
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         let obj = self.0.read();
         let props = activation.avm.display_properties;
@@ -188,24 +182,23 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
             .filter(|binding| binding.variable_name == name)
         {
             let _ = binding.text_field.set_html_text(
-                value.coerce_to_string(activation, context)?.to_string(),
-                context,
+                value.coerce_to_string(activation)?.to_string(),
+                activation.context,
             );
         }
 
-        if obj.base.has_own_property(activation, context, name) {
+        if obj.base.has_own_property(activation, name) {
             // 1) Actual proeprties on the underlying object
             obj.base.internal_set(
                 name,
                 value,
                 activation,
-                context,
                 (*self).into(),
                 Some((*self).into()),
             )
         } else if let Some(property) = props.read().get_by_name(&name) {
             // 2) Display object properties such as _x, _y
-            property.set(activation, context, obj.display_object, value)?;
+            property.set(activation, obj.display_object, value)?;
             Ok(())
         } else {
             // 3) TODO: Prototype
@@ -213,7 +206,6 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
                 name,
                 value,
                 activation,
-                context,
                 (*self).into(),
                 Some((*self).into()),
             )
@@ -222,8 +214,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -231,43 +222,30 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0
             .read()
             .base
-            .call(name, activation, context, this, base_proto, args)
+            .call(name, activation, this, base_proto, args)
     }
 
     fn call_setter(
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
-        self.0
-            .read()
-            .base
-            .call_setter(name, value, activation, context)
+        self.0.read().base.call_setter(name, value, activation)
     }
 
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         //TODO: Create a StageObject of some kind
-        self.0
-            .read()
-            .base
-            .create_bare_object(activation, context, this)
+        self.0.read().base.create_bare_object(activation, this)
     }
 
-    fn delete(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        gc_context: MutationContext<'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.0.read().base.delete(activation, gc_context, name)
+    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.0.read().base.delete(activation, name)
     }
 
     fn proto(&self) -> Option<Object<'gc>> {
@@ -322,7 +300,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -337,7 +315,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
 
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -351,7 +329,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
 
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool {
@@ -361,14 +339,9 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
             .remove_watcher(activation, gc_context, name)
     }
 
-    fn has_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
         let obj = self.0.read();
-        if obj.base.has_property(activation, context, name) {
+        if obj.base.has_property(activation, name) {
             return true;
         }
 
@@ -393,7 +366,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
 
         if obj
             .display_object
-            .get_level_by_path(name, context, case_sensitive)
+            .get_level_by_path(name, activation.context, case_sensitive)
             .is_some()
         {
             return true;
@@ -402,36 +375,24 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         false
     }
 
-    fn has_own_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
         // Note that `hasOwnProperty` does NOT return true for child display objects.
-        self.0
-            .read()
-            .base
-            .has_own_property(activation, context, name)
+        self.0.read().base.has_own_property(activation, name)
     }
 
-    fn has_own_virtual(
+    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.0.read().base.has_own_virtual(activation, name)
+    }
+
+    fn is_property_enumerable(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         name: &str,
     ) -> bool {
-        self.0
-            .read()
-            .base
-            .has_own_virtual(activation, context, name)
-    }
-
-    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc>, name: &str) -> bool {
         self.0.read().base.is_property_enumerable(activation, name)
     }
 
-    fn get_keys(&self, activation: &mut Activation<'_, 'gc>) -> Vec<String> {
+    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
         // Keys from the underlying object are listed first, followed by
         // child display objects in order from highest depth to lowest depth.
         let obj = self.0.read();
@@ -527,38 +488,29 @@ pub struct DisplayProperty<'gc> {
     set: Option<DisplaySetter<'gc>>,
 }
 
-pub type DisplayGetter<'gc> = fn(
-    &mut Activation<'_, 'gc>,
-    &mut UpdateContext<'_, 'gc, '_>,
-    DisplayObject<'gc>,
-) -> Result<Value<'gc>, Error<'gc>>;
+pub type DisplayGetter<'gc> =
+    fn(&mut Activation<'_, '_, 'gc, '_>, DisplayObject<'gc>) -> Result<Value<'gc>, Error<'gc>>;
 
-pub type DisplaySetter<'gc> = fn(
-    &mut Activation<'_, 'gc>,
-    &mut UpdateContext<'_, 'gc, '_>,
-    DisplayObject<'gc>,
-    Value<'gc>,
-) -> Result<(), Error<'gc>>;
+pub type DisplaySetter<'gc> =
+    fn(&mut Activation<'_, '_, 'gc, '_>, DisplayObject<'gc>, Value<'gc>) -> Result<(), Error<'gc>>;
 
 impl<'gc> DisplayProperty<'gc> {
     pub fn get(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: DisplayObject<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        (self.get)(activation, context, this)
+        (self.get)(activation, this)
     }
 
     pub fn set(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: DisplayObject<'gc>,
         value: Value<'gc>,
     ) -> Result<(), Error<'gc>> {
         self.set
-            .map(|f| f(activation, context, this, value))
+            .map(|f| f(activation, this, value))
             .unwrap_or(Ok(()))
     }
 }
@@ -635,90 +587,81 @@ impl<'gc> DisplayPropertyMap<'gc> {
 }
 
 fn x<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this.x().into())
 }
 
 fn set_x<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_x(context.gc_context, val);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_x(activation.context.gc_context, val);
     }
     Ok(())
 }
 
 fn y<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this.y().into())
 }
 
 fn set_y<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_y(context.gc_context, val);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_y(activation.context.gc_context, val);
     }
     Ok(())
 }
 
 fn x_scale<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let val = this.scale_x(context.gc_context) * 100.0;
+    let val = this.scale_x(activation.context.gc_context) * 100.0;
     Ok(val.into())
 }
 
 fn set_x_scale<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_scale_x(context.gc_context, val / 100.0);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_scale_x(activation.context.gc_context, val / 100.0);
     }
     Ok(())
 }
 
 fn y_scale<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let scale_y = this.scale_y(context.gc_context) * 100.0;
+    let scale_y = this.scale_y(activation.context.gc_context) * 100.0;
     Ok(scale_y.into())
 }
 
 fn set_y_scale<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_scale_y(context.gc_context, val / 100.0);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_scale_y(activation.context.gc_context, val / 100.0);
     }
     Ok(())
 }
 
 fn current_frame<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
@@ -729,8 +672,7 @@ fn current_frame<'gc>(
 }
 
 fn total_frames<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
@@ -741,8 +683,7 @@ fn total_frames<'gc>(
 }
 
 fn alpha<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let val = this.alpha() * 100.0;
@@ -750,20 +691,18 @@ fn alpha<'gc>(
 }
 
 fn set_alpha<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_alpha(context.gc_context, val / 100.0);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_alpha(activation.context.gc_context, val / 100.0);
     }
     Ok(())
 }
 
 fn visible<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let val = this.visible();
@@ -771,74 +710,70 @@ fn visible<'gc>(
 }
 
 fn set_visible<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     // Because this property dates to the era of Flash 4, this is actually coerced to an integer.
     // `_visible = "false";` coerces to NaN and has no effect.
-    if let Some(n) = property_coerce_to_number(activation, context, val)? {
-        this.set_visible(context.gc_context, n != 0.0);
+    if let Some(n) = property_coerce_to_number(activation, val)? {
+        this.set_visible(activation.context.gc_context, n != 0.0);
     }
     Ok(())
 }
 
 fn width<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this.width().into())
 }
 
 fn set_width<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_width(context.gc_context, val);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_width(activation.context.gc_context, val);
     }
     Ok(())
 }
 
 fn height<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this.height().into())
 }
 
 fn set_height<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, context, val)? {
-        this.set_height(context.gc_context, val);
+    if let Some(val) = property_coerce_to_number(activation, val)? {
+        this.set_height(activation.context.gc_context, val);
     }
     Ok(())
 }
 
 fn rotation<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(this.rotation(context.gc_context).to_degrees().into())
+    Ok(this
+        .rotation(activation.context.gc_context)
+        .to_degrees()
+        .into())
 }
 
 fn set_rotation<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     degrees: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(mut degrees) = property_coerce_to_number(activation, context, degrees)? {
+    if let Some(mut degrees) = property_coerce_to_number(activation, degrees)? {
         // Normalize into the range of [-180, 180].
         degrees %= 360.0;
         if degrees < -180.0 {
@@ -846,22 +781,20 @@ fn set_rotation<'gc>(
         } else if degrees > 180.0 {
             degrees -= 360.0
         }
-        this.set_rotation(context.gc_context, degrees.to_radians());
+        this.set_rotation(activation.context.gc_context, degrees.to_radians());
     }
     Ok(())
 }
 
 fn target<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, this.slash_path()).into())
+    Ok(AvmString::new(activation.context.gc_context, this.slash_path()).into())
 }
 
 fn frames_loaded<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
@@ -872,27 +805,24 @@ fn frames_loaded<'gc>(
 }
 
 fn name<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(AvmString::new(context.gc_context, this.name().to_string()).into())
+    Ok(AvmString::new(activation.context.gc_context, this.name().to_string()).into())
 }
 
 fn set_name<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     mut this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    let name = val.coerce_to_string(activation, context)?;
-    this.set_name(context.gc_context, &name);
+    let name = val.coerce_to_string(activation)?;
+    this.set_name(activation.context.gc_context, &name);
     Ok(())
 }
 
 fn drop_target<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm_warn!(activation, "Unimplemented property _droptarget");
@@ -900,21 +830,19 @@ fn drop_target<'gc>(
 }
 
 fn url<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .as_movie_clip()
         .and_then(|mc| mc.movie())
         .and_then(|mov| mov.url().map(|s| s.to_string()))
-        .map(|s| AvmString::new(context.gc_context, s).into())
+        .map(|s| AvmString::new(activation.context.gc_context, s).into())
         .unwrap_or_else(|| "".into()))
 }
 
 fn high_quality<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm_warn!(activation, "Unimplemented property _highquality");
@@ -922,8 +850,7 @@ fn high_quality<'gc>(
 }
 
 fn set_high_quality<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
@@ -932,8 +859,7 @@ fn set_high_quality<'gc>(
 }
 
 fn focus_rect<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm_warn!(activation, "Unimplemented property _focusrect");
@@ -941,8 +867,7 @@ fn focus_rect<'gc>(
 }
 
 fn set_focus_rect<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
@@ -951,8 +876,7 @@ fn set_focus_rect<'gc>(
 }
 
 fn sound_buf_time<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm_warn!(activation, "Unimplemented property _soundbuftime");
@@ -960,8 +884,7 @@ fn sound_buf_time<'gc>(
 }
 
 fn set_sound_buf_time<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
@@ -970,8 +893,7 @@ fn set_sound_buf_time<'gc>(
 }
 
 fn quality<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm_warn!(activation, "Unimplemented property _quality");
@@ -979,8 +901,7 @@ fn quality<'gc>(
 }
 
 fn set_quality<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     _this: DisplayObject<'gc>,
     _val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
@@ -989,30 +910,27 @@ fn set_quality<'gc>(
 }
 
 fn x_mouse<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let local = this.global_to_local(*context.mouse_position);
+    let local = this.global_to_local(*activation.context.mouse_position);
     Ok(local.0.to_pixels().into())
 }
 
 fn y_mouse<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let local = this.global_to_local(*context.mouse_position);
+    let local = this.global_to_local(*activation.context.mouse_position);
     Ok(local.1.to_pixels().into())
 }
 
 fn property_coerce_to_number<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, '_, 'gc, '_>,
     value: Value<'gc>,
 ) -> Result<Option<f64>, Error<'gc>> {
     if value != Value::Undefined && value != Value::Null {
-        let n = value.coerce_to_f64(activation, context)?;
+        let n = value.coerce_to_f64(activation)?;
         if n.is_finite() {
             return Ok(Some(n));
         }

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -45,7 +45,7 @@ impl<'gc> SuperObject<'gc> {
     pub fn from_this_and_base_proto(
         this: Object<'gc>,
         base_proto: Object<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Self, Error<'gc>> {
         Ok(Self(GcCell::allocate(
             activation.context.gc_context,
@@ -64,7 +64,7 @@ impl<'gc> SuperObject<'gc> {
     /// Retrieve the constructor associated with the super proto.
     fn super_constr(
         self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Option<Object<'gc>>, Error<'gc>> {
         if let Some(super_proto) = self.super_proto() {
             Ok(Some(
@@ -82,7 +82,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     fn get_local(
         &self,
         _name: &str,
-        _activation: &mut Activation<'_, '_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(Value::Undefined)
@@ -92,7 +92,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         &self,
         _name: &str,
         _value: Value<'gc>,
-        _activation: &mut Activation<'_, '_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         //TODO: What happens if you set `super.__proto__`?
         Ok(())
@@ -100,7 +100,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
         _base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -122,7 +122,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         &self,
         name: &str,
         args: &[Value<'gc>],
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let child = self.0.read().child;
         let super_proto = self.super_proto();
@@ -141,7 +141,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
         self.0.read().child.call_setter(name, value, activation)
     }
@@ -149,7 +149,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         if let Some(proto) = self.proto() {
@@ -161,7 +161,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         }
     }
 
-    fn delete(&self, _activation: &mut Activation<'_, '_, 'gc, '_>, _name: &str) -> bool {
+    fn delete(&self, _activation: &mut Activation<'_, 'gc, '_>, _name: &str) -> bool {
         //`super` cannot have properties deleted from it
         false
     }
@@ -209,7 +209,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        _activation: &mut Activation<'_, '_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
         _gc_context: MutationContext<'gc, '_>,
         _name: &str,
         _get: Object<'gc>,
@@ -221,7 +221,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
     fn set_watcher(
         &self,
-        _activation: &mut Activation<'_, '_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
         _gc_context: MutationContext<'gc, '_>,
         _name: Cow<str>,
         _callback: Object<'gc>,
@@ -232,7 +232,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
     fn remove_watcher(
         &self,
-        _activation: &mut Activation<'_, '_, 'gc, '_>,
+        _activation: &mut Activation<'_, 'gc, '_>,
         _gc_context: MutationContext<'gc, '_>,
         _name: Cow<str>,
     ) -> bool {
@@ -240,27 +240,23 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         false
     }
 
-    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.0.read().child.has_property(activation, name)
     }
 
-    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.0.read().child.has_own_property(activation, name)
     }
 
-    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_virtual(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.0.read().child.has_own_virtual(activation, name)
     }
 
-    fn is_property_enumerable(
-        &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.0.read().child.is_property_enumerable(activation, name)
     }
 
-    fn get_keys(&self, _activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
+    fn get_keys(&self, _activation: &mut Activation<'_, 'gc, '_>) -> Vec<String> {
         vec![]
     }
 

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -8,7 +8,6 @@ use crate::avm1::object::search_prototype;
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ObjectPtr, ScriptObject, TObject, Value};
 use crate::avm_warn;
-use crate::context::UpdateContext;
 use crate::display_object::DisplayObject;
 use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -46,11 +45,10 @@ impl<'gc> SuperObject<'gc> {
     pub fn from_this_and_base_proto(
         this: Object<'gc>,
         base_proto: Object<'gc>,
-        _activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Self, Error<'gc>> {
         Ok(Self(GcCell::allocate(
-            context.gc_context,
+            activation.context.gc_context,
             SuperObjectData {
                 child: this,
                 base_proto,
@@ -66,14 +64,13 @@ impl<'gc> SuperObject<'gc> {
     /// Retrieve the constructor associated with the super proto.
     fn super_constr(
         self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Option<Object<'gc>>, Error<'gc>> {
         if let Some(super_proto) = self.super_proto() {
             Ok(Some(
                 super_proto
-                    .get("__constructor__", activation, context)?
-                    .coerce_to_object(activation, context),
+                    .get("__constructor__", activation)?
+                    .coerce_to_object(activation),
             ))
         } else {
             Ok(None)
@@ -85,8 +82,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     fn get_local(
         &self,
         _name: &str,
-        _activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
+        _activation: &mut Activation<'_, '_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(Value::Undefined)
@@ -96,8 +92,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         &self,
         _name: &str,
         _value: Value<'gc>,
-        _activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
+        _activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         //TODO: What happens if you set `super.__proto__`?
         Ok(())
@@ -105,17 +100,15 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         _this: Object<'gc>,
         _base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
-        if let Some(constr) = self.super_constr(activation, context)? {
+        if let Some(constr) = self.super_constr(activation)? {
             constr.call(
                 name,
                 activation,
-                context,
                 self.0.read().child,
                 self.super_proto(),
                 args,
@@ -129,12 +122,11 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         &self,
         name: &str,
         args: &[Value<'gc>],
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let child = self.0.read().child;
         let super_proto = self.super_proto();
-        let (method, base_proto) = search_prototype(super_proto, name, activation, context, child)?;
+        let (method, base_proto) = search_prototype(super_proto, name, activation, child)?;
         let method = method;
 
         if let Value::Object(_) = method {
@@ -142,47 +134,34 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
             avm_warn!(activation, "Super method {} is not callable", name);
         }
 
-        method.call(name, activation, context, child, base_proto, args)
+        method.call(name, activation, child, base_proto, args)
     }
 
     fn call_setter(
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
-        self.0
-            .read()
-            .child
-            .call_setter(name, value, activation, context)
+        self.0.read().child.call_setter(name, value, activation)
     }
 
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         if let Some(proto) = self.proto() {
-            proto.create_bare_object(activation, context, this)
+            proto.create_bare_object(activation, this)
         } else {
             // TODO: What happens when you `new super` but there's no
             // super? Is this code even reachable?!
-            self.0
-                .read()
-                .child
-                .create_bare_object(activation, context, this)
+            self.0.read().child.create_bare_object(activation, this)
         }
     }
 
-    fn delete(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _gc_context: MutationContext<'gc, '_>,
-        _name: &str,
-    ) -> bool {
+    fn delete(&self, _activation: &mut Activation<'_, '_, 'gc, '_>, _name: &str) -> bool {
         //`super` cannot have properties deleted from it
         false
     }
@@ -230,7 +209,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
+        _activation: &mut Activation<'_, '_, 'gc, '_>,
         _gc_context: MutationContext<'gc, '_>,
         _name: &str,
         _get: Object<'gc>,
@@ -242,7 +221,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
     fn set_watcher(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
+        _activation: &mut Activation<'_, '_, 'gc, '_>,
         _gc_context: MutationContext<'gc, '_>,
         _name: Cow<str>,
         _callback: Object<'gc>,
@@ -253,7 +232,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
 
     fn remove_watcher(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
+        _activation: &mut Activation<'_, '_, 'gc, '_>,
         _gc_context: MutationContext<'gc, '_>,
         _name: Cow<str>,
     ) -> bool {
@@ -261,44 +240,27 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         false
     }
 
-    fn has_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.0.read().child.has_property(activation, context, name)
+    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.0.read().child.has_property(activation, name)
     }
 
-    fn has_own_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.0
-            .read()
-            .child
-            .has_own_property(activation, context, name)
+    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.0.read().child.has_own_property(activation, name)
     }
 
-    fn has_own_virtual(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.0
-            .read()
-            .child
-            .has_own_virtual(activation, context, name)
+    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.0.read().child.has_own_virtual(activation, name)
     }
 
-    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc>, name: &str) -> bool {
+    fn is_property_enumerable(
+        &self,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
+        name: &str,
+    ) -> bool {
         self.0.read().child.is_property_enumerable(activation, name)
     }
 
-    fn get_keys(&self, _activation: &mut Activation<'_, 'gc>) -> Vec<String> {
+    fn get_keys(&self, _activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
         vec![]
     }
 

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -41,9 +41,9 @@ impl<'gc> ValueObject<'gc> {
             ob
         } else {
             let proto = match &value {
-                Value::Bool(_) => Some(activation.avm.prototypes.boolean),
-                Value::Number(_) => Some(activation.avm.prototypes.number),
-                Value::String(_) => Some(activation.avm.prototypes.string),
+                Value::Bool(_) => Some(activation.context.avm1.prototypes.boolean),
+                Value::Number(_) => Some(activation.context.avm1.prototypes.number),
+                Value::String(_) => Some(activation.context.avm1.prototypes.string),
                 _ => None,
             };
 

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -36,7 +36,7 @@ impl<'gc> ValueObject<'gc> {
     ///
     /// If a class exists for a given value type, this function automatically
     /// selects the correct prototype for it from the system prototypes list.
-    pub fn boxed(activation: &mut Activation<'_, '_, 'gc, '_>, value: Value<'gc>) -> Object<'gc> {
+    pub fn boxed(activation: &mut Activation<'_, 'gc, '_>, value: Value<'gc>) -> Object<'gc> {
         if let Value::Object(ob) = value {
             ob
         } else {
@@ -119,7 +119,7 @@ impl<'gc> TObject<'gc> for ValueObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(ValueObject::empty_box(

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
-use crate::avm1::{Object, ScriptObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
@@ -36,11 +36,7 @@ impl<'gc> ValueObject<'gc> {
     ///
     /// If a class exists for a given value type, this function automatically
     /// selects the correct prototype for it from the system prototypes list.
-    pub fn boxed(
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        value: Value<'gc>,
-    ) -> Object<'gc> {
+    pub fn boxed(activation: &mut Activation<'_, '_, 'gc, '_>, value: Value<'gc>) -> Object<'gc> {
         if let Value::Object(ob) = value {
             ob
         } else {
@@ -52,9 +48,9 @@ impl<'gc> ValueObject<'gc> {
             };
 
             let obj = ValueObject(GcCell::allocate(
-                context.gc_context,
+                activation.context.gc_context,
                 ValueObjectData {
-                    base: ScriptObject::object(context.gc_context, proto),
+                    base: ScriptObject::object(activation.context.gc_context, proto),
                     value: Value::Undefined,
                 },
             ));
@@ -64,26 +60,15 @@ impl<'gc> ValueObject<'gc> {
                 Value::Bool(_) => {
                     let _ = crate::avm1::globals::boolean::constructor(
                         activation,
-                        context,
                         obj.into(),
                         &[value],
                     );
                 }
                 Value::Number(_) => {
-                    let _ = crate::avm1::globals::number::number(
-                        activation,
-                        context,
-                        obj.into(),
-                        &[value],
-                    );
+                    let _ = crate::avm1::globals::number::number(activation, obj.into(), &[value]);
                 }
                 Value::String(_) => {
-                    let _ = crate::avm1::globals::string::string(
-                        activation,
-                        context,
-                        obj.into(),
-                        &[value],
-                    );
+                    let _ = crate::avm1::globals::string::string(activation, obj.into(), &[value]);
                 }
                 _ => (),
             }
@@ -134,11 +119,13 @@ impl<'gc> TObject<'gc> for ValueObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ValueObject::empty_box(context.gc_context, Some(this)))
+        Ok(ValueObject::empty_box(
+            activation.context.gc_context,
+            Some(this),
+        ))
     }
 
     fn as_value_object(&self) -> Option<ValueObject<'gc>> {

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -60,7 +60,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(self
@@ -74,7 +74,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         self.node().set_attribute_value(
             activation.context.gc_context,
@@ -86,7 +86,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -98,7 +98,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
         self.base().call_setter(name, value, activation)
     }
@@ -106,7 +106,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         //TODO: `new xmlnode.attributes()` returns undefined, not an object
@@ -114,7 +114,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         Ok(Value::Undefined.coerce_to_object(activation))
     }
 
-    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.node()
             .delete_attribute(activation.context.gc_context, &XMLName::from_str(name));
         self.base().delete(activation, name)
@@ -134,7 +134,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -147,7 +147,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -159,7 +159,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool {
@@ -196,29 +196,25 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         self.base().set_proto(gc_context, prototype);
     }
 
-    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().has_property(activation, name)
     }
 
-    fn has_own_property(&self, _activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_property(&self, _activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.node()
             .attribute_value(&XMLName::from_str(name))
             .is_some()
     }
 
-    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_virtual(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().has_own_virtual(activation, name)
     }
 
-    fn is_property_enumerable(
-        &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().is_property_enumerable(activation, name)
     }
 
-    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
+    fn get_keys(&self, activation: &mut Activation<'_, 'gc, '_>) -> Vec<String> {
         self.base().get_keys(activation)
     }
 

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::{ObjectPtr, TObject};
 use crate::avm1::property::Attribute;
-use crate::avm1::{AvmString, Object, ScriptObject, UpdateContext, Value};
+use crate::avm1::{AvmString, Object, ScriptObject, Value};
 use crate::xml::{XMLName, XMLNode};
 use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
@@ -60,14 +60,13 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     fn get_local(
         &self,
         name: &str,
-        _activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(self
             .node()
             .attribute_value(&XMLName::from_str(name))
-            .map(|s| AvmString::new(context.gc_context, s).into())
+            .map(|s| AvmString::new(activation.context.gc_context, s).into())
             .unwrap_or_else(|| Value::Undefined))
     }
 
@@ -75,60 +74,50 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         self.node().set_attribute_value(
-            context.gc_context,
+            activation.context.gc_context,
             &XMLName::from_str(name),
-            &value.coerce_to_string(activation, context)?,
+            &value.coerce_to_string(activation)?,
         );
-        self.base().set(name, value, activation, context)
+        self.base().set(name, value, activation)
     }
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
-        self.base()
-            .call(name, activation, context, this, base_proto, args)
+        self.base().call(name, activation, this, base_proto, args)
     }
 
     fn call_setter(
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
-        self.base().call_setter(name, value, activation, context)
+        self.base().call_setter(name, value, activation)
     }
 
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         //TODO: `new xmlnode.attributes()` returns undefined, not an object
         avm_warn!(activation, "Cannot create new XML Attributes object");
-        Ok(Value::Undefined.coerce_to_object(activation, context))
+        Ok(Value::Undefined.coerce_to_object(activation))
     }
 
-    fn delete(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        gc_context: MutationContext<'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
         self.node()
-            .delete_attribute(gc_context, &XMLName::from_str(name));
-        self.base().delete(activation, gc_context, name)
+            .delete_attribute(activation.context.gc_context, &XMLName::from_str(name));
+        self.base().delete(activation, name)
     }
 
     fn add_property(
@@ -145,7 +134,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -158,7 +147,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -170,7 +159,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, 'gc>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool {
@@ -207,40 +196,29 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         self.base().set_proto(gc_context, prototype);
     }
 
-    fn has_property(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.base().has_property(activation, context, name)
+    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.base().has_property(activation, name)
     }
 
-    fn has_own_property(
-        &self,
-        _activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn has_own_property(&self, _activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
         self.node()
             .attribute_value(&XMLName::from_str(name))
             .is_some()
     }
 
-    fn has_own_virtual(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        self.base().has_own_virtual(activation, context, name)
+    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        self.base().has_own_virtual(activation, name)
     }
 
-    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc>, name: &str) -> bool {
+    fn is_property_enumerable(
+        &self,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
+        name: &str,
+    ) -> bool {
         self.base().is_property_enumerable(activation, name)
     }
 
-    fn get_keys(&self, activation: &mut Activation<'_, 'gc>) -> Vec<String> {
+    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
         self.base().get_keys(activation)
     }
 

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -67,7 +67,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
             Ok(node
                 .script_object(
                     activation.context.gc_context,
-                    Some(activation.avm.prototypes().xml_node),
+                    Some(activation.context.avm1.prototypes().xml_node),
                 )
                 .into())
         } else {

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -60,7 +60,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
     fn get_local(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if let Some(mut node) = self.document().get_node_by_id(name) {
@@ -79,14 +79,14 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error<'gc>> {
         self.base().set(name, value, activation)
     }
     fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -98,7 +98,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Option<Object<'gc>> {
         self.base().call_setter(name, value, activation)
     }
@@ -106,7 +106,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         //TODO: `new xmlnode.attributes()` returns undefined, not an object
@@ -114,7 +114,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         Ok(Value::Undefined.coerce_to_object(activation))
     }
 
-    fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().delete(activation, name)
     }
 
@@ -132,7 +132,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
 
     fn add_property_with_case(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
@@ -145,7 +145,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
 
     fn set_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
@@ -157,7 +157,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
 
     fn remove_watcher(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
     ) -> bool {
@@ -194,28 +194,24 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         self.base().set_proto(gc_context, prototype);
     }
 
-    fn has_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().has_property(activation, name)
     }
 
-    fn has_own_property(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.document().get_node_by_id(name).is_some()
             || self.base().has_own_property(activation, name)
     }
 
-    fn has_own_virtual(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    fn has_own_virtual(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().has_own_virtual(activation, name)
     }
 
-    fn is_property_enumerable(
-        &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
+    fn is_property_enumerable(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.base().is_property_enumerable(activation, name)
     }
 
-    fn get_keys(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Vec<String> {
+    fn get_keys(&self, activation: &mut Activation<'_, 'gc, '_>) -> Vec<String> {
         let mut keys = self.base().get_keys(activation);
         keys.extend(self.document().get_node_ids().into_iter());
         keys

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -3,7 +3,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
-use crate::avm1::{Object, ScriptObject, UpdateContext};
+use crate::avm1::{Object, ScriptObject};
 use crate::impl_custom_object;
 use crate::xml::{XMLDocument, XMLNode};
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -77,11 +77,13 @@ impl<'gc> TObject<'gc> for XMLObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        _activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(XMLObject::empty_node(context.gc_context, Some(this)))
+        Ok(XMLObject::empty_node(
+            activation.context.gc_context,
+            Some(this),
+        ))
     }
 
     fn as_xml_node(&self) -> Option<XMLNode<'gc>> {

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -77,7 +77,7 @@ impl<'gc> TObject<'gc> for XMLObject<'gc> {
     #[allow(clippy::new_ret_no_self)]
     fn create_bare_object(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(XMLObject::empty_node(

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -239,7 +239,7 @@ impl<'gc> Scope<'gc> {
     pub fn resolve(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if self.locals().has_property(activation, name) {
@@ -254,7 +254,7 @@ impl<'gc> Scope<'gc> {
     }
 
     /// Check if a particular property in the scope chain is defined.
-    pub fn is_defined(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    pub fn is_defined(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         if self.locals().has_property(activation, name) {
             return true;
         }
@@ -276,7 +276,7 @@ impl<'gc> Scope<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<(), Error<'gc>> {
         if self.class == ScopeClass::Target || self.locals().has_property(activation, name) {
@@ -307,7 +307,7 @@ impl<'gc> Scope<'gc> {
     }
 
     /// Delete a value from scope
-    pub fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+    pub fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         if self.locals().has_property(activation, name) {
             return self.locals().delete(activation, name);
         }

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -243,7 +243,7 @@ impl<'gc> Scope<'gc> {
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if self.locals().has_property(activation, name) {
-            return Ok(self.locals().get(name, activation)?.into());
+            return self.locals().get(name, activation);
         }
         if let Some(scope) = self.parent() {
             return scope.resolve(name, activation, this);

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, UpdateContext, Value};
+use crate::avm1::{Object, ScriptObject, TObject, Value};
 use enumset::EnumSet;
 use gc_arena::{GcCell, MutationContext};
 use std::cell::Ref;
@@ -239,15 +239,14 @@ impl<'gc> Scope<'gc> {
     pub fn resolve(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        if self.locals().has_property(activation, context, name) {
-            return Ok(self.locals().get(name, activation, context)?);
+        if self.locals().has_property(activation, name) {
+            return Ok(self.locals().get(name, activation)?.into());
         }
         if let Some(scope) = self.parent() {
-            return scope.resolve(name, activation, context, this);
+            return scope.resolve(name, activation, this);
         }
 
         //TODO: Should undefined variables halt execution?
@@ -255,18 +254,13 @@ impl<'gc> Scope<'gc> {
     }
 
     /// Check if a particular property in the scope chain is defined.
-    pub fn is_defined(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-    ) -> bool {
-        if self.locals().has_property(activation, context, name) {
+    pub fn is_defined(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        if self.locals().has_property(activation, name) {
             return true;
         }
 
         if let Some(scope) = self.parent() {
-            return scope.is_defined(activation, context, name);
+            return scope.is_defined(activation, name);
         }
 
         false
@@ -282,24 +276,22 @@ impl<'gc> Scope<'gc> {
         &self,
         name: &str,
         value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<(), Error<'gc>> {
-        if self.class == ScopeClass::Target || self.locals().has_property(activation, context, name)
-        {
+        if self.class == ScopeClass::Target || self.locals().has_property(activation, name) {
             // Value found on this object, so overwrite it.
             // Or we've hit the executing movie clip, so create it here.
-            self.locals().set(name, value, activation, context)
+            self.locals().set(name, value, activation)
         } else if let Some(scope) = self.parent() {
             // Traverse the scope chain in search of the value.
-            scope.set(name, value, activation, context, this)
+            scope.set(name, value, activation, this)
         } else {
             // This probably shouldn't happen -- all AVM1 code runs in reference to some movieclip,
             // so we should always have a movieclip scope.
             // Define on the top-level scope.
             debug_assert!(false, "Scope::set: No top-level movie clip scope");
-            self.locals().set(name, value, activation, context)
+            self.locals().set(name, value, activation)
         }
     }
 
@@ -315,19 +307,13 @@ impl<'gc> Scope<'gc> {
     }
 
     /// Delete a value from scope
-    pub fn delete(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        name: &str,
-        mc: MutationContext<'gc, '_>,
-    ) -> bool {
-        if self.locals().has_property(activation, context, name) {
-            return self.locals().delete(activation, mc, name);
+    pub fn delete(&self, activation: &mut Activation<'_, '_, 'gc, '_>, name: &str) -> bool {
+        if self.locals().has_property(activation, name) {
+            return self.locals().delete(activation, name);
         }
 
         if let Some(scope) = self.parent() {
-            return scope.delete(activation, context, name, mc);
+            return scope.delete(activation, name);
         }
 
         false

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -20,11 +20,11 @@ use std::sync::Arc;
 
 pub fn with_avm<F>(swf_version: u8, test: F)
 where
-    F: for<'a, 'gc> FnOnce(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
+    F: for<'a, 'gc> FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
 {
     fn in_the_arena<'a, 'gc: 'a, F>(swf_version: u8, test: F, gc_context: MutationContext<'gc, '_>)
     where
-        F: FnOnce(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
+        F: FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
     {
         let mut avm1 = Avm1::new(gc_context, swf_version);
         let swf = Arc::new(SwfMovie::empty(swf_version));
@@ -72,11 +72,11 @@ where
         root.set_name(context.gc_context, "");
 
         fn run_test<'a, 'gc: 'a, F>(
-            activation: &mut Activation<'_, '_, 'gc, '_>,
+            activation: &mut Activation<'_, 'gc, '_>,
             root: DisplayObject<'gc>,
             test: F,
         ) where
-            F: FnOnce(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
+            F: FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
         {
             let this = root.object().coerce_to_object(activation);
             let result = test(activation, this);
@@ -89,7 +89,7 @@ where
         let base_clip = *context.levels.get(&0).unwrap();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
-            &mut context,
+            context,
             ActivationIdentifier::root("[Test]"),
             swf_version,
             globals,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -34,6 +34,8 @@ where
         let mut levels = BTreeMap::new();
         levels.insert(0, root);
 
+        let globals = avm1.global_object_cell();
+
         let mut context = UpdateContext {
             gc_context,
             player_version: 32,
@@ -85,7 +87,6 @@ where
             }
         }
 
-        let globals = avm1.global_object_cell();
         let base_clip = *context.levels.get(&0).unwrap();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -26,7 +26,7 @@ where
     where
         F: FnOnce(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
     {
-        let mut avm = Avm1::new(gc_context, swf_version);
+        let mut avm1 = Avm1::new(gc_context, swf_version);
         let swf = Arc::new(SwfMovie::empty(swf_version));
         let mut root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
@@ -52,7 +52,7 @@ where
             library: &mut Library::default(),
             navigator: &mut NullNavigatorBackend::new(),
             renderer: &mut NullRenderer::new(),
-            system_prototypes: avm.prototypes().clone(),
+            system_prototypes: avm1.prototypes().clone(),
             mouse_hovered_object: None,
             mouse_position: &(Twips::new(0), Twips::new(0)),
             drag_object: &mut None,
@@ -66,8 +66,9 @@ where
             unbound_text_fields: &mut Vec::new(),
             timers: &mut Timers::new(),
             needs_render: &mut false,
+            avm1: &mut avm1,
         };
-        root.post_instantiation(&mut avm, &mut context, root, None, false);
+        root.post_instantiation(&mut context, root, None, false);
         root.set_name(context.gc_context, "");
 
         fn run_test<'a, 'gc: 'a, F>(
@@ -84,11 +85,10 @@ where
             }
         }
 
-        let globals = avm.global_object_cell();
+        let globals = avm1.global_object_cell();
         let base_clip = *context.levels.get(&0).unwrap();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
-            &mut avm,
             &mut context,
             ActivationIdentifier::root("[Test]"),
             swf_version,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -2,6 +2,7 @@ use crate::avm1::activation::{Activation, ActivationIdentifier};
 use crate::avm1::error::Error;
 use crate::avm1::globals::system::SystemProperties;
 use crate::avm1::{Avm1, Object, Timers, UpdateContext};
+use crate::avm2::Avm2;
 use crate::backend::audio::NullAudioBackend;
 use crate::backend::input::NullInputBackend;
 use crate::backend::navigator::NullNavigatorBackend;
@@ -27,6 +28,7 @@ where
         F: FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
     {
         let mut avm1 = Avm1::new(gc_context, swf_version);
+        let mut avm2 = Avm2::new(gc_context);
         let swf = Arc::new(SwfMovie::empty(swf_version));
         let mut root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
@@ -69,6 +71,7 @@ where
             timers: &mut Timers::new(),
             needs_render: &mut false,
             avm1: &mut avm1,
+            avm2: &mut avm2,
         };
         root.post_instantiation(&mut context, root, None, false);
         root.set_name(context.gc_context, "");

--- a/core/src/avm1/tests.rs
+++ b/core/src/avm1/tests.rs
@@ -4,15 +4,13 @@ use crate::avm1::TObject;
 
 #[test]
 fn locals_into_form_values() {
-    with_avm(19, |activation, context, _this| -> Result<(), Error> {
+    with_avm(19, |activation, _this| -> Result<(), Error> {
         let my_locals = activation.scope().locals().to_owned();
         my_locals
-            .set("value1", "string".into(), activation, context)
+            .set("value1", "string".into(), activation)
             .unwrap();
-        my_locals
-            .set("value2", 2.0.into(), activation, context)
-            .unwrap();
-        let my_local_values = activation.locals_into_form_values(context);
+        my_locals.set("value2", 2.0.into(), activation).unwrap();
+        let my_local_values = activation.locals_into_form_values();
 
         assert_eq!(my_local_values.len(), 2);
         assert_eq!(my_local_values.get("value1"), Some(&"string".to_string()));

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -7,7 +7,7 @@
 //! TODO: Could we use this for AVM2 timers as well?
 
 use crate::avm1::object::search_prototype;
-use crate::avm1::{Activation, ActivationIdentifier, Avm1, Object, TObject, Value};
+use crate::avm1::{Activation, ActivationIdentifier, Object, TObject, Value};
 use crate::context::UpdateContext;
 use gc_arena::Collect;
 use std::collections::{binary_heap::PeekMut, BinaryHeap};
@@ -26,11 +26,7 @@ pub struct Timers<'gc> {
 
 impl<'gc> Timers<'gc> {
     /// Ticks all timers and runs necessary callbacks.
-    pub fn update_timers(
-        avm: &mut Avm1<'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        dt: f64,
-    ) -> Option<f64> {
+    pub fn update_timers(context: &mut UpdateContext<'_, 'gc, '_>, dt: f64) -> Option<f64> {
         context.timers.cur_time = context
             .timers
             .cur_time
@@ -42,11 +38,10 @@ impl<'gc> Timers<'gc> {
         }
 
         let mut activation = Activation::from_nothing(
-            avm,
             context,
             ActivationIdentifier::root("[Timer Callback]"),
             context.swf.header().version,
-            avm.global_object_cell(),
+            context.avm1.global_object_cell(),
             context.levels.get(&0).copied().unwrap(),
         );
 

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -43,35 +43,36 @@ impl<'gc> Timers<'gc> {
 
         let mut activation = Activation::from_nothing(
             avm,
+            context,
             ActivationIdentifier::root("[Timer Callback]"),
             context.swf.header().version,
             avm.global_object_cell(),
-            context.gc_context,
             context.levels.get(&0).copied().unwrap(),
         );
 
         // TODO: `this` is undefined for non-method timer callbacks, but our VM
         // currently doesn't allow `this` to be a Value.
-        let undefined = Value::Undefined.coerce_to_object(&mut activation, context);
+        let undefined = Value::Undefined.coerce_to_object(&mut activation);
 
         let mut tick_count = 0;
-        let cur_time = context.timers.cur_time;
+        let cur_time = activation.context.timers.cur_time;
 
         // We have to be careful because the timer list can be mutated while updating;
         // a timer callback could add more timers, clear timers, etc.
-        while context
+        while activation
+            .context
             .timers
             .peek()
             .map(|timer| timer.tick_time)
             .unwrap_or(cur_time)
             < cur_time
         {
-            let timer = context.timers.peek().unwrap();
+            let timer = activation.context.timers.peek().unwrap();
 
             // TODO: This is only really necessary because BinaryHeap lacks `remove` or `retain` on stable.
             // We can remove the timers straightaway in `clearInterval` once this is stable.
             if !timer.is_alive.get() {
-                context.timers.pop();
+                activation.context.timers.pop();
                 continue;
             }
 
@@ -79,8 +80,8 @@ impl<'gc> Timers<'gc> {
             // SANITY: Only allow so many ticks per timer per update.
             if tick_count > Self::MAX_TICKS {
                 // Reset our time to a little bit before the nearest timer.
-                let next_time = context.timers.peek_mut().unwrap().tick_time;
-                context.timers.cur_time = next_time.wrapping_sub(100);
+                let next_time = activation.context.timers.peek_mut().unwrap().tick_time;
+                activation.context.timers.cur_time = next_time.wrapping_sub(100);
                 break;
             }
 
@@ -93,9 +94,9 @@ impl<'gc> Timers<'gc> {
                 TimerCallback::Method { this, method_name } => {
                     // Fetch the callback method from the object.
                     if let Ok((f, base_proto)) =
-                        search_prototype(Some(this), &method_name, &mut activation, context, this)
+                        search_prototype(Some(this), &method_name, &mut activation, this)
                     {
-                        let f = f.coerce_to_object(&mut activation, context);
+                        let f = f.coerce_to_object(&mut activation);
                         Some((this, base_proto, f))
                     } else {
                         None
@@ -107,18 +108,17 @@ impl<'gc> Timers<'gc> {
                 let _ = function.call(
                     "[Timer Callback]",
                     &mut activation,
-                    context,
                     this,
                     base_proto,
                     &params,
                 );
             }
 
-            let mut timer = context.timers.peek_mut().unwrap();
+            let mut timer = activation.context.timers.peek_mut().unwrap();
             if timer.is_timeout {
                 // Timeouts only fire once.
                 drop(timer);
-                context.timers.pop();
+                activation.context.timers.pop();
             } else {
                 // Reset setInterval timers. `peek_mut` re-sorts the timer in the priority queue.
                 timer.tick_time = timer.tick_time.wrapping_add(timer.interval);
@@ -126,7 +126,8 @@ impl<'gc> Timers<'gc> {
         }
 
         // Return estimated time until next timer tick.
-        context
+        activation
+            .context
             .timers
             .peek()
             .map(|timer| (timer.tick_time.wrapping_sub(cur_time)) as f64 / Self::TIMER_SCALE)

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -37,12 +37,16 @@ impl<'gc> Timers<'gc> {
             return None;
         }
 
+        let version = context.swf.header().version;
+        let globals = context.avm1.global_object_cell();
+        let level0 = context.levels.get(&0).copied().unwrap();
+
         let mut activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root("[Timer Callback]"),
-            context.swf.header().version,
-            context.avm1.global_object_cell(),
-            context.levels.get(&0).copied().unwrap(),
+            version,
+            globals,
+            level0,
         );
 
         // TODO: `this` is undefined for non-method timer callbacks, but our VM

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -38,7 +38,7 @@ impl<'gc> Timers<'gc> {
         }
 
         let mut activation = Activation::from_nothing(
-            context,
+            context.reborrow(),
             ActivationIdentifier::root("[Timer Callback]"),
             context.swf.header().version,
             context.avm1.global_object_cell(),

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -297,10 +297,10 @@ impl<'gc> Value<'gc> {
             (Value::Bool(a), Value::Bool(b)) => Ok((a == b).into()),
             (Value::Object(a), Value::Object(b)) => Ok(Object::ptr_eq(*a, *b).into()),
             (Value::Object(a), Value::Null) | (Value::Object(a), Value::Undefined) => {
-                Ok(Object::ptr_eq(*a, activation.avm.global_object_cell()).into())
+                Ok(Object::ptr_eq(*a, activation.context.avm1.global_object_cell()).into())
             }
             (Value::Null, Value::Object(b)) | (Value::Undefined, Value::Object(b)) => {
-                Ok(Object::ptr_eq(*b, activation.avm.global_object_cell()).into())
+                Ok(Object::ptr_eq(*b, activation.context.avm1.global_object_cell()).into())
             }
             (Value::Undefined, Value::Null) => Ok(true.into()),
             (Value::Null, Value::Undefined) => Ok(true.into()),
@@ -416,8 +416,8 @@ impl<'gc> Value<'gc> {
     }
 
     /// Coerce a value to a string.
-    pub fn coerce_to_string<'a>(
-        &'a self,
+    pub fn coerce_to_string(
+        &self,
         activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
@@ -436,8 +436,8 @@ impl<'gc> Value<'gc> {
             Value::Bool(true) => "true".into(),
             Value::Bool(false) => "false".into(),
             Value::Number(v) => match f64_to_string(*v) {
-                Cow::Borrowed(str) => str.into(),
-                Cow::Owned(str) => AvmString::new(activation.context.gc_context, str),
+                Cow::Borrowed(s) => s.into(),
+                Cow::Owned(s) => AvmString::new(activation.context.gc_context, s),
             },
             Value::String(v) => v.to_owned(),
         })

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -1,7 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::value_object::ValueObject;
-use crate::avm1::{AvmString, Object, TObject, UpdateContext};
+use crate::avm1::{AvmString, Object, TObject};
 use std::borrow::Cow;
 use std::f64::NAN;
 
@@ -133,11 +133,7 @@ impl<'gc> Value<'gc> {
     /// * In SWF6 and lower, `undefined` is coerced to `0.0` (like `false`)
     /// rather than `NaN` as required by spec.
     /// * In SWF5 and lower, hexadecimal is unsupported.
-    fn primitive_as_number(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        _context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> f64 {
+    fn primitive_as_number(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> f64 {
         match self {
             Value::Undefined if activation.current_swf_version() < 7 => 0.0,
             Value::Null if activation.current_swf_version() < 7 => 0.0,
@@ -201,14 +197,13 @@ impl<'gc> Value<'gc> {
     /// ECMA-262 2nd edition s. 9.3 ToNumber
     pub fn coerce_to_f64(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<f64, Error<'gc>> {
         Ok(match self {
             Value::Object(_) => self
-                .to_primitive_num(activation, context)?
-                .primitive_as_number(activation, context),
-            val => val.primitive_as_number(activation, context),
+                .to_primitive_num(activation)?
+                .primitive_as_number(activation),
+            val => val.primitive_as_number(activation),
         })
     }
 
@@ -225,11 +220,10 @@ impl<'gc> Value<'gc> {
     ///   return `undefined` rather than yielding a runtime error.
     pub fn to_primitive_num(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(match self {
-            Value::Object(object) => object.call_method("valueOf", &[], activation, context)?,
+            Value::Object(object) => object.call_method("valueOf", &[], activation)?,
             val => val.to_owned(),
         })
     }
@@ -239,18 +233,17 @@ impl<'gc> Value<'gc> {
     pub fn abstract_lt(
         &self,
         other: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        let prim_self = self.to_primitive_num(activation, context)?;
-        let prim_other = other.to_primitive_num(activation, context)?;
+        let prim_self = self.to_primitive_num(activation)?;
+        let prim_other = other.to_primitive_num(activation)?;
 
         if let (Value::String(a), Value::String(b)) = (&prim_self, &prim_other) {
             return Ok(a.to_string().bytes().lt(b.to_string().bytes()).into());
         }
 
-        let num_self = prim_self.primitive_as_number(activation, context);
-        let num_other = prim_other.primitive_as_number(activation, context);
+        let num_self = prim_self.primitive_as_number(activation);
+        let num_other = prim_other.primitive_as_number(activation);
 
         if num_self.is_nan() || num_other.is_nan() {
             return Ok(Value::Undefined);
@@ -279,8 +272,7 @@ impl<'gc> Value<'gc> {
     pub fn abstract_eq(
         &self,
         other: Value<'gc>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         coerced: bool,
     ) -> Result<Value<'gc>, Error<'gc>> {
         match (self, &other) {
@@ -313,54 +305,52 @@ impl<'gc> Value<'gc> {
             (Value::Undefined, Value::Null) => Ok(true.into()),
             (Value::Null, Value::Undefined) => Ok(true.into()),
             (Value::Number(_), Value::String(_)) => Ok(self.abstract_eq(
-                Value::Number(other.coerce_to_f64(activation, context)?),
+                Value::Number(other.coerce_to_f64(activation)?),
                 activation,
-                context,
                 true,
             )?),
             (Value::String(_), Value::Number(_)) => {
-                Ok(Value::Number(self.coerce_to_f64(activation, context)?)
-                    .abstract_eq(other, activation, context, true)?)
+                Ok(Value::Number(self.coerce_to_f64(activation)?)
+                    .abstract_eq(other, activation, true)?)
             }
-            (Value::Bool(_), _) => Ok(Value::Number(self.coerce_to_f64(activation, context)?)
-                .abstract_eq(other, activation, context, true)?),
+            (Value::Bool(_), _) => Ok(Value::Number(self.coerce_to_f64(activation)?)
+                .abstract_eq(other, activation, true)?),
             (_, Value::Bool(_)) => Ok(self.abstract_eq(
-                Value::Number(other.coerce_to_f64(activation, context)?),
+                Value::Number(other.coerce_to_f64(activation)?),
                 activation,
-                context,
                 true,
             )?),
             (Value::String(_), Value::Object(_)) => {
-                let non_obj_other = other.to_primitive_num(activation, context)?;
+                let non_obj_other = other.to_primitive_num(activation)?;
                 if let Value::Object(_) = non_obj_other {
                     return Ok(false.into());
                 }
 
-                Ok(self.abstract_eq(non_obj_other, activation, context, true)?)
+                Ok(self.abstract_eq(non_obj_other, activation, true)?)
             }
             (Value::Number(_), Value::Object(_)) => {
-                let non_obj_other = other.to_primitive_num(activation, context)?;
+                let non_obj_other = other.to_primitive_num(activation)?;
                 if let Value::Object(_) = non_obj_other {
                     return Ok(false.into());
                 }
 
-                Ok(self.abstract_eq(non_obj_other, activation, context, true)?)
+                Ok(self.abstract_eq(non_obj_other, activation, true)?)
             }
             (Value::Object(_), Value::String(_)) => {
-                let non_obj_self = self.to_primitive_num(activation, context)?;
+                let non_obj_self = self.to_primitive_num(activation)?;
                 if let Value::Object(_) = non_obj_self {
                     return Ok(false.into());
                 }
 
-                Ok(non_obj_self.abstract_eq(other, activation, context, true)?)
+                Ok(non_obj_self.abstract_eq(other, activation, true)?)
             }
             (Value::Object(_), Value::Number(_)) => {
-                let non_obj_self = self.to_primitive_num(activation, context)?;
+                let non_obj_self = self.to_primitive_num(activation)?;
                 if let Value::Object(_) = non_obj_self {
                     return Ok(false.into());
                 }
 
-                Ok(non_obj_self.abstract_eq(other, activation, context, true)?)
+                Ok(non_obj_self.abstract_eq(other, activation, true)?)
             }
             _ => Ok(false.into()),
         }
@@ -386,11 +376,9 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_u16(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<u16, Error<'gc>> {
-        self.coerce_to_f64(activation, context)
-            .map(f64_to_wrapping_u16)
+        self.coerce_to_f64(activation).map(f64_to_wrapping_u16)
     }
 
     /// Coerce a number to an `i16` following the wrapping behavior ECMAScript specifications.
@@ -399,11 +387,9 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_i16(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<i16, Error<'gc>> {
-        self.coerce_to_f64(activation, context)
-            .map(f64_to_wrapping_i16)
+        self.coerce_to_f64(activation).map(f64_to_wrapping_i16)
     }
 
     /// Coerce a number to an `i32` following the ECMAScript specifications for `ToInt32`.
@@ -413,11 +399,9 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_i32(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<i32, Error<'gc>> {
-        self.coerce_to_f64(activation, context)
-            .map(f64_to_wrapping_i32)
+        self.coerce_to_f64(activation).map(f64_to_wrapping_i32)
     }
 
     /// Coerce a number to an `u32` following the ECMAScript specifications for `ToUInt32`.
@@ -426,26 +410,21 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_u32(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<u32, Error<'gc>> {
-        self.coerce_to_f64(activation, context)
-            .map(f64_to_wrapping_u32)
+        self.coerce_to_f64(activation).map(f64_to_wrapping_u32)
     }
 
     /// Coerce a value to a string.
     pub fn coerce_to_string<'a>(
         &'a self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
-            Value::Object(object) => {
-                match object.call_method("toString", &[], activation, context)? {
-                    Value::String(s) => s,
-                    _ => "[type Object]".into(),
-                }
-            }
+            Value::Object(object) => match object.call_method("toString", &[], activation)? {
+                Value::String(s) => s,
+                _ => "[type Object]".into(),
+            },
             Value::Undefined => {
                 if activation.current_swf_version() >= 7 {
                     "undefined".into()
@@ -458,7 +437,7 @@ impl<'gc> Value<'gc> {
             Value::Bool(false) => "false".into(),
             Value::Number(v) => match f64_to_string(*v) {
                 Cow::Borrowed(str) => str.into(),
-                Cow::Owned(str) => AvmString::new(context.gc_context, str),
+                Cow::Owned(str) => AvmString::new(activation.context.gc_context, str),
             },
             Value::String(v) => v.to_owned(),
         })
@@ -492,25 +471,20 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn coerce_to_object(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Object<'gc> {
-        ValueObject::boxed(activation, context, self.to_owned())
+    pub fn coerce_to_object(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Object<'gc> {
+        ValueObject::boxed(activation, self.to_owned())
     }
 
     pub fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
         if let Value::Object(object) = self {
-            object.call(name, activation, context, this, base_proto, args)
+            object.call(name, activation, this, base_proto, args)
         } else {
             Ok(Value::Undefined)
         }
@@ -586,43 +560,32 @@ mod test {
     use crate::avm1::object::{Object, TObject};
     use crate::avm1::test_utils::with_avm;
     use crate::avm1::{AvmString, Value};
-    use crate::context::UpdateContext;
     use enumset::EnumSet;
     use std::f64::{INFINITY, NAN, NEG_INFINITY};
 
     #[test]
     fn to_primitive_num() {
-        with_avm(6, |activation, context, _this| -> Result<(), Error> {
+        with_avm(6, |activation, _this| -> Result<(), Error> {
             let true_value = Value::Bool(true);
             let undefined = Value::Undefined;
             let false_value = Value::Bool(false);
             let null = Value::Null;
 
+            assert_eq!(true_value.to_primitive_num(activation).unwrap(), true_value);
+            assert_eq!(undefined.to_primitive_num(activation).unwrap(), undefined);
             assert_eq!(
-                true_value.to_primitive_num(activation, context).unwrap(),
-                true_value
-            );
-            assert_eq!(
-                undefined.to_primitive_num(activation, context).unwrap(),
-                undefined
-            );
-            assert_eq!(
-                false_value.to_primitive_num(activation, context).unwrap(),
+                false_value.to_primitive_num(activation).unwrap(),
                 false_value
             );
-            assert_eq!(null.to_primitive_num(activation, context).unwrap(), null);
+            assert_eq!(null.to_primitive_num(activation).unwrap(), null);
 
-            let (protos, global, _) = create_globals(context.gc_context);
+            let (protos, global, _) = create_globals(activation.context.gc_context);
             let vglobal = Value::Object(global);
 
-            assert_eq!(
-                vglobal.to_primitive_num(activation, context).unwrap(),
-                undefined
-            );
+            assert_eq!(vglobal.to_primitive_num(activation).unwrap(), undefined);
 
             fn value_of_impl<'gc>(
-                _: &mut Activation<'_, 'gc>,
-                _: &mut UpdateContext<'_, 'gc, '_>,
+                _activation: &mut Activation<'_, '_, 'gc, '_>,
                 _: Object<'gc>,
                 _: &[Value<'gc>],
             ) -> Result<Value<'gc>, Error<'gc>> {
@@ -630,24 +593,22 @@ mod test {
             }
 
             let valueof = FunctionObject::function(
-                context.gc_context,
+                activation.context.gc_context,
                 Executable::Native(value_of_impl),
                 Some(protos.function),
                 protos.function,
             );
 
-            let o = ScriptObject::object_cell(context.gc_context, Some(protos.object));
+            let o = ScriptObject::object_cell(activation.context.gc_context, Some(protos.object));
             o.define_value(
-                context.gc_context,
+                activation.context.gc_context,
                 "valueOf",
                 valueof.into(),
                 EnumSet::empty(),
             );
 
             assert_eq!(
-                Value::Object(o)
-                    .to_primitive_num(activation, context)
-                    .unwrap(),
+                Value::Object(o).to_primitive_num(activation).unwrap(),
                 Value::Number(5.0)
             );
 
@@ -658,20 +619,20 @@ mod test {
     #[test]
     #[allow(clippy::float_cmp)]
     fn to_number_swf7() {
-        with_avm(7, |activation, context, _this| -> Result<(), Error> {
+        with_avm(7, |activation, _this| -> Result<(), Error> {
             let t = Value::Bool(true);
             let u = Value::Undefined;
             let f = Value::Bool(false);
             let n = Value::Null;
 
-            assert_eq!(t.coerce_to_f64(activation, context).unwrap(), 1.0);
-            assert!(u.coerce_to_f64(activation, context).unwrap().is_nan());
-            assert_eq!(f.coerce_to_f64(activation, context).unwrap(), 0.0);
-            assert!(n.coerce_to_f64(activation, context).unwrap().is_nan());
+            assert_eq!(t.coerce_to_f64(activation).unwrap(), 1.0);
+            assert!(u.coerce_to_f64(activation).unwrap().is_nan());
+            assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
+            assert!(n.coerce_to_f64(activation).unwrap().is_nan());
 
-            let bo = Value::Object(ScriptObject::bare_object(context.gc_context).into());
+            let bo = Value::Object(ScriptObject::bare_object(activation.context.gc_context).into());
 
-            assert!(bo.coerce_to_f64(activation, context).unwrap().is_nan());
+            assert!(bo.coerce_to_f64(activation).unwrap().is_nan());
 
             Ok(())
         });
@@ -680,20 +641,20 @@ mod test {
     #[test]
     #[allow(clippy::float_cmp)]
     fn to_number_swf6() {
-        with_avm(6, |activation, context, _this| -> Result<(), Error> {
+        with_avm(6, |activation, _this| -> Result<(), Error> {
             let t = Value::Bool(true);
             let u = Value::Undefined;
             let f = Value::Bool(false);
             let n = Value::Null;
 
-            assert_eq!(t.coerce_to_f64(activation, context).unwrap(), 1.0);
-            assert_eq!(u.coerce_to_f64(activation, context).unwrap(), 0.0);
-            assert_eq!(f.coerce_to_f64(activation, context).unwrap(), 0.0);
-            assert_eq!(n.coerce_to_f64(activation, context).unwrap(), 0.0);
+            assert_eq!(t.coerce_to_f64(activation).unwrap(), 1.0);
+            assert_eq!(u.coerce_to_f64(activation).unwrap(), 0.0);
+            assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
+            assert_eq!(n.coerce_to_f64(activation).unwrap(), 0.0);
 
-            let bo = Value::Object(ScriptObject::bare_object(context.gc_context).into());
+            let bo = Value::Object(ScriptObject::bare_object(activation.context.gc_context).into());
 
-            assert_eq!(bo.coerce_to_f64(activation, context).unwrap(), 0.0);
+            assert_eq!(bo.coerce_to_f64(activation).unwrap(), 0.0);
 
             Ok(())
         });
@@ -701,38 +662,26 @@ mod test {
 
     #[test]
     fn abstract_lt_num() {
-        with_avm(8, |activation, context, _this| -> Result<(), Error> {
+        with_avm(8, |activation, _this| -> Result<(), Error> {
             let a = Value::Number(1.0);
             let b = Value::Number(2.0);
 
-            assert_eq!(
-                a.abstract_lt(b, activation, context).unwrap(),
-                Value::Bool(true)
-            );
+            assert_eq!(a.abstract_lt(b, activation).unwrap(), Value::Bool(true));
 
             let nan = Value::Number(NAN);
-            assert_eq!(
-                a.abstract_lt(nan, activation, context).unwrap(),
-                Value::Undefined
-            );
+            assert_eq!(a.abstract_lt(nan, activation).unwrap(), Value::Undefined);
 
             let inf = Value::Number(INFINITY);
-            assert_eq!(
-                a.abstract_lt(inf, activation, context).unwrap(),
-                Value::Bool(true)
-            );
+            assert_eq!(a.abstract_lt(inf, activation).unwrap(), Value::Bool(true));
 
             let neg_inf = Value::Number(NEG_INFINITY);
             assert_eq!(
-                a.abstract_lt(neg_inf, activation, context).unwrap(),
+                a.abstract_lt(neg_inf, activation).unwrap(),
                 Value::Bool(false)
             );
 
             let zero = Value::Number(0.0);
-            assert_eq!(
-                a.abstract_lt(zero, activation, context).unwrap(),
-                Value::Bool(false)
-            );
+            assert_eq!(a.abstract_lt(zero, activation).unwrap(), Value::Bool(false));
 
             Ok(())
         });
@@ -740,38 +689,35 @@ mod test {
 
     #[test]
     fn abstract_gt_num() {
-        with_avm(8, |activation, context, _this| -> Result<(), Error> {
+        with_avm(8, |activation, _this| -> Result<(), Error> {
             let a = Value::Number(1.0);
             let b = Value::Number(2.0);
 
             assert_eq!(
-                b.abstract_lt(a.clone(), activation, context).unwrap(),
+                b.abstract_lt(a.clone(), activation).unwrap(),
                 Value::Bool(false)
             );
 
             let nan = Value::Number(NAN);
             assert_eq!(
-                nan.abstract_lt(a.clone(), activation, context).unwrap(),
+                nan.abstract_lt(a.clone(), activation).unwrap(),
                 Value::Undefined
             );
 
             let inf = Value::Number(INFINITY);
             assert_eq!(
-                inf.abstract_lt(a.clone(), activation, context).unwrap(),
+                inf.abstract_lt(a.clone(), activation).unwrap(),
                 Value::Bool(false)
             );
 
             let neg_inf = Value::Number(NEG_INFINITY);
             assert_eq!(
-                neg_inf.abstract_lt(a.clone(), activation, context).unwrap(),
+                neg_inf.abstract_lt(a.clone(), activation).unwrap(),
                 Value::Bool(true)
             );
 
             let zero = Value::Number(0.0);
-            assert_eq!(
-                zero.abstract_lt(a, activation, context).unwrap(),
-                Value::Bool(true)
-            );
+            assert_eq!(zero.abstract_lt(a, activation).unwrap(), Value::Bool(true));
 
             Ok(())
         });
@@ -779,14 +725,17 @@ mod test {
 
     #[test]
     fn abstract_lt_str() {
-        with_avm(8, |activation, context, _this| -> Result<(), Error> {
-            let a = Value::String(AvmString::new(context.gc_context, "a".to_owned()));
-            let b = Value::String(AvmString::new(context.gc_context, "b".to_owned()));
+        with_avm(8, |activation, _this| -> Result<(), Error> {
+            let a = Value::String(AvmString::new(
+                activation.context.gc_context,
+                "a".to_owned(),
+            ));
+            let b = Value::String(AvmString::new(
+                activation.context.gc_context,
+                "b".to_owned(),
+            ));
 
-            assert_eq!(
-                a.abstract_lt(b, activation, context).unwrap(),
-                Value::Bool(true)
-            );
+            assert_eq!(a.abstract_lt(b, activation).unwrap(), Value::Bool(true));
 
             Ok(())
         })
@@ -794,14 +743,17 @@ mod test {
 
     #[test]
     fn abstract_gt_str() {
-        with_avm(8, |activation, context, _this| -> Result<(), Error> {
-            let a = Value::String(AvmString::new(context.gc_context, "a".to_owned()));
-            let b = Value::String(AvmString::new(context.gc_context, "b".to_owned()));
+        with_avm(8, |activation, _this| -> Result<(), Error> {
+            let a = Value::String(AvmString::new(
+                activation.context.gc_context,
+                "a".to_owned(),
+            ));
+            let b = Value::String(AvmString::new(
+                activation.context.gc_context,
+                "b".to_owned(),
+            ));
 
-            assert_eq!(
-                b.abstract_lt(a, activation, context).unwrap(),
-                Value::Bool(false)
-            );
+            assert_eq!(b.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 
             Ok(())
         })

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -133,7 +133,7 @@ impl<'gc> Value<'gc> {
     /// * In SWF6 and lower, `undefined` is coerced to `0.0` (like `false`)
     /// rather than `NaN` as required by spec.
     /// * In SWF5 and lower, hexadecimal is unsupported.
-    fn primitive_as_number(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> f64 {
+    fn primitive_as_number(&self, activation: &mut Activation<'_, 'gc, '_>) -> f64 {
         match self {
             Value::Undefined if activation.current_swf_version() < 7 => 0.0,
             Value::Null if activation.current_swf_version() < 7 => 0.0,
@@ -197,7 +197,7 @@ impl<'gc> Value<'gc> {
     /// ECMA-262 2nd edition s. 9.3 ToNumber
     pub fn coerce_to_f64(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<f64, Error<'gc>> {
         Ok(match self {
             Value::Object(_) => self
@@ -220,7 +220,7 @@ impl<'gc> Value<'gc> {
     ///   return `undefined` rather than yielding a runtime error.
     pub fn to_primitive_num(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(match self {
             Value::Object(object) => object.call_method("valueOf", &[], activation)?,
@@ -233,7 +233,7 @@ impl<'gc> Value<'gc> {
     pub fn abstract_lt(
         &self,
         other: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let prim_self = self.to_primitive_num(activation)?;
         let prim_other = other.to_primitive_num(activation)?;
@@ -272,7 +272,7 @@ impl<'gc> Value<'gc> {
     pub fn abstract_eq(
         &self,
         other: Value<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         coerced: bool,
     ) -> Result<Value<'gc>, Error<'gc>> {
         match (self, &other) {
@@ -376,7 +376,7 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_u16(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<u16, Error<'gc>> {
         self.coerce_to_f64(activation).map(f64_to_wrapping_u16)
     }
@@ -387,7 +387,7 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_i16(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<i16, Error<'gc>> {
         self.coerce_to_f64(activation).map(f64_to_wrapping_i16)
     }
@@ -399,7 +399,7 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_i32(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<i32, Error<'gc>> {
         self.coerce_to_f64(activation).map(f64_to_wrapping_i32)
     }
@@ -410,7 +410,7 @@ impl<'gc> Value<'gc> {
     #[allow(dead_code)]
     pub fn coerce_to_u32(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<u32, Error<'gc>> {
         self.coerce_to_f64(activation).map(f64_to_wrapping_u32)
     }
@@ -418,7 +418,7 @@ impl<'gc> Value<'gc> {
     /// Coerce a value to a string.
     pub fn coerce_to_string(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         Ok(match self {
             Value::Object(object) => match object.call_method("toString", &[], activation)? {
@@ -471,14 +471,14 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn coerce_to_object(&self, activation: &mut Activation<'_, '_, 'gc, '_>) -> Object<'gc> {
+    pub fn coerce_to_object(&self, activation: &mut Activation<'_, 'gc, '_>) -> Object<'gc> {
         ValueObject::boxed(activation, self.to_owned())
     }
 
     pub fn call(
         &self,
         name: &str,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
         args: &[Value<'gc>],
@@ -585,7 +585,7 @@ mod test {
             assert_eq!(vglobal.to_primitive_num(activation).unwrap(), undefined);
 
             fn value_of_impl<'gc>(
-                _activation: &mut Activation<'_, '_, 'gc, '_>,
+                _activation: &mut Activation<'_, 'gc, '_>,
                 _: Object<'gc>,
                 _: &[Value<'gc>],
             ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -9,7 +9,6 @@ use crate::avm2::script_object::ScriptObject;
 use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::{Collect, MutationContext};
 use std::f64::NAN;
 
@@ -19,8 +18,7 @@ mod function;
 mod object;
 
 fn trace<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `Class`
@@ -13,8 +12,7 @@ use gc_arena::MutationContext;
 /// Notably, you cannot construct new classes this way, so this returns an
 /// error.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -5,13 +5,11 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `flash.display.DisplayObject`'s constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -5,13 +5,11 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `flash.display.DisplayObjectContainer`'s constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/flash/display/interactiveobject.rs
+++ b/core/src/avm2/globals/flash/display/interactiveobject.rs
@@ -5,13 +5,11 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `flash.display.InteractiveObject`'s constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -5,13 +5,11 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `flash.display.MovieClip`'s constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -5,13 +5,11 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `flash.display.Sprite`'s constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -5,13 +5,11 @@ use crate::avm2::object::Object;
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `flash.events.EventDispatcher`'s constructor.
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -7,13 +7,11 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::script_object::ScriptObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `Function`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _action_context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -22,8 +20,7 @@ pub fn constructor<'gc>(
 
 /// Implements `Function.prototype.call`
 fn call<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     func: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -32,9 +29,9 @@ fn call<'gc>(
 
     if let Some(func) = func {
         if args.len() > 1 {
-            Ok(func.call(this, &args[1..], activation, context, base_proto)?)
+            Ok(func.call(this, &args[1..], activation, base_proto)?)
         } else {
-            Ok(func.call(this, &[], activation, context, base_proto)?)
+            Ok(func.call(this, &[], activation, base_proto)?)
         }
     } else {
         Err("Not a callable function".into())

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -6,13 +6,11 @@ use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::MutationContext;
 
 /// Implements `Object`
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -21,44 +19,40 @@ pub fn constructor<'gc>(
 
 /// Implements `Object.prototype.toString`
 fn to_string<'gc>(
-    _: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     Ok(this
-        .map(|t| t.to_string(context.gc_context))
+        .map(|t| t.to_string(activation.context.gc_context))
         .unwrap_or(Ok(Value::Undefined))?)
 }
 
 /// Implements `Object.prototype.toLocaleString`
 fn to_locale_string<'gc>(
-    _: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     Ok(this
-        .map(|t| t.to_string(context.gc_context))
+        .map(|t| t.to_string(activation.context.gc_context))
         .unwrap_or(Ok(Value::Undefined))?)
 }
 
 /// Implements `Object.prototype.valueOf`
 fn value_of<'gc>(
-    _: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     Ok(this
-        .map(|t| t.value_of(context.gc_context))
+        .map(|t| t.value_of(activation.context.gc_context))
         .unwrap_or(Ok(Value::Undefined))?)
 }
 
 /// `Object.prototype.hasOwnProperty`
 pub fn has_own_property<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -79,8 +73,7 @@ pub fn has_own_property<'gc>(
 
 /// `Object.prototype.isPrototypeOf`
 pub fn is_prototype_of<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -102,8 +95,7 @@ pub fn is_prototype_of<'gc>(
 
 /// `Object.prototype.propertyIsEnumerable`
 pub fn property_is_enumerable<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _context: &mut UpdateContext<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -124,8 +116,7 @@ pub fn property_is_enumerable<'gc>(
 
 /// `Object.prototype.setPropertyIsEnumerable`
 pub fn set_property_is_enumerable<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    context: &mut UpdateContext<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -142,7 +133,7 @@ pub fn set_property_is_enumerable<'gc>(
     if let Some(ns) = this.resolve_any(name)? {
         if !ns.is_private() {
             let qname = QName::new(ns, name);
-            this.set_local_property_is_enumerable(context.gc_context, &qname, is_enum)?;
+            this.set_local_property_is_enumerable(activation.context.gc_context, &qname, is_enum)?;
         }
     }
 

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::Object;
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::context::UpdateContext;
 use gc_arena::{Collect, CollectionContext, Gc, MutationContext};
 use std::fmt;
 use std::rc::Rc;
@@ -30,8 +29,7 @@ pub struct CollectWrapper<T>(T);
 /// your function yields `None`, you must ensure that the top-most activation
 /// in the AVM1 runtime will return with the value of this function.
 pub type NativeMethod<'gc> = fn(
-    &mut Activation<'_, 'gc>,
-    &mut UpdateContext<'_, 'gc, '_>,
+    &mut Activation<'_, 'gc, '_>,
     Option<Object<'gc>>,
     &[Value<'gc>],
 ) -> Result<Value<'gc>, Error>;

--- a/core/src/avm2/return_value.rs
+++ b/core/src/avm2/return_value.rs
@@ -4,7 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::function::Executable;
 use crate::avm2::object::Object;
 use crate::avm2::{Error, Value};
-use crate::context::UpdateContext;
 use std::fmt;
 
 /// Represents the return value of a function call that has not yet executed.
@@ -83,11 +82,7 @@ impl<'gc> ReturnValue<'gc> {
     ///
     /// All return values must eventually resolved - it is a compile error to
     /// fail to do so.
-    pub fn resolve(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) -> Result<Value<'gc>, Error> {
+    pub fn resolve(self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Value<'gc>, Error> {
         match self {
             Self::Immediate(v) => Ok(v),
             Self::ResultOf {
@@ -95,13 +90,7 @@ impl<'gc> ReturnValue<'gc> {
                 unbound_reciever,
                 arguments,
                 base_proto,
-            } => executable.exec(
-                unbound_reciever,
-                &arguments,
-                activation,
-                context,
-                base_proto,
-            ),
+            } => executable.exec(unbound_reciever, &arguments, activation, base_proto),
         }
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -3,6 +3,7 @@ use crate::avm1;
 
 use crate::avm1::globals::system::SystemProperties;
 use crate::avm1::{Avm1, Object, Timers, Value};
+use crate::avm2::Avm2;
 use crate::backend::input::InputBackend;
 use crate::backend::storage::StorageBackend;
 use crate::backend::{audio::AudioBackend, navigator::NavigatorBackend, render::RenderBackend};
@@ -117,6 +118,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The AVM1 global state.
     pub avm1: &'a mut Avm1<'gc>,
+
+    /// The AVM2 global state.
+    pub avm2: &'a mut Avm2<'gc>,
 }
 
 unsafe impl<'a, 'gc, 'gc_context> Collect for UpdateContext<'a, 'gc, 'gc_context> {
@@ -145,6 +149,7 @@ unsafe impl<'a, 'gc, 'gc_context> Collect for UpdateContext<'a, 'gc, 'gc_context
         self.unbound_text_fields.trace(cc);
         self.timers.trace(cc);
         self.avm1.trace(cc);
+        self.avm2.trace(cc);
     }
 }
 
@@ -188,6 +193,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             unbound_text_fields: self.unbound_text_fields,
             timers: self.timers,
             avm1: self.avm1,
+            avm2: self.avm2,
         }
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -156,7 +156,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
     /// update context without adding further lifetimes for it's borrowing.
     /// Please note that you will not be able to use the original update
     /// context until this reborrowed copy has fallen out of scope.
-    pub fn reborrow<'b>(&'b self) -> UpdateContext<'b, 'gc, 'gc_context>
+    pub fn reborrow<'b>(&'b mut self) -> UpdateContext<'b, 'gc, 'gc_context>
     where
         'a: 'b,
     {
@@ -175,12 +175,12 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             storage: self.storage,
             rng: self.rng,
             levels: self.levels,
-            system_prototypes: self.system_prototypes,
+            system_prototypes: self.system_prototypes.clone(),
             mouse_hovered_object: self.mouse_hovered_object,
             mouse_position: self.mouse_position,
             drag_object: self.drag_object,
             stage_size: self.stage_size,
-            player: self.player,
+            player: self.player.clone(),
             load_manager: self.load_manager,
             system: self.system,
             instance_counter: self.instance_counter,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -2,7 +2,7 @@
 use crate::avm1;
 
 use crate::avm1::globals::system::SystemProperties;
-use crate::avm1::{Object, Timers, Value};
+use crate::avm1::{Avm1, Object, Timers, Value};
 use crate::backend::input::InputBackend;
 use crate::backend::storage::StorageBackend;
 use crate::backend::{audio::AudioBackend, navigator::NavigatorBackend, render::RenderBackend};
@@ -114,6 +114,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// Timed callbacks created with `setInterval`/`setTimeout`.
     pub timers: &'a mut Timers<'gc>,
+
+    /// The AVM1 global state.
+    pub avm1: &'a mut Avm1<'gc>,
 }
 
 /// A queued ActionScript call.

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -14,7 +14,7 @@ use crate::prelude::*;
 use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::transform::TransformStack;
 use core::fmt;
-use gc_arena::{Collect, MutationContext};
+use gc_arena::{Collect, CollectionContext, MutationContext};
 use rand::rngs::SmallRng;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::{Arc, Mutex, Weak};
@@ -117,6 +117,79 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The AVM1 global state.
     pub avm1: &'a mut Avm1<'gc>,
+}
+
+unsafe impl<'a, 'gc, 'gc_context> Collect for UpdateContext<'a, 'gc, 'gc_context> {
+    fn trace(&self, cc: CollectionContext) {
+        self.action_queue.trace(cc);
+        self.background_color.trace(cc);
+        self.library.trace(cc);
+        self.player_version.trace(cc);
+        self.needs_render.trace(cc);
+        self.swf.trace(cc);
+        self.audio.trace(cc);
+        self.navigator.trace(cc);
+        self.renderer.trace(cc);
+        self.input.trace(cc);
+        self.storage.trace(cc);
+        self.rng.trace(cc);
+        self.levels.trace(cc);
+        self.system_prototypes.trace(cc);
+        self.mouse_hovered_object.trace(cc);
+        self.mouse_position.trace(cc);
+        self.drag_object.trace(cc);
+        self.load_manager.trace(cc);
+        self.system.trace(cc);
+        self.instance_counter.trace(cc);
+        self.shared_objects.trace(cc);
+        self.unbound_text_fields.trace(cc);
+        self.timers.trace(cc);
+        self.avm1.trace(cc);
+    }
+}
+
+impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
+    /// Transform a borrowed update context into an owned update context with
+    /// a shorter internal lifetime.
+    ///
+    /// This is particularly useful for structures that may wish to hold an
+    /// update context without adding further lifetimes for it's borrowing.
+    /// Please note that you will not be able to use the original update
+    /// context until this reborrowed copy has fallen out of scope.
+    pub fn reborrow<'b>(&'b self) -> UpdateContext<'b, 'gc, 'gc_context>
+    where
+        'a: 'b,
+    {
+        UpdateContext {
+            action_queue: self.action_queue,
+            background_color: self.background_color,
+            gc_context: self.gc_context,
+            library: self.library,
+            player_version: self.player_version,
+            needs_render: self.needs_render,
+            swf: self.swf,
+            audio: self.audio,
+            navigator: self.navigator,
+            renderer: self.renderer,
+            input: self.input,
+            storage: self.storage,
+            rng: self.rng,
+            levels: self.levels,
+            system_prototypes: self.system_prototypes,
+            mouse_hovered_object: self.mouse_hovered_object,
+            mouse_position: self.mouse_position,
+            drag_object: self.drag_object,
+            stage_size: self.stage_size,
+            player: self.player,
+            load_manager: self.load_manager,
+            system: self.system,
+            instance_counter: self.instance_counter,
+            shared_objects: self.shared_objects,
+            unbound_text_fields: self.unbound_text_fields,
+            timers: self.timers,
+            avm1: self.avm1,
+        }
+    }
 }
 
 /// A queued ActionScript call.

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -912,20 +912,16 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
         }
     }
 
-    fn bind_text_field_variables(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) {
+    fn bind_text_field_variables(&self, activation: &mut Activation<'_, '_, 'gc, '_>) {
         // Check all unbound text fields to see if they apply to this object.
         // TODO: Replace with `Vec::drain_filter` when stable.
         let mut i = 0;
-        let mut len = context.unbound_text_fields.len();
+        let mut len = activation.context.unbound_text_fields.len();
         while i < len {
-            if context.unbound_text_fields[i]
-                .try_bind_text_field_variable(activation, context, false)
+            if activation.context.unbound_text_fields[i]
+                .try_bind_text_field_variable(activation, false)
             {
-                context.unbound_text_fields.swap_remove(i);
+                activation.context.unbound_text_fields.swap_remove(i);
                 len -= 1;
             } else {
                 i += 1;

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1,4 +1,4 @@
-use crate::avm1::{Avm1, Object, TObject, Value};
+use crate::avm1::{Object, TObject, Value};
 use crate::context::{RenderContext, UpdateContext};
 use crate::player::NEWEST_PLAYER_VERSION;
 use crate::prelude::*;
@@ -723,14 +723,13 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     /// so forth.
     fn handle_clip_event(
         &self,
-        _avm: &mut Avm1<'gc>,
         _context: &mut UpdateContext<'_, 'gc, '_>,
         _event: ClipEvent,
     ) -> ClipEventResult {
         ClipEventResult::NotHandled
     }
 
-    fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext<'_, 'gc, '_>) {}
+    fn run_frame(&mut self, _context: &mut UpdateContext<'_, 'gc, '_>) {}
     fn render(&self, _context: &mut RenderContext<'_, 'gc>) {}
 
     fn unload(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
@@ -834,7 +833,6 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
 
     fn mouse_pick(
         &self,
-        _avm: &mut Avm1<'gc>,
         _context: &mut UpdateContext<'_, 'gc, '_>,
         _self_node: DisplayObject<'gc>,
         _pos: (Twips, Twips),
@@ -844,7 +842,6 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
 
     fn post_instantiation(
         &mut self,
-        _avm: &mut Avm1<'gc>,
         _context: &mut UpdateContext<'_, 'gc, '_>,
         _display_object: DisplayObject<'gc>,
         _init_object: Option<Object<'gc>>,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -909,7 +909,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
         }
     }
 
-    fn bind_text_field_variables(&self, activation: &mut Activation<'_, '_, 'gc, '_>) {
+    fn bind_text_field_variables(&self, activation: &mut Activation<'_, 'gc, '_>) {
         // Check all unbound text fields to see if they apply to this object.
         // TODO: Replace with `Vec::drain_filter` when stable.
         let mut i = 0;

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -1,6 +1,5 @@
 //! Bitmap display object
 
-use crate::avm1::Avm1;
 use crate::backend::render::BitmapHandle;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
@@ -80,7 +79,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         }
     }
 
-    fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext) {
+    fn run_frame(&mut self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1,7 +1,7 @@
 //! `EditText` display object and support code.
 use crate::avm1::activation::Activation;
 use crate::avm1::globals::text_field::attach_virtual_properties;
-use crate::avm1::{Avm1, AvmString, Object, StageObject, TObject, Value};
+use crate::avm1::{AvmString, Object, StageObject, TObject, Value};
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::drawing::Drawing;
@@ -838,7 +838,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         Some(self.0.read().static_data.swf.clone())
     }
 
-    fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext) {
+    fn run_frame(&mut self, _context: &mut UpdateContext) {
         // Noop
     }
 
@@ -848,7 +848,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
     fn post_instantiation(
         &mut self,
-        avm: &mut Avm1<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         display_object: DisplayObject<'gc>,
         _init_object: Option<Object<'gc>>,
@@ -887,7 +886,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         drop(text);
 
         // If this text field has a variable set, initialize text field binding.
-        avm.run_with_stack_frame_for_display_object(
+        context.avm1.run_with_stack_frame_for_display_object(
             (*self).into(),
             context.swf.version(),
             context,

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -500,11 +500,7 @@ impl<'gc> EditText<'gc> {
         }
     }
 
-    pub fn set_variable(
-        self,
-        variable: Option<String>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
-    ) {
+    pub fn set_variable(self, variable: Option<String>, activation: &mut Activation<'_, 'gc, '_>) {
         // Clear previous binding.
         if let Some(stage_object) = self
             .0
@@ -529,7 +525,7 @@ impl<'gc> EditText<'gc> {
             .initial_text
             .clone()
             .unwrap_or_default();
-        let _ = self.set_text(text, activation.context);
+        let _ = self.set_text(text, &mut activation.context);
 
         self.0.write(activation.context.gc_context).variable = variable;
         self.try_bind_text_field_variable(activation, true);
@@ -704,7 +700,7 @@ impl<'gc> EditText<'gc> {
     /// This is called when the text field is created, and, if the text field is in the unbound list, anytime a display object is created.
     pub fn try_bind_text_field_variable(
         self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
         set_initial_value: bool,
     ) -> bool {
         let mut bound = false;
@@ -737,7 +733,7 @@ impl<'gc> EditText<'gc> {
                                         .coerce_to_string(activation)
                                         .unwrap_or_default()
                                         .to_string(),
-                                    activation.context,
+                                    &mut activation.context,
                                 );
                             } else {
                                 // Otherwise, we initialize the proprty with the text field's text, if it's non-empty.
@@ -782,7 +778,7 @@ impl<'gc> EditText<'gc> {
 
     /// Propagates a text change to the bound display object.
     ///
-    pub fn propagate_text_binding(self, activation: &mut Activation<'_, '_, 'gc, '_>) {
+    pub fn propagate_text_binding(self, activation: &mut Activation<'_, 'gc, '_>) {
         if !self.0.read().firing_variable_binding {
             self.0
                 .write(activation.context.gc_context)
@@ -797,7 +793,7 @@ impl<'gc> EditText<'gc> {
                     activation.resolve_variable_path(self.parent().unwrap(), &variable_path)
                 {
                     let text = if self.0.read().is_html {
-                        let html_tree = self.html_tree(activation.context).as_node();
+                        let html_tree = self.html_tree(&mut activation.context).as_node();
                         let html_string_result = html_tree.into_string(&mut |_node| true);
                         html_string_result.unwrap_or_default()
                     } else {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -503,14 +503,19 @@ impl<'gc> EditText<'gc> {
     pub fn set_variable(
         self,
         variable: Option<String>,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
     ) {
         // Clear previous binding.
-        if let Some(stage_object) = self.0.write(context.gc_context).bound_stage_object.take() {
-            stage_object.clear_text_field_binding(context.gc_context, self);
+        if let Some(stage_object) = self
+            .0
+            .write(activation.context.gc_context)
+            .bound_stage_object
+            .take()
+        {
+            stage_object.clear_text_field_binding(activation.context.gc_context, self);
         } else {
-            context
+            activation
+                .context
                 .unbound_text_fields
                 .retain(|&text_field| !DisplayObject::ptr_eq(text_field.into(), self.into()));
         }
@@ -524,10 +529,10 @@ impl<'gc> EditText<'gc> {
             .initial_text
             .clone()
             .unwrap_or_default();
-        let _ = self.set_text(text, context);
+        let _ = self.set_text(text, activation.context);
 
-        self.0.write(context.gc_context).variable = variable;
-        self.try_bind_text_field_variable(activation, context, true);
+        self.0.write(activation.context.gc_context).variable = variable;
+        self.try_bind_text_field_variable(activation, true);
     }
 
     /// Construct a base text transform for this `EditText`, to be used for
@@ -699,8 +704,7 @@ impl<'gc> EditText<'gc> {
     /// This is called when the text field is created, and, if the text field is in the unbound list, anytime a display object is created.
     pub fn try_bind_text_field_variable(
         self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
+        activation: &mut Activation<'_, '_, 'gc, '_>,
         set_initial_value: bool,
     ) -> bool {
         let mut bound = false;
@@ -718,23 +722,22 @@ impl<'gc> EditText<'gc> {
             activation.run_with_child_frame_for_display_object(
                 "[Text Field Binding]",
                 parent,
-                context.swf.header().version,
-                context,
-                |activation, context| {
+                activation.context.swf.header().version,
+                |activation| {
                     if let Ok(Some((object, property))) =
-                        activation.resolve_variable_path(context, parent, &variable)
+                        activation.resolve_variable_path(parent, &variable)
                     {
                         // If this text field was just created, we immediately propagate the text to the variable (or vice versa).
                         if set_initial_value {
                             // If the property exists on the object, we overwrite the text with the property's value.
-                            if object.has_property(activation, context, property) {
-                                let value = object.get(property, activation, context).unwrap();
+                            if object.has_property(activation, property) {
+                                let value = object.get(property, activation).unwrap();
                                 let _ = self.set_text(
                                     value
-                                        .coerce_to_string(activation, context)
+                                        .coerce_to_string(activation)
                                         .unwrap_or_default()
                                         .to_string(),
-                                    context,
+                                    activation.context,
                                 );
                             } else {
                                 // Otherwise, we initialize the proprty with the text field's text, if it's non-empty.
@@ -743,19 +746,20 @@ impl<'gc> EditText<'gc> {
                                 if !text.is_empty() {
                                     let _ = object.set(
                                         property,
-                                        AvmString::new(context.gc_context, self.text()).into(),
+                                        AvmString::new(activation.context.gc_context, self.text())
+                                            .into(),
                                         activation,
-                                        context,
                                     );
                                 }
                             }
                         }
 
                         if let Some(stage_object) = object.as_stage_object() {
-                            self.0.write(context.gc_context).bound_stage_object =
-                                Some(stage_object);
+                            self.0
+                                .write(activation.context.gc_context)
+                                .bound_stage_object = Some(stage_object);
                             stage_object.register_text_field_binding(
-                                context.gc_context,
+                                activation.context.gc_context,
                                 self,
                                 property,
                             );
@@ -778,26 +782,22 @@ impl<'gc> EditText<'gc> {
 
     /// Propagates a text change to the bound display object.
     ///
-    pub fn propagate_text_binding(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-    ) {
+    pub fn propagate_text_binding(self, activation: &mut Activation<'_, '_, 'gc, '_>) {
         if !self.0.read().firing_variable_binding {
-            self.0.write(context.gc_context).firing_variable_binding = true;
+            self.0
+                .write(activation.context.gc_context)
+                .firing_variable_binding = true;
             if let Some(variable) = self.variable() {
                 // Avoid double-borrows by copying the string.
                 // TODO: Can we avoid this somehow? Maybe when we have a better string type.
                 let variable_path = variable.to_string();
                 drop(variable);
 
-                if let Ok(Some((object, property))) = activation.resolve_variable_path(
-                    context,
-                    self.parent().unwrap(),
-                    &variable_path,
-                ) {
+                if let Ok(Some((object, property))) =
+                    activation.resolve_variable_path(self.parent().unwrap(), &variable_path)
+                {
                     let text = if self.0.read().is_html {
-                        let html_tree = self.html_tree(context).as_node();
+                        let html_tree = self.html_tree(activation.context).as_node();
                         let html_string_result = html_tree.into_string(&mut |_node| true);
                         html_string_result.unwrap_or_default()
                     } else {
@@ -809,20 +809,20 @@ impl<'gc> EditText<'gc> {
                     activation.run_with_child_frame_for_display_object(
                         "[Propagate Text Binding]",
                         self.parent().unwrap(),
-                        context.swf.header().version,
-                        context,
-                        |activation, context| {
+                        activation.context.swf.header().version,
+                        |activation| {
                             let _ = object.set(
                                 property,
-                                AvmString::new(context.gc_context, text).into(),
+                                AvmString::new(activation.context.gc_context, text).into(),
                                 activation,
-                                context,
                             );
                         },
                     );
                 }
             }
-            self.0.write(context.gc_context).firing_variable_binding = false;
+            self.0
+                .write(activation.context.gc_context)
+                .firing_variable_binding = false;
         }
     }
 }
@@ -891,12 +891,12 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             (*self).into(),
             context.swf.version(),
             context,
-            |activation, context| {
-                if !self.try_bind_text_field_variable(activation, context, true) {
-                    context.unbound_text_fields.push(*self);
+            |activation| {
+                if !self.try_bind_text_field_variable(activation, true) {
+                    activation.context.unbound_text_fields.push(*self);
                 }
                 // People can bind to properties of TextFields the same as other display objects.
-                self.bind_text_field_variables(activation, context);
+                self.bind_text_field_variables(activation);
             },
         );
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1,7 +1,7 @@
 //! `EditText` display object and support code.
 use crate::avm1::activation::Activation;
 use crate::avm1::globals::text_field::attach_virtual_properties;
-use crate::avm1::{AvmString, Object, StageObject, TObject, Value};
+use crate::avm1::{Avm1, AvmString, Object, StageObject, TObject, Value};
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::drawing::Drawing;
@@ -882,7 +882,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         drop(text);
 
         // If this text field has a variable set, initialize text field binding.
-        context.avm1.run_with_stack_frame_for_display_object(
+        Avm1::run_with_stack_frame_for_display_object(
             (*self).into(),
             context.swf.version(),
             context,

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -1,4 +1,3 @@
-use crate::avm1::Avm1;
 use crate::backend::render::ShapeHandle;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
@@ -54,7 +53,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         bounds
     }
 
-    fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext) {
+    fn run_frame(&mut self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -1,4 +1,3 @@
-use crate::avm1::Avm1;
 use crate::backend::render::{RenderBackend, ShapeHandle};
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
@@ -52,7 +51,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         Some(*self)
     }
 
-    fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext) {
+    fn run_frame(&mut self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1159,7 +1159,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                             }
                         }
                     }
-                    self.0.write(context.gc_context).object = Some(object);
+                    self.0.write(activation.context.gc_context).object = Some(object);
                     let _ = constructor.construct_on_existing(&mut activation, object, &[]);
                 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1071,7 +1071,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 }
 
                 let mut activation = Activation::from_nothing(
-                    context,
+                    context.reborrow(),
                     ActivationIdentifier::root("[Mouse Pick]"),
                     context.swf.version(),
                     context.avm1.global_object_cell(),
@@ -1134,7 +1134,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             // If we are not, then this must be queued to be ran first-thing
             if instantiated_from_avm && self.0.read().avm1_constructor.is_some() {
                 let mut activation = Activation::from_nothing(
-                    context,
+                    context.reborrow(),
                     ActivationIdentifier::root("[Construct]"),
                     context.swf.version(),
                     context.avm1.global_object_cell(),
@@ -1173,7 +1173,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             );
             if let Some(init_object) = init_object {
                 let mut activation = Activation::from_nothing(
-                    context,
+                    context.reborrow(),
                     ActivationIdentifier::root("[Init]"),
                     context.swf.version(),
                     context.avm1.global_object_cell(),

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -1,4 +1,3 @@
-use crate::avm1::Avm1;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::prelude::*;
@@ -53,7 +52,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         Some(self.0.read().static_data.swf.clone())
     }
 
-    fn run_frame(&mut self, _avm: &mut Avm1<'gc>, _context: &mut UpdateContext) {
+    fn run_frame(&mut self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -351,7 +351,7 @@ impl TextFormat {
     ) -> Result<Object<'gc>, crate::avm1::error::Error<'gc>> {
         let object = ScriptObject::object(
             activation.context.gc_context,
-            Some(activation.avm.prototypes().text_format),
+            Some(activation.context.avm1.prototypes().text_format),
         );
 
         object.set(
@@ -469,7 +469,7 @@ impl TextFormat {
         if let Some(ts) = &self.tab_stops {
             let tab_stops = ScriptObject::array(
                 activation.context.gc_context,
-                Some(activation.avm.prototypes().array),
+                Some(activation.context.avm1.prototypes().array),
             );
 
             tab_stops.set_length(activation.context.gc_context, ts.len());

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -87,7 +87,7 @@ pub struct TextFormat {
 fn getstr_from_avm1_object<'gc>(
     object: Object<'gc>,
     name: &str,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Option<String>, crate::avm1::error::Error<'gc>> {
     Ok(match object.get(name, activation)? {
         Value::Undefined => None,
@@ -99,7 +99,7 @@ fn getstr_from_avm1_object<'gc>(
 fn getfloat_from_avm1_object<'gc>(
     object: Object<'gc>,
     name: &str,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Option<f64>, crate::avm1::error::Error<'gc>> {
     Ok(match object.get(name, activation)? {
         Value::Undefined => None,
@@ -111,7 +111,7 @@ fn getfloat_from_avm1_object<'gc>(
 fn getbool_from_avm1_object<'gc>(
     object: Object<'gc>,
     name: &str,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Option<bool>, crate::avm1::error::Error<'gc>> {
     Ok(match object.get(name, activation)? {
         Value::Undefined => None,
@@ -123,7 +123,7 @@ fn getbool_from_avm1_object<'gc>(
 fn getfloatarray_from_avm1_object<'gc>(
     object: Object<'gc>,
     name: &str,
-    activation: &mut Activation<'_, '_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Option<Vec<f64>>, crate::avm1::error::Error<'gc>> {
     Ok(match object.get(name, activation)? {
         Value::Undefined => None,
@@ -195,7 +195,7 @@ impl TextFormat {
     /// Construct a `TextFormat` from an object that is
     pub fn from_avm1_object<'gc>(
         object1: Object<'gc>,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Self, crate::avm1::error::Error<'gc>> {
         Ok(Self {
             font: getstr_from_avm1_object(object1, "font", activation)?,
@@ -347,7 +347,7 @@ impl TextFormat {
     /// Construct a `TextFormat` AVM1 object from this text format object.
     pub fn as_avm1_object<'gc>(
         &self,
-        activation: &mut Activation<'_, '_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Object<'gc>, crate::avm1::error::Error<'gc>> {
         let object = ScriptObject::object(
             activation.context.gc_context,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1,7 +1,7 @@
 //! Management of async loaders
 
 use crate::avm1::activation::{Activation, ActivationIdentifier};
-use crate::avm1::{AvmString, Object, TObject, Value};
+use crate::avm1::{Avm1, AvmString, Object, TObject, Value};
 use crate::backend::navigator::OwnedFuture;
 use crate::context::{ActionQueue, ActionType};
 use crate::display_object::{DisplayObject, MorphShape, TDisplayObject};
@@ -435,7 +435,7 @@ impl<'gc> Loader<'gc> {
                         .replace_with_movie(uc.gc_context, None);
 
                     if let Some(broadcaster) = broadcaster {
-                        uc.avm1.run_stack_frame_for_method(
+                        Avm1::run_stack_frame_for_method(
                             clip,
                             broadcaster,
                             NEWEST_PLAYER_VERSION,
@@ -469,7 +469,7 @@ impl<'gc> Loader<'gc> {
                         };
 
                         if let Some(broadcaster) = broadcaster {
-                            uc.avm1.run_stack_frame_for_method(
+                            Avm1::run_stack_frame_for_method(
                                 clip,
                                 broadcaster,
                                 NEWEST_PLAYER_VERSION,
@@ -506,7 +506,7 @@ impl<'gc> Loader<'gc> {
                         }
 
                         if let Some(broadcaster) = broadcaster {
-                            uc.avm1.run_stack_frame_for_method(
+                            Avm1::run_stack_frame_for_method(
                                 clip,
                                 broadcaster,
                                 NEWEST_PLAYER_VERSION,
@@ -543,7 +543,7 @@ impl<'gc> Loader<'gc> {
                         };
 
                         if let Some(broadcaster) = broadcaster {
-                            uc.avm1.run_stack_frame_for_method(
+                            Avm1::run_stack_frame_for_method(
                                 clip,
                                 broadcaster,
                                 NEWEST_PLAYER_VERSION,
@@ -596,12 +596,9 @@ impl<'gc> Loader<'gc> {
                     _ => return Err(Error::NotFormLoader),
                 };
 
-                let mut activation = Activation::from_nothing(
+                let mut activation = Activation::from_stub(
                     uc.reborrow(),
                     ActivationIdentifier::root("[Form Loader]"),
-                    uc.swf.version(),
-                    uc.avm1.global_object_cell(),
-                    *uc.levels.get(&0).unwrap(),
                 );
 
                 for (k, v) in form_urlencoded::parse(&data) {
@@ -646,19 +643,18 @@ impl<'gc> Loader<'gc> {
                     _ => return Err(Error::NotLoadVarsLoader),
                 };
 
-                let mut activation = Activation::from_nothing(
+                let mut activation = Activation::from_stub(
                     uc.reborrow(),
                     ActivationIdentifier::root("[Form Loader]"),
-                    uc.swf.version(),
-                    uc.avm1.global_object_cell(),
-                    *uc.levels.get(&0).unwrap(),
                 );
 
                 match data {
                     Ok(data) => {
                         // Fire the onData method with the loaded string.
-                        let string_data =
-                            AvmString::new(uc.gc_context, String::from_utf8_lossy(&data));
+                        let string_data = AvmString::new(
+                            activation.context.gc_context,
+                            String::from_utf8_lossy(&data),
+                        );
                         let _ = that.call_method("onData", &[string_data.into()], &mut activation);
                     }
                     Err(_) => {
@@ -754,7 +750,7 @@ impl<'gc> Loader<'gc> {
 
                         let object =
                             node.script_object(uc.gc_context, Some(uc.avm1.prototypes().xml_node));
-                        uc.avm1.run_stack_frame_for_method(
+                        Avm1::run_stack_frame_for_method(
                             active_clip,
                             object,
                             NEWEST_PLAYER_VERSION,
@@ -763,7 +759,7 @@ impl<'gc> Loader<'gc> {
                             &[200.into()],
                         );
 
-                        uc.avm1.run_stack_frame_for_method(
+                        Avm1::run_stack_frame_for_method(
                             active_clip,
                             object,
                             NEWEST_PLAYER_VERSION,
@@ -791,7 +787,7 @@ impl<'gc> Loader<'gc> {
                         let object =
                             node.script_object(uc.gc_context, Some(uc.avm1.prototypes().xml_node));
 
-                        uc.avm1.run_stack_frame_for_method(
+                        Avm1::run_stack_frame_for_method(
                             active_clip,
                             object,
                             NEWEST_PLAYER_VERSION,
@@ -800,7 +796,7 @@ impl<'gc> Loader<'gc> {
                             &[404.into()],
                         );
 
-                        uc.avm1.run_stack_frame_for_method(
+                        Avm1::run_stack_frame_for_method(
                             active_clip,
                             object,
                             NEWEST_PLAYER_VERSION,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -370,13 +370,14 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
-            player.lock().expect("Could not lock player!!").update(
-                |_avm2, uc| -> Result<(), Error> {
+            player
+                .lock()
+                .expect("Could not lock player!!")
+                .update(|uc| -> Result<(), Error> {
                     url = uc.navigator.resolve_relative_url(&url).into_owned();
 
                     Ok(())
-                },
-            )?;
+                })?;
 
             let data = (fetch.await)
                 .and_then(|data| Ok((data.len(), SwfMovie::from_data(&data, Some(url.clone()))?)));
@@ -414,8 +415,10 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
-            player.lock().expect("Could not lock player!!").update(
-                |_avm2, uc| -> Result<(), Error> {
+            player
+                .lock()
+                .expect("Could not lock player!!")
+                .update(|uc| -> Result<(), Error> {
                     url = uc.navigator.resolve_relative_url(&url).into_owned();
 
                     let (clip, broadcaster) = match uc.load_manager.get_loader(handle) {
@@ -446,8 +449,7 @@ impl<'gc> Loader<'gc> {
                     }
 
                     Ok(())
-                },
-            )?;
+                })?;
 
             let data = (fetch.await)
                 .and_then(|data| Ok((data.len(), SwfMovie::from_data(&data, Some(url.clone()))?)));
@@ -457,7 +459,7 @@ impl<'gc> Loader<'gc> {
                 player
                     .lock()
                     .expect("Could not lock player!!")
-                    .update(|_avm2, uc| {
+                    .update(|uc| {
                         let (clip, broadcaster) = match uc.load_manager.get_loader(handle) {
                             Some(Loader::Movie {
                                 target_clip,
@@ -530,8 +532,10 @@ impl<'gc> Loader<'gc> {
                 //error types we can actually inspect.
                 //This also can get errors from decoding an invalid SWF file,
                 //too. We should distinguish those to player code.
-                player.lock().expect("Could not lock player!!").update(
-                    |_avm2, uc| -> Result<(), Error> {
+                player
+                    .lock()
+                    .expect("Could not lock player!!")
+                    .update(|uc| -> Result<(), Error> {
                         let (clip, broadcaster) = match uc.load_manager.get_loader(handle) {
                             Some(Loader::Movie {
                                 target_clip,
@@ -564,8 +568,7 @@ impl<'gc> Loader<'gc> {
                         };
 
                         Ok(())
-                    },
-                )
+                    })
             }
         })
     }
@@ -588,7 +591,7 @@ impl<'gc> Loader<'gc> {
             let data = fetch.await?;
 
             // Fire the load handler.
-            player.lock().unwrap().update(|_avm2, uc| {
+            player.lock().unwrap().update(|uc| {
                 let loader = uc.load_manager.get_loader(handle);
                 let that = match loader {
                     Some(&Loader::Form { target_object, .. }) => target_object,
@@ -635,7 +638,7 @@ impl<'gc> Loader<'gc> {
             let data = fetch.await;
 
             // Fire the load handler.
-            player.lock().unwrap().update(|_avm2, uc| {
+            player.lock().unwrap().update(|uc| {
                 let loader = uc.load_manager.get_loader(handle);
                 let that = match loader {
                     Some(&Loader::LoadVars { target_object, .. }) => target_object,
@@ -737,7 +740,7 @@ impl<'gc> Loader<'gc> {
                 let xmlstring = String::from_utf8(data)?;
 
                 player.lock().expect("Could not lock player!!").update(
-                    |_avm2, uc| -> Result<(), Error> {
+                    |uc| -> Result<(), Error> {
                         let (mut node, active_clip) = match uc.load_manager.get_loader(handle) {
                             Some(Loader::XML {
                                 target_node,
@@ -773,7 +776,7 @@ impl<'gc> Loader<'gc> {
                 )?;
             } else {
                 player.lock().expect("Could not lock player!!").update(
-                    |_avm2, uc| -> Result<(), Error> {
+                    |uc| -> Result<(), Error> {
                         let (mut node, active_clip) = match uc.load_manager.get_loader(handle) {
                             Some(Loader::XML {
                                 target_node,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -56,10 +56,9 @@ pub enum Error {
 }
 
 pub type FormLoadHandler<'gc> =
-    fn(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>, data: &[u8]) -> Result<(), Error>;
+    fn(&mut Activation<'_, 'gc, '_>, Object<'gc>, data: &[u8]) -> Result<(), Error>;
 
-pub type FormErrorHandler<'gc> =
-    fn(&mut Activation<'_, '_, 'gc, '_>, Object<'gc>) -> Result<(), Error>;
+pub type FormErrorHandler<'gc> = fn(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> Result<(), Error>;
 
 impl From<crate::avm1::error::Error<'_>> for Error {
     fn from(error: crate::avm1::error::Error<'_>) -> Self {
@@ -598,7 +597,7 @@ impl<'gc> Loader<'gc> {
                 };
 
                 let mut activation = Activation::from_nothing(
-                    uc,
+                    uc.reborrow(),
                     ActivationIdentifier::root("[Form Loader]"),
                     uc.swf.version(),
                     uc.avm1.global_object_cell(),
@@ -648,7 +647,7 @@ impl<'gc> Loader<'gc> {
                 };
 
                 let mut activation = Activation::from_nothing(
-                    uc,
+                    uc.reborrow(),
                     ActivationIdentifier::root("[Form Loader]"),
                     uc.swf.version(),
                     uc.avm1.global_object_cell(),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -331,7 +331,7 @@ impl Player {
 
             // Set the version parameter on the root.
             let mut activation = Activation::from_nothing(
-                context,
+                context.reborrow(),
                 ActivationIdentifier::root("[Version Setter]"),
                 context.swf.version(),
                 context.avm1.global_object_cell(),
@@ -454,7 +454,7 @@ impl Player {
                         let mut dumper = VariableDumper::new("  ");
 
                         let mut activation = Activation::from_nothing(
-                            context,
+                            context.reborrow(),
                             ActivationIdentifier::root("[Variable Dumper]"),
                             context.swf.version(),
                             context.avm1.global_object_cell(),
@@ -843,7 +843,7 @@ impl Player {
                     events,
                 } => {
                     let mut activation = Activation::from_nothing(
-                        context,
+                        context.reborrow(),
                         ActivationIdentifier::root("[Construct]"),
                         context.swf.version(),
                         context.avm1.global_object_cell(),
@@ -1112,7 +1112,7 @@ impl Player {
     pub fn flush_shared_objects(&mut self) {
         self.update(|_avm2, context| {
             let mut activation = Activation::from_nothing(
-                context,
+                context.reborrow(),
                 ActivationIdentifier::root("[Flush]"),
                 context.swf.version(),
                 context.avm1.global_object_cell(),


### PR DESCRIPTION
This PR implements a handful of refactors inspired by some investigatory work I did trying to implement support for AVM2 display objects. Since `DisplayObject` functions take the context and AVM1 separately, any attempt to allow it to interact with AVM2 code would also mean all of it's trait methods would need to take AVM2. This would cascade into everything else, which makes it a good candidate for wrapping it into the UpdateContext.

One particular design goal of the Activation API (which @Dinnerbone helpfully informed me of) is to prevent multiple functions from executing concurrently. The Activation holds a mutable borrow on it's AVM specifically to force the use of the AVM to mirror an execution stack. If you make a new Activation, the old one can't be accessed until the new one finishes, because there's a borrow in there. Ergo, I also needed to have the Activation hold the entire UpdateContext, rather than just having it not hold anything like I had originally thought of.

This is based on refactor work done by @Dinnerbone, which wound up going the same way I was going. However, it was never completed due to some particularly terrible lifetime issues in `avm1::globals::array`. That particular module passes around a lot of closures which the borrow checker had problems inferring lifetimes for. I changed his PR from having the Activation borrow an UpdateContext, to having it own an UpdateContext, which drops a lifetime off the Activation. Anyone with an UpdateContext that wants an Activation must now call `context.reborrow()` to shift the lifetimes around. (This constitutes a copy operation, which I'm not thrilled about.) Anyone with an Activation who wants an UpdateContext can mutably borrow it from the Activation.

(I'm not sure what the performance implications of this are. There is at least one thing in the context which is an `Rc` rather than a borrow. Taking a borrow on an activation's update context should at least be free.)

There are also a few other knock-on effects caused by this reshuffling, which I'll note here:

- `avm1::globals::array::sort_compare_numeric` now no longer takes a closure as a parameter. This function was only ever called with two possible functions based on the same flag, and having a closure as input caused an unsolvable lifetime bug. I instead just hand it the flag and the resulting closure is now 'static. I am not sure why this code even worked on master.
- `Avm1`'s "run stack frame" methods can no longer take a self parameter, since the VM is already in the context it gets. They are now associated functions.

### TODOs

- [x] Move UpdateContext inside AVM1 Activation and remove it as a parameter from most AVM1 code
- [x] Move AVM1 inside UpdateContext and remove it as a parameter from DisplayObject methods
- [x] Do the same to AVM2 and it's Activation type