### PR TITLE
Add a panic screen for web

### DIFF
--- a/web/packages/core/src/ruffle-object.js
+++ b/web/packages/core/src/ruffle-object.js
@@ -25,7 +25,6 @@ module.exports = class RuffleObject extends RufflePlayer {
             "sameDomain"
         );
         let url = null;
-        console.log("AllowScriptAccess: " + allowScriptAccess);
 
         if (this.attributes.data) {
             url = this.attributes.data.value;
@@ -44,6 +43,30 @@ module.exports = class RuffleObject extends RufflePlayer {
             //Kick off the SWF download.
             this.stream_swf_url(url);
         }
+    }
+
+    debug_player_info() {
+        let error_text = super.debug_player_info();
+        error_text += "Player type: Object\n";
+
+        let url = null;
+
+        if (this.attributes.data) {
+            url = this.attributes.data.value;
+        } else if (this.params.movie) {
+            url = this.params.movie;
+        }
+        error_text += `SWF URL: ${url}\n`;
+
+        Object.keys(this.params).forEach((key) => {
+            error_text += `Param ${key}: ${this.params[key]}\n`;
+        });
+
+        Object.keys(this.attributes).forEach((key) => {
+            error_text += `Attribute ${key}: ${this.attributes[key]}\n`;
+        });
+
+        return error_text;
     }
 
     get data() {

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -126,7 +126,11 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
      */
     async ensure_fresh_instance() {
         if (this.instance) {
-            this.instance.destroy();
+            try {
+                this.instance.destroy();
+            } catch (e) {
+                console.warn("Error destroying old ruffle player:", e);
+            }
             this.instance = null;
             console.log("Ruffle instance destroyed.");
         }
@@ -286,6 +290,28 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
      */
     set trace_observer(observer) {
         this.instance.set_trace_observer(observer);
+    }
+
+    /*
+     * Panics this specific player, forcefully destroying all resources and displays an error message to the user.
+     *
+     * This should be called when something went absolutely, incredibly and disastrously wrong and there is no chance
+     * of recovery.
+     *
+     * Ruffle will attempt to isolate all damage to this specific player instance, but no guarantees can be made if there
+     * was a core issue which triggered the panic. If Ruffle is unable to isolate the cause to a specific player, then
+     * all players will panic and Ruffle will become "poisoned" - no more players will run on this page until it is
+     * reloaded fresh.
+     */
+    panic() {
+        if (this.instance) {
+            try {
+                this.instance.destroy();
+            } catch (e) {
+                console.error("Whilst panicking ruffle, an additional error was encountered during destruction:", e);
+            }
+            this.instance = null;
+        }
     }
 };
 

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -126,11 +126,7 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
      */
     async ensure_fresh_instance() {
         if (this.instance) {
-            try {
-                this.instance.destroy();
-            } catch (e) {
-                console.warn("Error destroying old ruffle player:", e);
-            }
+            this.instance.destroy();
             this.instance = null;
             console.log("Ruffle instance destroyed.");
         }
@@ -313,14 +309,7 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
      */
     panic() {
         if (this.instance) {
-            try {
-                this.instance.destroy();
-            } catch (e) {
-                console.error(
-                    "Whilst panicking ruffle, an additional error was encountered during destruction:",
-                    e
-                );
-            }
+            this.instance.destroy();
             this.instance = null;
         }
         // Clears out any existing content (ie play button or canvas) and replaces it with the error screen

--- a/web/packages/core/src/shadow-template.js
+++ b/web/packages/core/src/shadow-template.js
@@ -61,16 +61,33 @@ ruffle_shadow_tmpl.innerHTML = `
         }
     
         #panic-title {
-            margin-top: 5%;
+            margin-top: 30px;
             text-align: center;
             font-size: 42px;
             font-weight: bold;
         }
     
         #panic-body {
-            margin: 5%;
             text-align: center;
             font-size: 20px;
+            position: absolute;
+            top: 100px;
+            bottom: 80px;
+            left: 50px;
+            right: 50px;
+        }
+
+        #panic-body textarea {
+            width: 100%;
+            height: 100%;
+        }
+    
+        #panic-footer {
+            position: absolute;
+            bottom: 30px;
+            text-align: center;
+            font-size: 20px;
+            width: 100%;
         }
     
         #panic ul {

--- a/web/packages/core/src/shadow-template.js
+++ b/web/packages/core/src/shadow-template.js
@@ -46,6 +46,46 @@ ruffle_shadow_tmpl.innerHTML = `
         #play_button:hover .icon {
             filter: brightness(1.3);
         }
+
+        #panic {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            /* Inverted colours from play button! */
+            background: linear-gradient(180deg, rgba(253,58,64,1) 0%, rgba(253,161,56,1) 100%);
+            color: black;
+        }
+    
+        #panic a {
+            color: #37528C;
+        }
+    
+        #panic-title {
+            margin-top: 5%;
+            text-align: center;
+            font-size: 42px;
+            font-weight: bold;
+        }
+    
+        #panic-body {
+            margin: 5%;
+            text-align: center;
+            font-size: 20px;
+        }
+    
+        #panic ul {
+            margin: 35px 0 0 0;
+            padding: 0;
+            max-width: 100%;
+            display: flex;
+            list-style-type: none;
+            justify-content: center;
+            align-items: center;
+        }
+    
+        #panic li {
+            padding: 10px 50px;
+        }
     </style>
     <style id="dynamic_styles"></style>
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -117,8 +117,8 @@ impl Ruffle {
     /// This method should only be called once per player.
     pub fn stream_from(&mut self, movie_url: &str) {
         INSTANCES.with(|instances| {
-            let mut instances = instances.borrow_mut();
-            let instance = instances.get_mut(self.0).unwrap();
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
             instance.core.lock().unwrap().fetch_root_movie(movie_url);
         });
     }
@@ -134,8 +134,8 @@ impl Ruffle {
         });
 
         INSTANCES.with(|instances| {
-            let mut instances = instances.borrow_mut();
-            let instance = instances.get_mut(self.0).unwrap();
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
             instance.core.lock().unwrap().set_root_movie(movie);
         });
 
@@ -145,8 +145,8 @@ impl Ruffle {
     pub fn play(&mut self) {
         // Remove instance from the active list.
         INSTANCES.with(|instances| {
-            let mut instances = instances.borrow_mut();
-            let instance = instances.get_mut(self.0).unwrap();
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
             instance.core.lock().unwrap().set_is_playing(true);
             log::info!("PLAY!");
         });
@@ -202,8 +202,8 @@ impl Ruffle {
         }
 
         INSTANCES.with(move |instances| {
-            if let Ok(mut instances) = instances.try_borrow_mut() {
-                if let Some(instance) = instances.get_mut(self.0) {
+            if let Ok(instances) = instances.try_borrow() {
+                if let Some(instance) = instances.get(self.0) {
                     if let Ok(mut player) = instance.core.try_lock() {
                         return external_to_js_value(player.call_internal_interface(name, args));
                     }
@@ -325,8 +325,8 @@ impl Ruffle {
             {
                 let mouse_move_callback = Closure::wrap(Box::new(move |js_event: PointerEvent| {
                     INSTANCES.with(move |instances| {
-                        let mut instances = instances.borrow_mut();
-                        if let Some(instance) = instances.get_mut(index) {
+                        let instances = instances.borrow();
+                        if let Some(instance) = instances.get(index) {
                             let event = PlayerEvent::MouseMove {
                                 x: f64::from(js_event.offset_x()) * instance.device_pixel_ratio,
                                 y: f64::from(js_event.offset_y()) * instance.device_pixel_ratio,
@@ -412,8 +412,8 @@ impl Ruffle {
             {
                 let mouse_up_callback = Closure::wrap(Box::new(move |js_event: PointerEvent| {
                     INSTANCES.with(move |instances| {
-                        let mut instances = instances.borrow_mut();
-                        if let Some(instance) = instances.get_mut(index) {
+                        let instances = instances.borrow();
+                        if let Some(instance) = instances.get(index) {
                             if let Some(target) = js_event.current_target() {
                                 let _ = target
                                     .unchecked_ref::<Element>()
@@ -446,8 +446,8 @@ impl Ruffle {
             {
                 let mouse_wheel_callback = Closure::wrap(Box::new(move |js_event: WheelEvent| {
                     INSTANCES.with(move |instances| {
-                        let mut instances = instances.borrow_mut();
-                        if let Some(instance) = instances.get_mut(index) {
+                        let instances = instances.borrow();
+                        if let Some(instance) = instances.get(index) {
                             let delta = match js_event.delta_mode() {
                                 WheelEvent::DOM_DELTA_LINE => {
                                     MouseWheelDelta::Lines(-js_event.delta_y())
@@ -484,7 +484,7 @@ impl Ruffle {
             {
                 let key_down_callback = Closure::wrap(Box::new(move |js_event: KeyboardEvent| {
                     INSTANCES.with(|instances| {
-                        if let Some(instance) = instances.borrow_mut().get_mut(index) {
+                        if let Some(instance) = instances.borrow().get(index) {
                             if instance.has_focus {
                                 let code = js_event.code();
                                 instance
@@ -535,7 +535,7 @@ impl Ruffle {
                 let key_up_callback = Closure::wrap(Box::new(move |js_event: KeyboardEvent| {
                     js_event.prevent_default();
                     INSTANCES.with(|instances| {
-                        if let Some(instance) = instances.borrow_mut().get_mut(index) {
+                        if let Some(instance) = instances.borrow().get(index) {
                             if instance.has_focus {
                                 let code = js_event.code();
                                 instance

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -152,7 +152,7 @@ impl Ruffle {
         });
     }
 
-    pub fn destroy(&mut self) -> Result<(), JsValue> {
+    pub fn destroy(&mut self) {
         // Remove instance from the active list.
         if let Some(instance) = INSTANCES.with(|instances| {
             let mut instances = instances.borrow_mut();
@@ -175,13 +175,12 @@ impl Ruffle {
             // Cancel the animation handler, if it's still active.
             if let Some(id) = instance.animation_handler_id {
                 if let Some(window) = web_sys::window() {
-                    return window.cancel_animation_frame(id.into());
+                    let _ = window.cancel_animation_frame(id.into());
                 }
             }
         }
 
         // Player is dropped at this point.
-        Ok(())
     }
 
     #[allow(clippy::boxed_local)] // for js_bind


### PR DESCRIPTION
If a panic happens (either a rust hard panic, or something that makes a specific player unusable) then this screen will show up:
![image](https://user-images.githubusercontent.com/317625/93005795-d4889400-f554-11ea-8fbe-e2a2af2fbad0.png)

If you click on "view error details", you'll get a big dump that you can copy paste from:
![image](https://user-images.githubusercontent.com/317625/93005801-eec27200-f554-11ea-9064-afa7b7783bb9.png)

The hope is that users won't ever see this, of course, but we should make it as easy as possible to identify and report any scenario that makes this happen.

If it's a full rust panic, then we poison ruffle on this page and prevent further players from being made - the reason being, the panic probably caused us to be in a bad state and may not have even had a player trigger it at all. We shouldn't take the risk that the next player works, and do what we can to put this in the users face so they can come report it to us.

Future goals should be to fill out the details even more (swf info? renderer backend type?), make it possible to bring up the details on a whim (to help report issues that aren't panics), and add a github issue template that we can link to for this.