### PR TITLE
avm1: Implement listeners and onChanged for TextField (close #2297)

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -436,6 +436,10 @@ impl<'gc> Avm1<'gc> {
         self.max_recursion_depth = max_recursion_depth
     }
 
+    pub fn broadcaster_functions(&self) -> BroadcasterFunctions<'gc> {
+        self.broadcaster_functions
+    }
+
     #[cfg(feature = "avm_debug")]
     #[inline]
     pub fn show_debug_output(&self) -> bool {

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute::*;
-use crate::avm1::{search_prototype, Object, ScriptObject, Value};
+use crate::avm1::{Object, ScriptObject, Value};
 use gc_arena::{Collect, MutationContext};
 
 #[derive(Clone, Collect, Debug, Copy)]
@@ -130,12 +130,7 @@ pub fn broadcast_internal<'gc>(
             let listener = listeners.array_element(i);
 
             if let Value::Object(listener) = listener {
-                let (callback, base_proto) =
-                    search_prototype(Some(listener), method_name, activation, listener)?;
-
-                // .call does nothing if the method is undefined, as opposed to emitting a warning
-                // This is a good thing since not all listeners will have all methods
-                callback.call(method_name, activation, listener, base_proto, call_args)?;
+                listener.call_method(method_name, call_args, activation)?;
             }
         }
 


### PR DESCRIPTION
This PR implements `TextField.addListener()`, `TextField.removeListener()`, `TextField.broadcastMessage()`, `TextField._listeners`, and `TextField.onChanged()`. This closes #2297 and checks off more boxes on #280.

It works by calling `AsBroadcaster.initialize()` on newly created `TextField`s, which seems to match Flash's behavior. The new `EditText::on_changed()` method is called whenever the text changes and broadcasts the `onChanged` event to all listeners.

There are a couple of other small changes:

- `AsBroadcaster::broadcast_message()` no longer warns if a listener does not have a handler for the given event.
- `Avm1` now exposes `broadcaster_functions` through a public method.

This is my first contribution to Ruffle -- or to any open-source project, for that matter -- so feedback is welcome!
