### PR TITLE
web: Fixes and improvements in `navigate_to_url`

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -172,6 +172,9 @@ pub trait NavigatorBackend {
         vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     );
 
+    /// Execute a JavaScript code.
+    fn run_script(&self, js_code: &str);
+
     /// Fetch data at a given URL and return it some time in the future.
     fn fetch(&self, url: &str, request_options: RequestOptions) -> OwnedFuture<Vec<u8>, Error>;
 
@@ -358,6 +361,8 @@ impl NavigatorBackend for NullNavigatorBackend {
         _vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     ) {
     }
+
+    fn run_script(&self, _js_code: &str) {}
 
     fn fetch(&self, url: &str, _opts: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
         let mut path = self.relative_base_path.clone();

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -111,6 +111,8 @@ impl NavigatorBackend for ExternalNavigatorBackend {
         };
     }
 
+    fn run_script(&self, _js_code: &str) {}
+
     fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
         // TODO: honor sandbox type (local-with-filesystem, local-with-network, remote, ...)
         let full_url = match self.movie_url.clone().join(url) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -333,7 +333,10 @@ impl Ruffle {
             .into_js_result()?;
 
         let audio = Box::new(WebAudioBackend::new()?);
-        let navigator = Box::new(WebNavigatorBackend::new(config.upgrade_to_https));
+        let navigator = Box::new(WebNavigatorBackend::new(
+            allow_script_access,
+            config.upgrade_to_https,
+        ));
         let input = Box::new(WebInputBackend::new(&canvas));
         let locale = Box::new(WebLocaleBackend::new());
 

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -43,26 +43,11 @@ impl NavigatorBackend for WebNavigatorBackend {
         vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     ) {
         if let Some(window) = window() {
-            let document = match window.document() {
-                Some(document) => document,
-                None => return,
-            };
-            let body = match document.body() {
-                Some(body) => body,
-                None => return,
-            };
-
-            if url.trim().starts_with("javascript:") {
+            if let Some(url) = url.trim().strip_prefix("javascript:") {
                 let target = window_spec.unwrap_or_else(|| "".to_string());
 
                 if target.is_empty() || target == "_self" || target == "undefined" {
-                    let code = url.replacen("javascript:", "", 1);
-
-                    let script = document.create_element("script").unwrap();
-                    script.set_inner_html(&code);
-
-                    let _append = body.append_child(&script);
-                    let _remove = body.remove_child(&script);
+                    self.run_script(url);
                 }
             } else {
                 let window_url = if url.is_empty() {
@@ -80,16 +65,24 @@ impl NavigatorBackend for WebNavigatorBackend {
                 };
 
                 //TODO: Should we return a result for failed opens? Does Flash care?
-                #[allow(unused_must_use)]
                 match (vars_method, window_spec) {
                     (Some((navmethod, formvars)), window_spec) => {
+                        let document = match window.document() {
+                            Some(document) => document,
+                            None => return,
+                        };
+                        let body = match document.body() {
+                            Some(body) => body,
+                            None => return,
+                        };
+
                         let form = document
                             .create_element("form")
                             .unwrap()
                             .dyn_into::<web_sys::HtmlFormElement>()
                             .unwrap();
 
-                        form.set_attribute(
+                        let _ = form.set_attribute(
                             "method",
                             match navmethod {
                                 NavigationMethod::GET => "get",
@@ -97,37 +90,56 @@ impl NavigatorBackend for WebNavigatorBackend {
                             },
                         );
 
-                        form.set_attribute("action", &form_url);
+                        let _ = form.set_attribute("action", &form_url);
 
                         if let Some(target) = window_spec {
-                            form.set_attribute("target", &target);
+                            let _ = form.set_attribute("target", &target);
                         }
 
                         for (k, v) in formvars.iter() {
                             let hidden = document.create_element("input").unwrap();
 
-                            hidden.set_attribute("type", "hidden");
-                            hidden.set_attribute("name", k);
-                            hidden.set_attribute("value", v);
+                            let _ = hidden.set_attribute("type", "hidden");
+                            let _ = hidden.set_attribute("name", k);
+                            let _ = hidden.set_attribute("value", v);
 
-                            form.append_child(&hidden);
+                            let _ = form.append_child(&hidden);
                         }
 
-                        body.append_child(&form);
-                        form.submit();
+                        let _ = body.append_child(&form);
+                        let _ = form.submit();
                     }
                     (_, Some(ref window_name)) if !window_name.is_empty() => {
                         if !window_url.is_empty() {
-                            window.open_with_url_and_target(&window_url, window_name);
+                            let _ = window.open_with_url_and_target(&window_url, window_name);
                         }
                     }
                     _ => {
                         if !window_url.is_empty() {
-                            window.location().assign(&window_url);
+                            let _ = window.location().assign(&window_url);
                         }
                     }
                 };
             }
+        }
+    }
+
+    fn run_script(&self, js_code: &str) {
+        if let Some(window) = window() {
+            let document = match window.document() {
+                Some(document) => document,
+                None => return,
+            };
+            let body = match document.body() {
+                Some(body) => body,
+                None => return,
+            };
+
+            let script = document.create_element("script").unwrap();
+            script.set_inner_html(&js_code);
+
+            let _ = body.append_child(&script);
+            let _ = body.remove_child(&script);
         }
     }
 

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -55,7 +55,7 @@ impl NavigatorBackend for WebNavigatorBackend {
             if url.trim().starts_with("javascript:") {
                 let target = window_spec.unwrap_or_else(|| "".to_string());
 
-                if target == "" || target == "_self" || target == "undefined" {
+                if target.is_empty() || target == "_self" || target == "undefined" {
                     let code = url.replacen("javascript:", "", 1);
 
                     let script = document.create_element("script").unwrap();


### PR DESCRIPTION
This PR is a bit experimental for me as it implies changes on the Rust side, which is a language I'm absolutely not familiar with. But I feel like I had to give it a try. :) Hope it's not too bad. Here are the changes:

- Fix #1102: `window.location().assign(&window_url);` refreshes the page if the URL is an empty string. To match Flash's behavior (which does nothing in this situation), the PR just checks if `window_url` is all but an empty string. Also, it appears that an URL only containing blank spaces defaults to "./" in Flash, so I've added this special case as well.

- Fix #2214: Upgrading to HTTPS could lead the browser to display a security warning on sites that don't use a certificate, so this PR only enables the upgrade to HTTPS when Ruffle has to deal with forms. Speaking of forms, they didn't send any data because of a little mistake: `<hidden>` elements were created instead of `<input>`.

- Finally, a more reliable way to execute JavaScript code is added. For instance, these wouldn't work currently:

`getURL("javascript:myVar=999");`
In Firefox, the whole page would be replaced by "999".

```
getURL("javascript:myUnloadFunc()");
getURL("page.html");
```
`myUnloadFunc()` wouldn't be executed.