### PR TITLE
web: Disable automatic publicPath in webpack configs

### DIFF
--- a/web/packages/core/webpack.config.js
+++ b/web/packages/core/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = (env, argv) => {
     return {
         entry: path.resolve(__dirname, "index.js"),
         output: {
+            publicPath: "",
             path: path.resolve(__dirname, "dist"),
             filename: "ruffle.js",
             chunkFilename: "core.ruffle.[contenthash].js",

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = (env, argv) => {
     return {
         entry: path.resolve(__dirname, "www/index.js"),
         output: {
+            publicPath: "",
             path: path.resolve(__dirname, "dist"),
             filename: "index.js",
         },

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = (env, argv) => {
             lv0: path.resolve(__dirname, "js/lv0.js"),
         },
         output: {
+            publicPath: "",
             path: path.resolve(__dirname, "build/dist"),
             filename: "[name].js",
             chunkFilename: "core.ruffle.js",

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = (env, argv) => {
     return {
         entry: path.resolve(__dirname, "js/ruffle.js"),
         output: {
+            publicPath: "",
             path: path.resolve(__dirname, "dist"),
             filename: "ruffle.js",
             chunkFilename: "core.ruffle.[contenthash].js",


### PR DESCRIPTION
Fixes #1354.

webpack5 added automatic publicPath detection (see https://webpack.js.org/migrate/5/). Our JS code tries to do automatic path detection on its own (public-path.js), which may have been conflicting with this. I was unable to produce the specific error locally, but it seems to have something to do with the way drupal dynamically inserts the script element (using jquery replaceWith?). The page in #1354 also uses a manually set `public_path` config setting for Ruffle.

Disable the automatic detection in all of the webpack configs for now, which should match the webpack 4 behavior.