### PR TITLE
core: Extend text input to accept multibyte characters (closes #1802)

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -10,6 +10,7 @@ use crate::font::{round_down_to_pixel, Glyph};
 use crate::html::{BoxBounds, FormatSpans, LayoutBox, LayoutContent, TextFormat};
 use crate::prelude::*;
 use crate::shape_utils::DrawCommand;
+use crate::string_utils;
 use crate::tag_utils::SwfMovie;
 use crate::transform::Transform;
 use crate::types::{Degrees, Percent};
@@ -995,11 +996,7 @@ impl<'gc> EditText<'gc> {
                             && local_position.1 <= params.height()
                         {
                             if local_position.0 >= x + (advance / 2) {
-                                let mut idx = pos + 1;
-                                while !text.is_char_boundary(idx) {
-                                    idx += 1;
-                                }
-                                result = Some(idx);
+                                result = Some(string_utils::next_char_boundary(text, pos));
                             } else {
                                 result = Some(pos);
                             }
@@ -1037,10 +1034,7 @@ impl<'gc> EditText<'gc> {
                     if selection.start() > 0 {
                         // Delete previous character
                         let text = self.text();
-                        let mut start = selection.start() - 1;
-                        while !text.is_char_boundary(start) {
-                            start -= 1;
-                        }
+                        let start = string_utils::prev_char_boundary(&text, selection.start());
                         self.replace_text(start, selection.start(), "", context);
                         self.set_selection(
                             Some(TextSelection::for_position(start)),
@@ -1054,10 +1048,7 @@ impl<'gc> EditText<'gc> {
                     if selection.end() < self.text_length() {
                         // Delete next character
                         let text = self.text();
-                        let mut end = selection.start() + 1;
-                        while !text.is_char_boundary(end) {
-                            end += 1;
-                        }
+                        let end = string_utils::next_char_boundary(&text, selection.start());
                         self.replace_text(selection.start(), end, "", context);
                         // No need to change selection
                         changed = true;
@@ -1422,19 +1413,13 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                     let length = text.len();
                     match key_code {
                         ButtonKeyCode::Left if selection.to > 0 => {
-                            selection.to -= 1;
-                            while !text.is_char_boundary(selection.to) {
-                                selection.to -= 1;
-                            }
+                            selection.to = string_utils::prev_char_boundary(text, selection.to);
                             if !context.input.is_key_down(KeyCode::Shift) {
                                 selection.from = selection.to;
                             }
                         }
                         ButtonKeyCode::Right if selection.to < length => {
-                            selection.to += 1;
-                            while !text.is_char_boundary(selection.to) {
-                                selection.to += 1;
-                            }
+                            selection.to = string_utils::next_char_boundary(text, selection.to);
                             if !context.input.is_key_down(KeyCode::Shift) {
                                 selection.from = selection.to;
                             }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -392,6 +392,7 @@ impl<'gc> EditText<'gc> {
     }
 
     pub fn text_format(self, from: usize, to: usize) -> TextFormat {
+        // TODO: Convert to byte indices
         self.0.read().text_spans.get_text_format(from, to)
     }
 
@@ -402,6 +403,7 @@ impl<'gc> EditText<'gc> {
         tf: TextFormat,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) {
+        // TODO: Convert to byte indices
         self.0
             .write(context.gc_context)
             .text_spans
@@ -993,7 +995,11 @@ impl<'gc> EditText<'gc> {
                             && local_position.1 <= params.height()
                         {
                             if local_position.0 >= x + (advance / 2) {
-                                result = Some(pos + 1);
+                                let mut idx = pos + 1;
+                                while !text.is_char_boundary(idx) {
+                                    idx += 1;
+                                }
+                                result = Some(idx);
                             } else {
                                 result = Some(pos);
                             }
@@ -1030,9 +1036,14 @@ impl<'gc> EditText<'gc> {
                     // Backspace with caret
                     if selection.start() > 0 {
                         // Delete previous character
-                        self.replace_text(selection.start() - 1, selection.start(), "", context);
+                        let text = self.text();
+                        let mut start = selection.start() - 1;
+                        while !text.is_char_boundary(start) {
+                            start -= 1;
+                        }
+                        self.replace_text(start, selection.start(), "", context);
                         self.set_selection(
-                            Some(TextSelection::for_position(selection.start() - 1)),
+                            Some(TextSelection::for_position(start)),
                             context.gc_context,
                         );
                         changed = true;
@@ -1042,22 +1053,26 @@ impl<'gc> EditText<'gc> {
                     // Delete with caret
                     if selection.end() < self.text_length() {
                         // Delete next character
-                        self.replace_text(selection.start(), selection.start() + 1, "", context);
+                        let text = self.text();
+                        let mut end = selection.start() + 1;
+                        while !text.is_char_boundary(end) {
+                            end += 1;
+                        }
+                        self.replace_text(selection.start(), end, "", context);
                         // No need to change selection
                         changed = true;
                     }
                 }
-                32..=126 => {
-                    // ASCII
-                    // TODO: Make this actually good and not basic ASCII :)
+                code if !(code as char).is_control() => {
                     self.replace_text(
                         selection.start(),
                         selection.end(),
                         &character.to_string(),
                         context,
                     );
+                    let new_start = selection.start() + character.len_utf8();
                     self.set_selection(
-                        Some(TextSelection::for_position(selection.start() + 1)),
+                        Some(TextSelection::for_position(new_start)),
                         context.gc_context,
                     );
                     changed = true;
@@ -1400,31 +1415,34 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                 ClipEventResult::Handled
             }
             ClipEvent::KeyPress { key_code } => {
-                let mut text = self.0.write(context.gc_context);
-                let selection = text.selection;
+                let mut edit_text = self.0.write(context.gc_context);
+                let selection = edit_text.selection;
                 if let Some(mut selection) = selection {
-                    let length = text.text_spans.text().len();
+                    let text = edit_text.text_spans.text();
+                    let length = text.len();
                     match key_code {
                         ButtonKeyCode::Left if selection.to > 0 => {
-                            if context.input.is_key_down(KeyCode::Shift) {
+                            selection.to -= 1;
+                            while !text.is_char_boundary(selection.to) {
                                 selection.to -= 1;
-                            } else {
-                                selection.to -= 1;
+                            }
+                            if !context.input.is_key_down(KeyCode::Shift) {
                                 selection.from = selection.to;
                             }
                         }
                         ButtonKeyCode::Right if selection.to < length => {
-                            if context.input.is_key_down(KeyCode::Shift) {
+                            selection.to += 1;
+                            while !text.is_char_boundary(selection.to) {
                                 selection.to += 1;
-                            } else {
-                                selection.to += 1;
+                            }
+                            if !context.input.is_key_down(KeyCode::Shift) {
                                 selection.from = selection.to;
                             }
                         }
                         _ => {}
                     }
                     selection.clamp(length);
-                    text.selection = Some(selection);
+                    edit_text.selection = Some(selection);
                     ClipEventResult::Handled
                 } else {
                     ClipEventResult::NotHandled

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -7,6 +7,7 @@ use crate::font::{EvalParameters, Font};
 use crate::html::dimensions::{BoxBounds, Position, Size};
 use crate::html::text_format::{FormatSpans, TextFormat, TextSpan};
 use crate::shape_utils::DrawCommand;
+use crate::string_utils;
 use crate::tag_utils::SwfMovie;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cmp::{max, min};
@@ -720,16 +721,10 @@ impl<'gc> LayoutBox<'gc> {
 
                             // This ensures that the space causing the line break
                             // is included in the line it broke.
-                            let next_breakpoint = if last_breakpoint + breakpoint + 1 >= text.len()
-                            {
-                                text.len()
-                            } else {
-                                let mut nb = last_breakpoint + breakpoint + 1;
-                                while !text.is_char_boundary(nb) {
-                                    nb += 1;
-                                }
-                                nb
-                            };
+                            let next_breakpoint = string_utils::next_char_boundary(
+                                text,
+                                last_breakpoint + breakpoint,
+                            );
 
                             layout_context.append_text(
                                 &text[last_breakpoint..next_breakpoint],

--- a/core/src/string_utils.rs
+++ b/core/src/string_utils.rs
@@ -1,5 +1,29 @@
 ///! Utilities for operating on strings in SWF files.
 
+/// Gets the position of the previous char
+/// `pos` must already lie on a char boundary
+pub fn prev_char_boundary(slice: &str, pos: usize) -> usize {
+    if pos == 0 {
+        return pos;
+    }
+
+    let mut idx = pos - 1;
+    while !slice.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
+/// Gets the byte position of the next char
+/// `pos` must already lie on a char boundary
+pub fn next_char_boundary(slice: &str, pos: usize) -> usize {
+    if let Some(c) = slice[pos..].chars().next() {
+        pos + c.len_utf8()
+    } else {
+        slice.len()
+    }
+}
+
 /// Creates a `String` from an iterator of UTF-16 code units.
 /// TODO: Unpaired surrogates will get replaced with the Unicode replacement character.
 pub fn utf16_iter_to_string<I: Iterator<Item = u16>>(it: I) -> String {


### PR DESCRIPTION
As discussed in #1802, typing a multibyte character into a text input was broken. The first issue was solved in #1860 but there were numerous occasions where characters were expected to be single bytes. This pr fixes that by changing any references to text to deal in character space rather than byte space.

I'm aware that `get_byte_pos()` adds an O(n) performance hit. However, as far as I can tell, there is no way around this and slow is better than incorrect!

Since the faux device font doesn't include any multibyte characters, I provide this swf for testing. It embeds 2000+ typewriter glyphs and sets `TextField.embedFonts = true;`.

[text_input_embeddedfonts.zip](https://github.com/ruffle-rs/ruffle/files/5684773/text_input_embeddedfonts.zip)

This pr will close #1802 
