### PR TITLE
desktop: Don't render while minimized

### DIFF
--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -909,7 +909,13 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             Ok(frame) => frame,
             Err(e) => {
                 log::warn!("Couldn't begin new render frame: {}", e);
-                panic!();
+                // Attemp to recreate the swap chain in this case.
+                self.target.resize(
+                    &self.descriptors.device,
+                    self.target.width(),
+                    self.target.height(),
+                );
+                return;
             }
         };
 


### PR DESCRIPTION
On desktop, don't render while the window is minimized.

In the wgpu backend, don't panic if swap chain fails to grab a
texture. Instead recreate the swap chain and bail on the current
frame. This may get cleaned up in upstream wgpu at some point,
but we should probably not render when minimized regardless.

Fixes panic when minimizing with the wgpu vulkan backend (#2065).