### PR TITLE
Add symbol names to optimized wasm files

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -54,3 +54,6 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.19"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O', '-g']


### PR DESCRIPTION
This is not full debug into, just symbol names section:

https://github.com/WebAssembly/binaryen/blob/master/src/tools/optimization-options.h#L128

Downside: release wasm is bigger by ~10% (currently 3.88MB -> 4.26MB) for all users

Upsides:
- meaningful stack traces on the "something went wrong!" screens, simplifying early analysis of new issues (eg `wasm:wasm-function[1463]:0x272b18` -> `<ruffle_core::display_object::edit_text::EditText as ruffle_core::display_object::TDisplayObject>::unload`),

(unfortunately in practice this only helps in Firefox, as Chrome's error stack appears to have limited depth and only shows `panic!()`'s inner frames)

- you can now easily profile demo page or extension using chrome/firefox profilers.