### PR TITLE
web: Drop wasm-pack, invoke wasm-bindgen and wasm-opt directly from npm

### DIFF
--- a/.github/workflows/release_nightlies.yml
+++ b/.github/workflows/release_nightlies.yml
@@ -82,13 +82,23 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: wasm32-unknown-unknown
 
       - name: Install linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack
+      - name: Install wasm-bindgen
+        run: cargo install wasm-bindgen-cli
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: binaryen
+
+      - name: Install binaryen
+        shell: bash -l {0}
+        run: conda install -c conda-forge binaryen
 
       - name: Setup node
         if: matrix.os == 'ubuntu-latest'
@@ -99,6 +109,7 @@ jobs:
       - name: Build web
         if: matrix.os == 'ubuntu-latest'
         working-directory: web
+        shell: bash -l {0}
         run: |
           npm run bootstrap
           npm run build

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -33,16 +33,27 @@ jobs:
       with:
         profile: minimal
         toolchain: ${{ matrix.rust_version }}
+        target: wasm32-unknown-unknown
 
     - name: Install linux dependencies
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
-    - name: Install wasm-pack
-      run: cargo install wasm-pack
+    - name: Install wasm-bindgen
+      run: cargo install wasm-bindgen-cli
+
+    - name: Setup conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: binaryen
+
+    - name: Install binaryen
+      shell: bash -l {0}
+      run: conda install -c conda-forge binaryen
 
     - name: Build web
       working-directory: web
+      shell: bash -l {0}
       run: |
         npm run bootstrap
         npm run format:check

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ dist/
 pkg/
 web/packages/core/docs
 web/packages/core/tsd
-wasm-pack.log
 *.swd
 
 # NPM

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -56,5 +56,3 @@ features = [
 [dev-dependencies]
 wasm-bindgen-test = "0.3.19"
 
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-O', '-g']

--- a/web/README.md
+++ b/web/README.md
@@ -44,15 +44,29 @@ We do not have a Minimum Supported Rust Version policy. If it fails to build, it
 to update to the latest stable version of rust. You may run `rustup update` to do this (if you installed
 rust using the above instructions).
 
+For the compiler to be able to output WebAssembly, an additional target has to be added to it: `rustup target add wasm32-unknown-unknown`
+
 #### Node.js
 
 Follow the instructions [to install node.js](https://nodejs.org/en/) on your machine.
 
 We recommend using the currently active LTS 12, but we do also run tests with maintenance LTS 10.
 
-#### wasm-pack
+#### wasm-bindgen
 
-Follow the instructions [to install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) on your machine.
+This can be installed with `cargo install wasm-bindgen-cli`.
+
+#### Binaryen
+
+This is optional, used to further optimize the built WebAssembly module.
+Some ways to install Binaryen:
+ - download one of the [prebuilt releases](https://github.com/WebAssembly/binaryen/releases/)
+ - using your Linux distribution's package manager (`sudo apt install binaryen`, `sudo dnf install binaryen`)
+ - from [Homebrew](https://formulae.brew.sh/formula/binaryen)
+ - from [Anaconda](https://anaconda.org/conda-forge/binaryen)
+ - [compile it yourself](https://github.com/WebAssembly/binaryen#building)
+
+Just make sure the `wasm-opt` program is in `$PATH`, and that it works.
 
 ### Building
 

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -12,7 +12,7 @@
         "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
         "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
         "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --out-dir ./pkg --out-name ruffle_web",
-        "build:wasm-opt": "wasm-opt ./pkg/ruffle_web_bg.wasm -O -g --output ./pkg/ruffle_web_bg.opt.wasm && mv ./pkg/ruffle_web_bg.opt.wasm ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-note",
+        "build:wasm-opt": "wasm-opt ./pkg/ruffle_web_bg.wasm -O -g --output ./pkg/ruffle_web_bg.opt.wasm && move-file ./pkg/ruffle_web_bg.opt.wasm ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-note",
         "build:wasm-opt-note": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.'",
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
@@ -31,7 +31,8 @@
         "replace-in-file": "^6.1.0",
         "ts-node": "^9.0.0",
         "typedoc": "^0.20.0",
-        "typescript": "^4.0.5"
+        "typescript": "^4.0.5",
+        "move-file-cli": "^2.0.0"
     },
     "dependencies": {
         "@types/source-map": "^0.5.2"

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -9,9 +9,12 @@
         "pkg/"
     ],
     "scripts": {
-        "build": "npm run build:wasm && npm run build:ts",
+        "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
+        "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
+        "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --out-dir ./pkg --out-name ruffle_web",
+        "build:wasm-opt": "wasm-opt ./pkg/ruffle_web_bg.wasm -O -g --output ./pkg/ruffle_web_bg.opt.wasm && mv ./pkg/ruffle_web_bg.opt.wasm ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-note",
+        "build:wasm-opt-note": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.'",
         "build:ts": "tsc -d && node tools/set_version.js",
-        "build:wasm": "wasm-pack build ../../ --out-dir packages/core/pkg",
         "docs": "typedoc",
         "test": "mocha -r esm -r ts-node/register test/**.ts"
     },


### PR DESCRIPTION
This should resolve the CI failures of #2173 which are caused by `wasm-opt` crashing.
I tried this patch on top of those changes, and all the checks passed.

The crash happens because the last release of `wasm-pack` (v0.9.1) was a long time ago (see: https://github.com/rustwasm/wasm-pack/issues/951 and https://github.com/rustwasm/wasm-pack/issues/929, among others), and it's hardcoded to use `binaryen` (incl. `wasm-opt`) version either 78 or 90 (the latter according to @adrian17) and it is not able to use any other `wasm-opt`, for example one in `$PATH` (see: https://github.com/rustwasm/wasm-pack/blob/v0.9.1/src/wasm_opt.rs#L50-L68).
Sadly, `wasm-opt` in this version trips up on the bounds checks in the `idct_channel` function, as found out by @kmeisthax. To me it seems that the crash was caused by the `precompute` (and `precompute-propagate`) passes, the former of which is enabled by the simple `-O` option.

With these changes, `wasm-bindgen` and `wasm-opt` are invoked directly by `npm` - the latter from (at the moment) binaryen version 99 (which no longer crashes, and potentially performs better too), installed from conda-forge, using the preinstalled `miniconda` package manager.

The one thing I haven't (couldn't) fully test is the "Release Nightly" workflow, but given that the changes are the same as to the "Test Web", I _think_ (:crossed_fingers:) it _should_ be fine.