### PR TITLE
exporter: Fix panic when using --frames (fix #1614)

### DIFF
--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -171,7 +171,10 @@ impl TextureTarget {
                 }
 
                 let bgra = BgraImage::from_raw(self.size.width, self.size.height, buffer);
-                bgra.map(|image| image.convert())
+                let ret = bgra.map(|image| image.convert());
+                drop(map);
+                self.buffer.unmap();
+                ret
             }
             Err(e) => {
                 log::error!("Unknown error reading capture buffer: {:?}", e);


### PR DESCRIPTION
Unmap buffer to prevent panic when capturing frame.