### PR TITLE
render: Avoid asserts in masking state

### DIFF
--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1298,7 +1298,7 @@ impl RenderBackend for WebGlRenderBackend {
     }
 
     fn push_mask(&mut self) {
-        assert!(
+        debug_assert!(
             self.mask_state == MaskState::NoMask || self.mask_state == MaskState::DrawMaskedContent
         );
         self.num_masks += 1;
@@ -1307,19 +1307,19 @@ impl RenderBackend for WebGlRenderBackend {
     }
 
     fn activate_mask(&mut self) {
-        assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskStencil);
+        debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskStencil);
         self.mask_state = MaskState::DrawMaskedContent;
         self.mask_state_dirty = true;
     }
 
     fn deactivate_mask(&mut self) {
-        assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskedContent);
+        debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskedContent);
         self.mask_state = MaskState::ClearMaskStencil;
         self.mask_state_dirty = true;
     }
 
     fn pop_mask(&mut self) {
-        assert!(self.num_masks > 0 && self.mask_state == MaskState::ClearMaskStencil);
+        debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::ClearMaskStencil);
         self.num_masks -= 1;
         self.mask_state = if self.num_masks == 0 {
             MaskState::NoMask

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -1249,7 +1249,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     }
 
     fn push_mask(&mut self) {
-        assert!(
+        debug_assert!(
             self.mask_state == MaskState::NoMask || self.mask_state == MaskState::DrawMaskedContent
         );
         self.num_masks += 1;
@@ -1257,17 +1257,17 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     }
 
     fn activate_mask(&mut self) {
-        assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskStencil);
+        debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskStencil);
         self.mask_state = MaskState::DrawMaskedContent;
     }
 
     fn deactivate_mask(&mut self) {
-        assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskedContent);
+        debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::DrawMaskedContent);
         self.mask_state = MaskState::ClearMaskStencil;
     }
 
     fn pop_mask(&mut self) {
-        assert!(self.num_masks > 0 && self.mask_state == MaskState::ClearMaskStencil);
+        debug_assert!(self.num_masks > 0 && self.mask_state == MaskState::ClearMaskStencil);
         self.num_masks -= 1;
         self.mask_state = if self.num_masks == 0 {
             MaskState::NoMask


### PR DESCRIPTION
Switch to debug_assert! instead of assert! in mask checks to avoid
panicking (#1347). This will render incorrectly and still needs
to be fixed, but we should fail gracefully and avoid killing the
entire player.