### PR TITLE
web: Properly handle multibyte characters in text input

### DIFF
--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -310,10 +310,17 @@ pub fn web_key_to_codepoint(key: &str) -> Option<char> {
     // Single character strings will be an actual printable char that we can use as text input.
     // All the other special values are multiple characters (e.g. "ArrowLeft").
     // It's probably better to explicitly match on all the variants.
-    match key {
-        key if key.len() == 1 => key.chars().next(),
-        "Backspace" => Some(8 as char),
-        "Delete" => Some(127 as char),
-        _ => None,
+    let mut chars = key.chars();
+    let (c1, c2) = (chars.next(), chars.next());
+    if c2.is_none() {
+        // Single character.
+        c1
+    } else {
+        // Check for special characters.
+        match key {
+            "Backspace" => Some(8 as char),
+            "Delete" => Some(127 as char),
+            _ => None,
+        }
     }
 }


### PR DESCRIPTION
We were checking for byte length == 1 instead of # of characters to determine if KeyboardEvent.key was a printable character.

Thanks to @JMcKiern for pointing this out. Fixes part of #1802.