### PR TITLE
Add graphics options to desktop CLI

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -73,9 +73,12 @@ impl From<PowerPreference> for ruffle_render_wgpu::wgpu::PowerPreference {
     version = include_str!(concat!(env!("OUT_DIR"), "/version-info.txt")),
 )]
 struct Opt {
+    /// Path to a flash movie (swf) to play
     #[clap(name = "FILE", parse(from_os_str))]
     input_path: PathBuf,
 
+    /// Type of graphics backend to use. Not all options may be supported by your current system.
+    /// Default will attempt to pick the most supported graphics backend.
     #[clap(
         long,
         short,
@@ -85,6 +88,10 @@ struct Opt {
     )]
     graphics: GraphicsBackend,
 
+    /// Power preference for the graphics device used. High power usage tends to prefer dedicated GPUs,
+    /// whereas a low power usage tends prefer integrated GPUs.
+    /// Default will pick the best device depending on the status of your computer (ie, wall-power
+    /// may choose high, battery power may choose low)
     #[clap(
         long,
         short,

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -128,6 +128,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
         window: &W,
         size: (u32, u32),
         backend: wgpu::BackendBit,
+        power_preference: wgpu::PowerPreference,
     ) -> Result<Self, Error> {
         if wgpu::BackendBit::SECONDARY.contains(backend) {
             log::warn!(
@@ -141,7 +142,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
         let surface = unsafe { instance.create_surface(window) };
 
         let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::HighPerformance,
+            power_preference,
             compatible_surface: Some(&surface),
         }))
         .ok_or_else(|| {

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -1,6 +1,7 @@
 use lyon::lyon_algorithms::path::Path;
 use ruffle_core::shape_utils::DrawCommand;
 use ruffle_core::swf;
+use std::borrow::Cow;
 use std::mem::size_of;
 use swf::{GradientSpread, Twips};
 use wgpu::util::DeviceExt;
@@ -12,6 +13,45 @@ macro_rules! create_debug_label {
             None
         }
     )
+}
+
+pub fn format_list<'a>(values: &[&'a str], connector: &'a str) -> Cow<'a, str> {
+    match values.len() {
+        0 => Cow::Borrowed(""),
+        1 => Cow::Borrowed(values[0]),
+        _ => Cow::Owned(
+            values[0..values.len() - 1].join(", ")
+                + " "
+                + connector
+                + " "
+                + values[values.len() - 1],
+        ),
+    }
+}
+
+pub fn get_backend_names(backends: wgpu::BackendBit) -> Vec<&'static str> {
+    let mut names = Vec::new();
+
+    if backends.contains(wgpu::BackendBit::VULKAN) {
+        names.push("Vulkan");
+    }
+    if backends.contains(wgpu::BackendBit::DX12) {
+        names.push("DirectX 12");
+    }
+    if backends.contains(wgpu::BackendBit::DX11) {
+        names.push("DirectX 11");
+    }
+    if backends.contains(wgpu::BackendBit::METAL) {
+        names.push("Metal");
+    }
+    if backends.contains(wgpu::BackendBit::GL) {
+        names.push("Open GL");
+    }
+    if backends.contains(wgpu::BackendBit::BROWSER_WEBGPU) {
+        names.push("Web GPU");
+    }
+
+    names
 }
 
 pub fn create_buffer_with_data(


### PR DESCRIPTION
Help output now reads:

```
Ruffle 0.1.0-nightly (6bff48d6 2020-08-25)
Mike Welsh <mwelsh@gmail.com>

USAGE:
    ruffle_desktop.exe [OPTIONS] <FILE>

ARGS:
    <FILE>    Path to a flash movie (swf) to play

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -g, --graphics <graphics>    Type of graphics backend to use. Not all options may be supported by your current
                                 system. Default will attempt to pick the most supported graphics backend [default:
                                 default]  [possible values: default, vulkan, metal, dx12, dx11]
    -p, --power <power>          Power preference for the graphics device used. High power usage tends to prefer
                                 dedicated GPUs, whereas a low power usage tends prefer integrated GPUs. Default will
                                 pick the best device depending on the status of your computer (ie, wall-power may
                                 choose high, battery power may choose low) [default: default]  [possible values:
                                 default, low, high]
```