### PR TITLE
core: Implement TextField control characters

### DIFF
--- a/core/src/backend/input.rs
+++ b/core/src/backend/input.rs
@@ -17,6 +17,9 @@ pub trait InputBackend: Downcast {
     /// Changes the mouse cursor image.
     fn set_mouse_cursor(&mut self, cursor: MouseCursor);
 
+    /// Get the clipboard content
+    fn clipboard_content(&mut self) -> String;
+
     /// Set the clipboard to the given content
     fn set_clipboard_content(&mut self, content: String);
 }
@@ -53,6 +56,10 @@ impl InputBackend for NullInputBackend {
     fn show_mouse(&mut self) {}
 
     fn set_mouse_cursor(&mut self, _cursor: MouseCursor) {}
+
+    fn clipboard_content(&mut self) -> String {
+        "".to_string()
+    }
 
     fn set_clipboard_content(&mut self, _content: String) {}
 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -5,7 +5,7 @@ use crate::backend::input::MouseCursor;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::drawing::Drawing;
-use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode};
+use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, TextControlCode};
 use crate::font::{round_down_to_pixel, Glyph};
 use crate::html::{BoxBounds, FormatSpans, LayoutBox, LayoutContent, TextFormat};
 use crate::prelude::*;
@@ -1054,6 +1054,87 @@ impl<'gc> EditText<'gc> {
         }
 
         None
+    }
+
+    pub fn text_control_input(
+        self,
+        control_code: TextControlCode,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+    ) {
+        if !self.0.read().is_editable && control_code.is_edit_input() {
+            return;
+        }
+
+        if let Some(selection) = self.selection() {
+            let mut changed = false;
+            let is_selectable = self.0.read().is_selectable;
+            match control_code {
+                TextControlCode::SelectAll => {
+                    if is_selectable {
+                        self.set_selection(
+                            Some(TextSelection::for_range(0, self.text().len())),
+                            context.gc_context,
+                        );
+                    }
+                }
+                TextControlCode::Copy => {
+                    if !selection.is_caret() {
+                        let text = &self.text()[selection.start()..selection.end()];
+                        context.input.set_clipboard_content(text.to_string());
+                    }
+                }
+                TextControlCode::Paste => {
+                    let text = &context.input.clipboard_content();
+                    self.replace_text(selection.start(), selection.end(), text, context);
+                    let new_start = selection.start() + text.len();
+                    if is_selectable {
+                        self.set_selection(
+                            Some(TextSelection::for_position(new_start)),
+                            context.gc_context,
+                        );
+                    } else {
+                        self.set_selection(
+                            Some(TextSelection::for_position(self.text().len())),
+                            context.gc_context,
+                        );
+                    }
+                    changed = true;
+                }
+                TextControlCode::Cut => {
+                    if !selection.is_caret() {
+                        let text = &self.text()[selection.start()..selection.end()];
+                        context.input.set_clipboard_content(text.to_string());
+
+                        self.replace_text(selection.start(), selection.end(), "", context);
+                        if is_selectable {
+                            self.set_selection(
+                                Some(TextSelection::for_position(selection.start())),
+                                context.gc_context,
+                            );
+                        } else {
+                            self.set_selection(
+                                Some(TextSelection::for_position(self.text().len())),
+                                context.gc_context,
+                            );
+                        }
+                        changed = true;
+                    }
+                }
+                _ => {}
+            }
+            if changed {
+                let globals = context.avm1.global_object_cell();
+                let swf_version = context.swf.header().version;
+                let mut activation = Activation::from_nothing(
+                    context.reborrow(),
+                    ActivationIdentifier::root("[Propagate Text Binding]"),
+                    swf_version,
+                    globals,
+                    self.into(),
+                );
+                self.propagate_text_binding(&mut activation);
+            }
+        }
     }
 
     pub fn text_input(self, character: char, context: &mut UpdateContext<'_, 'gc, '_>) {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -11,6 +11,7 @@ pub enum PlayerEvent {
     MouseLeft,
     MouseWheel { delta: MouseWheelDelta },
     TextInput { codepoint: char },
+    TextControl { code: TextControlCode },
 }
 
 /// The distance scrolled by the mouse wheel.
@@ -134,6 +135,29 @@ impl ClipEvent {
             ClipEvent::ReleaseOutside => Some("onReleaseOutside"),
             ClipEvent::Unload => Some("onUnload"),
         }
+    }
+}
+
+/// Control inputs to a text field
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TextControlCode {
+    // TODO: Extend this
+    SelectAll,
+    Copy,
+    Paste,
+    Cut,
+    Backspace,
+    Enter,
+    Delete,
+}
+
+impl TextControlCode {
+    /// Indicates whether this is an event that edits the text content
+    pub fn is_edit_input(self) -> bool {
+        matches!(
+            self,
+            Self::Paste | Self::Cut | Self::Backspace | Self::Enter | Self::Delete
+        )
     }
 }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -689,6 +689,14 @@ impl Player {
             });
         }
 
+        if let PlayerEvent::TextControl { code } = event {
+            self.mutate_with_update_context(|context| {
+                if let Some(text) = context.focus_tracker.get().and_then(|o| o.as_edit_text()) {
+                    text.text_control_input(code, context);
+                }
+            });
+        }
+
         // Propagate clip events.
         self.mutate_with_update_context(|context| {
             let (clip_event, listener) = match event {

--- a/desktop/src/input.rs
+++ b/desktop/src/input.rs
@@ -212,6 +212,12 @@ impl InputBackend for WinitInputBackend {
         self.window.set_cursor_icon(icon);
     }
 
+    fn clipboard_content(&mut self) -> String {
+        self.clipboard
+            .get_contents()
+            .unwrap_or_else(|_| "".to_string())
+    }
+
     fn set_clipboard_content(&mut self, content: String) {
         self.clipboard.set_contents(content).unwrap();
     }

--- a/desktop/src/input.rs
+++ b/desktop/src/input.rs
@@ -484,6 +484,10 @@ fn winit_to_ruffle_text_control(
             _ => None,
         }
     } else {
-        None
+        match key {
+            VirtualKeyCode::Back => Some(TextControlCode::Backspace),
+            VirtualKeyCode::Delete => Some(TextControlCode::Delete),
+            _ => None,
+        }
     }
 }

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -195,6 +195,11 @@ impl InputBackend for WebInputBackend {
         self.update_mouse_cursor();
     }
 
+    fn clipboard_content(&mut self) -> String {
+        log::warn!("get clipboard not implemented");
+        "".to_string()
+    }
+
     fn set_clipboard_content(&mut self, _content: String) {
         log::warn!("set clipboard not implemented");
     }

--- a/web/src/input.rs
+++ b/web/src/input.rs
@@ -359,7 +359,10 @@ pub fn web_to_text_control(key: &str, ctrl_key: bool) -> Option<TextControlCode>
             None
         }
     } else {
-        // TODO: Check for special characters.
-        None
+        match key {
+            "Delete" => Some(TextControlCode::Delete),
+            "Backspace" => Some(TextControlCode::Backspace),
+            _ => None,
+        }
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -730,13 +730,17 @@ impl Ruffle {
 
                                 let key_code = input.last_key_code();
                                 let key_char = input.last_key_char();
+                                let text_control = input.last_text_control();
 
-                                if key_code != KeyCode::Unknown {
-                                    core.handle_event(PlayerEvent::KeyDown { key_code });
-                                }
-
-                                if let Some(codepoint) = key_char {
-                                    core.handle_event(PlayerEvent::TextInput { codepoint });
+                                if let Some(code) = text_control {
+                                    core.handle_event(PlayerEvent::TextControl { code });
+                                } else {
+                                    if key_code != KeyCode::Unknown {
+                                        core.handle_event(PlayerEvent::KeyDown { key_code });
+                                    }
+                                    if let Some(codepoint) = key_char {
+                                        core.handle_event(PlayerEvent::TextInput { codepoint });
+                                    }
                                 }
 
                                 js_event.prevent_default();


### PR DESCRIPTION
This pr implements some control character handling for text fields (eg CtrlC, CtrlV).

I'm submitting this as a draft to make sure that I'm going about this the right way.

## TODO

- [ ] - <kbd>Up</kbd>, <kbd>Down</kbd> - Should move caret between lines
- [ ] - <kbd>Home</kbd>, <kbd>End</kbd> - Should go to the start/end of the line
- [ ] - <kbd>Ctrl+Left</kbd>, <kbd>Ctrl+Right</kbd> - Should go to the start/end of the previous/next word

