### PR TITLE
core: Fix memory leak caused by unbound text variables

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -869,8 +869,9 @@ impl<'gc> EditText<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         set_initial_value: bool,
     ) -> bool {
-        let mut bound = false;
         if let Some(var_path) = self.variable() {
+            let mut bound = false;
+
             // Any previous binding should have been cleared.
             debug_assert!(self.0.read().bound_stage_object.is_none());
 
@@ -930,9 +931,11 @@ impl<'gc> EditText<'gc> {
                     }
                 },
             );
+            bound
+        } else {
+            // No variable for this text field; success by default
+            true
         }
-
-        bound
     }
 
     /// Unsets a bound display object from this text field.


### PR DESCRIPTION
Text fields without variables would return as unbound in
EditText::try_bind_text_field_variable, causing them to be added
to the unbound textfield list even though they had no variable
setting. Return successful bidning by default to avoid adding
these textfields to the unbound list.