### PR TITLE
web: Detect swf extension using the `URL()` constructor

### DIFF
--- a/web/packages/selfhosted/test/polyfill/pdf_with_get/expected.html
+++ b/web/packages/selfhosted/test/polyfill/pdf_with_get/expected.html
@@ -1,0 +1,5 @@
+<object
+    data="file.pdf?foo=bar.swf"
+    width="500"
+    height="500"
+></object>

--- a/web/packages/selfhosted/test/polyfill/pdf_with_get/index.html
+++ b/web/packages/selfhosted/test/polyfill/pdf_with_get/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>PDF with .swf GET</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <object
+                data="file.pdf?foo=bar.swf"
+                width="500"
+                height="500"
+            ></object>
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/pdf_with_get/test.js
+++ b/web/packages/selfhosted/test/polyfill/pdf_with_get/test.js
@@ -1,0 +1,19 @@
+const { inject_ruffle_and_wait, open_test } = require("../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("PDF with .swf GET", () => {
+    it("loads the test", () => {
+        open_test(browser, __dirname);
+    });
+
+    it("doesn't polyfill with ruffle", () => {
+        inject_ruffle_and_wait(browser);
+        const actual = browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});


### PR DESCRIPTION
I think this should be better and more reliable, as mentioned in https://github.com/ruffle-rs/ruffle/pull/1281#issuecomment-706362765.
Also, a code like `<object data="fake.pdf?a=foolme.swf"></object>` is currently detected as an SWF and converted to a `ruffle-object`. The PR fixes this case and adds another test.