### PR TITLE
render: Fix some issues with text rendering

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1352,6 +1352,8 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             }
         }
 
+        context.transform_stack.pop();
+
         context.renderer.deactivate_mask();
         context.renderer.draw_rect(
             Color::from_rgb(0, 0xff),
@@ -1359,7 +1361,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         );
         context.renderer.pop_mask();
 
-        context.transform_stack.pop();
         context.transform_stack.pop();
         context.transform_stack.pop();
     }


### PR DESCRIPTION
 * `draw_rect` was sometimes not working properly on mobile, because the same VAO was shared for bitmapped quads and colored quads; this happened to work on desktop because the attribute locations were the same, but on mobile this was not the case. Quick fix is to make separate VAOs for bitmapped quads and colored quads. Fixes #1834 (and hopefully #900).
 * The textfield stencil mask was drawn slightly offset when being cleared., Clear the proper area, which fixes some artifacts (fixes #1496, #1554).
