### PR TITLE
Merge streamSwfUrl and streamSwfData into a singular 'load' method

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -1,54 +1,13 @@
 /**
  * Represents the various types of auto-play behaviours that are supported.
  */
-export enum AutoPlay {
-    /**
-     * The player should automatically play the movie as soon as it is loaded.
-     *
-     * If the browser does not support automatic audio, the movie will begin
-     * muted.
-     */
-    On = "on",
-
-    /**
-     * The player should not attempt to automatically play the movie.
-     *
-     * This will leave it to the user or API to actually play when appropriate.
-     */
-    Off = "off",
-
-    /**
-     * The player should automatically play the movie as soon as it is deemed
-     * "appropriate" to do so.
-     *
-     * The exact behaviour depends on the browser, but commonly requires some
-     * form of user interaction on the page in order to allow auto playing videos
-     * with sound.
-     */
-    Auto = "auto",
-}
-
-/**
- * When the player is muted, this controls whether or not Ruffle will show a
- * "click to unmute" overlay on top of the movie.
- */
-export enum UnmuteOverlay {
-    /**
-     * Show an overlay explaining that the movie is muted.
-     */
-    Visible = "visible",
-
-    /**
-     * Don't show an overlay and pretend that everything is fine.
-     */
-    Hidden = "hidden",
-}
+import { BaseLoadOptions } from "./load-options";
 
 /**
  * The configuration object to control Ruffle's behaviour on the website
  * that it is included on.
  */
-export interface Config {
+export interface Config extends BaseLoadOptions {
     /**
      * A map of public paths from source name to URL.
      */
@@ -72,19 +31,4 @@ export interface Config {
      * @default true
      */
     polyfills?: boolean;
-
-    /**
-     * Controls the auto-play behaviour of Ruffle.
-     *
-     * @default AutoPlay.Auto
-     */
-    autoplay?: AutoPlay;
-
-    /**
-     * Controls the visiblity of the unmute overlay when the player
-     * is started muted.
-     *
-     * @default UnmuteOverlay.Visible
-     */
-    unmuteOverlay?: UnmuteOverlay;
 }

--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -13,3 +13,4 @@ export * from "./source-api";
 export * from "./version";
 export * from "./version-range";
 export * from "./config";
+export * from "./load-options";

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -1,0 +1,37 @@
+/**
+ * Any options used for loading a movie.
+ */
+export interface BaseLoadOptions {
+    /**
+     * Also known as "flashvars" - these are values that may be passed to
+     * and loaded by the movie.
+     *
+     * If a URL if specified when loading the movie, some parameters will
+     * be extracted by the query portion of that URL and then overwritten
+     * by any explicitly set here.
+     */
+    parameters?: URLSearchParams | string | Record<string, string>;
+}
+
+/**
+ * Options to load a movie by URL.
+ */
+export interface URLLoadOptions extends BaseLoadOptions {
+    /**
+     * The URL to load a movie from.
+     *
+     * If there is a query portion of this URL, then default [[parameters]]
+     * will be extracted from that.
+     */
+    url: string;
+}
+
+/**
+ * Options to load a movie by a data stream.
+ */
+export interface DataLoadOptions extends BaseLoadOptions {
+    /**
+     * The data to load a movie from.
+     */
+    data: Iterable<number>;
+}

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -1,3 +1,46 @@
+export enum AutoPlay {
+    /**
+     * The player should automatically play the movie as soon as it is loaded.
+     *
+     * If the browser does not support automatic audio, the movie will begin
+     * muted.
+     */
+    On = "on",
+
+    /**
+     * The player should not attempt to automatically play the movie.
+     *
+     * This will leave it to the user or API to actually play when appropriate.
+     */
+    Off = "off",
+
+    /**
+     * The player should automatically play the movie as soon as it is deemed
+     * "appropriate" to do so.
+     *
+     * The exact behaviour depends on the browser, but commonly requires some
+     * form of user interaction on the page in order to allow auto playing videos
+     * with sound.
+     */
+    Auto = "auto",
+}
+
+/**
+ * When the player is muted, this controls whether or not Ruffle will show a
+ * "click to unmute" overlay on top of the movie.
+ */
+export enum UnmuteOverlay {
+    /**
+     * Show an overlay explaining that the movie is muted.
+     */
+    Visible = "visible",
+
+    /**
+     * Don't show an overlay and pretend that everything is fine.
+     */
+    Hidden = "hidden",
+}
+
 /**
  * Any options used for loading a movie.
  */
@@ -11,6 +54,21 @@ export interface BaseLoadOptions {
      * by any explicitly set here.
      */
     parameters?: URLSearchParams | string | Record<string, string>;
+
+    /**
+     * Controls the auto-play behaviour of Ruffle.
+     *
+     * @default AutoPlay.Auto
+     */
+    autoplay?: AutoPlay;
+
+    /**
+     * Controls the visibility of the unmute overlay when the player
+     * is started muted.
+     *
+     * @default UnmuteOverlay.Visible
+     */
+    unmuteOverlay?: UnmuteOverlay;
 }
 
 /**

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -33,14 +33,14 @@ export class RuffleEmbed extends RufflePlayer {
      */
     connectedCallback(): void {
         super.connectedCallback();
-        let parameters = null;
+        let parameters;
         const flashvars = this.attributes.getNamedItem("flashvars");
         if (flashvars) {
             parameters = flashvars.value;
         }
         const src = this.attributes.getNamedItem("src");
         if (src) {
-            this.streamSwfUrl(src.value, parameters);
+            this.load({ url: src.value, parameters });
         }
     }
 
@@ -89,14 +89,14 @@ export class RuffleEmbed extends RufflePlayer {
     ): void {
         super.attributeChangedCallback(name, oldValue, newValue);
         if (this.isConnected && name === "src") {
-            let parameters = null;
+            let parameters;
             const flashvars = this.attributes.getNamedItem("flashvars");
             if (flashvars) {
                 parameters = flashvars.value;
             }
             const src = this.attributes.getNamedItem("src");
             if (src) {
-                this.streamSwfUrl(src.value, parameters);
+                this.load({ url: src.value, parameters });
             }
         }
     }

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -8,6 +8,7 @@ import {
     RufflePlayer,
 } from "./ruffle-player";
 import { registerElement } from "./register-element";
+import { URLLoadOptions } from "./load-options";
 
 /**
  * Find and return the first value in obj with the given key.
@@ -113,7 +114,11 @@ export class RuffleObject extends RufflePlayer {
             );
 
             //Kick off the SWF download.
-            this.streamSwfUrl(url, parameters);
+            const options: URLLoadOptions = { url };
+            if (parameters) {
+                options.parameters = parameters;
+            }
+            this.load(options);
         }
     }
 

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -97,7 +97,7 @@ function localFileSelected() {
     if (file) {
         let fileReader = new FileReader();
         fileReader.onload = () => {
-            player.playSwfData(fileReader.result);
+            player.load({ data: fileReader.result });
         };
         fileReader.readAsArrayBuffer(file);
     }
@@ -105,7 +105,7 @@ function localFileSelected() {
 
 function loadRemoteFile(url) {
     fetch(url).then((response) => {
-        response.arrayBuffer().then((data) => player.playSwfData(data));
+        response.arrayBuffer().then((data) => player.load({ data }));
     });
 }
 


### PR DESCRIPTION
`player.load("url")` == `player.load({url: "...."})`
`player.load({data: ....})`

Also options like parameters, autoplay and muteOverlay are now options of the load - but can be inherited from the player or from global.