### PR TITLE
desktop: Add file dialogs to Ruffle if no FILE argv V2 (close #1774)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,6 +2979,7 @@ dependencies = [
  "lyon",
  "ruffle_core",
  "ruffle_render_wgpu",
+ "tinyfiledialogs",
  "url 2.2.0",
  "webbrowser",
  "winapi 0.3.9",
@@ -3512,6 +3513,15 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tinyfiledialogs"
+version = "3.3.10"
+source = "git+https://github.com/jdm/tinyfiledialogs-rs?rev=1a235d1#1a235d1b14f05354af23ecd0781dba2fe72fdd83"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.2.0"
 clipboard = "0.5.0"
 dirs = "3.0"
 isahc = "0.9.13"
+tinyfiledialogs = {git ="https://github.com/jdm/tinyfiledialogs-rs", rev="1a235d1"}
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
Alternative to #1816 using https://github.com/jdm/tinyfiledialogs-rs

I found no problems with the switch.

Introduce file dialogs if no FILE argv is passed.
Use altered version of tiny file dialogs due to https://github.com/jdm/tinyfiledialogs-rs/issues/19