### PR TITLE
Refinements to meta user interface (attempt 2)

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -294,7 +294,7 @@ export class RufflePlayer extends HTMLElement {
                         </div>
                         <div id="panic-footer">
                             <ul>
-                                <li><a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#configure-wasm-mime-type">view Ruffle wiki</a></li>
+                                <li><a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#configure-wasm-mime-type">View Ruffle Wiki</a></li>
                             </ul>
                         </div>
                     </div>
@@ -742,8 +742,8 @@ export class RufflePlayer extends HTMLElement {
                 </div>
                 <div id="panic-footer">
                     <ul>
-                        <li><a href="https://github.com/ruffle-rs/ruffle/issues/new">report bug</a></li>
-                        <li><a href="#" id="panic-view-details">view error details</a></li>
+                        <li><a href="https://github.com/ruffle-rs/ruffle/issues/new">Report Bug</a></li>
+                        <li><a href="#" id="panic-view-details">View Error Details</a></li>
                     </ul>
                 </div>
             </div>

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -11,39 +11,38 @@ ruffleShadowTemplate.innerHTML = `
             width: 550px;
             height: 400px;
             font-family: Arial, sans-serif;
-            letter-spacing: 0.4px;
             touch-action: none;
             user-select: none;
             -webkit-user-select: none;
             -webkit-tap-highlight-color: transparent;
             position: relative;
         }
+        
+        /* All of these use the dimensions specified by the embed */
+        #container,
+        #container canvas,
+        #play_button,
+        #unmute_overlay,
+        #unmute_overlay .background,
+        #panic {
+            width: inherit;
+            height: inherit;
+        }
 
         #container {
             position: relative;
-            width: 100%;
-            height: 100%;
             overflow: hidden;
-        }
-
-        #container canvas {
-            width: 100%;
-            height: 100%;
         }
 
         #play_button,
         #unmute_overlay {
             position: absolute;
-            width: 100%;
-            height: 100%;
             cursor: pointer;
             display: none;
         }
         
         #unmute_overlay .background {
             position: absolute;
-            width: 100%;
-            height: 100%;
             background-color: #000;
             opacity: 0.7;
         }
@@ -58,7 +57,7 @@ ruffleShadowTemplate.innerHTML = `
             max-width: 384px;
             max-height: 384px;
             transform: translate(-50%, -50%);
-            opacity: 0.7;
+            opacity: 0.8;
         }
 
         #play_button:hover .icon,
@@ -70,8 +69,6 @@ ruffleShadowTemplate.innerHTML = `
             position: absolute;
             font-size: 20px;
             text-align: center;
-            width: 100%;
-            height: 100%;
             /* Inverted colours from play button! */
             background: linear-gradient(180deg, rgba(253,58,64,1) 0%, rgba(253,161,56,1) 100%);
             color: #FFF;
@@ -87,7 +84,7 @@ ruffleShadowTemplate.innerHTML = `
         }
 
         #panic-title {
-            width: 100%;
+            width: inherit;
             top: 30px;
             font-size: 42px;
             font-weight: bold;
@@ -107,13 +104,13 @@ ruffleShadowTemplate.innerHTML = `
 
         #panic-footer {
             bottom: 30px;
-            width: 100%;
+            width: inherit;
         }
 
         #panic ul {
             margin: 35px 0 0 0;
             padding: 0;
-            max-width: 100%;
+            width: inherit;
             display: flex;
             list-style-type: none;
             justify-content: center;
@@ -125,11 +122,13 @@ ruffleShadowTemplate.innerHTML = `
         }
 
         #right_click_menu {
-            background-color: #37528c;
             color: #FFAD33;
+            background-color: #37528c;
             border-radius: 5px;
+            box-shadow: 0px 5px 15px -5px #000;
             position: absolute;
             text-align: left;
+            letter-spacing: 0.4px;
             list-style: none;
             padding: 0;
             margin: 0;
@@ -161,11 +160,15 @@ ruffleShadowTemplate.innerHTML = `
             color: #FFAD33;
         }
 
-        #right_click_menu > :first-child,
-        #right_click_menu > :last-child {
+        #right_click_menu > :first-child {
             border-top-right-radius: 5px;
             border-top-left-radius: 5px;
         }
+
+        #right_click_menu > :last-child {
+            border-bottom-right-radius: 5px;
+            border-bottom-left-radius: 5px;
+        } 
     </style>
     <style id="dynamic_styles"></style>
 

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -10,6 +10,8 @@ ruffleShadowTemplate.innerHTML = `
             /* Default width/height; this will get overridden by user styles/attributes */
             width: 550px;
             height: 400px;
+            font-family: Arial, sans-serif;
+            letter-spacing: 0.4px;
             touch-action: none;
             user-select: none;
             -webkit-user-select: none;
@@ -29,29 +31,7 @@ ruffleShadowTemplate.innerHTML = `
             height: 100%;
         }
 
-        #play_button {
-            position: absolute;
-            width: 100%;
-            height: 100%;
-            cursor: pointer;
-            display: none;
-        }
-
-        #play_button .icon {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            width: 90%;
-            height: 90%;
-            max-width: 500px;
-            max-height: 500px;
-            transform: translate(-50%, -50%);
-        }
-
-        #play_button:hover .icon {
-            filter: brightness(1.3);
-        }
-        
+        #play_button,
         #unmute_overlay {
             position: absolute;
             width: 100%;
@@ -65,45 +45,55 @@ ruffleShadowTemplate.innerHTML = `
             width: 100%;
             height: 100%;
             background-color: #000;
-            opacity: 0.8;
+            opacity: 0.7;
         }
         
+        #play_button .icon,
         #unmute_overlay .icon {
-            position: relative;
+            position: absolute;
             top: 50%;
             left: 50%;
-            width: 90%;
-            height: 90%;
-            max-width: 500px;
-            max-height: 500px;
+            width: 50%;
+            height: 50%;
+            max-width: 384px;
+            max-height: 384px;
             transform: translate(-50%, -50%);
-            opacity: 0.6;
+            opacity: 0.7;
+        }
+
+        #play_button:hover .icon,
+        #unmute_overlay:hover .icon {
+            opacity: 1;
         }
 
         #panic {
             position: absolute;
+            font-size: 20px;
+            text-align: center;
             width: 100%;
             height: 100%;
             /* Inverted colours from play button! */
             background: linear-gradient(180deg, rgba(253,58,64,1) 0%, rgba(253,161,56,1) 100%);
-            color: #000;
+            color: #FFF;
         }
 
         #panic a {
             color: #37528C;
+            font-weight: bold;
+        }
+        
+        #panic > div {
+            position: absolute;
         }
 
         #panic-title {
-            margin-top: 30px;
-            text-align: center;
+            width: 100%;
+            top: 30px;
             font-size: 42px;
             font-weight: bold;
         }
 
         #panic-body {
-            text-align: center;
-            font-size: 20px;
-            position: absolute;
             top: 100px;
             bottom: 80px;
             left: 50px;
@@ -116,10 +106,7 @@ ruffleShadowTemplate.innerHTML = `
         }
 
         #panic-footer {
-            position: absolute;
             bottom: 30px;
-            text-align: center;
-            font-size: 20px;
             width: 100%;
         }
 
@@ -142,6 +129,7 @@ ruffleShadowTemplate.innerHTML = `
             color: #FFAD33;
             border-radius: 5px;
             position: absolute;
+            text-align: left;
             list-style: none;
             padding: 0;
             margin: 0;
@@ -162,7 +150,7 @@ ruffleShadowTemplate.innerHTML = `
 
         #right_click_menu .disabled {
             cursor: default;
-            color: #94672f;
+            color: #94672F;
         }
 
         #right_click_menu .active:hover {
@@ -173,14 +161,10 @@ ruffleShadowTemplate.innerHTML = `
             color: #FFAD33;
         }
 
-        #right_click_menu > :first-child {
+        #right_click_menu > :first-child,
+        #right_click_menu > :last-child {
             border-top-right-radius: 5px;
             border-top-left-radius: 5px;
-        }
-
-        #right_click_menu > :last-child {
-            border-bottom-right-radius: 5px;
-            border-bottom-left-radius: 5px;
         }
     </style>
     <style id="dynamic_styles"></style>

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -11,6 +11,7 @@ ruffleShadowTemplate.innerHTML = `
             width: 550px;
             height: 400px;
             font-family: Arial, sans-serif;
+			letter-spacing: 0.4px;
             touch-action: none;
             user-select: none;
             -webkit-user-select: none;
@@ -128,7 +129,6 @@ ruffleShadowTemplate.innerHTML = `
             box-shadow: 0px 5px 15px -5px #000;
             position: absolute;
             text-align: left;
-            letter-spacing: 0.4px;
             list-style: none;
             padding: 0;
             margin: 0;

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -11,7 +11,7 @@ ruffleShadowTemplate.innerHTML = `
             width: 550px;
             height: 400px;
             font-family: Arial, sans-serif;
-			letter-spacing: 0.4px;
+            letter-spacing: 0.4px;
             touch-action: none;
             user-select: none;
             -webkit-user-select: none;


### PR DESCRIPTION
- Fonts are no longer inherited, Arial is used instead
- Play button is smaller and shares same styling as unmute button
- Context menu text is always aligned to the left, added drop shadow for visibility
- Panic screen text displays in white instead of black (it's much easier to read this way)
- CSS is cleaner and less redundant

Opinions on the new play button and context menu styling are welcome.