### PR TITLE
webgl: Bump gradient color count to 15

### DIFF
--- a/render/webgl/shaders/gradient.frag
+++ b/render/webgl/shaders/gradient.frag
@@ -8,8 +8,8 @@ uniform vec4 add_color;
 uniform mat3 u_matrix;
 
 uniform int u_gradient_type;
-uniform float u_ratios[8];
-uniform vec4 u_colors[8];
+uniform float u_ratios[15];
+uniform vec4 u_colors[15];
 uniform int u_num_colors;
 uniform int u_repeat_mode;
 uniform float u_focal_point;
@@ -95,14 +95,35 @@ void main() {
     } else if( t <= u_ratios[7] ) {
         a = (t - u_ratios[6]) / (u_ratios[7] - u_ratios[6]);
         color = mix(u_colors[6], u_colors[7], a);
+    } else if( t <= u_ratios[8] ) {
+        a = (t - u_ratios[7]) / (u_ratios[8] - u_ratios[7]);
+        color = mix(u_colors[7], u_colors[8], a);
+    } else if( t <= u_ratios[9] ) {
+        a = (t - u_ratios[8]) / (u_ratios[9] - u_ratios[8]);
+        color = mix(u_colors[8], u_colors[9], a);
+    } else if( t <= u_ratios[10] ) {
+        a = (t - u_ratios[9]) / (u_ratios[10] - u_ratios[9]);
+        color = mix(u_colors[9], u_colors[10], a);
+    } else if( t <= u_ratios[11] ) {
+        a = (t - u_ratios[10]) / (u_ratios[11] - u_ratios[10]);
+        color = mix(u_colors[10], u_colors[11], a);
+    } else if( t <= u_ratios[12] ) {
+        a = (t - u_ratios[11]) / (u_ratios[12] - u_ratios[11]);
+        color = mix(u_colors[11], u_colors[12], a);
+    } else if( t <= u_ratios[13] ) {
+        a = (t - u_ratios[12]) / (u_ratios[13] - u_ratios[12]);
+        color = mix(u_colors[12], u_colors[13], a);
+    } else if( t <= u_ratios[14] ) {
+        a = (t - u_ratios[13]) / (u_ratios[14] - u_ratios[13]);
+        color = mix(u_colors[13], u_colors[14], a);
     } else {
-        color = u_colors[7];
+        color = u_colors[14];
     }
 
     if( u_interpolation != 0 ) {
         color = vec4(linear_to_srgb(vec3(color)), color.a);
     }
 
-    gl_FragColor = mult_color * color + add_color;;
+    gl_FragColor = mult_color * color + add_color;
 }
 

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -66,6 +66,8 @@ pub struct WebGlRenderBackend {
     view_matrix: [[f32; 4]; 4],
 }
 
+const MAX_GRADIENT_COLORS: usize = 15;
+
 impl WebGlRenderBackend {
     pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, Error> {
         // Create WebGL context.
@@ -479,9 +481,9 @@ impl WebGlRenderBackend {
                     },
                 ),
                 TessDrawType::Gradient(gradient) => {
-                    let mut ratios = [0.0; 8];
-                    let mut colors = [[0.0; 4]; 8];
-                    let num_colors = gradient.num_colors as usize;
+                    let mut ratios = [0.0; MAX_GRADIENT_COLORS];
+                    let mut colors = [[0.0; 4]; MAX_GRADIENT_COLORS];
+                    let num_colors = (gradient.num_colors as usize).min(MAX_GRADIENT_COLORS);
                     ratios[..num_colors].copy_from_slice(&gradient.ratios[..num_colors]);
                     colors[..num_colors].copy_from_slice(&gradient.colors[..num_colors]);
                     // Convert to linear color space if this is a linear-interpolated gradient.
@@ -1244,8 +1246,8 @@ struct Texture {
 struct Gradient {
     matrix: [[f32; 3]; 3],
     gradient_type: i32,
-    ratios: [f32; 8],
-    colors: [[f32; 4]; 8],
+    ratios: [f32; MAX_GRADIENT_COLORS],
+    colors: [[f32; 4]; MAX_GRADIENT_COLORS],
     num_colors: u32,
     repeat_mode: i32,
     focal_point: f32,


### PR DESCRIPTION
Increase the number of colors allowed in gradients allowed by WebGL to 15. Also clamp the color count to 15 in case we get too many colors (previously would panic). Addresses #1214.