### PR TITLE
improve the Spanish translation

### DIFF
--- a/web/packages/extension/build/_locales/en/messages.json
+++ b/web/packages/extension/build/_locales/en/messages.json
@@ -9,7 +9,7 @@
         "message": "Ignore website compatibility warnings"
     },
     "status_init": {
-        "message": "Reading current tab..."
+        "message": "Reading current tab…"
     },
     "status_no_tabs": {
         "message": "There is no active tab."
@@ -18,7 +18,7 @@
         "message": "An error occurred when looking up the current tab."
     },
     "status_message_init": {
-        "message": "Checking Ruffle status on current tab..."
+        "message": "Checking Ruffle status on current tab…"
     },
     "status_result_running": {
         "message": "Ruffle is loaded and running Flash content on the current tab."

--- a/web/packages/extension/build/_locales/es/messages.json
+++ b/web/packages/extension/build/_locales/es/messages.json
@@ -1,56 +1,56 @@
 {
     "settings_ruffle_enable": {
-        "message": "Reproducer contenido Flash en Ruffle"
+        "message": "Ejecutar Flash con Ruffle"
     },
     "settings_page_ignore_optout": {
-        "message": "Reproducer contenido Flash en sitios que deshabilitan Ruffle"
+        "message": "Ejecutar Flash incluso con Ruffle desactivado por la página"
     },
     "settings_ignore_optout": {
-        "message": "Ignorar avisos de compatibilidad de sitos web"
+        "message": "Ignorar avisos de compatibilidad en páginas de internet"
     },
     "status_init": {
-        "message": "Leyendo pestaña actual..."
+        "message": "Leyendo la pestaña actual…"
     },
     "status_no_tabs": {
         "message": "No hay pestaña activada."
     },
     "status_tabs_error": {
-        "message": "Occuró un error buscando la pestaña actual."
+        "message": "Occurió un error buscando la pestaña actual."
     },
     "status_message_init": {
-        "message": "Verificando estado de Ruffle en la pestaña actual..."
+        "message": "Verificando el estado de Ruffle en la pestaña actual…"
     },
     "status_result_running": {
-        "message": "Ruffle está cargado y reproduciendo contenido Flash en la pestaña actual."
+        "message": "Ruffle está cargado y ejecutando Flash en la pestaña actual."
     },
     "status_result_optout": {
-        "message": "Ruffle no está cargado porque la página actual se marcó incompatible."
+        "message": "Ruffle sin porque la página lo ha desactivado."
     },
     "status_result_disabled": {
-        "message": "Ruffle no está cargado porque fue desactivdo por el usario."
+        "message": "Ruffle sin cargar porque el usuario lo ha desactivado."
     },
     "status_result_error": {
-        "message": "Ocurró un error consultando la instancia de Ruffle de la pestaña actual."
+        "message": "Ocurró un error al comprobar el estado de Ruffle en la pestaña actual."
     },
     "status_result_protected": {
-        "message": "Ruffle no puede cargar en páginas protegidas por el navegador."
+        "message": "Ruffle no se puede cargar en las páginas protegidas por el navegador."
     },
     "action_reload": {
-        "message": "Recargar pestaña para aplicar cambios"
+        "message": "Recargar la pestaña para aplicar los cambios"
     },
     "open_settings_page": {
-        "message": "Abrir Página de Configuración"
+        "message": "Abrir la página de configuración"
     },
     "settings_page": {
-        "message": "Página de Configuración"
+        "message": "Página de configuración"
     },
     "description": {
-        "message": "Pone Flash en el web, donde debe ser, otra vez."
+        "message": "Flash de nuevo en internet, donde debe estar."
     },
     "save_settings": {
-        "message": "Guardar Configuración"
+        "message": "Grabar configuración"
     },
     "settings_saved": {
-        "message": "Configuración Guardado"
+        "message": "Configuración grabada"
     }
 }


### PR DESCRIPTION
@Justin-CB did a great work translating Ruffle into Spanish.

I hope some polishing could make it better.

I also replaced `...` with `…` (the proper Unicode character) in both English and Spanish.

BTW, are there other translation files than this one?

Many thanks for your good work. 