### PR TITLE
In ASSetPropFlags, don't crash on flags > 7

### DIFF
--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -348,17 +348,24 @@ pub fn as_set_prop_flags<'gc>(
         }
     };
 
-    let set_attributes = EnumSet::<Attribute>::from_u128(
-        args.get(2)
-            .unwrap_or(&Value::Number(0.0))
-            .coerce_to_f64(activation)? as u128,
-    );
+    let set_flags = args
+        .get(2)
+        .unwrap_or(&Value::Number(0.0))
+        .coerce_to_f64(activation)? as u128;
+    let clear_flags = args
+        .get(2)
+        .unwrap_or(&Value::Number(0.0))
+        .coerce_to_f64(activation)? as u128;
 
-    let clear_attributes = EnumSet::<Attribute>::from_u128(
-        args.get(3)
-            .unwrap_or(&Value::Number(0.0))
-            .coerce_to_f64(activation)? as u128,
-    );
+    if set_flags > 0b111 || clear_flags > 0b111 {
+        avm_warn!(
+            activation,
+            "ASSetPropFlags: Unimplemented support for flags > 7"
+        );
+    }
+
+    let set_attributes = EnumSet::<Attribute>::from_u128(set_flags & 0b111);
+    let clear_attributes = EnumSet::<Attribute>::from_u128(clear_flags & 0b111);
 
     match properties {
         Some(properties) => {


### PR DESCRIPTION
Apparently there are some even less documented flags that affect property visibility depending on SWF version? And there are some games in the wild that use it.
This fixes the crash in https://github.com/ruffle-rs/ruffle/issues/2464 and lets the game screen show up (though not much more, as it just loops infinitely).