### PR TITLE
Open shadow DOM

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -117,7 +117,7 @@ export class RufflePlayer extends HTMLElement {
     constructor() {
         super();
 
-        this.shadow = this.attachShadow({ mode: "closed" });
+        this.shadow = this.attachShadow({ mode: "open" });
         this.shadow.appendChild(ruffleShadowTemplate.content.cloneNode(true));
 
         this.dynamicStyles = <HTMLStyleElement>(


### PR DESCRIPTION
It is discouraged to use closed shadow DOM.
This makes it open.