### PR TITLE
avm1: Swap rendering order of MovieClip

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1674,8 +1674,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
     fn render(&self, context: &mut RenderContext<'_, 'gc>) {
         context.transform_stack.push(&*self.transform());
-        crate::display_object::render_children(context, &self.0.read().children);
         self.0.read().drawing.render(context);
+        crate::display_object::render_children(context, &self.0.read().children);
         context.transform_stack.pop();
     }
 


### PR DESCRIPTION
Renders drawing API behind siblings in the same clip.

Along with #1483 this fixes the rest of the rendering problems in the non-AS3 widgets in #1098 