### PR TITLE
web: Don't polyfill object tags already containing a ruffle-embed

### DIFF
--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -182,6 +182,10 @@ export class RuffleObject extends RufflePlayer {
      * @returns True if the element looks like a flash object.
      */
     static isInterdictable(elem: HTMLElement): boolean {
+        // Don't polyfill if there's already a <ruffle-embed> inside the <object>.
+        if (elem.getElementsByTagName("ruffle-embed").length > 0) {
+            return false;
+        }
         // Don't polyfill if no movie specified.
         const data = elem.attributes.getNamedItem("data")?.value.toLowerCase();
         const params = paramsOf(elem);

--- a/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/expected.html
@@ -1,0 +1,19 @@
+<object
+    type="application/x-shockwave-flash"
+    classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+    width="550"
+    height="400"
+    codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"
+>
+    <param name="movie" value="/test_assets/example.swf" />
+    <param name="quality" value="high" />
+    <param name="menu" value="false" />
+    <ruffle-embed
+        src="/test_assets/example.swf"
+        width="550"
+        height="400"
+        quality="high"
+        menu="false"
+        pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
+    />
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>OBJECT with RUFFLE-EMBED</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <object
+                type="application/x-shockwave-flash"
+                classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+                width="550"
+                height="400"
+                codebase="http://fpdownload.adobe.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0"
+            >
+                <param name="movie" value="/test_assets/example.swf" />
+                <param name="quality" value="high" />
+                <param name="menu" value="false" />
+                <ruffle-embed
+                    src="/test_assets/example.swf"
+                    width="550"
+                    height="400"
+                    quality="high"
+                    menu="false"
+                    pluginspage="http://www.adobe.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"
+                />
+            </object>
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/test.js
@@ -1,0 +1,19 @@
+const { inject_ruffle_and_wait, open_test } = require("../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Object with ruffle-embed tag", () => {
+    it("loads the test", () => {
+        open_test(browser, __dirname);
+    });
+
+    it("already polyfilled with ruffle", () => {
+        inject_ruffle_and_wait(browser);
+        const actual = browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});


### PR DESCRIPTION
```
<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000">
      <param name="movie" value="file.swf" />
      <embed src="file.swf">
</object>
```

With the recent changes, the above code converts `<embed>` to `<ruffle-embed>`, letting `<object>` unchanged. However, if anything was appened to the DOM, the MutationObserver would take a look at the tag again: as the `<embed>` tag no longer exists, it would polyfill the `<object>`, changing it to `<ruffle-object>`.

This is particularly noticeable in #1744: scroll down to "Bravais Lattice Structures" and hit F5.

This PR prevents polyfilling `<object>` tags that already contain a `<ruffle-embed>`.

