### PR TITLE
Fix rendering order of DisplayObjects and drawings

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -551,7 +551,10 @@ fn create_empty_movie_clip<'gc>(
                 .wrapping_add(AVM_DEPTH_BIAS),
         ),
         _ => {
-            avm_error!(activation, "MovieClip.createEmptyMovieClip: Too few parameters");
+            avm_error!(
+                activation,
+                "MovieClip.createEmptyMovieClip: Too few parameters",
+            );
             return Ok(Value::Undefined);
         }
     };
@@ -658,7 +661,10 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
             depth.coerce_to_i32(activation)?.wrapping_add(depth_bias),
         ),
         _ => {
-            avm_error!(activation, "MovieClip.duplicateMovieClip: Too few parameters");
+            avm_error!(
+                activation,
+                "MovieClip.duplicateMovieClip: Too few parameters",
+            );
             return Ok(Value::Undefined);
         }
     };

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -551,7 +551,7 @@ fn create_empty_movie_clip<'gc>(
                 .wrapping_add(AVM_DEPTH_BIAS),
         ),
         _ => {
-            avm_error!(activation, "MovieClip.attachMovie: Too few parameters");
+            avm_error!(activation, "MovieClip.createEmptyMovieClip: Too few parameters");
             return Ok(Value::Undefined);
         }
     };
@@ -658,7 +658,7 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
             depth.coerce_to_i32(activation)?.wrapping_add(depth_bias),
         ),
         _ => {
-            avm_error!(activation, "MovieClip.attachMovie: Too few parameters");
+            avm_error!(activation, "MovieClip.duplicateMovieClip: Too few parameters");
             return Ok(Value::Undefined);
         }
     };

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1674,8 +1674,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
     fn render(&self, context: &mut RenderContext<'_, 'gc>) {
         context.transform_stack.push(&*self.transform());
-        crate::display_object::render_children(context, &self.0.read().children);
         self.0.read().drawing.render(context);
+        crate::display_object::render_children(context, &self.0.read().children);
         context.transform_stack.pop();
     }
 


### PR DESCRIPTION
Previously `DisplayObject`s were rendered before any drawings, which means that drawings were displayed in front of all `DisplayObject`s.
While I didn't find any evidence for that, it seems like the order should be the opposite, as observed in some games:
* [Shopping Cart Hero](https://chat.kongregate.com/gamez/0003/6396/live/ShoppingCartHero.swf)
* [Free Rider 2](http://www.onemorelevel.com/games3/freerider2x.swf)

As a drive by, I corrected some error messages in `MovieClip` to name the actually called method.

**EDIT**: By the time of fixing the issue, someone came with an identical fix in #1503, so this PR is only necessary for correcting the error messages.