### PR TITLE
core: Fix issue where unloaded buttons can still trigger mouse rollout events (close #1603)

### DIFF
--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -438,6 +438,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
             let tracker = context.focus_tracker;
             tracker.set(None, context);
         }
+        self.set_removed(context.gc_context, true);
     }
 }
 


### PR DESCRIPTION
In https://github.com/ruffle-rs/ruffle/issues/1603, I found a situation where a button could trigger a rollout event, even after moving to a frame where the button isn't loaded anymore.

After looking around the codebase a bit, it seems like there is a [check meant to prevent this situation.](https://github.com/ruffle-rs/ruffle/blob/master/core/src/player.rs#L770), but it seems like this check wasn't working because - unlike all other kinds of display object - the Button doesn't actually have a line in its unload function that flags it as removed.

As far as I can tell, after this change the behaviour does now match what flash player does.