### PR TITLE
core: Move device font to Library (fix #1995)

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -405,7 +405,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         if let Some(font) = library
             .get_font_by_name(&span.font, span.bold, span.italic)
             .filter(|f| !is_device_font && f.has_glyphs())
-            .or_else(|| library.device_font())
+            .or_else(|| context.library.device_font())
         {
             self.font = Some(font);
             return self.font;
@@ -463,7 +463,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         if let Some(bullet_font) = library
             .get_font_by_name(&span.font, span.bold, span.italic)
             .filter(|f| f.has_glyphs())
-            .or_else(|| library.device_font())
+            .or_else(|| context.library.device_font())
             .or(self.font)
         {
             let mut bullet_cursor = self.cursor;

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -23,7 +23,6 @@ pub struct MovieLibrary<'gc> {
     characters: HashMap<CharacterId, Character<'gc>>,
     export_characters: PropertyMap<Character<'gc>>,
     jpeg_tables: Option<Vec<u8>>,
-    device_font: Option<Font<'gc>>,
     fonts: HashMap<FontDescriptor, Font<'gc>>,
     avm_type: AvmType,
     avm2_domain: Option<Avm2Domain<'gc>>,
@@ -35,7 +34,6 @@ impl<'gc> MovieLibrary<'gc> {
             characters: HashMap::new(),
             export_characters: PropertyMap::new(),
             jpeg_tables: None,
-            device_font: None,
             fonts: HashMap::new(),
             avm_type,
             avm2_domain: None,
@@ -193,16 +191,6 @@ impl<'gc> MovieLibrary<'gc> {
         self.jpeg_tables.as_ref().map(|data| &data[..])
     }
 
-    /// Returns the device font for use when a font is unavailable.
-    pub fn device_font(&self) -> Option<Font<'gc>> {
-        self.device_font
-    }
-
-    /// Sets the device font.
-    pub fn set_device_font(&mut self, font: Option<Font<'gc>>) {
-        self.device_font = font;
-    }
-
     /// Check if the current movie's VM type is compatible with running code on
     /// a particular VM. If it is not, then this yields an error.
     pub fn check_avm_type(&mut self, new_type: AvmType) -> Result<(), Error> {
@@ -243,6 +231,9 @@ impl<'gc> MovieLibrary<'gc> {
 pub struct Library<'gc> {
     /// All the movie libraries.
     movie_libraries: PtrWeakKeyHashMap<Weak<SwfMovie>, MovieLibrary<'gc>>,
+
+    /// The embedded device font.
+    device_font: Option<Font<'gc>>,
 }
 
 unsafe impl<'gc> gc_arena::Collect for Library<'gc> {
@@ -251,6 +242,7 @@ unsafe impl<'gc> gc_arena::Collect for Library<'gc> {
         for (_, val) in self.movie_libraries.iter() {
             val.trace(cc);
         }
+        self.device_font.trace(cc);
     }
 }
 
@@ -290,12 +282,23 @@ impl<'gc> Library<'gc> {
 
         self.movie_libraries.get_mut(&movie).unwrap()
     }
+
+    /// Returns the device font for use when a font is unavailable.
+    pub fn device_font(&self) -> Option<Font<'gc>> {
+        self.device_font
+    }
+
+    /// Sets the device font.
+    pub fn set_device_font(&mut self, font: Option<Font<'gc>>) {
+        self.device_font = font;
+    }
 }
 
 impl<'gc> Default for Library<'gc> {
     fn default() -> Self {
         Self {
             movie_libraries: PtrWeakKeyHashMap::new(),
+            device_font: None,
         }
     }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -391,10 +391,7 @@ impl Player {
                     }
                 };
 
-            context
-                .library
-                .library_for_movie_mut(context.swf.clone())
-                .set_device_font(device_font);
+            context.library.set_device_font(device_font);
 
             // Set the version parameter on the root.
             let mut activation = Activation::from_stub(


### PR DESCRIPTION
Move device font from Library to MovieLibrary since it should be global to the player. This allows the device font to work correctly when a movie loads other SWFs. Fixes #1995.