### PR TITLE
core: Remove unimplemented! in decode_define_bits_lossless

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -424,7 +424,13 @@ pub fn decode_define_bits_lossless(
             }
             out_data
         }
-        _ => unimplemented!("{:?} {:?}", swf_tag.version, swf_tag.format),
+        _ => {
+            return Err(format!(
+                "Unexpected DefineBitsLossless{} format: {:?} ",
+                swf_tag.version, swf_tag.format,
+            )
+            .into());
+        }
     };
 
     Ok(Bitmap {


### PR DESCRIPTION
Remove another call to `unimplemented!` to avoid potential panics.