### PR TITLE
*: fix spelling mistakes

### DIFF
--- a/.github/workflows/release_nightlies.yml
+++ b/.github/workflows/release_nightlies.yml
@@ -83,7 +83,7 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Install linux depencencies
+      - name: Install linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -28,7 +28,7 @@ jobs:
         override: true
         components: rustfmt, clippy
 
-    - name: Install linux depencencies
+    - name: Install linux dependencies
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -33,7 +33,7 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.rust_version }}
 
-    - name: Install linux depencencies
+    - name: Install linux dependencies
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -102,7 +102,7 @@ pub struct Avm1<'gc> {
     /// `ActionDefineFunction2` defined functions do not use these slots.
     registers: [Value<'gc>; 4],
 
-    /// If a serious error has occured, or a user has requested it, the AVM may be halted.
+    /// If a serious error has occurred, or a user has requested it, the AVM may be halted.
     /// This will completely prevent any further actions from being executed.
     halted: bool,
 

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1835,7 +1835,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
             // When SetTarget has an invalid target, subsequent GetVariables act
             // as if they are targeting root, but subsequent Play/Stop/etc.
-            // fail silenty.
+            // fail silently.
             new_target_clip = None;
         }
 
@@ -1869,7 +1869,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             }
             Value::Object(o) => {
                 if let Some(clip) = o.as_display_object() {
-                    // Movieclips can be targetted directly
+                    // Movieclips can be targeted directly
                     self.set_target_clip(Some(clip));
                 } else {
                     // Other objects get coerced to string

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -129,7 +129,7 @@ pub fn parse_int<'gc>(
         }
 
         // Auto-detect hexadecimal prefix and strip it.
-        // Emulate bug: the prefix is stripped irregardless of the radix.
+        // Emulate bug: the prefix is stripped regardless of the radix.
         //   parseInt('0x100', 10) == 100  // not 0
         //   parseInt('0x100', 36) == 1296 // not 1540944
         // Emulate bug: the prefix is expected before the sign or spaces.

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -540,7 +540,7 @@ fn to_upper_case<'gc>(
     .into())
 }
 
-/// Normalizes an  index paramter used in `String` functions such as `substring`.
+/// Normalizes an  index parameter used in `String` functions such as `substring`.
 /// The returned index will be within the range of `[0, len]`.
 fn string_index(i: i32, len: usize) -> usize {
     if i > 0 {
@@ -555,7 +555,7 @@ fn string_index(i: i32, len: usize) -> usize {
     }
 }
 
-/// Normalizes an wrapping index paramter used in `String` functions such as `slice`.
+/// Normalizes an wrapping index parameter used in `String` functions such as `slice`.
 /// Negative values will count backwards from `len`.
 /// The returned index will be within the range of `[0, len]`.
 fn string_wrapping_index(i: i32, len: usize) -> usize {

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -292,7 +292,7 @@ fn variable<'gc>(
         }
     }
 
-    // Unset `variable` retuns null, not undefined
+    // Unset `variable` returns null, not undefined
     Ok(Value::Null)
 }
 

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -966,7 +966,7 @@ pub fn xml_doc_type_decl<'gc>(
             return Ok(AvmString::new(
                 activation.context.gc_context,
                 result.unwrap_or_else(|e| {
-                    avm_warn!(activation, "Error occured when serializing DOCTYPE: {}", e);
+                    avm_warn!(activation, "Error occurred when serializing DOCTYPE: {}", e);
                     "".to_string()
                 }),
             )

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -9,7 +9,7 @@ use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
 
-/// A SounObject that is tied to a sound from the AudioBackend.
+/// A SoundObject that is tied to a sound from the AudioBackend.
 #[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
 pub struct SoundObject<'gc>(GcCell<'gc, SoundObjectData<'gc>>);
@@ -27,7 +27,7 @@ pub struct SoundObjectData<'gc> {
     /// The instance of the last played sound on this object.
     sound_instance: Option<SoundInstanceHandle>,
 
-    /// Sounds in AVM1 are tied to a speicifc movie clip.
+    /// Sounds in AVM1 are tied to a specific movie clip.
     owner: Option<DisplayObject<'gc>>,
 
     /// Position of the last playing sound in milliseconds.

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -190,7 +190,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         }
 
         if obj.base.has_own_property(activation, name) {
-            // 1) Actual proeprties on the underlying object
+            // 1) Actual properties on the underlying object
             obj.base.internal_set(
                 name,
                 value,

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -69,7 +69,7 @@ impl<'gc> Timers<'gc> {
             let timer = activation.context.timers.peek().unwrap();
 
             // TODO: This is only really necessary because BinaryHeap lacks `remove` or `retain` on stable.
-            // We can remove the timers straightaway in `clearInterval` once this is stable.
+            // We can remove the timers straight away in `clearInterval` once this is stable.
             if !timer.is_alive.get() {
                 activation.context.timers.pop();
                 continue;

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -314,7 +314,7 @@ pub fn for_each<'gc>(
             .cloned()
             .unwrap_or(Value::Undefined)
             .coerce_to_object(activation)?;
-        let reciever = args
+        let receiver = args
             .get(1)
             .cloned()
             .unwrap_or(Value::Null)
@@ -326,10 +326,10 @@ pub fn for_each<'gc>(
             let (i, item) = r?;
 
             callback.call(
-                reciever,
+                receiver,
                 &[item, i.into(), this.into()],
                 activation,
-                reciever.and_then(|r| r.proto()),
+                receiver.and_then(|r| r.proto()),
             )?;
         }
     }
@@ -349,7 +349,7 @@ pub fn map<'gc>(
             .cloned()
             .unwrap_or(Value::Undefined)
             .coerce_to_object(activation)?;
-        let reciever = args
+        let receiver = args
             .get(1)
             .cloned()
             .unwrap_or(Value::Null)
@@ -361,10 +361,10 @@ pub fn map<'gc>(
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
             let new_item = callback.call(
-                reciever,
+                receiver,
                 &[item, i.into(), this.into()],
                 activation,
-                reciever.and_then(|r| r.proto()),
+                receiver.and_then(|r| r.proto()),
             )?;
 
             new_array.push(new_item);
@@ -388,7 +388,7 @@ pub fn filter<'gc>(
             .cloned()
             .unwrap_or(Value::Undefined)
             .coerce_to_object(activation)?;
-        let reciever = args
+        let receiver = args
             .get(1)
             .cloned()
             .unwrap_or(Value::Null)
@@ -401,10 +401,10 @@ pub fn filter<'gc>(
             let (i, item) = r?;
             let is_allowed = callback
                 .call(
-                    reciever,
+                    receiver,
                     &[item.clone(), i.into(), this.into()],
                     activation,
-                    reciever.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.proto()),
                 )?
                 .coerce_to_boolean();
 
@@ -431,7 +431,7 @@ pub fn every<'gc>(
             .cloned()
             .unwrap_or(Value::Undefined)
             .coerce_to_object(activation)?;
-        let reciever = args
+        let receiver = args
             .get(1)
             .cloned()
             .unwrap_or(Value::Null)
@@ -445,10 +445,10 @@ pub fn every<'gc>(
 
             is_every &= callback
                 .call(
-                    reciever,
+                    receiver,
                     &[item, i.into(), this.into()],
                     activation,
-                    reciever.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.proto()),
                 )?
                 .coerce_to_boolean();
         }
@@ -471,7 +471,7 @@ pub fn some<'gc>(
             .cloned()
             .unwrap_or(Value::Undefined)
             .coerce_to_object(activation)?;
-        let reciever = args
+        let receiver = args
             .get(1)
             .cloned()
             .unwrap_or(Value::Null)
@@ -485,10 +485,10 @@ pub fn some<'gc>(
 
             is_some |= callback
                 .call(
-                    reciever,
+                    receiver,
                     &[item, i.into(), this.into()],
                     activation,
-                    reciever.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.proto()),
                 )?
                 .coerce_to_boolean();
         }
@@ -787,7 +787,7 @@ enum SortOptions {
     /// Reject sorting on arrays with multiple equivalent values.
     UniqueSort,
 
-    /// Yield a list of indicies rather than sorting the array in-place.
+    /// Yield a list of indices rather than sorting the array in-place.
     ReturnIndexedArray,
 
     /// Request numeric value sort.

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -46,7 +46,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// into account.
     fn get_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error>;
@@ -54,24 +54,24 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Retrieve a property by it's QName.
     fn get_property(
         &mut self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         if !self.has_instantiated_property(name) {
             for abc_trait in self.get_trait(name)? {
-                self.install_trait(activation, abc_trait, reciever)?;
+                self.install_trait(activation, abc_trait, receiver)?;
             }
         }
 
         let has_no_getter = self.has_own_virtual_setter(name) && !self.has_own_virtual_getter(name);
 
         if self.has_own_property(name)? && !has_no_getter {
-            return self.get_property_local(reciever, name, activation);
+            return self.get_property_local(receiver, name, activation);
         }
 
         if let Some(mut proto) = self.proto() {
-            return proto.get_property(reciever, name, activation);
+            return proto.get_property(receiver, name, activation);
         }
 
         Ok(Value::Undefined)
@@ -96,7 +96,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Set a property on this specific object.
     fn set_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -105,19 +105,19 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Set a property by it's QName.
     fn set_property(
         &mut self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
         if !self.has_instantiated_property(name) {
             for abc_trait in self.get_trait(name)? {
-                self.install_trait(activation, abc_trait, reciever)?;
+                self.install_trait(activation, abc_trait, receiver)?;
             }
         }
 
         if self.has_own_virtual_setter(name) {
-            return self.set_property_local(reciever, name, value, activation);
+            return self.set_property_local(receiver, name, value, activation);
         }
 
         let mut proto = self.proto();
@@ -126,19 +126,19 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             //we're calling a virtual setter. If you call `set_property` on
             //a non-virtual you will actually alter the prototype.
             if my_proto.has_own_virtual_setter(name) {
-                return my_proto.set_property(reciever, name, value, activation);
+                return my_proto.set_property(receiver, name, value, activation);
             }
 
             proto = my_proto.proto();
         }
 
-        reciever.set_property_local(reciever, name, value, activation)
+        receiver.set_property_local(receiver, name, value, activation)
     }
 
     /// Init a property on this specific object.
     fn init_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -147,19 +147,19 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Init a property by it's QName.
     fn init_property(
         &mut self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
         if !self.has_instantiated_property(name) {
             for abc_trait in self.get_trait(name)? {
-                self.install_trait(activation, abc_trait, reciever)?;
+                self.install_trait(activation, abc_trait, receiver)?;
             }
         }
 
         if self.has_own_virtual_setter(name) {
-            return self.init_property_local(reciever, name, value, activation);
+            return self.init_property_local(receiver, name, value, activation);
         }
 
         let mut proto = self.proto();
@@ -168,13 +168,13 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             //we're calling a virtual setter. If you call `set_property` on
             //a non-virtual you will actually alter the prototype.
             if my_proto.has_own_virtual_setter(name) {
-                return my_proto.init_property(reciever, name, value, activation);
+                return my_proto.init_property(receiver, name, value, activation);
             }
 
             proto = my_proto.proto();
         }
 
-        reciever.init_property_local(reciever, name, value, activation)
+        receiver.init_property_local(receiver, name, value, activation)
     }
 
     /// Retrieve a slot by it's index.
@@ -426,9 +426,9 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &mut self,
         activation: &mut Activation<'_, 'gc, '_>,
         trait_entry: Trait<'gc>,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
     ) -> Result<Value<'gc>, Error> {
-        self.install_foreign_trait(activation, trait_entry, self.get_scope(), reciever)
+        self.install_foreign_trait(activation, trait_entry, self.get_scope(), receiver)
     }
 
     /// Install a trait from anywyere.
@@ -440,7 +440,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         activation: &mut Activation<'_, 'gc, '_>,
         trait_entry: Trait<'gc>,
         scope: Option<GcCell<'gc, Scope<'gc>>>,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
     ) -> Result<Value<'gc>, Error> {
         let fn_proto = activation.avm2().prototypes().function;
         let trait_name = trait_entry.name().clone();
@@ -475,7 +475,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     method.clone(),
                     scope,
                     fn_proto,
-                    Some(reciever),
+                    Some(receiver),
                 );
                 self.install_method(
                     activation.context.gc_context,
@@ -494,7 +494,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     method.clone(),
                     scope,
                     fn_proto,
-                    Some(reciever),
+                    Some(receiver),
                 );
                 self.install_getter(
                     activation.context.gc_context,
@@ -513,7 +513,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                     method.clone(),
                     scope,
                     fn_proto,
-                    Some(reciever),
+                    Some(receiver),
                 );
                 self.install_setter(
                     activation.context.gc_context,
@@ -532,7 +532,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                         .unwrap_or_else(|| QName::dynamic_name("Object"));
 
                     let super_class: Result<Object<'gc>, Error> = self
-                        .get_property(reciever, &super_name, activation)?
+                        .get_property(receiver, &super_name, activation)?
                         .coerce_to_object(activation)
                         .map_err(|_e| {
                             format!("Could not resolve superclass {:?}", super_name.local_name())

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -84,7 +84,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
 
     fn get_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
@@ -96,7 +96,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             }
         }
 
-        let rv = read.base.get_property_local(reciever, name, activation)?;
+        let rv = read.base.get_property_local(receiver, name, activation)?;
 
         drop(read);
 
@@ -105,7 +105,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
 
     fn set_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -122,7 +122,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
 
         let rv = write
             .base
-            .set_property_local(reciever, name, value, activation)?;
+            .set_property_local(receiver, name, value, activation)?;
 
         drop(write);
 
@@ -133,7 +133,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
 
     fn init_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -150,7 +150,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
 
         let rv = write
             .base
-            .init_property_local(reciever, name, value, activation)?;
+            .init_property_local(receiver, name, value, activation)?;
 
         drop(write);
 

--- a/core/src/avm2/object/custom_object.rs
+++ b/core/src/avm2/object/custom_object.rs
@@ -5,12 +5,12 @@ macro_rules! impl_avm2_custom_object_properties {
     ($field:ident) => {
         fn get_property_local(
             self,
-            reciever: Object<'gc>,
+            receiver: Object<'gc>,
             name: &QName<'gc>,
             activation: &mut Activation<'_, 'gc, '_>,
         ) -> Result<Value<'gc>, Error> {
             let read = self.0.read();
-            let rv = read.$field.get_property_local(reciever, name, activation)?;
+            let rv = read.$field.get_property_local(receiver, name, activation)?;
 
             drop(read);
 
@@ -19,7 +19,7 @@ macro_rules! impl_avm2_custom_object_properties {
 
         fn set_property_local(
             self,
-            reciever: Object<'gc>,
+            receiver: Object<'gc>,
             name: &QName<'gc>,
             value: Value<'gc>,
             activation: &mut Activation<'_, 'gc, '_>,
@@ -27,7 +27,7 @@ macro_rules! impl_avm2_custom_object_properties {
             let mut write = self.0.write(activation.context.gc_context);
             let rv = write
                 .$field
-                .set_property_local(reciever, name, value, activation)?;
+                .set_property_local(receiver, name, value, activation)?;
 
             drop(write);
 
@@ -38,7 +38,7 @@ macro_rules! impl_avm2_custom_object_properties {
 
         fn init_property_local(
             self,
-            reciever: Object<'gc>,
+            receiver: Object<'gc>,
             name: &QName<'gc>,
             value: Value<'gc>,
             activation: &mut Activation<'_, 'gc, '_>,
@@ -46,7 +46,7 @@ macro_rules! impl_avm2_custom_object_properties {
             let mut write = self.0.write(activation.context.gc_context);
             let rv = write
                 .$field
-                .init_property_local(reciever, name, value, activation)?;
+                .init_property_local(receiver, name, value, activation)?;
 
             drop(write);
 

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -44,7 +44,7 @@ impl<'gc> FunctionObject<'gc> {
     ///
     /// This function returns both the class itself, and the static class
     /// initializer method that you should call before interacting with the
-    /// class. The latter should be called using the former as a reciever.
+    /// class. The latter should be called using the former as a receiver.
     ///
     /// `base_class` is allowed to be `None`, corresponding to a `null` value
     /// in the VM. This corresponds to no base class, and in practice appears
@@ -210,9 +210,9 @@ impl<'gc> FunctionObject<'gc> {
         method: Method<'gc>,
         scope: Option<GcCell<'gc, Scope<'gc>>>,
         fn_proto: Object<'gc>,
-        reciever: Option<Object<'gc>>,
+        receiver: Option<Object<'gc>>,
     ) -> Object<'gc> {
-        let exec = Some(Executable::from_method(method, scope, reciever, mc));
+        let exec = Some(Executable::from_method(method, scope, receiver, mc));
 
         FunctionObject(GcCell::allocate(
             mc,
@@ -302,13 +302,13 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
 
     fn call(
         self,
-        reciever: Option<Object<'gc>>,
+        receiver: Option<Object<'gc>>,
         arguments: &[Value<'gc>],
         activation: &mut Activation<'_, 'gc, '_>,
         base_proto: Option<Object<'gc>>,
     ) -> Result<Value<'gc>, Error> {
         if let Some(exec) = &self.0.read().exec {
-            exec.exec(reciever, arguments, activation, base_proto)
+            exec.exec(receiver, arguments, activation, base_proto)
         } else {
             Err("Not a callable function!".into())
         }

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -77,21 +77,21 @@ pub struct ScriptObjectData<'gc> {
 impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn get_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         let rv = self
             .0
             .read()
-            .get_property_local(reciever, name, activation)?;
+            .get_property_local(receiver, name, activation)?;
 
         rv.resolve(activation)
     }
 
     fn set_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -99,7 +99,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         let rv = self
             .0
             .write(activation.context.gc_context)
-            .set_property_local(reciever, name, value, activation)?;
+            .set_property_local(receiver, name, value, activation)?;
 
         rv.resolve(activation)?;
 
@@ -108,7 +108,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     fn init_property_local(
         self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -116,7 +116,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         let rv = self
             .0
             .write(activation.context.gc_context)
-            .init_property_local(reciever, name, value, activation)?;
+            .init_property_local(receiver, name, value, activation)?;
 
         rv.resolve(activation)?;
 
@@ -415,14 +415,14 @@ impl<'gc> ScriptObjectData<'gc> {
 
     pub fn get_property_local(
         &self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<ReturnValue<'gc>, Error> {
         let prop = self.values.get(name);
 
         if let Some(prop) = prop {
-            prop.get(reciever, activation.base_proto().or(self.proto))
+            prop.get(receiver, activation.base_proto().or(self.proto))
         } else {
             Ok(Value::Undefined.into())
         }
@@ -430,7 +430,7 @@ impl<'gc> ScriptObjectData<'gc> {
 
     pub fn set_property_local(
         &mut self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -451,7 +451,7 @@ impl<'gc> ScriptObjectData<'gc> {
         } else if self.values.contains_key(name) {
             let prop = self.values.get_mut(name).unwrap();
             let proto = self.proto;
-            prop.set(reciever, activation.base_proto().or(proto), value)
+            prop.set(receiver, activation.base_proto().or(proto), value)
         } else {
             //TODO: Not all classes are dynamic like this
             self.enumerants.push(name.clone());
@@ -464,7 +464,7 @@ impl<'gc> ScriptObjectData<'gc> {
 
     pub fn init_property_local(
         &mut self,
-        reciever: Object<'gc>,
+        receiver: Object<'gc>,
         name: &QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -475,7 +475,7 @@ impl<'gc> ScriptObjectData<'gc> {
                 Ok(Value::Undefined.into())
             } else {
                 let proto = self.proto;
-                prop.init(reciever, activation.base_proto().or(proto), value)
+                prop.init(receiver, activation.base_proto().or(proto), value)
             }
         } else {
             //TODO: Not all classes are dynamic like this

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -460,7 +460,7 @@ impl<'gc> Value<'gc> {
         Ok(EnumSet::from_u32_truncated(self.coerce_to_u32(activation)?))
     }
 
-    /// Mininum number of digits after which numbers are formatted as
+    /// Minimum number of digits after which numbers are formatted as
     /// exponential strings.
     const MIN_DIGITS: f64 = -6.0;
 

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -64,7 +64,7 @@ pub trait AudioBackend {
     /// Used by SWF `StartSound` tag with `SoundEvent::Stop`.
     fn stop_sounds_with_handle(&mut self, handle: SoundHandle);
 
-    /// Returns wheter a sound clip is playing.
+    /// Returns whether a sound clip is playing.
     /// Used by SWF `StartSouynd` tag with `SoundEvent:Start`,
     /// which only plays a sound if that sound is not already playing.
     fn is_sound_playing_with_handle(&mut self, handle: SoundHandle) -> bool;

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -192,7 +192,7 @@ pub trait NavigatorBackend {
     /// Resolve a relative URL.
     ///
     /// This function must not change URLs which are already protocol, domain,
-    /// and path absolute. For URLs that are relative, the implementator of
+    /// and path absolute. For URLs that are relative, the implementer of
     /// this function may opt to convert them to absolute using an implementor
     /// defined base. For a web browser, the most obvious base would be the
     /// current document's base URL, while the most obvious base for a desktop
@@ -254,7 +254,7 @@ impl NullExecutor {
     ///
     /// If any task in the executor yields an error, then this function will
     /// stop polling futures and return that error. Otherwise, it will yield
-    /// `Ok`, indicating that no errors occured. More work may still be
+    /// `Ok`, indicating that no errors occurred. More work may still be
     /// available,
     pub fn poll_all(&mut self) -> Result<(), Error> {
         self.flush_channel();

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -48,7 +48,7 @@ pub struct DisplayObjectBase<'gc> {
     skew: f64,
 
     /// The first child of this display object in order of execution.
-    /// This is differen than render order.
+    /// This is different than render order.
     first_child: Option<DisplayObject<'gc>>,
 
     /// The previous sibling of this display object in order of execution.

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -10,9 +10,9 @@ use gc_arena::{Collect, Gc, GcCell};
 /// This can only be instanitated on the display list in SWFv9 AVM2 files.
 /// In AVM1, this is only a library symbol that is referenced by `Graphic`.
 /// Normally bitmaps are drawn in Flash as part of a Shape tag (`Graphic`),
-/// but starting in AVM2, a raw `Bitmap` display object can be crated
+/// but starting in AVM2, a raw `Bitmap` display object can be created
 /// with the `PlaceObject3` tag.
-/// It can also be crated in ActionScript using the `Bitmap` class.
+/// It can also be created in ActionScript using the `Bitmap` class.
 #[derive(Clone, Debug, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Bitmap<'gc>(GcCell<'gc, BitmapData<'gc>>);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -822,7 +822,7 @@ impl<'gc> MovieClip<'gc> {
             self.0.write(context.gc_context).tag_stream_pos = 0;
             self.0.write(context.gc_context).current_frame = 0;
 
-            // Remove all display objects that were created after the desination frame.
+            // Remove all display objects that were created after the destination frame.
             // TODO: We want to do something like self.children.retain here,
             // but BTreeMap::retain does not exist.
             let children: SmallVec<[_; 16]> = self

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -78,7 +78,7 @@ pub struct LayoutContext<'a, 'gc> {
 
     /// The first box within the current line.
     ///
-    /// If equal to the length of the array, then no layout boxes currenly
+    /// If equal to the length of the array, then no layout boxes currently
     /// exist for this line.
     current_line: usize,
 
@@ -116,7 +116,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             .unwrap_or_else(|| Twips::new(0))
     }
 
-    /// Calculate the line-to-line leading present on ths line, including the
+    /// Calculate the line-to-line leading present on this line, including the
     /// font-leading above.
     fn line_leading_adjustment(&self) -> Twips {
         self.font

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -276,7 +276,7 @@ pub enum Loader<'gc> {
         /// into a clip that has not yet fired it's Load event causes the
         /// loader to be prematurely removed. This flag is only set when either
         /// the movie has been replaced (and thus Load events can be trusted)
-        /// or an error has occured (in which case we don't care about the
+        /// or an error has occurred (in which case we don't care about the
         /// loader anymore).
         load_complete: bool,
     },

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -611,7 +611,7 @@ impl Player {
                 }
             }
 
-            // Fire event listener on appropraite object
+            // Fire event listener on appropriate object
             if let Some((listener_type, event_name, args)) = listener {
                 context.action_queue.queue_actions(
                     *context.levels.get(&0).expect("root level"),
@@ -720,7 +720,7 @@ impl Player {
                     }
                 }
 
-                // RollOver on new node.I stil
+                // RollOver on new node.I still
                 new_cursor = MouseCursor::Arrow;
                 if let Some(node) = new_hovered {
                     new_cursor = MouseCursor::Hand;

--- a/core/src/property_map.rs
+++ b/core/src/property_map.rs
@@ -186,7 +186,7 @@ impl<'a> Equivalent<PropertyName> for CaseSensitiveStr<'a> {
 
 /// The property keys stored in the property map.
 /// This uses a case insensitive hash to ensure that properties can be found in
-/// SWFv6, which is case insensitve. The equality check is handled by the `Equivalent`
+/// SWFv6, which is case insensitive. The equality check is handled by the `Equivalent`
 /// impls above, which allow it to be either case-sensitive or insensitive.
 /// Note that the property of if key1 == key2 -> hash(key1) == hash(key2) still holds.
 #[derive(Debug, Clone, PartialEq, Eq, Collect)]

--- a/core/src/shape_utils.rs
+++ b/core/src/shape_utils.rs
@@ -184,7 +184,7 @@ impl PathSegment {
         self.start() == self.end()
     }
 
-    /// Attemps to merge another path segment.
+    /// Attempts to merge another path segment.
     /// One path's start must meet the other path's end.
     /// Returns true if the merge is successful.
     fn try_merge(&mut self, other: &mut PathSegment, directed: bool) -> bool {
@@ -722,7 +722,7 @@ mod tests {
  *  if the edge cross the ray downward (+y), we add 1 to the winding number.
  *  if the edge cross the ray upward (-y), we add -1 to the winding number.
  *
- * We must also handle intersection with edge endpoints consistenly to avoid double counting:
+ * We must also handle intersection with edge endpoints consistently to avoid double counting:
  *  the initial point of an edge is considered for upwards rays.
  *  the final point of an edge is considered for downward rays.
  *
@@ -1206,7 +1206,7 @@ fn winding_number_curve(
         };
 
         // If curve point is to the right of the ray origin, the ray will hit it.
-        // We don't have to do the problematic 0 <= t <= 1 check because this vertical slice is guarnateed
+        // We don't have to do the problematic 0 <= t <= 1 check because this vertical slice is guaranteed
         // to contain the monotonic segment, and our roots are returned in order by `solve_quadratic`.
         // Adjust the winding as appropriate.
         if direction != 0 {

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -258,7 +258,7 @@ impl SwfSlice {
 
     /// Construct a reader for this slice.
     ///
-    /// The `from` paramter is the offset to start reading the slice from.
+    /// The `from` parameter is the offset to start reading the slice from.
     pub fn read_from(&self, from: u64) -> swf::read::Reader<std::io::Cursor<&[u8]>> {
         let mut cursor = std::io::Cursor::new(self.data());
         cursor.set_position(from);

--- a/core/tests/swfs/avm1/__framework__/ArgumentDefinition.as
+++ b/core/tests/swfs/avm1/__framework__/ArgumentDefinition.as
@@ -6,7 +6,7 @@ class ArgumentDefinition {
     var values : Array;
 
     /*
-    * Construct a new argument defintion with the given name of the argument.
+    * Construct a new argument definition with the given name of the argument.
     *
     * If you include an 'inherit' argument, every value from that will be copied to this.
     */

--- a/core/tests/swfs/avm1/__framework__/ClassDefinition.as
+++ b/core/tests/swfs/avm1/__framework__/ClassDefinition.as
@@ -8,7 +8,7 @@ class ClassDefinition {
     var clazz : Object;
 
     /*
-    * Construct a new class defintion with the given name of the class,
+    * Construct a new class definition with the given name of the class,
     * a function that will always return a new constructed object of that class,
     * and a function that can be used to 'represent' the object (such as tracing its properties).
     */

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -25,11 +25,11 @@ struct SizeOpt {
     #[clap(long = "scale", default_value = "1.0")]
     scale: f32,
 
-    /// Optionaly override the output width
+    /// Optionally override the output width
     #[clap(long = "width")]
     width: Option<u32>,
 
-    /// Optionaly override the output height
+    /// Optionally override the output height
     #[clap(long = "height")]
     height: Option<u32>,
 }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -617,7 +617,7 @@ impl WebGlRenderBackend {
     }
 
     fn set_stencil_state(&mut self) {
-        // Set stencil state for masking, if neccessary.
+        // Set stencil state for masking, if necessary.
         if self.mask_state_dirty {
             if self.num_masks > 0 {
                 self.gl.enable(Gl::STENCIL_TEST);

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Organization
 //!
-//! This library consits of a `read` module for decoding SWF data, and a `write` library for
+//! This library consists of a `read` module for decoding SWF data, and a `write` library for
 //! writing SWF data.
 
 extern crate byteorder;

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -1,6 +1,6 @@
 //! The data structures used in an Adobe SWF file.
 //!
-//! These structures are documented in the Adobe SWF File Foramt Specification
+//! These structures are documented in the Adobe SWF File Format Specification
 //! version 19 (henceforth SWF19):
 //! https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf
 use enumset::{EnumSet, EnumSetType};
@@ -40,7 +40,7 @@ pub struct Header {
     pub num_frames: u16,
 }
 
-/// The compression foramt used internally by the SWF file.
+/// The compression format used internally by the SWF file.
 ///
 /// The vast majority of SWFs will use zlib compression.
 /// [SWF19 p.27](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=27)

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -69,7 +69,7 @@ pub fn write_swf<W: Write>(swf: &Swf, mut output: W) -> Result<()> {
         Compression::Zlib => write_zlib_swf(&mut output, &swf_body)?,
 
         // LZMA header.
-        // SWF format has a mangled LZMA header, so we have to do some magic to conver the
+        // SWF format has a mangled LZMA header, so we have to do some magic to convert the
         // standard LZMA header to SWF format.
         // https://adobe.ly/2s8oYzn
         Compression::Lzma => write_lzma_swf(&mut output, &swf_body)?,

--- a/web/packages/core/src/public-api.js
+++ b/web/packages/core/src/public-api.js
@@ -21,7 +21,7 @@ exports.PublicAPI = class PublicAPI {
      * if it exists.
      *
      * Constructing a Public API will also trigger it to initialize Ruffle once
-     * the page loads, if the API has not already been superceded.
+     * the page loads, if the API has not already been superseded.
      *
      * @param {object} prev What used to be in the public API slot.
      *
@@ -43,7 +43,7 @@ exports.PublicAPI = class PublicAPI {
                 this.conflict = prev.conflict;
                 this.newest_name = prev.newest_name;
 
-                prev.superceded();
+                prev.superseded();
             } else if (
                 prev.constructor === Object &&
                 prev.config !== undefined
@@ -194,17 +194,17 @@ exports.PublicAPI = class PublicAPI {
     }
 
     /**
-     * Indicates that this version of the public API has been superceded by a
+     * Indicates that this version of the public API has been superseded by a
      * newer version.
      *
      * This should only be called by a newer version of the Public API.
-     * Identical versions of the Public API should not supercede older versions
+     * Identical versions of the Public API should not supersede older versions
      * of that same API.
      *
      * Unfortunately, we can't disable polyfills after-the-fact, so this
      * only lets you disable the init event...
      */
-    superceded() {
+    superseded() {
         this.invoked = true;
     }
 

--- a/web/packages/extension/build/_locales/en/messages.json
+++ b/web/packages/extension/build/_locales/en/messages.json
@@ -15,7 +15,7 @@
         "message": "There is no active tab."
     },
     "status_tabs_error": {
-        "message": "An error occured when looking up the current tab."
+        "message": "An error occurred when looking up the current tab."
     },
     "status_message_init": {
         "message": "Checking Ruffle status on current tab..."
@@ -30,7 +30,7 @@
         "message": "Ruffle is not loaded because it was disabled by the user."
     },
     "status_result_error": {
-        "message": "An error occured when querying the current tab's instance of Ruffle."
+        "message": "An error occurred when querying the current tab's instance of Ruffle."
     },
     "status_result_protected": {
         "message": "Ruffle cannot load on protected browser pages."

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -42,7 +42,7 @@ static RUFFLE_GLOBAL_PANIC: Once = Once::new();
 thread_local! {
     /// We store the actual instances of the ruffle core in a static pool.
     /// This gives us a clear boundary between the JS side and Rust side, avoiding
-    /// issues with lifetimes and type paramters (which cannot be exported with wasm-bindgen).
+    /// issues with lifetimes and type parameters (which cannot be exported with wasm-bindgen).
     static INSTANCES: RefCell<Arena<RefCell<RuffleInstance>>> = RefCell::new(Arena::new());
 
     static CURRENT_CONTEXT: RefCell<Option<*mut UpdateContext<'static, 'static, 'static>>> = RefCell::new(None);
@@ -284,7 +284,7 @@ impl Ruffle {
             core,
             js_player,
             canvas: canvas.clone(),
-            canvas_width: 0, // Intiailize canvas width and height to 0 to force an initial canvas resize.
+            canvas_width: 0, // Initialize canvas width and height to 0 to force an initial canvas resize.
             canvas_height: 0,
             device_pixel_ratio: window.device_pixel_ratio(),
             animation_handler: None,

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -155,7 +155,7 @@ impl NavigatorBackend for WebNavigatorBackend {
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>) {
         spawn_local(async move {
             if let Err(e) = future.await {
-                log::error!("Asynchronous error occured: {}", e);
+                log::error!("Asynchronous error occurred: {}", e);
             }
         })
     }


### PR DESCRIPTION
Done with `codespell --skip="./target" -q2 -w` (except for 2 manual fixes)