### PR TITLE
avm1: Implement Key.getAscii

### DIFF
--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -23,12 +23,21 @@ pub fn is_down<'gc>(
     }
 }
 
+pub fn get_ascii<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let ord = activation.context.input.last_key_char().unwrap_or_default() as u32;
+    Ok(ord.into())
+}
+
 pub fn get_code<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let code: u8 = activation.context.input.get_last_key_code().into();
+    let code: u8 = activation.context.input.last_key_code().into();
     Ok(code.into())
 }
 
@@ -161,6 +170,14 @@ pub fn create_key_object<'gc>(
     key.force_set_function(
         "isDown",
         is_down,
+        gc_context,
+        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        fn_proto,
+    );
+
+    key.force_set_function(
+        "getAscii",
+        get_ascii,
         gc_context,
         Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
         fn_proto,

--- a/core/src/backend/input.rs
+++ b/core/src/backend/input.rs
@@ -4,7 +4,9 @@ use downcast_rs::Downcast;
 pub trait InputBackend: Downcast {
     fn is_key_down(&self, key: KeyCode) -> bool;
 
-    fn get_last_key_code(&self) -> KeyCode;
+    fn last_key_code(&self) -> KeyCode;
+
+    fn last_key_char(&self) -> Option<char>;
 
     fn mouse_visible(&self) -> bool;
 
@@ -34,8 +36,12 @@ impl InputBackend for NullInputBackend {
         false
     }
 
-    fn get_last_key_code(&self) -> KeyCode {
+    fn last_key_code(&self) -> KeyCode {
         KeyCode::Unknown
+    }
+
+    fn last_key_char(&self) -> Option<char> {
+        None
     }
 
     fn mouse_visible(&self) -> bool {

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -2,7 +2,7 @@ use ruffle_core::backend::input::{InputBackend, MouseCursor};
 use ruffle_core::events::KeyCode;
 use ruffle_web_common::JsResult;
 use std::collections::HashSet;
-use web_sys::HtmlCanvasElement;
+use web_sys::{HtmlCanvasElement, KeyboardEvent};
 
 /// An implementation of `InputBackend` utilizing `web_sys` bindings to input
 /// APIs
@@ -12,6 +12,7 @@ pub struct WebInputBackend {
     cursor_visible: bool,
     cursor: MouseCursor,
     last_key: KeyCode,
+    last_char: Option<char>,
 }
 
 impl WebInputBackend {
@@ -22,19 +23,24 @@ impl WebInputBackend {
             cursor_visible: true,
             cursor: MouseCursor::Arrow,
             last_key: KeyCode::Unknown,
+            last_char: None,
         }
     }
 
     /// Register a key press for a given code string.
-    pub fn keydown(&mut self, code: String) {
+    pub fn keydown(&mut self, event: &KeyboardEvent) {
+        let code = event.code();
         self.last_key = web_to_ruffle_key_code(&code).unwrap_or(KeyCode::Unknown);
         self.keys_down.insert(code);
+        self.last_char = web_key_to_codepoint(&event.key());
     }
 
     /// Register a key release for a given code string.
-    pub fn keyup(&mut self, code: String) {
+    pub fn keyup(&mut self, event: &KeyboardEvent) {
+        let code = event.code();
         self.last_key = web_to_ruffle_key_code(&code).unwrap_or(KeyCode::Unknown);
         self.keys_down.remove(&code);
+        self.last_char = web_key_to_codepoint(&event.key());
     }
 
     fn update_mouse_cursor(&self) {
@@ -162,8 +168,12 @@ impl InputBackend for WebInputBackend {
         }
     }
 
-    fn get_last_key_code(&self) -> KeyCode {
+    fn last_key_code(&self) -> KeyCode {
         self.last_key
+    }
+
+    fn last_key_char(&self) -> Option<char> {
+        self.last_char
     }
 
     fn mouse_visible(&self) -> bool {


### PR DESCRIPTION
Initial implementation of `Key.getAscii()`, which returns the ASCII value of the last pressed key.

This allows [Peasant's Quest](https://homestarrunner.com/disk4of12.html) to be playable.

Unfortunately winit keyboard events do not yet provide the API to easily implement this correctly (see https://github.com/rust-windowing/winit/issues/753) -- we need something like web `KeyboardEvent.key` that can provide us with the printed representation of a key on both press and release -- so this is implemented sub-optimally on desktop currently. I'm also unsure of the exact behavior of the Flash Player with international key layouts (seems like it works like the deprecated web `KeyboardEvent.which`, that respects international layout for ASCII characters, but reverts to QWERTY for non-ASCII?).