### PR TITLE
Add more try/catch's to stop error spam crashing sites(fix #1138)

### DIFF
--- a/web/packages/core/src/polyfills.js
+++ b/web/packages/core/src/polyfills.js
@@ -116,22 +116,39 @@ function handleFrames(frameList) {
          * Also, this way we should be able to handle frame       *
          * frame navigation, which is good.                       */
         setTimeout(function () {
-            if (
-                current_frame.contentDocument.readyState &&
-                current_frame.contentDocument.readyState == "complete"
-            ) {
-                loadFrame(current_frame.contentWindow);
+            try {
+                if (
+                    current_frame.contentDocument &&
+                    current_frame.contentDocument.readyState &&
+                    current_frame.contentDocument.readyState == "complete"
+                ) {
+                    loadFrame(current_frame.contentWindow);
+                }
+            } catch (e) {
+                console.log(
+                    "error loading ruffle player into frame: " + e.message
+                );
             }
         }, 500);
-        if ((originalOnLoad = current_frame.onload)) {
-            current_frame.onload = function (event) {
-                originalOnLoad(event);
-                load_ruffle_player_into_frame(event);
-            };
-        } else {
-            current_frame.onload = load_ruffle_player_into_frame;
+        try {
+            if ((originalOnLoad = current_frame.onload)) {
+                current_frame.onload = function (event) {
+                    try {
+                        originalOnLoad(event);
+                    } catch (e) {
+                        console.log(
+                            "Error calling original onload: " + e.message
+                        );
+                    }
+                    load_ruffle_player_into_frame(event);
+                };
+            } else {
+                current_frame.onload = load_ruffle_player_into_frame;
+            }
+            polyfill_frames_common(current_frame.contentWindow);
+        } catch (e) {
+            console.log("error loading ruffle player into frame: " + e.message);
         }
-        polyfill_frames_common(current_frame.contentWindow);
     }
 }
 

--- a/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/expected.html
+++ b/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/expected.html
@@ -1,0 +1,9 @@
+<ruffle-embed
+    type="application/x-shockwave-flash"
+    src="/test_assets/example.swf"
+    width="550"
+    height="400"
+    quality="high"
+    menu="false"
+    pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
+/>

--- a/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/index.html
+++ b/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Frame Test</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <embed
+                type="application/x-shockwave-flash"
+                src="/test_assets/example.swf"
+                width="550"
+                height="400"
+                quality="high"
+                menu="false"
+                pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
+            />
+        </div>
+        <iframe src="https://example.com"></iframe>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/test.js
+++ b/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/test.js
@@ -1,0 +1,30 @@
+const {
+    open_test,
+    inject_ruffle_and_wait,
+    play_and_monitor,
+} = require("../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Doesn't error with cross-origin frames", () => {
+    it("Loads the test", () => {
+        open_test(browser, __dirname);
+    });
+
+    it("Polyfills with ruffle", () => {
+        inject_ruffle_and_wait(browser);
+        const actual = browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-embed />")
+        );
+    });
+});

--- a/web/packages/selfhosted/test/polyfill/utils.js
+++ b/web/packages/selfhosted/test/polyfill/utils.js
@@ -13,26 +13,58 @@ function wait_for_ruffle(browser) {
     browser.waitUntil(() => is_ruffle_loaded(browser), {
         timeoutMsg: "Expected Ruffle to load",
     });
+    throw_if_error(browser);
+}
+
+function setup_error_handler(browser) {
+    browser.execute(() => {
+        window.ruffleErrors = [];
+        window.addEventListener("error", (error) => {
+            window.ruffleErrors.push(error);
+        });
+    });
+}
+
+function has_error(browser) {
+    return browser.execute(
+        () => window.ruffleErrors && window.ruffleErrors.length > 0
+    );
+}
+
+function throw_if_error(browser) {
+    return browser.execute(() => {
+        if (window.ruffleErrors && window.ruffleErrors.length > 0) {
+            throw window.ruffleErrors[0];
+        }
+    });
 }
 
 function inject_ruffle(browser) {
+    setup_error_handler(browser);
     browser.execute(() => {
         const script = document.createElement("script");
         script.type = "text/javascript";
         script.src = "/dist/ruffle.js";
         document.head.appendChild(script);
     });
+    throw_if_error(browser);
 }
 
 function play_and_monitor(browser, player) {
+    throw_if_error(browser);
+
     // TODO: better way to test for this in the API
     browser.waitUntil(
         () => {
-            return browser.execute((player) => {
-                return (
-                    player.play_button_clicked !== undefined && player.instance
-                );
-            }, player);
+            return (
+                has_error(browser) ||
+                browser.execute((player) => {
+                    return (
+                        player.play_button_clicked !== undefined &&
+                        player.instance
+                    );
+                }, player)
+            );
         },
         {
             timeoutMsg: "Expected player to have initialized",


### PR DESCRIPTION
In my testing, this fixes #1138
My frame polyfill code incorrectly assumed that the frame polyfill would only fail @ 1 point in the polyfilling process & I put a `try{...}catch(){...}` statement there. We can't polyfill cross-origin frames from within the site unfortunately(a limitation imposed by the browser), so the best we can do is catch the error(The extension can load into all frames with an option in the `manifest.json`). 