### PR TITLE
Add "Settings Saved" to locales

### DIFF
--- a/web/packages/extension/build/_locales/en/messages.json
+++ b/web/packages/extension/build/_locales/en/messages.json
@@ -49,5 +49,8 @@
     },
     "save_settings": {
         "message": "Save Settings"
+    },
+    "settings_saved": {
+        "message": "Settings Saved"
     }
 }

--- a/web/packages/extension/build/_locales/es/messages.json
+++ b/web/packages/extension/build/_locales/es/messages.json
@@ -49,5 +49,8 @@
     },
     "save_settings": {
         "message": "Guardar Configuración"
+    },
+    "settings_saved": {
+        "message": "Configuración Guardado"
     }
 }

--- a/web/packages/extension/js/settings.js
+++ b/web/packages/extension/js/settings.js
@@ -27,6 +27,6 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
             ruffle_enable: play_flash_checkbox.checked,
             ignore_optout: ignore_optout_checkbox.checked,
         });
-        alert("Settings Saved");
+        alert(get_i18n_string("settings_saved"));
     };
 });


### PR DESCRIPTION
I overlooked this one message when creating the extension settings pull request(adding the infrastructure for internationalization & Spanish translations was included). Also, we should probably try to get a few people on board to translate the extension into other languages.