### PR TITLE
Implement BitmapData.copyPixels()

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1,9 +1,9 @@
 //! flash.display.BitmapData object
 
-use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bitmap_data::{BitmapDataObject, ChannelOptions, Color};
+use crate::avm1::{activation::Activation, object::bitmap_data::BitmapData};
 use crate::avm1::{Object, TObject, Value};
 use crate::character::Character;
 use crate::display_object::TDisplayObject;
@@ -613,13 +613,127 @@ pub fn hit_test<'gc>(
 }
 
 pub fn copy_pixels<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
-    _args: &[Value<'gc>],
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            log::warn!("BitmapData.copyPixels - not yet implemented");
+            let source_bitmap = args
+                .get(0)
+                .unwrap_or(&Value::Undefined)
+                .coerce_to_object(activation);
+
+            let source_rect = args
+                .get(1)
+                .unwrap_or(&Value::Undefined)
+                .coerce_to_object(activation);
+
+            let src_min_x = source_rect
+                .get("x", activation)?
+                .coerce_to_i32(activation)?;
+            let src_min_y = source_rect
+                .get("y", activation)?
+                .coerce_to_i32(activation)?;
+            let src_width = source_rect
+                .get("width", activation)?
+                .coerce_to_i32(activation)?;
+            let src_height = source_rect
+                .get("height", activation)?
+                .coerce_to_i32(activation)?;
+
+            let dest_point = args
+                .get(2)
+                .unwrap_or(&Value::Undefined)
+                .coerce_to_object(activation);
+
+            let dest_x = dest_point.get("x", activation)?.coerce_to_i32(activation)?;
+            let dest_y = dest_point.get("y", activation)?.coerce_to_i32(activation)?;
+
+            if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
+                if !src_bitmap.disposed() {
+                    // dealing with object aliasing...
+                    let src_bitmap_clone: BitmapData; // only initialized if source is the same object as self
+                    let src_bitmap_data_cell = src_bitmap.bitmap_data();
+                    let src_bitmap_gc_ref; // only initialized if source is a different object than self
+                    let source_bitmap_ref = // holds the reference to either of the ones above
+                        if GcCell::ptr_eq(src_bitmap.bitmap_data(), bitmap_data.bitmap_data()) {
+                            src_bitmap_clone = src_bitmap_data_cell.read().clone();
+                            &src_bitmap_clone
+                        } else {
+                            src_bitmap_gc_ref = src_bitmap_data_cell.read();
+                            &src_bitmap_gc_ref
+                        };
+
+                    if args.len() >= 5 {
+                        let alpha_point = args
+                            .get(4)
+                            .unwrap_or(&Value::Undefined)
+                            .coerce_to_object(activation);
+
+                        let alpha_x = alpha_point
+                            .get("x", activation)?
+                            .coerce_to_i32(activation)?;
+
+                        let alpha_y = alpha_point
+                            .get("y", activation)?
+                            .coerce_to_i32(activation)?;
+
+                        let alpha_bitmap = args
+                            .get(3)
+                            .unwrap_or(&Value::Undefined)
+                            .coerce_to_object(activation);
+
+                        if let Some(alpha_bitmap) = alpha_bitmap.as_bitmap_data_object() {
+                            if !alpha_bitmap.disposed() {
+                                // dealing with aliasing the same way as for the source
+                                let alpha_bitmap_clone: BitmapData;
+                                let alpha_bitmap_data_cell = alpha_bitmap.bitmap_data();
+                                let alpha_bitmap_gc_ref;
+                                let alpha_bitmap_ref = if GcCell::ptr_eq(
+                                    alpha_bitmap.bitmap_data(),
+                                    bitmap_data.bitmap_data(),
+                                ) {
+                                    alpha_bitmap_clone = alpha_bitmap_data_cell.read().clone();
+                                    &alpha_bitmap_clone
+                                } else {
+                                    alpha_bitmap_gc_ref = alpha_bitmap_data_cell.read();
+                                    &alpha_bitmap_gc_ref
+                                };
+
+                                let merge_alpha = if args.len() >= 6 {
+                                    args.get(5)
+                                        .unwrap_or(&Value::Undefined)
+                                        .as_bool(activation.swf_version())
+                                } else {
+                                    true
+                                };
+
+                                bitmap_data
+                                    .bitmap_data()
+                                    .write(activation.context.gc_context)
+                                    .copy_pixels(
+                                        source_bitmap_ref,
+                                        (src_min_x, src_min_y, src_width, src_height),
+                                        (dest_x, dest_y),
+                                        Some((alpha_bitmap_ref, (alpha_x, alpha_y), merge_alpha)),
+                                    );
+                            }
+                        }
+                    } else {
+                        bitmap_data
+                            .bitmap_data()
+                            .write(activation.context.gc_context)
+                            .copy_pixels(
+                                source_bitmap_ref,
+                                (src_min_x, src_min_y, src_width, src_height),
+                                (dest_x, dest_y),
+                                None,
+                            );
+                    }
+                }
+            }
+
             return Ok(Value::Undefined);
         }
     }


### PR DESCRIPTION
This adds the main content (left-scrolling foreground image) to [z0r.de/7463](https://z0r.de/L/z0r-de_7463.swf), solving another third of #2073.
This should also help with #2240, although other missing features seem to block this from making any difference there.

I tried to test this implementation with a variety of different parameter sets, using this test script: [BitmapCopyPixels.as](https://gist.github.com/torokati44/efd3c97d15ca51b1242af63a1f2adb2e)

Which produces this image in the Adobe player:

![image](https://user-images.githubusercontent.com/288816/104532063-b076b580-560f-11eb-97f3-09b0d126a887.png)

There is at most 1 value of difference from this in any channel of any pixel when run in Ruffle, as shown in this exaggerated difference image:

![image](https://user-images.githubusercontent.com/288816/104531743-2890ab80-560f-11eb-9158-e8eb4091c2f2.png)

These are most likely rounding errors or other slight imprecisions. I don't find these to be too big of an issue.
The output is visually exactly the same, at least to my eyes.