### PR TITLE
avm1: Fix issues with SharedObjects

### DIFF
--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -278,7 +278,7 @@ pub fn get_local<'gc>(
         EnumSet::empty(),
     );
 
-    activation.context.shared_objects.insert(name, this);
+    activation.context.shared_objects.insert(full_name, this);
 
     Ok(this.into())
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -176,11 +176,16 @@ pub fn get_local<'gc>(
         return Ok(Value::Null);
     };
 
-    let mut movie_url = if let Some(url) = movie.url().and_then(|url| url::Url::parse(url).ok()) {
-        url
+    let mut movie_url = if let Some(url) = movie.url() {
+        if let Ok(url) = url::Url::parse(url) {
+            url
+        } else {
+            log::error!("SharedObject::get_local: Unable to parse movie URL");
+            return Ok(Value::Null);
+        }
     } else {
-        log::error!("SharedObject::get_local: Unable to parse movie URL");
-        return Ok(Value::Null);
+        // No URL (loading local data). Use a dummy URL to allow SharedObjects to work.
+        url::Url::parse("file://localhost").unwrap()
     };
     movie_url.set_query(None);
     movie_url.set_fragment(None);


### PR DESCRIPTION
 * Fix incorrect name used for cached SharedObjects (fix #2149)
 * Use dummy URL for SharedObject path when movie URL is unavailable (fix #2150)

Thanks to @Toad06 and @adrian17 for the tips!