### PR TITLE
webgl: Use mult color for draw_rect (fix #2189)

### DIFF
--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1234,14 +1234,13 @@ impl RenderBackend for WebGlRenderBackend {
             ],
         ];
 
-        let mult_color = [1.0, 1.0, 1.0, 1.0];
-
-        let add_color = [
+        let mult_color = [
             color.r as f32 * 255.0,
             color.g as f32 * 255.0,
             color.b as f32 * 255.0,
             color.a as f32 * 255.0,
         ];
+        let add_color = [0.0; 4];
 
         self.set_stencil_state();
 


### PR DESCRIPTION
`draw_rect` should use mult_color instead of add_color because the vertex color is white. Fixes #2189.