### PR TITLE
chore: Don't mutably borrow self in TDisplayObject

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2637,7 +2637,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         if let Some(level) = self.context.levels.get(&level_id) {
             *level
         } else {
-            let mut level: DisplayObject<'_> = MovieClip::new(
+            let level: DisplayObject<'_> = MovieClip::new(
                 SwfSlice::empty(self.base_clip().movie().unwrap()),
                 self.context.gc_context,
             )

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -504,7 +504,7 @@ fn attach_movie<'gc>(
         return Ok(Value::Undefined);
     }
 
-    if let Ok(mut new_clip) = activation
+    if let Ok(new_clip) = activation
         .context
         .library
         .library_for_movie(movie_clip.movie().unwrap())
@@ -552,7 +552,7 @@ fn create_empty_movie_clip<'gc>(
         .movie()
         .or_else(|| activation.base_clip().movie())
         .unwrap();
-    let mut new_clip = MovieClip::new(SwfSlice::empty(swf_movie), activation.context.gc_context);
+    let new_clip = MovieClip::new(SwfSlice::empty(swf_movie), activation.context.gc_context);
 
     // Set name and attach to parent.
     new_clip.set_name(activation.context.gc_context, &new_instance_name);
@@ -596,7 +596,7 @@ fn create_text_field<'gc>(
         .unwrap_or(Value::Undefined)
         .coerce_to_f64(activation)?;
 
-    let mut text_field: DisplayObject<'gc> =
+    let text_field: DisplayObject<'gc> =
         EditText::new(&mut activation.context, movie, x, y, width, height).into();
     text_field.set_name(
         activation.context.gc_context,
@@ -657,7 +657,7 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
         return Ok(Value::Undefined);
     }
 
-    if let Ok(mut new_clip) = activation
+    if let Ok(new_clip) = activation
         .context
         .library
         .library_for_movie(movie_clip.movie().unwrap())

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -140,7 +140,7 @@ fn color_transform<'gc>(
 
 fn set_color_transform<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut clip: MovieClip<'gc>,
+    clip: MovieClip<'gc>,
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let as_color_transform = value.coerce_to_object(activation);
@@ -165,7 +165,7 @@ fn matrix<'gc>(
 
 fn set_matrix<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut clip: MovieClip<'gc>,
+    clip: MovieClip<'gc>,
     value: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let as_matrix = value.coerce_to_object(activation);
@@ -205,7 +205,7 @@ fn pixel_bounds<'gc>(
 pub fn apply_to_display_object<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     transform: Object<'gc>,
-    mut display_object: DisplayObject<'gc>,
+    display_object: DisplayObject<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(transform) = transform.as_transform_object() {
         if let Some(clip) = transform.clip() {

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -868,7 +868,7 @@ mod tests {
             let mut avm1 = Avm1::new(gc_context, swf_version);
             let mut avm2 = Avm2::new(gc_context);
             let swf = Arc::new(SwfMovie::empty(swf_version));
-            let mut root: DisplayObject<'_> =
+            let root: DisplayObject<'_> =
                 MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
             root.set_depth(gc_context, 0);
             let mut levels = BTreeMap::new();

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -592,7 +592,7 @@ fn x<'gc>(
 
 fn set_x<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
@@ -610,7 +610,7 @@ fn y<'gc>(
 
 fn set_y<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
@@ -621,7 +621,7 @@ fn set_y<'gc>(
 
 fn x_scale<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let val = this.scale_x(activation.context.gc_context) * 100.0;
     Ok(val.into())
@@ -629,7 +629,7 @@ fn x_scale<'gc>(
 
 fn set_x_scale<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
@@ -640,7 +640,7 @@ fn set_x_scale<'gc>(
 
 fn y_scale<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_y = this.scale_y(activation.context.gc_context) * 100.0;
     Ok(scale_y.into())
@@ -648,7 +648,7 @@ fn y_scale<'gc>(
 
 fn set_y_scale<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
@@ -708,7 +708,7 @@ fn visible<'gc>(
 
 fn set_visible<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     // Because this property dates to the era of Flash 4, this is actually coerced to an integer.
@@ -728,7 +728,7 @@ fn width<'gc>(
 
 fn set_width<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
@@ -746,7 +746,7 @@ fn height<'gc>(
 
 fn set_height<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(val) = property_coerce_to_number(activation, val)? {
@@ -757,7 +757,7 @@ fn set_height<'gc>(
 
 fn rotation<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
         .rotation(activation.context.gc_context)
@@ -767,7 +767,7 @@ fn rotation<'gc>(
 
 fn set_rotation<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     degrees: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     if let Some(mut degrees) = property_coerce_to_number(activation, degrees)? {
@@ -810,7 +810,7 @@ fn name<'gc>(
 
 fn set_name<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: DisplayObject<'gc>,
+    this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
     let name = val.coerce_to_string(activation)?;

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -30,7 +30,7 @@ where
         let mut avm1 = Avm1::new(gc_context, swf_version);
         let mut avm2 = Avm2::new(gc_context);
         let swf = Arc::new(SwfMovie::empty(swf_version));
-        let mut root: DisplayObject<'gc> =
+        let root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
         root.set_depth(gc_context, 0);
         let mut levels = BTreeMap::new();

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -417,16 +417,16 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     }
 
     fn place_frame(&self) -> u16;
-    fn set_place_frame(&mut self, context: MutationContext<'gc, '_>, frame: u16);
+    fn set_place_frame(&self, context: MutationContext<'gc, '_>, frame: u16);
 
     fn transform(&self) -> Ref<Transform>;
     fn matrix(&self) -> Ref<Matrix>;
-    fn matrix_mut(&mut self, context: MutationContext<'gc, '_>) -> RefMut<Matrix>;
-    fn set_matrix(&mut self, context: MutationContext<'gc, '_>, matrix: &Matrix);
+    fn matrix_mut(&self, context: MutationContext<'gc, '_>) -> RefMut<Matrix>;
+    fn set_matrix(&self, context: MutationContext<'gc, '_>, matrix: &Matrix);
     fn color_transform(&self) -> Ref<ColorTransform>;
     fn color_transform_mut(&self, context: MutationContext<'gc, '_>) -> RefMut<ColorTransform>;
     fn set_color_transform(
-        &mut self,
+        &self,
         context: MutationContext<'gc, '_>,
         color_transform: &ColorTransform,
     );
@@ -472,7 +472,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
 
     /// Sets the `x` position in pixels of this display object in local space.
     /// Set by the `_x`/`x` ActionScript properties.
-    fn set_x(&mut self, gc_context: MutationContext<'gc, '_>, value: f64);
+    fn set_x(&self, gc_context: MutationContext<'gc, '_>, value: f64);
 
     /// The `y` position in pixels of this display object in local space.
     /// Returned by the `_y`/`y` ActionScript properties.
@@ -480,39 +480,39 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
 
     /// Sets the `y` position in pixels of this display object in local space.
     /// Set by the `_y`/`y` ActionScript properties.
-    fn set_y(&mut self, gc_context: MutationContext<'gc, '_>, value: f64);
+    fn set_y(&self, gc_context: MutationContext<'gc, '_>, value: f64);
 
     /// The rotation in radians this display object in local space.
     /// Returned by the `_rotation`/`rotation` ActionScript properties.
     /// Note that the ActionScript properties return the angle in degrees;
     /// the conversion to degrees is done in the AVM.
-    fn rotation(&mut self, gc_context: MutationContext<'gc, '_>) -> f64;
+    fn rotation(&self, gc_context: MutationContext<'gc, '_>) -> f64;
 
     /// Sets the rotation in radians this display object in local space.
     /// Set by the `_rotation`/`rotation` ActionScript properties.
     /// Note that the ActionScript properties set the angle in degrees;
     /// the conversion to radians is done in the AVM.
-    fn set_rotation(&mut self, gc_context: MutationContext<'gc, '_>, radians: f64);
+    fn set_rotation(&self, gc_context: MutationContext<'gc, '_>, radians: f64);
 
     /// The X axis scale for this display object in local space.
     /// The normal scale is 1.
     /// Returned by the `_xscale`/`scaleX` ActionScript properties.
-    fn scale_x(&mut self, gc_context: MutationContext<'gc, '_>) -> f64;
+    fn scale_x(&self, gc_context: MutationContext<'gc, '_>) -> f64;
 
     /// Sets the scale of the X axis for this display object in local space.
     /// The normal scale is 1.
     /// Set by the `_xscale`/`scaleX` ActionScript properties.
-    fn set_scale_x(&mut self, gc_context: MutationContext<'gc, '_>, value: f64);
+    fn set_scale_x(&self, gc_context: MutationContext<'gc, '_>, value: f64);
 
     /// The Y axis scale for this display object in local space.
     /// The normal scale is 1.
     /// Returned by the `_yscale`/`scaleY` ActionScript properties.
-    fn scale_y(&mut self, gc_context: MutationContext<'gc, '_>) -> f64;
+    fn scale_y(&self, gc_context: MutationContext<'gc, '_>) -> f64;
 
     /// Sets the Y axis scale for this display object in local space.
     /// The normal scale is 1.
     /// Returned by the `_yscale`/`scaleY` ActionScript properties.
-    fn set_scale_y(&mut self, gc_context: MutationContext<'gc, '_>, value: f64);
+    fn set_scale_y(&self, gc_context: MutationContext<'gc, '_>, value: f64);
 
     /// Sets the pixel width of this display object in local space.
     /// The width is based on the AABB of the object.
@@ -526,7 +526,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     /// The width is based on the AABB of the object.
     /// Set by the ActionScript `_width`/`width` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
-    fn set_width(&mut self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_width(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let object_bounds = self.bounds();
         let object_width = (object_bounds.x_max - object_bounds.x_min).to_pixels();
         let object_height = (object_bounds.y_max - object_bounds.y_min).to_pixels();
@@ -563,7 +563,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     /// Sets the pixel height of this display object in local space.
     /// Set by the ActionScript `_height`/`height` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
-    fn set_height(&mut self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_height(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let object_bounds = self.bounds();
         let object_width = (object_bounds.x_max - object_bounds.x_min).to_pixels();
         let object_height = (object_bounds.y_max - object_bounds.y_min).to_pixels();
@@ -601,7 +601,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     /// Set by the `_alpha`/`alpha` ActionScript properties.
     fn set_alpha(&self, gc_context: MutationContext<'gc, '_>, value: f64);
     fn name(&self) -> Ref<str>;
-    fn set_name(&mut self, context: MutationContext<'gc, '_>, name: &str);
+    fn set_name(&self, context: MutationContext<'gc, '_>, name: &str);
 
     /// Returns the dot-syntax path to this display object, e.g. `_level0.foo.clip`
     fn path(&self) -> String {
@@ -630,7 +630,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     }
 
     fn clip_depth(&self) -> Depth;
-    fn set_clip_depth(&mut self, context: MutationContext<'gc, '_>, depth: Depth);
+    fn set_clip_depth(&self, context: MutationContext<'gc, '_>, depth: Depth);
     fn parent(&self) -> Option<DisplayObject<'gc>>;
     fn set_parent(&self, context: MutationContext<'gc, '_>, parent: Option<DisplayObject<'gc>>);
     fn first_child(&self) -> Option<DisplayObject<'gc>>;
@@ -680,7 +680,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
         None
     }
     fn removed(&self) -> bool;
-    fn set_removed(&mut self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_removed(&self, context: MutationContext<'gc, '_>, value: bool);
 
     /// Whether this display object is visible.
     /// Invisible objects are not rendered, but otherwise continue to exist normally.
@@ -690,7 +690,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     /// Sets whether this display object will be visible.
     /// Invisible objects are not rendered, but otherwise continue to exist normally.
     /// Returned by the `_visible`/`visible` ActionScript properties.
-    fn set_visible(&mut self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_visible(&self, context: MutationContext<'gc, '_>, value: bool);
 
     /// Whether this display object has been transformed by ActionScript.
     /// When this flag is set, changes from SWF `PlaceObject` tags are ignored.
@@ -711,12 +711,12 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
         ClipEventResult::NotHandled
     }
 
-    fn run_frame(&mut self, _context: &mut UpdateContext<'_, 'gc, '_>) {}
+    fn run_frame(&self, _context: &mut UpdateContext<'_, 'gc, '_>) {}
     fn render(&self, _context: &mut RenderContext<'_, 'gc>) {}
 
-    fn unload(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
+    fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Unload children.
-        for mut child in self.children() {
+        for child in self.children() {
             child.unload(context);
         }
 
@@ -743,7 +743,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
         None
     }
     fn apply_place_object(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         place_object: &swf::PlaceObject,
     ) {
@@ -786,7 +786,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     }
 
     fn copy_display_properties_from(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         other: DisplayObject<'gc>,
     ) {
@@ -823,7 +823,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     }
 
     fn post_instantiation(
-        &mut self,
+        &self,
         _context: &mut UpdateContext<'_, 'gc, '_>,
         _display_object: DisplayObject<'gc>,
         _init_object: Option<Object<'gc>>,
@@ -883,7 +883,7 @@ pub trait TDisplayObject<'gc>: 'gc + Collect + Debug + Into<DisplayObject<'gc>> 
     }
 
     /// Assigns a default instance name `instanceN` to this object.
-    fn set_default_instance_name(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
+    fn set_default_instance_name(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         if self.name().is_empty() {
             let name = format!("instance{}", *context.instance_counter);
             self.set_name(context.gc_context, &name);
@@ -924,7 +924,7 @@ macro_rules! impl_display_object_sansbounds {
         fn place_frame(&self) -> u16 {
             self.0.read().$field.place_frame()
         }
-        fn set_place_frame(&mut self, context: gc_arena::MutationContext<'gc, '_>, frame: u16) {
+        fn set_place_frame(&self, context: gc_arena::MutationContext<'gc, '_>, frame: u16) {
             self.0.write(context).$field.set_place_frame(context, frame)
         }
         fn transform(&self) -> std::cell::Ref<crate::transform::Transform> {
@@ -934,7 +934,7 @@ macro_rules! impl_display_object_sansbounds {
             std::cell::Ref::map(self.0.read(), |o| o.$field.matrix())
         }
         fn matrix_mut(
-            &mut self,
+            &self,
             context: gc_arena::MutationContext<'gc, '_>,
         ) -> std::cell::RefMut<swf::Matrix> {
             std::cell::RefMut::map(self.0.write(context), |o| o.$field.matrix_mut(context))
@@ -949,7 +949,7 @@ macro_rules! impl_display_object_sansbounds {
             std::cell::RefMut::map(self.0.write(context), |o| o.$field.color_transform_mut())
         }
         fn set_color_transform(
-            &mut self,
+            &self,
             context: gc_arena::MutationContext<'gc, '_>,
             color_transform: &crate::color_transform::ColorTransform,
         ) {
@@ -958,22 +958,22 @@ macro_rules! impl_display_object_sansbounds {
                 .$field
                 .set_color_transform(context, color_transform)
         }
-        fn rotation(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>) -> f64 {
+        fn rotation(&self, gc_context: gc_arena::MutationContext<'gc, '_>) -> f64 {
             self.0.write(gc_context).$field.rotation()
         }
-        fn set_rotation(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>, radians: f64) {
+        fn set_rotation(&self, gc_context: gc_arena::MutationContext<'gc, '_>, radians: f64) {
             self.0.write(gc_context).$field.set_rotation(radians)
         }
-        fn scale_x(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>) -> f64 {
+        fn scale_x(&self, gc_context: gc_arena::MutationContext<'gc, '_>) -> f64 {
             self.0.write(gc_context).$field.scale_x()
         }
-        fn set_scale_x(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
+        fn set_scale_x(&self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
             self.0.write(gc_context).$field.set_scale_x(value)
         }
-        fn scale_y(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>) -> f64 {
+        fn scale_y(&self, gc_context: gc_arena::MutationContext<'gc, '_>) -> f64 {
             self.0.write(gc_context).$field.scale_y()
         }
-        fn set_scale_y(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
+        fn set_scale_y(&self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
             self.0.write(gc_context).$field.set_scale_y(value)
         }
         fn alpha(&self) -> f64 {
@@ -985,14 +985,14 @@ macro_rules! impl_display_object_sansbounds {
         fn name(&self) -> std::cell::Ref<str> {
             std::cell::Ref::map(self.0.read(), |o| o.$field.name())
         }
-        fn set_name(&mut self, context: gc_arena::MutationContext<'gc, '_>, name: &str) {
+        fn set_name(&self, context: gc_arena::MutationContext<'gc, '_>, name: &str) {
             self.0.write(context).$field.set_name(context, name)
         }
         fn clip_depth(&self) -> crate::prelude::Depth {
             self.0.read().$field.clip_depth()
         }
         fn set_clip_depth(
-            &mut self,
+            &self,
             context: gc_arena::MutationContext<'gc, '_>,
             depth: crate::prelude::Depth,
         ) {
@@ -1041,13 +1041,13 @@ macro_rules! impl_display_object_sansbounds {
         fn removed(&self) -> bool {
             self.0.read().$field.removed()
         }
-        fn set_removed(&mut self, context: gc_arena::MutationContext<'gc, '_>, value: bool) {
+        fn set_removed(&self, context: gc_arena::MutationContext<'gc, '_>, value: bool) {
             self.0.write(context).$field.set_removed(value)
         }
         fn visible(&self) -> bool {
             self.0.read().$field.visible()
         }
-        fn set_visible(&mut self, context: gc_arena::MutationContext<'gc, '_>, value: bool) {
+        fn set_visible(&self, context: gc_arena::MutationContext<'gc, '_>, value: bool) {
             self.0.write(context).$field.set_visible(value);
         }
         fn transformed_by_script(&self) -> bool {
@@ -1091,20 +1091,16 @@ macro_rules! impl_display_object {
         fn x(&self) -> f64 {
             self.0.read().$field.x()
         }
-        fn set_x(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
+        fn set_x(&self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
             self.0.write(gc_context).$field.set_x(value)
         }
         fn y(&self) -> f64 {
             self.0.read().$field.y()
         }
-        fn set_y(&mut self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
+        fn set_y(&self, gc_context: gc_arena::MutationContext<'gc, '_>, value: f64) {
             self.0.write(gc_context).$field.set_y(value)
         }
-        fn set_matrix(
-            &mut self,
-            context: gc_arena::MutationContext<'gc, '_>,
-            matrix: &swf::Matrix,
-        ) {
+        fn set_matrix(&self, context: gc_arena::MutationContext<'gc, '_>, matrix: &swf::Matrix) {
             self.0.write(context).$field.set_matrix(context, matrix)
         }
     };

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -79,7 +79,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         }
     }
 
-    fn run_frame(&mut self, _context: &mut UpdateContext) {
+    fn run_frame(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -135,7 +135,7 @@ impl<'gc> Button<'gc> {
         let mut new_children = Vec::new();
         for record in &write.static_data.read().records {
             if record.states.contains(&swf_state) {
-                if let Ok(mut child) = context
+                if let Ok(child) = context
                     .library
                     .library_for_movie_mut(movie.clone())
                     .instantiate_by_id(record.id, context.gc_context)
@@ -156,7 +156,7 @@ impl<'gc> Button<'gc> {
         drop(write);
 
         let mut prev_child = None;
-        for (mut child, depth) in new_children {
+        for (child, depth) in new_children {
             // Wire up new execution list.
             if let Some(prev_child) = prev_child {
                 child.set_prev_sibling(context.gc_context, Some(prev_child));
@@ -188,7 +188,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
     }
 
     fn post_instantiation(
-        &mut self,
+        &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         display_object: DisplayObject<'gc>,
         _init_object: Option<Object<'gc>>,
@@ -207,7 +207,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         }
     }
 
-    fn run_frame(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
+    fn run_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         let self_display_object = (*self).into();
         let initialized = self.0.read().initialized;
 
@@ -227,7 +227,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
                         .library_for_movie_mut(read.static_data.read().swf.clone())
                         .instantiate_by_id(record.id, context.gc_context)
                     {
-                        Ok(mut child) => {
+                        Ok(child) => {
                             child.set_matrix(context.gc_context, &record.matrix);
                             child.set_parent(context.gc_context, Some(self_display_object));
                             child.set_depth(context.gc_context, record.depth.into());
@@ -247,7 +247,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
 
             drop(read);
 
-            for (mut child, depth) in new_children {
+            for (child, depth) in new_children {
                 child.post_instantiation(context, child, None, false);
                 self.0
                     .write(context.gc_context)
@@ -256,7 +256,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
             }
         }
 
-        for mut child in self.children() {
+        for child in self.children() {
             child.run_frame(context);
         }
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -249,7 +249,7 @@ impl<'gc> EditText<'gc> {
             is_device_font: false,
         };
 
-        let mut text_field = Self::from_swf_tag(context, swf_movie, swf_tag);
+        let text_field = Self::from_swf_tag(context, swf_movie, swf_tag);
 
         // Set position.
         let mut matrix = text_field.matrix_mut(context.gc_context);
@@ -834,7 +834,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         Some(self.0.read().static_data.swf.clone())
     }
 
-    fn run_frame(&mut self, _context: &mut UpdateContext) {
+    fn run_frame(&self, _context: &mut UpdateContext) {
         // Noop
     }
 
@@ -843,7 +843,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn post_instantiation(
-        &mut self,
+        &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         display_object: DisplayObject<'gc>,
         _init_object: Option<Object<'gc>>,
@@ -915,7 +915,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         (edit_text.base.transform.matrix.tx + offset).to_pixels()
     }
 
-    fn set_x(&mut self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_x(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let mut edit_text = self.0.write(gc_context);
         let offset = edit_text.bounds.x_min;
         edit_text.base.transform.matrix.tx = Twips::from_pixels(value) - offset;
@@ -930,7 +930,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         (edit_text.base.transform.matrix.ty + offset).to_pixels()
     }
 
-    fn set_y(&mut self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_y(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let mut edit_text = self.0.write(gc_context);
         let offset = edit_text.bounds.y_min;
         edit_text.base.transform.matrix.ty = Twips::from_pixels(value) - offset;
@@ -943,7 +943,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.0.read().bounds.width().to_pixels()
     }
 
-    fn set_width(&mut self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_width(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let mut write = self.0.write(gc_context);
 
         write.bounds.set_width(Twips::from_pixels(value));
@@ -957,7 +957,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.0.read().bounds.height().to_pixels()
     }
 
-    fn set_height(&mut self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_height(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let mut write = self.0.write(gc_context);
 
         write.bounds.set_height(Twips::from_pixels(value));
@@ -967,7 +967,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn set_matrix(&mut self, context: MutationContext<'gc, '_>, matrix: &Matrix) {
+    fn set_matrix(&self, context: MutationContext<'gc, '_>, matrix: &Matrix) {
         self.0.write(context).base.set_matrix(context, matrix);
         self.redraw_border(context);
     }
@@ -1016,7 +1016,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         false
     }
 
-    fn unload(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
+    fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Unbind any display objects bound to this text.
         if let Some(stage_object) = self.0.write(context.gc_context).bound_stage_object.take() {
             stage_object.clear_text_field_binding(context.gc_context, *self);

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -53,7 +53,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         bounds
     }
 
-    fn run_frame(&mut self, _context: &mut UpdateContext) {
+    fn run_frame(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -51,7 +51,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
         Some(*self)
     }
 
-    fn run_frame(&mut self, _context: &mut UpdateContext) {
+    fn run_frame(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -535,7 +535,7 @@ impl<'gc> MovieClip<'gc> {
     pub fn add_child_from_avm(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        mut child: DisplayObject<'gc>,
+        child: DisplayObject<'gc>,
         depth: Depth,
     ) {
         let mut parent = self.0.write(context.gc_context);
@@ -753,7 +753,7 @@ impl<'gc> MovieClip<'gc> {
         place_object: &swf::PlaceObject,
         copy_previous_properties: bool,
     ) -> Option<DisplayObject<'gc>> {
-        if let Ok(mut child) = context
+        if let Ok(child) = context
             .library
             .library_for_movie_mut(self.movie().unwrap()) //TODO
             .instantiate_by_id(id, context.gc_context)
@@ -948,11 +948,11 @@ impl<'gc> MovieClip<'gc> {
                 // If the ID is 0, we are modifying a previous child. Otherwise, we're replacing it.
                 // If it's a rewind, we removed any dead children above, so we always
                 // modify the previous child.
-                Some(mut prev_child) if params.id() == 0 || is_rewind => {
+                Some(prev_child) if params.id() == 0 || is_rewind => {
                     prev_child.apply_place_object(context.gc_context, &params.place_object);
                 }
                 _ => {
-                    if let Some(mut child) = clip.instantiate_child(
+                    if let Some(child) = clip.instantiate_child(
                         self_display_object,
                         context,
                         params.id(),
@@ -1012,9 +1012,9 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         Some(self.0.read().movie())
     }
 
-    fn run_frame(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
+    fn run_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Children must run first.
-        for mut child in self.children() {
+        for child in self.children() {
             child.run_frame(context);
         }
 
@@ -1118,7 +1118,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn post_instantiation(
-        &mut self,
+        &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         display_object: DisplayObject<'gc>,
         init_object: Option<Object<'gc>>,
@@ -1228,8 +1228,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             .unwrap_or(Value::Undefined)
     }
 
-    fn unload(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        for mut child in self.children() {
+    fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
+        for child in self.children() {
             child.unload(context);
         }
 
@@ -1374,7 +1374,7 @@ impl<'gc> MovieClipData<'gc> {
     fn remove_child_from_exec_list(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        mut child: DisplayObject<'gc>,
+        child: DisplayObject<'gc>,
     ) {
         // Remove from children linked list.
         let prev = child.prev_sibling();
@@ -2264,7 +2264,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                 }
             }
             PlaceObjectAction::Modify => {
-                if let Some(mut child) = self
+                if let Some(child) = self
                     .0
                     .read()
                     .children

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -52,7 +52,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         Some(self.0.read().static_data.swf.clone())
     }
 
-    fn run_frame(&mut self, _context: &mut UpdateContext) {
+    fn run_frame(&self, _context: &mut UpdateContext) {
         // Noop
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -307,7 +307,7 @@ impl Player {
         self.swf = movie;
 
         self.mutate_with_update_context(|context| {
-            let mut root: DisplayObject =
+            let root: DisplayObject =
                 MovieClip::from_movie(context.gc_context, context.swf.clone()).into();
             root.set_depth(context.gc_context, 0);
             root.post_instantiation(context, root, None, false);
@@ -740,7 +740,7 @@ impl Player {
             // want to run frames on
             let levels: Vec<_> = update_context.levels.values().copied().collect();
 
-            for mut level in levels {
+            for level in levels {
                 level.run_frame(update_context);
             }
         });


### PR DESCRIPTION
Replace `&mut self` receivers in `TDisplayObject` methods with `&self` receivers.

The use of `&mut` was inconsistent across TDisplayObject methods. Although logically these methods were mutating the display object, `&mut` or lack thereof is more about whether a borrow requires exclusive access or shared access, not whether the data is constant (see https://docs.rs/dtolnay/0.0.9/dtolnay/macro._02__reference_types.html). `TDisplayObject` is already `Copy` and designed to use interior mutability, so `&mut self` in some methods was inconsistent and overly restrictive. This also matches the API of the `Cell`/`RefCell` types.