### PR TITLE
desktop: #1774 add file dialogs when the Ruffle desktop app is opened

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Install linux dependencies
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev
 
     - name: Run all rust tests
       uses: actions-rs/cargo@v1

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install linux dependencies
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev
 
     - name: Install wasm-pack
       run: cargo install wasm-pack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,6 +2231,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nfd"
+version = "0.0.4"
+source = "git+https://github.com/EmbarkStudios/nfd-rs?rev=90ff6d2#90ff6d29d33be8bc4b3e9605cb5921ff9d6456b6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "nix"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,6 +2985,7 @@ dependencies = [
  "jpeg-decoder",
  "log",
  "lyon",
+ "nfd",
  "ruffle_core",
  "ruffle_render_wgpu",
  "url 2.2.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.2.0"
 clipboard = "0.5.0"
 dirs = "3.0"
 isahc = "0.9.13"
+nfd = {git = "https://github.com/EmbarkStudios/nfd-rs", rev="90ff6d2"}
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -14,6 +14,7 @@ use crate::executor::GlutinAsyncExecutor;
 use clap::Clap;
 use isahc::config::RedirectPolicy;
 use isahc::prelude::*;
+use nfd::{open_file_dialog, Response};
 use ruffle_core::{
     backend::audio::{AudioBackend, NullAudioBackend},
     Player,
@@ -44,7 +45,7 @@ use winit::window::{Icon, WindowBuilder};
 struct Opt {
     /// Path to a flash movie (swf) to play
     #[clap(name = "FILE", parse(from_os_str))]
-    input_path: PathBuf,
+    input_path: Option<PathBuf>,
 
     /// A "flashvars" parameter to provide to the movie.
     /// This can be repeated multiple times, for example -Pkey=value -Pfoo=bar
@@ -128,17 +129,37 @@ fn load_movie_from_path(
 }
 
 fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
-    let movie_url = if opt.input_path.exists() {
-        let absolute_path = opt
-            .input_path
-            .canonicalize()
-            .unwrap_or_else(|_| opt.input_path.to_owned());
-        Url::from_file_path(absolute_path)
-            .map_err(|_| "Path must be absolute and cannot be a URL")?
-    } else {
-        Url::parse(opt.input_path.to_str().unwrap_or_default())
-            .map_err(|_| "Input path is not a file and could not be parsed as a URL.")?
+    let movie_url = match &opt.input_path {
+        Some(path) => {
+            if path.exists() {
+                let absolute_path = path.canonicalize().unwrap_or_else(|_| path.to_owned());
+                Url::from_file_path(absolute_path)
+                    .map_err(|_| "Path must be absolute and cannot be a URL")?
+            } else {
+                Url::parse(path.to_str().unwrap_or_default())
+                    .map_err(|_| "Input path is not a file and could not be parsed as a URL.")?
+            }
+        }
+        None => {
+            let result = open_file_dialog(Option::from("swf"), None)?;
+
+            let selected = match result {
+                Response::Okay(file_path) => PathBuf::from(file_path),
+                // OkayMultiple result is not possible with open_file_dialog but must be covered
+                Response::OkayMultiple(_) => {
+                    return Err("Multiple file selection is not supported".into())
+                }
+                Response::Cancel => return Ok(()),
+            };
+
+            let absolute_path = selected
+                .canonicalize()
+                .unwrap_or_else(|_| selected.to_owned());
+            Url::from_file_path(absolute_path)
+                .map_err(|_| "Path must be absolute and cannot be a URL")?
+        }
     };
+
     let mut movie = load_movie_from_path(movie_url.to_owned(), opt.proxy.to_owned())?;
     let movie_size = LogicalSize::new(movie.width(), movie.height());
 
@@ -186,14 +207,19 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     )?);
     let (executor, chan) = GlutinAsyncExecutor::new(event_loop.create_proxy());
     let navigator = Box::new(navigator::ExternalNavigatorBackend::new(
-        movie_url,
+        movie_url.clone(),
         chan,
         event_loop.create_proxy(),
         opt.proxy,
     )); //TODO: actually implement this backend type
     let input = Box::new(input::WinitInputBackend::new(window.clone()));
     let storage = Box::new(DiskStorageBackend::new(
-        opt.input_path.file_name().unwrap_or_default().as_ref(),
+        movie_url
+            .to_file_path()
+            .unwrap_or_default()
+            .file_name()
+            .unwrap_or_default()
+            .as_ref(),
     ));
     let locale = Box::new(locale::DesktopLocaleBackend::new());
     let player = Player::new(


### PR DESCRIPTION
So I think this PR is ready and it's been tested on Linux and windows (a Mac user test would also be appreciated). I have one reservation as the published crate https://github.com/saurvs/nfd-rs is stale, so I have referenced a forked branch with open PR instead.

Notes: 

I'm on Ubuntu/Linux and I needed `libgtk-3-dev` in order to install `nfd-rs`

I also get a console warning
```
Gtk-Message: 16:35:11.230: GtkDialog mapped without a transient parent. This is discouraged.

```
