### PR TITLE
docs: Add double quotes to RUST_LOG to improve clarity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Ruffle is a young project, and there is still much Flash functionality that is u
 
 ## Debugging ActionScript Content
 
-If you build Ruffle with `--features avm_debug` and enable debug logging (`RUST_LOG=warn,ruffle_core=debug`) then you will
+If you build Ruffle with `--features avm_debug` and enable debug logging (`RUST_LOG="warn,ruffle_core=debug"`) then you will
 activate a few built-in debugging utilities inside Ruffle, listed below.
 
 ### Warnings and Errors


### PR DESCRIPTION
I was having issues with getting the avm_debug feature to work. It turns out that I was incorrectly reading `RUST_LOG=warn,ruffle_core=debug` in CONTRIBUTING.md as two separate commands: `RUST_LOG=warn` and `ruffle_core=debug`. It should just be one command. 

This pr adds double quotes to the command to make this clearer: `RUST_LOG="warn,ruffle_core=debug"`. 

I understand that setting an environment variable using double quotes works in both bash and PowerShell. **However, it doesn't work in Command Prompt with `set`.**