### PR TITLE
web/desktop: Add basic dialog handling (closes #1978)

### DIFF
--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -1,4 +1,5 @@
 pub mod audio;
+pub mod dialog;
 pub mod input;
 pub mod locale;
 pub mod log;

--- a/core/src/backend/dialog.rs
+++ b/core/src/backend/dialog.rs
@@ -1,0 +1,36 @@
+pub trait DialogBackend {
+    fn message(&self, message: &str);
+    fn yes_no(&self, message: &str) -> bool;
+    fn ok_cancel(&self, message: &str) -> bool;
+}
+
+/// DialogBackend that does mostly nothing
+///
+/// For tests, this backend will return true for question dialogs
+/// as positive responses are usually less disruptive.
+
+pub struct NullDialogBackend {}
+
+impl NullDialogBackend {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl DialogBackend for NullDialogBackend {
+    fn message(&self, _message: &str) {}
+
+    fn yes_no(&self, _message: &str) -> bool {
+        true
+    }
+
+    fn ok_cancel(&self, _message: &str) -> bool {
+        true
+    }
+}
+
+impl Default for NullDialogBackend {
+    fn default() -> Self {
+        NullDialogBackend::new()
+    }
+}

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -208,6 +208,7 @@ pub struct Player {
     self_reference: Option<Weak<Mutex<Self>>>,
 }
 
+#[allow(clippy::too_many_arguments)]
 impl Player {
     pub fn new(
         renderer: Renderer,

--- a/core/tests/regression_tests.rs
+++ b/core/tests/regression_tests.rs
@@ -3,6 +3,7 @@
 //! Trace output can be compared with correct output from the official Flash Payer.
 
 use approx::assert_relative_eq;
+use ruffle_core::backend::dialog::NullDialogBackend;
 use ruffle_core::backend::locale::NullLocaleBackend;
 use ruffle_core::backend::log::LogBackend;
 use ruffle_core::backend::navigator::{NullExecutor, NullNavigatorBackend};
@@ -674,6 +675,7 @@ fn run_swf(
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
         Box::new(TestLogBackend::new(trace_output.clone())),
+        Box::new(NullDialogBackend::new()),
     )?;
     player.lock().unwrap().set_root_movie(Arc::new(movie));
     player

--- a/desktop/src/dialog.rs
+++ b/desktop/src/dialog.rs
@@ -1,0 +1,49 @@
+use tinyfiledialogs::{
+    message_box_ok, message_box_ok_cancel, message_box_yes_no, MessageBoxIcon, OkCancel, YesNo,
+};
+
+use ruffle_core::backend::dialog::DialogBackend;
+
+pub struct DesktopDialogBackend {}
+
+impl DesktopDialogBackend {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl DialogBackend for DesktopDialogBackend {
+    fn message(&self, title: &str, message: &str) {
+        message_box_ok(title, message, MessageBoxIcon::Info)
+    }
+
+    fn yes_no(&self, message: &str) -> bool {
+        match message_box_yes_no(
+            "Confirm Dialog",
+            message,
+            MessageBoxIcon::Question,
+            YesNo::Yes,
+        ) {
+            YesNo::Yes => true,
+            YesNo::No => false,
+        }
+    }
+
+    fn ok_cancel(&self, message: &str) -> bool {
+        match message_box_ok_cancel(
+            "Confirm Dialog",
+            message,
+            MessageBoxIcon::Question,
+            OkCancel::Ok,
+        ) {
+            OkCancel::Ok => true,
+            OkCancel::Cancel => false,
+        }
+    }
+}
+
+impl Default for DesktopDialogBackend {
+    fn default() -> Self {
+        DesktopDialogBackend::new()
+    }
+}

--- a/desktop/src/dialog.rs
+++ b/desktop/src/dialog.rs
@@ -13,8 +13,8 @@ impl DesktopDialogBackend {
 }
 
 impl DialogBackend for DesktopDialogBackend {
-    fn message(&self, title: &str, message: &str) {
-        message_box_ok(title, message, MessageBoxIcon::Info)
+    fn message(&self, message: &str) {
+        message_box_ok("Message", message, MessageBoxIcon::Info)
     }
 
     fn yes_no(&self, message: &str) -> bool {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -2,6 +2,7 @@
 
 mod audio;
 mod custom_event;
+mod dialog;
 mod executor;
 mod input;
 mod locale;
@@ -222,6 +223,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or_default()
             .as_ref(),
     ));
+    let dialog = Box::new(dialog::DesktopDialogBackend::new());
     let locale = Box::new(locale::DesktopLocaleBackend::new());
     let player = Player::new(
         renderer,
@@ -231,6 +233,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         storage,
         locale,
         Box::new(NullLogBackend::new()),
+        dialog,
     )?;
     player.lock().unwrap().set_root_movie(Arc::new(movie));
     player.lock().unwrap().set_is_playing(true); // Desktop player will auto-play.

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -3,6 +3,7 @@ use futures::executor::block_on;
 use image::RgbaImage;
 use indicatif::{ProgressBar, ProgressStyle};
 use ruffle_core::backend::audio::NullAudioBackend;
+use ruffle_core::backend::dialog::NullDialogBackend;
 use ruffle_core::backend::input::NullInputBackend;
 use ruffle_core::backend::locale::NullLocaleBackend;
 use ruffle_core::backend::log::NullLogBackend;
@@ -111,6 +112,7 @@ fn take_screenshot(
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
         Box::new(NullLogBackend::new()),
+        Box::new(NullDialogBackend::new()),
     )?;
 
     player

--- a/web/src/dialog.rs
+++ b/web/src/dialog.rs
@@ -1,0 +1,38 @@
+use wasm_bindgen::prelude::*;
+
+use ruffle_core::backend::dialog::DialogBackend;
+
+#[wasm_bindgen]
+extern "C" {
+    fn alert(s: &str);
+
+    fn confirm(s: &str) -> bool;
+}
+
+impl WebDialogBackend {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+pub struct WebDialogBackend {}
+
+impl DialogBackend for WebDialogBackend {
+    fn message(&self, message: &str) {
+        alert(message);
+    }
+
+    fn yes_no(&self, message: &str) -> bool {
+        confirm(message)
+    }
+
+    fn ok_cancel(&self, message: &str) -> bool {
+        confirm(message)
+    }
+}
+
+impl Default for WebDialogBackend {
+    fn default() -> Self {
+        WebDialogBackend::new()
+    }
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use generational_arena::{Arena, Index};
 use js_sys::{Array, Function, Object, Uint8Array};
-use ruffle_core::backend::dialog::DialogBackend;
 use ruffle_core::backend::input::InputBackend;
 use ruffle_core::backend::render::RenderBackend;
 use ruffle_core::backend::storage::MemoryStorageBackend;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Ruffle web frontend.
 mod audio;
+mod dialog;
 mod input;
 mod locale;
 mod log_adapter;
@@ -16,6 +17,7 @@ use crate::{
 };
 use generational_arena::{Arena, Index};
 use js_sys::{Array, Function, Object, Uint8Array};
+use ruffle_core::backend::dialog::DialogBackend;
 use ruffle_core::backend::input::InputBackend;
 use ruffle_core::backend::render::RenderBackend;
 use ruffle_core::backend::storage::MemoryStorageBackend;
@@ -316,7 +318,7 @@ impl Ruffle {
 
         let trace_observer = Arc::new(RefCell::new(JsValue::UNDEFINED));
         let log = Box::new(WebLogBackend::new(trace_observer.clone()));
-
+        let dialog = Box::new(dialog::WebDialogBackend::new());
         let core = ruffle_core::Player::new(
             renderer,
             audio,
@@ -325,6 +327,7 @@ impl Ruffle {
             local_storage,
             locale,
             log,
+            dialog,
         )?;
 
         // Create instance.


### PR DESCRIPTION
Use built in dialogs for JS and system for now. We can use more complex UI later (and deal with the async in JS, and styling etc) if we want custom dialogs, but this at least offers something we can use immediately.

![image](https://user-images.githubusercontent.com/4811358/102268737-f6aafd00-3f1b-11eb-869e-060273932941.png)

![image](https://user-images.githubusercontent.com/4811358/102268771-ff033800-3f1b-11eb-8029-9a2a0a14732e.png)
