### PR TITLE
core: Properly handle masker-inside-masker (fix #1347)

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -326,6 +326,10 @@ pub struct RenderContext<'a, 'gc> {
 
     /// The stack of clip depths, used in masking.
     pub clip_depth_stack: Vec<Depth>,
+
+    /// Whether to allow pushing a new mask. A masker-inside-a-masker does not work in Flash, instead
+    /// causing the inner mask to be included as part of the outer mask. Maskee-inside-a-maskee works as one expects.
+    pub allow_mask: bool,
 }
 
 /// The type of action being run.

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1160,15 +1160,19 @@ pub fn render_children<'gc>(
             let (prev_clip_depth, clip_child) = clip_depth_stack.pop().unwrap();
             clip_depth = prev_clip_depth;
             context.renderer.deactivate_mask();
+            context.allow_mask = false;
             clip_child.render(context);
+            context.allow_mask = true;
             context.renderer.pop_mask();
         }
-        if child.clip_depth() > 0 && child.allow_as_mask() {
+        if context.allow_mask && child.clip_depth() > 0 && child.allow_as_mask() {
             // Push and render the mask.
             clip_depth_stack.push((clip_depth, child));
             clip_depth = child.clip_depth();
             context.renderer.push_mask();
+            context.allow_mask = false;
             child.render(context);
+            context.allow_mask = true;
             context.renderer.activate_mask();
         } else if child.visible() {
             // Normal child.
@@ -1179,7 +1183,9 @@ pub fn render_children<'gc>(
     // Pop any remaining masks.
     for (_, clip_child) in clip_depth_stack.into_iter().rev() {
         context.renderer.deactivate_mask();
+        context.allow_mask = false;
         clip_child.render(context);
+        context.allow_mask = true;
         context.renderer.pop_mask();
     }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -847,6 +847,7 @@ impl Player {
                 transform_stack,
                 view_bounds,
                 clip_depth_stack: vec![],
+                allow_mask: true,
             };
 
             for (_depth, level) in root_data.levels.iter() {


### PR DESCRIPTION
If a masker is placed inside a masker, the inner mask is inactive and
instead renders as normal, masked by the outer mask. Properly
handle this case on the core side by only pushing new masks if we
are not currently drawing the mask stencil.

Maskee inside maskee still functions as expected. (i.e., a clip
using a mask  can be masked itself).