### PR TITLE
desktop: Fix #1025, invalid audio stream config on ALSA

### DIFF
--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -92,13 +92,7 @@ impl CpalAudioBackend {
             .ok_or("No audio devices available")?;
 
         // Create audio stream for device.
-        let mut supported_configs = device
-            .supported_output_configs()
-            .map_err(|_| "No supported audio format")?;
-        let config = supported_configs
-            .next()
-            .ok_or("No supported audio formats")?
-            .with_max_sample_rate();
+        let config = device.default_output_config()?;
         let sample_format = config.sample_format();
         let config = cpal::StreamConfig::from(config);
 


### PR DESCRIPTION
When using ALSA, cpal was returning bogus sample rates from
`Device::supported_output_configs`, causing the audio stream to
fail to initialize.

Use `Device::default_output_config` instead.