### PR TITLE
avm1: Improve loops treatment in Sound.start

### DIFF
--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -378,11 +378,8 @@ fn start<'gc>(
         .unwrap_or(&Value::Number(1.0))
         .coerce_to_f64(activation)?;
 
-    let loops = if loops >= 1.0 && loops <= f64::from(std::i16::MAX) {
-        loops as u16
-    } else {
-        1
-    };
+    // TODO: Handle loops > std::u16::MAX.
+    let loops = (loops as u16).max(1);
 
     use swf::{SoundEvent, SoundInfo};
     if let Some(sound_object) = this.as_sound_object() {


### PR DESCRIPTION
The second argument of `Sound.start`, `loops`, can be greater than `std::u16::MAX`, but previously greater values were treated as 1.
Ideally, the solution is to respect those values, but since `SoundInfo` holds a `u16`, a short-term solution is to treat them as `std::u16::MAX` instead.

Extracted from #1445 since this commit is unrelated.