### PR TITLE
web: Add letterbox setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ dependencies = [
  "quick-xml",
  "rand",
  "ruffle_macros",
+ "serde",
  "smallvec",
  "swf",
  "thiserror",
@@ -3132,6 +3133,7 @@ dependencies = [
  "ruffle_render_canvas",
  "ruffle_render_webgl",
  "ruffle_web_common",
+ "serde",
  "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3267,6 +3269,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3820,6 +3833,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,7 @@ num-traits = "0.2"
 instant = "0.1"
 encoding_rs = "0.8.26"
 rand = { version = "0.8.1", features = ["std", "small_rng"], default-features = false }
+serde = { version = "1.0.118", features = ["derive"], optional = true }
 
 [dependencies.jpeg-decoder]
 version = "0.1.20"
@@ -45,7 +46,7 @@ approx = "0.4.0"
 pretty_assertions = "0.6.1"
 
 [features]
-default = ["minimp3"]
+default = ["minimp3", "serde"]
 lzma = ["swf/lzma"]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 avm_debug = []

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -41,7 +41,6 @@ pub trait RenderBackend: Downcast {
     fn render_shape(&mut self, shape: ShapeHandle, transform: &Transform);
     fn draw_rect(&mut self, color: Color, matrix: &Matrix);
     fn end_frame(&mut self);
-    fn draw_letterbox(&mut self, letterbox: Letterbox);
     fn push_mask(&mut self);
     fn activate_mask(&mut self);
     fn deactivate_mask(&mut self);
@@ -79,13 +78,6 @@ pub struct BitmapInfo {
     pub handle: BitmapHandle,
     pub width: u16,
     pub height: u16,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum Letterbox {
-    None,
-    Letterbox(f32),
-    Pillarbox(f32),
 }
 
 pub struct NullRenderer;
@@ -165,7 +157,6 @@ impl RenderBackend for NullRenderer {
     fn render_bitmap(&mut self, _bitmap: BitmapHandle, _transform: &Transform, _smoothing: bool) {}
     fn render_shape(&mut self, _shape: ShapeHandle, _transform: &Transform) {}
     fn draw_rect(&mut self, _color: Color, _matrix: &Matrix) {}
-    fn draw_letterbox(&mut self, _letterbox: Letterbox) {}
     fn push_mask(&mut self) {}
     fn activate_mask(&mut self) {}
     fn deactivate_mask(&mut self) {}

--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -1,4 +1,5 @@
 pub trait UiBackend {
+    fn is_fullscreen(&self) -> bool;
     fn message(&self, message: &str);
 }
 
@@ -12,6 +13,9 @@ impl NullUiBackend {
 }
 
 impl UiBackend for NullUiBackend {
+    fn is_fullscreen(&self) -> bool {
+        false
+    }
     fn message(&self, _message: &str) {}
 }
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Controls whether the content is letterboxed or pillarboxed when the
+/// player's aspect ratio does not match the movie's aspect ratio.
+///
+/// When letterboxed, black bars will be rendered around the exterior
+/// margins of the content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename = "letterbox"))]
+pub enum Letterbox {
+    /// The content will never be letterboxed.
+    #[cfg_attr(feature = "serde", serde(rename = "off"))]
+    Off,
+
+    /// The content will only be letterboxed if the content is running fullscreen.
+    #[cfg_attr(feature = "serde", serde(rename = "fullscreen"))]
+    Fullscreen,
+
+    /// The content will always be letterboxed.
+    #[cfg_attr(feature = "serde", serde(rename = "on"))]
+    On,
+}
+
+impl Default for Letterbox {
+    fn default() -> Self {
+        Letterbox::Fullscreen
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,11 +43,12 @@ mod vminterface;
 mod xml;
 
 pub mod backend;
+pub mod config;
 pub mod external;
 
 pub use chrono;
 pub use events::PlayerEvent;
 pub use indexmap;
-pub use player::{Letterbox, Player};
+pub use player::Player;
 pub use swf;
 pub use swf::Color;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,6 +48,6 @@ pub mod external;
 pub use chrono;
 pub use events::PlayerEvent;
 pub use indexmap;
-pub use player::Player;
+pub use player::{Letterbox, Player};
 pub use swf;
 pub use swf::Color;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -185,6 +185,7 @@ pub struct Player {
     viewport_height: u32,
     movie_width: u32,
     movie_height: u32,
+    letterbox: Letterbox,
 
     mouse_pos: (Twips, Twips),
     is_mouse_down: bool,
@@ -282,6 +283,7 @@ impl Player {
             movie_height,
             viewport_width: movie_width,
             viewport_height: movie_height,
+            letterbox: Letterbox::Fullscreen,
 
             mouse_pos: (Twips::new(0), Twips::new(0)),
             is_mouse_down: false,
@@ -515,6 +517,14 @@ impl Player {
 
     pub fn needs_render(&self) -> bool {
         self.needs_render
+    }
+
+    pub fn letterbox(&self) -> Letterbox {
+        self.letterbox
+    }
+
+    pub fn set_letterbox(&mut self, letterbox: Letterbox) {
+        self.letterbox = letterbox
     }
 
     pub fn movie_width(&self) -> u32 {
@@ -1317,6 +1327,12 @@ impl Player {
     }
 
     fn draw_letterbox(&mut self) {
+        if self.letterbox == Letterbox::Off
+            || (self.letterbox == Letterbox::Fullscreen && !self.user_interface.is_fullscreen())
+        {
+            return;
+        }
+
         let black = Color::from_rgb(0, 255);
         let viewport_width = self.viewport_width as f32;
         let viewport_height = self.viewport_height as f32;
@@ -1384,4 +1400,11 @@ unsafe impl<'gc> gc_arena::Collect for DragObject<'gc> {
     fn trace(&self, cc: gc_arena::CollectionContext) {
         self.display_object.trace(cc);
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Letterbox {
+    Off,
+    Fullscreen,
+    On,
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -27,6 +27,8 @@ use gc_arena::{make_arena, ArenaParameters, Collect, GcCell};
 use instant::Instant;
 use log::info;
 use rand::{rngs::SmallRng, SeedableRng};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::ops::DerefMut;
@@ -1403,8 +1405,21 @@ unsafe impl<'gc> gc_arena::Collect for DragObject<'gc> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename = "letterbox"))]
 pub enum Letterbox {
+    #[cfg_attr(feature = "serde", serde(rename = "off"))]
     Off,
+
+    #[cfg_attr(feature = "serde", serde(rename = "fullscreen"))]
     Fullscreen,
+
+    #[cfg_attr(feature = "serde", serde(rename = "on"))]
     On,
+}
+
+impl Default for Letterbox {
+    fn default() -> Self {
+        Letterbox::Fullscreen
+    }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -9,6 +9,7 @@ use crate::backend::locale::LocaleBackend;
 use crate::backend::navigator::{NavigatorBackend, RequestOptions};
 use crate::backend::storage::StorageBackend;
 use crate::backend::{audio::AudioBackend, log::LogBackend, render::RenderBackend, ui::UiBackend};
+use crate::config::Letterbox;
 use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
 use crate::display_object::{EditText, MorphShape, MovieClip};
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, PlayerEvent};
@@ -27,8 +28,6 @@ use gc_arena::{make_arena, ArenaParameters, Collect, GcCell};
 use instant::Instant;
 use log::info;
 use rand::{rngs::SmallRng, SeedableRng};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::ops::DerefMut;
@@ -1401,25 +1400,5 @@ pub struct DragObject<'gc> {
 unsafe impl<'gc> gc_arena::Collect for DragObject<'gc> {
     fn trace(&self, cc: gc_arena::CollectionContext) {
         self.display_object.trace(cc);
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename = "letterbox"))]
-pub enum Letterbox {
-    #[cfg_attr(feature = "serde", serde(rename = "off"))]
-    Off,
-
-    #[cfg_attr(feature = "serde", serde(rename = "fullscreen"))]
-    Fullscreen,
-
-    #[cfg_attr(feature = "serde", serde(rename = "on"))]
-    On,
-}
-
-impl Default for Letterbox {
-    fn default() -> Self {
-        Letterbox::Fullscreen
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -16,7 +16,7 @@ use clap::Clap;
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use ruffle_core::{
     backend::audio::{AudioBackend, NullAudioBackend},
-    Player,
+    Letterbox, Player,
 };
 use ruffle_render_wgpu::WgpuRenderBackend;
 use std::path::{Path, PathBuf};
@@ -235,13 +235,13 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         Box::new(NullLogBackend::new()),
         user_interface,
     )?;
-    player.lock().unwrap().set_root_movie(Arc::new(movie));
-    player.lock().unwrap().set_is_playing(true); // Desktop player will auto-play.
-
-    player
-        .lock()
-        .unwrap()
-        .set_viewport_dimensions(viewport_size.width, viewport_size.height);
+    {
+        let mut player = player.lock().unwrap();
+        player.set_root_movie(Arc::new(movie));
+        player.set_is_playing(true); // Desktop player will auto-play.
+        player.set_letterbox(Letterbox::On);
+        player.set_viewport_dimensions(viewport_size.width, viewport_size.height);
+    }
 
     let mut mouse_pos = PhysicalPosition::new(0.0, 0.0);
     let mut time = Instant::now();

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -16,7 +16,8 @@ use clap::Clap;
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use ruffle_core::{
     backend::audio::{AudioBackend, NullAudioBackend},
-    Letterbox, Player,
+    config::Letterbox,
+    Player,
 };
 use ruffle_render_wgpu::WgpuRenderBackend;
 use std::path::{Path, PathBuf};

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -11,6 +11,11 @@ impl DesktopUiBackend {
 }
 
 impl UiBackend for DesktopUiBackend {
+    fn is_fullscreen(&self) -> bool {
+        // TODO: Return proper value when fullscreen implemented on desktop.
+        false
+    }
+
     fn message(&self, message: &str) {
         message_box_ok("Ruffle", message, MessageBoxIcon::Info)
     }

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -1,6 +1,6 @@
 use ruffle_core::backend::render::{
     swf::{self, CharacterId, GradientInterpolation, GradientSpread},
-    Bitmap, BitmapFormat, BitmapHandle, BitmapInfo, Color, JpegTagFormat, Letterbox, MovieLibrary,
+    Bitmap, BitmapFormat, BitmapHandle, BitmapInfo, Color, JpegTagFormat, MovieLibrary,
     RenderBackend, ShapeHandle, Transform,
 };
 use ruffle_core::color_transform::ColorTransform;
@@ -638,35 +638,6 @@ impl RenderBackend for WebCanvasRenderBackend {
         self.context.fill_rect(0.0, 0.0, 1.0, 1.0);
 
         self.clear_color_filter();
-    }
-
-    fn draw_letterbox(&mut self, letterbox: Letterbox) {
-        self.context.reset_transform().unwrap();
-        self.context.set_fill_style(&"black".into());
-
-        match letterbox {
-            Letterbox::None => (),
-            Letterbox::Letterbox(margin_height) => {
-                self.context
-                    .fill_rect(0.0, 0.0, self.viewport_width.into(), margin_height.into());
-                self.context.fill_rect(
-                    0.0,
-                    (self.viewport_height as f32 - margin_height).into(),
-                    self.viewport_width.into(),
-                    self.viewport_height.into(),
-                );
-            }
-            Letterbox::Pillarbox(margin_width) => {
-                self.context
-                    .fill_rect(0.0, 0.0, margin_width.into(), self.viewport_height.into());
-                self.context.fill_rect(
-                    (self.viewport_width as f32 - margin_width).into(),
-                    0.0,
-                    margin_width.into(),
-                    self.viewport_height.into(),
-                );
-            }
-        }
     }
 
     fn push_mask(&mut self) {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -5,7 +5,7 @@ use lyon::tessellation::{
 };
 use ruffle_core::backend::render::swf::{self, FillStyle};
 use ruffle_core::backend::render::{
-    srgb_to_linear, Bitmap, BitmapFormat, BitmapHandle, BitmapInfo, Color, Letterbox, MovieLibrary,
+    srgb_to_linear, Bitmap, BitmapFormat, BitmapHandle, BitmapInfo, Color, MovieLibrary,
     RenderBackend, ShapeHandle, Transform,
 };
 use ruffle_core::shape_utils::{DistilledShape, DrawPath};
@@ -43,7 +43,7 @@ pub mod clap;
 
 use crate::bitmaps::BitmapSamplers;
 use crate::globals::Globals;
-use ruffle_core::swf::{Matrix, Twips};
+use ruffle_core::swf::Matrix;
 use std::collections::HashMap;
 use std::path::Path;
 pub use wgpu;
@@ -1245,76 +1245,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                 &self.descriptors.queue,
                 vec![draw_encoder.finish()],
             );
-        }
-    }
-
-    fn draw_letterbox(&mut self, letterbox: Letterbox) {
-        match letterbox {
-            Letterbox::None => {}
-            Letterbox::Letterbox(margin) => {
-                self.draw_rect(
-                    Color {
-                        r: 0,
-                        g: 0,
-                        b: 0,
-                        a: 255,
-                    },
-                    &Matrix::create_box(
-                        self.viewport_width,
-                        margin,
-                        0.0,
-                        Twips::zero(),
-                        Twips::zero(),
-                    ),
-                );
-                self.draw_rect(
-                    Color {
-                        r: 0,
-                        g: 0,
-                        b: 0,
-                        a: 255,
-                    },
-                    &Matrix::create_box(
-                        self.viewport_width,
-                        margin,
-                        0.0,
-                        Twips::zero(),
-                        Twips::from_pixels((self.viewport_height - margin) as f64),
-                    ),
-                );
-            }
-            Letterbox::Pillarbox(margin) => {
-                self.draw_rect(
-                    Color {
-                        r: 0,
-                        g: 0,
-                        b: 0,
-                        a: 255,
-                    },
-                    &Matrix::create_box(
-                        margin,
-                        self.viewport_height,
-                        0.0,
-                        Twips::zero(),
-                        Twips::zero(),
-                    ),
-                );
-                self.draw_rect(
-                    Color {
-                        r: 0,
-                        g: 0,
-                        b: 0,
-                        a: 255,
-                    },
-                    &Matrix::create_box(
-                        margin,
-                        self.viewport_height,
-                        0.0,
-                        Twips::from_pixels((self.viewport_width - margin) as f64),
-                        Twips::zero(),
-                    ),
-                );
-            }
         }
     }
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -32,15 +32,16 @@ ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 url = "2.2.0"
-wasm-bindgen = "0.2.69"
+wasm-bindgen = { version = "0.2.69", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.19"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
+serde = { version = "1.0.118", features = ["derive"] }
 
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["puremp3", "wasm-bindgen"]
+features = ["puremp3", "serde", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.45"

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -26,6 +26,30 @@ export enum AutoPlay {
 }
 
 /**
+ * Controls whether the content is letterboxed or pillarboxed when the
+ * player's aspect ratio does not match the movie's aspect ratio.
+ *
+ * When letterboxed, black bars will be rendered around the exterior
+ * margins of the content.
+ */
+export enum Letterbox {
+    /**
+     * The content will never be letterboxed.
+     */
+    Off = "off",
+
+    /**
+     * The content will only be letterboxed if the content is running fullscreen.
+     */
+    Fullscreen = "fullscreen",
+
+    /**
+     * The content will always be letterboxed.
+     */
+    On = "on",
+}
+
+/**
  * When the player is muted, this controls whether or not Ruffle will show a
  * "click to unmute" overlay on top of the movie.
  */
@@ -61,6 +85,14 @@ export interface BaseLoadOptions {
      * @default AutoPlay.Auto
      */
     autoplay?: AutoPlay;
+
+    /**
+     * Controls letterbox behavior when the Flash container size does not
+     * match the movie size.
+     *
+     * @default Letterbox.Fullscreen
+     */
+    letterbox?: Letterbox;
 
     /**
      * Controls the visibility of the unmute overlay when the player

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -316,8 +316,6 @@ export class RufflePlayer extends HTMLElement {
             this.container,
             this,
             this.allowScriptAccess,
-            config.upgradeToHttps !== false &&
-                window.location.protocol === "https:",
             config
         );
         console.log("New Ruffle instance created.");

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -317,7 +317,8 @@ export class RufflePlayer extends HTMLElement {
             this,
             this.allowScriptAccess,
             config.upgradeToHttps !== false &&
-                window.location.protocol === "https:"
+                window.location.protocol === "https:",
+            config
         );
         console.log("New Ruffle instance created.");
 

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -20,6 +20,11 @@ let localFileInput = document.getElementById("local-file");
 let animOptGroup = document.getElementById("anim-optgroup");
 let gamesOptGroup = document.getElementById("games-optgroup");
 
+// Default config used by the player.
+let config = {
+    letterbox: "on",
+};
+
 window.addEventListener("DOMContentLoaded", () => {
     ruffle = window.RufflePlayer.newest();
     player = ruffle.createPlayer();
@@ -97,16 +102,14 @@ function localFileSelected() {
     if (file) {
         let fileReader = new FileReader();
         fileReader.onload = () => {
-            player.load({ data: fileReader.result });
+            player.load({ data: fileReader.result, ...config });
         };
         fileReader.readAsArrayBuffer(file);
     }
 }
 
 function loadRemoteFile(url) {
-    fetch(url).then((response) => {
-        response.arrayBuffer().then((data) => player.load({ data }));
-    });
+    player.load({ url, ...config });
 }
 
 function replacePlayer() {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -100,6 +100,9 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = "displayMessage")]
     fn display_message(this: &JavascriptPlayer, message: &str);
+
+    #[wasm_bindgen(method, getter, js_name = "isFullscreen")]
+    fn is_fullscreen(this: &JavascriptPlayer) -> bool;
 }
 
 struct JavascriptInterface {

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -23,6 +23,10 @@ impl WebNavigatorBackend {
         let window = web_sys::window().expect("window()");
         let performance = window.performance().expect("window.performance()");
 
+        // Upgarde to HTTPS takes effect if the current page is hosted on HTTPS.
+        let upgrade_to_https =
+            upgrade_to_https && window.location().protocol().unwrap_or_default() == "https:";
+
         WebNavigatorBackend {
             start_time: performance.now(),
             performance,

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -12,6 +12,10 @@ impl WebUiBackend {
 }
 
 impl UiBackend for WebUiBackend {
+    fn is_fullscreen(&self) -> bool {
+        self.js_player.is_fullscreen()
+    }
+
     fn message(&self, message: &str) {
         self.js_player.display_message(message);
     }


### PR DESCRIPTION
This PR adds a new "letterbox" setting for web:
 * `off`: No letterboxing. Matches Flash behavior. Areas outside the movie stage will be visible.
 * `fullscreen`: Letterboxing is only done in fullscreen mode.
 * `on`: Letterboxing will always occur when the container aspect ratio doesn't match the movie's aspect ratio.

On web, this defaults to "fullscreen", because we should match the appearance of native Flash in a web page, but we still activate it in fullscreen mode because it will usually look better.
On desktop, this still defaults to "on", because it will usually look better, as most content isn't designed to show outside the stage area. (TODO: Make this user-configurable on desktop).

The demo page turns letterboxing on to match the previous behavior.

`RenderBackend::draw_letterbox` has also been removed in favor of using `RenderBackend::draw_rect` to draw the letterbox.

TODO: When we implement stage.scaleMode, auto-disable letterboxing when `scaleMode` is changed to `"exactFit"`, as this means the content is designed to be fluidly resized.

This PR also adds a `config` module to `ruffle_core` in anticipation of sharing some settings between web and desktop. These options will support `serde` (and possibly `clap`?), allowing us to serialize these settings the same on both platforms. On web, the config gets passed from the JS to Rust. On desktop, I foresee saving and loading the config as JSON in the app data directory.
