### PR TITLE
Actually unload movies when we get an empty URL in GetURL & GetURL2

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1173,14 +1173,21 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     let fetch = self.context.navigator.fetch(&url, RequestOptions::get());
                     let level = self.resolve_level(level_id);
 
-                    let process = self.context.load_manager.load_movie_into_clip(
-                        self.context.player.clone().unwrap(),
-                        level,
-                        fetch,
-                        url,
-                        None,
-                    );
-                    self.context.navigator.spawn_future(process);
+                    if url == "" {
+                        //Blank URL on movie loads = unload!
+                        if let Some(mut mc) = level.as_movie_clip() {
+                            mc.replace_with_movie(self.context.gc_context, None)
+                        }
+                    } else {
+                        let process = self.context.load_manager.load_movie_into_clip(
+                            self.context.player.clone().unwrap(),
+                            level,
+                            fetch,
+                            url,
+                            None,
+                        );
+                        self.context.navigator.spawn_future(process);
+                    }
                 }
                 Err(e) => avm_warn!(
                     self,

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1261,15 +1261,23 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     Cow::Borrowed(&url),
                     NavigationMethod::from_send_vars_method(swf_method),
                 );
-                let fetch = self.context.navigator.fetch(&url, opts);
-                let process = self.context.load_manager.load_movie_into_clip(
-                    self.context.player.clone().unwrap(),
-                    clip_target,
-                    fetch,
-                    url.to_string(),
-                    None,
-                );
-                self.context.navigator.spawn_future(process);
+
+                if url == "" {
+                    //Blank URL on movie loads = unload!
+                    if let Some(mut mc) = clip_target.as_movie_clip() {
+                        mc.replace_with_movie(self.context.gc_context, None)
+                    }
+                } else {
+                    let fetch = self.context.navigator.fetch(&url, opts);
+                    let process = self.context.load_manager.load_movie_into_clip(
+                        self.context.player.clone().unwrap(),
+                        clip_target,
+                        fetch,
+                        url.to_string(),
+                        None,
+                    );
+                    self.context.navigator.spawn_future(process);
+                }
             }
 
             return Ok(FrameControl::Continue);

--- a/core/src/avm1/fscommand.rs
+++ b/core/src/avm1/fscommand.rs
@@ -6,7 +6,6 @@ use crate::avm_warn;
 
 /// Parse an FSCommand URL.
 pub fn parse(url: &str) -> Option<&str> {
-    log::info!("Checking {}", url);
     if url.to_lowercase().starts_with("fscommand:") {
         Some(&url["fscommand:".len()..])
     } else {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -437,8 +437,6 @@ impl<'gc> Loader<'gc> {
                         .unwrap()
                         .replace_with_movie(uc.gc_context, None);
 
-                    dbg!("movie_loader 440");
-
                     if let Some(broadcaster) = broadcaster {
                         Avm1::run_stack_frame_for_method(
                             clip,


### PR DESCRIPTION
This fixes #1145 and it's cinematic 24FPS DDoS attacks. Or at least it should - @Toad06 pls confirm.

Notably, this behavior was already covered by the tests, but the buggy implementation broke the failure mechanism on the test. I have no idea how to improve the test to work around this, but I can manually confirm that it no longer tries to load a file every *frame* in the movie in http://www.annie-cordy.com/disco/discographie80.html.

This covers both `GetUrl` and `GetUrl2`, both of which use empty URLs to signal an unload. Ruffle's load manager semantics are just different enough to make that little hack not work, so we have to just check for empty URLs in both actions.