### PR TITLE
Implement BitmapData.scroll()

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -656,13 +656,26 @@ pub fn pixel_dissolve<'gc>(
 }
 
 pub fn scroll<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
-    _args: &[Value<'gc>],
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            log::warn!("BitmapData.scroll - not yet implemented");
+            let x = args
+                .get(0)
+                .unwrap_or(&Value::Undefined)
+                .coerce_to_i32(activation)?;
+            let y = args
+                .get(1)
+                .unwrap_or(&Value::Undefined)
+                .coerce_to_i32(activation)?;
+
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .scroll(x, y);
+
             return Ok(Value::Undefined);
         }
     }


### PR DESCRIPTION
This makes the right-scrolling background particles of [z0r.de/7463](https://z0r.de/L/z0r-de_7463.swf) work, fixing 1/3 of #2073.

I've tested this code manually with [a couple different parametrizations](https://gist.github.com/torokati44/96a24e15b0ba2c9db1e9ddde2aae5721), the visual results always exactly matched that of Adobe Flash Player.
I'm not sure if any of this is supposed to be added as some actual test cases, and if so, exactly how - I personally used `mtasc` to build the `.swf`s.

Performance-wise I tried to avoid any redundant range checks (hence the `unwrap`), and conversions to/from premultiplied alpha format.
_(There might be faster ways to do this, especially if there is something of a `memcpy`-like intrinsic on `Vec`s of simple types, with selectable operation order, but I'm not aware of anything like that (yet), nor do I think it is that critical. [Perhaps the compiler recognizes some data access patterns even, and optimizes the pixel-wise iteration into something more batched, but I haven't checked the generated code.])_

Since I'm not that experienced with Rust, I struggled a bit with conditionally reversing the coordinate ranges (and reusing the one for the `x` dimension, within the `y` loop), that's why there is some clumsy setup with the `Iterator` trait object bindings in there. If there is a simpler way to do this, I'd be happy to hear about it.

BTW, @CUB3D, may I ask, what was the reason for putting `32` in the name of some of the pixel-manipulating functions on BitmapData? To me, it seems that the 'exact pair' (with the most direct access to the `pixels` field) of `get_pixel_raw` is `set_pixel32_raw`, and I found this inconsistency slightly strange.