### PR TITLE
swf: Fall back to WINDOWS-1252 for text decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,6 +3391,7 @@ version = "0.1.2"
 dependencies = [
  "approx",
  "byteorder",
+ "encoding_rs",
  "enumset",
  "flate2",
  "libflate 1.0.3",

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -14,6 +14,7 @@ byteorder = "1.3"
 enumset = "1.0.1"
 num-derive = "0.3"
 num-traits = "0.2"
+encoding_rs = "0.8"
 libflate = {version = "1.0", optional = true}
 log = "0.4"
 smallvec = "1.4.2"


### PR DESCRIPTION
Older Flash files (in this case, Mata Nui Online Game) use WINDOWS-1252 encoding for text. By trying this encoding using the encoding_rs crate if utf-8 decoding fails, the little guards at the lava gate have something to say again.

I don't know Rust please don't bully I just wanna play my lego games