### PR TITLE
Allow configuring log level on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,6 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
+ "serde",
 ]
 
 [[package]]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -27,7 +27,7 @@ console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"
 generational-arena = "0.2.8"
 js-sys = "0.3.46"
-log = "0.4"
+log = { version = "0.4", features = ["serde"] }
 ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -66,6 +66,17 @@ export enum UnmuteOverlay {
 }
 
 /**
+ * Console logging level.
+ */
+export enum LogLevel {
+    Error = "error",
+    Warn = "warn",
+    Info = "info",
+    Debug = "debug",
+    Trace = "trace",
+}
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -131,6 +142,13 @@ export interface BaseLoadOptions {
      * @default true
      */
     warnOnUnsupportedContent?: boolean;
+
+    /**
+     * Console logging level.
+     *
+     * @default LogLevel.Error
+     */
+    logLevel?: LogLevel;
 }
 
 /**

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -25,6 +25,7 @@ const gamesOptGroup = document.getElementById("games-optgroup");
 // Default config used by the player.
 const config = {
     letterbox: "on",
+    logLevel: "warn",
 };
 
 window.addEventListener("DOMContentLoaded", async () => {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -124,6 +124,9 @@ pub struct Config {
 
     #[serde(rename = "warnOnUnsupportedContent")]
     warn_on_unsupported_content: bool,
+
+    #[serde(rename = "logLevel")]
+    log_level: log::Level,
 }
 
 impl Default for Config {
@@ -133,6 +136,7 @@ impl Default for Config {
             letterbox: Default::default(),
             upgrade_to_https: true,
             warn_on_unsupported_content: true,
+            log_level: log::Level::Error,
         }
     }
 }
@@ -411,7 +415,7 @@ impl Ruffle {
         allow_script_access: bool,
         config: Config,
     ) -> Result<Ruffle, Box<dyn Error>> {
-        let _ = console_log::init_with_level(log::Level::Trace);
+        let _ = console_log::init_with_level(config.log_level);
 
         let window = web_sys::window().ok_or("Expected window")?;
         let document = window.document().ok_or("Expected document")?;


### PR DESCRIPTION
New default in API is "error".
Demo page uses "warn".

I'd also love to set "warn" in extension, but I couldn't actually found the config in extension's source. Any hints?