### PR TITLE
avm1: Don't mutably borrow self in TObject

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1066,7 +1066,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         //e.g. `class Whatever extends Object.prototype` or `class Whatever extends 5`
         let super_proto = superclass.get("prototype", self)?.coerce_to_object(self);
 
-        let mut sub_prototype: Object<'gc> =
+        let sub_prototype: Object<'gc> =
             ScriptObject::object(self.context.gc_context, Some(super_proto)).into();
 
         sub_prototype.set("constructor", superclass.into(), self)?;
@@ -1410,7 +1410,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             interfaces.push(self.context.avm1.pop().coerce_to_object(self));
         }
 
-        let mut prototype = constr.get("prototype", self)?.coerce_to_object(self);
+        let prototype = constr.get("prototype", self)?.coerce_to_object(self);
 
         prototype.set_interfaces(self.context.gc_context, interfaces);
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -569,7 +569,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     fn construct_on_existing(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        mut this: Object<'gc>,
+        this: Object<'gc>,
         args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
         this.set("__constructor__", (*self).into(), activation)?;
@@ -671,7 +671,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     }
 
     fn set_attributes(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
         set_attributes: EnumSet<Attribute>,
@@ -760,11 +760,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     }
 
     /// Set the interface list for this object. (Only useful for prototypes.)
-    fn set_interfaces(
-        &mut self,
-        gc_context: MutationContext<'gc, '_>,
-        iface_list: Vec<Object<'gc>>,
-    ) {
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
         self.base.set_interfaces(gc_context, iface_list)
     }
 

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -13,7 +13,7 @@ use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    mut this: Object<'gc>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // The target display object that this color will modify.

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -308,7 +308,7 @@ pub fn as_set_prop_flags<'gc>(
     _: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut object = if let Some(object) = args.get(0).map(|v| v.coerce_to_object(activation)) {
+    let object = if let Some(object) = args.get(0).map(|v| v.coerce_to_object(activation)) {
         object
     } else {
         avm_warn!(

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -227,7 +227,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Attributes can be set, cleared, or left as-is using the pairs of `set_`
     /// and `clear_attributes` parameters.
     fn set_attributes(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
         set_attributes: EnumSet<Attribute>,
@@ -323,11 +323,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn interfaces(&self) -> Vec<Object<'gc>>;
 
     /// Set the interface list for this object. (Only useful for prototypes.)
-    fn set_interfaces(
-        &mut self,
-        gc_context: MutationContext<'gc, '_>,
-        iface_list: Vec<Object<'gc>>,
-    );
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>);
 
     /// Determine if this object is an instance of a class.
     ///

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -67,7 +67,7 @@ macro_rules! impl_custom_object_without_set {
         }
 
         fn set_attributes(
-            &mut self,
+            &self,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: Option<&str>,
             set_attributes: enumset::EnumSet<crate::avm1::property::Attribute>,
@@ -162,7 +162,7 @@ macro_rules! impl_custom_object_without_set {
         }
 
         fn set_interfaces(
-            &mut self,
+            &self,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             iface_list: Vec<crate::avm1::Object<'gc>>,
         ) {

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -605,7 +605,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     }
 
     fn set_attributes(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
         set_attributes: EnumSet<Attribute>,
@@ -723,7 +723,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         self.0.read().interfaces.clone()
     }
 
-    fn set_interfaces(&mut self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
         self.0.write(context).interfaces = iface_list;
     }
 

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -270,7 +270,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
     }
 
     fn set_attributes(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
         set_attributes: EnumSet<Attribute>,
@@ -438,7 +438,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0.read().base.interfaces()
     }
 
-    fn set_interfaces(&mut self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
         self.0
             .write(context)
             .base

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -187,7 +187,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     }
 
     fn set_attributes(
-        &mut self,
+        &self,
         _gc_context: MutationContext<'gc, '_>,
         _name: Option<&str>,
         _set_attributes: EnumSet<Attribute>,
@@ -298,11 +298,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         vec![]
     }
 
-    fn set_interfaces(
-        &mut self,
-        _gc_context: MutationContext<'gc, '_>,
-        _iface_list: Vec<Object<'gc>>,
-    ) {
+    fn set_interfaces(&self, _gc_context: MutationContext<'gc, '_>, _iface_list: Vec<Object<'gc>>) {
         //`super` probably cannot have interfaces set on it
     }
 

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -178,7 +178,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     }
 
     fn set_attributes(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
         set_attributes: EnumSet<Attribute>,
@@ -230,7 +230,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         self.base().interfaces()
     }
 
-    fn set_interfaces(&mut self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
         self.base().set_interfaces(context, iface_list)
     }
 

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -176,7 +176,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
     }
 
     fn set_attributes(
-        &mut self,
+        &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
         set_attributes: EnumSet<Attribute>,
@@ -229,7 +229,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         self.base().interfaces()
     }
 
-    fn set_interfaces(&mut self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
         self.base().set_interfaces(context, iface_list)
     }
 


### PR DESCRIPTION
Replace inconsistent usage of `&mut self` with `&self` in `avm1::TObject`.