### PR TITLE
core: Implement MovieClip._lockroot in avm1

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -212,6 +212,7 @@ pub fn create_proto<'gc>(
         "transform" => [transform, set_transform],
         "enabled" => [enabled, set_enabled],
         "focusEnabled" => [focus_enabled, set_focus_enabled],
+        "_lockroot" => [lock_root, set_lock_root],
     );
 
     object.into()
@@ -1234,5 +1235,22 @@ fn set_focus_enabled<'gc>(
         value.as_bool(activation.current_swf_version()),
         &mut activation.context,
     );
+    Ok(())
+}
+
+fn lock_root<'gc>(
+    this: MovieClip<'gc>,
+    _activation: &mut Activation<'_, 'gc, '_>,
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this.lock_root().into())
+}
+
+fn set_lock_root<'gc>(
+    this: MovieClip<'gc>,
+    activation: &mut Activation<'_, 'gc, '_>,
+    value: Value<'gc>,
+) -> Result<(), Error<'gc>> {
+    let lock_root = value.as_bool(activation.current_swf_version());
+    this.set_lock_root(activation.context.gc_context, lock_root);
     Ok(())
 }

--- a/core/tests/regression_tests.rs
+++ b/core/tests/regression_tests.rs
@@ -135,7 +135,7 @@ swf_tests! {
     (movieclip_prototype_extension, "avm1/movieclip_prototype_extension", 1),
     (movieclip_hittest, "avm1/movieclip_hittest", 1),
     (movieclip_hittest_shapeflag, "avm1/movieclip_hittest_shapeflag", 10),
-    #[ignore] (movieclip_lockroot, "avm1/movieclip_lockroot", 10),
+    (movieclip_lockroot, "avm1/movieclip_lockroot", 10),
     #[ignore] (textfield_text, "avm1/textfield_text", 1),
     (recursive_prototypes, "avm1/recursive_prototypes", 2),
     (stage_object_children, "avm1/stage_object_children", 2),


### PR DESCRIPTION
MovieClip._lockroot should now work for AS1/2. This fixes #1124.

Some notes:

1. Differently from the [documentation](https://open-flash.github.io/mirrors/as2-language-reference/), the `_lockroot` property is `false` by default, not `undefined`. This change reflects actual SWF functionality, not the docs.
2. The `_lockroot` property is not defined in the [SWF format specs](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf) so it doesn't have a formal `GetProperty` index.
3. Tests introduced in #1815 are now active.

As usual, comments welcome. This introduces some new functionality (that the ability to _keep_ some flags when loading a movie into another movie) so I want to make sure I'm not disrupting the architecture too much.