### PR TITLE
ci: Upload nightly web demo to GitHub Pages

### DIFF
--- a/.github/workflows/release_nightlies.yml
+++ b/.github/workflows/release_nightlies.yml
@@ -197,3 +197,40 @@ jobs:
           asset_path: ./web/packages/extension/dist/ruffle_extension.zip
           asset_name: ruffle_nightly_${{ needs.create-nightly-release.outputs.date }}_extension.zip
           asset_content_type: application/zip
+
+      - name: Clone web demo
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/checkout@v2
+        with:
+          repository: ruffle-rs/demo
+          path: demo
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false # Needed to allow commit via RUFFLE_BUILD_TOKEN below
+
+      - name: Update web demo
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd demo
+
+          # Delete the old build.
+          rm -f *.js *.wasm *.html
+
+          # Copy the fresh build into this folder.
+          cp -f ../web/packages/demo/dist/* .
+
+          # Create git commit. Amend previous commit to avoid daily commit spam.
+          git config user.email "ruffle@ruffle.rs"
+          git config user.name "RuffleBuild"
+          git add *
+          git commit --amend -am "Nightly build ${{ needs.create-nightly-release.outputs.date }}"
+          cd ..
+
+      - name: Push web demo
+        if: matrix.os == 'ubuntu-latest'
+        uses: ad-m/github-push-action@master
+        with:
+          repository: ruffle-rs/demo
+          github_token: ${{ secrets.RUFFLE_BUILD_TOKEN }}
+          directory: demo
+          force: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       <img src="https://img.shields.io/discord/610531541889581066" alt="Ruffle Discord">
   </a>
   <br>
-  <strong><a href="https://ruffle.rs">website</a> | <a href="http://ruffle-rs.s3-website-us-west-1.amazonaws.com/builds/web-demo/index.html">demo</a> | <a href="http://ruffle-rs.s3-website-us-west-1.amazonaws.com/">nightly builds</a> | <a href="https://github.com/ruffle-rs/ruffle/wiki">wiki</a></strong>
+  <strong><a href="https://ruffle.rs">website</a> | <a href="https://ruffle.rs/demo">demo</a> | <a href="https://github.com/ruffle-rs/ruffle/releases">nightly builds</a> | <a href="https://github.com/ruffle-rs/ruffle/wiki">wiki</a></strong>
 </p>
 
 # Ruffle

--- a/web/packages/demo/README.md
+++ b/web/packages/demo/README.md
@@ -7,7 +7,7 @@ It also serves as a nice local test to run Ruffle in the web locally, for develo
 
 ### Hosted demo
 
-To view this demo online right now, [check out the hosted demo](http://ruffle-rs.s3-website-us-west-1.amazonaws.com/builds/web-demo/index.html).
+To view this demo online right now, [check out the hosted demo](https://ruffle.rs/demo).
 
 It's exactly the same code as this directory, updated nightly.
 


### PR DESCRIPTION
Upload the nightly web demo to GitHub Pages via GitHub Actions pushing to https://github.com/ruffle-rs/demo as opposed to using to upload to S3.