### PR TITLE
demo: Only accept .swf and .spl extensions when selecting a local file

### DIFF
--- a/web/packages/demo/www/index.html
+++ b/web/packages/demo/www/index.html
@@ -159,7 +159,7 @@
             <div id="file-picker">
                 <div id="local-file-container">
                     Local SWF:
-                    <input type="file" id="local-file" />
+                    <input type="file" accept=".swf,.spl" id="local-file" />
                 </div>
                 <div id="sample-swfs-container">
                     <span id="sample-swfs-label">Sample SWF:</span>


### PR DESCRIPTION
The popup window will only display the files that match this criteria.
Could help prevent issues like #2169 in the future.