### PR TITLE
render: Fix masking issues on wgpu/webgl backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-macro"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e97b4e522f9e55523001238ac59d13a8603af57f69980de5d8de4bbbe8ada6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +914,27 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "enum-map"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f81f09b9cb18af2ea1da2688a1d6b1762b4f938d7495bb034bce48d4c608043"
+dependencies = [
+ "array-macro",
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57001dfb2532f5a103ff869656887fae9a8defa7d236f3e39d2ee86ed629ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "enumset"
@@ -2604,6 +2631,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "clap",
+ "enum-map",
  "futures",
  "image",
  "jpeg-decoder",

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -40,6 +40,7 @@ pub trait RenderBackend: Downcast {
     fn draw_letterbox(&mut self, letterbox: Letterbox);
     fn push_mask(&mut self);
     fn activate_mask(&mut self);
+    fn deactivate_mask(&mut self);
     fn pop_mask(&mut self);
 }
 impl_downcast!(RenderBackend);
@@ -143,6 +144,7 @@ impl RenderBackend for NullRenderer {
     fn draw_letterbox(&mut self, _letterbox: Letterbox) {}
     fn push_mask(&mut self) {}
     fn activate_mask(&mut self) {}
+    fn deactivate_mask(&mut self) {}
     fn pop_mask(&mut self) {}
 }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1029,6 +1029,11 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             self.render_layout_box(context, layout_box);
         }
 
+        context.renderer.deactivate_mask();
+        context.renderer.draw_rect(
+            Color::from_rgb(0, 0xff),
+            &(context.transform_stack.transform().matrix * mask),
+        );
         context.renderer.pop_mask();
 
         context.transform_stack.pop();

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3.6"
 bytemuck = "1.4.1"
 raw-window-handle = "0.3.3"
 clap = { version = "3.0.0-beta.2", optional = true }
+enum-map = "0.6.3"
 
 [features]
 render_debug_labels = []

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -369,7 +369,7 @@ fn create_bitmap_pipeline(
                 &[wgpu::ColorStateDescriptor {
                     format: wgpu::TextureFormat::Bgra8Unorm,
                     color_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::SrcAlpha,
+                        src_factor: wgpu::BlendFactor::One,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                         operation: wgpu::BlendOperation::Add,
                     },
@@ -433,7 +433,7 @@ fn create_bitmap_pipeline(
                 &[wgpu::ColorStateDescriptor {
                     format: wgpu::TextureFormat::Bgra8Unorm,
                     color_blend: wgpu::BlendDescriptor {
-                        src_factor: wgpu::BlendFactor::SrcAlpha,
+                        src_factor: wgpu::BlendFactor::One,
                         dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
                         operation: wgpu::BlendOperation::Add,
                     },


### PR DESCRIPTION
Change the usage of the stencil buffer to avoid running out of stencil bits when too many nested masks are active. This could be seen in some movies/games like Achievement Unlocked.

Use the increment/decrement stencil ops to indicate masked areas. Each level of masking increments the stencil buffer in the masked area. This also cleans things up on wgpu which requires us to make pipeline states in advance; now we only need a few stencil states for masking as opposed to hundreds.

This does require an extra draw of the mask to decrement the stencil buffer when the mask is popped. `RenderBackend::deactivate_mask` was added to handle this; any draw between `deactivate_mask` and `pop_mask` should decrement the stencil value (on backends that care about it). TODO: We could get away with drawing a rect around the bounds of the mask when we are clearing it; currently we redraw the actual mask shape.