### PR TITLE
web: Fix cors issues with http (close ruffle-rs#1486) alternative

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -198,6 +198,12 @@ pub trait NavigatorBackend {
     /// current document's base URL, while the most obvious base for a desktop
     /// client would be the file-URL form of the current path.
     fn resolve_relative_url<'a>(&mut self, url: &'a str) -> Cow<'a, str>;
+
+    /// Handle any context specific pre-processing
+    ///
+    /// Changing http -> https for example. This function may alter any part of the
+    /// URL (generally only if configured to do so by the user).
+    fn pre_process_url(&self, url: Url) -> Url;
 }
 
 /// A null implementation of an event loop that only supports blocking.
@@ -377,5 +383,9 @@ impl NavigatorBackend for NullNavigatorBackend {
         } else {
             url.into()
         }
+    }
+
+    fn pre_process_url(&self, url: Url) -> Url {
+        url
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -76,6 +76,10 @@ struct Opt {
     /// (Optional) Proxy to use when loading movies via URL
     #[clap(long, case_insensitive = true)]
     proxy: Option<Url>,
+
+    /// (Optional) Replace all embedded http URLs with https
+    #[clap(long, case_insensitive = true, takes_value = false)]
+    upgrade_to_https: bool,
 }
 
 #[cfg(feature = "render_trace")]
@@ -207,6 +211,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         chan,
         event_loop.create_proxy(),
         opt.proxy,
+        opt.upgrade_to_https,
     )); //TODO: actually implement this backend type
     let input = Box::new(input::WinitInputBackend::new(window.clone()));
     let storage = Box::new(DiskStorageBackend::new(

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -69,6 +69,19 @@ export interface BaseLoadOptions {
      * @default UnmuteOverlay.Visible
      */
     unmuteOverlay?: UnmuteOverlay;
+
+    /**
+     * Whether or not to auto-upgrade all embedded URLs to https.
+     *
+     * Flash content that embeds http urls will be blocked from
+     * accessing those urls by the browser when Ruffle is loaded
+     * in a https context. Set to `true` to automatically change
+     * `http://` to `https://` for all embedded URLs when Ruffle is
+     * loaded in an https context.
+     *
+     * @default true
+     */
+    upgradeToHttps?: boolean;
 }
 
 /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -314,7 +314,9 @@ export class RufflePlayer extends HTMLElement {
         this.instance = new ruffleConstructor(
             this.container,
             this,
-            this.allowScriptAccess
+            this.allowScriptAccess,
+            config.upgradeToHttps !== false &&
+                window.location.protocol === "https:"
         );
         console.log("New Ruffle instance created.");
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -115,6 +115,7 @@ impl Ruffle {
         parent: HtmlElement,
         js_player: JavascriptPlayer,
         allow_script_access: bool,
+        upgrade_to_https: bool,
     ) -> Result<Ruffle, JsValue> {
         if RUFFLE_GLOBAL_PANIC.is_completed() {
             // If an actual panic happened, then we can't trust the state it left us in.
@@ -122,7 +123,7 @@ impl Ruffle {
             return Err("Ruffle is panicking!".into());
         }
         set_panic_handler();
-        Ruffle::new_internal(parent, js_player, allow_script_access)
+        Ruffle::new_internal(parent, js_player, allow_script_access, upgrade_to_https)
             .map_err(|_| "Error creating player".into())
     }
 
@@ -284,6 +285,7 @@ impl Ruffle {
         parent: HtmlElement,
         js_player: JavascriptPlayer,
         allow_script_access: bool,
+        upgrade_to_https: bool,
     ) -> Result<Ruffle, Box<dyn Error>> {
         let _ = console_log::init_with_level(log::Level::Trace);
 
@@ -296,7 +298,7 @@ impl Ruffle {
             .into_js_result()?;
 
         let audio = Box::new(WebAudioBackend::new()?);
-        let navigator = Box::new(WebNavigatorBackend::new());
+        let navigator = Box::new(WebNavigatorBackend::new(upgrade_to_https));
         let input = Box::new(WebInputBackend::new(&canvas));
         let locale = Box::new(WebLocaleBackend::new());
 


### PR DESCRIPTION
Alternative to #1897 using `Url` arguments instead.

I must confess, I think I prefer #1897 so far, but I'll leave that to review to decide.