### PR TITLE
Enable pdf test, which works now

### DIFF
--- a/web/packages/selfhosted/test/polyfill/pdf/test.js
+++ b/web/packages/selfhosted/test/polyfill/pdf/test.js
@@ -10,8 +10,7 @@ describe("PDF object", () => {
         open_test(browser, __dirname);
     });
 
-    // TODO: This is broken today.
-    it.skip("doesn't polyfill with ruffle", () => {
+    it("doesn't polyfill with ruffle", () => {
         inject_ruffle_and_wait(browser);
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");


### PR DESCRIPTION
It's been working for a couple months, but I just forgot to remove the `.skip` from the call.