### PR TITLE
Fix play button alignment in web

### DIFF
--- a/web/packages/core/src/shadow-template.js
+++ b/web/packages/core/src/shadow-template.js
@@ -34,7 +34,7 @@ ruffle_shadow_tmpl.innerHTML = `
         }
 
         #play_button .icon {
-            position: relative;
+            position: absolute;
             top: 50%;
             left: 50%;
             width: 90%;


### PR DESCRIPTION
Should resolve https://github.com/ruffle-rs/ruffle/issues/1669

This should make the alignment correct on all browsers. `position: absolute` is relative to nearest ancestor that has `position: absolute | relative`. In this case it's parent has it set so this should mean it goes to correct position regardless.