### PR TITLE
core: TextField selection fixes

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -773,7 +773,7 @@ impl<'gc> EditText<'gc> {
                 font.get_baseline_for_height(params.height()) - params.height();
             font.evaluate(
                 text,
-                self.text_transform(color, baseline_adjustmnet),
+                self.text_transform(color.clone(), baseline_adjustmnet),
                 params,
                 |pos, transform, glyph: &Glyph, advance, x| {
                     // If it's highlighted, override the color.
@@ -817,9 +817,7 @@ impl<'gc> EditText<'gc> {
                                     x + Twips::from_pixels(-1.0),
                                     Twips::from_pixels(2.0),
                                 );
-                            context
-                                .renderer
-                                .draw_rect(Color::from_rgb(0x000000, 0xFF), &caret);
+                            context.renderer.draw_rect(color.clone(), &caret);
                         } else if pos == length - 1 && caret_pos == length {
                             let caret = context.transform_stack.transform().matrix
                                 * Matrix::create_box(
@@ -829,9 +827,7 @@ impl<'gc> EditText<'gc> {
                                     x + advance,
                                     Twips::from_pixels(2.0),
                                 );
-                            context
-                                .renderer
-                                .draw_rect(Color::from_rgb(0x000000, 0xFF), &caret);
+                            context.renderer.draw_rect(color.clone(), &caret);
                         }
                     }
                 },

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1447,15 +1447,29 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
                     let text = edit_text.text_spans.text();
                     let length = text.len();
                     match key_code {
-                        ButtonKeyCode::Left if selection.to > 0 => {
-                            selection.to = string_utils::prev_char_boundary(text, selection.to);
-                            if !context.input.is_key_down(KeyCode::Shift) {
+                        ButtonKeyCode::Left => {
+                            if (context.input.is_key_down(KeyCode::Shift) || selection.is_caret())
+                                && selection.to > 0
+                            {
+                                selection.to = string_utils::prev_char_boundary(text, selection.to);
+                                if !context.input.is_key_down(KeyCode::Shift) {
+                                    selection.from = selection.to;
+                                }
+                            } else if !context.input.is_key_down(KeyCode::Shift) {
+                                selection.to = selection.start();
                                 selection.from = selection.to;
                             }
                         }
-                        ButtonKeyCode::Right if selection.to < length => {
-                            selection.to = string_utils::next_char_boundary(text, selection.to);
-                            if !context.input.is_key_down(KeyCode::Shift) {
+                        ButtonKeyCode::Right => {
+                            if (context.input.is_key_down(KeyCode::Shift) || selection.is_caret())
+                                && selection.to < length
+                            {
+                                selection.to = string_utils::next_char_boundary(text, selection.to);
+                                if !context.input.is_key_down(KeyCode::Shift) {
+                                    selection.from = selection.to;
+                                }
+                            } else if !context.input.is_key_down(KeyCode::Shift) {
+                                selection.to = selection.end();
                                 selection.from = selection.to;
                             }
                         }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -762,6 +762,12 @@ impl<'gc> EditText<'gc> {
             None
         };
 
+        let start = if let LayoutContent::Text { start, .. } = &lbox.content() {
+            *start
+        } else {
+            0
+        };
+
         // If the font can't be found or has no glyph information, use the "device font" instead.
         // We're cheating a bit and not actually rendering text using the OS/web.
         // Instead, we embed an SWF version of Noto Sans to use as the "device font", and render
@@ -778,7 +784,7 @@ impl<'gc> EditText<'gc> {
                 |pos, transform, glyph: &Glyph, advance, x| {
                     // If it's highlighted, override the color.
                     match selection {
-                        Some(selection) if selection.contains(pos) => {
+                        Some(selection) if selection.contains(start + pos) => {
                             // Draw black selection rect
                             let selection_box = context.transform_stack.transform().matrix
                                 * Matrix::create_box(

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -777,23 +777,34 @@ impl<'gc> EditText<'gc> {
                 params,
                 |pos, transform, glyph: &Glyph, advance, x| {
                     // If it's highlighted, override the color.
-                    // TODO: We should draw a black background and change the color to white,
-                    //  but for now let's just change it to be slightly different colour.
                     match selection {
                         Some(selection) if selection.contains(pos) => {
+                            // Draw black selection rect
+                            let selection_box = context.transform_stack.transform().matrix
+                                * Matrix::create_box(
+                                    advance.to_pixels() as f32,
+                                    params.height().to_pixels() as f32,
+                                    0.0,
+                                    x + Twips::from_pixels(-1.0),
+                                    Twips::from_pixels(2.0),
+                                );
+                            context
+                                .renderer
+                                .draw_rect(Color::from_rgb(0x000000, 0xFF), &selection_box);
+
+                            // Set text color to white
                             context.transform_stack.push(&Transform {
                                 matrix: transform.matrix,
-                                color_transform: transform.color_transform
-                                    * ColorTransform {
-                                        r_mult: 0.75,
-                                        g_mult: 0.75,
-                                        b_mult: 0.75,
-                                        a_mult: 1.0,
-                                        r_add: 0.0,
-                                        g_add: 0.0,
-                                        b_add: 1.0,
-                                        a_add: 0.0,
-                                    },
+                                color_transform: ColorTransform {
+                                    r_mult: 1.0,
+                                    g_mult: 1.0,
+                                    b_mult: 1.0,
+                                    a_mult: 1.0,
+                                    r_add: 0.0,
+                                    g_add: 0.0,
+                                    b_add: 0.0,
+                                    a_add: 0.0,
+                                },
                             });
                         }
                         _ => {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -769,11 +769,11 @@ impl<'gc> EditText<'gc> {
         if let Some((text, _tf, font, params, color)) =
             lbox.as_renderable_text(edit_text.text_spans.text())
         {
-            let baseline_adjustmnet =
+            let baseline_adjustment =
                 font.get_baseline_for_height(params.height()) - params.height();
             font.evaluate(
                 text,
-                self.text_transform(color.clone(), baseline_adjustmnet),
+                self.text_transform(color.clone(), baseline_adjustment),
                 params,
                 |pos, transform, glyph: &Glyph, advance, x| {
                     // If it's highlighted, override the color.


### PR DESCRIPTION
This pr makes a number of changes related to the selection of text in TextFields:

- 6f3251a4e7ec3673b6d4706295a387994b5cbcce changes the caret color to match the text color.
- 4aa535f0b95d4c8618660d630aafef61d9f9b295 renders a selection as white text with black background.
- d4e5a1f4b1e744e8156a9329e07db55a050ec371 fixes a spelling mistake ("adjustmnet" -> "adjustment").
- eaa3533e7872c43eb207c51604d31017cbf34be4 changes the behaviour of pressing left <kbd>&#8592;</kbd> or right <kbd>&#8594;</kbd> when there is text selected. Previously, if `4..6` was selected, pressing left would move to `3` instead of correctly moving to `4`.
- e70478ecc5c63077df7e3a4866ebf3916de86e64 fixes a bug with the selection when text is split across multiple lines.

Note that the height of the selection box (and the caret) is still slightly off from what it is in Flash. This is not fixed in this PR. I think that the size of the selection box is somehow related to the height of the glyphs (which I guess is different from `params.height()` where `params` returned from `LayoutBox::as_renderable_text()`). I will have to look into this more.

I have attached a test .swf (with its .fla):
[selection_testing.zip](https://github.com/ruffle-rs/ruffle/files/5740202/selection_testing.zip)

