### PR TITLE
render: Fix stroke width < 1px

### DIFF
--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -246,7 +246,7 @@ impl ShapeTessellator {
                         BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
 
                     // TODO(Herschel): 0 width indicates "hairline".
-                    let width = if style.width.to_pixels() >= 1.0 {
+                    let width = if style.width.to_pixels() > 0.0 {
                         style.width.to_pixels() as f32
                     } else {
                         1.0

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -582,7 +582,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                         BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
 
                     // TODO(Herschel): 0 width indicates "hairline".
-                    let width = if style.width.to_pixels() >= 1.0 {
+                    let width = if style.width.to_pixels() > 0.0 {
                         style.width.to_pixels() as f32
                     } else {
                         1.0


### PR DESCRIPTION
Previously, strokes with width of less than 1 pixel were rendered with width of exactly 1 pixel.