### PR TITLE
avm1: Don't fire button events when invisible (fix #1521)

### DIFF
--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -326,6 +326,10 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         event: ClipEvent,
     ) -> ClipEventResult {
+        if !self.visible() {
+            return ClipEventResult::NotHandled;
+        }
+
         if event.propagates() {
             for child in self.iter_execution_list() {
                 if child.handle_clip_event(context, event) == ClipEventResult::Handled {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1774,6 +1774,10 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         event: ClipEvent,
     ) -> ClipEventResult {
+        if event.is_button_event() && !self.visible() {
+            return ClipEventResult::NotHandled;
+        }
+
         if event.propagates() {
             for child in self.iter_execution_list() {
                 if child.handle_clip_event(context, event) == ClipEventResult::Handled {


### PR DESCRIPTION
Buttons should not fire their events when they are invisible (importantly `keyPress` events). Fixes #1521.