### PR TITLE
desktop: Switch task to ready state on wake

### DIFF
--- a/desktop/src/executor.rs
+++ b/desktop/src/executor.rs
@@ -202,7 +202,7 @@ impl GlutinAsyncExecutor {
             if !task.is_completed() {
                 if !self.waiting_for_poll {
                     self.waiting_for_poll = true;
-
+                    task.set_ready();
                     if self.event_loop.send_event(RuffleEvent::TaskPoll).is_err() {
                         log::warn!("A task was queued on an event loop that has already ended. It will not be polled.");
                     }

--- a/desktop/src/task.rs
+++ b/desktop/src/task.rs
@@ -40,6 +40,11 @@ impl Task {
         self.state == TaskState::Ready
     }
 
+    /// Marks this task to as ready to make progress.
+    pub fn set_ready(&mut self) {
+        self.state = TaskState::Ready
+    }
+
     /// Returns `true` if the task is awaiting further progress.
     #[allow(dead_code)]
     pub fn is_blocked(&self) -> bool {


### PR DESCRIPTION
A task in our executor would never return to the `Ready` state if it yielded, causing it to never complete once pending. Reset the task to the ready state once it wakes so that it can continue to make progress.