### PR TITLE
core: ADPCM decoder produces less artefacts

### DIFF
--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -142,20 +142,7 @@ impl<R: Read> AdpcmDecoder<R> {
         // TODO(Herschel): Other implementations use some bit-tricks for this.
         let sign_mask = 1 << (self.bits_per_sample - 1);
         let magnitude = data & !sign_mask;
-        // let delta =
-        //     Self::SAMPLE_DELTA_CALCULATOR[self.bits_per_sample - 2](self.left_step, magnitude);
         let delta = (self.decoder)(self.left_step, magnitude);
-        // Iterative version
-        // let mut delta = self.left_step >> (self.bits_per_sample - 1);
-        // let mut counter = (self.bits_per_sample - 2) as i8;
-        // let mut bit_place = 1;
-        // for _i in 0..(self.bits_per_sample - 1) {
-        //     if (magnitude & bit_place) != 0 {
-        //         delta += self.left_step >> counter;
-        //     }
-        //     counter -= 1;
-        //     bit_place = bit_place << 1;
-        // }
 
         if (data & sign_mask) != 0 {
             self.left_sample -= delta;
@@ -183,8 +170,6 @@ impl<R: Read> AdpcmDecoder<R> {
             let sign_mask = 1 << (self.bits_per_sample - 1);
             let magnitude = data & !sign_mask;
             let delta = (self.decoder)(self.right_step, magnitude);
-            // let delta =
-            //     Self::SAMPLE_DELTA_CALCULATOR[self.bits_per_sample - 2](self.right_step, magnitude);
 
             if (data & sign_mask) != 0 {
                 self.right_sample -= delta;

--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -33,6 +33,59 @@ impl<R: Read> AdpcmDecoder<R> {
         29794, 32767,
     ];
 
+    const SAMPLE_DELTA_CALCULATOR: [fn(i32, i32) -> i32; 4] = [
+        // 2 bits
+        |step: i32, magnitude: i32| {
+            let mut delta = step >> 1;
+            if magnitude & 1 != 0 {
+                delta += step;
+            };
+            delta
+        },
+        // 3 bits
+        |step: i32, magnitude: i32| {
+            let mut delta = step >> 2;
+            if magnitude & 1 != 0 {
+                delta += step >> 1;
+            }
+            if magnitude & 2 != 0 {
+                delta += step;
+            }
+            delta
+        },
+        // 4 bits
+        |step: i32, magnitude: i32| {
+            let mut delta = step >> 3;
+            if magnitude & 1 != 0 {
+                delta += step >> 2;
+            }
+            if magnitude & 2 != 0 {
+                delta += step >> 1;
+            }
+            if magnitude & 4 != 0 {
+                delta += step;
+            }
+            delta
+        },
+        // 5 bits
+        |step: i32, magnitude: i32| {
+            let mut delta = step >> 4;
+            if magnitude & 1 != 0 {
+                delta += step >> 3;
+            }
+            if magnitude & 2 != 0 {
+                delta += step >> 2;
+            }
+            if magnitude & 4 != 0 {
+                delta += step >> 1;
+            }
+            if magnitude & 8 != 0 {
+                delta += step;
+            }
+            delta
+        },
+    ];
+
     pub fn new(inner: R, is_stereo: bool, sample_rate: u16) -> Self {
         let mut reader = BitReader::new(inner);
         let bits_per_sample = reader.read::<u8>(2).unwrap_or_else(|e| {
@@ -47,6 +100,7 @@ impl<R: Read> AdpcmDecoder<R> {
         let right_sample = 0;
         let right_step_index = 0;
         let right_step = 0;
+
         Self {
             inner: reader,
             sample_rate,
@@ -85,17 +139,28 @@ impl<R: Read> AdpcmDecoder<R> {
         // TODO(Herschel): Other implementations use some bit-tricks for this.
         let sign_mask = 1 << (self.bits_per_sample - 1);
         let magnitude = data & !sign_mask;
-        let delta = (2 * magnitude + 1) * self.left_step / sign_mask;
+        let delta = Self::SAMPLE_DELTA_CALCULATOR[self.bits_per_sample - 2](self.left_step, magnitude);
+        // Iterative version
+        // let mut delta = self.left_step >> (self.bits_per_sample - 1);
+        // let mut counter = (self.bits_per_sample - 2) as i8;
+        // let mut bit_place = 1;
+        // for _i in 0..(self.bits_per_sample - 1) {
+        //     if (magnitude & bit_place) != 0 {
+        //         delta += self.left_step >> counter;
+        //     }
+        //     counter -= 1;
+        //     bit_place = bit_place << 1;
+        // }
 
         if (data & sign_mask) != 0 {
             self.left_sample -= delta;
         } else {
             self.left_sample += delta;
         }
-        if self.left_sample < -32767 {
-            self.left_sample = -32767;
-        } else if self.left_sample > 32767 {
-            self.left_sample = 32767;
+        if self.left_sample < (i16::MIN as i32) {
+            self.left_sample = i16::MIN as i32;
+        } else if self.left_sample > (i16::MAX as i32) {
+            self.left_sample = i16::MAX as i32;
         }
 
         let i = magnitude as usize;
@@ -112,17 +177,18 @@ impl<R: Read> AdpcmDecoder<R> {
 
             let sign_mask = 1 << (self.bits_per_sample - 1);
             let magnitude = data & !sign_mask;
-            let delta = (2 * magnitude + 1) * self.right_step / sign_mask;
+            let delta =
+                Self::SAMPLE_DELTA_CALCULATOR[self.bits_per_sample - 2](self.right_step, magnitude);
 
             if (data & sign_mask) != 0 {
                 self.right_sample -= delta;
             } else {
                 self.right_sample += delta;
             }
-            if self.right_sample < -32767 {
-                self.right_sample = -32767;
-            } else if self.right_sample > 32767 {
-                self.right_sample = 32767;
+            if self.right_sample < (i16::MIN as i32) {
+                self.right_sample = i16::MIN as i32;
+            } else if self.right_sample > (i16::MAX as i32) {
+                self.right_sample = i16::MAX as i32;
             }
 
             let i = magnitude as usize;


### PR DESCRIPTION
Due to the way equation `(magnitude + 0.5) * step / 2^(bits_per_sample - 2)` was approximated in ADPCM implementation linked from SWF documentation, the results can differ by [`0`, `bits_per_sample - 1`]. This results in variable audio artefacts, as can be heard in [these files](https://drive.google.com/drive/folders/1YYce0XjutZqmrTLCbw6q1C6AfNqoJPxL?usp=sharing).

```python
bits_per_sample = 4
data = 1
magnitude = 1
step = 7

################# (1)

delta = (magnitude + 0.5) * step / 2**(bits_per_sample - 2)
print(delta) # delta == 2.625 or 2 when cast to int

################# (2)

delta = step >> 3
if magnitude & 4:
    delta += step
if magnitude & 2:
    delta += step >> 1
if magnitude & 1:
    delta += step >> 2
print(delta) # delta == 1
```

The differance between deltas is caused due to sum of divisions (bit shifts) in `(2)`. And as each value must be `int`, they are floored and the &lfloor;x&rfloor; + &lfloor;y&rfloor; `(2)` &le; &lfloor;x + y&rfloor; `(1)` inequality takes effect.

