### PR TITLE
web: Prevent crash when native `Window` function is overridden

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -6,7 +6,7 @@
 
 import { Ruffle } from "../pkg/ruffle_web";
 
-import { setArrayPrototypeReduce } from "./js-polyfills";
+import { setPolyfillsOnLoad } from "./js-polyfills";
 
 /**
  * Load ruffle from an automatically-detected location.
@@ -19,14 +19,9 @@ import { setArrayPrototypeReduce } from "./js-polyfills";
  * instances.
  */
 async function fetchRuffle(): Promise<{ new (...args: any[]): Ruffle }> {
-    if (
-        typeof Array.prototype.reduce !== "function" ||
-        Array.prototype.reduce.toString().indexOf("[native code]") === -1
-    ) {
-        // Some external libraries override the `Array.prototype.reduce` method in a way
-        // that causes Webpack to crash (#1507, #1865), so we need to override it again.
-        setArrayPrototypeReduce();
-    }
+    // Apply some pure JavaScript polyfills to prevent conflicts with external
+    // libraries, if needed.
+    setPolyfillsOnLoad();
 
     try {
         // If ruffleRuntimePath is defined then we are executing inside the extension


### PR DESCRIPTION
When the native `Window` function is overridden, a code like `window instanceof Window` (used in wasm-bindgen) always returns false or causes a TypeError. As a consequence, Ruffle crashes.

To fix that, this PR adds a new JS polyfill that tries to override `Window` again using `window.constructor`.

Fixes #2156.