### PR TITLE
Use fnv hash in property_map.

### DIFF
--- a/core/src/property_map.rs
+++ b/core/src/property_map.rs
@@ -5,17 +5,20 @@
 //! enumeration order.
 
 use crate::string_utils;
+use fnv::FnvBuildHasher;
 use gc_arena::Collect;
 use indexmap::{Equivalent, IndexMap};
 use std::hash::{Hash, Hasher};
 
+type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
+
 /// A map from property names to values.
 #[derive(Debug)]
-pub struct PropertyMap<V>(IndexMap<PropertyName, V>);
+pub struct PropertyMap<V>(FnvIndexMap<PropertyName, V>);
 
 impl<V> PropertyMap<V> {
     pub fn new() -> Self {
-        Self(IndexMap::new())
+        Self(FnvIndexMap::default())
     }
 
     pub fn contains_key(&self, key: &str, case_sensitive: bool) -> bool {
@@ -120,7 +123,7 @@ pub enum Entry<'a, V> {
 }
 
 pub struct OccupiedEntry<'a, V> {
-    map: &'a mut IndexMap<PropertyName, V>,
+    map: &'a mut FnvIndexMap<PropertyName, V>,
     index: usize,
 }
 
@@ -140,7 +143,7 @@ impl<'a, V> OccupiedEntry<'a, V> {
 }
 
 pub struct VacantEntry<'a, V> {
-    map: &'a mut IndexMap<PropertyName, V>,
+    map: &'a mut FnvIndexMap<PropertyName, V>,
     key: &'a str,
 }
 


### PR DESCRIPTION
String hashing for property/variable accesses are still one of the biggest things on profiles.
On my Firefox profiles, this change drops time spent hashing by half and total time spent in tick() by 10%. Also makes Meat Boy slightly - but noticeably - less choppy on my machine (still not anywhere near fluid though).