### PR TITLE
Build windows binaries with crt-static

### DIFF
--- a/.github/workflows/release_nightlies.yml
+++ b/.github/workflows/release_nightlies.yml
@@ -104,7 +104,17 @@ jobs:
           npm run build
           npm run docs
 
-      - name: Build desktop
+      - name: Build Windows desktop
+        if: matrix.os == 'windows-latest'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+        env:
+          RUSTFLAGS: -Ctarget-feature=+crt-static
+
+      - name: Build Mac / Ubuntu
+        if: matrix.os != 'windows-latest'
         uses: actions-rs/cargo@v1
         with:
           command: build

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ Ruffle is in the proof-of-concept stage and can currently run early Flash animat
 
 ## Using Ruffle
 
-The easiest way to try out Ruffle is to visit the [web demo page](https://ruffle.rs/demo/), then click the "Browse..." button to load an SWF file of your choice. 
+The easiest way to try out Ruffle is to visit the [web demo page](https://ruffle.rs/demo/), then click the "Browse..." button to load an SWF file of your choice.
 
 [Nightly builds](https://ruffle.rs/#releases) of Ruffle are available for desktop and web platforms including the browser extension.
-
-Windows desktop builds require the x64 [2015-2019 Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads).
 
 For more detailed instructions, see our [wiki page](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle).
 


### PR DESCRIPTION
This is to prevent errors about missing `VCRUNTIME140_1.dll` etc without forcing the users to install the redistributables themselves.

You can see other projects doing the same:
https://github.com/rustwasm/wasm-pack/commit/d6146b25a580de72487c17aceab896b859df546e
https://github.com/bytecodealliance/wasmtime/commit/8ce68732f68197dedd47bbfeea5f83b43c23fe7a

I built Ruffle with this and confirmed that it launches without errors on a W8.1 laptop without redistributables and a freshly installed W10 VM, where the previous Ruffle releases couldn't launch.

However, neither the laptop nor the VM had sufficient graphics acceleration support, so all games ran with just a white window - so technically I didn't check if it 100% works on a modern machine without the redistributables. Would be nice if someone could confirm this works before merging.