### PR TITLE
desktop: Fullscreen fixes

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,7 +47,6 @@ pub mod config;
 pub mod external;
 
 pub use chrono;
-pub use events::KeyCode;
 pub use events::PlayerEvent;
 pub use indexmap;
 pub use player::Player;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -366,6 +366,17 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
                             Some(_) => None,
                         });
                     }
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                state: ElementState::Pressed,
+                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                                ..
+                            },
+                        ..
+                    } => {
+                        window.set_fullscreen(None);
+                    }
                     WindowEvent::KeyboardInput { .. } | WindowEvent::ReceivedCharacter(_) => {
                         let mut player_lock = player.lock().unwrap();
                         if let Some(event) = player_lock

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -250,6 +250,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     let mut time = Instant::now();
     let mut next_frame_time = Instant::now();
     let mut minimized = false;
+    let mut fullscreen_down = false;
     loop {
         // Poll UI events
         event_loop.run(move |event, _window_target, control_flow| {
@@ -361,10 +362,24 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
                             },
                         ..
                     } if modifiers.alt() => {
-                        window.set_fullscreen(match window.fullscreen() {
-                            None => Some(Fullscreen::Borderless(None)),
-                            Some(_) => None,
-                        });
+                        if !fullscreen_down {
+                            window.set_fullscreen(match window.fullscreen() {
+                                None => Some(Fullscreen::Borderless(None)),
+                                Some(_) => None,
+                            });
+                        }
+                        fullscreen_down = true;
+                    }
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                state: ElementState::Released,
+                                virtual_keycode: Some(VirtualKeyCode::Return),
+                                ..
+                            },
+                        ..
+                    } if fullscreen_down => {
+                        fullscreen_down = false;
                     }
                     WindowEvent::KeyboardInput {
                         input:


### PR DESCRIPTION
A follow-up for #1510:
* Include a missing commit (because of force-push).
* Add <kbd>Esc</kbd> shortcut to exit fullscreen, like Flash Player.
* Prevent entering/exiting fullscreen repeatedly by holding <kbd>Alt</kbd>+<kbd>Enter</kbd>.