### PR TITLE
web: Add pause method for web player

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -15,8 +15,8 @@ pub type SoundInstanceHandle = Index;
 type Error = Box<dyn std::error::Error>;
 
 pub trait AudioBackend {
-    fn play(&mut self) {}
-    fn pause(&mut self) {}
+    fn play(&mut self);
+    fn pause(&mut self);
     fn register_sound(&mut self, swf_sound: &swf::Sound) -> Result<SoundHandle, Error>;
     fn preload_sound_stream_head(
         &mut self,
@@ -104,6 +104,8 @@ impl NullAudioBackend {
 }
 
 impl AudioBackend for NullAudioBackend {
+    fn play(&mut self) {}
+    fn pause(&mut self) {}
     fn register_sound(&mut self, _sound: &swf::Sound) -> Result<SoundHandle, Error> {
         Ok(self.sounds.insert(()))
     }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -16,6 +16,7 @@ type Error = Box<dyn std::error::Error>;
 
 pub trait AudioBackend {
     fn prime_audio(&mut self) {}
+    fn suspend_audio(&mut self) {}
     fn register_sound(&mut self, swf_sound: &swf::Sound) -> Result<SoundHandle, Error>;
     fn preload_sound_stream_head(
         &mut self,

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -15,8 +15,8 @@ pub type SoundInstanceHandle = Index;
 type Error = Box<dyn std::error::Error>;
 
 pub trait AudioBackend {
-    fn prime_audio(&mut self) {}
-    fn suspend_audio(&mut self) {}
+    fn play(&mut self) {}
+    fn pause(&mut self) {}
     fn register_sound(&mut self, swf_sound: &swf::Sound) -> Result<SoundHandle, Error>;
     fn preload_sound_stream_head(
         &mut self,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -435,9 +435,9 @@ impl Player {
     pub fn set_is_playing(&mut self, v: bool) {
         if v {
             // Allow auto-play after user gesture for web backends.
-            self.audio.prime_audio();
+            self.audio.play();
         } else {
-            self.audio.suspend_audio();
+            self.audio.pause();
         }
         self.is_playing = v;
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -436,6 +436,8 @@ impl Player {
         if v {
             // Allow auto-play after user gesture for web backends.
             self.audio.prime_audio();
+        } else {
+            self.audio.suspend_audio();
         }
         self.is_playing = v;
     }

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -315,6 +315,14 @@ impl AudioBackend for CpalAudioBackend {
         Ok(self.sounds.insert(sound))
     }
 
+    fn play(&mut self) {
+        self.stream.0.play().expect("Error trying to resume CPAL audio stream. This feature may not be supported by your audio device.");
+    }
+
+    fn pause(&mut self) {
+        self.stream.0.pause().expect("Error trying to pause CPAL audio stream. This feature may not be supported by your audio device.");
+    }
+
     fn start_stream(
         &mut self,
         clip_id: swf::CharacterId,

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -186,6 +186,15 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
         }
     }
 
+    pause() {
+        if (this.instance) {
+            this.instance.pause();
+            if (this.play_button) {
+                this.play_button.style.display = "block";
+            }
+        }
+    }
+
     /**
      * Load a movie's data into this Ruffle Player instance.
      *

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -752,12 +752,12 @@ impl AudioBackend for WebAudioBackend {
         NUM_SOUNDS_LOADING.with(|n| n.get() == 0)
     }
 
-    fn prime_audio(&mut self) {
+    fn play(&mut self) {
         // Allow audio to start playing after a user gesture.
         let _ = self.context.resume();
     }
 
-    fn suspend_audio(&mut self) {
+    fn pause(&mut self) {
         // Suspend audio to be resumed later.
         let _ = self.context.suspend();
     }

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -757,6 +757,11 @@ impl AudioBackend for WebAudioBackend {
         let _ = self.context.resume();
     }
 
+    fn suspend_audio(&mut self) {
+        // Suspend audio to be resumed later.
+        let _ = self.context.suspend();
+    }
+
     fn stop_all_sounds(&mut self) {
         SOUND_INSTANCES.with(|instances| {
             let mut instances = instances.borrow_mut();

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -161,6 +161,16 @@ impl Ruffle {
         });
     }
 
+    pub fn pause(&mut self) {
+        // Remove instance from the active list.
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            instance.borrow().core.lock().unwrap().set_is_playing(false);
+            log::info!("PAUSE!");
+        });
+    }
+
     pub fn destroy(&mut self) {
         // Remove instance from the active list.
         if let Some(instance) = INSTANCES.with(|instances| {


### PR DESCRIPTION
Adds a suspend_audio method to compliment prime_audio on WebAudioBackend, as well as logic in player.rs on the set_is_playing method to suspend audio when is_playing is set to false. Exposes pause method for the ruffle player in JavaScript with logic to display the play button when paused.

I'm always learning! So please let me know if I need to fix something.

I tested the pause by adding a pause button to the web demo page with a click event. Something like this below:
```html
<button id="pause">Pause</button>

<script>
    document.getElementById("pause").addEventListener("click", function() {
        document.getElementById("player").pause()
    }, false);
</script>
```