### PR TITLE
web: Fix minor issues in `ruffle-player.ts`

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -303,7 +303,7 @@ export class RufflePlayer extends HTMLElement {
                         </div>
                         <div id="panic-footer">
                             <ul>
-                                <li><a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#configure-wasm-mime-type">View Ruffle Wiki</a></li>
+                                <li><a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#configure-webassembly-mime-type">View Ruffle Wiki</a></li>
                             </ul>
                         </div>
                     </div>
@@ -331,7 +331,7 @@ export class RufflePlayer extends HTMLElement {
                     resolve();
                 }, 200);
             });
-            this.container.style.visibility = "visible";
+            this.container.style.visibility = "";
         }
 
         const autoplay = config.autoplay ?? AutoPlay.Auto;
@@ -353,7 +353,7 @@ export class RufflePlayer extends HTMLElement {
                         const style = (<ElementCSSInlineStyle>node).style;
                         style.visibility =
                             unmuteVisibility == UnmuteOverlay.Visible
-                                ? "visible"
+                                ? ""
                                 : "hidden";
                     }
                 });
@@ -768,7 +768,7 @@ export class RufflePlayer extends HTMLElement {
                 </div>
                 <div id="panic-footer">
                     <ul>
-                        <li><a href=${issueLink}>Report Bug</a></li>
+                        <li><a href="${issueLink}">Report Bug</a></li>
                         <li><a href="#" id="panic-view-details">View Error Details</a></li>
                     </ul>
                 </div>

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -334,16 +334,16 @@ export class RufflePlayer extends HTMLElement {
             this.container.style.visibility = "";
         }
 
-        const autoplay =
-            Object.values(Object(AutoPlay)).indexOf(config.autoplay) >= 0
-                ? config.autoplay
-                : AutoPlay.Auto;
-        const unmuteVisibility =
-            Object.values(Object(UnmuteOverlay)).indexOf(
-                config.unmuteOverlay
-            ) >= 0
-                ? config.unmuteOverlay
-                : UnmuteOverlay.Visible;
+        const autoplay = Object.values(Object(AutoPlay)).includes(
+            config.autoplay
+        )
+            ? config.autoplay
+            : AutoPlay.Auto;
+        const unmuteVisibility = Object.values(Object(UnmuteOverlay)).includes(
+            config.unmuteOverlay
+        )
+            ? config.unmuteOverlay
+            : UnmuteOverlay.Visible;
 
         if (
             autoplay == AutoPlay.On ||

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -334,8 +334,16 @@ export class RufflePlayer extends HTMLElement {
             this.container.style.visibility = "";
         }
 
-        const autoplay = config.autoplay ?? AutoPlay.Auto;
-        const unmuteVisibility = config.unmuteOverlay ?? UnmuteOverlay.Visible;
+        const autoplay =
+            Object.values(Object(AutoPlay)).indexOf(config.autoplay) >= 0
+                ? config.autoplay
+                : AutoPlay.Auto;
+        const unmuteVisibility =
+            Object.values(Object(UnmuteOverlay)).indexOf(
+                config.unmuteOverlay
+            ) >= 0
+                ? config.unmuteOverlay
+                : UnmuteOverlay.Visible;
 
         if (
             autoplay == AutoPlay.On ||


### PR DESCRIPTION
`<embed src="file.swf" style="visibility:hidden;" />`
This code doesn't hide the file in the current builds because the `container` div is set to `visibility: visible`. To remove this override, the PR changes the div visibility from "visible" to an empty string.

`autoplay: "invalidValue"`
When the `autoplay` option is set to an incorrect value, the value remains unchanged and doesn't default to one of the expected values ("auto" in this case) in the current builds. Same goes for `unmuteOverlay`. The PR ensures a fallback to the default value.