### PR TITLE
swf: Allow construct clip events in SWFv6

### DIFF
--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2356,7 +2356,9 @@ impl<R: Read> Reader<R> {
                 self.read_u16()?;
             } else {
                 self.read_ubits(5)?;
-                if self.read_bit()? && self.version >= 7 {
+                if self.read_bit()? {
+                    // Construct was only added in SWF7, but it's not version-gated;
+                    // Construct events will still fire in SWF6 in a v7+ player. (#1424)
                     event_list.insert(ClipEventFlag::Construct);
                 }
                 if self.read_bit()? {

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2237,8 +2237,7 @@ impl<W: Write> Writer<W> {
         self.write_bit(clip_events.contains(ClipEventFlag::Data))?;
         if self.version >= 6 {
             self.write_ubits(5, 0)?;
-            let has_construct = self.version >= 7 && clip_events.contains(ClipEventFlag::Construct);
-            self.write_bit(has_construct)?;
+            self.write_bit(clip_events.contains(ClipEventFlag::Construct))?;
             self.write_bit(clip_events.contains(ClipEventFlag::KeyPress))?;
             self.write_bit(clip_events.contains(ClipEventFlag::DragOut))?;
             self.write_u8(0)?;


### PR DESCRIPTION
Even though `onClipEvent(construct)` was added in SWFv7, it is not version-gated and will still run in an SWFv6 file in a v7+ player. Some out-of-spec SWFs in the wild actually rely on this. Remove the SWF version check to allow the event to run.

Fixes #1424.