### PR TITLE
chore: Update bitstream-io to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ checksum = "614aa3f2bac03707e62a84d18a48dd3d9ea6171313fd5e6a53b5054d8ae74601"
 
 [[package]]
 name = "bitstream-io"
-version = "0.9.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b66dc4e6b6d83f3afd41eb3006cd332a60d4e18496a31f2caa4069914d773f"
+checksum = "03539c739e37dab2c322ce07b1990089ca1fc7ad14b813e1538bf11bef98fe06"
 
 [[package]]
 name = "blake2b_simd"
@@ -2984,7 +2984,7 @@ name = "ruffle_core"
 version = "0.1.0"
 dependencies = [
  "approx",
- "bitstream-io 0.9.0",
+ "bitstream-io 1.0.0",
  "chrono",
  "downcast-rs",
  "encoding_rs",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bitstream-io = "0.9.0"
+bitstream-io = "1.0.0"
 flate2 = "1.0.19"
 fnv = "1.0.7"
 gc-arena = "0.2.0"

--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -1,5 +1,5 @@
 use super::{Decoder, SeekableDecoder};
-use bitstream_io::{BigEndian, BitReader};
+use bitstream_io::{BigEndian, BitRead, BitReader};
 use std::io::{Cursor, Read};
 
 pub struct AdpcmDecoder<R: Read> {


### PR DESCRIPTION
Closes #2153.