### PR TITLE
text: Fix some issues with HTML parsing

### DIFF
--- a/core/src/xml/namespace.rs
+++ b/core/src/xml/namespace.rs
@@ -85,6 +85,20 @@ impl XMLName {
             Cow::Borrowed(&self.name)
         }
     }
+
+    /// Compares both names as case-insensitve ASCII (for use in HTML parsing).
+    /// TODO: We shouldn't need this when we have a proper HTML parser.
+    pub fn eq_ignore_ascii_case(&self, other: &XMLName) -> bool {
+        if !self.name.eq_ignore_ascii_case(&other.name) {
+            return false;
+        }
+
+        match (&self.namespace, &other.namespace) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.eq_ignore_ascii_case(&b),
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Debug for XMLName {

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -1042,6 +1042,19 @@ impl<'gc> XMLNode<'gc> {
         }
     }
 
+    /// Retrieve the value of a single attribute on this node, case-insensitively.
+    ///
+    /// TODO: Probably won't need this when we have a proper HTML parser.
+    pub fn attribute_value_ignore_ascii_case(self, name: &XMLName) -> Option<String> {
+        match &*self.0.read() {
+            XMLNodeData::Element { attributes, .. } => attributes
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.clone()),
+            _ => None,
+        }
+    }
+
     /// Set the value of a single attribute on this node.
     ///
     /// If the node does not contain attributes, then this function silently fails.


### PR DESCRIPTION
Small fixes for a few issues with HTML parsing:
 * Fix for duplicated characters when parsing HTML entities (#1026)
 * Add support for numeric HTML entities, decimal and hex (#1026)
 * HTML entities are case insensitive
 * If an invalid HTML entity is parsed, output the text as-is
 * HTML tags/attributes are case insensitive (#1021) (different Flash version could emit differently cased HTML).

The true fixes for these would involve rolling a specific HTML parser; for example, opening and closing tags with different cases would currently still break.