### PR TITLE
core: Fix getBytesLoaded and getBytesTotal returning inaccurate counts

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -794,7 +794,7 @@ fn get_bytes_loaded<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok((movie_clip.movie().unwrap().data().len() + 20).into())
+    Ok((movie_clip.movie().unwrap().total_bytes()).into())
 }
 
 fn get_bytes_total<'gc>(
@@ -802,7 +802,7 @@ fn get_bytes_total<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok((movie_clip.movie().unwrap().data().len() + 20).into())
+    Ok((movie_clip.movie().unwrap().total_bytes()).into())
 }
 
 fn get_next_highest_depth<'gc>(

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -107,7 +107,7 @@ pub fn get_progress<'gc>(
                 "bytesLoaded",
                 movieclip
                     .movie()
-                    .map(|mv| (mv.data().len() + 21).into())
+                    .map(|mv| (mv.total_bytes()).into())
                     .unwrap_or(Value::Undefined),
                 EnumSet::empty(),
             );
@@ -116,7 +116,7 @@ pub fn get_progress<'gc>(
                 "bytesTotal",
                 movieclip
                     .movie()
-                    .map(|mv| (mv.data().len() + 21).into())
+                    .map(|mv| (mv.total_bytes()).into())
                     .unwrap_or(Value::Undefined),
                 EnumSet::empty(),
             );

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -17,6 +17,9 @@ pub struct SwfMovie {
     /// The SWF header parsed from the data stream.
     header: Header,
 
+    /// The entire length of the uncompressed movie in bytes, including the header.
+    total_bytes: usize,
+
     /// Uncompressed SWF data.
     data: Vec<u8>,
 
@@ -38,6 +41,7 @@ impl SwfMovie {
                 frame_rate: 1.0,
                 num_frames: 0,
             },
+            total_bytes: 13,
             data: vec![],
             url: None,
             parameters: PropertyMap::new(),
@@ -52,6 +56,7 @@ impl SwfMovie {
     pub fn from_movie_and_subdata(&self, data: Vec<u8>, source: &SwfMovie) -> Self {
         Self {
             header: self.header.clone(),
+            total_bytes: self.total_bytes - self.data.len() + data.len(),
             data,
             url: source.url.clone(),
             parameters: source.parameters.clone(),
@@ -87,6 +92,7 @@ impl SwfMovie {
 
         Ok(Self {
             header,
+            total_bytes: swf_stream.uncompressed_length,
             data,
             url,
             parameters: PropertyMap::new(),
@@ -100,6 +106,10 @@ impl SwfMovie {
     /// Get the version of the SWF.
     pub fn version(&self) -> u8 {
         self.header.version
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
     }
 
     pub fn data(&self) -> &[u8] {

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -85,9 +85,7 @@ pub fn read_swf_header<'a, R: Read + 'a>(mut input: R) -> Result<SwfStream<'a>> 
     let compression = Reader::read_compression_type(&mut input)?;
     let version = input.read_u8()?;
 
-    // Uncompressed length includes the 4-byte header and 4-byte uncompressed length itself,
-    // subtract it here.
-    let uncompressed_length = input.read_u32::<LittleEndian>()? - 8;
+    let uncompressed_length = input.read_u32::<LittleEndian>()?;
 
     // Now the SWF switches to a compressed stream.
     let decompressed_input: Box<dyn Read> = match compression {
@@ -108,7 +106,9 @@ pub fn read_swf_header<'a, R: Read + 'a>(mut input: R) -> Result<SwfStream<'a>> 
                     version
                 );
             }
-            make_lzma_reader(input, uncompressed_length)?
+            // Uncompressed length includes the 4-byte header and 4-byte uncompressed length itself,
+            // subtract it here.
+            make_lzma_reader(input, uncompressed_length - 8)?
         }
     };
 


### PR DESCRIPTION
The implementation of these functions that SWF headers have a constant
size of either 20 or 21, when in fact it can vary. This assumption was
was causing at least one preloader to get stuck forever, because the
wrong number of loaded bytes was being returned.
https://homestuck.net/games/alabaster-silent-hive/argh.swf

Instead, if we just keep track of the uncompressed_length from the swf
header and return it from these functions, the byte count is correct.