### PR TITLE
Add trace capturing API to core & web, and use it in browser based tests

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -459,7 +459,6 @@ pub fn root_error_handler<'gc>(activation: &mut Activation<'_, 'gc, '_>, error: 
             .coerce_to_string(activation)
             .unwrap_or_else(|_| "undefined".into());
         activation.context.log.avm_trace(&message);
-        log::info!(target: "avm_trace", "{}", message);
     } else {
         log::error!("{}", error);
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -455,10 +455,11 @@ impl<'gc> Avm1<'gc> {
 
 pub fn root_error_handler<'gc>(activation: &mut Activation<'_, 'gc, '_>, error: Error<'gc>) {
     if let Error::ThrownValue(error) = &error {
-        let string = error
+        let message = error
             .coerce_to_string(activation)
             .unwrap_or_else(|_| "undefined".into());
-        log::info!(target: "avm_trace", "{}", string);
+        activation.context.logging.avm_trace(&message);
+        log::info!(target: "avm_trace", "{}", message);
     } else {
         log::error!("{}", error);
     }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -458,7 +458,7 @@ pub fn root_error_handler<'gc>(activation: &mut Activation<'_, 'gc, '_>, error: 
         let message = error
             .coerce_to_string(activation)
             .unwrap_or_else(|_| "undefined".into());
-        activation.context.logging.avm_trace(&message);
+        activation.context.log.avm_trace(&message);
         log::info!(target: "avm_trace", "{}", message);
     } else {
         log::error!("{}", error);

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1799,7 +1799,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 base_clip.path()
             );
             self.context.log.avm_trace(&message);
-            log::info!(target: "avm_trace", "{}", message);
 
             // When SetTarget has an invalid target, subsequent GetVariables act
             // as if they are targeting root, but subsequent Play/Stop/etc.
@@ -2063,7 +2062,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             val.coerce_to_string(self)?
         };
         self.context.log.avm_trace(&out);
-        log::info!(target: "avm_trace", "{}", out);
         Ok(FrameControl::Continue)
     }
 
@@ -2129,7 +2127,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 let message =
                     "Error: A 'with' action failed because the specified object did not exist.\n";
                 self.context.log.avm_trace(&message);
-                log::info!(target: "avm_trace", "{}", message);
                 Ok(FrameControl::Continue)
             }
 

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1793,7 +1793,13 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         } else {
             avm_warn!(self, "SetTarget failed: {} not found", target);
             // TODO: Emulate AVM1 trace error message.
-            log::info!(target: "avm_trace", "Target not found: Target=\"{}\" Base=\"{}\"", target, base_clip.path());
+            let message = format!(
+                "Target not found: Target=\"{}\" Base=\"{}\"",
+                target,
+                base_clip.path()
+            );
+            self.context.logging.avm_trace(&message);
+            log::info!(target: "avm_trace", "{}", message);
 
             // When SetTarget has an invalid target, subsequent GetVariables act
             // as if they are targeting root, but subsequent Play/Stop/etc.
@@ -2120,7 +2126,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             // Undefined/null with is ignored.
             Value::Undefined | Value::Null => {
                 // Mimic Flash's error output.
-                log::info!(target: "avm_trace", "Error: A 'with' action failed because the specified object did not exist.\n");
+                let message =
+                    "Error: A 'with' action failed because the specified object did not exist.\n";
+                self.context.logging.avm_trace(&message);
+                log::info!(target: "avm_trace", "{}", message);
                 Ok(FrameControl::Continue)
             }
 

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2056,6 +2056,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         } else {
             val.coerce_to_string(self)?
         };
+        self.context.log.avm_trace(&out);
         log::info!(target: "avm_trace", "{}", out);
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1798,7 +1798,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 target,
                 base_clip.path()
             );
-            self.context.logging.avm_trace(&message);
+            self.context.log.avm_trace(&message);
             log::info!(target: "avm_trace", "{}", message);
 
             // When SetTarget has an invalid target, subsequent GetVariables act
@@ -2128,7 +2128,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 // Mimic Flash's error output.
                 let message =
                     "Error: A 'with' action failed because the specified object did not exist.\n";
-                self.context.logging.avm_trace(&message);
+                self.context.log.avm_trace(&message);
                 log::info!(target: "avm_trace", "{}", message);
                 Ok(FrameControl::Continue)
             }

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -847,6 +847,7 @@ mod tests {
     use crate::backend::audio::NullAudioBackend;
     use crate::backend::input::NullInputBackend;
     use crate::backend::locale::NullLocaleBackend;
+    use crate::backend::log::NullLogBackend;
     use crate::backend::navigator::NullNavigatorBackend;
     use crate::backend::render::NullRenderer;
     use crate::backend::storage::MemoryStorageBackend;
@@ -897,6 +898,7 @@ mod tests {
                 navigator: &mut NullNavigatorBackend::new(),
                 renderer: &mut NullRenderer::new(),
                 locale: &mut NullLocaleBackend::new(),
+                log: &mut NullLogBackend::new(),
                 system_prototypes: avm1.prototypes().clone(),
                 mouse_hovered_object: None,
                 mouse_position: &(Twips::new(0), Twips::new(0)),

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -6,6 +6,7 @@ use crate::avm2::Avm2;
 use crate::backend::audio::NullAudioBackend;
 use crate::backend::input::NullInputBackend;
 use crate::backend::locale::NullLocaleBackend;
+use crate::backend::log::NullLogBackend;
 use crate::backend::navigator::NullNavigatorBackend;
 use crate::backend::render::NullRenderer;
 use crate::backend::storage::MemoryStorageBackend;
@@ -58,6 +59,7 @@ where
             navigator: &mut NullNavigatorBackend::new(),
             renderer: &mut NullRenderer::new(),
             locale: &mut NullLocaleBackend::new(),
+            log: &mut NullLogBackend::new(),
             system_prototypes: avm1.prototypes().clone(),
             mouse_hovered_object: None,
             mouse_position: &(Twips::new(0), Twips::new(0)),

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -31,7 +31,7 @@ fn trace<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(s) = args.get(0) {
         let message = s.clone().coerce_to_string(activation)?;
-        activation.context.logging.avm_trace(&message);
+        activation.context.log.avm_trace(&message);
         log::info!(target: "avm_trace", "{}", message);
     }
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -32,7 +32,6 @@ fn trace<'gc>(
     if let Some(s) = args.get(0) {
         let message = s.clone().coerce_to_string(activation)?;
         activation.context.log.avm_trace(&message);
-        log::info!(target: "avm_trace", "{}", message);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -30,7 +30,9 @@ fn trace<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     if let Some(s) = args.get(0) {
-        log::info!(target: "avm_trace", "{}", s.clone().coerce_to_string(activation)?);
+        let message = s.clone().coerce_to_string(activation)?;
+        activation.context.logging.avm_trace(&message);
+        log::info!(target: "avm_trace", "{}", message);
     }
 
     Ok(Value::Undefined)

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -1,6 +1,7 @@
 pub mod audio;
 pub mod input;
 pub mod locale;
+pub mod log;
 pub mod navigator;
 pub mod render;
 pub mod storage;

--- a/core/src/backend/log.rs
+++ b/core/src/backend/log.rs
@@ -1,0 +1,22 @@
+pub trait LogBackend {
+    fn avm_trace(&self, message: &str);
+}
+
+/// Logging backend that does nothing.
+pub struct NullLogBackend {}
+
+impl NullLogBackend {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl LogBackend for NullLogBackend {
+    fn avm_trace(&self, _message: &str) {}
+}
+
+impl Default for NullLogBackend {
+    fn default() -> Self {
+        NullLogBackend::new()
+    }
+}

--- a/core/src/backend/log.rs
+++ b/core/src/backend/log.rs
@@ -2,7 +2,7 @@ pub trait LogBackend {
     fn avm_trace(&self, message: &str);
 }
 
-/// Logging backend that does nothing.
+/// Logging backend that just reroutes traces to the log crate
 pub struct NullLogBackend {}
 
 impl NullLogBackend {
@@ -12,7 +12,9 @@ impl NullLogBackend {
 }
 
 impl LogBackend for NullLogBackend {
-    fn avm_trace(&self, _message: &str) {}
+    fn avm_trace(&self, message: &str) {
+        log::info!(target: "avm_trace", "{}", message);
+    }
 }
 
 impl Default for NullLogBackend {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -6,6 +6,7 @@ use crate::avm1::{Avm1, Object, Timers, Value};
 use crate::avm2::Avm2;
 use crate::backend::input::InputBackend;
 use crate::backend::locale::LocaleBackend;
+use crate::backend::log::LogBackend;
 use crate::backend::storage::StorageBackend;
 use crate::backend::{audio::AudioBackend, navigator::NavigatorBackend, render::RenderBackend};
 use crate::display_object::EditText;
@@ -71,6 +72,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The locale backend, used for localisation and personalisation
     pub locale: &'a mut dyn LocaleBackend,
+
+    /// The logging backend, used for trace output capturing
+    pub log: &'a mut dyn LogBackend,
 
     /// The RNG, used by the AVM `RandomNumber` opcode,  `Math.random(),` and `random()`.
     pub rng: &'a mut SmallRng,
@@ -185,6 +189,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             navigator: self.navigator,
             renderer: self.renderer,
             locale: self.locale,
+            log: self.log,
             input: self.input,
             storage: self.storage,
             rng: self.rng,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1198,8 +1198,8 @@ impl Player {
         })
     }
 
-    pub fn logging_backend(&self) -> &Logging {
-        &self.logging
+    pub fn log_backend(&self) -> &Log {
+        &self.log
     }
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1197,6 +1197,10 @@ impl Player {
             }
         })
     }
+
+    pub fn logging_backend(&self) -> &Logging {
+        &self.logging
+    }
 }
 
 pub struct DragObject<'gc> {

--- a/core/tests/regression_tests.rs
+++ b/core/tests/regression_tests.rs
@@ -5,6 +5,7 @@
 use approx::assert_abs_diff_eq;
 use log::{Metadata, Record};
 use ruffle_core::backend::locale::NullLocaleBackend;
+use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::backend::navigator::{NullExecutor, NullNavigatorBackend};
 use ruffle_core::backend::storage::MemoryStorageBackend;
 use ruffle_core::backend::{
@@ -521,6 +522,7 @@ fn run_swf(
         Box::new(NullInputBackend::new()),
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
+        Box::new(NullLogBackend::new()),
     )?;
     player.lock().unwrap().set_root_movie(Arc::new(movie));
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::storage::DiskStorageBackend;
+use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::tag_utils::SwfMovie;
 use std::rc::Rc;
 use winit::dpi::{LogicalSize, PhysicalPosition};
@@ -168,7 +169,15 @@ fn run_player(
         input_path.file_name().unwrap_or_default().as_ref(),
     ));
     let locale = Box::new(locale::DesktopLocaleBackend::new());
-    let player = Player::new(renderer, audio, navigator, input, storage, locale)?;
+    let player = Player::new(
+        renderer,
+        audio,
+        navigator,
+        input,
+        storage,
+        locale,
+        Box::new(NullLogBackend::new()),
+    )?;
     player.lock().unwrap().set_root_movie(Arc::new(movie));
     player.lock().unwrap().set_is_playing(true); // Desktop player will auto-play.
 

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -5,6 +5,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use ruffle_core::backend::audio::NullAudioBackend;
 use ruffle_core::backend::input::NullInputBackend;
 use ruffle_core::backend::locale::NullLocaleBackend;
+use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::backend::navigator::NullNavigatorBackend;
 use ruffle_core::backend::storage::MemoryStorageBackend;
 use ruffle_core::tag_utils::SwfMovie;
@@ -89,6 +90,7 @@ fn take_screenshot(
         Box::new(NullInputBackend::new()),
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
+        Box::new(NullLogBackend::new()),
     )?;
 
     player

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -29,6 +29,7 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
 
         self.instance = null;
         self.allow_script_access = false;
+        self._trace_observer = null;
 
         self.Ruffle = load_ruffle();
 
@@ -276,6 +277,15 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
         this[name] = (...args) => {
             return instance.call_exposed_callback(name, args);
         };
+    }
+
+    /*
+     * Sets a trace observer on this flash player.
+     *
+     * The observer will be called, as a function, for each message that the playing movie will "trace" (output).
+     */
+    set trace_observer(observer) {
+        this.instance.set_trace_observer(observer);
     }
 };
 

--- a/web/packages/selfhosted/test/polyfill/embed_default/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_default/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Embed tag", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-embed />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_insensitive/test.js
@@ -1,4 +1,8 @@
-const { open_test, inject_ruffle_and_wait } = require("../utils");
+const {
+    open_test,
+    inject_ruffle_and_wait,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -17,5 +21,12 @@ describe("Embed with case-insensitive MIME type", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-embed />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_type/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Embed without type attribute", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-embed />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.js
@@ -1,4 +1,8 @@
-const { open_test, inject_ruffle_and_wait } = require("../utils");
+const {
+    open_test,
+    inject_ruffle_and_wait,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -17,5 +21,12 @@ describe("Object with case-insensitive MIME type", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.js
@@ -1,4 +1,8 @@
-const { open_test, inject_ruffle_and_wait } = require("../utils");
+const {
+    open_test,
+    inject_ruffle_and_wait,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -17,5 +21,12 @@ describe("Object with case-insensitive clsid", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_data/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_data/test.js
@@ -1,4 +1,8 @@
-const { open_test, inject_ruffle_and_wait } = require("../utils");
+const {
+    open_test,
+    inject_ruffle_and_wait,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -17,5 +21,12 @@ describe("Object with only data attribute", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_default/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_default/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Object tag", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_ie_only/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_ie_only/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Object for old IE must work everywhere", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Object without type attribute", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Object without type and classid attributes", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Object with unexpected string", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/test.js
@@ -1,4 +1,8 @@
-const { inject_ruffle_and_wait, open_test } = require("../utils");
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
 const { expect, use } = require("chai");
 const chaiHtml = require("chai-html");
 const fs = require("fs");
@@ -15,5 +19,12 @@ describe("Object with wrong type attribute value", () => {
         const actual = browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-object />")
+        );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/utils.js
+++ b/web/packages/selfhosted/test/polyfill/utils.js
@@ -24,6 +24,45 @@ function inject_ruffle(browser) {
     });
 }
 
+function play_and_monitor(browser, player) {
+    // TODO: better way to test for this in the API
+    browser.waitUntil(
+        () => {
+            return browser.execute((player) => {
+                return (
+                    player.play_button_clicked !== undefined && player.instance
+                );
+            }, player);
+        },
+        {
+            timeoutMsg: "Expected player to have initialized",
+        }
+    );
+
+    browser.execute((player) => {
+        player.__ruffle_log__ = "";
+        player.trace_observer = (msg) => {
+            player.__ruffle_log__ += msg + "\n";
+        };
+
+        // TODO: make this an actual intended api...
+        player.play_button_clicked();
+    }, player);
+
+    browser.waitUntil(
+        () => {
+            return (
+                browser.execute((player) => {
+                    return player.__ruffle_log__;
+                }, player) === "Hello from Flash!\n"
+            );
+        },
+        {
+            timeoutMsg: "Expected Ruffle to trace a message",
+        }
+    );
+}
+
 function inject_ruffle_and_wait(browser) {
     inject_ruffle(browser);
     wait_for_ruffle(browser);
@@ -40,6 +79,7 @@ function open_test(browser, absolute_dir, file_name) {
 module.exports = {
     is_ruffle_loaded,
     wait_for_ruffle,
+    play_and_monitor,
     inject_ruffle,
     inject_ruffle_and_wait,
     open_test,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use generational_arena::{Arena, Index};
 use js_sys::{Array, Function, Object, Uint8Array};
+use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::backend::render::RenderBackend;
 use ruffle_core::backend::storage::MemoryStorageBackend;
 use ruffle_core::backend::storage::StorageBackend;
@@ -231,8 +232,17 @@ impl Ruffle {
             })
             .unwrap_or_else(|| Box::new(MemoryStorageBackend::default()));
 
-        let core =
-            ruffle_core::Player::new(renderer, audio, navigator, input, local_storage, locale)?;
+        let log = Box::new(NullLogBackend::new());
+
+        let core = ruffle_core::Player::new(
+            renderer,
+            audio,
+            navigator,
+            input,
+            local_storage,
+            locale,
+            log,
+        )?;
 
         // Create instance.
         let instance = RuffleInstance {

--- a/web/src/log_adapter.rs
+++ b/web/src/log_adapter.rs
@@ -1,0 +1,23 @@
+use js_sys::Function;
+use ruffle_core::backend::log::LogBackend;
+use std::cell::RefCell;
+use std::sync::Arc;
+use wasm_bindgen::{JsCast, JsValue};
+
+pub struct WebLogBackend {
+    trace_observer: Arc<RefCell<JsValue>>,
+}
+
+impl WebLogBackend {
+    pub fn new(trace_observer: Arc<RefCell<JsValue>>) -> Self {
+        Self { trace_observer }
+    }
+}
+
+impl LogBackend for WebLogBackend {
+    fn avm_trace(&self, message: &str) {
+        if let Some(function) = self.trace_observer.borrow().dyn_ref::<Function>() {
+            let _ = function.call1(&function, &JsValue::from_str(message));
+        }
+    }
+}

--- a/web/src/log_adapter.rs
+++ b/web/src/log_adapter.rs
@@ -16,6 +16,7 @@ impl WebLogBackend {
 
 impl LogBackend for WebLogBackend {
     fn avm_trace(&self, message: &str) {
+        log::info!(target: "avm_trace", "{}", message);
         if let Some(function) = self.trace_observer.borrow().dyn_ref::<Function>() {
             let _ = function.call1(&function, &JsValue::from_str(message));
         }


### PR DESCRIPTION
This will let us test things for reals in the browser soon (ie ExternalInterface or params), and could be a useful API to expose.

Primary difference between this and capturing via `log` is that you can't capture per movie that way.

One thought for consideration: Could we scrap `log` entirely (in ruffle_core) and make all warnings etc go through the backend, so we can provide all info per-movie and include fancier things like location in movie as a structural part of the message? Is that a terrible idea?