### PR TITLE
Allow file selection via query params in web demo

### DIFF
--- a/web/packages/demo/README.md
+++ b/web/packages/demo/README.md
@@ -25,7 +25,7 @@ The demo provides the ability to have a list of sample SWFs to choose from.
 This can be helpful if you have a list of useful SWFs to test through, and we use it ourselves
 to showcase Ruffle on various games or animations.
 
-To use this, add a new file `swfs.json` next to `index.html` in the demo. The contents should look like this:
+To use this, add a new file `swfs.json` in this directory. The contents should look like this:
 
 ```json
 {
@@ -34,31 +34,36 @@ To use this, add a new file `swfs.json` next to `index.html` in the demo. The co
             "location": "swfs/alien_hominid.swf",
             "title": "Alien Hominid",
             "author": "Tom Fulp and Dan Paladin",
-            "authorLink": "https://www.newgrounds.com"
+            "authorLink": "https://www.newgrounds.com",
+            "type": "Game"
         },
         {
             "location": "swfs/saturday_morning_watchmen.swf",
             "title": "Saturday Morning Watchmen",
             "author": "Harry Partridge",
-            "authorLink": "https://twitter.com/HappyHarryToons"
+            "authorLink": "https://twitter.com/HappyHarryToons",
+            "type": "Animation"
         },
         {
             "location": "swfs/synj1.swf",
             "title": "Synj vs. Horrid Part 1",
             "author": "Dan Paladin",
-            "authorLink": "https://www.thebehemoth.com"
+            "authorLink": "https://www.thebehemoth.com",
+            "type": "Animation"
         },
         {
             "location": "swfs/synj2.swf",
             "title": "Synj vs. Horrid Part 2",
             "author": "Dan Paladin",
-            "authorLink": "https://www.thebehemoth.com"
+            "authorLink": "https://www.thebehemoth.com",
+            "type": "Animation"
         },
         {
             "location": "swfs/wasted_sky.swf",
             "title": "Wasted Sky",
             "author": "Tom Fulp",
-            "authorLink": "https://www.newgrounds.com"
+            "authorLink": "https://www.newgrounds.com",
+            "type": "Game"
         }
     ]
 }

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -9,6 +9,7 @@ window.RufflePlayer = PublicAPI.negotiate(
 let ruffle;
 let player;
 let jsonData;
+let initialFile;
 
 let container = document.getElementById("main");
 let author_container = document.getElementById("author-container");
@@ -24,6 +25,7 @@ window.addEventListener("DOMContentLoaded", () => {
     player = ruffle.createPlayer();
     player.id = "player";
     container.appendChild(player);
+    initialFile = new URLSearchParams(window.location.search).get("file");
     fetch("swfs.json").then((response) => {
         if (response.ok) {
             response.json().then((data) => {
@@ -40,11 +42,22 @@ window.addEventListener("DOMContentLoaded", () => {
                     }
                 });
                 sampleFileInputContainer.style.display = "inline-block";
-                // Load a random file.
-                let rn = Math.floor(
-                    Math.random() * Math.floor(jsonData.swfs.length)
-                );
-                sampleFileInput.selectedIndex = rn + 1;
+
+                if (initialFile) {
+                    let opts = Array.from(sampleFileInput.options).map(
+                        (item) => item.value
+                    );
+                    sampleFileInput.selectedIndex = Math.max(
+                        opts.findIndex((item) => item.endsWith(initialFile)),
+                        0
+                    );
+                } else {
+                    // Load a random file.
+                    let rn = Math.floor(
+                        Math.random() * Math.floor(jsonData.swfs.length)
+                    );
+                    sampleFileInput.selectedIndex = rn + 1;
+                }
                 sampleFileSelected();
             });
         } else {


### PR DESCRIPTION
Resolves https://github.com/ruffle-rs/ruffle/issues/1642

Allows the specification of an initial file via ?file=synj1.swf. If no match is found, it will instead just use the first demo. When doing so I also noticed the README.md was slightly out of date so have updated accordingly. Happy to split off into a separate PR. 