### PR TITLE
swf: Use lzma-rs for LZMA SWFs (fix #405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +798,15 @@ dependencies = [
  "thiserror",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
 ]
 
 [[package]]
@@ -2232,14 +2247,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzma-sys"
-version = "0.1.17"
+name = "lzma-rs"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+checksum = "adc181f57e3b64bb860c476fe5751eb6f60e9fcf588b1447e24c0757c1c3101f"
 dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -3844,10 +3858,10 @@ dependencies = [
  "flate2",
  "libflate 1.0.3",
  "log",
+ "lzma-rs",
  "num-derive",
  "num-traits",
  "smallvec 1.5.1",
- "xz2",
 ]
 
 [[package]]
@@ -4789,12 +4803,3 @@ name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
-
-[[package]]
-name = "xz2"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
-dependencies = [
- "lzma-sys",
-]

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -80,21 +80,10 @@ impl SwfMovie {
         // Sometimes SWFs will have an incorrectly compressed stream,
         // but will otherwise decompress fine up to the End tag.
         // So just warn on this case and try to continue gracefully.
-        let data = if header.compression == swf::Compression::Lzma {
-            // TODO: The LZMA decoder is still funky.
-            // It always errors, and doesn't return all the data if you use read_to_end,
-            // but read_exact at least returns the data... why?
-            // Does the decoder need to be flushed somehow?
-            let mut data = vec![0u8; swf_stream.uncompressed_length];
-            let _ = reader.get_mut().read_exact(&mut data);
-            data
-        } else {
-            let mut data = Vec::with_capacity(swf_stream.uncompressed_length);
-            if let Err(e) = reader.get_mut().read_to_end(&mut data) {
-                return Err(format!("Error decompressing SWF, may be corrupt: {}", e).into());
-            }
-            data
-        };
+        let mut data = Vec::with_capacity(swf_stream.uncompressed_length);
+        if let Err(e) = reader.get_mut().read_to_end(&mut data) {
+            return Err(format!("Error decompressing SWF, may be corrupt: {}", e).into());
+        }
 
         Ok(Self {
             header,

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -18,11 +18,11 @@ libflate = {version = "1.0", optional = true}
 log = "0.4"
 smallvec = "1.5.1"
 flate2 = {version = "1.0", optional = true}
-xz2 = {version = "0.1.6", optional = true}
+lzma-rs = {version = "0.1.3", optional = true }
 
 [dev-dependencies]
 approx = "0.4.0"
 
 [features]
-default = ["flate2"]
-lzma = ["xz2"]
+default = ["flate2", "lzma"]
+lzma = ["lzma-rs"]

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -16,8 +16,6 @@ extern crate libflate;
 #[macro_use]
 extern crate num_derive;
 extern crate num_traits;
-#[cfg(feature = "lzma")]
-extern crate xz2;
 
 pub mod avm1;
 pub mod avm2;


### PR DESCRIPTION
Pure Rust decoder that functions on desktop and wasm (thanks to @gendx!)
Enable lzma feature by default.

TODO: Switch to lzma-rs streaming API when stable on crates.io.
Currently decodes entire stream at once.