### PR TITLE
web: Update polyfill to maintain compatibility with prototype.js

### DIFF
--- a/web/packages/core/src/js-polyfills.ts
+++ b/web/packages/core/src/js-polyfills.ts
@@ -1,5 +1,11 @@
 /* eslint @typescript-eslint/no-explicit-any: "off" */
 
+declare global {
+    interface Window {
+        Prototype?: any;
+    }
+}
+
 /**
  * Polyfills the `Array.prototype.reduce` method.
  *
@@ -8,9 +14,19 @@
  * https://tc39.github.io/ecma262/#sec-array.prototype.reduce
  *
  */
-export function setArrayPrototypeReduce(): void {
+export function setArrayPrototypeReduce(): any {
     Object.defineProperty(Array.prototype, "reduce", {
         value: function (...args: any) {
+            if (
+                args.length === 0 &&
+                window.Prototype &&
+                window.Prototype.Version &&
+                window.Prototype.Version < "1.6.1"
+            ) {
+                // Off-spec: compatibility with prototype.js
+                return this.length > 1 ? this : this[0];
+            }
+
             const callback = args[0];
             if (this === null) {
                 throw new TypeError(


### PR DESCRIPTION
Following https://github.com/ruffle-rs/ruffle/pull/2051#issuecomment-748685349, let's add a special case to the `Array.prototype.reduce` polyfill to maintain compatibility with `prototype.js`. The previous PR didn't break anything on the known affected sites, as these sites use versions where the `reduce` method is defined but not used anywhere. However, [an older version of the library](http://prototypejs.org/assets/2007/1/18/prototype.js) uses the method in another function, which has the potential to break things. This can also prevent issues with user-defined code.