### PR TITLE
web: Prevent crashes caused by external libraries

### DIFF
--- a/web/packages/core/src/js-polyfills.ts
+++ b/web/packages/core/src/js-polyfills.ts
@@ -1,0 +1,53 @@
+/* eslint @typescript-eslint/no-explicit-any: "off" */
+
+/**
+ * Polyfills the `Array.prototype.reduce` method.
+ *
+ * Production steps of ECMA-262, Edition 5, 15.4.4.21
+ * Reference: https://es5.github.io/#x15.4.4.21
+ * https://tc39.github.io/ecma262/#sec-array.prototype.reduce
+ *
+ */
+export function setArrayPrototypeReduce(): void {
+    Object.defineProperty(Array.prototype, "reduce", {
+        value: function (...args: any) {
+            const callback = args[0];
+            if (this === null) {
+                throw new TypeError(
+                    "Array.prototype.reduce called on null or undefined"
+                );
+            }
+            if (typeof callback !== "function") {
+                throw new TypeError(`${callback} is not a function`);
+            }
+
+            const o = Object(this);
+            const len = o.length >>> 0;
+            let k = 0;
+            let value;
+
+            if (args.length >= 2) {
+                value = args[1];
+            } else {
+                while (k < len && !(k in o)) {
+                    k++;
+                }
+                if (k >= len) {
+                    throw new TypeError(
+                        "Reduce of empty array with no initial value"
+                    );
+                }
+                value = o[k++];
+            }
+
+            while (k < len) {
+                if (k in o) {
+                    value = callback(value, o[k], k, o);
+                }
+                k++;
+            }
+
+            return value;
+        },
+    });
+}


### PR DESCRIPTION
Some libraries (especially `prototype.js`) overrides the `Array.prototype.reduce` method in a way that doesn't match the specification, causing Webpack to crash. This PR adds code to override the method again and prevent issues. The polyfill used is from the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce#Polyfill).

Fixes #1507, #1630, #1830, #1865, #2011, #2042, #2049 (lots of duplicates here, they're almost all related to `prototype.js`).