### PR TITLE
Added link to the Using Ruffle wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ Ruffle is an Adobe Flash Player emulator written in the Rust programming languag
 
 Ruffle is in the proof-of-concept stage and can currently run early Flash animations and games. Basic ActionScript 1.0/2.0 support is in place and improving; ActionScript 3.0 support is forthcoming. For more info, read the [project roadmap](https://github.com/ruffle-rs/ruffle/wiki/Roadmap).
 
-## Nightly builds
+## Using Ruffle
 
-[Nightly builds](https://github.com/ruffle-rs/ruffle/releases) of Ruffle are available for desktop and web platforms including the browser extension.
+The easiest way to try out Ruffle is to visit the [web demo page](https://ruffle.rs/demo/), then click the "Browse..." button to load an SWF file of your choice. 
+
+[Nightly builds](https://github.com/ruffle-rs/ruffle/releases) of Ruffle are available for desktop and web platforms including the browser extension. To download a build, click the Assets dropdown, then click the appropriate file for your platform.
 
 Windows desktop builds require the x64 [2015-2019 Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads).
+
+For more detailed instructions, see our [wiki page](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle).
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ruffle is in the proof-of-concept stage and can currently run early Flash animat
 
 The easiest way to try out Ruffle is to visit the [web demo page](https://ruffle.rs/demo/), then click the "Browse..." button to load an SWF file of your choice. 
 
-[Nightly builds](https://github.com/ruffle-rs/ruffle/releases) of Ruffle are available for desktop and web platforms including the browser extension. To download a build, click the Assets dropdown, then click the appropriate file for your platform.
+[Nightly builds](https://ruffle.rs/#releases) of Ruffle are available for desktop and web platforms including the browser extension.
 
 Windows desktop builds require the x64 [2015-2019 Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads).
 


### PR DESCRIPTION
Renamed the "Nightly Builds" section to "Using Ruffle", added info about the web demo, and added link to the "Using Ruffle" wiki page