### PR TITLE
webgl: Return error if MSAA renderbuffer cannot be created

### DIFF
--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -25,6 +25,6 @@ default-features = false
 
 [dependencies.web-sys]
 version = "0.3.45"
-features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebGlFramebuffer", "WebGlProgram", 
-            "WebGlRenderbuffer", "WebGlRenderingContext", "WebGl2RenderingContext", "WebGlShader", "WebGlTexture", "WebGlUniformLocation", 
-            "WebGlVertexArrayObject"]
+features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebglDebugRendererInfo",
+            "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGl2RenderingContext",
+            "WebGlShader", "WebGlTexture", "WebGlUniformLocation", "WebGlVertexArrayObject"]

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -347,6 +347,7 @@ impl WebGlRenderBackend {
             self.viewport_width as i32,
             self.viewport_height as i32,
         );
+        gl.check_error("renderbuffer_storage_multisample (color)")?;
 
         let stencil_renderbuffer = gl
             .create_renderbuffer()
@@ -359,6 +360,7 @@ impl WebGlRenderBackend {
             self.viewport_width as i32,
             self.viewport_height as i32,
         );
+        gl.check_error("renderbuffer_storage_multisample (stencil)")?;
 
         gl.bind_framebuffer(Gl2::FRAMEBUFFER, Some(&render_framebuffer));
         gl.framebuffer_renderbuffer(
@@ -1417,3 +1419,27 @@ impl ShaderProgram {
 }
 
 impl WebGlRenderBackend {}
+
+trait GlExt {
+    fn check_error(&self, error_msg: &'static str) -> Result<(), Error>;
+}
+
+impl GlExt for Gl {
+    /// Check if GL returned an error for the previous operation.
+    fn check_error(&self, error_msg: &'static str) -> Result<(), Error> {
+        match self.get_error() {
+            Self::NO_ERROR => Ok(()),
+            error => Err(format!("WebGL: Error in {}: {}", error_msg, error).into()),
+        }
+    }
+}
+
+impl GlExt for Gl2 {
+    /// Check if GL returned an error for the previous operation.
+    fn check_error(&self, error_msg: &'static str) -> Result<(), Error> {
+        match self.get_error() {
+            Self::NO_ERROR => Ok(()),
+            error => Err(format!("WebGL: Error in {}: {}", error_msg, error).into()),
+        }
+    }
+}

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -342,7 +342,7 @@ impl WebGlRenderBackend {
         gl.bind_renderbuffer(Gl2::RENDERBUFFER, Some(&color_renderbuffer));
         gl.renderbuffer_storage_multisample(
             Gl2::RENDERBUFFER,
-            4,
+            self.msaa_sample_count as i32,
             Gl2::RGB8,
             self.viewport_width as i32,
             self.viewport_height as i32,
@@ -354,7 +354,7 @@ impl WebGlRenderBackend {
         gl.bind_renderbuffer(Gl2::RENDERBUFFER, Some(&stencil_renderbuffer));
         gl.renderbuffer_storage_multisample(
             Gl2::RENDERBUFFER,
-            4,
+            self.msaa_sample_count as i32,
             Gl2::STENCIL_INDEX8,
             self.viewport_width as i32,
             self.viewport_height as i32,

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{
     HtmlCanvasElement, OesVertexArrayObject, WebGl2RenderingContext as Gl2, WebGlBuffer,
     WebGlFramebuffer, WebGlProgram, WebGlRenderbuffer, WebGlRenderingContext as Gl, WebGlShader,
-    WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject,
+    WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject, WebglDebugRendererInfo,
 };
 
 type Error = Box<dyn std::error::Error>;
@@ -74,6 +74,7 @@ impl WebGlRenderBackend {
             ("alpha", JsValue::FALSE),
             ("antialias", JsValue::FALSE),
             ("depth", JsValue::FALSE),
+            ("failIfMajorPerformanceCaveat", JsValue::TRUE), // fail if no GPU available
         ];
         let context_options = js_sys::Object::new();
         for (name, value) in options.iter() {
@@ -138,6 +139,18 @@ impl WebGlRenderBackend {
                 return Err("Unable to create WebGL rendering context".into());
             }
         };
+
+        // Get WebGL driver info.
+        let driver_info = if gl.get_extension("WEBGL_debug_renderer_info").is_ok() {
+            gl.get_parameter(WebglDebugRendererInfo::UNMASKED_RENDERER_WEBGL)
+                .ok()
+                .and_then(|val| val.as_string())
+                .unwrap_or_else(|| "<unknown>".to_string())
+        } else {
+            "<unknown>".to_string()
+        };
+
+        log::info!("WebGL graphics driver: {}", driver_info);
 
         let color_vertex = Self::compile_shader(&gl, Gl::VERTEX_SHADER, COLOR_VERTEX_GLSL)?;
         let texture_vertex = Self::compile_shader(&gl, Gl::VERTEX_SHADER, TEXTURE_VERTEX_GLSL)?;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -835,8 +835,9 @@ fn create_renderer(
             .into_js_result()?
             .dyn_into()
             .map_err(|_| "Expected HtmlCanvasElement")?;
-        if let Ok(renderer) = ruffle_render_webgl::WebGlRenderBackend::new(&canvas) {
-            return Ok((canvas, Box::new(renderer)));
+        match ruffle_render_webgl::WebGlRenderBackend::new(&canvas) {
+            Ok(renderer) => return Ok((canvas, Box::new(renderer))),
+            Err(error) => log::error!("Error creating WebGL renderer: {}", error),
         }
     }
 
@@ -848,8 +849,9 @@ fn create_renderer(
             .into_js_result()?
             .dyn_into()
             .map_err(|_| "Expected HtmlCanvasElement")?;
-        if let Ok(renderer) = ruffle_render_canvas::WebCanvasRenderBackend::new(&canvas) {
-            return Ok((canvas, Box::new(renderer)));
+        match ruffle_render_canvas::WebCanvasRenderBackend::new(&canvas) {
+            Ok(renderer) => return Ok((canvas, Box::new(renderer))),
+            Err(error) => log::error!("Error creating canvas renderer: {}", error),
         }
     }
 


### PR DESCRIPTION
 * Clamp the MSAA sample count to the amount returned by WebGL MAX_SAMPLES constant. This was intended already, but the value was mistakenly not used in the renderbuffer creation.
* Return an error if WebGL fails to create the multisampled renderbuffer. Previously this failed silently, and the WebGL backend tried to run but couldn't render. Returning an error allows us to fallback to the canvas backend. 

Addresses #1185, allowing it to fall back to canvas. However, in that specific case, the renderbuffer creation somehow fails even though MAX_SAMPLES indicates we have support for the MSAA mode. This still requires investigation (why does it fail? Maybe we can fall back to 2x or no AA instead of bailing out all the way to the canvas backend).