### PR TITLE
H.263 decoder + initial video support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "h263-rs"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=837f075d280680abc8dd3fc3d47656d5a770c48e#837f075d280680abc8dd3fc3d47656d5a770c48e"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=ce3d3c798190be1c78c47099e76d095756a195ac#ce3d3c798190be1c78c47099e76d095756a195ac"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=837f075d280680abc8dd3fc3d47656d5a770c48e#837f075d280680abc8dd3fc3d47656d5a770c48e"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=ce3d3c798190be1c78c47099e76d095756a195ac#ce3d3c798190be1c78c47099e76d095756a195ac"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "h263-rs-yuv"
+version = "0.1.0"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=837f075d280680abc8dd3fc3d47656d5a770c48e#837f075d280680abc8dd3fc3d47656d5a770c48e"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3044,7 @@ dependencies = [
  "generational-arena",
  "gif",
  "h263-rs",
+ "h263-rs-yuv",
  "indexmap",
  "instant",
  "jpeg-decoder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "h263-rs"
+version = "0.1.0"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=837f075d280680abc8dd3fc3d47656d5a770c48e#837f075d280680abc8dd3fc3d47656d5a770c48e"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,6 +3038,7 @@ dependencies = [
  "gc-arena-derive",
  "generational-arena",
  "gif",
+ "h263-rs",
  "indexmap",
  "instant",
  "jpeg-decoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,9 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+
+[profile.dev.package.h263-rs]
+opt-level = 3
+
+[profile.dev.package.h263-rs-yuv]
+opt-level = 3

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,6 +36,7 @@ encoding_rs = "0.8.28"
 rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.127", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e" }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 json = "0.12.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,8 +36,8 @@ encoding_rs = "0.8.28"
 rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.127", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e" }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e" }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e", optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e", optional = true }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 json = "0.12.4"
@@ -54,6 +54,7 @@ env_logger = "0.9.0"
 
 [features]
 default = ["minimp3", "serde"]
+h263 = ["h263-rs", "h263-rs-yuv"]
 lzma = ["lzma-rs", "swf/lzma"]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 avm_debug = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,8 +36,8 @@ encoding_rs = "0.8.28"
 rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.127", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e", optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e", optional = true }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "ce3d3c798190be1c78c47099e76d095756a195ac", optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "ce3d3c798190be1c78c47099e76d095756a195ac", optional = true }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 json = "0.12.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,6 +37,7 @@ rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = 
 serde = { version = "1.0.127", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
 h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e" }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "837f075d280680abc8dd3fc3d47656d5a770c48e" }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 json = "0.12.4"

--- a/core/src/backend/video.rs
+++ b/core/src/backend/video.rs
@@ -108,6 +108,9 @@ pub trait VideoBackend {
     /// `RenderBackend`. `VideoBackend` implementations are allowed to return
     /// an error if a drawable bitmap cannot be produced for the given
     /// renderer.
+    ///
+    /// Any previously returned bitmaps may be updated, invalidated, or
+    /// reclaimed by whatever means the decoder implementation chooses.
     fn decode_video_stream_frame(
         &mut self,
         stream: VideoStreamHandle,

--- a/core/src/backend/video.rs
+++ b/core/src/backend/video.rs
@@ -32,6 +32,13 @@ impl<'a> EncodedFrame<'a> {
     }
 }
 
+/// A decoded frame of video in RGBA format.
+struct DecodedFrame {
+    width: u16,
+    height: u16,
+    rgba: Vec<u8>,
+}
+
 /// What dependencies a given video frame has on any previous frames.
 #[derive(Copy, Clone, Debug)]
 pub enum FrameDependency {

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -2,19 +2,10 @@
 
 use crate::backend::render::{BitmapHandle, BitmapInfo, RenderBackend};
 use crate::backend::video::{
-    EncodedFrame, Error, FrameDependency, VideoBackend, VideoStreamHandle,
+    DecodedFrame, EncodedFrame, Error, FrameDependency, VideoBackend, VideoStreamHandle,
 };
 use generational_arena::Arena;
-use h263_rs::parser::{decode_picture, H263Reader};
-use h263_rs::{DecoderOption, H263State, PictureTypeCode};
-use h263_rs_yuv::bt601::yuv420_to_rgba;
 use swf::{VideoCodec, VideoDeblocking};
-
-/// A single preloaded video stream.
-pub enum VideoStream {
-    /// An H.263 video stream.
-    H263(H263State, Option<BitmapHandle>),
-}
 
 /// Software video backend that proxies to CPU-only codec implementations that
 /// ship with Ruffle.
@@ -44,13 +35,13 @@ impl VideoBackend for SoftwareVideoBackend {
         codec: VideoCodec,
         _filter: VideoDeblocking,
     ) -> Result<VideoStreamHandle, Error> {
-        match codec {
-            VideoCodec::H263 => Ok(self.streams.insert(VideoStream::H263(
-                H263State::new(DecoderOption::SORENSON_SPARK_BITSTREAM),
-                None,
-            ))),
-            _ => Err(format!("Unsupported video codec type {:?}", codec).into()),
-        }
+        let decoder: Box<dyn VideoDecoder> = match codec {
+            VideoCodec::H263 => Box::new(h263::H263Decoder::new()),
+            _ => return Err(format!("Unsupported video codec type {:?}", codec).into()),
+        };
+        let stream = VideoStream::new(decoder);
+        let stream_handle = self.streams.insert(stream);
+        Ok(stream_handle)
     }
 
     fn preload_video_stream_frame(
@@ -63,21 +54,7 @@ impl VideoBackend for SoftwareVideoBackend {
             .get_mut(stream)
             .ok_or("Unregistered video stream")?;
 
-        match stream {
-            VideoStream::H263(_state, _last_bitmap) => {
-                let mut reader = H263Reader::from_source(encoded_frame.data());
-                let picture =
-                    decode_picture(&mut reader, DecoderOption::SORENSON_SPARK_BITSTREAM, None)?
-                        .ok_or("Picture in video stream is not a picture")?;
-
-                match picture.picture_type {
-                    PictureTypeCode::IFrame => Ok(FrameDependency::None),
-                    PictureTypeCode::PFrame => Ok(FrameDependency::Past),
-                    PictureTypeCode::DisposablePFrame => Ok(FrameDependency::Past),
-                    _ => Err("Invalid picture type code!".into()),
-                }
-            }
-        }
+        stream.decoder.preload_frame(encoded_frame)
     }
 
     fn decode_video_stream_frame(
@@ -91,38 +68,129 @@ impl VideoBackend for SoftwareVideoBackend {
             .get_mut(stream)
             .ok_or("Unregistered video stream")?;
 
-        match stream {
-            VideoStream::H263(state, last_bitmap) => {
-                let mut reader = H263Reader::from_source(encoded_frame.data());
+        let frame = stream.decoder.decode_frame(encoded_frame)?;
+        let handle = if let Some(bitmap) = stream.bitmap {
+            renderer.update_texture(bitmap, frame.width.into(), frame.height.into(), frame.rgba)?
+        } else {
+            renderer.register_bitmap_raw(frame.width.into(), frame.height.into(), frame.rgba)?
+        };
+        stream.bitmap = Some(handle);
 
-                state.decode_next_picture(&mut reader)?;
+        Ok(BitmapInfo {
+            handle,
+            width: frame.width,
+            height: frame.height,
+        })
+    }
+}
 
-                let picture = state
-                    .get_last_picture()
-                    .expect("Decoding a picture should let us grab that picture");
+/// A single preloaded video stream.
+struct VideoStream {
+    bitmap: Option<BitmapHandle>,
+    decoder: Box<dyn VideoDecoder>,
+}
 
-                let (width, height) = picture
-                    .format()
-                    .into_width_and_height()
-                    .ok_or("H.263 decoder error!")?;
-                let chroma_width = picture.chroma_samples_per_row();
-                let (y, b, r) = picture.as_yuv();
-                let rgba = yuv420_to_rgba(y, b, r, width.into(), chroma_width);
+impl VideoStream {
+    fn new(decoder: Box<dyn VideoDecoder>) -> Self {
+        Self {
+            decoder,
+            bitmap: None,
+        }
+    }
+}
 
-                let handle = if let Some(lb) = last_bitmap {
-                    renderer.update_texture(*lb, width.into(), height.into(), rgba)?
-                } else {
-                    renderer.register_bitmap_raw(width.into(), height.into(), rgba)?
-                };
+/// Trait for video decoders.
+/// This should be implemented for each video codec.
+trait VideoDecoder {
+    /// Preload a frame.
+    ///
+    /// No decoding is intended to happen at this point in time. Instead, the
+    /// video data should be inspected to determine inter-frame dependencies
+    /// between this and any previous frames in the stream.
+    ///
+    /// Frames should be preloaded in the order that they are recieved.
+    ///
+    /// Any dependencies listed here are inherent to the video bitstream. The
+    /// containing video stream is also permitted to introduce additional
+    /// interframe dependencies.
+    fn preload_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<FrameDependency, Error>;
 
-                *last_bitmap = Some(handle);
+    /// Decode a frame of a given video stream.
+    ///
+    /// This function is provided the external index of the frame, the codec
+    /// used to decode the data, and what codec to decode it with. The codec
+    /// provided here must match the one used to register the video stream.
+    ///
+    /// Frames may be decoded in any order that does not violate the frame
+    /// dependencies declared by the output of `preload_video_stream_frame`.
+    ///
+    /// The decoded frame should be returned. An `Error` can be returned if
+    /// a drawable bitmap can not be produced.
+    fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error>;
+}
 
-                Ok(BitmapInfo {
-                    handle,
-                    width,
-                    height,
-                })
+mod h263 {
+    use crate::backend::video::software::VideoDecoder;
+    use crate::backend::video::{DecodedFrame, EncodedFrame, Error, FrameDependency};
+    use h263_rs::parser::{decode_picture, H263Reader};
+    use h263_rs::{DecoderOption, H263State, PictureTypeCode};
+    use h263_rs_yuv::bt601::yuv420_to_rgba;
+
+    /// H263 video decoder.
+    pub struct H263Decoder(H263State);
+
+    impl H263Decoder {
+        pub fn new() -> Self {
+            Self(H263State::new(DecoderOption::SORENSON_SPARK_BITSTREAM))
+        }
+    }
+
+    impl VideoDecoder for H263Decoder {
+        fn preload_frame(
+            &mut self,
+            encoded_frame: EncodedFrame<'_>,
+        ) -> Result<FrameDependency, Error> {
+            let mut reader = H263Reader::from_source(encoded_frame.data());
+            let picture =
+                decode_picture(&mut reader, DecoderOption::SORENSON_SPARK_BITSTREAM, None)?
+                    .ok_or("Picture in video stream is not a picture")?;
+
+            match picture.picture_type {
+                PictureTypeCode::IFrame => Ok(FrameDependency::None),
+                PictureTypeCode::PFrame => Ok(FrameDependency::Past),
+                PictureTypeCode::DisposablePFrame => Ok(FrameDependency::Past),
+                _ => Err("Invalid picture type code!".into()),
             }
+        }
+
+        fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error> {
+            let mut reader = H263Reader::from_source(encoded_frame.data());
+
+            self.0.decode_next_picture(&mut reader)?;
+
+            let picture = self
+                .0
+                .get_last_picture()
+                .expect("Decoding a picture should let us grab that picture");
+
+            let (width, height) = picture
+                .format()
+                .into_width_and_height()
+                .ok_or("H.263 decoder error!")?;
+            let chroma_width = picture.chroma_samples_per_row();
+            let (y, b, r) = picture.as_yuv();
+            let rgba = yuv420_to_rgba(y, b, r, width.into(), chroma_width);
+            Ok(DecodedFrame {
+                width,
+                height,
+                rgba,
+            })
+        }
+    }
+
+    impl Default for H263Decoder {
+        fn default() -> Self {
+            Self::new()
         }
     }
 }

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -103,8 +103,9 @@ impl VideoBackend for SoftwareVideoBackend {
                     .format()
                     .into_width_and_height()
                     .ok_or("H.263 decoder error!")?;
+                let chroma_width = picture.chroma_samples_per_row();
                 let (y, b, r) = picture.as_yuv();
-                let rgba = yuv420_to_rgba(y, b, r, width.into());
+                let rgba = yuv420_to_rgba(y, b, r, width.into(), chroma_width);
 
                 let handle = renderer.register_bitmap_raw(width.into(), height.into(), rgba)?;
 

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -28,6 +28,7 @@ impl SoftwareVideoBackend {
 }
 
 impl VideoBackend for SoftwareVideoBackend {
+    #[allow(unreachable_code, unused_variables)]
     fn register_video_stream(
         &mut self,
         _num_frames: u32,
@@ -36,6 +37,7 @@ impl VideoBackend for SoftwareVideoBackend {
         _filter: VideoDeblocking,
     ) -> Result<VideoStreamHandle, Error> {
         let decoder: Box<dyn VideoDecoder> = match codec {
+            #[cfg(feature = "h263")]
             VideoCodec::H263 => Box::new(h263::H263Decoder::new()),
             _ => return Err(format!("Unsupported video codec type {:?}", codec).into()),
         };
@@ -129,6 +131,7 @@ trait VideoDecoder {
     fn decode_frame(&mut self, encoded_frame: EncodedFrame<'_>) -> Result<DecodedFrame, Error>;
 }
 
+#[cfg(feature = "h263")]
 mod h263 {
     use crate::backend::video::software::VideoDecoder;
     use crate::backend::video::{DecodedFrame, EncodedFrame, Error, FrameDependency};

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -7,6 +7,7 @@ use crate::backend::video::{
 use generational_arena::Arena;
 use h263_rs::parser::{decode_picture, H263Reader};
 use h263_rs::{DecoderOption, H263State, PictureTypeCode};
+use h263_rs_yuv::bt601::yuv420_to_rgba;
 use swf::{VideoCodec, VideoDeblocking};
 
 /// A single preloaded video stream.
@@ -61,7 +62,7 @@ impl VideoBackend for SoftwareVideoBackend {
             .ok_or("Unregistered video stream")?;
 
         match stream {
-            VideoStream::H263(state) => {
+            VideoStream::H263(_state) => {
                 let mut reader = H263Reader::from_source(encoded_frame.data());
                 let picture =
                     decode_picture(&mut reader, DecoderOption::SORENSON_SPARK_BITSTREAM, None)?
@@ -98,10 +99,20 @@ impl VideoBackend for SoftwareVideoBackend {
                     .get_last_picture()
                     .expect("Decoding a picture should let us grab that picture");
 
-                //TODO: YUV 4:2:0 decoding
-                //TODO: Construct a bitmap drawable for the renderer and hand
-                //it back
-                unimplemented!("oops");
+                let (width, height) = picture
+                    .format()
+                    .into_width_and_height()
+                    .ok_or("H.263 decoder error!")?;
+                let (y, b, r) = picture.as_yuv();
+                let rgba = yuv420_to_rgba(y, b, r, width.into());
+
+                let handle = renderer.register_bitmap_raw(width.into(), height.into(), rgba)?;
+
+                Ok(BitmapInfo {
+                    handle,
+                    width,
+                    height,
+                })
             }
         }
     }

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -1,6 +1,6 @@
 //! Pure software video decoding backend.
 
-use crate::backend::render::{BitmapInfo, RenderBackend};
+use crate::backend::render::{BitmapHandle, BitmapInfo, RenderBackend};
 use crate::backend::video::{
     EncodedFrame, Error, FrameDependency, VideoBackend, VideoStreamHandle,
 };
@@ -12,7 +12,8 @@ use swf::{VideoCodec, VideoDeblocking};
 
 /// A single preloaded video stream.
 pub enum VideoStream {
-    H263(H263State),
+    /// An H.263 video stream.
+    H263(H263State, Option<BitmapHandle>),
 }
 
 /// Software video backend that proxies to CPU-only codec implementations that
@@ -44,9 +45,10 @@ impl VideoBackend for SoftwareVideoBackend {
         _filter: VideoDeblocking,
     ) -> Result<VideoStreamHandle, Error> {
         match codec {
-            VideoCodec::H263 => Ok(self.streams.insert(VideoStream::H263(H263State::new(
-                DecoderOption::SORENSON_SPARK_BITSTREAM,
-            )))),
+            VideoCodec::H263 => Ok(self.streams.insert(VideoStream::H263(
+                H263State::new(DecoderOption::SORENSON_SPARK_BITSTREAM),
+                None,
+            ))),
             _ => Err(format!("Unsupported video codec type {:?}", codec).into()),
         }
     }
@@ -62,7 +64,7 @@ impl VideoBackend for SoftwareVideoBackend {
             .ok_or("Unregistered video stream")?;
 
         match stream {
-            VideoStream::H263(_state) => {
+            VideoStream::H263(_state, _last_bitmap) => {
                 let mut reader = H263Reader::from_source(encoded_frame.data());
                 let picture =
                     decode_picture(&mut reader, DecoderOption::SORENSON_SPARK_BITSTREAM, None)?
@@ -90,7 +92,7 @@ impl VideoBackend for SoftwareVideoBackend {
             .ok_or("Unregistered video stream")?;
 
         match stream {
-            VideoStream::H263(state) => {
+            VideoStream::H263(state, last_bitmap) => {
                 let mut reader = H263Reader::from_source(encoded_frame.data());
 
                 state.decode_next_picture(&mut reader)?;
@@ -107,7 +109,13 @@ impl VideoBackend for SoftwareVideoBackend {
                 let (y, b, r) = picture.as_yuv();
                 let rgba = yuv420_to_rgba(y, b, r, width.into(), chroma_width);
 
-                let handle = renderer.register_bitmap_raw(width.into(), height.into(), rgba)?;
+                let handle = if let Some(lb) = last_bitmap {
+                    renderer.update_texture(*lb, width.into(), height.into(), rgba)?
+                } else {
+                    renderer.register_bitmap_raw(width.into(), height.into(), rgba)?
+                };
+
+                *last_bitmap = Some(handle);
 
                 Ok(BitmapInfo {
                     handle,

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -5,10 +5,14 @@ use crate::backend::video::{
     EncodedFrame, Error, FrameDependency, VideoBackend, VideoStreamHandle,
 };
 use generational_arena::Arena;
+use h263_rs::parser::{decode_picture, H263Reader};
+use h263_rs::{DecoderOption, H263State, PictureTypeCode};
 use swf::{VideoCodec, VideoDeblocking};
 
 /// A single preloaded video stream.
-pub enum VideoStream {}
+pub enum VideoStream {
+    H263(H263State),
+}
 
 /// Software video backend that proxies to CPU-only codec implementations that
 /// ship with Ruffle.
@@ -38,33 +42,67 @@ impl VideoBackend for SoftwareVideoBackend {
         codec: VideoCodec,
         _filter: VideoDeblocking,
     ) -> Result<VideoStreamHandle, Error> {
-        Err(format!("Unsupported video codec type {:?}", codec).into())
+        match codec {
+            VideoCodec::H263 => Ok(self.streams.insert(VideoStream::H263(H263State::new(
+                DecoderOption::SORENSON_SPARK_BITSTREAM,
+            )))),
+            _ => Err(format!("Unsupported video codec type {:?}", codec).into()),
+        }
     }
 
     fn preload_video_stream_frame(
         &mut self,
         stream: VideoStreamHandle,
-        _encoded_frame: EncodedFrame<'_>,
+        encoded_frame: EncodedFrame<'_>,
     ) -> Result<FrameDependency, Error> {
-        let _stream = self
+        let stream = self
             .streams
             .get_mut(stream)
             .ok_or("Unregistered video stream")?;
 
-        unreachable!()
+        match stream {
+            VideoStream::H263(state) => {
+                let mut reader = H263Reader::from_source(encoded_frame.data());
+                let picture =
+                    decode_picture(&mut reader, DecoderOption::SORENSON_SPARK_BITSTREAM, None)?
+                        .ok_or("Picture in video stream is not a picture")?;
+
+                match picture.picture_type {
+                    PictureTypeCode::IFrame => Ok(FrameDependency::None),
+                    PictureTypeCode::PFrame => Ok(FrameDependency::Past),
+                    PictureTypeCode::DisposablePFrame => Ok(FrameDependency::Past),
+                    _ => Err("Invalid picture type code!".into()),
+                }
+            }
+        }
     }
 
     fn decode_video_stream_frame(
         &mut self,
         stream: VideoStreamHandle,
-        _encoded_frame: EncodedFrame<'_>,
-        _renderer: &mut dyn RenderBackend,
+        encoded_frame: EncodedFrame<'_>,
+        renderer: &mut dyn RenderBackend,
     ) -> Result<BitmapInfo, Error> {
-        let _stream = self
+        let stream = self
             .streams
             .get_mut(stream)
             .ok_or("Unregistered video stream")?;
 
-        unreachable!()
+        match stream {
+            VideoStream::H263(state) => {
+                let mut reader = H263Reader::from_source(encoded_frame.data());
+
+                state.decode_next_picture(&mut reader)?;
+
+                let picture = state
+                    .get_last_picture()
+                    .expect("Decoding a picture should let us grab that picture");
+
+                //TODO: YUV 4:2:0 decoding
+                //TODO: Construct a bitmap drawable for the renderer and hand
+                //it back
+                unimplemented!("oops");
+            }
+        }
     }
 }

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -135,7 +135,7 @@ trait VideoDecoder {
 mod h263 {
     use crate::backend::video::software::VideoDecoder;
     use crate::backend::video::{DecodedFrame, EncodedFrame, Error, FrameDependency};
-    use h263_rs::parser::{decode_picture, H263Reader};
+    use h263_rs::parser::H263Reader;
     use h263_rs::{DecoderOption, H263State, PictureTypeCode};
     use h263_rs_yuv::bt601::yuv420_to_rgba;
 
@@ -154,9 +154,10 @@ mod h263 {
             encoded_frame: EncodedFrame<'_>,
         ) -> Result<FrameDependency, Error> {
             let mut reader = H263Reader::from_source(encoded_frame.data());
-            let picture =
-                decode_picture(&mut reader, DecoderOption::SORENSON_SPARK_BITSTREAM, None)?
-                    .ok_or("Picture in video stream is not a picture")?;
+            let picture = self
+                .0
+                .parse_picture(&mut reader, None)?
+                .ok_or("Picture in video stream is not a picture")?;
 
             match picture.picture_type {
                 PictureTypeCode::IFrame => Ok(FrameDependency::None),

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -30,7 +30,14 @@ winapi = "0.3.9"
 embed-resource = "1"
 
 [features]
+default = ["h263"]
+
+# core features
 avm_debug = ["ruffle_core/avm_debug"]
+h263 = ["ruffle_core/h263"]
+lzma = ["ruffle_core/lzma"]
+
+# wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
 render_trace = ["ruffle_render_wgpu/render_trace"]
-lzma = ["ruffle_core/lzma"]
+

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -546,7 +546,7 @@ fn run_timedemo(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     let navigator = Box::new(NullNavigatorBackend::new());
     let storage = Box::new(MemoryStorageBackend::default());
     let locale = Box::new(locale::DesktopLocaleBackend::new());
-    let video = Box::new(video::NullVideoBackend::new());
+    let video = Box::new(video::SoftwareVideoBackend::new());
     let log = Box::new(log_backend::NullLogBackend::new());
     let ui = Box::new(NullUiBackend::new());
     let player = Player::new(renderer, audio, navigator, storage, locale, video, log, ui)?;

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -15,8 +15,13 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["canvas", "console_error_panic_hook", "console_log", "webgl"]
-lzma = ["ruffle_core/lzma"]
+
+# core features
 avm_debug = ["ruffle_core/avm_debug"]
+h263 = ["ruffle_core/h263"]
+lzma = ["ruffle_core/lzma"]
+
+# web features
 canvas = ["ruffle_render_canvas"]
 webgl = ["ruffle_render_webgl"]
 
@@ -43,7 +48,7 @@ base64 = "0.13.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["serde", "wasm-bindgen"]
+features = ["h263", "serde", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.50"


### PR DESCRIPTION
This PR comprises a pure-Rust software H.263 decoder, a new backend type for interfacing with all future video decoders, and a very basic implementation of the `Video` display object type, only suitable for playing embedded video streams with no interactivity.

I'm marking this as a draft PR because people are already testing this branch, so I might as well announce it properly and get it into CI. The decoder is horribly badly optimized - even in release mode 480p video takes 8-16x longer to decode than ffmpeg. I ultimately want to write GPU shaders that do most of the per-pixel maths, but if I can get the CPU side to decode 480p video then I think this will be good.

I've explicitly designed the Video Backend to be able to support external video decoding APIs, mostly so that Desktop can proxy out to system codecs in the future. It may also be useful going forward for H.264 support on web.

# Progress

- [x] Write and implement a software H.263 decoder
- [x] Optimize it to play 480p video performantly
- [x] Add some sort of detection for out-of-order seeks (attempting to seek to a PFrame should instead seek back to the previous IFrame, else the video will be corrupted until the next IFrame)
- [ ] Much ado about patents (see below)

# Out of scope

Please note that the following features are not supported and are out of scope for this PR

- FLV/F4V demuxing - only SWF embedded bitstreams are supported
- On2 VP6, Screen Video, or H.264 decoding (the latter of which we'll likely have to proxy out to Media Source Extensions)
- Non-Stage framerates (as SWF bitstreams always run at Stage framerate)
- ActionScript representations of the video (neither AVM1 nor 2)

# Patents

Before I release the draft lock, I need to do at least a cursory review of any remaining known H.263 patents to determine if they cover material this PR can handle. From [https://meta.wikimedia.org/wiki/Have_the_patents_for_h.263_expired_yet%3F](this list on Wikimedia Meta) there appear to only be a handful of active patent grants, and most of them would cover later versions of H.263 that Sorenson never bothered to support. For example, the Nokia patent that is supposedly live until 2023 covers certain error recovery techniques and the Supplemental Enhancement Information extension that Sorenson doesn't support; it would likely not cover this PR.

If there is still patent coverage, then we'd either need to delay merging of the PR, or add new config options to allow building Ruffle without certain codecs (and Public API changes to negotiate codec support). I don't know if we'd need to do this for VP6; the entire point of Macromedia using On2 codecs instead of ISO/IEC standards was that they were deliberately designed to be royalty-free. H.264 will likely be covered for years to come and my plan for that codec is to just forward the bitstream straight to MSE, as it still has broad (and accelerated) browser support.