### PR TITLE
web: Make slider color change if slider is checked

### DIFF
--- a/web/packages/extension/build/popup.html
+++ b/web/packages/extension/build/popup.html
@@ -66,7 +66,7 @@
         border-radius: 5px;
         margin: 4px 0px auto 15px;
 
-        background-color: #966214;
+        background-color: #a0a0a0;
     }
 
     .RufflePopup-checkbox_slider:after {
@@ -85,10 +85,14 @@
         transition: left 0.1s;
     }
 
+    .RufflePopup-checkbox_with_slider:checked ~ .RufflePopup-checkbox_slider {
+        background-color: #966214;
+    }
+
     .RufflePopup-checkbox_with_slider:checked ~ .RufflePopup-checkbox_slider:after {
         left: 85%;
     }
-    
+
     .RufflePopup-reload_button {
         display: block;
         overflow: hidden;


### PR DESCRIPTION
This sets the background color of the sliders in the extension to `#a0a0a0` when unchecked. The aim is to make it clear whether or not the option is enabled.

Let me know if there's a better color.

**Before:**
![ruffle_ext_before](https://user-images.githubusercontent.com/9341692/101397276-6427af80-38c4-11eb-919d-e2158661c3eb.png)

**After:**
![ruffle_ext_after](https://user-images.githubusercontent.com/9341692/101397281-668a0980-38c4-11eb-880d-5477099b738c.png)
