### PR TITLE
desktop: Support URL paths and Proxy options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
 name = "calloop"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +684,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.38+curl-7.73.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498ecfb4f59997fd40023d62a9f1e506e768b2baeb59a1d311eb9751cdcd7e3f"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +957,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-map"
@@ -1386,6 +1432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1530,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "isahc"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac245314704d62c121785203fb4d6f41f137167fcc91beec0b55bd6c4bb8c800"
+dependencies = [
+ "bytes",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "http",
+ "lazy_static",
+ "log",
+ "mime",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1585,6 +1667,28 @@ checksum = "3557c9384f7f757f6d139cd3a4c62ef4e850696c16bf27924a5538c8a09717a1"
 dependencies = [
  "cfg-if",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.4+1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1759,6 +1863,12 @@ dependencies = [
  "log",
  "objc",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimp3"
@@ -2111,6 +2221,25 @@ name = "once_cell"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2568,6 +2697,7 @@ dependencies = [
  "env_logger",
  "generational-arena",
  "image",
+ "isahc",
  "jpeg-decoder",
  "log",
  "lyon",
@@ -2749,6 +2879,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,6 +2974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sluice"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed13b7cb46f13a15db2c4740f087a848acc8b31af89f95844d40137451f89b1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3018,18 @@ dependencies = [
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
+]
+
+[[package]]
+name = "socket2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3070,8 +3234,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3081,6 +3258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -3141,6 +3328,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -52,6 +52,9 @@ pub enum Error {
     #[error("Network error")]
     NetworkError(#[from] std::io::Error),
 
+    #[error("Network unavailable.")]
+    NetworkUnavailable,
+
     // TODO: We can't support lifetimes on this error object yet (or we'll need some backends inside
     // the GC arena). We're losing info here. How do we fix that?
     #[error("Error running avm1 script: {0}")]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -23,6 +23,7 @@ webbrowser = "0.5.5"
 url = "2.1.1"
 clipboard = "0.5.0"
 dirs = "3.0"
+isahc = "0.9.10"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -12,6 +12,7 @@ mod task;
 use crate::custom_event::RuffleEvent;
 use crate::executor::GlutinAsyncExecutor;
 use clap::Clap;
+use isahc::prelude::*;
 use ruffle_core::{
     backend::audio::{AudioBackend, NullAudioBackend},
     Player,
@@ -20,11 +21,13 @@ use ruffle_render_wgpu::WgpuRenderBackend;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
+use url::Url;
 
 use crate::storage::DiskStorageBackend;
 use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
+use std::io::Read;
 use std::rc::Rc;
 use winit::dpi::{LogicalSize, PhysicalPosition};
 use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
@@ -67,6 +70,14 @@ struct Opt {
     #[clap(long, parse(from_os_str))]
     #[cfg(feature = "render_trace")]
     trace_path: Option<PathBuf>,
+
+    /// (Optional) HTTP Proxy to use when loading movies via URL
+    #[clap(long, case_insensitive = true)]
+    http_proxy: Option<Url>,
+
+    /// (Optional) HTTPS Proxy to use when loading movies via URL
+    #[clap(long, case_insensitive = true)]
+    https_proxy: Option<Url>,
 }
 
 #[cfg(feature = "render_trace")]
@@ -99,8 +110,28 @@ fn main() {
     }
 }
 
+fn load_movie_from_path(movie_url: Url) -> Result<SwfMovie, Box<dyn std::error::Error>> {
+    if movie_url.scheme() == "file" {
+        if let Ok(path) = movie_url.to_file_path() {
+            return SwfMovie::from_path(path);
+        }
+    }
+    let client = HttpClient::new()?;
+    let res = client.get(movie_url.to_string())?;
+    let mut buffer: Vec<u8> = Vec::new();
+    res.into_body().read_to_end(&mut buffer)?;
+    SwfMovie::from_data(&buffer, Some(movie_url.to_string()))
+}
+
 fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
-    let mut movie = SwfMovie::from_path(&opt.input_path)?;
+    let movie_url = if opt.input_path.exists() {
+        let absolute_path = opt.input_path.to_owned().canonicalize()?;
+        Url::from_file_path(absolute_path).map_err(|_| "Path cannot be a URL")?
+    } else {
+        Url::parse(opt.input_path.to_str().unwrap_or_default())
+            .map_err(|_| "Input path is not a file and could not be parsed as a URL.")?
+    };
+    let mut movie = load_movie_from_path(movie_url.to_owned())?;
     let movie_size = LogicalSize::new(movie.width(), movie.height());
 
     for parameter in &opt.parameters {
@@ -118,15 +149,13 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     let icon = Icon::from_rgba(icon_bytes.to_vec(), 32, 32)?;
 
     let event_loop: EventLoop<RuffleEvent> = EventLoop::with_user_event();
+    let window_title = movie_url
+        .path_segments()
+        .and_then(|segments| segments.last())
+        .unwrap_or_else(|| movie_url.as_str());
     let window = Rc::new(
         WindowBuilder::new()
-            .with_title(format!(
-                "Ruffle - {}",
-                opt.input_path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-            ))
+            .with_title(format!("Ruffle - {}", window_title))
             .with_window_icon(Some(icon))
             .with_inner_size(movie_size)
             .build(&event_loop)?,
@@ -148,12 +177,12 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         trace_path(&opt),
     )?);
     let (executor, chan) = GlutinAsyncExecutor::new(event_loop.create_proxy());
-    let navigator = Box::new(navigator::ExternalNavigatorBackend::with_base_path(
-        opt.input_path
-            .parent()
-            .unwrap_or_else(|| std::path::Path::new("")),
+    let navigator = Box::new(navigator::ExternalNavigatorBackend::new(
+        movie_url,
         chan,
         event_loop.create_proxy(),
+        opt.http_proxy,
+        opt.https_proxy,
     )); //TODO: actually implement this backend type
     let input = Box::new(input::WinitInputBackend::new(window.clone()));
     let storage = Box::new(DiskStorageBackend::new(

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -12,6 +12,7 @@ mod task;
 use crate::custom_event::RuffleEvent;
 use crate::executor::GlutinAsyncExecutor;
 use clap::Clap;
+use isahc::config::RedirectPolicy;
 use isahc::prelude::*;
 use ruffle_core::{
     backend::audio::{AudioBackend, NullAudioBackend},
@@ -116,7 +117,9 @@ fn load_movie_from_path(
         }
     }
     let proxy = proxy.and_then(|url| url.as_str().parse().ok());
-    let builder = HttpClient::builder().proxy(proxy);
+    let builder = HttpClient::builder()
+        .proxy(proxy)
+        .redirect_policy(RedirectPolicy::Follow);
     let client = builder.build()?;
     let res = client.get(movie_url.to_string())?;
     let mut buffer: Vec<u8> = Vec::new();

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -1,6 +1,7 @@
 //! Navigator backend for web
 
 use crate::custom_event::RuffleEvent;
+use isahc::config::RedirectPolicy;
 use isahc::prelude::*;
 use ruffle_core::backend::navigator::{
     NavigationMethod, NavigatorBackend, OwnedFuture, RequestOptions,
@@ -45,7 +46,9 @@ impl ExternalNavigatorBackend {
         proxy: Option<Url>,
     ) -> Self {
         let proxy = proxy.and_then(|url| url.as_str().parse().ok());
-        let builder = HttpClient::builder().proxy(proxy);
+        let builder = HttpClient::builder()
+            .proxy(proxy)
+            .redirect_policy(RedirectPolicy::Follow);
 
         let client = builder.build().ok().map(Rc::new);
 

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -42,12 +42,10 @@ impl ExternalNavigatorBackend {
         movie_url: Url,
         channel: Sender<OwnedFuture<(), Error>>,
         event_loop: EventLoopProxy<RuffleEvent>,
-        http_proxy: Option<Url>,
-        https_proxy: Option<Url>,
+        proxy: Option<Url>,
     ) -> Self {
-        let http_proxy = http_proxy.and_then(|url| url.as_str().parse().ok());
-        let https_proxy = https_proxy.and_then(|url| url.as_str().parse().ok());
-        let builder = HttpClient::builder().proxy(http_proxy).proxy(https_proxy);
+        let proxy = proxy.and_then(|url| url.as_str().parse().ok());
+        let builder = HttpClient::builder().proxy(proxy);
 
         let client = builder.build().ok().map(Rc::new);
 


### PR DESCRIPTION
Loads movies via URL when possible.

Proxies for HTTP and HTTPS can be set via --http-proxy and --https-proxy respectively.