### PR TITLE
text: Default color for text spans should be black

### DIFF
--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -710,7 +710,7 @@ impl Default for TextSpan {
                 r: 0,
                 g: 0,
                 b: 0,
-                a: 0,
+                a: 255,
             },
             align: swf::TextAlign::Left,
             bold: false,


### PR DESCRIPTION
Previously color defaulted to 0% alpha, causing text to be
invisible if the text field did not specify a defualt color.