### PR TITLE
web: Add "Download .swf" context menu item

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -90,6 +90,7 @@ export class RufflePlayer extends HTMLElement {
     private playButton: HTMLElement;
     private unmuteOverlay: HTMLElement;
     private rightClickMenu: HTMLElement;
+    private swfUrl?: string;
     private instance: Ruffle | null;
     private _trace_observer: ((message: string) => void) | null;
 
@@ -406,6 +407,7 @@ export class RufflePlayer extends HTMLElement {
 
                 if ("url" in options) {
                     console.log("Loading SWF file " + options.url);
+                    this.swfUrl = options.url;
 
                     const parameters = {
                         ...sanitizeParameters(
@@ -496,6 +498,18 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
+    /**
+     * Opens the loaded SWF in a new tab, causing the browser to download the file.
+     */
+    downloadSwf(): void {
+        if (this.instance && this.swfUrl) {
+            console.log("Downloading SWF: " + this.swfUrl);
+            window.open(this.swfUrl);
+        } else {
+            console.error("SWF download failed");
+        }
+    }
+
     private contextMenuItems(): ContextMenuItem[] {
         const items = [];
         if (this.fullscreenEnabled) {
@@ -510,6 +524,12 @@ export class RufflePlayer extends HTMLElement {
                     onClick: this.enterFullscreen.bind(this),
                 });
             }
+        }
+        if (this.instance && this.swfUrl) {
+            items.push({
+                text: `Download .swf`,
+                onClick: this.downloadSwf.bind(this),
+            });
         }
         items.push({
             text: `Ruffle %VERSION_NAME%`,


### PR DESCRIPTION
As I proposed in #1885, it would be nice to have a download option in the context menu to easily download the loaded SWF.

The use case is downloading an SWF from a web page linked in an issue. I don't really want to go crawling through the html to find the SWF url before I can start analyzing it on my own machine.

However, there is the risk that people wouldn't like it being so easy to download SWFs from their site.