### PR TITLE
avm2: Add various stubs

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -445,6 +445,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         flash::system::loadercontext::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
+    class(
+        activation,
+        gs,
+        flash::system::securitydomain::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
 
     // package `flash.utils`
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -332,6 +332,14 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         f64::INFINITY.into(),
     );
 
+    // package `flash.accessibility`
+    class(
+        activation,
+        gs,
+        flash::accessibility::accessibilityproperties::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     // package `flash.events`
     class(
         activation,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -404,6 +404,14 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         implicit_deriver,
     )?;
 
+    // package `flash.geom`
+    class(
+        activation,
+        gs,
+        flash::geom::matrix::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     // package `flash.utils`
     class(
         activation,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -376,6 +376,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::loader::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::loaderinfo::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -439,6 +439,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         flash::system::applicationdomain::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
+    class(
+        activation,
+        gs,
+        flash::system::loadercontext::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
 
     // package `flash.utils`
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -362,6 +362,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::shape::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::sprite::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -376,6 +376,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::loaderinfo::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::shader::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -418,6 +418,14 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         implicit_deriver,
     )?;
 
+    // package `flash.system`
+    class(
+        activation,
+        gs,
+        flash::system::applicationdomain::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     // package `flash.utils`
     class(
         activation,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -376,6 +376,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::shader::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::shape::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -424,6 +424,14 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         implicit_deriver,
     )?;
 
+    // package `flash.net`
+    class(
+        activation,
+        gs,
+        flash::net::urlrequest::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     // package `flash.system`
     class(
         activation,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -382,6 +382,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::shaderdata::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::shape::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -398,5 +398,13 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         implicit_deriver,
     )?;
 
+    // package `flash.utils`
+    class(
+        activation,
+        gs,
+        flash::utils::bytearray::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     Ok(())
 }

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -336,6 +336,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::event::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::eventdispatcher::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -353,6 +353,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         flash::events::eventdispatcher::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
+    class(
+        activation,
+        gs,
+        flash::events::uncaughterrorevents::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
 
     // package `flash.display`
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -344,6 +344,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::errorevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::event::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -388,6 +388,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::imeevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::ioerrorevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -545,6 +545,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         flash::geom::matrix::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
+    class(
+        activation,
+        gs,
+        flash::geom::rectangle::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
 
     // package `flash.net`
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -336,7 +336,9 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
-        flash::accessibility::accessibilityimplementation::create_class(activation.context.gc_context),
+        flash::accessibility::accessibilityimplementation::create_class(
+            activation.context.gc_context
+        ),
         implicit_deriver,
     )?;
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -386,6 +386,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::nativedragevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::progressevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -398,6 +398,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::softkeyboardevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::textevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -436,6 +436,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::transformgestureevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::uncaughterrorevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -376,6 +376,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::gestureevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::httpstatusevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -550,6 +550,14 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         implicit_deriver,
     )?;
 
+    // package `flash.display3d`
+    class(
+        activation,
+        gs,
+        flash::display3d::context3d::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     // package `flash.geom`
     class(
         activation,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -474,6 +474,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::nativemenuitem::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::shader::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -356,6 +356,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::textevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::uncaughterrorevents::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -368,6 +368,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::uncaughterrorevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::uncaughterrorevents::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -528,13 +528,19 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::sprite::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::stage::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
     class(
         activation,
         gs,
-        flash::display::sprite::create_class(activation.context.gc_context),
+        flash::display::stage3d::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -404,6 +404,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::touchevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::uncaughterrorevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -336,6 +336,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::accessibility::accessibilityimplementation::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::accessibility::accessibilityproperties::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -370,6 +370,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::focusevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::httpstatusevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -466,6 +466,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::nativemenu::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::shader::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -362,13 +362,13 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
-        flash::events::ioerrorevent::create_class(activation.context.gc_context),
+        flash::events::httpstatusevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
     class(
         activation,
         gs,
-        flash::events::httpstatusevent::create_class(activation.context.gc_context),
+        flash::events::ioerrorevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;
     class(

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -412,6 +412,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::pressandtapgestureevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::progressevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -362,6 +362,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::httpstatusevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::textevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -528,6 +528,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::display::stage::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::display::sprite::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -362,6 +362,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::ioerrorevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::httpstatusevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -374,6 +374,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::keyboardevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::progressevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -380,6 +380,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::mouseevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::progressevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -574,6 +574,14 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         implicit_deriver,
     )?;
 
+    // package `flash.text`
+    class(
+        activation,
+        gs,
+        flash::text::textsnapshot::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+
     // package `flash.utils`
     class(
         activation,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -374,6 +374,12 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
     class(
         activation,
         gs,
+        flash::events::progressevent::create_class(activation.context.gc_context),
+        implicit_deriver,
+    )?;
+    class(
+        activation,
+        gs,
         flash::events::textevent::create_class(activation.context.gc_context),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -337,7 +337,7 @@ pub fn load_player_globals<'gc>(activation: &mut Activation<'_, 'gc, '_>) -> Res
         activation,
         gs,
         flash::accessibility::accessibilityimplementation::create_class(
-            activation.context.gc_context
+            activation.context.gc_context,
         ),
         implicit_deriver,
     )?;

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -4,4 +4,5 @@ pub mod accessibility;
 pub mod display;
 pub mod events;
 pub mod geom;
+pub mod system;
 pub mod utils;

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -4,5 +4,6 @@ pub mod accessibility;
 pub mod display;
 pub mod events;
 pub mod geom;
+pub mod net;
 pub mod system;
 pub mod utils;

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -1,4 +1,5 @@
 //! `flash` namespace
 
+pub mod accessibility;
 pub mod display;
 pub mod events;

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -3,3 +3,5 @@
 pub mod accessibility;
 pub mod display;
 pub mod events;
+pub mod geom;
+pub mod utils;

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -2,6 +2,7 @@
 
 pub mod accessibility;
 pub mod display;
+pub mod display3d;
 pub mod events;
 pub mod geom;
 pub mod net;

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -6,4 +6,5 @@ pub mod events;
 pub mod geom;
 pub mod net;
 pub mod system;
+pub mod text;
 pub mod utils;

--- a/core/src/avm2/globals/flash/accessibility.rs
+++ b/core/src/avm2/globals/flash/accessibility.rs
@@ -1,0 +1,3 @@
+//! `flash.accessibility` namespace
+
+pub mod accessibilityproperties;

--- a/core/src/avm2/globals/flash/accessibility.rs
+++ b/core/src/avm2/globals/flash/accessibility.rs
@@ -1,3 +1,4 @@
 //! `flash.accessibility` namespace
 
+pub mod accessibilityimplementation;
 pub mod accessibilityproperties;

--- a/core/src/avm2/globals/flash/accessibility/accessibilityimplementation.rs
+++ b/core/src/avm2/globals/flash/accessibility/accessibilityimplementation.rs
@@ -1,0 +1,42 @@
+//! `flash.accessibility.AccessibilityImplementation` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.accessibility.AccessibilityImplementation`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.accessibility.AccessibilityImplementation`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `AccessibilityImplementation`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(
+            Namespace::package("flash.accessibility"),
+            "AccessibilityImplementation",
+        ),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
+++ b/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
@@ -30,7 +30,10 @@ pub fn class_init<'gc>(
 /// Construct `AccessibilityProperties`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     Class::new(
-        QName::new(Namespace::package("flash.accessibility"), "AccessibilityProperties"),
+        QName::new(
+            Namespace::package("flash.accessibility"),
+            "AccessibilityProperties"
+        ),
         Some(QName::new(Namespace::public_namespace(), "Object").into()),
         Method::from_builtin(instance_init),
         Method::from_builtin(class_init),

--- a/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
+++ b/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
@@ -1,0 +1,39 @@
+//! `flash.accessibility.AccessibilityProperties` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.accessibility.AccessibilityProperties`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.accessibility.AccessibilityProperties`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `AccessibilityProperties`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.accessibility"), "AccessibilityProperties"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
+++ b/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
@@ -32,7 +32,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     Class::new(
         QName::new(
             Namespace::package("flash.accessibility"),
-            "AccessibilityProperties"
+            "AccessibilityProperties",
         ),
         Some(QName::new(Namespace::public_namespace(), "Object").into()),
         Method::from_builtin(instance_init),

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -4,5 +4,6 @@ pub mod displayobject;
 pub mod displayobjectcontainer;
 pub mod interactiveobject;
 pub mod movieclip;
+pub mod shader;
 pub mod shape;
 pub mod sprite;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -4,4 +4,5 @@ pub mod displayobject;
 pub mod displayobjectcontainer;
 pub mod interactiveobject;
 pub mod movieclip;
+pub mod shape;
 pub mod sprite;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -6,5 +6,6 @@ pub mod interactiveobject;
 pub mod loaderinfo;
 pub mod movieclip;
 pub mod shader;
+pub mod shaderdata;
 pub mod shape;
 pub mod sprite;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -3,6 +3,7 @@
 pub mod displayobject;
 pub mod displayobjectcontainer;
 pub mod interactiveobject;
+pub mod loaderinfo;
 pub mod movieclip;
 pub mod shader;
 pub mod shape;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -3,6 +3,7 @@
 pub mod displayobject;
 pub mod displayobjectcontainer;
 pub mod interactiveobject;
+pub mod loader;
 pub mod loaderinfo;
 pub mod movieclip;
 pub mod shader;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -7,6 +7,7 @@ pub mod loader;
 pub mod loaderinfo;
 pub mod movieclip;
 pub mod nativemenu;
+pub mod nativemenuitem;
 pub mod shader;
 pub mod shaderdata;
 pub mod shape;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -6,6 +6,7 @@ pub mod interactiveobject;
 pub mod loader;
 pub mod loaderinfo;
 pub mod movieclip;
+pub mod nativemenu;
 pub mod shader;
 pub mod shaderdata;
 pub mod shape;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -11,4 +11,5 @@ pub mod nativemenuitem;
 pub mod shader;
 pub mod shaderdata;
 pub mod shape;
+pub mod stage;
 pub mod sprite;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -13,3 +13,4 @@ pub mod shaderdata;
 pub mod shape;
 pub mod sprite;
 pub mod stage;
+pub mod stage3d;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -11,5 +11,5 @@ pub mod nativemenuitem;
 pub mod shader;
 pub mod shaderdata;
 pub mod shape;
-pub mod stage;
 pub mod sprite;
+pub mod stage;

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -1,0 +1,45 @@
+//! `flash.display.Loader` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.Loader`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.Loader`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Loader`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "Loader"),
+        Some(
+            QName::new(
+                Namespace::package("flash.display"),
+                "DisplayObjectContainer",
+            )
+            .into(),
+        ),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -1,0 +1,39 @@
+//! `flash.display.LoaderInfo` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.LoaderInfo`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.LoaderInfo`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `LoaderInfo`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "LoaderInfo"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/nativemenu.rs
+++ b/core/src/avm2/globals/flash/display/nativemenu.rs
@@ -1,0 +1,39 @@
+//! `flash.display.NativeMenu` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.NativeMenu`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.NativeMenu`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `NativeMenu`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "NativeMenu"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/nativemenuitem.rs
+++ b/core/src/avm2/globals/flash/display/nativemenuitem.rs
@@ -1,0 +1,39 @@
+//! `flash.display.NativeMenuItem` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.NativeMenuItem`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.NativeMenuItem`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `NativeMenuItem`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "NativeMenuItem"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/shader.rs
+++ b/core/src/avm2/globals/flash/display/shader.rs
@@ -1,0 +1,39 @@
+//! `flash.display.Shader` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.Shader`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.Shader`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Shader`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "Shader"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/shaderdata.rs
+++ b/core/src/avm2/globals/flash/display/shaderdata.rs
@@ -1,0 +1,39 @@
+//! `flash.display.ShaderData` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.ShaderData`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.ShaderData`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `ShaderData`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "ShaderData"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -1,0 +1,39 @@
+//! `flash.display.Shape` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.Shape`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.Shape`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Shape`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "Shape"),
+        Some(QName::new(Namespace::package("flash.display"), "DisplayObject").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -1,0 +1,45 @@
+//! `flash.display.Stage` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.Stage`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.Stage`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Stage`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "Stage"),
+        Some(
+            QName::new(
+                Namespace::package("flash.display"),
+                "DisplayObjectContainer",
+            )
+            .into(),
+        ),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display/stage3d.rs
+++ b/core/src/avm2/globals/flash/display/stage3d.rs
@@ -1,0 +1,39 @@
+//! `flash.display.Stage3D` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.Stage3D`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.Stage3D`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Stage3D`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display"), "Stage3D"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/display3d.rs
+++ b/core/src/avm2/globals/flash/display3d.rs
@@ -1,0 +1,3 @@
+//! `flash.display3D` namespace
+
+pub mod context3d;

--- a/core/src/avm2/globals/flash/display3d/context3d.rs
+++ b/core/src/avm2/globals/flash/display3d/context3d.rs
@@ -1,0 +1,39 @@
+//! `flash.display3D.Context3D` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display3D.Context3D`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display3D.Context3D`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Context3D`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.display3D"), "Context3D"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -2,3 +2,4 @@
 
 pub mod event;
 pub mod eventdispatcher;
+pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -1,3 +1,4 @@
 //! `flash.events` namespace
 
+pub mod event;
 pub mod eventdispatcher;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -1,5 +1,6 @@
 //! `flash.events` namespace
 
+pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
 pub mod textevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -7,6 +7,7 @@ pub mod httpstatusevent;
 pub mod ioerrorevent;
 pub mod keyboardevent;
 pub mod mouseevent;
+pub mod nativedragevent;
 pub mod progressevent;
 pub mod textevent;
 pub mod uncaughterrorevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -4,4 +4,5 @@ pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
 pub mod textevent;
+pub mod uncaughterrorevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -5,6 +5,7 @@ pub mod event;
 pub mod eventdispatcher;
 pub mod httpstatusevent;
 pub mod ioerrorevent;
+pub mod keyboardevent;
 pub mod progressevent;
 pub mod textevent;
 pub mod uncaughterrorevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -10,5 +10,6 @@ pub mod mouseevent;
 pub mod nativedragevent;
 pub mod progressevent;
 pub mod textevent;
+pub mod touchevent;
 pub mod uncaughterrorevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -10,6 +10,7 @@ pub mod ioerrorevent;
 pub mod keyboardevent;
 pub mod mouseevent;
 pub mod nativedragevent;
+pub mod pressandtapgestureevent;
 pub mod progressevent;
 pub mod softkeyboardevent;
 pub mod textevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -5,6 +5,7 @@ pub mod event;
 pub mod eventdispatcher;
 pub mod httpstatusevent;
 pub mod ioerrorevent;
+pub mod progressevent;
 pub mod textevent;
 pub mod uncaughterrorevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -6,6 +6,7 @@ pub mod eventdispatcher;
 pub mod focusevent;
 pub mod gestureevent;
 pub mod httpstatusevent;
+pub mod imeevent;
 pub mod ioerrorevent;
 pub mod keyboardevent;
 pub mod mouseevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -3,6 +3,7 @@
 pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
+pub mod focusevent;
 pub mod httpstatusevent;
 pub mod ioerrorevent;
 pub mod keyboardevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -14,5 +14,6 @@ pub mod progressevent;
 pub mod softkeyboardevent;
 pub mod textevent;
 pub mod touchevent;
+pub mod transformgestureevent;
 pub mod uncaughterrorevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -4,6 +4,7 @@ pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
 pub mod httpstatusevent;
+pub mod ioerrorevent;
 pub mod textevent;
 pub mod uncaughterrorevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -3,6 +3,7 @@
 pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
+pub mod httpstatusevent;
 pub mod textevent;
 pub mod uncaughterrorevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -9,6 +9,7 @@ pub mod keyboardevent;
 pub mod mouseevent;
 pub mod nativedragevent;
 pub mod progressevent;
+pub mod softkeyboardevent;
 pub mod textevent;
 pub mod touchevent;
 pub mod uncaughterrorevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -2,4 +2,5 @@
 
 pub mod event;
 pub mod eventdispatcher;
+pub mod textevent;
 pub mod uncaughterrorevents;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -4,6 +4,7 @@ pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
 pub mod focusevent;
+pub mod gestureevent;
 pub mod httpstatusevent;
 pub mod ioerrorevent;
 pub mod keyboardevent;

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -6,6 +6,7 @@ pub mod eventdispatcher;
 pub mod httpstatusevent;
 pub mod ioerrorevent;
 pub mod keyboardevent;
+pub mod mouseevent;
 pub mod progressevent;
 pub mod textevent;
 pub mod uncaughterrorevent;

--- a/core/src/avm2/globals/flash/events/errorevent.rs
+++ b/core/src/avm2/globals/flash/events/errorevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.ErrorEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.ErrorEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.ErrorEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `ErrorEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "ErrorEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "TextEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -1,0 +1,39 @@
+//! `flash.events.Event` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.Event`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.Event`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Event`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "Event"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/focusevent.rs
+++ b/core/src/avm2/globals/flash/events/focusevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.FocusEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.FocusEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.FocusEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `FocusEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "FocusEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/gestureevent.rs
+++ b/core/src/avm2/globals/flash/events/gestureevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.GestureEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.GestureEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.GestureEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `GestureEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "GestureEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/httpstatusevent.rs
+++ b/core/src/avm2/globals/flash/events/httpstatusevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.HTTPStatusEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.HTTPStatusEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.HTTPStatusEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `HTTPStatusEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "HTTPStatusEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/imeevent.rs
+++ b/core/src/avm2/globals/flash/events/imeevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.IMEEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.IMEEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.IMEEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `IMEEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "IMEEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "TextEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/ioerrorevent.rs
+++ b/core/src/avm2/globals/flash/events/ioerrorevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.IOErrorEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.IOErrorEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.IOErrorEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `IOErrorEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "IOErrorEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "ErrorEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/keyboardevent.rs
+++ b/core/src/avm2/globals/flash/events/keyboardevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.KeyboardEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.KeyboardEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.KeyboardEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `KeyboardEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "KeyboardEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/mouseevent.rs
+++ b/core/src/avm2/globals/flash/events/mouseevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.MouseEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.MouseEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.MouseEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `MouseEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "MouseEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/nativedragevent.rs
+++ b/core/src/avm2/globals/flash/events/nativedragevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.NativeDragEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.NativeDragEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.NativeDragEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `NativeDragEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "NativeDragEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "MouseEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/pressandtapgestureevent.rs
+++ b/core/src/avm2/globals/flash/events/pressandtapgestureevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.PressAndTapGestureEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.PressAndTapGestureEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.PressAndTapGestureEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `PressAndTapGestureEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "PressAndTapGestureEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "GestureEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/pressandtapgestureevent.rs
+++ b/core/src/avm2/globals/flash/events/pressandtapgestureevent.rs
@@ -30,7 +30,10 @@ pub fn class_init<'gc>(
 /// Construct `PressAndTapGestureEvent`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     Class::new(
-        QName::new(Namespace::package("flash.events"), "PressAndTapGestureEvent"),
+        QName::new(
+            Namespace::package("flash.events"),
+            "PressAndTapGestureEvent",
+        ),
         Some(QName::new(Namespace::package("flash.events"), "GestureEvent").into()),
         Method::from_builtin(instance_init),
         Method::from_builtin(class_init),

--- a/core/src/avm2/globals/flash/events/progressevent.rs
+++ b/core/src/avm2/globals/flash/events/progressevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.ProgressEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.ProgressEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.ProgressEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `ProgressEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "ProgressEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/softkeyboardevent.rs
+++ b/core/src/avm2/globals/flash/events/softkeyboardevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.SoftKeyboardEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.SoftKeyboardEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.SoftKeyboardEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `SoftKeyboardEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "SoftKeyboardEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/textevent.rs
+++ b/core/src/avm2/globals/flash/events/textevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.TextEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.TextEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.TextEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `TextEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "TextEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/touchevent.rs
+++ b/core/src/avm2/globals/flash/events/touchevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.TouchEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.TouchEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.TouchEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `TouchEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "TouchEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/transformgestureevent.rs
+++ b/core/src/avm2/globals/flash/events/transformgestureevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.TransformGestureEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.TransformGestureEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.TransformGestureEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `TransformGestureEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "TransformGestureEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "GestureEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/uncaughterrorevent.rs
+++ b/core/src/avm2/globals/flash/events/uncaughterrorevent.rs
@@ -1,0 +1,39 @@
+//! `flash.events.UncaughtErrorEvent` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.UncaughtErrorEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.UncaughtErrorEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `UncaughtErrorEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "UncaughtErrorEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "ErrorEvent").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/events/uncaughterrorevents.rs
+++ b/core/src/avm2/globals/flash/events/uncaughterrorevents.rs
@@ -1,0 +1,39 @@
+//! `flash.events.UncaughtErrorEvents` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.UncaughtErrorEvents`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.UncaughtErrorEvents`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `UncaughtErrorEvents`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.events"), "UncaughtErrorEvents"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/geom.rs
+++ b/core/src/avm2/globals/flash/geom.rs
@@ -1,0 +1,3 @@
+//! `flash.geom` namespace
+
+pub mod matrix;

--- a/core/src/avm2/globals/flash/geom.rs
+++ b/core/src/avm2/globals/flash/geom.rs
@@ -1,3 +1,4 @@
 //! `flash.geom` namespace
 
 pub mod matrix;
+pub mod rectangle;

--- a/core/src/avm2/globals/flash/geom/matrix.rs
+++ b/core/src/avm2/globals/flash/geom/matrix.rs
@@ -1,0 +1,39 @@
+//! `flash.geom.Matrix` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.geom.Matrix`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.geom.Matrix`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Matrix`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.geom"), "Matrix"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/geom/rectangle.rs
+++ b/core/src/avm2/globals/flash/geom/rectangle.rs
@@ -1,0 +1,39 @@
+//! `flash.geom.Rectangle` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.geom.Rectangle`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.geom.Rectangle`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Rectangle`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.geom"), "Rectangle"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -1,0 +1,3 @@
+//! `flash.net` namespace
+
+pub mod urlrequest;

--- a/core/src/avm2/globals/flash/net/urlrequest.rs
+++ b/core/src/avm2/globals/flash/net/urlrequest.rs
@@ -1,0 +1,39 @@
+//! `flash.net.URLRequest` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.net.URLRequest`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.net.URLRequest`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `URLRequest`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.net"), "URLRequest"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/system.rs
+++ b/core/src/avm2/globals/flash/system.rs
@@ -1,0 +1,3 @@
+//! `flash.system` namespace
+
+pub mod applicationdomain;

--- a/core/src/avm2/globals/flash/system.rs
+++ b/core/src/avm2/globals/flash/system.rs
@@ -1,3 +1,4 @@
 //! `flash.system` namespace
 
 pub mod applicationdomain;
+pub mod loadercontext;

--- a/core/src/avm2/globals/flash/system.rs
+++ b/core/src/avm2/globals/flash/system.rs
@@ -2,3 +2,4 @@
 
 pub mod applicationdomain;
 pub mod loadercontext;
+pub mod securitydomain;

--- a/core/src/avm2/globals/flash/system/applicationdomain.rs
+++ b/core/src/avm2/globals/flash/system/applicationdomain.rs
@@ -1,0 +1,39 @@
+//! `flash.system.ApplicationDomain` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.system.ApplicationDomain`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.system.ApplicationDomain`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `ApplicationDomain`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.system"), "ApplicationDomain"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/system/loadercontext.rs
+++ b/core/src/avm2/globals/flash/system/loadercontext.rs
@@ -1,0 +1,39 @@
+//! `flash.system.LoaderContext` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.system.LoaderContext`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.system.LoaderContext`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `LoaderContext`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.system"), "LoaderContext"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/system/securitydomain.rs
+++ b/core/src/avm2/globals/flash/system/securitydomain.rs
@@ -1,0 +1,39 @@
+//! `flash.system.SecurityDomain` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.system.SecurityDomain`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.system.SecurityDomain`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `SecurityDomain`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.system"), "SecurityDomain"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/text.rs
+++ b/core/src/avm2/globals/flash/text.rs
@@ -1,0 +1,3 @@
+//! `flash.text` namespace
+
+pub mod textsnapshot;

--- a/core/src/avm2/globals/flash/text/textsnapshot.rs
+++ b/core/src/avm2/globals/flash/text/textsnapshot.rs
@@ -1,0 +1,39 @@
+//! `flash.text.TextSnapshot` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.text.TextSnapshot`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.text.TextSnapshot`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `TextSnapshot`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.text"), "TextSnapshot"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -1,0 +1,3 @@
+//! `flash.utils` namespace
+
+pub mod bytearray;

--- a/core/src/avm2/globals/flash/utils/bytearray.rs
+++ b/core/src/avm2/globals/flash/utils/bytearray.rs
@@ -1,0 +1,39 @@
+//! `flash.utils.ByteArray` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.utils.ByteArray`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.utils.ByteArray`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `ByteArray`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.utils"), "ByteArray"),
+        Some(QName::new(Namespace::public_namespace(), "Object").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}


### PR DESCRIPTION
This PR, when it is done, will have almost all of the required stubs to add in function prototypes for the `flash.display.Shape` tree. And every other file in the AVM3 tree.

Omitted:
- All interfaces
- All objects with type arguments (Vector)