### PR TITLE
Remove redundant SystemPrototypes from UpdateContext.

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -101,7 +101,7 @@ pub fn get_rectangle<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            let proto = activation.context.system_prototypes.rectangle_constructor;
+            let proto = activation.context.avm1.prototypes.rectangle_constructor;
             let rect = proto.construct(
                 activation,
                 &[
@@ -331,7 +331,7 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            let proto = activation.context.system_prototypes.bitmap_data_constructor;
+            let proto = activation.context.avm1.prototypes.bitmap_data_constructor;
             let new_bitmap_data = proto.construct(
                 activation,
                 &[
@@ -554,7 +554,7 @@ pub fn get_color_bounds_rect<'gc>(
                     .read()
                     .color_bounds_rect(find_color, mask, color);
 
-                let proto = activation.context.system_prototypes.rectangle_constructor;
+                let proto = activation.context.avm1.prototypes.rectangle_constructor;
                 let rect =
                     proto.construct(activation, &[x.into(), y.into(), w.into(), h.into()])?;
                 return Ok(rect.into());
@@ -908,7 +908,7 @@ pub fn load_bitmap<'gc>(
 
     if let Some(Character::Bitmap(bitmap_object)) = character {
         if let Some(bitmap) = renderer.get_bitmap_pixels(bitmap_object.bitmap_handle()) {
-            let proto = activation.context.system_prototypes.bitmap_data_constructor;
+            let proto = activation.context.avm1.prototypes.bitmap_data_constructor;
             let new_bitmap =
                 proto.construct(activation, &[bitmap.width.into(), bitmap.height.into()])?;
             let new_bitmap_object = new_bitmap.as_bitmap_data_object().unwrap();

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -124,7 +124,8 @@ pub fn clone<'gc>(
     if let Some(this) = this.as_color_matrix_filter_object() {
         let proto = activation
             .context
-            .system_prototypes
+            .avm1
+            .prototypes
             .color_matrix_filter_constructor;
 
         let matrix = this.get("matrix", activation)?;

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -461,8 +461,8 @@ fn equals<'gc>(
         let other_y = other.get("y", activation)?;
         let other_width = other.get("width", activation)?;
         let other_height = other.get("height", activation)?;
-        let proto = activation.context.system_prototypes.rectangle;
-        let constructor = activation.context.system_prototypes.rectangle_constructor;
+        let proto = activation.context.avm1.prototypes.rectangle;
+        let constructor = activation.context.avm1.prototypes.rectangle_constructor;
         return Ok((this_x == other_x
             && this_y == other_y
             && this_width == other_width

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -903,7 +903,6 @@ mod tests {
                 renderer: &mut NullRenderer::new(),
                 locale: &mut NullLocaleBackend::new(),
                 log: &mut NullLogBackend::new(),
-                system_prototypes: avm1.prototypes().clone(),
                 mouse_hovered_object: None,
                 mouse_position: &(Twips::new(0), Twips::new(0)),
                 drag_object: &mut None,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -64,7 +64,6 @@ where
             renderer: &mut NullRenderer::new(),
             locale: &mut NullLocaleBackend::new(),
             log: &mut NullLogBackend::new(),
-            system_prototypes: avm1.prototypes().clone(),
             mouse_hovered_object: None,
             mouse_position: &(Twips::new(0), Twips::new(0)),
             drag_object: &mut None,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,5 +1,4 @@
 //! Contexts and helper types passed between functions.
-use crate::avm1;
 
 use crate::avm1::globals::system::SystemProperties;
 use crate::avm1::{Avm1, Object as Avm1Object, Timers, Value as Avm1Value};
@@ -85,10 +84,6 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// All loaded levels of the current player.
     pub levels: &'a mut BTreeMap<u32, DisplayObject<'gc>>,
 
-    /// The current set of system-specified prototypes to use when constructing
-    /// new built-in objects.
-    pub system_prototypes: avm1::SystemPrototypes<'gc>,
-
     /// The display object that the mouse is currently hovering over.
     pub mouse_hovered_object: Option<DisplayObject<'gc>>,
 
@@ -163,7 +158,6 @@ unsafe impl<'a, 'gc, 'gc_context> Collect for UpdateContext<'a, 'gc, 'gc_context
         self.storage.trace(cc);
         self.rng.trace(cc);
         self.levels.trace(cc);
-        self.system_prototypes.trace(cc);
         self.mouse_hovered_object.trace(cc);
         self.mouse_position.trace(cc);
         self.drag_object.trace(cc);
@@ -208,7 +202,6 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             storage: self.storage,
             rng: self.rng,
             levels: self.levels,
-            system_prototypes: self.system_prototypes.clone(),
             mouse_hovered_object: self.mouse_hovered_object,
             mouse_position: self.mouse_position,
             drag_object: self.drag_object,

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -200,7 +200,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
             let object = StageObject::for_display_object(
                 context.gc_context,
                 display_object,
-                Some(context.system_prototypes.button),
+                Some(context.avm1.prototypes().button),
             );
             mc.object = Some(object.into());
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1165,7 +1165,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             let object = StageObject::for_display_object(
                 context.gc_context,
                 display_object,
-                Some(context.system_prototypes.text_field),
+                Some(context.avm1.prototypes().text_field),
             )
             .into();
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1448,7 +1448,7 @@ impl<'gc> MovieClip<'gc> {
             let object: Avm1Object<'gc> = StageObject::for_display_object(
                 context.gc_context,
                 display_object,
-                Some(context.system_prototypes.movie_clip),
+                Some(context.avm1.prototypes().movie_clip),
             )
             .into();
             if let Some(init_object) = init_object {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1167,7 +1167,6 @@ impl Player {
                 mouse_position,
                 drag_object,
                 stage_size: (stage_width, stage_height),
-                system_prototypes: avm1.prototypes().clone(),
                 player,
                 load_manager,
                 system: system_properties,


### PR DESCRIPTION
Turned out it's already in Avm1 struct, so this patch is mostly just mechanical conversion of `context.system_prototypes` to `context.avm1.prototypes`.

This reduces size of UpdateContext by over 1kB and significantly speeds up some games with lots of calls; in N v1.2, my FPS counter improved from 35-50FPS to 50-70FPS.