### PR TITLE
web: Add query string to `Report Bug` link

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -90,6 +90,7 @@ export class RufflePlayer extends HTMLElement {
     private playButton: HTMLElement;
     private unmuteOverlay: HTMLElement;
     private rightClickMenu: HTMLElement;
+    private swfUrl?: string;
     private instance: Ruffle | null;
     private _trace_observer: ((message: string) => void) | null;
 
@@ -406,6 +407,7 @@ export class RufflePlayer extends HTMLElement {
 
                 if ("url" in options) {
                     console.log("Loading SWF file " + options.url);
+                    this.swfUrl = new URL(options.url, document.location.href).href;
 
                     const parameters = {
                         ...sanitizeParameters(
@@ -726,6 +728,8 @@ export class RufflePlayer extends HTMLElement {
 
         errorText += "\n# Page Info\n";
         errorText += `Page URL: ${document.location.href}\n`;
+        if (this.swfUrl)
+            errorText += `SWF URL: ${this.swfUrl}\n`;
 
         errorText += "\n# Browser Info\n";
         errorText += `Useragent: ${window.navigator.userAgent}\n`;

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -744,8 +744,8 @@ export class RufflePlayer extends HTMLElement {
         errorText += `Built: %BUILD_DATE%\n`;
         errorText += `Commit: %COMMIT_HASH%\n`;
 
-        let issueTitle = `Ruffle Error on ${document.location.href}`;
-        let issueLink =
+        const issueTitle = `Ruffle Error on ${document.location.href}`;
+        const issueLink =
             "https://github.com/ruffle-rs/ruffle/issues/new?title=" +
             encodeURIComponent(issueTitle) +
             "&body=" +

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -407,7 +407,10 @@ export class RufflePlayer extends HTMLElement {
 
                 if ("url" in options) {
                     console.log("Loading SWF file " + options.url);
-                    this.swfUrl = new URL(options.url, document.location.href).href;
+                    this.swfUrl = new URL(
+                        options.url,
+                        document.location.href
+                    ).href;
 
                     const parameters = {
                         ...sanitizeParameters(
@@ -728,8 +731,7 @@ export class RufflePlayer extends HTMLElement {
 
         errorText += "\n# Page Info\n";
         errorText += `Page URL: ${document.location.href}\n`;
-        if (this.swfUrl)
-            errorText += `SWF URL: ${this.swfUrl}\n`;
+        if (this.swfUrl) errorText += `SWF URL: ${this.swfUrl}\n`;
 
         errorText += "\n# Browser Info\n";
         errorText += `Useragent: ${window.navigator.userAgent}\n`;
@@ -743,9 +745,11 @@ export class RufflePlayer extends HTMLElement {
         errorText += `Commit: %COMMIT_HASH%\n`;
 
         let issueTitle = `Ruffle Error on ${document.location.href}`;
-        let issueLink = "https://github.com/ruffle-rs/ruffle/issues/new?title="
-            + encodeURIComponent(issueTitle)
-            + "&body=" + encodeURIComponent(errorText);
+        let issueLink =
+            "https://github.com/ruffle-rs/ruffle/issues/new?title=" +
+            encodeURIComponent(issueTitle) +
+            "&body=" +
+            encodeURIComponent(errorText);
 
         // Clears out any existing content (ie play button or canvas) and replaces it with the error screen
         this.container.innerHTML = `

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -407,10 +407,14 @@ export class RufflePlayer extends HTMLElement {
 
                 if ("url" in options) {
                     console.log("Loading SWF file " + options.url);
-                    this.swfUrl = new URL(
-                        options.url,
-                        document.location.href
-                    ).href;
+                    try {
+                        this.swfUrl = new URL(
+                            options.url,
+                            document.location.href
+                        ).href;
+                    } catch {
+                        this.swfUrl = options.url;
+                    }
 
                     const parameters = {
                         ...sanitizeParameters(

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -709,6 +709,40 @@ export class RufflePlayer extends HTMLElement {
         }
         this.panicked = true;
 
+        let errorText = "# Error Info\n";
+
+        if (error instanceof Error) {
+            errorText += `Error name: ${error.name}\n`;
+            errorText += `Error message: ${error.message}\n`;
+            if (error.stack) {
+                errorText += `Error stack:\n\`\`\`\n${error.stack}\n\`\`\`\n`;
+            }
+        } else {
+            errorText += `Error: ${error}\n`;
+        }
+
+        errorText += "\n# Player Info\n";
+        errorText += this.debugPlayerInfo();
+
+        errorText += "\n# Page Info\n";
+        errorText += `Page URL: ${document.location.href}\n`;
+
+        errorText += "\n# Browser Info\n";
+        errorText += `Useragent: ${window.navigator.userAgent}\n`;
+        errorText += `OS: ${window.navigator.platform}\n`;
+
+        errorText += "\n# Ruffle Info\n";
+        errorText += `Version: %VERSION_NUMBER%\n`;
+        errorText += `Name: %VERSION_NAME%\n`;
+        errorText += `Channel: %VERSION_CHANNEL%\n`;
+        errorText += `Built: %BUILD_DATE%\n`;
+        errorText += `Commit: %COMMIT_HASH%\n`;
+
+        let issueTitle = `Ruffle Error on ${document.location.href}`;
+        let issueLink = "https://github.com/ruffle-rs/ruffle/issues/new?title="
+            + encodeURIComponent(issueTitle)
+            + "&body=" + encodeURIComponent(errorText);
+
         // Clears out any existing content (ie play button or canvas) and replaces it with the error screen
         this.container.innerHTML = `
             <div id="panic">
@@ -719,7 +753,7 @@ export class RufflePlayer extends HTMLElement {
                 </div>
                 <div id="panic-footer">
                     <ul>
-                        <li><a href="https://github.com/ruffle-rs/ruffle/issues/new">Report Bug</a></li>
+                        <li><a href=${issueLink}>Report Bug</a></li>
                         <li><a href="#" id="panic-view-details">View Error Details</a></li>
                     </ul>
                 </div>
@@ -728,35 +762,6 @@ export class RufflePlayer extends HTMLElement {
         (<HTMLLinkElement>(
             this.container.querySelector("#panic-view-details")
         )).onclick = () => {
-            let errorText = "# Error Info\n";
-
-            if (error instanceof Error) {
-                errorText += `Error name: ${error.name}\n`;
-                errorText += `Error message: ${error.message}\n`;
-                if (error.stack) {
-                    errorText += `Error stack:\n\`\`\`\n${error.stack}\n\`\`\`\n`;
-                }
-            } else {
-                errorText += `Error: ${error}\n`;
-            }
-
-            errorText += "\n# Player Info\n";
-            errorText += this.debugPlayerInfo();
-
-            errorText += "\n# Page Info\n";
-            errorText += `Page URL: ${document.location.href}\n`;
-
-            errorText += "\n# Browser Info\n";
-            errorText += `Useragent: ${window.navigator.userAgent}\n`;
-            errorText += `OS: ${window.navigator.platform}\n`;
-
-            errorText += "\n# Ruffle Info\n";
-            errorText += `Version: %VERSION_NUMBER%\n`;
-            errorText += `Name: %VERSION_NAME%\n`;
-            errorText += `Channel: %VERSION_CHANNEL%\n`;
-            errorText += `Built: %BUILD_DATE%\n`;
-            errorText += `Commit: %COMMIT_HASH%\n`;
-
             this.container.querySelector(
                 "#panic-body"
             )!.innerHTML = `<textarea>${errorText}</textarea>`;


### PR DESCRIPTION
This automatically fills in the issue report so that the user doesn't have to copy-paste the error details from Ruffle to GitHub. Closes #1753 

Let me know if there is a better Issue Title.

Also, it could be worth including a description from the user perhaps?

For example:
```
# Description

[Please explain what was happening when you encountered the error]
```