### PR TITLE
docs: Add `tests` to list of commit prefixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ web: Fix incorrect rendering of gradients (close #23)
    * `avm1:`
    * `docs:`
    * `chore:`
+   * `tests:`
  * Capitalize the first letter following the tag
  * Limit line length to 72 characters
  * Use the present tense and imperative mood ("fix", not "fixed" nor "fixes")


### PR DESCRIPTION
I noticed that `tests:` was used in a number of commits (eg 852f26bdeb029cef9bd072674b3edf03642a34b1, 457d707ec24433ce6ca814da99bc89a5e2770305, c018ac065c7e007ea5e42fae90cbb66e7bc98f4e) but it was missing from the list in CONTRIBUTING.md 