### PR TITLE
avm1: Allow native constructors to modify `this`, properly implement Object constructor

### DIFF
--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -36,7 +36,7 @@ pub fn call<'gc>(
     func: Object<'gc>,
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = match myargs.get(0) {
+    let mut this = match myargs.get(0) {
         Some(Value::Object(this)) => *this,
         _ => activation.context.avm1.globals,
     };
@@ -51,7 +51,7 @@ pub fn call<'gc>(
         Some(exec) => exec.exec(
             "[Anonymous]",
             activation,
-            this,
+            &mut this,
             None,
             args,
             ExecutionReason::FunctionCall,
@@ -67,7 +67,7 @@ pub fn apply<'gc>(
     func: Object<'gc>,
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = match myargs.get(0) {
+    let mut this = match myargs.get(0) {
         Some(Value::Object(this)) => *this,
         _ => activation.context.avm1.globals,
     };
@@ -89,7 +89,7 @@ pub fn apply<'gc>(
         Some(exec) => exec.exec(
             "[Anonymous]",
             activation,
-            this,
+            &mut this,
             None,
             &child_args,
             ExecutionReason::FunctionCall,

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -13,10 +13,15 @@ use std::borrow::Cow;
 
 /// Implements `Object` constructor
 pub fn constructor<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
-    _this: Object<'gc>,
-    _args: &[Value<'gc>],
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: &mut Object<'gc>,
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(val) = args.get(0) {
+        // If argument is an object, return a reference to that object.
+        // If it's a primitive type, box it.
+        *this = val.coerce_to_object(activation);
+    }
     Ok(Value::Undefined)
 }
 
@@ -384,7 +389,7 @@ pub fn create_object_object<'gc>(
     let object_function = FunctionObject::function_and_constructor(
         gc_context,
         Executable::Native(object_function),
-        Executable::Native(constructor),
+        Executable::NativeConstructor(constructor),
         Some(fn_proto),
         proto,
     );

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -130,7 +130,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn construct_on_existing(
         &self,
         _activation: &mut Activation<'_, 'gc, '_>,
-        mut _this: Object<'gc>,
+        _this: &mut Object<'gc>,
         _args: &[Value<'gc>],
     ) -> Result<(), Error<'gc>> {
         Ok(())

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -41,7 +41,7 @@ impl<'gc> Watcher<'gc> {
         name: &str,
         old_value: Value<'gc>,
         new_value: Value<'gc>,
-        this: Object<'gc>,
+        mut this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
     ) -> Result<Value<'gc>, crate::avm1::error::Error<'gc>> {
         let args = [
@@ -57,7 +57,7 @@ impl<'gc> Watcher<'gc> {
             executable.exec(
                 name,
                 activation,
-                this,
+                &mut this,
                 base_proto,
                 &args,
                 ExecutionReason::Special,
@@ -255,7 +255,7 @@ impl<'gc> ScriptObject<'gc> {
         name: &str,
         mut value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
+        mut this: Object<'gc>,
         base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if name == "__proto__" {
@@ -303,7 +303,7 @@ impl<'gc> ScriptObject<'gc> {
                             let _ = exec.exec(
                                 "[Setter]",
                                 activation,
-                                this,
+                                &mut this,
                                 Some(this_proto),
                                 &[value.clone()],
                                 ExecutionReason::Special,
@@ -366,7 +366,7 @@ impl<'gc> ScriptObject<'gc> {
                         let _ = exec.exec(
                             "[Setter]",
                             activation,
-                            this,
+                            &mut this,
                             base_proto,
                             &[value],
                             ExecutionReason::Special,
@@ -396,7 +396,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         &self,
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
+        mut this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if name == "__proto__" {
             return Ok(self.proto().map_or(Value::Undefined, Value::Object));
@@ -422,7 +422,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
                 match exec.exec(
                     "[Getter]",
                     activation,
-                    this,
+                    &mut this,
                     Some((*self).into()),
                     &[],
                     ExecutionReason::Special,

--- a/core/src/avm1/object/transform_object.rs
+++ b/core/src/avm1/object/transform_object.rs
@@ -73,8 +73,8 @@ impl<'gc> TObject<'gc> for TransformObject<'gc> {
             .and_then(|o| o.as_movie_clip());
 
         let this = if clip.is_some() {
-            let this = prototype.create_bare_object(activation, prototype)?;
-            self.construct_on_existing(activation, this, args)?;
+            let mut this = prototype.create_bare_object(activation, prototype)?;
+            self.construct_on_existing(activation, &mut this, args)?;
             this
         } else {
             // TODO: This should return an unboxed undefined.

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1421,7 +1421,7 @@ impl<'gc> MovieClip<'gc> {
                     .get("prototype", &mut activation)
                     .map(|v| v.coerce_to_object(&mut activation))
                 {
-                    let object: Avm1Object<'gc> = StageObject::for_display_object(
+                    let mut object: Avm1Object<'gc> = StageObject::for_display_object(
                         activation.context.gc_context,
                         self.into(),
                         Some(prototype),
@@ -1438,7 +1438,7 @@ impl<'gc> MovieClip<'gc> {
                     if run_frame {
                         self.run_frame(&mut activation.context);
                     }
-                    let _ = constructor.construct_on_existing(&mut activation, object, &[]);
+                    let _ = constructor.construct_on_existing(&mut activation, &mut object, &[]);
                 }
 
                 return;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -949,7 +949,7 @@ impl Player {
                         .get("prototype", &mut activation)
                         .map(|v| v.coerce_to_object(&mut activation))
                     {
-                        if let Value::Object(object) = actions.clip.object() {
+                        if let Value::Object(mut object) = actions.clip.object() {
                             object.set_proto(activation.context.gc_context, Some(prototype));
                             for event in events {
                                 let _ = activation.run_child_frame_for_action(
@@ -960,7 +960,11 @@ impl Player {
                                 );
                             }
 
-                            let _ = constructor.construct_on_existing(&mut activation, object, &[]);
+                            let _ = constructor.construct_on_existing(
+                                &mut activation,
+                                &mut object,
+                                &[],
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
* Add `NativeFunction::NativeConstructor` that takes `&mut Object` to allow the constructor to modify the underlying type.
  * TODO: I added NativeConstructor to avoid too much noise at the moment; but if this is the way we want to go, we could only have `Executable::NativeFunction` that takes `this: &mut Object<'gc>`. This would require changing the signature of all built-in functions, a more invasive change that I wanted some opinions on
  * `this` needs to be a mutable ref to allow the underlying type of the object to be changed (#1469, #701)
  * TODO: Maybe `this` should be a `&mut Value`? (BitmapData constructor returning undefined in #1577, #843)
* Properly implement `Object` constructor to coerce its argument to an object.
   * Fixes #1464, #1469, #1635.

