### PR TITLE
core: onKeyUp/Down method handlers fire only if clip has focus (fix #2120)

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2056,15 +2056,18 @@ impl<'gc> MovieClipData<'gc> {
                 // (e.g., clip.onEnterFrame = foo).
                 if context.swf.version() >= 6 {
                     if let Some(name) = event.method_name() {
-                        context.action_queue.queue_actions(
-                            self_display_object,
-                            ActionType::Method {
-                                object,
-                                name,
-                                args: vec![],
-                            },
-                            event == ClipEvent::Unload,
-                        );
+                        // Keyboard events don't fire their methods unless the movieclip has focus (#2120).
+                        if !event.is_key_event() || self.has_focus {
+                            context.action_queue.queue_actions(
+                                self_display_object,
+                                ActionType::Method {
+                                    object,
+                                    name,
+                                    args: vec![],
+                                },
+                                event == ClipEvent::Unload,
+                            );
+                        }
                     }
                 }
             }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -106,6 +106,11 @@ impl ClipEvent {
         )
     }
 
+    /// Indicates whether this is a keyboard event type (keyUp, keyDown, keyPress).
+    pub fn is_key_event(self) -> bool {
+        matches!(self, Self::KeyDown | Self::KeyUp | Self::KeyPress { .. })
+    }
+
     /// Returns the method name of the event handler for this event.
     pub fn method_name(self) -> Option<&'static str> {
         match self {


### PR DESCRIPTION
`onKeyDown` and `onKeyUp` should only fire on a movie clip when it has focus, via an explicit `Selection.setFocus` call, or when highlighted via Tab in button mode (both TODO). Note that the instance `onClipEvent(keyDown)` fire regardless of focus.

Fixes #2120.