### PR TITLE
web: Avoid double polyfilling embed-inside-object

### DIFF
--- a/web/packages/selfhosted/test/polyfill/embed_missing_src/expected.html
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_src/expected.html
@@ -1,0 +1,3 @@
+<embed
+    type="application/x-shockwave-flash"
+/>

--- a/web/packages/selfhosted/test/polyfill/embed_missing_src/index.html
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Embed without src attribute</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <embed
+                type="application/x-shockwave-flash"
+            />
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/embed_missing_src/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_src/test.js
@@ -1,0 +1,19 @@
+const { inject_ruffle_and_wait, open_test } = require("../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Embed without src attribute", () => {
+    it("loads the test", () => {
+        open_test(browser, __dirname);
+    });
+
+    it("doesn't polyfill with ruffle", () => {
+        inject_ruffle_and_wait(browser);
+        const actual = browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/expected.html
@@ -1,0 +1,18 @@
+<object
+    classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+    width="550"
+    height="400"
+    codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"
+>
+    <param name="movie" value="/test_assets/example.swf" />
+    <param name="quality" value="high" />
+    <param name="menu" value="false" />
+    <ruffle-embed
+        src="/test_assets/example.swf"
+        width="550"
+        height="400"
+        quality="high"
+        menu="false"
+        pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
+    />
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>OBJECT 4 - UNEXPECTED STRING IN OBJECT</title>
+    </head>
+
+    <body>
+        <!-- Only classid is specified on object, not type, so embed should take precedence -->
+        <div id="test-container">
+            <object
+                classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+                width="550"
+                height="400"
+                codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"
+            >
+                <param name="movie" value="/test_assets/example.swf" />
+                <param name="quality" value="high" />
+                <param name="menu" value="false" />
+                <embed
+                    src="/test_assets/example.swf"
+                    width="550"
+                    height="400"
+                    quality="high"
+                    menu="false"
+                    pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
+                />
+            </object>
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.js
@@ -1,0 +1,30 @@
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Object with clsid and embed", () => {
+    it("loads the test", () => {
+        open_test(browser, __dirname);
+    });
+
+    it("polyfills with ruffle", () => {
+        inject_ruffle_and_wait(browser);
+        const actual = browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", () => {
+        play_and_monitor(
+            browser,
+            browser.$("#test-container").$("<ruffle-embed />")
+        );
+    });
+});

--- a/web/packages/selfhosted/test/polyfill/object_default/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_default/expected.html
@@ -1,4 +1,4 @@
-<ruffle-object
+<object
     type="application/x-shockwave-flash"
     classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
     width="550"
@@ -16,4 +16,4 @@
         menu="false"
         pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
     />
-</ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_default/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_default/test.js
@@ -24,7 +24,7 @@ describe("Object tag", () => {
     it("Plays a movie", () => {
         play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/expected.html
@@ -1,4 +1,4 @@
-<ruffle-object
+<object
         type="application/x-shockwave-flash"
         classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
         width="550"
@@ -11,10 +11,11 @@
     <param name="flashvars" value="a=1&b=3+%253&d[]=foo" />
     <ruffle-embed
             src="/test_assets/flashvars.swf?a=default&c"
+            flashvars="a=1&b=3+%253&d[]=foo"
             width="550"
             height="400"
             quality="high"
             menu="false"
             pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
     />
-</ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/index.html
@@ -20,6 +20,7 @@
                 <param name="flashvars" value="a=1&b=3+%253&d[]=foo" />
                 <embed
                     src="/test_assets/flashvars.swf?a=default&c"
+                    flashvars="a=1&b=3+%253&d[]=foo"
                     width="550"
                     height="400"
                     quality="high"

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/test.js
@@ -24,7 +24,7 @@ describe("Object tag", () => {
     it("Plays a movie with flashvars", () => {
         play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />"),
+            browser.$("#test-container").$("<ruffle-embed />"),
             `// _level0.a
 1
 

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/expected.html
@@ -1,4 +1,4 @@
-<ruffle-object
+<object
         type="application/x-shockwave-flash"
         classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
         width="550"
@@ -16,4 +16,4 @@
             menu="false"
             pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
     />
-</ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.js
@@ -24,7 +24,7 @@ describe("Object tag", () => {
     it("Plays a movie with flashvars", () => {
         play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />"),
+            browser.$("#test-container").$("<ruffle-embed />"),
             `// _level0.a
 1
 

--- a/web/packages/selfhosted/test/polyfill/object_missing_data/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_missing_data/expected.html
@@ -1,0 +1,3 @@
+<object
+    type="application/x-shockwave-flash"
+></object>

--- a/web/packages/selfhosted/test/polyfill/object_missing_data/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_missing_data/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Object without data attribute (SWFObject)</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <object
+                type="application/x-shockwave-flash"
+            ></object>
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/object_missing_data/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_data/test.js
@@ -1,0 +1,19 @@
+const { open_test, inject_ruffle_and_wait } = require("../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Object without data attribute", () => {
+    it("loads the test", () => {
+        open_test(browser, __dirname);
+    });
+
+    it("doesn't polyfill with ruffle", () => {
+        inject_ruffle_and_wait(browser);
+        const actual = browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/expected.html
@@ -1,4 +1,4 @@
-<ruffle-object
+<object
     classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
     width="550"
     height="400"
@@ -15,4 +15,4 @@
         menu="false"
         pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
     />
-</ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/test.js
@@ -24,7 +24,7 @@ describe("Object without type attribute", () => {
     it("Plays a movie", () => {
         play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/expected.html
@@ -6,12 +6,4 @@
     <param name="movie" value="/test_assets/example.swf" />
     <param name="quality" value="high" />
     <param name="menu" value="false" />
-    <ruffle-embed
-        src="/test_assets/example.swf"
-        width="550"
-        height="400"
-        quality="high"
-        menu="false"
-        pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
-    />
 </ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/expected.html
@@ -1,4 +1,5 @@
-<ruffle-object
+<object
+    "YeahWhyDoingThis"
     type="application/x-shockwave-flash"
     classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
     width="550"
@@ -16,4 +17,4 @@
         menu="false"
         pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
     />
-</ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.js
@@ -24,7 +24,7 @@ describe("Object with unexpected string", () => {
     it("Plays a movie", () => {
         play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/expected.html
@@ -1,4 +1,4 @@
-<ruffle-object
+<object
     type="DUNNO"
     classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
     width="550"
@@ -16,4 +16,4 @@
         menu="false"
         pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
     />
-</ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/test.js
@@ -24,7 +24,7 @@ describe("Object with wrong type attribute value", () => {
     it("Plays a movie", () => {
         play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });


### PR DESCRIPTION
The standard method of embedding an SWF uses an embed-inside-object, and would incorrectly get polyfilled twice, creating two Ruffle instances:

```
<object>
  <param name="movie" value="TrailForSnail.swf" />
  <embed src="TrailForSnail.swf" />
</object>
```
This was especially noticeable with the new autoplay functionality. Avoid copying over embed tags from within a polyfilled object tag.