### PR TITLE
Fake passage of time to fool busy-loop frame limiters

### DIFF
--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -922,6 +922,8 @@ mod tests {
                 update_start: Instant::now(),
                 max_execution_duration: Duration::from_secs(15),
                 focus_tracker: FocusTracker::new(gc_context),
+                times_get_time_called: 0,
+                time_offset: &mut 0,
             };
 
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -83,6 +83,8 @@ where
             update_start: Instant::now(),
             max_execution_duration: Duration::from_secs(15),
             focus_tracker: FocusTracker::new(gc_context),
+            times_get_time_called: 0,
+            time_offset: &mut 0,
         };
         root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
         root.set_name(context.gc_context, "");

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -141,6 +141,12 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// A tracker for the current keyboard focused element
     pub focus_tracker: FocusTracker<'gc>,
+
+    /// How many times getTimer() was called so far. Used to detect busy-loops.
+    pub times_get_time_called: u32,
+
+    /// This frame's current fake time offset, used to pretend passage of time in time functions
+    pub time_offset: &'a mut u32,
 }
 
 unsafe impl<'a, 'gc, 'gc_context> Collect for UpdateContext<'a, 'gc, 'gc_context> {
@@ -219,6 +225,8 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             update_start: self.update_start,
             max_execution_duration: self.max_execution_duration,
             focus_tracker: self.focus_tracker,
+            times_get_time_called: self.times_get_time_called,
+            time_offset: self.time_offset,
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ruffle-rs/ruffle/issues/1020.

Ping @Dinnerbone as the original idea came from him. Please check if my reasoning in the comments is sound :) 
Also feel free to bikeshed conditions for incrementing `time_offset`.

This came out more elegant than I expected, but still feels a bit brittle.
In particular, we now need to remember to apply `time_offset` whenever we calculate current date visible to script. I did it in the opcode and avm1 Date constructor, but the same will need to be applied in avm2 Date (and possibly other places in the future?).
Also, as explained in the comment, this causes a subtle incompatibility in regards to timers; in Flash, a blocking busy loop would affect timeout/interval callbacks, but here it does not. However, 1. it was already similarly incompatible before, just for different reasons; 2. this should be a very rare combination; 3. timers are supposed to be nondeterministic, so even if that happens, it hopefully shouldn't noticeably affect any games. For these reasons I'm not tackling this issue.

This fixes extreme FPS issues on games like:
https://www.newgrounds.com/portal/view/301341
http://www.xgenstudios.com/game.php?keyword=madness-accelerant
While also preventing high CPU usage coming from busy looping.

If you know any other games with this behavior, please let me know so I can test them.