### PR TITLE
Mask texts to hide overflows

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -3,6 +3,7 @@ pub use crate::{transform::Transform, Color};
 use downcast_rs::Downcast;
 use std::io::Read;
 pub use swf;
+use swf::Matrix;
 
 pub trait RenderBackend: Downcast {
     fn set_viewport_dimensions(&mut self, width: u32, height: u32);
@@ -34,6 +35,7 @@ pub trait RenderBackend: Downcast {
     fn begin_frame(&mut self, clear: Color);
     fn render_bitmap(&mut self, bitmap: BitmapHandle, transform: &Transform);
     fn render_shape(&mut self, shape: ShapeHandle, transform: &Transform);
+    fn draw_rect(&mut self, color: Color, matrix: &Matrix);
     fn end_frame(&mut self);
     fn draw_letterbox(&mut self, letterbox: Letterbox);
     fn push_mask(&mut self);
@@ -137,6 +139,7 @@ impl RenderBackend for NullRenderer {
     fn end_frame(&mut self) {}
     fn render_bitmap(&mut self, _bitmap: BitmapHandle, _transform: &Transform) {}
     fn render_shape(&mut self, _shape: ShapeHandle, _transform: &Transform) {}
+    fn draw_rect(&mut self, _color: Color, _matrix: &Matrix) {}
     fn draw_letterbox(&mut self, _letterbox: Letterbox) {}
     fn push_mask(&mut self) {}
     fn activate_mask(&mut self) {}


### PR DESCRIPTION
| Name | Old | New | Expected |
| ---- | --- | --- | -------- |
| [edittext_align](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_align/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_align/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266097-e57e1300-f7a9-11ea-8a49-c910c749fcdf.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_align/expected.png) |
| [edittext_bullet](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_bullet/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_bullet/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266164-f7f84c80-f7a9-11ea-83b3-79bd2fa4a5e9.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_bullet/expected.png) |
| [edittext_font_size](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_font_size/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_font_size/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266194-00508780-f7aa-11ea-978e-a9de2f58d369.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_font_size/expected.png) |
| [edittext_html_roundtrip](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_html_roundtrip/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_html_roundtrip/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266208-03e40e80-f7aa-11ea-865a-a4dcb2e21707.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_html_roundtrip/expected.png) |
| [edittext_margins](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_margins/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_margins/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266216-06deff00-f7aa-11ea-8c60-9dbdab9a137f.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_margins/expected.png) |
| [edittext_newlines](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_newlines/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_newlines/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266222-09415900-f7aa-11ea-8ab2-c0c6d1cba867.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_newlines/expected.png) |
| [edittext_tab_stops](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_tab_stops/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_tab_stops/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266227-0ba3b300-f7aa-11ea-82b1-a33c315316e5.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_tab_stops/expected.png) |
| [edittext_underline](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_underline/test.swf) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_underline/actual.png) | ![](https://user-images.githubusercontent.com/317625/93266236-0e9ea380-f7aa-11ea-85c0-d9aad665a958.png) | ![](https://raw.githubusercontent.com/ruffle-rs/visual-tests/86f2d6baf205c43fe2075f818ef5066542e3d1bd/tests/text/edittext_underline/expected.png) |


One interesting one to note is that whilst `edittext_font_size` looks like it got worse - in actuality, this is a bug in Flash. I think they're reusing the same stencil buffer for all editboxes and if you render lots in the same draw call then they can overlap. If you play with them using the cursor and trigger individual redraws then the overflow will pop in and out, depending on the order in which you trigger them. We should treat Ruffle as the expected one in this test, when we have it looking better.

I've tested all 3 backends to visually confirm they work the same, as this does add a new `draw_rect` method to the API.