### PR TITLE
desktop: Add fullscreen keyboard shortcut

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod config;
 pub mod external;
 
 pub use chrono;
+pub use events::KeyCode;
 pub use events::PlayerEvent;
 pub use indexmap;
 pub use player::Player;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -357,8 +357,8 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
                         {
                             match event {
                                 ruffle_core::PlayerEvent::KeyDown {
-                                    key_code: ruffle_core::KeyCode::F11,
-                                } => {
+                                    key_code: ruffle_core::KeyCode::Return,
+                                } if player_lock.input().is_key_down(ruffle_core::KeyCode::Alt) => {
                                     if window.fullscreen().is_none() {
                                         window.set_fullscreen(Some(
                                             winit::window::Fullscreen::Borderless(None),
@@ -366,12 +366,6 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
                                     } else {
                                         window.set_fullscreen(None)
                                     }
-                                    window.request_redraw();
-                                }
-                                ruffle_core::PlayerEvent::KeyDown {
-                                    key_code: ruffle_core::KeyCode::Escape,
-                                } => {
-                                    window.set_fullscreen(None);
                                     window.request_redraw();
                                 }
                                 _ => {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -224,7 +224,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     )); //TODO: actually implement this backend type
     let input = Box::new(input::WinitInputBackend::new(window.clone()));
     let storage = Box::new(DiskStorageBackend::new());
-    let user_interface = Box::new(ui::DesktopUiBackend::new());
+    let user_interface = Box::new(ui::DesktopUiBackend::new(window.clone()));
     let locale = Box::new(locale::DesktopLocaleBackend::new());
     let player = Player::new(
         renderer,

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -355,9 +355,31 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
                             .unwrap()
                             .handle_event(event)
                         {
-                            player_lock.handle_event(event);
-                            if player_lock.needs_render() {
-                                window.request_redraw();
+                            match event {
+                                ruffle_core::PlayerEvent::KeyDown {
+                                    key_code: ruffle_core::KeyCode::F11,
+                                } => {
+                                    if window.fullscreen().is_none() {
+                                        window.set_fullscreen(Some(
+                                            winit::window::Fullscreen::Borderless(None),
+                                        ));
+                                    } else {
+                                        window.set_fullscreen(None)
+                                    }
+                                    window.request_redraw();
+                                }
+                                ruffle_core::PlayerEvent::KeyDown {
+                                    key_code: ruffle_core::KeyCode::Escape,
+                                } => {
+                                    window.set_fullscreen(None);
+                                    window.request_redraw();
+                                }
+                                _ => {
+                                    player_lock.handle_event(event);
+                                    if player_lock.needs_render() {
+                                        window.request_redraw();
+                                    }
+                                }
                             }
                         }
                     }

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -1,28 +1,24 @@
-use tinyfiledialogs::{message_box_ok, MessageBoxIcon};
-
 use ruffle_core::backend::ui::UiBackend;
+use std::rc::Rc;
+use tinyfiledialogs::{message_box_ok, MessageBoxIcon};
+use winit::window::Window;
 
-pub struct DesktopUiBackend {}
+pub struct DesktopUiBackend {
+    window: Rc<Window>,
+}
 
 impl DesktopUiBackend {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(window: Rc<Window>) -> Self {
+        Self { window }
     }
 }
 
 impl UiBackend for DesktopUiBackend {
     fn is_fullscreen(&self) -> bool {
-        // TODO: Return proper value when fullscreen implemented on desktop.
-        false
+        self.window.fullscreen().is_some()
     }
 
     fn message(&self, message: &str) {
         message_box_ok("Ruffle", message, MessageBoxIcon::Info)
-    }
-}
-
-impl Default for DesktopUiBackend {
-    fn default() -> Self {
-        DesktopUiBackend::new()
     }
 }


### PR DESCRIPTION
This PR adds Alt+Enter as a keyboard shortcut to toggle fullscreen.
Should more or less fix #186.
The major downside here is that the player will never receive events for Alt+Enter. I see 3 alternatives:
1. Choose a different (less common) keyboard shortcut - but I think Alt+Enter is rare enough.
2. Continue passing those events to the player - but this may cause unintended behavior.
3. Add the fullscreen option to a context menu, so it doesn't interfere with any player events - but winit doesn't support context menus out-of-the-box.