### PR TITLE
web: Add backgroundColor option

### DIFF
--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -892,12 +892,7 @@ mod tests {
                 action_queue: &mut crate::context::ActionQueue::new(),
                 audio: &mut NullAudioBackend::new(),
                 input: &mut NullInputBackend::new(),
-                background_color: &mut Color {
-                    r: 0,
-                    g: 0,
-                    b: 0,
-                    a: 0,
-                },
+                background_color: &mut None,
                 library: &mut Library::default(),
                 navigator: &mut NullNavigatorBackend::new(),
                 renderer: &mut NullRenderer::new(),

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -53,12 +53,7 @@ where
             audio: &mut NullAudioBackend::new(),
             input: &mut NullInputBackend::new(),
             action_queue: &mut ActionQueue::new(),
-            background_color: &mut Color {
-                r: 0,
-                g: 0,
-                b: 0,
-                a: 0,
-            },
+            background_color: &mut None,
             library: &mut Library::default(),
             navigator: &mut NullNavigatorBackend::new(),
             renderer: &mut NullRenderer::new(),

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -35,7 +35,7 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The background color of the Stage. Changed by the `SetBackgroundColor` SWF tag.
     /// TODO: Move this into a `Stage` display object.
-    pub background_color: &'a mut Color,
+    pub background_color: &'a mut Option<Color>,
 
     /// The mutation context to allocate and mutate `GcCell` types.
     pub gc_context: MutationContext<'gc, 'gc_context>,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2899,9 +2899,13 @@ impl<'gc, 'a> MovieClip<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<&'a [u8]>,
     ) -> DecodeResult {
+        // Set background color if none set
+        // bgcolor attribute on the HTML embed would override this
+        // Also note that a laoded child SWF could change background color only
+        // if parent SWF is missing SetBackgroundColor tag.
         let background_color = reader.read_rgb()?;
-        if self.parent().is_none() {
-            *context.background_color = background_color;
+        if context.background_color.is_none() {
+            *context.background_color = Some(background_color);
         }
         Ok(())
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -172,7 +172,7 @@ pub struct Player {
     rng: SmallRng,
 
     gc_arena: GcArena,
-    background_color: Color,
+    background_color: Option<Color>,
 
     frame_rate: f64,
 
@@ -248,12 +248,7 @@ impl Player {
             is_playing: false,
             needs_render: true,
 
-            background_color: Color {
-                r: 255,
-                g: 255,
-                b: 255,
-                a: 255,
-            },
+            background_color: None,
             transform_stack: TransformStack::new(),
             view_matrix: Default::default(),
             inverse_view_matrix: Default::default(),
@@ -901,7 +896,11 @@ impl Player {
     }
 
     pub fn render(&mut self) {
-        self.renderer.begin_frame(self.background_color.clone());
+        let background_color = self
+            .background_color
+            .clone()
+            .unwrap_or_else(|| Color::from_rgb(0xffffff, 255));
+        self.renderer.begin_frame(background_color);
 
         let (renderer, transform_stack) = (&mut self.renderer, &mut self.transform_stack);
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -521,6 +521,14 @@ impl Player {
         self.needs_render
     }
 
+    pub fn background_color(&self) -> Option<Color> {
+        self.background_color.clone()
+    }
+
+    pub fn set_background_color(&mut self, color: Option<Color>) {
+        self.background_color = color
+    }
+
     pub fn letterbox(&self) -> Letterbox {
         self.letterbox
     }

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -87,6 +87,15 @@ export interface BaseLoadOptions {
     autoplay?: AutoPlay;
 
     /**
+     * Controls the background color of the player.
+     * Must be an HTML color (e.g. "#FFFFFF"). CSS colors are not allowed.
+     * `null` uses the background color of the SWF file.
+     *
+     * @default null
+     */
+    backgroundColor?: string | null;
+
+    /**
      * Controls letterbox behavior when the Flash container size does not
      * match the movie size.
      *

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -34,23 +34,21 @@ export class RuffleEmbed extends RufflePlayer {
      */
     connectedCallback(): void {
         super.connectedCallback();
-        let parameters;
-
-        const flashvars = this.attributes.getNamedItem("flashvars");
-        if (flashvars) {
-            parameters = flashvars.value;
-        }
-
-        const allowScriptAccess =
-            this.attributes.getNamedItem("allowScriptAccess")?.value ?? null;
-
         const src = this.attributes.getNamedItem("src");
         if (src) {
+            const allowScriptAccess =
+                this.attributes.getNamedItem("allowScriptAccess")?.value ??
+                null;
+
             this.allowScriptAccess = isScriptAccessAllowed(
                 allowScriptAccess,
                 src.value
             );
-            this.load({ url: src.value, parameters });
+            this.load({
+                url: src.value,
+                parameters: this.attributes.getNamedItem("flashvars")?.value,
+                backgroundColor: this.attributes.getNamedItem("bgcolor")?.value,
+            });
         }
     }
 

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -106,6 +106,12 @@ export class RuffleObject extends RufflePlayer {
             this.getAttribute("flashvars")
         );
 
+        const backgroundColor = findCaseInsensitive(
+            this.params,
+            "bgcolor",
+            this.getAttribute("bgcolor")
+        );
+
         if (url) {
             this.allowScriptAccess = isScriptAccessAllowed(
                 allowScriptAccess,
@@ -116,6 +122,9 @@ export class RuffleObject extends RufflePlayer {
             const options: URLLoadOptions = { url };
             if (parameters) {
                 options.parameters = parameters;
+            }
+            if (backgroundColor) {
+                options.backgroundColor = backgroundColor;
             }
             this.load(options);
         }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -413,6 +413,12 @@ export class RufflePlayer extends HTMLElement {
                     ...options,
                 };
 
+                // Pre-emptively set background color of container while Ruffle/SWF loads.
+                if (config.backgroundColor) {
+                    this.container.style.backgroundColor =
+                        config.backgroundColor;
+                }
+
                 await this.ensureFreshInstance(config);
 
                 if ("url" in options) {


### PR DESCRIPTION
 * Change `Player::background_color` to an `Option`.
   * If this is not set, the first `SetBackgroundColor` tag encountered sets the background color of the player.
   * Otherwise, the SWF background color is ignored and the supplied color is used.
   * Note that this is a slight improvement from previous behavior (#1100); a child SWF can set the background color if the parent SWF is missing a SetBackgroundColor tag. This matches behavior in the official Flash Player (tested via hex-edited SWFs).
 * Add `backgroundColor` option to the web settings, allowing the user to override the SWF background color.
 * The polyfill now understand the `bgcolor` HTML attribute on Flash embeds, setting the background color appropriately.

Fixes #2135.