### PR TITLE
web: Include git details into the build

### DIFF
--- a/web/packages/core/.eslintrc.json
+++ b/web/packages/core/.eslintrc.json
@@ -3,6 +3,9 @@
         "browser": true
     },
     "globals": {
-        "__webpack_public_path__": true
+        "__webpack_public_path__": true,
+        "__COMMIT_HASH__": true,
+        "__COMMIT_DATE__": true,
+        "__CHANNEL__": true
     }
 }

--- a/web/packages/core/src/ruffle-player.js
+++ b/web/packages/core/src/ruffle-player.js
@@ -255,7 +255,11 @@ exports.RufflePlayer = class RufflePlayer extends HTMLElement {
 
         const element = document.createElement("li");
         element.className = "menu_item active";
-        element.innerText = `About Ruffle ${window.RufflePlayer.version}`;
+        const version =
+            __CHANNEL__ === "nightly"
+                ? `nightly ${__COMMIT_DATE__}`
+                : window.RufflePlayer.version;
+        element.innerText = `Ruffle ${version}`;
         element.addEventListener("click", () => {
             window.open("https://ruffle.rs", "_blank");
         });

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -2,6 +2,7 @@
 
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 const path = require("path");
 
 module.exports = (env, argv) => {
@@ -9,6 +10,16 @@ module.exports = (env, argv) => {
     if (argv && argv.mode) {
         mode = argv.mode;
     }
+
+    const commitHash = require("child_process")
+        .execSync("git rev-parse --short HEAD")
+        .toString();
+
+    const commitDate = require("child_process")
+        .execSync("git log -1 --date=short --pretty=format:%cd")
+        .toString();
+
+    const channel = process.env.CFG_RELEASE_CHANNEL || "nightly".toLowerCase();
 
     console.log(`Building ${mode}...`);
 
@@ -25,6 +36,11 @@ module.exports = (env, argv) => {
         },
         plugins: [
             new CleanWebpackPlugin(),
+            new webpack.DefinePlugin({
+                __COMMIT_HASH__: JSON.stringify(commitHash),
+                __COMMIT_DATE__: JSON.stringify(commitDate),
+                __CHANNEL__: JSON.stringify(channel),
+            }),
             new CopyWebpackPlugin({
                 patterns: [
                     {

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -2,6 +2,7 @@
 
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 const path = require("path");
 
 module.exports = (env, argv) => {
@@ -9,6 +10,16 @@ module.exports = (env, argv) => {
     if (argv && argv.mode) {
         mode = argv.mode;
     }
+
+    const commitHash = require("child_process")
+        .execSync("git rev-parse --short HEAD")
+        .toString();
+
+    const commitDate = require("child_process")
+        .execSync("git log -1 --date=short --pretty=format:%cd")
+        .toString();
+
+    const channel = process.env.CFG_RELEASE_CHANNEL || "nightly".toLowerCase();
 
     console.log(`Building ${mode}...`);
 
@@ -31,6 +42,11 @@ module.exports = (env, argv) => {
         },
         plugins: [
             new CleanWebpackPlugin(),
+            new webpack.DefinePlugin({
+                __COMMIT_HASH__: JSON.stringify(commitHash),
+                __COMMIT_DATE__: JSON.stringify(commitDate),
+                __CHANNEL__: JSON.stringify(channel),
+            }),
             new CopyPlugin({
                 patterns: [{ from: "LICENSE*" }, { from: "README.md" }],
             }),

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -2,6 +2,7 @@
 
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 const path = require("path");
 
 module.exports = (env, argv) => {
@@ -9,6 +10,16 @@ module.exports = (env, argv) => {
     if (argv && argv.mode) {
         mode = argv.mode;
     }
+
+    const commitHash = require("child_process")
+        .execSync("git rev-parse --short HEAD")
+        .toString();
+
+    const commitDate = require("child_process")
+        .execSync("git log -1 --date=short --pretty=format:%cd")
+        .toString();
+
+    const channel = process.env.CFG_RELEASE_CHANNEL || "nightly".toLowerCase();
 
     console.log(`Building ${mode}...`);
 
@@ -26,6 +37,11 @@ module.exports = (env, argv) => {
         },
         plugins: [
             new CleanWebpackPlugin(),
+            new webpack.DefinePlugin({
+                __COMMIT_HASH__: JSON.stringify(commitHash),
+                __COMMIT_DATE__: JSON.stringify(commitDate),
+                __CHANNEL__: JSON.stringify(channel),
+            }),
             new CopyPlugin({
                 patterns: [{ from: "LICENSE*" }, { from: "README.md" }],
             }),


### PR DESCRIPTION
Now the menu will look like this on nightlies:
![image](https://user-images.githubusercontent.com/317625/98174628-75605380-1ef5-11eb-9845-b72b06178106.png)


This commit exposes a big issue we have in our build system for web stuff right now. Technically core and selfhosted aren't building and packaging - the end users (selfhosted, extension and demo) are. Need to revisit that.