### PR TITLE
Relax bounds checks when executing AVM1 code

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -423,7 +423,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     pub fn run_actions(&mut self, code: SwfSlice) -> Result<ReturnType<'gc>, Error<'gc>> {
-        let mut read = Reader::new(code.as_ref(), self.swf_version());
+        let mut read = Reader::new(&code.movie.data()[..], self.swf_version());
+        read.seek(code.start as isize);
 
         loop {
             let result = self.do_action(&code, &mut read);
@@ -449,7 +450,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             }
         }
 
-        if reader.pos() >= (data.end - data.start) {
+        if reader.pos() >= data.end {
             //Executing beyond the end of a function constitutes an implicit return.
             Ok(FrameControl::Return(ReturnType::Implicit))
         } else if let Some(action) = reader.read_action()? {

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -211,6 +211,26 @@ impl SwfSlice {
         }
     }
 
+    /// Construct a new SwfSlice from a movie subslice.
+    ///
+    /// This function allows subslices outside the current slice to be formed,
+    /// as long as they are valid subslices of the movie itself.
+    pub fn to_unbounded_subslice(&self, slice: &[u8]) -> Option<SwfSlice> {
+        let self_pval = self.movie.data().as_ptr() as usize;
+        let self_len = self.movie.data().len();
+        let slice_pval = slice.as_ptr() as usize;
+
+        if self_pval <= slice_pval && slice_pval < (self_pval + self_len) {
+            Some(SwfSlice {
+                movie: self.movie.clone(),
+                start: slice_pval - self_pval,
+                end: (slice_pval - self_pval) + slice.len(),
+            })
+        } else {
+            None
+        }
+    }
+
     /// Construct a new SwfSlice from a Reader and a size.
     ///
     /// This is intended to allow constructing references to the contents of a


### PR DESCRIPTION
From what I've heard on the grapevine, obfuscation tools like to do some dirty, nasty tricks and hide AVM1 code inside of unknown tags. This code is later accessed by backwards references outside of the current function data stream. We obviously fail to handle such references as we dutifully check bounds whenever indexing embedded data streams (e.g. an AVM1 function). This results in obfuscated code returning immediately.

This PR relaxes the bounds check so that any valid substream of the decoded SWF data is allowed to be constructed, even if it lies outside the current one. We still treat execution beyond the end of the current stream boundary as an implicit return; but otherwise illegal backwards references are now allowed, as well as defining functions or with/try scopes inside of them.

I tested this PR against Super Mario Flash, since someone mentioned it in Discord. Without this PR, the movie just loops. With the PR, it goes ingame, but the actual game level does not render - Mario just walks along a black background.