### PR TITLE
web: Fix extension and self-hosted builds conflicting with each other

### DIFF
--- a/web/packages/core/src/globals.d.ts
+++ b/web/packages/core/src/globals.d.ts
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/naming-convention:off */
 
 declare let __webpack_public_path__: string;
-declare let runtime_path: string;
+declare let ruffleRuntimePath: string;
 declare let __CHANNEL__: string;
 declare let __COMMIT_DATE__: string;

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -18,19 +18,19 @@ import { Ruffle } from "../pkg/ruffle_web";
  */
 async function fetchRuffle(): Promise<{ new (...args: any[]): Ruffle }> {
     try {
-        //If runtime_path is defined then we are executing inside the extension
-        //closure. In that case, we configure our local Webpack instance
-        __webpack_public_path__ = runtime_path + "dist/";
+        // If ruffleRuntimePath is defined then we are executing inside the extension
+        // closure. In that case, we configure our local Webpack instance.
+        __webpack_public_path__ = ruffleRuntimePath + "dist/";
     } catch (e) {
-        //Checking an undefined closure variable usually throws ReferencError,
-        //so we need to catch it here and continue onward.
+        // Checking an undefined closure variable usually throws ReferencError,
+        // so we need to catch it here and continue onward.
         if (!(e instanceof ReferenceError)) {
             throw e;
         }
     }
 
-    //We currently assume that if we are not executing inside the extension,
-    //then we can use webpack to get Ruffle.
+    // We currently assume that if we are not executing inside the extension,
+    // then we can use webpack to get Ruffle.
     const module = await import("../pkg/ruffle_web");
     return module.Ruffle;
 }

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -62,19 +62,15 @@ export class PublicAPI {
         this.conflict = null;
 
         if (prev !== undefined && prev !== null) {
-            if (
-                prev instanceof PublicAPI ||
-                ("version" in prev && prev.version == this.version)
-            ) {
+            if (prev instanceof PublicAPI) {
                 /// We're upgrading from a previous API to a new one.
-                const previous = <PublicAPI>prev;
-                this.sources = previous.sources;
-                this.config = previous.config;
-                this.invoked = previous.invoked;
-                this.conflict = previous.conflict;
-                this.newestName = previous.newestName;
+                this.sources = prev.sources;
+                this.config = prev.config;
+                this.invoked = prev.invoked;
+                this.conflict = prev.conflict;
+                this.newestName = prev.newestName;
 
-                previous.superseded();
+                prev.superseded();
             } else if (
                 prev.constructor === Object &&
                 prev.config instanceof Object
@@ -282,8 +278,8 @@ export class PublicAPI {
         sourceAPI: SourceAPI | undefined
     ): PublicAPI {
         let publicAPI: PublicAPI;
-        if (prevRuffle?.constructor.name === PublicAPI.name) {
-            publicAPI = <PublicAPI>prevRuffle;
+        if (prevRuffle instanceof PublicAPI) {
+            publicAPI = prevRuffle;
         } else {
             publicAPI = new PublicAPI(prevRuffle);
         }

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -33,7 +33,8 @@ export function publicPath(config: Config, source_name: string): string {
     } else if (
         document.currentScript !== undefined &&
         document.currentScript !== null &&
-        "src" in document.currentScript
+        "src" in document.currentScript &&
+        document.currentScript.src !== ""
     ) {
         // Default to the directory where this script resides.
         try {

--- a/web/packages/extension/.eslintrc.json
+++ b/web/packages/extension/.eslintrc.json
@@ -4,6 +4,6 @@
         "webextensions": true
     },
     "globals": {
-        "obfuscated_event_prefix": true
+        "obfuscatedEventPrefix": true
     }
 }

--- a/web/packages/extension/js/index.js
+++ b/web/packages/extension/js/index.js
@@ -7,20 +7,17 @@ window.RufflePlayer = PublicAPI.negotiate(
 );
 
 if (obfuscatedEventPrefix) {
-    document.addEventListener(
-        obfuscatedEventPrefix + "_request",
-        function (e) {
-            let body = JSON.parse(e.detail);
-            let response = {};
+    document.addEventListener(obfuscatedEventPrefix + "_request", function (e) {
+        let body = JSON.parse(e.detail);
+        let response = {};
 
-            if (body.action === "get_page_options") {
-                //response.page_options = page_options;
-            }
-
-            let event = new CustomEvent(obfuscatedEventPrefix + "_response", {
-                detail: JSON.stringify(response),
-            });
-            document.dispatchEvent(event);
+        if (body.action === "get_page_options") {
+            //response.page_options = page_options;
         }
-    );
+
+        let event = new CustomEvent(obfuscatedEventPrefix + "_response", {
+            detail: JSON.stringify(response),
+        });
+        document.dispatchEvent(event);
+    });
 }

--- a/web/packages/extension/js/index.js
+++ b/web/packages/extension/js/index.js
@@ -6,9 +6,9 @@ window.RufflePlayer = PublicAPI.negotiate(
     new SourceAPI("extension")
 );
 
-if (obfuscated_event_prefix) {
+if (obfuscatedEventPrefix) {
     document.addEventListener(
-        obfuscated_event_prefix + "_request",
+        obfuscatedEventPrefix + "_request",
         function (e) {
             let body = JSON.parse(e.detail);
             let response = {};
@@ -17,7 +17,7 @@ if (obfuscated_event_prefix) {
                 //response.page_options = page_options;
             }
 
-            let event = new CustomEvent(obfuscated_event_prefix + "_response", {
+            let event = new CustomEvent(obfuscatedEventPrefix + "_response", {
                 detail: JSON.stringify(response),
             });
             document.dispatchEvent(event);

--- a/web/packages/extension/js/lv0.js
+++ b/web/packages/extension/js/lv0.js
@@ -26,18 +26,18 @@ const {
 } = require("./util.js");
 
 get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
-    let page_optout = document.documentElement.hasAttribute(
+    let pageOptout = document.documentElement.hasAttribute(
         "data-ruffle-optout"
     );
     try {
         if (
-            !page_optout &&
+            !pageOptout &&
             window.top &&
             window.top.document &&
             window.top.document.documentElement
         ) {
             /* In case the opting out page uses iframes */
-            page_optout = window.top.document.documentElement.hasAttribute(
+            pageOptout = window.top.document.documentElement.hasAttribute(
                 "data-ruffle-optout"
             );
         }
@@ -45,28 +45,28 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
         console.log("Unable to check top-level optout: " + e.message);
     }
 
-    let should_load_untrusted_world = !(page_optout || window.RufflePlayer);
-    let obfuscated_event_prefix =
+    let shouldLoadUntrustedWorld = !(pageOptout || window.RufflePlayer);
+    let obfuscatedEventPrefix =
         "rufEvent" + Math.floor(Math.random() * 100000000000);
-    let next_response_promise = null;
-    let next_response_promise_resolve = null;
+    let nextResponsePromise = null;
+    let nextResponsePromiseResolve = null;
 
     if (data) {
-        should_load_untrusted_world =
+        shouldLoadUntrustedWorld =
             data.ruffle_enable &&
-            !((page_optout && !data.ignore_optout) || window.RufflePlayer);
+            !((pageOptout && !data.ignore_optout) || window.RufflePlayer);
     } else {
         console.log("Couldn't read settings.");
     }
 
     document.addEventListener(
-        obfuscated_event_prefix + "_response",
+        obfuscatedEventPrefix + "_response",
         function (e) {
-            if (next_response_promise_resolve !== null) {
-                next_response_promise_resolve(e);
+            if (nextResponsePromiseResolve !== null) {
+                nextResponsePromiseResolve(e);
 
-                next_response_promise = null;
-                next_response_promise_resolve = null;
+                nextResponsePromise = null;
+                nextResponsePromiseResolve = null;
             }
         }
     );
@@ -75,14 +75,14 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
      * Returns a promise which resolves the next time we receive our custom
      * event response.
      */
-    function next_response() {
-        if (next_response_promise == null) {
-            next_response_promise = new Promise(function (resolve) {
-                next_response_promise_resolve = resolve;
+    function nextResponse() {
+        if (nextResponsePromise == null) {
+            nextResponsePromise = new Promise(function (resolve) {
+                nextResponsePromiseResolve = resolve;
             });
         }
 
-        return next_response_promise;
+        return nextResponsePromise;
     }
 
     /**
@@ -95,29 +95,29 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
      * @param request The request data from the background/popup page
      * @returns Response data to reply to the sender with.
      */
-    async function marshal_message_into_untrusted_world(request) {
-        let req_event = new CustomEvent(obfuscated_event_prefix + "_request", {
+    async function marshalMessageIntoUntrustedWorld(request) {
+        let reqEvent = new CustomEvent(obfuscatedEventPrefix + "_request", {
             detail: JSON.stringify(request),
         });
-        let resp_event_handler = next_response();
+        let respEventHandler = nextResponse();
 
-        document.dispatchEvent(req_event);
+        document.dispatchEvent(reqEvent);
 
-        let resp_event = await resp_event_handler;
-        return JSON.parse(resp_event.detail);
+        let respEvent = await respEventHandler;
+        return JSON.parse(respEvent.detail);
     }
 
-    set_message_listener(function (request, sender, response_callback) {
-        if (should_load_untrusted_world) {
-            let response_promise = marshal_message_into_untrusted_world(
+    set_message_listener(function (request, sender, responseCallback) {
+        if (shouldLoadUntrustedWorld) {
+            let responsePromise = marshalMessageIntoUntrustedWorld(
                 request
             );
-            response_promise
+            responsePromise
                 .then(function (response) {
-                    response_callback({
+                    responseCallback({
                         loaded: true,
                         tab_settings: data,
-                        optout: page_optout,
+                        optout: pageOptout,
                         untrusted_response: response,
                     });
                 })
@@ -131,46 +131,46 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
 
             return true;
         } else {
-            response_callback({
+            responseCallback({
                 loaded: false,
                 tab_settings: data,
-                optout: page_optout,
+                optout: pageOptout,
             });
 
             return false;
         }
     });
 
-    const ext_path = get_extension_url();
+    const extPath = get_extension_url();
 
-    if (should_load_untrusted_world) {
+    if (shouldLoadUntrustedWorld) {
         // We must run the plugin polyfill before any flash detection scripts.
         // Unfortunately, this might still be too late for some websites when using Chrome (issue #969).
-        let polyfill_script = document.createElement("script");
-        polyfill_script.innerHTML =
+        let polyfillScript = document.createElement("script");
+        polyfillScript.innerHTML =
             '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
         (document.head || document.documentElement).appendChild(
-            polyfill_script
+            polyfillScript
         );
 
         // Load Ruffle script asynchronously. By doing so, we can inject extra variables and isolate them from the global scope.
         (async function () {
-            let ruffle_src_resp = await fetch(ext_path + "dist/ruffle.js");
-            if (ruffle_src_resp.ok) {
-                let ruffle_source =
+            let ruffleSrcResp = await fetch(extPath + "dist/ruffle.js");
+            if (ruffleSrcResp.ok) {
+                let ruffleSource =
                     '(function () { var ruffleRuntimePath = "' +
-                    ext_path +
-                    '";\nvar obfuscated_event_prefix = "' +
-                    obfuscated_event_prefix +
+                    extPath +
+                    '";\nvar obfuscatedEventPrefix = "' +
+                    obfuscatedEventPrefix +
                     '";\n' +
-                    (await ruffle_src_resp.text()) +
+                    (await ruffleSrcResp.text()) +
                     "}())";
-                let ruffle_script = document.createElement("script");
-                ruffle_script.appendChild(
-                    document.createTextNode(ruffle_source)
+                let ruffleScript = document.createElement("script");
+                ruffleScript.appendChild(
+                    document.createTextNode(ruffleSource)
                 );
                 (document.head || document.documentElement).appendChild(
-                    ruffle_script
+                    ruffleScript
                 );
             } else {
                 console.error("Critical error loading Ruffle into page");

--- a/web/packages/extension/js/lv0.js
+++ b/web/packages/extension/js/lv0.js
@@ -141,26 +141,40 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
         }
     });
 
-    let ext_path = get_extension_url();
+    const ext_path = get_extension_url();
 
     if (should_load_untrusted_world) {
-        let setup_scriptelem = document.createElement("script");
-        let setup_src =
-            'var runtime_path = "' +
-            ext_path +
-            '";\nvar obfuscated_event_prefix = "' +
-            obfuscated_event_prefix +
-            '";' +
+        // We must run the plugin polyfill before any flash detection scripts.
+        // Unfortunately, this might still be too late for some websites when using Chrome (issue #969).
+        let polyfill_script = document.createElement("script");
+        polyfill_script.innerHTML =
             '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
-        let scriptelem = document.createElement("script");
-        setup_scriptelem.innerHTML = setup_src;
-        /* The setup_scriptelem sets runtime_path & obfuscated_event_prefix *
-         * and runs the plugin polyfill, which must run before any flash    *
-         * detection scripts.                                               */
         (document.head || document.documentElement).appendChild(
-            setup_scriptelem
+            polyfill_script
         );
-        scriptelem.src = ext_path + "dist/ruffle.js";
-        (document.head || document.documentElement).appendChild(scriptelem);
+
+        // Load Ruffle script asynchronously. By doing so, we can inject extra variables and isolate them from the global scope.
+        (async function () {
+            let ruffle_src_resp = await fetch(ext_path + "dist/ruffle.js");
+            if (ruffle_src_resp.ok) {
+                let ruffle_source =
+                    '(function () { var ruffleRuntimePath = "' +
+                    ext_path +
+                    '";\nvar obfuscated_event_prefix = "' +
+                    obfuscated_event_prefix +
+                    '";\n' +
+                    (await ruffle_src_resp.text()) +
+                    "}())";
+                let ruffle_script = document.createElement("script");
+                ruffle_script.appendChild(
+                    document.createTextNode(ruffle_source)
+                );
+                (document.head || document.documentElement).appendChild(
+                    ruffle_script
+                );
+            } else {
+                console.error("Critical error loading Ruffle into page");
+            }
+        })();
     }
 });

--- a/web/packages/extension/js/lv0.js
+++ b/web/packages/extension/js/lv0.js
@@ -109,9 +109,7 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
 
     set_message_listener(function (request, sender, responseCallback) {
         if (shouldLoadUntrustedWorld) {
-            let responsePromise = marshalMessageIntoUntrustedWorld(
-                request
-            );
+            let responsePromise = marshalMessageIntoUntrustedWorld(request);
             responsePromise
                 .then(function (response) {
                     responseCallback({
@@ -149,9 +147,7 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
         let polyfillScript = document.createElement("script");
         polyfillScript.innerHTML =
             '(function(){class RuffleMimeType{constructor(a,b,c){this.type=a,this.description=b,this.suffixes=c}}class RuffleMimeTypeArray{constructor(a){this.__mimetypes=[],this.__named_mimetypes={};for(let b of a)this.install(b)}install(a){let b=this.__mimetypes.length;this.__mimetypes.push(a),this.__named_mimetypes[a.type]=a,this[a.type]=a,this[b]=a}item(a){return this.__mimetypes[a]}namedItem(a){return this.__named_mimetypes[a]}get length(){return this.__mimetypes.length}}class RufflePlugin extends RuffleMimeTypeArray{constructor(a,b,c,d){super(d),this.name=a,this.description=b,this.filename=c}install(a){a.enabledPlugin||(a.enabledPlugin=this),super.install(a)}}class RufflePluginArray{constructor(a){this.__plugins=[],this.__named_plugins={};for(let b of a)this.install(b)}install(a){let b=this.__plugins.length;this.__plugins.push(a),this.__named_plugins[a.name]=a,this[a.name]=a,this[b]=a}item(a){return this.__plugins[a]}namedItem(a){return this.__named_plugins[a]}get length(){return this.__plugins.length}}const FLASH_PLUGIN=new RufflePlugin("Shockwave Flash","Shockwave Flash 32.0 r0","ruffle.js",[new RuffleMimeType("application/futuresplash","Shockwave Flash","spl"),new RuffleMimeType("application/x-shockwave-flash","Shockwave Flash","swf"),new RuffleMimeType("application/x-shockwave-flash2-preview","Shockwave Flash","swf"),new RuffleMimeType("application/vnd.adobe.flash-movie","Shockwave Flash","swf")]);function install_plugin(a){navigator.plugins.install||Object.defineProperty(navigator,"plugins",{value:new RufflePluginArray(navigator.plugins),writable:!1}),navigator.plugins.install(a),0<a.length&&!navigator.mimeTypes.install&&Object.defineProperty(navigator,"mimeTypes",{value:new RuffleMimeTypeArray(navigator.mimeTypes),writable:!1});for(var b=0;b<a.length;b+=1)navigator.mimeTypes.install(a[b])}install_plugin(FLASH_PLUGIN);})();';
-        (document.head || document.documentElement).appendChild(
-            polyfillScript
-        );
+        (document.head || document.documentElement).appendChild(polyfillScript);
 
         // Load Ruffle script asynchronously. By doing so, we can inject extra variables and isolate them from the global scope.
         (async function () {
@@ -166,9 +162,7 @@ get_sync_storage(["ruffle_enable", "ignore_optout"], function (data) {
                     (await ruffleSrcResp.text()) +
                     "}())";
                 let ruffleScript = document.createElement("script");
-                ruffleScript.appendChild(
-                    document.createTextNode(ruffleSource)
-                );
+                ruffleScript.appendChild(document.createTextNode(ruffleSource));
                 (document.head || document.documentElement).appendChild(
                     ruffleScript
                 );


### PR DESCRIPTION
The web extension currently declares the `runtime_path` variable in the global scope (`extension/js/lv0.js`): this is causing self-hosted builds to be detected as the web extension, because the `fetchRuffle` function assumes that if this variable is set, then we are executing inside the extension (`core/src/load-ruffle.ts`).

- Ruffle script is now injected in an asynchronous function (lv0.js), restoring a previous behavior (https://github.com/ruffle-rs/ruffle/blob/42d724292fc09e7d139df4603963e4229b0983a1/web/extension/build/js/lv0.js). 
- `runtime_path` is renamed to `ruffleRuntimePath` to help preventing conflicts with external scripts.
- Some recent changes in `core/src/public-api.ts` have been reverted. For instance, `prevRuffle?.constructor.name === PublicAPI.name` wasn't checking the source names ("local" or "extension") but... the function names, so `PublicAPI.name` was just returning "PublicAPI" (actually a single letter because minification/obfuscation is enabled), so that didn't seem to help much unless I'm missing something. Also, the `conflict` property always remained `null`.


Should fix #1355, #1702 and #1948.
Also seems to fix #1311.