### PR TITLE
web: Fix spurious keyUp events (fix #1886)

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -591,9 +591,6 @@ impl Ruffle {
 
                                 let key_code = input.last_key_code();
                                 let key_char = input.last_key_char();
-                                if key_code != KeyCode::Unknown {
-                                    core.handle_event(PlayerEvent::KeyUp { key_code });
-                                }
 
                                 if key_code != KeyCode::Unknown {
                                     core.handle_event(PlayerEvent::KeyDown { key_code });


### PR DESCRIPTION
Remove incorrect key up events from being fired during key down. I believe this was a copy-paste flub from #1769.

Fixes #1886.