### PR TITLE
render: Pass library to RenderBackend::register_shape (fix #2037)

### DIFF
--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -2,8 +2,10 @@ use crate::backend::render::ShapeHandle;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::prelude::*;
+use crate::tag_utils::SwfMovie;
 use crate::types::{Degrees, Percent};
 use gc_arena::{Collect, GcCell};
+use std::sync::Arc;
 
 #[derive(Clone, Debug, Collect, Copy)]
 #[collect(no_drop)]
@@ -16,11 +18,18 @@ pub struct GraphicData<'gc> {
 }
 
 impl<'gc> Graphic<'gc> {
-    pub fn from_swf_tag(context: &mut UpdateContext<'_, 'gc, '_>, swf_shape: swf::Shape) -> Self {
+    pub fn from_swf_tag(
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        swf_shape: swf::Shape,
+        movie: Arc<SwfMovie>,
+    ) -> Self {
+        let library = context.library.library_for_movie(movie);
         let static_data = GraphicStatic {
             id: swf_shape.id,
             bounds: swf_shape.shape_bounds.clone().into(),
-            render_handle: context.renderer.register_shape((&swf_shape).into()),
+            render_handle: context
+                .renderer
+                .register_shape((&swf_shape).into(), library),
             shape: swf_shape,
         };
         Graphic(GcCell::allocate(

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2172,7 +2172,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> DecodeResult {
         // Certain backends may have to preload morph shape frames, so defer registering until the end.
         let swf_shape = reader.read_define_morph_shape(version)?;
-        let morph_shape = MorphShapeStatic::from_swf_tag(context.renderer, &swf_shape);
+        let morph_shape = MorphShapeStatic::from_swf_tag(context, &swf_shape, self.movie());
         morph_shapes.insert(swf_shape.id, morph_shape);
         Ok(())
     }
@@ -2186,7 +2186,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> DecodeResult {
         let swf_shape = reader.read_define_shape(version)?;
         let id = swf_shape.id;
-        let graphic = Graphic::from_swf_tag(context, swf_shape);
+        let graphic = Graphic::from_swf_tag(context, swf_shape, self.movie());
         context
             .library
             .library_for_movie_mut(self.movie())
@@ -2215,7 +2215,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
                 if let Some(morph_shape) = morph_shapes.get_mut(&id) {
                     ids.insert(place_object.depth.into(), id);
                     if let Some(ratio) = place_object.ratio {
-                        morph_shape.register_ratio(context.renderer, ratio);
+                        morph_shape.register_ratio(context, ratio);
                     }
                 }
             }
@@ -2224,7 +2224,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
                     if let Some(morph_shape) = morph_shapes.get_mut(&id) {
                         ids.insert(place_object.depth.into(), id);
                         if let Some(ratio) = place_object.ratio {
-                            morph_shape.register_ratio(context.renderer, ratio);
+                            morph_shape.register_ratio(context, ratio);
                         }
                     }
                 }
@@ -2233,7 +2233,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
                 if let Some(morph_shape) = morph_shapes.get_mut(&id) {
                     ids.insert(place_object.depth.into(), id);
                     if let Some(ratio) = place_object.ratio {
-                        morph_shape.register_ratio(context.renderer, ratio);
+                        morph_shape.register_ratio(context, ratio);
                     }
                 } else {
                     ids.remove(&place_object.depth.into());
@@ -2295,7 +2295,6 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let mut jpeg_data = Vec::with_capacity(data_len);
         reader.get_mut().read_to_end(&mut jpeg_data)?;
         let bitmap_info = context.renderer.register_bitmap_jpeg(
-            id,
             &jpeg_data,
             context
                 .library
@@ -2328,7 +2327,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let data_len = tag_len - 2;
         let mut jpeg_data = Vec::with_capacity(data_len);
         reader.get_mut().read_to_end(&mut jpeg_data)?;
-        let bitmap_info = context.renderer.register_bitmap_jpeg_2(id, &jpeg_data)?;
+        let bitmap_info = context.renderer.register_bitmap_jpeg_2(&jpeg_data)?;
         let bitmap = crate::display_object::Bitmap::new(
             context,
             id,
@@ -2366,7 +2365,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .read_to_end(&mut alpha_data)?;
         let bitmap_info = context
             .renderer
-            .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data)?;
+            .register_bitmap_jpeg_3(&jpeg_data, &alpha_data)?;
         let bitmap = Bitmap::new(
             context,
             id,
@@ -2405,7 +2404,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .read_to_end(&mut alpha_data)?;
         let bitmap_info = context
             .renderer
-            .register_bitmap_jpeg_3(id, &jpeg_data, &alpha_data)?;
+            .register_bitmap_jpeg_3(&jpeg_data, &alpha_data)?;
         let bitmap = Bitmap::new(
             context,
             id,

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -181,10 +181,10 @@ impl Drawing {
             };
 
             if let Some(handle) = self.render_handle.get() {
-                context.renderer.replace_shape(shape, handle);
+                context.renderer.replace_shape(shape, None, handle);
             } else {
                 self.render_handle
-                    .set(Some(context.renderer.register_shape(shape)));
+                    .set(Some(context.renderer.register_shape(shape, None)));
             }
         }
 

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -1,7 +1,7 @@
 use crate::avm2::Domain as Avm2Domain;
 use crate::backend::audio::SoundHandle;
 use crate::character::Character;
-use crate::display_object::TDisplayObject;
+use crate::display_object::{Bitmap, TDisplayObject};
 use crate::font::{Font, FontDescriptor};
 use crate::prelude::*;
 use crate::property_map::{Entry, PropertyMap};
@@ -140,6 +140,14 @@ impl<'gc> MovieLibrary<'gc> {
             Character::Button(button) => Ok(button.instantiate(gc_context)),
             Character::Text(text) => Ok(text.instantiate(gc_context)),
             _ => Err("Not a DisplayObject".into()),
+        }
+    }
+
+    pub fn get_bitmap(&self, id: CharacterId) -> Option<Bitmap<'gc>> {
+        if let Some(&Character::Bitmap(bitmap)) = self.characters.get(&id) {
+            Some(bitmap)
+        } else {
+            None
         }
     }
 

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -5,7 +5,10 @@ use lyon::tessellation::{
     FillAttributes, FillTessellator, StrokeAttributes, StrokeTessellator, StrokeVertexConstructor,
 };
 use lyon::tessellation::{FillOptions, StrokeOptions};
-use ruffle_core::backend::render::swf::{self, FillStyle, GradientInterpolation, Twips};
+use ruffle_core::backend::render::{
+    swf::{self, FillStyle, GradientInterpolation, Twips},
+    BitmapHandle,
+};
 use ruffle_core::shape_utils::{DistilledShape, DrawCommand, DrawPath};
 
 pub struct ShapeTessellator {
@@ -21,9 +24,9 @@ impl ShapeTessellator {
         }
     }
 
-    pub fn tessellate_shape<F>(&mut self, shape: DistilledShape, get_bitmap_dimensions: F) -> Mesh
+    pub fn tessellate_shape<F>(&mut self, shape: DistilledShape, get_bitmap: F) -> Mesh
     where
-        F: Fn(swf::CharacterId) -> Option<(u32, u32)>,
+        F: Fn(swf::CharacterId) -> Option<(u32, u32, BitmapHandle)>,
     {
         let mut mesh = Vec::new();
 
@@ -219,17 +222,20 @@ impl ShapeTessellator {
                             continue;
                         }
 
-                        let (bitmap_width, bitmap_height) =
-                            (get_bitmap_dimensions)(*id).unwrap_or((1, 1));
+                        if let Some((bitmap_width, bitmap_height, bitmap)) = get_bitmap(*id) {
+                            let bitmap = Bitmap {
+                                matrix: swf_bitmap_to_gl_matrix(
+                                    *matrix,
+                                    bitmap_width,
+                                    bitmap_height,
+                                ),
+                                bitmap,
+                                is_smoothed: *is_smoothed,
+                                is_repeating: *is_repeating,
+                            };
 
-                        let bitmap = Bitmap {
-                            matrix: swf_bitmap_to_gl_matrix(*matrix, bitmap_width, bitmap_height),
-                            id: *id,
-                            is_smoothed: *is_smoothed,
-                            is_repeating: *is_repeating,
-                        };
-
-                        flush_draw(DrawType::Bitmap(bitmap), &mut mesh, &mut lyon_mesh);
+                            flush_draw(DrawType::Bitmap(bitmap), &mut mesh, &mut lyon_mesh);
+                        }
                     }
                 },
                 DrawPath::Stroke {
@@ -341,7 +347,7 @@ pub struct Vertex {
 #[derive(Clone, Debug)]
 pub struct Bitmap {
     pub matrix: [[f32; 3]; 3],
-    pub id: swf::CharacterId,
+    pub bitmap: BitmapHandle,
     pub is_smoothed: bool,
     pub is_repeating: bool,
 }

--- a/render/wgpu/src/shapes.rs
+++ b/render/wgpu/src/shapes.rs
@@ -45,7 +45,6 @@ pub enum DrawType {
     Bitmap {
         texture_transforms: wgpu::Buffer,
         texture_view: wgpu::TextureView,
-        id: CharacterId,
         is_smoothed: bool,
         is_repeating: bool,
         bind_group: wgpu::BindGroup,
@@ -65,7 +64,6 @@ pub enum IncompleteDrawType {
         is_smoothed: bool,
         is_repeating: bool,
         texture_view: wgpu::TextureView,
-        id: CharacterId,
     },
 }
 
@@ -167,7 +165,6 @@ impl IncompleteDrawType {
                 is_smoothed,
                 is_repeating,
                 texture_view,
-                id,
             } => {
                 let tex_transforms_ubo = create_buffer_with_data(
                     device,
@@ -207,7 +204,6 @@ impl IncompleteDrawType {
                     draw_type: DrawType::Bitmap {
                         texture_transforms: tex_transforms_ubo,
                         texture_view,
-                        id,
                         is_smoothed,
                         is_repeating,
                         bind_group,


### PR DESCRIPTION
Pass the movie library to `register_shape` methods so that bitmap
charcter IDs can be resolved immediately on the proper SWF.

This fixes #2037, which cause incorrect bitmaps to be used when
multiple movies were loaded.