### PR TITLE
Add a config option to disable the message about ActionScript 3 support

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -150,6 +150,8 @@ pub struct Player {
 
     swf: Arc<SwfMovie>,
 
+    warn_on_unsupported_content: bool,
+
     is_playing: bool,
     needs_render: bool,
 
@@ -240,6 +242,8 @@ impl Player {
             player_version: NEWEST_PLAYER_VERSION,
 
             swf: fake_movie.clone(),
+
+            warn_on_unsupported_content: true,
 
             is_playing: false,
             needs_render: true,
@@ -533,6 +537,14 @@ impl Player {
     fn should_letterbox(&self) -> bool {
         self.letterbox == Letterbox::On
             || (self.letterbox == Letterbox::Fullscreen && self.user_interface.is_fullscreen())
+    }
+
+    pub fn warn_on_unsupported_content(&self) -> bool {
+        self.warn_on_unsupported_content
+    }
+
+    pub fn set_warn_on_unsupported_content(&mut self, warn_on_unsupported_content: bool) {
+        self.warn_on_unsupported_content = warn_on_unsupported_content
     }
 
     pub fn movie_width(&self) -> u32 {
@@ -868,7 +880,7 @@ impl Player {
                 lib.register_character(id, crate::character::Character::MorphShape(morph_shape));
             }
         });
-        if is_action_script_3 {
+        if is_action_script_3 && self.warn_on_unsupported_content {
             self.user_interface.message("This SWF contains ActionScript 3 which is not yet supported by Ruffle. The movie may not work as intended.");
         }
     }

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -114,6 +114,14 @@ export interface BaseLoadOptions {
      * @default true
      */
     upgradeToHttps?: boolean;
+
+    /**
+     * Whether or not to display an overlay with a warning when
+     * loading a movie with unsupported content.
+     *
+     * @default true
+     */
+    warnOnUnsupportedContent?: boolean;
 }
 
 /**

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -118,6 +118,9 @@ pub struct Config {
 
     #[serde(rename = "upgradeToHttps")]
     upgrade_to_https: bool,
+
+    #[serde(rename = "warnOnUnsupportedContent")]
+    warn_on_unsupported_content: bool,
 }
 
 impl Default for Config {
@@ -125,6 +128,7 @@ impl Default for Config {
         Self {
             letterbox: Default::default(),
             upgrade_to_https: true,
+            warn_on_unsupported_content: true,
         }
     }
 }
@@ -359,6 +363,9 @@ impl Ruffle {
             user_interface,
         )?;
         core.lock().unwrap().set_letterbox(config.letterbox);
+        core.lock()
+            .unwrap()
+            .set_warn_on_unsupported_content(config.warn_on_unsupported_content);
 
         // Create instance.
         let instance = RuffleInstance {


### PR DESCRIPTION
This is an attempt to fix #2321.

I'm not that experienced with TypeScript either; and I'm not sure if I put the new field and methods in the right places in all files - both regarding to into which struct, and in which order relative to the already existing fields.

Also the names might not be the best. Feel free to scrutinize/criticize!

Finally, should I also add a new command line argument for the desktop version to provide the same functionality?