### PR TITLE
web: Display helpful errors when Ruffle fails to initialize

### DIFF
--- a/web/packages/core/src/globals.d.ts
+++ b/web/packages/core/src/globals.d.ts
@@ -4,3 +4,8 @@ declare let __webpack_public_path__: string;
 declare let ruffleRuntimePath: string;
 declare let __CHANNEL__: string;
 declare let __COMMIT_DATE__: string;
+
+interface Error {
+    ruffleIsExtension?: boolean;
+    ruffleIndexError?: number;
+}


### PR DESCRIPTION
This PR is intended to help users of the selfhosted build, when Ruffle fails to initialize. To do so, new error messages are implemented.

Messages likely need to be improved. I also wonder if there's a better way to detect certain errors (eg. 404 and CORS). If this gets merged, we'll have to mention about the CORS issue on the wiki.