### PR TITLE
core: Seed RNG with timestamp (fix #1182)

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -238,7 +238,7 @@ impl Player {
             view_matrix: Default::default(),
             inverse_view_matrix: Default::default(),
 
-            rng: SmallRng::from_seed([0u8; 16]), // TODO(Herschel): Get a proper seed on all platforms.
+            rng: SmallRng::seed_from_u64(chrono::Utc::now().timestamp_millis() as u64),
 
             gc_arena: GcArena::new(ArenaParameters::default(), |gc_context| {
                 GcRoot(GcCell::allocate(


### PR DESCRIPTION
Use millisecond timestamp from `chrono::DateTime` to seed the RNG as this is available on all platforms.
Longer term, it might be good to have a `PlayerBuilder` that takes care of wiring up the `Player` along with seeding the RNG.

Fixes #1182.