### PR TITLE
core: Use movie URL for SharedObject path

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -214,14 +214,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         opt.upgrade_to_https,
     )); //TODO: actually implement this backend type
     let input = Box::new(input::WinitInputBackend::new(window.clone()));
-    let storage = Box::new(DiskStorageBackend::new(
-        movie_url
-            .to_file_path()
-            .unwrap_or_default()
-            .file_name()
-            .unwrap_or_default()
-            .as_ref(),
-    ));
+    let storage = Box::new(DiskStorageBackend::new());
     let locale = Box::new(locale::DesktopLocaleBackend::new());
     let player = Player::new(
         renderer,

--- a/desktop/src/storage.rs
+++ b/desktop/src/storage.rs
@@ -9,11 +9,8 @@ pub struct DiskStorageBackend {
 }
 
 impl DiskStorageBackend {
-    pub fn new(scope: &Path) -> Self {
-        let base_path = dirs::data_local_dir()
-            .unwrap()
-            .join(Path::new("ruffle"))
-            .join(scope);
+    pub fn new() -> Self {
+        let base_path = dirs::data_local_dir().unwrap().join(Path::new("ruffle"));
 
         // Create a base dir if one doesn't exist yet
         if !base_path.exists() {
@@ -50,6 +47,14 @@ impl StorageBackend for DiskStorageBackend {
 
     fn put_string(&mut self, name: &str, value: String) -> bool {
         let full_path = self.base_path.join(Path::new(name));
+        if let Some(parent_dir) = full_path.parent() {
+            if !parent_dir.exists() {
+                if let Err(r) = fs::create_dir_all(&parent_dir) {
+                    log::warn!("Unable to create storage dir {}", r);
+                    return false;
+                }
+            }
+        }
 
         match File::create(full_path) {
             Ok(mut file) => {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -302,12 +302,8 @@ impl Ruffle {
         let input = Box::new(WebInputBackend::new(&canvas));
         let locale = Box::new(WebLocaleBackend::new());
 
-        let current_domain = window.location().href().unwrap();
-
         let local_storage = match window.local_storage() {
-            Ok(Some(s)) => {
-                Box::new(LocalStorageBackend::new(s, current_domain)) as Box<dyn StorageBackend>
-            }
+            Ok(Some(s)) => Box::new(LocalStorageBackend::new(s)) as Box<dyn StorageBackend>,
             err => {
                 log::warn!("Unable to use localStorage: {:?}\nData will not save.", err);
                 Box::new(MemoryStorageBackend::default())

--- a/web/src/storage.rs
+++ b/web/src/storage.rs
@@ -3,29 +3,24 @@ use web_sys::Storage;
 
 pub struct LocalStorageBackend {
     storage: Storage,
-    prefix: String,
 }
 
 impl LocalStorageBackend {
-    pub(crate) fn new(storage: Storage, prefix: String) -> Self {
-        LocalStorageBackend { storage, prefix }
+    pub(crate) fn new(storage: Storage) -> Self {
+        LocalStorageBackend { storage }
     }
 }
 
 impl StorageBackend for LocalStorageBackend {
     fn get_string(&self, name: &str) -> Option<String> {
-        self.storage
-            .get(&format!("{}-{}", self.prefix, name))
-            .unwrap_or_default()
+        self.storage.get(name).unwrap_or_default()
     }
 
     fn put_string(&mut self, name: &str, value: String) -> bool {
-        self.storage
-            .set(&format!("{}-{}", self.prefix, name), &value)
-            .is_ok()
+        self.storage.set(name, &value).is_ok()
     }
 
     fn remove_key(&mut self, name: &str) {
-        let _ = self.storage.delete(&format!("{}-{}", self.prefix, name));
+        let _ = self.storage.delete(name);
     }
 }


### PR DESCRIPTION
On web, SharedObjects were being keyed by the website URL; however, this was causing issues both with query parameters (#855, #2046) and with loaded movies. In the Flash Player, SharedObjects are keyed by the SWF's URL.

Switch to using the SWF's URL, and implement the localPath and secure parameters in `SharedObject.getLocal`. By default, the full SWF path is used, but supplying a local path allows you to make the SharedObject accessible to more paths on the same domain (for example, a local path of `/` will allow the object to be accessible by all SWFs on the same domain).

This also affects storage on desktop; for example, data from a local SWF is now stored in `userdata/ruffle/localhost/path/to/file.swf/sharedObjectName`. This should more closely match the Flash Player (compare the Flash Player shared object directory on Windows: `AppData\Roaming\Macromedia\Flash Player\#SharedObjects`)

This change will invalidate any current SharedObject saved data.
Fix #379, #855.