### PR TITLE
web: Read the `allowScriptAccess` property from `embed` tags

### DIFF
--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -3,6 +3,7 @@ import {
     FUTURESPLASH_MIMETYPE,
     FLASH7_AND_8_MIMETYPE,
     FLASH_MOVIE_MIMETYPE,
+    isScriptAccessAllowed,
     isSwfFilename,
     RufflePlayer,
 } from "./ruffle-player";
@@ -34,12 +35,21 @@ export class RuffleEmbed extends RufflePlayer {
     connectedCallback(): void {
         super.connectedCallback();
         let parameters;
+
         const flashvars = this.attributes.getNamedItem("flashvars");
         if (flashvars) {
             parameters = flashvars.value;
         }
+
+        const allowScriptAccess =
+            this.attributes.getNamedItem("allowScriptAccess")?.value ?? null;
+
         const src = this.attributes.getNamedItem("src");
         if (src) {
+            this.allowScriptAccess = isScriptAccessAllowed(
+                allowScriptAccess,
+                src.value
+            );
             this.load({ url: src.value, parameters });
         }
     }

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -4,6 +4,7 @@ import {
     FLASH7_AND_8_MIMETYPE,
     FLASH_MOVIE_MIMETYPE,
     FLASH_ACTIVEX_CLASSID,
+    isScriptAccessAllowed,
     isSwfFilename,
     RufflePlayer,
 } from "./ruffle-player";
@@ -89,7 +90,7 @@ export class RuffleObject extends RufflePlayer {
         const allowScriptAccess = findCaseInsensitive(
             this.params,
             "allowScriptAccess",
-            "sameDomain"
+            null
         );
         let url = null;
 
@@ -106,15 +107,12 @@ export class RuffleObject extends RufflePlayer {
         );
 
         if (url) {
-            this.allowScriptAccess = !!(
-                allowScriptAccess &&
-                (allowScriptAccess.toLowerCase() === "always" ||
-                    (allowScriptAccess.toLowerCase() === "samedomain" &&
-                        new URL(window.location.href).origin ===
-                            new URL(url, window.location.href).origin))
+            this.allowScriptAccess = isScriptAccessAllowed(
+                allowScriptAccess,
+                url
             );
 
-            //Kick off the SWF download.
+            // Kick off the SWF download.
             const options: URLLoadOptions = { url };
             if (parameters) {
                 options.parameters = parameters;

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -815,6 +815,38 @@ export class RufflePlayer extends HTMLElement {
 }
 
 /**
+ * Returns whether a SWF file can call JavaScript code in the surrounding HTML file.
+ *
+ * @param access The value of the `allowScriptAccess` attribute.
+ * @param url The URL of the SWF file.
+ * @returns True if script access is allowed.
+ */
+export function isScriptAccessAllowed(
+    access: string | null,
+    url: string
+): boolean {
+    if (!access) {
+        access = "sameDomain";
+    }
+    switch (access.toLowerCase()) {
+        case "always":
+            return true;
+        case "never":
+            return false;
+        case "samedomain":
+        default:
+            try {
+                return (
+                    new URL(window.location.href).origin ===
+                    new URL(url, window.location.href).origin
+                );
+            } catch {
+                return false;
+            }
+    }
+}
+
+/**
  * Returns whether the given filename ends in a known flash extension.
  *
  * @param filename The filename to test.


### PR DESCRIPTION
`<embed src="file.swf" type="application/x-shockwave-flash"  allowscriptaccess="always" />`

Ruffle would currently ignore the `allowscriptaccess` attribute in the above tag. This PR fixes this issue.
Reported by nosamu on Discord.