### PR TITLE
Migrate from enumset to bitflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "d9fe5e32de01730eb1f6b7f5b51c17e03e2325bf40a74f754f04f130043affff"
 
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a0559bcd3f7a482690d98be41c08a43e92f669b179433e95ddf5e8b8fd36a3"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
@@ -147,9 +147,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -160,25 +160,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.10.1"
+name = "base-x"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -293,9 +278,9 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "calloop"
@@ -359,7 +344,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
@@ -393,7 +378,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "os_str_bytes",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
  "unicode-width",
@@ -487,20 +472,19 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.4.0"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9417a0c314565e2abffaece67e95a8cb51f9238cd39f3764d9dfdf09e72b20c"
+checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
 dependencies = [
  "bytes",
  "memchr",
- "pin-project-lite 0.1.11",
 ]
 
 [[package]]
 name = "console"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
+checksum = "7cc80946b3480f421c2f17ed1cb841753a371c7c5104f51d507e13f532c856aa"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -509,7 +493,6 @@ dependencies = [
  "terminal_size",
  "unicode-width",
  "winapi 0.3.9",
- "winapi-util",
 ]
 
 [[package]]
@@ -534,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -546,12 +529,29 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784ad0fbab4f3e9cef09f20e0aea6000ae08d2cb98ac4c0abc53df18803d702f"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.24",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
+checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
 dependencies = [
- "time",
- "url 1.7.2",
+ "cookie",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.2.24",
+ "url",
 ]
 
 [[package]]
@@ -686,7 +686,7 @@ dependencies = [
  "nix 0.15.0",
  "oboe",
  "parking_lot",
- "stdweb",
+ "stdweb 0.1.3",
  "thiserror",
  "web-sys",
  "winapi 0.3.9",
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
+checksum = "10bcb9d7dcbf7002aaffbb53eac22906b64cdcc127971dcc387d8eb7c95d5560"
 dependencies = [
  "quote",
  "syn",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d658711a12632b5574c8d5b3fc5d2f0d2f87b9fbf9237ee0f759b88bb6bdec"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -842,23 +842,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d3514d243331d8acde56bfcf45d0147aabbda853c2f49dce081ea85f9a7220"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.9.3",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f63c369ef0c17ad17585d31d5f2bf10dece2710bf0766e01db57a6f9849a2e"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote",
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "derivative"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
+checksum = "eaed5874effa6cde088c644ddcdcb4ffd1511391c5be4fdd7a5ccd02c7e4a183"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1019,6 +1019,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dispatch"
@@ -1094,28 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumset"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "959a80a2062fedd66ed41d99736212de987b3a8c83a4c2cef243968075256bd1"
-dependencies = [
- "enumset_derive",
- "num-traits",
-]
-
-[[package]]
-name = "enumset_derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bef436ac71820c5cf768d7af9ba33121246b09a00e09a55d94ef8095a875ac"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,24 +1158,24 @@ dependencies = [
 
 [[package]]
 name = "fetch_unroll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c55005e95bbe15f5f72a73b6597d0dc82ddc97ffe2ca097a99dcd591fefbca"
+checksum = "c8d44807d562d137f063cbfe209da1c3f9f2fa8375e11166ef495daab7b847f9"
 dependencies = [
- "libflate 0.1.27",
+ "libflate",
  "tar",
  "ureq",
 ]
 
 [[package]]
 name = "filetime"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "winapi 0.3.9",
 ]
 
@@ -1221,7 +1205,7 @@ checksum = "0362ef9c4c1fa854ff95b4cb78045a86e810d804dc04937961988b45427104a9"
 dependencies = [
  "futures-core",
  "futures-sink",
- "pin-project 1.0.2",
+ "pin-project 1.0.4",
  "spinning_top",
 ]
 
@@ -1253,7 +1237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1322,16 +1306,16 @@ checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
 dependencies = [
  "fastrand",
  "futures-core",
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "waker-fn",
 ]
 
@@ -1375,7 +1359,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1423,11 +1407,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1441,7 +1425,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1667,27 +1651,27 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
  "bytes",
  "fnv",
@@ -1696,26 +1680,15 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -1816,15 +1789,15 @@ dependencies = [
  "sluice",
  "tracing",
  "tracing-futures",
- "url 2.2.0",
+ "url",
  "waker-fn",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jni"
@@ -1847,7 +1820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36bcc950632e48b86da402c5c077590583da5ac0d480103611d5374e7c967a3c"
 dependencies = [
  "cesu8",
- "combine 4.4.0",
+ "combine 4.5.2",
  "error-chain",
  "jni-sys",
  "log",
@@ -1927,21 +1900,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
-
-[[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-dependencies = [
- "adler32",
- "crc32fast",
- "rle-decode-fast",
- "take_mut",
-]
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libflate"
@@ -1963,9 +1924,9 @@ checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
 name = "libloading"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2497,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "oboe"
@@ -2538,9 +2499,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -2592,14 +2553,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2615,12 +2576,6 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -2649,11 +2604,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -2669,20 +2624,14 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
@@ -2773,9 +2722,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2784,6 +2733,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
+dependencies = [
+ "error-chain",
+ "idna",
+ "lazy_static",
+ "regex",
+ "url",
 ]
 
 [[package]]
@@ -2802,7 +2764,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2846,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -2899,21 +2861,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.15",
- "redox_syscall",
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2932,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "ring"
@@ -2959,11 +2930,11 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "ron"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a58080b7bb83b2ea28c3b7a9a994fd5e310330b7c8ca5258d99b98128ecfe4"
+checksum = "064ea8613fb712a19faf920022ec8ddf134984f100090764a4e1d768f3827f1f"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "bitflags",
  "serde",
 ]
@@ -2973,11 +2944,11 @@ name = "ruffle_core"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "bitflags",
  "bitstream-io 1.0.0",
  "chrono",
  "downcast-rs",
  "encoding_rs",
- "enumset",
  "flate2",
  "fnv",
  "gc-arena",
@@ -2992,7 +2963,7 @@ dependencies = [
  "minimp3",
  "num-traits",
  "num_enum 0.5.1",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "png",
  "pretty_assertions",
  "puremp3",
@@ -3003,7 +2974,7 @@ dependencies = [
  "smallvec",
  "swf",
  "thiserror",
- "url 2.2.0",
+ "url",
  "weak-table",
 ]
 
@@ -3027,7 +2998,7 @@ dependencies = [
  "ruffle_core",
  "ruffle_render_wgpu",
  "tinyfiledialogs",
- "url 2.2.0",
+ "url",
  "webbrowser",
  "winapi 0.3.9",
  "winit",
@@ -3045,12 +3016,12 @@ dependencies = [
 name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "fnv",
  "jpeg-decoder",
  "js-sys",
  "log",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "png",
  "ruffle_core",
  "ruffle_web_common",
@@ -3076,7 +3047,7 @@ dependencies = [
  "jpeg-decoder",
  "js-sys",
  "log",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "png",
  "ruffle_core",
  "ruffle_render_common_tess",
@@ -3135,7 +3106,7 @@ dependencies = [
  "ruffle_render_webgl",
  "ruffle_web_common",
  "serde",
- "url 2.2.0",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -3158,7 +3129,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -3177,12 +3148,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustls"
-version = "0.16.0"
+name = "rustc_version"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "base64 0.10.1",
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+dependencies = [
+ "base64",
  "log",
  "ring",
  "sct",
@@ -3253,19 +3233,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.118"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3282,6 +3277,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "shlex"
@@ -3340,13 +3341,12 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d1d080d3dc98d68251d073b231dfaa200fdc2ddebc435b313ad937d0ae9dfd"
+checksum = "316e13a3eb853ce7bf72ad3530dc186cb2005c57c521ef5f4ada5ee4eed74de6"
 dependencies = [
  "andrew",
  "bitflags",
- "byteorder",
  "calloop",
  "dlib",
  "lazy_static",
@@ -3360,13 +3360,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -3387,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "spirv_cross"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea964c42ce40326fe96111918abe71fa45076da1ea85769f3f1ab1cda9a1d496"
+checksum = "0ebd49af36be83ecd6290b57147e2a0e26145b832634b17146d934b197ca3713"
 dependencies = [
  "cc",
  "js-sys",
@@ -3407,10 +3406,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "standback"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66a8cff4fa24853fdf6b51f75c6d7f8206d7c75cab4e467bcd7f25c2b1febe0"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "storage-map"
@@ -3420,6 +3477,12 @@ checksum = "418bb14643aa55a7841d5303f72cf512cfb323b8cc221d51580500a1ca75206c"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -3438,12 +3501,12 @@ name = "swf"
 version = "0.1.2"
 dependencies = [
  "approx",
+ "bitflags",
  "bitstream-io 1.0.0",
  "byteorder",
  "encoding_rs",
- "enumset",
  "flate2",
- "libflate 1.0.3",
+ "libflate",
  "log",
  "lzma-rs",
  "num-derive",
@@ -3453,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3475,12 +3538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
 name = "tar"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,7 +3545,7 @@ checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "xattr",
 ]
 
@@ -3503,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -3542,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
@@ -3557,9 +3614,9 @@ checksum = "7572415bd688d401c52f6e36f4c8e805b9ae1622619303b9fa835d531db0acae"
 
 [[package]]
 name = "tiff"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abeb4e3f32a8973722c0254189e6890358e72b1bf11becb287ee0b23c595a41d"
+checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
 dependencies = [
  "jpeg-decoder",
  "miniz_oxide 0.4.3",
@@ -3568,13 +3625,50 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273d3ed44dca264b0d6b3665e8d48fb515042d42466fad93d2a45b90ec4058f7"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb 0.4.20",
+ "time-macros",
+ "version_check",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
@@ -3603,9 +3697,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
@@ -3618,7 +3712,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3718,30 +3812,21 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "0.11.4"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801125e6d1ba6864cf3a5a92cfb2f0b0a3ee73e40602a0cd206ad2f3c040aa96"
+checksum = "294b85ef5dbc3670a72e82a89971608a1fcc4ed5c7c5a2895230d31a95f0569b"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "chunked_transfer",
  "cookie",
- "lazy_static",
+ "cookie_store",
+ "log",
+ "once_cell",
  "qstring",
  "rustls",
- "url 2.2.0",
+ "url",
  "webpki",
  "webpki-roots",
-]
-
-[[package]]
-name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
 ]
 
 [[package]]
@@ -3751,9 +3836,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.0",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3825,9 +3910,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3923,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222b227f47871e47d657c1c5e5360b4af9a877aa9c892716787be1c192c78c42"
+checksum = "bdbdbe01d03b2267809f3ed99495b37395387fde789e0f2ebb78e8b43f75b6d7"
 dependencies = [
  "bitflags",
  "downcast-rs",
@@ -3939,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-commons"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230b3ffeda101f877ff8ecb8573f5d26e7beb345b197807c4df34ec06879a3e6"
+checksum = "480450f76717edd64ad04a4426280d737fc3d10a236b982df7b1aee19f0e2d56"
 dependencies = [
  "nix 0.18.0",
  "once_cell",
@@ -3951,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aad1b4301cdccfb5f64056a4736e8155a5f4734bac41fdbca80b1fdbe1ab3e1"
+checksum = "d6eb122c160223a7660feeaf949d0100281d1279acaaed3720eb3c9894496e5f"
 dependencies = [
  "nix 0.18.0",
  "wayland-client",
@@ -3962,9 +4047,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc16a9db803cae58b45f9a84a6cf364434cc49a95c8b1ef98ffeb467d228bdc9"
+checksum = "319a82b4d3054dd25acc32d9aee0f84fa95b63bc983fffe4703b6b8d47e01a30"
 dependencies = [
  "bitflags",
  "wayland-client",
@@ -3974,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee5bd43a1d746efc486515fec561e47205f328b74802b959f10f5500f7e56cc"
+checksum = "7010ba5767b3fcd350decc59055390b4ebe6bd1b9279a9feb1f1888987f1133d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3985,9 +4070,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0814adbecc7ea97869971e1d1c1b657e31863dda6fd768f119ad3dc408a01e58"
+checksum = "6793834e0c35d11fd96a97297abe03d37be627e1847da52e17d7e0e3b51cc099"
 dependencies = [
  "dlib",
  "lazy_static",
@@ -4033,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.18.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]
@@ -4177,7 +4262,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "parking_lot",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "raw-window-handle",
  "smithay-client-toolkit",
  "wayland-client",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ png = { version = "0.16.8" }
 puremp3 = { version = "0.1", optional = true }
 ruffle_macros = { path = "macros" }
 swf = { path = "../swf" }
-enumset = "1.0.1"
+bitflags = "1.2.1"
 smallvec = "1.6.1"
 num_enum = "0.5.1"
 quick-xml = "0.20.0"

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -22,7 +22,7 @@ mod fscommand;
 pub mod function;
 pub mod globals;
 pub mod object;
-mod property;
+pub mod property;
 mod scope;
 mod string;
 mod timer;

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -14,7 +14,6 @@ use crate::ecma_conversions::f64_to_wrapping_u32;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
-use enumset::EnumSet;
 use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use indexmap::IndexMap;
 use rand::Rng;
@@ -1146,16 +1145,16 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         sub_prototype.set_attributes(
             self.context.gc_context,
             Some("constructor"),
-            Attribute::DontEnum.into(),
-            EnumSet::empty(),
+            Attribute::DONT_ENUM,
+            Attribute::empty(),
         );
 
         sub_prototype.set("__constructor__", superclass.into(), self)?;
         sub_prototype.set_attributes(
             self.context.gc_context,
             Some("__constructor__"),
-            Attribute::DontEnum.into(),
-            EnumSet::empty(),
+            Attribute::DONT_ENUM,
+            Attribute::empty(),
         );
 
         subclass.set("prototype", sub_prototype.into(), self)?;

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -3,13 +3,12 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::super_object::SuperObject;
-use crate::avm1::property::{Attribute, Attribute::*};
+use crate::avm1::property::Attribute;
 use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
 use crate::avm1::{Object, ObjectPtr, ScriptObject, TObject};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use crate::tag_utils::SwfSlice;
-use enumset::EnumSet;
 use gc_arena::{Collect, CollectionContext, Gc, GcCell, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
@@ -269,14 +268,14 @@ impl<'gc> Executable<'gc> {
                     activation.context.gc_context,
                     "callee",
                     callee.into(),
-                    DontEnum.into(),
+                    Attribute::DONT_ENUM,
                 );
                 // The caller is the previous callee.
                 arguments.define_value(
                     activation.context.gc_context,
                     "caller",
                     activation.callee.map(Value::from).unwrap_or(Value::Null),
-                    DontEnum.into(),
+                    Attribute::DONT_ENUM,
                 );
 
                 if !af.suppress_arguments {
@@ -499,9 +498,9 @@ impl<'gc> FunctionObject<'gc> {
             context,
             "constructor",
             Value::Object(function),
-            DontEnum.into(),
+            Attribute::DONT_ENUM,
         );
-        function.define_value(context, "prototype", prototype.into(), EnumSet::empty());
+        function.define_value(context, "prototype", prototype.into(), Attribute::empty());
 
         function
     }
@@ -588,16 +587,16 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         this.set_attributes(
             activation.context.gc_context,
             Some("__constructor__"),
-            Attribute::DontEnum.into(),
-            EnumSet::empty(),
+            Attribute::DONT_ENUM,
+            Attribute::empty(),
         );
         if activation.current_swf_version() < 7 {
             this.set("constructor", (*self).into(), activation)?;
             this.set_attributes(
                 activation.context.gc_context,
                 Some("constructor"),
-                Attribute::DontEnum.into(),
-                EnumSet::empty(),
+                Attribute::DONT_ENUM,
+                Attribute::empty(),
             );
         }
         if let Some(exec) = &self.data.read().constructor {
@@ -630,16 +629,16 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         this.set_attributes(
             activation.context.gc_context,
             Some("__constructor__"),
-            Attribute::DontEnum.into(),
-            EnumSet::empty(),
+            Attribute::DONT_ENUM,
+            Attribute::empty(),
         );
         if activation.current_swf_version() < 7 {
             this.set("constructor", (*self).into(), activation)?;
             this.set_attributes(
                 activation.context.gc_context,
                 Some("constructor"),
-                Attribute::DontEnum.into(),
-                EnumSet::empty(),
+                Attribute::DONT_ENUM,
+                Attribute::empty(),
             );
         }
         if let Some(exec) = &self.data.read().constructor {
@@ -709,7 +708,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base.define_value(gc_context, name, value, attributes)
     }
@@ -718,8 +717,8 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
-        set_attributes: EnumSet<Attribute>,
-        clear_attributes: EnumSet<Attribute>,
+        set_attributes: Attribute,
+        clear_attributes: Attribute,
     ) {
         self.base
             .set_attributes(gc_context, name, set_attributes, clear_attributes)
@@ -731,7 +730,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base
             .add_property(gc_context, name, get, set, attributes)
@@ -744,7 +743,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base
             .add_property_with_case(activation, gc_context, name, get, set, attributes)

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -1,9 +1,8 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::Collect;
 use gc_arena::MutationContext;
 use rand::Rng;
@@ -701,19 +700,29 @@ pub fn create_globals<'gc>(
         transform_proto,
     );
 
-    flash.define_value(gc_context, "geom", geom.into(), EnumSet::empty());
-    flash.define_value(gc_context, "filters", filters.into(), EnumSet::empty());
-    flash.define_value(gc_context, "display", display.into(), EnumSet::empty());
-    geom.define_value(gc_context, "Matrix", matrix.into(), EnumSet::empty());
-    geom.define_value(gc_context, "Point", point.into(), EnumSet::empty());
-    geom.define_value(gc_context, "Rectangle", rectangle.into(), EnumSet::empty());
+    flash.define_value(gc_context, "geom", geom.into(), Attribute::empty());
+    flash.define_value(gc_context, "filters", filters.into(), Attribute::empty());
+    flash.define_value(gc_context, "display", display.into(), Attribute::empty());
+    geom.define_value(gc_context, "Matrix", matrix.into(), Attribute::empty());
+    geom.define_value(gc_context, "Point", point.into(), Attribute::empty());
+    geom.define_value(
+        gc_context,
+        "Rectangle",
+        rectangle.into(),
+        Attribute::empty(),
+    );
     geom.define_value(
         gc_context,
         "ColorTransform",
         color_transform.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
-    geom.define_value(gc_context, "Transform", transform.into(), EnumSet::empty());
+    geom.define_value(
+        gc_context,
+        "Transform",
+        transform.into(),
+        Attribute::empty(),
+    );
 
     let bitmap_filter_proto =
         bitmap_filter::create_proto(gc_context, object_proto, Some(function_proto));
@@ -819,62 +828,62 @@ pub fn create_globals<'gc>(
         gc_context,
         "BitmapFilter",
         bitmap_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "BlurFilter",
         blur_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "BevelFilter",
         bevel_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "GlowFilter",
         glow_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "DropShadowFilter",
         drop_shadow_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "ColorMatrixFilter",
         color_matrix_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "DisplacementMapFilter",
         displacement_map_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "ConvolutionFilter",
         convolution_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     filters.define_value(
         gc_context,
         "GradientBevelFilter",
         gradient_bevel_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     filters.define_value(
         gc_context,
         "GradientGlowFilter",
         gradient_glow_filter.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     let bitmap_data_proto = bitmap_data::create_proto(gc_context, object_proto, function_proto);
@@ -885,7 +894,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "BitmapData",
         bitmap_data.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     let external = ScriptObject::object(gc_context, Some(object_proto));
@@ -895,12 +904,12 @@ pub fn create_globals<'gc>(
         function_proto,
     );
 
-    flash.define_value(gc_context, "external", external.into(), EnumSet::empty());
+    flash.define_value(gc_context, "external", external.into(), Attribute::empty());
     external.define_value(
         gc_context,
         "ExternalInterface",
         external_interface.into(),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     let mut globals = ScriptObject::bare_object(gc_context);
@@ -908,37 +917,57 @@ pub fn create_globals<'gc>(
         gc_context,
         "AsBroadcaster",
         as_broadcaster.into(),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
-    globals.define_value(gc_context, "flash", flash.into(), DontEnum.into());
-    globals.define_value(gc_context, "Array", array.into(), DontEnum.into());
-    globals.define_value(gc_context, "Button", button.into(), DontEnum.into());
-    globals.define_value(gc_context, "Color", color.into(), DontEnum.into());
-    globals.define_value(gc_context, "Error", error.into(), DontEnum.into());
-    globals.define_value(gc_context, "Object", object.into(), DontEnum.into());
-    globals.define_value(gc_context, "Function", function.into(), DontEnum.into());
-    globals.define_value(gc_context, "LoadVars", load_vars.into(), DontEnum.into());
-    globals.define_value(gc_context, "MovieClip", movie_clip.into(), DontEnum.into());
+    globals.define_value(gc_context, "flash", flash.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Array", array.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Button", button.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Color", color.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Error", error.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Object", object.into(), Attribute::DONT_ENUM);
+    globals.define_value(
+        gc_context,
+        "Function",
+        function.into(),
+        Attribute::DONT_ENUM,
+    );
+    globals.define_value(
+        gc_context,
+        "LoadVars",
+        load_vars.into(),
+        Attribute::DONT_ENUM,
+    );
+    globals.define_value(
+        gc_context,
+        "MovieClip",
+        movie_clip.into(),
+        Attribute::DONT_ENUM,
+    );
     globals.define_value(
         gc_context,
         "MovieClipLoader",
         movie_clip_loader.into(),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
-    globals.define_value(gc_context, "Sound", sound.into(), DontEnum.into());
-    globals.define_value(gc_context, "TextField", text_field.into(), DontEnum.into());
+    globals.define_value(gc_context, "Sound", sound.into(), Attribute::DONT_ENUM);
+    globals.define_value(
+        gc_context,
+        "TextField",
+        text_field.into(),
+        Attribute::DONT_ENUM,
+    );
     globals.define_value(
         gc_context,
         "TextFormat",
         text_format.into(),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
-    globals.define_value(gc_context, "XMLNode", xmlnode.into(), DontEnum.into());
-    globals.define_value(gc_context, "XML", xml.into(), DontEnum.into());
-    globals.define_value(gc_context, "String", string.into(), DontEnum.into());
-    globals.define_value(gc_context, "Number", number.into(), DontEnum.into());
-    globals.define_value(gc_context, "Boolean", boolean.into(), DontEnum.into());
-    globals.define_value(gc_context, "Date", date.into(), DontEnum.into());
+    globals.define_value(gc_context, "XMLNode", xmlnode.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "XML", xml.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "String", string.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Number", number.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Boolean", boolean.into(), Attribute::DONT_ENUM);
+    globals.define_value(gc_context, "Date", date.into(), Attribute::DONT_ENUM);
 
     let shared_object_proto = shared_object::create_proto(gc_context, object_proto, function_proto);
 
@@ -951,7 +980,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "SharedObject",
         shared_obj.into(),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
 
     let context_menu = FunctionObject::constructor(
@@ -965,7 +994,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "ContextMenu",
         context_menu.into(),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
 
     let selection = selection::create_selection_object(
@@ -975,7 +1004,12 @@ pub fn create_globals<'gc>(
         broadcaster_functions,
         array_proto,
     );
-    globals.define_value(gc_context, "Selection", selection.into(), DontEnum.into());
+    globals.define_value(
+        gc_context,
+        "Selection",
+        selection.into(),
+        Attribute::DONT_ENUM,
+    );
 
     let context_menu_item = FunctionObject::constructor(
         gc_context,
@@ -988,7 +1022,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "ContextMenuItem",
         context_menu_item.into(),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
 
     let system_security = system_security::create(gc_context, Some(object_proto), function_proto);
@@ -1010,7 +1044,7 @@ pub fn create_globals<'gc>(
         system_capabilities,
         system_ime,
     );
-    globals.define_value(gc_context, "System", system.into(), DontEnum.into());
+    globals.define_value(gc_context, "System", system.into(), Attribute::DONT_ENUM);
 
     globals.define_value(
         gc_context,
@@ -1020,7 +1054,7 @@ pub fn create_globals<'gc>(
             Some(object_proto),
             Some(function_proto),
         )),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
     globals.define_value(
         gc_context,
@@ -1032,7 +1066,7 @@ pub fn create_globals<'gc>(
             broadcaster_functions,
             array_proto,
         )),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
     globals.define_value(
         gc_context,
@@ -1044,7 +1078,7 @@ pub fn create_globals<'gc>(
             broadcaster_functions,
             array_proto,
         )),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
     globals.define_value(
         gc_context,
@@ -1056,72 +1090,90 @@ pub fn create_globals<'gc>(
             function_proto,
             broadcaster_functions,
         )),
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
     globals.force_set_function(
         "isFinite",
         is_finite,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
-    globals.force_set_function("isNaN", is_nan, gc_context, DontEnum, Some(function_proto));
+    globals.force_set_function(
+        "isNaN",
+        is_nan,
+        gc_context,
+        Attribute::DONT_ENUM,
+        Some(function_proto),
+    );
     globals.force_set_function(
         "parseInt",
         parse_int,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
     globals.force_set_function(
         "parseFloat",
         parse_float,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
-    globals.force_set_function("random", random, gc_context, DontEnum, Some(function_proto));
+    globals.force_set_function(
+        "random",
+        random,
+        gc_context,
+        Attribute::DONT_ENUM,
+        Some(function_proto),
+    );
     globals.force_set_function(
         "ASSetPropFlags",
         object::as_set_prop_flags,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
     globals.force_set_function(
         "clearInterval",
         clear_interval,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
     globals.force_set_function(
         "setInterval",
         set_interval,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
     globals.force_set_function(
         "setTimeout",
         set_timeout,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
     globals.force_set_function(
         "updateAfterEvent",
         update_after_event,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
-    globals.force_set_function("escape", escape, gc_context, DontEnum, Some(function_proto));
+    globals.force_set_function(
+        "escape",
+        escape,
+        gc_context,
+        Attribute::DONT_ENUM,
+        Some(function_proto),
+    );
     globals.force_set_function(
         "unescape",
         unescape,
         gc_context,
-        DontEnum,
+        Attribute::DONT_ENUM,
         Some(function_proto),
     );
 
@@ -1135,7 +1187,7 @@ pub fn create_globals<'gc>(
             function_proto,
         ),
         None,
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
     globals.add_property(
         gc_context,
@@ -1147,7 +1199,7 @@ pub fn create_globals<'gc>(
             function_proto,
         ),
         None,
-        DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
 
     (

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -42,15 +42,60 @@ pub fn create_array_object<'gc>(
     // TODO: These were added in Flash Player 7, but are available even to SWFv6 and lower
     // when run in Flash Player 7. Make these conditional if we add a parameter to control
     // target Flash Player version.
-    object.define_value(gc_context, "CASEINSENSITIVE", 1.into(), Attribute::all());
+    object.define_value(
+        gc_context,
+        "CASEINSENSITIVE",
+        1.into(),
+        Attribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | AttrAttribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | Attribute::READ_ONLY,
+    );
 
-    object.define_value(gc_context, "DESCENDING", 2.into(), Attribute::all());
+    object.define_value(
+        gc_context,
+        "DESCENDING",
+        2.into(),
+        Attribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | AttrAttribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | Attribute::READ_ONLY,
+    );
 
-    object.define_value(gc_context, "UNIQUESORT", 4.into(), Attribute::all());
+    object.define_value(
+        gc_context,
+        "UNIQUESORT",
+        4.into(),
+        Attribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | AttrAttribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | Attribute::READ_ONLY,
+    );
 
-    object.define_value(gc_context, "RETURNINDEXEDARRAY", 8.into(), Attribute::all());
+    object.define_value(
+        gc_context,
+        "RETURNINDEXEDARRAY",
+        8.into(),
+        Attribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | AttrAttribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | Attribute::READ_ONLY,
+    );
 
-    object.define_value(gc_context, "NUMERIC", 16.into(), Attribute::all());
+    object.define_value(
+        gc_context,
+        "NUMERIC",
+        16.into(),
+        Attribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | AttrAttribute::DONT_ENUM
+            | Attribute::DONT_DELETE
+            | Attribute::READ_ONLY,
+    );
 
     array
 }

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -42,40 +42,15 @@ pub fn create_array_object<'gc>(
     // TODO: These were added in Flash Player 7, but are available even to SWFv6 and lower
     // when run in Flash Player 7. Make these conditional if we add a parameter to control
     // target Flash Player version.
-    object.define_value(
-        gc_context,
-        "CASEINSENSITIVE",
-        1.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
+    object.define_value(gc_context, "CASEINSENSITIVE", 1.into(), Attribute::all());
 
-    object.define_value(
-        gc_context,
-        "DESCENDING",
-        2.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
+    object.define_value(gc_context, "DESCENDING", 2.into(), Attribute::all());
 
-    object.define_value(
-        gc_context,
-        "UNIQUESORT",
-        4.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
+    object.define_value(gc_context, "UNIQUESORT", 4.into(), Attribute::all());
 
-    object.define_value(
-        gc_context,
-        "RETURNINDEXEDARRAY",
-        8.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
+    object.define_value(gc_context, "RETURNINDEXEDARRAY", 8.into(), Attribute::all());
 
-    object.define_value(
-        gc_context,
-        "NUMERIC",
-        16.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
+    object.define_value(gc_context, "NUMERIC", 16.into(), Attribute::all());
 
     array
 }
@@ -663,78 +638,78 @@ pub fn create_proto<'gc>(
         "push",
         push,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "unshift",
         unshift,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "shift",
         shift,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
-    object.force_set_function("pop", pop, gc_context, Attribute::DontEnum, Some(fn_proto));
+    object.force_set_function("pop", pop, gc_context, Attribute::DONT_ENUM, Some(fn_proto));
     object.force_set_function(
         "reverse",
         reverse,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "join",
         join,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "slice",
         slice,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "splice",
         splice,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "concat",
         concat,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "toString",
         to_string,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "sort",
         sort,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "sortOn",
         sort_on,
         gc_context,
-        Attribute::DontEnum,
+        Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -46,55 +46,35 @@ pub fn create_array_object<'gc>(
         gc_context,
         "CASEINSENSITIVE",
         1.into(),
-        Attribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | AttrAttribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | Attribute::READ_ONLY,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
 
     object.define_value(
         gc_context,
         "DESCENDING",
         2.into(),
-        Attribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | AttrAttribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | Attribute::READ_ONLY,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
 
     object.define_value(
         gc_context,
         "UNIQUESORT",
         4.into(),
-        Attribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | AttrAttribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | Attribute::READ_ONLY,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
 
     object.define_value(
         gc_context,
         "RETURNINDEXEDARRAY",
         8.into(),
-        Attribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | AttrAttribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | Attribute::READ_ONLY,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
 
     object.define_value(
         gc_context,
         "NUMERIC",
         16.into(),
-        Attribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | AttrAttribute::DONT_ENUM
-            | Attribute::DONT_DELETE
-            | Attribute::READ_ONLY,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
 
     array

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::TObject;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, Value};
 use gc_arena::{Collect, MutationContext};
 
@@ -165,27 +165,32 @@ pub fn initialize_internal<'gc>(
 ) {
     let listeners = ScriptObject::array(gc_context, Some(array_proto));
 
-    broadcaster.define_value(gc_context, "_listeners", listeners.into(), DontEnum.into());
+    broadcaster.define_value(
+        gc_context,
+        "_listeners",
+        listeners.into(),
+        Attribute::DONT_ENUM.into(),
+    );
 
     broadcaster.define_value(
         gc_context,
         "addListener",
         functions.add_listener.into(),
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     broadcaster.define_value(
         gc_context,
         "removeListener",
         functions.remove_listener.into(),
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     broadcaster.define_value(
         gc_context,
         "broadcastMessage",
         functions.broadcast_message.into(),
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 }
 
@@ -200,7 +205,7 @@ pub fn create<'gc>(
         "initialize",
         initialize,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -214,7 +219,7 @@ pub fn create<'gc>(
         gc_context,
         "addListener",
         add_listener.into(),
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     let remove_listener = FunctionObject::function(
@@ -227,7 +232,7 @@ pub fn create<'gc>(
         gc_context,
         "removeListener",
         remove_listener.into(),
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     let broadcast_message = FunctionObject::function(
@@ -240,7 +245,7 @@ pub fn create<'gc>(
         gc_context,
         "broadcastMessage",
         broadcast_message.into(),
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     (

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -169,7 +169,7 @@ pub fn initialize_internal<'gc>(
         gc_context,
         "_listeners",
         listeners.into(),
-        Attribute::DONT_ENUM.into(),
+        Attribute::DONT_ENUM,
     );
 
     broadcaster.define_value(

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bevel_filter::{BevelFilterObject, BevelFilterType};
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -417,7 +417,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -434,7 +434,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -451,7 +451,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -468,7 +468,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -485,7 +485,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -502,7 +502,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -519,7 +519,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -536,7 +536,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -553,7 +553,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -570,7 +570,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -587,7 +587,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     script_object.add_property(
         gc_context,
@@ -604,7 +604,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
     object.into()
 }

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -3,11 +3,11 @@
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bitmap_data::{BitmapDataObject, ChannelOptions, Color};
+use crate::avm1::property::Attribute;
 use crate::avm1::{activation::Activation, object::bitmap_data::BitmapData};
 use crate::avm1::{Object, TObject, Value};
 use crate::character::Character;
 use crate::display_object::TDisplayObject;
-use enumset::EnumSet;
 use gc_arena::{GcCell, MutationContext};
 
 pub fn constructor<'gc>(
@@ -847,7 +847,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -860,7 +860,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -873,7 +873,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -886,144 +886,162 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.force_set_function(
         "getPixel",
         get_pixel,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "getPixel32",
         get_pixel32,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "setPixel",
         set_pixel,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "setPixel32",
         set_pixel32,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "copyChannel",
         copy_channel,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "fillRect",
         fill_rect,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
-    object.force_set_function("clone", clone, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "clone",
+        clone,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
     object.force_set_function(
         "dispose",
         dispose,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "floodFill",
         flood_fill,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
-    object.force_set_function("noise", noise, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "noise",
+        noise,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
     object.force_set_function(
         "colorTransform",
         color_transform,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "getColorBoundsRect",
         get_color_bounds_rect,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "perlinNoise",
         perlin_noise,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "applyFilter",
         apply_filter,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
-    object.force_set_function("draw", draw, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function("draw", draw, gc_context, Attribute::empty(), Some(fn_proto));
     object.force_set_function(
         "hitTest",
         hit_test,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "generateFilterRect",
         generate_filter_rect,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "copyPixels",
         copy_pixels,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
-    object.force_set_function("merge", merge, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "merge",
+        merge,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
     object.force_set_function(
         "paletteMap",
         palette_map,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "pixelDissolve",
         pixel_dissolve,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "scroll",
         scroll,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "threshold",
         threshold,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -1092,7 +1110,7 @@ pub fn create_bitmap_data_object<'gc>(
         "loadBitmap",
         load_bitmap,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -2,8 +2,8 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -275,7 +275,7 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let mut object = ScriptObject::object(gc_context, Some(proto));
 
-    object.force_set_function("clone", clone, gc_context, EnumSet::empty(), fn_proto);
+    object.force_set_function("clone", clone, gc_context, Attribute::empty(), fn_proto);
 
     object.into()
 }

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::blur_filter::BlurFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -133,7 +133,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -151,7 +151,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -169,7 +169,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     blur_filter.into()

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// `Boolean` constructor
@@ -72,14 +72,14 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "valueOf",
         value_of,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::display_object;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::display_object::{Button, TDisplayObject};
 use gc_arena::MutationContext;
@@ -17,7 +17,7 @@ macro_rules! with_button_props {
                 $name,
                 with_button_props!(getter $gc, $fn_proto, $get),
                 with_button_props!(setter $gc, $fn_proto, $($set),*),
-                DontDelete | DontEnum,
+                Attribute::DONT_DELETE | Attribute::DONT_ENUM,
             );
         )*
     };

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -22,7 +22,7 @@ pub fn constructor<'gc>(
     this.set_attributes(
         activation.context.gc_context,
         Some("target"),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Attribute::empty(),
     );
 
@@ -40,7 +40,7 @@ pub fn create_proto<'gc>(
         "getRGB",
         get_rgb,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -48,7 +48,7 @@ pub fn create_proto<'gc>(
         "getTransform",
         get_transform,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -56,7 +56,7 @@ pub fn create_proto<'gc>(
         "setRGB",
         set_rgb,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -64,7 +64,7 @@ pub fn create_proto<'gc>(
         "setTransform",
         set_transform,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -5,10 +5,9 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -23,8 +22,8 @@ pub fn constructor<'gc>(
     this.set_attributes(
         activation.context.gc_context,
         Some("target"),
-        DontDelete | ReadOnly | DontEnum,
-        EnumSet::empty(),
+        Attribute::all(),
+        Attribute::empty(),
     );
 
     Ok(this.into())
@@ -41,7 +40,7 @@ pub fn create_proto<'gc>(
         "getRGB",
         get_rgb,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -49,7 +48,7 @@ pub fn create_proto<'gc>(
         "getTransform",
         get_transform,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -57,7 +56,7 @@ pub fn create_proto<'gc>(
         "setRGB",
         set_rgb,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -65,7 +64,7 @@ pub fn create_proto<'gc>(
         "setTransform",
         set_transform,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::color_matrix_filter::ColorMatrixFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -88,7 +88,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     color_matrix_filter.into()

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -3,8 +3,8 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 use crate::avm1::object::color_transform_object::ColorTransformObject;
@@ -19,7 +19,7 @@ macro_rules! with_color_transform {
                 $name,
                 FunctionObject::function($gc, Executable::Native($get), Some($fn_proto), $fn_proto),
                 Some(FunctionObject::function($gc, Executable::Native($set), Some($fn_proto), $fn_proto)),
-                EnumSet::empty(),
+                Attribute::empty(),
             );
         )*
     }
@@ -260,7 +260,7 @@ pub fn create_proto<'gc>(
         "concat",
         concat,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -268,7 +268,7 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -143,7 +143,7 @@ pub fn create_proto<'gc>(
         "copy",
         copy,
         gc_context,
-        Attribute::DontEnum | Attribute::DontDelete,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
         Some(fn_proto),
     );
 
@@ -151,7 +151,7 @@ pub fn create_proto<'gc>(
         "hideBuiltInItems",
         hide_builtin_items,
         gc_context,
-        Attribute::DontEnum | Attribute::DontDelete,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -108,7 +108,7 @@ pub fn create_proto<'gc>(
         "copy",
         copy,
         gc_context,
-        Attribute::DontEnum | Attribute::DontDelete,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::convolution_filter::ConvolutionFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -337,7 +337,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -355,7 +355,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -373,7 +373,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -391,7 +391,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -409,7 +409,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -427,7 +427,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -445,7 +445,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -463,7 +463,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -481,7 +481,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     filter.into()

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -5,7 +5,6 @@ use crate::avm1::object::date_object::DateObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
 use chrono::{DateTime, Datelike, Duration, FixedOffset, LocalResult, TimeZone, Timelike, Utc};
-use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
 use num_traits::ToPrimitive;
 use std::f64::NAN;
@@ -28,7 +27,7 @@ macro_rules! implement_local_getters {
                     }
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+                Attribute::all(),
                 $fn_proto
             );
         )*
@@ -48,7 +47,7 @@ macro_rules! implement_methods {
                     }
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+                Attribute::all(),
                 $fn_proto
             );
         )*
@@ -72,7 +71,7 @@ macro_rules! implement_utc_getters {
                     }
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::DontDelete | Attribute::ReadOnly | Attribute::DontEnum,
+                Attribute::all(),
                 $fn_proto
             );
         )*
@@ -906,7 +905,7 @@ pub fn create_date_object<'gc>(
     );
     let mut object = date.as_script_object().unwrap();
 
-    object.force_set_function("UTC", create_utc, gc_context, EnumSet::empty(), fn_proto);
+    object.force_set_function("UTC", create_utc, gc_context, Attribute::empty(), fn_proto);
 
     date
 }

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -27,7 +27,7 @@ macro_rules! implement_local_getters {
                     }
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $fn_proto
             );
         )*
@@ -47,7 +47,7 @@ macro_rules! implement_methods {
                     }
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $fn_proto
             );
         )*
@@ -71,7 +71,7 @@ macro_rules! implement_utc_getters {
                     }
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $fn_proto
             );
         )*

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::displacement_map_filter::DisplacementMapFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -328,7 +328,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -346,7 +346,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -364,7 +364,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -382,7 +382,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -400,7 +400,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -418,7 +418,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -436,7 +436,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -454,7 +454,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -472,7 +472,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     filter.into()

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -3,10 +3,9 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
-use enumset::EnumSet;
+use crate::display_object::{DisplayObject, Lists, TDisplayObject, TDisplayObjectContainer};
 use gc_arena::MutationContext;
 
 /// Depths used/returned by ActionScript are offset by this amount from depths used inside the SWF/by the VM.
@@ -35,7 +34,7 @@ macro_rules! with_display_object {
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                DontDelete | ReadOnly | DontEnum,
+                Attribute::all(),
                 $fn_proto
             );
         )*
@@ -73,7 +72,7 @@ pub fn define_display_object_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.add_property(
@@ -91,7 +90,7 @@ pub fn define_display_object_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.add_property(
@@ -109,7 +108,7 @@ pub fn define_display_object_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 }
 
@@ -160,7 +159,7 @@ pub fn overwrite_root<'gc>(
         activation.context.gc_context,
         "_root",
         new_val,
-        EnumSet::new(),
+        Attribute::empty(),
     );
 
     Ok(Value::Undefined)
@@ -179,7 +178,7 @@ pub fn overwrite_global<'gc>(
         activation.context.gc_context,
         "_global",
         new_val,
-        EnumSet::new(),
+        Attribute::empty(),
     );
 
     Ok(Value::Undefined)
@@ -198,7 +197,7 @@ pub fn overwrite_parent<'gc>(
         activation.context.gc_context,
         "_parent",
         new_val,
-        EnumSet::new(),
+        Attribute::empty(),
     );
 
     Ok(Value::Undefined)
@@ -216,7 +215,7 @@ pub fn remove_display_object<'gc>(
     if depth >= AVM_DEPTH_BIAS && depth < AVM_MAX_REMOVE_DEPTH && !this.removed() {
         // Need a parent to remove from.
         if let Some(mut parent) = this.parent().and_then(|o| o.as_movie_clip()) {
-            parent.remove_child(&mut activation.context, this, EnumSet::all());
+            parent.remove_child(&mut activation.context, this, Lists::all());
         }
     }
 }

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -34,7 +34,7 @@ macro_rules! with_display_object {
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $fn_proto
             );
         )*
@@ -72,7 +72,7 @@ pub fn define_display_object_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -90,7 +90,7 @@ pub fn define_display_object_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -108,7 +108,7 @@ pub fn define_display_object_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 }
 

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::drop_shadow_filter::DropShadowFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -381,7 +381,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -399,7 +399,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -417,7 +417,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -435,7 +435,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -453,7 +453,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -471,7 +471,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -489,7 +489,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -507,7 +507,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -525,7 +525,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -543,7 +543,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -561,7 +561,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     drop_shadow_filter.into()

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -35,7 +35,7 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -2,9 +2,8 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -29,14 +28,14 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let mut object = ScriptObject::object(gc_context, Some(proto));
 
-    object.define_value(gc_context, "message", "Error".into(), EnumSet::empty());
-    object.define_value(gc_context, "name", "Error".into(), EnumSet::empty());
+    object.define_value(gc_context, "message", "Error".into(), Attribute::empty());
+    object.define_value(gc_context, "name", "Error".into(), Attribute::empty());
 
     object.force_set_function(
         "toString",
         to_string,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -81,18 +81,24 @@ pub fn create_external_interface_object<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.force_set_function(
         "addCallback",
         add_callback,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
-    object.force_set_function("call", call, gc_context, Attribute::all(), Some(fn_proto));
+    object.force_set_function(
+        "call",
+        call,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        Some(fn_proto),
+    );
 
     object.into()
 }

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -81,24 +81,18 @@ pub fn create_external_interface_object<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
     );
 
     object.force_set_function(
         "addCallback",
         add_callback,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
-    object.force_set_function(
-        "call",
-        call,
-        gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
-        Some(fn_proto),
-    );
+    object.force_set_function("call", call, gc_context, Attribute::all(), Some(fn_proto));
 
     object.into()
 }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -3,8 +3,8 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::ExecutionReason;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// Implements `new Function()`
@@ -121,15 +121,15 @@ pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc
     function_proto
         .as_script_object()
         .unwrap()
-        .force_set_function("call", call, gc_context, EnumSet::empty(), this);
+        .force_set_function("call", call, gc_context, Attribute::empty(), this);
     function_proto
         .as_script_object()
         .unwrap()
-        .force_set_function("apply", apply, gc_context, EnumSet::empty(), this);
+        .force_set_function("apply", apply, gc_context, Attribute::empty(), this);
     function_proto
         .as_script_object()
         .unwrap()
-        .force_set_function("toString", to_string, gc_context, EnumSet::empty(), this);
+        .force_set_function("toString", to_string, gc_context, Attribute::empty(), this);
 
     function_proto
 }

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::glow_filter::GlowFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -284,7 +284,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -302,7 +302,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -320,7 +320,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -338,7 +338,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -356,7 +356,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -374,7 +374,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -392,7 +392,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -410,7 +410,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     glow_filter.into()

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -5,8 +5,8 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_bevel_filter::GradientBevelFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -477,7 +477,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -495,7 +495,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -513,7 +513,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -531,7 +531,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -549,7 +549,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -567,7 +567,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -585,7 +585,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -603,7 +603,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -621,7 +621,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -639,7 +639,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -657,7 +657,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     color_matrix_filter.into()

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -5,8 +5,8 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_glow_filter::GradientGlowFilterObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -477,7 +477,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -495,7 +495,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -513,7 +513,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -531,7 +531,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -549,7 +549,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -567,7 +567,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -585,7 +585,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -603,7 +603,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -621,7 +621,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -639,7 +639,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     object.add_property(
@@ -657,7 +657,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     color_matrix_filter.into()

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -52,144 +52,37 @@ pub fn create_key_object<'gc>(
 
     broadcaster_functions.initialize(gc_context, key.into(), array_proto);
 
-    key.define_value(
-        gc_context,
-        "ALT",
-        18.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "BACKSPACE",
-        8.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "CAPSLOCK",
-        20.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "CONTROL",
-        17.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "DELETEKEY",
-        46.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "DOWN",
-        40.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "END",
-        35.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "ENTER",
-        13.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "ESCAPE",
-        27.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "HOME",
-        36.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "INSERT",
-        45.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "LEFT",
-        37.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "PGDN",
-        34.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "PGUP",
-        33.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "RIGHT",
-        39.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "SHIFT",
-        16.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "SPACE",
-        32.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "TAB",
-        9.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
-    key.define_value(
-        gc_context,
-        "UP",
-        38.into(),
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-    );
+    key.define_value(gc_context, "ALT", 18.into(), Attribute::all());
+    key.define_value(gc_context, "BACKSPACE", 8.into(), Attribute::all());
+    key.define_value(gc_context, "CAPSLOCK", 20.into(), Attribute::all());
+    key.define_value(gc_context, "CONTROL", 17.into(), Attribute::all());
+    key.define_value(gc_context, "DELETEKEY", 46.into(), Attribute::all());
+    key.define_value(gc_context, "DOWN", 40.into(), Attribute::all());
+    key.define_value(gc_context, "END", 35.into(), Attribute::all());
+    key.define_value(gc_context, "ENTER", 13.into(), Attribute::all());
+    key.define_value(gc_context, "ESCAPE", 27.into(), Attribute::all());
+    key.define_value(gc_context, "HOME", 36.into(), Attribute::all());
+    key.define_value(gc_context, "INSERT", 45.into(), Attribute::all());
+    key.define_value(gc_context, "LEFT", 37.into(), Attribute::all());
+    key.define_value(gc_context, "PGDN", 34.into(), Attribute::all());
+    key.define_value(gc_context, "PGUP", 33.into(), Attribute::all());
+    key.define_value(gc_context, "RIGHT", 39.into(), Attribute::all());
+    key.define_value(gc_context, "SHIFT", 16.into(), Attribute::all());
+    key.define_value(gc_context, "SPACE", 32.into(), Attribute::all());
+    key.define_value(gc_context, "TAB", 9.into(), Attribute::all());
+    key.define_value(gc_context, "UP", 38.into(), Attribute::all());
 
-    key.force_set_function(
-        "isDown",
-        is_down,
-        gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-        fn_proto,
-    );
+    key.force_set_function("isDown", is_down, gc_context, Attribute::all(), fn_proto);
 
     key.force_set_function(
         "getAscii",
         get_ascii,
         gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::all(),
         fn_proto,
     );
 
-    key.force_set_function(
-        "getCode",
-        get_code,
-        gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-        fn_proto,
-    );
+    key.force_set_function("getCode", get_code, gc_context, Attribute::all(), fn_proto);
 
     key.into()
 }

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -52,37 +52,144 @@ pub fn create_key_object<'gc>(
 
     broadcaster_functions.initialize(gc_context, key.into(), array_proto);
 
-    key.define_value(gc_context, "ALT", 18.into(), Attribute::all());
-    key.define_value(gc_context, "BACKSPACE", 8.into(), Attribute::all());
-    key.define_value(gc_context, "CAPSLOCK", 20.into(), Attribute::all());
-    key.define_value(gc_context, "CONTROL", 17.into(), Attribute::all());
-    key.define_value(gc_context, "DELETEKEY", 46.into(), Attribute::all());
-    key.define_value(gc_context, "DOWN", 40.into(), Attribute::all());
-    key.define_value(gc_context, "END", 35.into(), Attribute::all());
-    key.define_value(gc_context, "ENTER", 13.into(), Attribute::all());
-    key.define_value(gc_context, "ESCAPE", 27.into(), Attribute::all());
-    key.define_value(gc_context, "HOME", 36.into(), Attribute::all());
-    key.define_value(gc_context, "INSERT", 45.into(), Attribute::all());
-    key.define_value(gc_context, "LEFT", 37.into(), Attribute::all());
-    key.define_value(gc_context, "PGDN", 34.into(), Attribute::all());
-    key.define_value(gc_context, "PGUP", 33.into(), Attribute::all());
-    key.define_value(gc_context, "RIGHT", 39.into(), Attribute::all());
-    key.define_value(gc_context, "SHIFT", 16.into(), Attribute::all());
-    key.define_value(gc_context, "SPACE", 32.into(), Attribute::all());
-    key.define_value(gc_context, "TAB", 9.into(), Attribute::all());
-    key.define_value(gc_context, "UP", 38.into(), Attribute::all());
+    key.define_value(
+        gc_context,
+        "ALT",
+        18.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "BACKSPACE",
+        8.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "CAPSLOCK",
+        20.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "CONTROL",
+        17.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "DELETEKEY",
+        46.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "DOWN",
+        40.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "END",
+        35.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "ENTER",
+        13.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "ESCAPE",
+        27.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "HOME",
+        36.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "INSERT",
+        45.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "LEFT",
+        37.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "PGDN",
+        34.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "PGUP",
+        33.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "RIGHT",
+        39.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "SHIFT",
+        16.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "SPACE",
+        32.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "TAB",
+        9.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
+    key.define_value(
+        gc_context,
+        "UP",
+        38.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
 
-    key.force_set_function("isDown", is_down, gc_context, Attribute::all(), fn_proto);
+    key.force_set_function(
+        "isDown",
+        is_down,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
 
     key.force_set_function(
         "getAscii",
         get_ascii,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
-    key.force_set_function("getCode", get_code, gc_context, Attribute::all(), fn_proto);
+    key.force_set_function(
+        "getCode",
+        get_code,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
 
     key.into()
 }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -27,15 +27,27 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let mut object = ScriptObject::object(gc_context, Some(proto));
 
-    object.force_set_function("load", load, gc_context, Attribute::all(), Some(fn_proto));
+    object.force_set_function(
+        "load",
+        load,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        Some(fn_proto),
+    );
 
-    object.force_set_function("send", send, gc_context, Attribute::all(), Some(fn_proto));
+    object.force_set_function(
+        "send",
+        send,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "sendAndLoad",
         send_and_load,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -43,7 +55,7 @@ pub fn create_proto<'gc>(
         "decode",
         decode,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -51,7 +63,7 @@ pub fn create_proto<'gc>(
         "getBytesLoaded",
         get_bytes_loaded,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -59,7 +71,7 @@ pub fn create_proto<'gc>(
         "getBytesTotal",
         get_bytes_total,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -67,7 +79,7 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -75,14 +87,14 @@ pub fn create_proto<'gc>(
         gc_context,
         "contentType",
         "application/x-www-form-url-encoded".into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.force_set_function(
         "onLoad",
         on_load,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -90,7 +102,7 @@ pub fn create_proto<'gc>(
         "onData",
         on_data,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -98,7 +110,7 @@ pub fn create_proto<'gc>(
         "addRequestHeader",
         add_request_header,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -25,31 +25,17 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    use Attribute::*;
-
     let mut object = ScriptObject::object(gc_context, Some(proto));
 
-    object.force_set_function(
-        "load",
-        load,
-        gc_context,
-        DontDelete | DontEnum | ReadOnly,
-        Some(fn_proto),
-    );
+    object.force_set_function("load", load, gc_context, Attribute::all(), Some(fn_proto));
 
-    object.force_set_function(
-        "send",
-        send,
-        gc_context,
-        DontDelete | DontEnum | ReadOnly,
-        Some(fn_proto),
-    );
+    object.force_set_function("send", send, gc_context, Attribute::all(), Some(fn_proto));
 
     object.force_set_function(
         "sendAndLoad",
         send_and_load,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -57,7 +43,7 @@ pub fn create_proto<'gc>(
         "decode",
         decode,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -65,7 +51,7 @@ pub fn create_proto<'gc>(
         "getBytesLoaded",
         get_bytes_loaded,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -73,7 +59,7 @@ pub fn create_proto<'gc>(
         "getBytesTotal",
         get_bytes_total,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -81,7 +67,7 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -89,14 +75,14 @@ pub fn create_proto<'gc>(
         gc_context,
         "contentType",
         "application/x-www-form-url-encoded".into(),
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
     );
 
     object.force_set_function(
         "onLoad",
         on_load,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -104,7 +90,7 @@ pub fn create_proto<'gc>(
         "onData",
         on_data,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -112,7 +98,7 @@ pub fn create_proto<'gc>(
         "addRequestHeader",
         add_request_header,
         gc_context,
-        DontDelete | DontEnum | ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -343,7 +329,7 @@ fn spawn_load_var_fetch<'gc>(
             activation.context.gc_context,
             "_bytesLoaded",
             0.into(),
-            Attribute::DontDelete | Attribute::DontEnum,
+            Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         );
     } else {
         loader_object.set("_bytesLoaded", 0.into(), activation)?;
@@ -354,7 +340,7 @@ fn spawn_load_var_fetch<'gc>(
             activation.context.gc_context,
             "loaded",
             false.into(),
-            Attribute::DontDelete | Attribute::DontEnum,
+            Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         );
     } else {
         loader_object.set("loaded", false.into(), activation)?;

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -1,7 +1,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::Object;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
 use rand::Rng;
@@ -20,7 +20,7 @@ macro_rules! wrap_std {
                     }
                 },
                 $gc_context,
-                DontDelete | ReadOnly | DontEnum,
+                Attribute::all(),
                 $proto
             );
         )*
@@ -144,49 +144,49 @@ pub fn create<'gc>(
         gc_context,
         "E",
         std::f64::consts::E.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "LN10",
         std::f64::consts::LN_10.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "LN2",
         std::f64::consts::LN_2.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "LOG10E",
         std::f64::consts::LOG10_E.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "LOG2E",
         std::f64::consts::LOG2_E.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "PI",
         std::f64::consts::PI.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "SQRT1_2",
         std::f64::consts::FRAC_1_SQRT_2.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
     math.define_value(
         gc_context,
         "SQRT2",
         std::f64::consts::SQRT_2.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     wrap_std!(math, gc_context, fn_proto,
@@ -204,48 +204,12 @@ pub fn create<'gc>(
         "log" => f64::ln
     );
 
-    math.force_set_function(
-        "atan2",
-        atan2,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        fn_proto,
-    );
-    math.force_set_function(
-        "pow",
-        pow,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        fn_proto,
-    );
-    math.force_set_function(
-        "max",
-        max,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        fn_proto,
-    );
-    math.force_set_function(
-        "min",
-        min,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        fn_proto,
-    );
-    math.force_set_function(
-        "random",
-        random,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        fn_proto,
-    );
-    math.force_set_function(
-        "round",
-        round,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        fn_proto,
-    );
+    math.force_set_function("atan2", atan2, gc_context, Attribute::all(), fn_proto);
+    math.force_set_function("pow", pow, gc_context, Attribute::all(), fn_proto);
+    math.force_set_function("max", max, gc_context, Attribute::all(), fn_proto);
+    math.force_set_function("min", min, gc_context, Attribute::all(), fn_proto);
+    math.force_set_function("random", random, gc_context, Attribute::all(), fn_proto);
+    math.force_set_function("round", round, gc_context, Attribute::all(), fn_proto);
 
     math.into()
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -20,7 +20,7 @@ macro_rules! wrap_std {
                     }
                 },
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $proto
             );
         )*
@@ -144,49 +144,49 @@ pub fn create<'gc>(
         gc_context,
         "E",
         std::f64::consts::E.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "LN10",
         std::f64::consts::LN_10.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "LN2",
         std::f64::consts::LN_2.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "LOG10E",
         std::f64::consts::LOG10_E.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "LOG2E",
         std::f64::consts::LOG2_E.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "PI",
         std::f64::consts::PI.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "SQRT1_2",
         std::f64::consts::FRAC_1_SQRT_2.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
     math.define_value(
         gc_context,
         "SQRT2",
         std::f64::consts::SQRT_2.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     wrap_std!(math, gc_context, fn_proto,
@@ -204,12 +204,48 @@ pub fn create<'gc>(
         "log" => f64::ln
     );
 
-    math.force_set_function("atan2", atan2, gc_context, Attribute::all(), fn_proto);
-    math.force_set_function("pow", pow, gc_context, Attribute::all(), fn_proto);
-    math.force_set_function("max", max, gc_context, Attribute::all(), fn_proto);
-    math.force_set_function("min", min, gc_context, Attribute::all(), fn_proto);
-    math.force_set_function("random", random, gc_context, Attribute::all(), fn_proto);
-    math.force_set_function("round", round, gc_context, Attribute::all(), fn_proto);
+    math.force_set_function(
+        "atan2",
+        atan2,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
+    math.force_set_function(
+        "pow",
+        pow,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
+    math.force_set_function(
+        "max",
+        max,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
+    math.force_set_function(
+        "min",
+        min,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
+    math.force_set_function(
+        "random",
+        random,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
+    math.force_set_function(
+        "round",
+        round,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
 
     math.into()
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{point_to_object, value_to_point};
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 use swf::{Matrix, Twips};
 
@@ -427,7 +427,7 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -435,19 +435,31 @@ pub fn create_proto<'gc>(
         "identity",
         identity,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("clone", clone, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "clone",
+        clone,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
-    object.force_set_function("scale", scale, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "scale",
+        scale,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "rotate",
         rotate,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -455,7 +467,7 @@ pub fn create_proto<'gc>(
         "translate",
         translate,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -463,7 +475,7 @@ pub fn create_proto<'gc>(
         "concat",
         concat,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -471,7 +483,7 @@ pub fn create_proto<'gc>(
         "invert",
         invert,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -479,7 +491,7 @@ pub fn create_proto<'gc>(
         "createBox",
         create_box,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -487,7 +499,7 @@ pub fn create_proto<'gc>(
         "createGradientBox",
         create_gradient_box,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -495,7 +507,7 @@ pub fn create_proto<'gc>(
         "transformPoint",
         transform_point,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -503,7 +515,7 @@ pub fn create_proto<'gc>(
         "deltaTransformPoint",
         delta_transform_point,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -44,9 +44,21 @@ pub fn create_mouse_object<'gc>(
 
     broadcaster_functions.initialize(gc_context, mouse.into(), array_proto);
 
-    mouse.force_set_function("show", show_mouse, gc_context, Attribute::all(), fn_proto);
+    mouse.force_set_function(
+        "show",
+        show_mouse,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
 
-    mouse.force_set_function("hide", hide_mouse, gc_context, Attribute::all(), fn_proto);
+    mouse.force_set_function(
+        "hide",
+        hide_mouse,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        fn_proto,
+    );
 
     mouse.into()
 }

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -44,21 +44,9 @@ pub fn create_mouse_object<'gc>(
 
     broadcaster_functions.initialize(gc_context, mouse.into(), array_proto);
 
-    mouse.force_set_function(
-        "show",
-        show_mouse,
-        gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-        fn_proto,
-    );
+    mouse.force_set_function("show", show_mouse, gc_context, Attribute::all(), fn_proto);
 
-    mouse.force_set_function(
-        "hide",
-        hide_mouse,
-        gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
-        fn_proto,
-    );
+    mouse.force_set_function("hide", hide_mouse, gc_context, Attribute::all(), fn_proto);
 
     mouse.into()
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::display_object::{self, AVM_DEPTH_BIAS, AVM_MAX_DEPTH};
 use crate::avm1::globals::matrix::gradient_object_to_matrix;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::avm_error;
 use crate::avm_warn;
@@ -48,7 +48,7 @@ macro_rules! with_movie_clip {
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                DontDelete | ReadOnly | DontEnum,
+                Attribute::all(),
                 $fn_proto
             );
         )*
@@ -63,7 +63,7 @@ macro_rules! with_movie_clip_props {
                 $name,
                 with_movie_clip_props!(getter $gc, $fn_proto, $get),
                 with_movie_clip_props!(setter $gc, $fn_proto, $($set),*),
-                DontDelete | DontEnum,
+                Attribute::DONT_DELETE | Attribute::DONT_ENUM,
             );
         )*
     };
@@ -209,7 +209,7 @@ pub fn create_proto<'gc>(
         "removeMovieClip",
         remove_movie_clip,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -48,7 +48,7 @@ macro_rules! with_movie_clip {
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $fn_proto
             );
         )*
@@ -209,7 +209,7 @@ pub fn create_proto<'gc>(
         "removeMovieClip",
         remove_movie_clip,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -9,7 +9,6 @@ use crate::avm1::property::Attribute;
 use crate::avm1::{Object, Value};
 use crate::backend::navigator::RequestOptions;
 use crate::display_object::{DisplayObject, TDisplayObject};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -25,7 +24,7 @@ pub fn constructor<'gc>(
         activation.context.gc_context,
         "_listeners",
         Value::Object(listeners.into()),
-        Attribute::DontEnum.into(),
+        Attribute::DONT_ENUM,
     );
     listeners.set_array_element(0, Value::Object(this), activation.context.gc_context);
 
@@ -109,7 +108,7 @@ pub fn get_progress<'gc>(
                     .movie()
                     .map(|mv| (mv.header().uncompressed_length).into())
                     .unwrap_or(Value::Undefined),
-                EnumSet::empty(),
+                Attribute::empty(),
             );
             ret_obj.define_value(
                 activation.context.gc_context,
@@ -118,7 +117,7 @@ pub fn get_progress<'gc>(
                     .movie()
                     .map(|mv| (mv.header().uncompressed_length).into())
                     .unwrap_or(Value::Undefined),
-                EnumSet::empty(),
+                Attribute::empty(),
             );
 
             return Ok(ret_obj.into());
@@ -143,21 +142,21 @@ pub fn create_proto<'gc>(
         "loadClip",
         load_clip,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     mcl_proto.as_script_object().unwrap().force_set_function(
         "unloadClip",
         unload_clip,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     mcl_proto.as_script_object().unwrap().force_set_function(
         "getProgress",
         get_progress,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -4,9 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// `Number` constructor
@@ -63,7 +62,7 @@ pub fn create_number_object<'gc>(
         gc_context,
         "MAX_VALUE",
         std::f64::MAX.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.define_value(
@@ -72,28 +71,23 @@ pub fn create_number_object<'gc>(
         // Note this is actually the smallest positive denormalized f64.
         // Rust doesn't provide a constant for this (`MIN_POSITIVE` is a normal f64).
         Value::Number(f64::from_bits(1)),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
-    object.define_value(
-        gc_context,
-        "NaN",
-        std::f64::NAN.into(),
-        DontDelete | ReadOnly | DontEnum,
-    );
+    object.define_value(gc_context, "NaN", std::f64::NAN.into(), Attribute::all());
 
     object.define_value(
         gc_context,
         "NEGATIVE_INFINITY",
         std::f64::NEG_INFINITY.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.define_value(
         gc_context,
         "POSITIVE_INFINITY",
         std::f64::INFINITY.into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     number
@@ -112,14 +106,14 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "valueOf",
         value_of,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -62,7 +62,7 @@ pub fn create_number_object<'gc>(
         gc_context,
         "MAX_VALUE",
         std::f64::MAX.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.define_value(
@@ -71,23 +71,28 @@ pub fn create_number_object<'gc>(
         // Note this is actually the smallest positive denormalized f64.
         // Rust doesn't provide a constant for this (`MIN_POSITIVE` is a normal f64).
         Value::Number(f64::from_bits(1)),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
-    object.define_value(gc_context, "NaN", std::f64::NAN.into(), Attribute::all());
+    object.define_value(
+        gc_context,
+        "NaN",
+        std::f64::NAN.into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
 
     object.define_value(
         gc_context,
         "NEGATIVE_INFINITY",
         std::f64::NEG_INFINITY.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.define_value(
         gc_context,
         "POSITIVE_INFINITY",
         std::f64::INFINITY.into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     number

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -68,7 +68,7 @@ pub fn add_property<'gc>(
                     &name,
                     get.to_owned(),
                     None,
-                    Attribute::READ_ONLY,
+                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
                 );
             } else {
                 return Ok(false.into());
@@ -348,21 +348,21 @@ pub fn as_set_prop_flags<'gc>(
     let set_flags = args
         .get(2)
         .unwrap_or(&Value::Number(0.0))
-        .coerce_to_f64(activation)? as u128;
+        .coerce_to_f64(activation)? as u8;
+    let set_attributes = Attribute::from_bits_truncate(set_flags);
+
     let clear_flags = args
         .get(3)
         .unwrap_or(&Value::Number(0.0))
-        .coerce_to_f64(activation)? as u128;
+        .coerce_to_f64(activation)? as u8;
+    let clear_attributes = Attribute::from_bits_truncate(clear_flags);
 
-    if set_flags > 0b111 || clear_flags > 0b111 {
+    if set_attributes.bits() != set_flags || clear_attributes.bits() != clear_flags {
         avm_warn!(
             activation,
             "ASSetPropFlags: Unimplemented support for flags > 7"
         );
     }
-
-    let set_attributes = Attribute::from_bits_truncate(set_flags as u8);
-    let clear_attributes = Attribute::from_bits_truncate(clear_flags as u8);
 
     match properties {
         Some(properties) => {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -68,7 +68,7 @@ pub fn add_property<'gc>(
                     &name,
                     get.to_owned(),
                     None,
-                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                    Attribute::READ_ONLY,
                 );
             } else {
                 return Ok(false.into());

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -404,7 +404,7 @@ pub fn create_object_object<'gc>(
         "registerClass",
         register_class,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -2,11 +2,10 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
-use crate::avm1::property::Attribute::{self, *};
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
 use crate::display_object::TDisplayObject;
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::borrow::Cow;
 
@@ -60,7 +59,7 @@ pub fn add_property<'gc>(
                     &name,
                     get.to_owned(),
                     Some(set.to_owned()),
-                    EnumSet::empty(),
+                    Attribute::empty(),
                 );
             } else if let Value::Null = setter {
                 this.add_property_with_case(
@@ -69,7 +68,7 @@ pub fn add_property<'gc>(
                     &name,
                     get.to_owned(),
                     None,
-                    ReadOnly.into(),
+                    Attribute::READ_ONLY,
                 );
             } else {
                 return Ok(false.into());
@@ -248,56 +247,56 @@ pub fn fill_proto<'gc>(
         "addProperty",
         add_property,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "hasOwnProperty",
         has_own_property,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "isPropertyEnumerable",
         is_property_enumerable,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "isPrototypeOf",
         is_prototype_of,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "toString",
         to_string,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "valueOf",
         value_of,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "watch",
         watch,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object_proto.as_script_object().unwrap().force_set_function(
         "unwatch",
         unwatch,
         gc_context,
-        DontDelete | DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 }
@@ -351,7 +350,7 @@ pub fn as_set_prop_flags<'gc>(
         .unwrap_or(&Value::Number(0.0))
         .coerce_to_f64(activation)? as u128;
     let clear_flags = args
-        .get(2)
+        .get(3)
         .unwrap_or(&Value::Number(0.0))
         .coerce_to_f64(activation)? as u128;
 
@@ -362,8 +361,8 @@ pub fn as_set_prop_flags<'gc>(
         );
     }
 
-    let set_attributes = EnumSet::<Attribute>::from_u128(set_flags & 0b111);
-    let clear_attributes = EnumSet::<Attribute>::from_u128(clear_flags & 0b111);
+    let set_attributes = Attribute::from_bits_truncate(set_flags as u8);
+    let clear_attributes = Attribute::from_bits_truncate(clear_flags as u8);
 
     match properties {
         Some(properties) => {
@@ -405,7 +404,7 @@ pub fn create_object_object<'gc>(
         "registerClass",
         register_class,
         gc_context,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -5,7 +5,6 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::f64::NAN;
 
@@ -276,13 +275,19 @@ pub fn create_point_object<'gc>(
     );
     let mut object = point.as_script_object().unwrap();
 
-    object.force_set_function("distance", distance, gc_context, EnumSet::empty(), fn_proto);
-    object.force_set_function("polar", polar, gc_context, EnumSet::empty(), fn_proto);
+    object.force_set_function(
+        "distance",
+        distance,
+        gc_context,
+        Attribute::empty(),
+        fn_proto,
+    );
+    object.force_set_function("polar", polar, gc_context, Attribute::empty(), fn_proto);
     object.force_set_function(
         "interpolate",
         interpolate,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -300,27 +305,33 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("clone", clone, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "clone",
+        clone,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "equals",
         equals,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("add", add, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function("add", add, gc_context, Attribute::empty(), Some(fn_proto));
 
     object.force_set_function(
         "subtract",
         subtract,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -328,7 +339,7 @@ pub fn create_proto<'gc>(
         "normalize",
         normalize,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -336,7 +347,7 @@ pub fn create_proto<'gc>(
         "offset",
         offset,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -350,7 +361,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
 
     object.into()

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -361,7 +361,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
 
     object.into()

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -361,7 +361,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
 
     object.into()

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -6,7 +6,6 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::f64::NAN;
 
@@ -691,7 +690,7 @@ pub fn create_proto<'gc>(
         "toString",
         to_string,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -699,7 +698,7 @@ pub fn create_proto<'gc>(
         "isEmpty",
         is_empty,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -707,17 +706,23 @@ pub fn create_proto<'gc>(
         "setEmpty",
         set_empty,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("clone", clone, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "clone",
+        clone,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "contains",
         contains,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -725,7 +730,7 @@ pub fn create_proto<'gc>(
         "containsPoint",
         contains_point,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -733,7 +738,7 @@ pub fn create_proto<'gc>(
         "containsRectangle",
         contains_rectangle,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -741,17 +746,23 @@ pub fn create_proto<'gc>(
         "intersects",
         intersects,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("union", union, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "union",
+        union,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "inflate",
         inflate,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -759,7 +770,7 @@ pub fn create_proto<'gc>(
         "inflatePoint",
         inflate_point,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -767,7 +778,7 @@ pub fn create_proto<'gc>(
         "offset",
         offset,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -775,7 +786,7 @@ pub fn create_proto<'gc>(
         "offsetPoint",
         offset_point,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -783,7 +794,7 @@ pub fn create_proto<'gc>(
         "intersection",
         intersection,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -791,7 +802,7 @@ pub fn create_proto<'gc>(
         "equals",
         equals,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -810,7 +821,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -828,7 +839,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -846,7 +857,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -864,7 +875,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -882,7 +893,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -900,7 +911,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -918,7 +929,7 @@ pub fn create_proto<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontDelete | Attribute::DontEnum,
+        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
     );
 
     object.into()

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -147,7 +147,7 @@ pub fn create_selection_object<'gc>(
         "getBeginIndex",
         get_begin_index,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -155,7 +155,7 @@ pub fn create_selection_object<'gc>(
         "getEndIndex",
         get_end_index,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -163,7 +163,7 @@ pub fn create_selection_object<'gc>(
         "getCaretIndex",
         get_caret_index,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -171,7 +171,7 @@ pub fn create_selection_object<'gc>(
         "setSelection",
         set_selection,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -179,7 +179,7 @@ pub fn create_selection_object<'gc>(
         "setFocus",
         set_focus,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -187,7 +187,7 @@ pub fn create_selection_object<'gc>(
         "getFocus",
         get_focus,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -147,7 +147,7 @@ pub fn create_selection_object<'gc>(
         "getBeginIndex",
         get_begin_index,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -155,7 +155,7 @@ pub fn create_selection_object<'gc>(
         "getEndIndex",
         get_end_index,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -163,7 +163,7 @@ pub fn create_selection_object<'gc>(
         "getCaretIndex",
         get_caret_index,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -171,7 +171,7 @@ pub fn create_selection_object<'gc>(
         "setSelection",
         set_selection,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -179,7 +179,7 @@ pub fn create_selection_object<'gc>(
         "setFocus",
         set_focus,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -187,7 +187,7 @@ pub fn create_selection_object<'gc>(
         "getFocus",
         get_focus,
         gc_context,
-        Attribute::DontDelete | Attribute::DontEnum | Attribute::ReadOnly,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -1,10 +1,10 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
 use crate::avm_warn;
 use crate::display_object::TDisplayObject;
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 use crate::avm1::object::shared_object::SharedObject;
@@ -106,7 +106,7 @@ fn deserialize_object<'gc>(
                 activation.context.gc_context,
                 entry.0,
                 value,
-                EnumSet::empty(),
+                Attribute::empty(),
             );
         }
         obj.into()
@@ -141,7 +141,7 @@ fn deserialize_array<'gc>(
                     activation.context.gc_context,
                     entry.0,
                     value,
-                    EnumSet::empty(),
+                    Attribute::empty(),
                 );
             }
         }
@@ -282,7 +282,7 @@ pub fn get_local<'gc>(
         activation.context.gc_context,
         "data",
         data,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     activation.context.shared_objects.insert(full_name, this);
@@ -344,7 +344,7 @@ pub fn create_shared_object_object<'gc>(
         "deleteAll",
         delete_all,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -352,7 +352,7 @@ pub fn create_shared_object_object<'gc>(
         "getDiskUsage",
         get_disk_usage,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -360,7 +360,7 @@ pub fn create_shared_object_object<'gc>(
         "getLocal",
         get_local,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -368,7 +368,7 @@ pub fn create_shared_object_object<'gc>(
         "getRemote",
         get_remote,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -376,7 +376,7 @@ pub fn create_shared_object_object<'gc>(
         "getMaxSize",
         get_max_size,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -384,7 +384,7 @@ pub fn create_shared_object_object<'gc>(
         "addListener",
         add_listener,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -392,7 +392,7 @@ pub fn create_shared_object_object<'gc>(
         "removeListener",
         remove_listener,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         fn_proto,
     );
 
@@ -509,35 +509,53 @@ pub fn create_proto<'gc>(
     let shared_obj = SharedObject::empty_shared_obj(gc_context, Some(proto));
     let mut object = shared_obj.as_script_object().unwrap();
 
-    object.force_set_function("clear", clear, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "clear",
+        clear,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
-    object.force_set_function("close", close, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "close",
+        close,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "connect",
         connect,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("flush", flush, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function(
+        "flush",
+        flush,
+        gc_context,
+        Attribute::empty(),
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "getSize",
         get_size,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
-    object.force_set_function("send", send, gc_context, EnumSet::empty(), Some(fn_proto));
+    object.force_set_function("send", send, gc_context, Attribute::empty(), Some(fn_proto));
 
     object.force_set_function(
         "setFps",
         set_fps,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -545,7 +563,7 @@ pub fn create_proto<'gc>(
         "onStatus",
         on_status,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -553,7 +571,7 @@ pub fn create_proto<'gc>(
         "onSync",
         on_sync,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -44,7 +44,7 @@ pub fn create_proto<'gc>(
         "attachSound",
         attach_sound,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -58,7 +58,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.add_property(
@@ -71,14 +71,14 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.as_script_object().unwrap().force_set_function(
         "getBytesLoaded",
         get_bytes_loaded,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -86,7 +86,7 @@ pub fn create_proto<'gc>(
         "getBytesTotal",
         get_bytes_total,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -94,7 +94,7 @@ pub fn create_proto<'gc>(
         "getPan",
         get_pan,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -102,7 +102,7 @@ pub fn create_proto<'gc>(
         "getTransform",
         get_transform,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -110,7 +110,7 @@ pub fn create_proto<'gc>(
         "getVolume",
         get_volume,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -118,7 +118,7 @@ pub fn create_proto<'gc>(
         "loadSound",
         load_sound,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -132,14 +132,14 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.as_script_object().unwrap().force_set_function(
         "setPan",
         set_pan,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -147,7 +147,7 @@ pub fn create_proto<'gc>(
         "setTransform",
         set_transform,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -155,7 +155,7 @@ pub fn create_proto<'gc>(
         "setVolume",
         set_volume,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -163,7 +163,7 @@ pub fn create_proto<'gc>(
         "start",
         start,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -171,7 +171,7 @@ pub fn create_proto<'gc>(
         "stop",
         stop,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -4,7 +4,7 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, SoundObject, TObject, Value};
 use crate::avm_warn;
 use crate::character::Character;
@@ -44,7 +44,7 @@ pub fn create_proto<'gc>(
         "attachSound",
         attach_sound,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -58,7 +58,7 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.add_property(
@@ -71,14 +71,14 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.as_script_object().unwrap().force_set_function(
         "getBytesLoaded",
         get_bytes_loaded,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -86,7 +86,7 @@ pub fn create_proto<'gc>(
         "getBytesTotal",
         get_bytes_total,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -94,7 +94,7 @@ pub fn create_proto<'gc>(
         "getPan",
         get_pan,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -102,7 +102,7 @@ pub fn create_proto<'gc>(
         "getTransform",
         get_transform,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -110,7 +110,7 @@ pub fn create_proto<'gc>(
         "getVolume",
         get_volume,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -118,7 +118,7 @@ pub fn create_proto<'gc>(
         "loadSound",
         load_sound,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -132,14 +132,14 @@ pub fn create_proto<'gc>(
             fn_proto,
         ),
         None,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     object.as_script_object().unwrap().force_set_function(
         "setPan",
         set_pan,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -147,7 +147,7 @@ pub fn create_proto<'gc>(
         "setTransform",
         set_transform,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -155,7 +155,7 @@ pub fn create_proto<'gc>(
         "setVolume",
         set_volume,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -163,7 +163,7 @@ pub fn create_proto<'gc>(
         "start",
         start,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -171,7 +171,7 @@ pub fn create_proto<'gc>(
         "stop",
         stop,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -49,7 +49,7 @@ pub fn create_stage_object<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     stage.add_property(
@@ -98,7 +98,7 @@ pub fn create_stage_object<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     stage.into()

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -36,7 +36,7 @@ pub fn create_stage_object<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontEnum | Attribute::DontDelete,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
     );
 
     stage.add_property(
@@ -49,7 +49,7 @@ pub fn create_stage_object<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::all(),
     );
 
     stage.add_property(
@@ -67,7 +67,7 @@ pub fn create_stage_object<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontEnum | Attribute::DontDelete,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
     );
 
     stage.add_property(
@@ -85,7 +85,7 @@ pub fn create_stage_object<'gc>(
             Some(fn_proto),
             fn_proto,
         )),
-        Attribute::DontEnum | Attribute::DontDelete,
+        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
     );
 
     stage.add_property(
@@ -98,7 +98,7 @@ pub fn create_stage_object<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::DontEnum | Attribute::DontDelete | Attribute::ReadOnly,
+        Attribute::all(),
     );
 
     stage.into()

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -4,10 +4,9 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::string_utils;
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 /// `String` constructor
@@ -64,7 +63,7 @@ pub fn create_string_object<'gc>(
         "fromCharCode",
         from_char_code,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -84,28 +83,28 @@ pub fn create_proto<'gc>(
         "toString",
         to_string_value_of,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "valueOf",
         to_string_value_of,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     object.force_set_function(
         "charAt",
         char_at,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
     object.force_set_function(
         "charCodeAt",
         char_code_at,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -113,7 +112,7 @@ pub fn create_proto<'gc>(
         "concat",
         concat,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -121,7 +120,7 @@ pub fn create_proto<'gc>(
         "indexOf",
         index_of,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -129,31 +128,19 @@ pub fn create_proto<'gc>(
         "lastIndexOf",
         last_index_of,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
-    object.force_set_function(
-        "slice",
-        slice,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        Some(fn_proto),
-    );
+    object.force_set_function("slice", slice, gc_context, Attribute::all(), Some(fn_proto));
 
-    object.force_set_function(
-        "split",
-        split,
-        gc_context,
-        DontDelete | ReadOnly | DontEnum,
-        Some(fn_proto),
-    );
+    object.force_set_function("split", split, gc_context, Attribute::all(), Some(fn_proto));
 
     object.force_set_function(
         "substr",
         substr,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -161,7 +148,7 @@ pub fn create_proto<'gc>(
         "substring",
         substring,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -169,7 +156,7 @@ pub fn create_proto<'gc>(
         "toLowerCase",
         to_lower_case,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 
@@ -177,7 +164,7 @@ pub fn create_proto<'gc>(
         "toUpperCase",
         to_upper_case,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -63,7 +63,7 @@ pub fn create_string_object<'gc>(
         "fromCharCode",
         from_char_code,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -97,14 +97,14 @@ pub fn create_proto<'gc>(
         "charAt",
         char_at,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
     object.force_set_function(
         "charCodeAt",
         char_code_at,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -112,7 +112,7 @@ pub fn create_proto<'gc>(
         "concat",
         concat,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -120,7 +120,7 @@ pub fn create_proto<'gc>(
         "indexOf",
         index_of,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -128,19 +128,31 @@ pub fn create_proto<'gc>(
         "lastIndexOf",
         last_index_of,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
-    object.force_set_function("slice", slice, gc_context, Attribute::all(), Some(fn_proto));
+    object.force_set_function(
+        "slice",
+        slice,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        Some(fn_proto),
+    );
 
-    object.force_set_function("split", split, gc_context, Attribute::all(), Some(fn_proto));
+    object.force_set_function(
+        "split",
+        split,
+        gc_context,
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+        Some(fn_proto),
+    );
 
     object.force_set_function(
         "substr",
         substr,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -148,7 +160,7 @@ pub fn create_proto<'gc>(
         "substring",
         substring,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -156,7 +168,7 @@ pub fn create_proto<'gc>(
         "toLowerCase",
         to_lower_case,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 
@@ -164,7 +176,7 @@ pub fn create_proto<'gc>(
         "toUpperCase",
         to_upper_case,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -3,8 +3,8 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::system::SystemCapabilities;
 use crate::avm1::object::Object;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 macro_rules! capabilities_func {
@@ -39,39 +39,42 @@ macro_rules! capabilities_prop {
                 $name,
                 FunctionObject::function($gc_ctx, Executable::Native($func), Some($fn_proto), $fn_proto),
                 None,
-                EnumSet::empty()
+                Attribute::empty()
             );
         )*
     }};
 }
 
-capabilities_func!(get_has_64_bit_support, SystemCapabilities::Process64Bit);
-capabilities_func!(get_has_32_bit_support, SystemCapabilities::Process32Bit);
-capabilities_func!(get_is_acrobat_embedded, SystemCapabilities::AcrobatEmbedded);
+capabilities_func!(get_has_64_bit_support, SystemCapabilities::PROCESS_64_BIT);
+capabilities_func!(get_has_32_bit_support, SystemCapabilities::PROCESS_32_BIT);
+capabilities_func!(
+    get_is_acrobat_embedded,
+    SystemCapabilities::ACROBAT_EMBEDDED
+);
 capabilities_func!(get_has_tls, SystemCapabilities::TLS);
-capabilities_func!(get_has_accessibility, SystemCapabilities::Accessibility);
-capabilities_func!(get_has_audio, SystemCapabilities::Audio);
-capabilities_func!(get_has_audio_encoder, SystemCapabilities::AudioEncoder);
-capabilities_func!(get_has_embedded_video, SystemCapabilities::EmbeddedVideo);
+capabilities_func!(get_has_accessibility, SystemCapabilities::ACCESSIBILITY);
+capabilities_func!(get_has_audio, SystemCapabilities::AUDIO);
+capabilities_func!(get_has_audio_encoder, SystemCapabilities::AUDIO_ENCODER);
+capabilities_func!(get_has_embedded_video, SystemCapabilities::EMBEDDED_VIDEO);
 
 capabilities_func!(get_has_ime, SystemCapabilities::IME);
 capabilities_func!(get_has_mp3, SystemCapabilities::MP3);
-capabilities_func!(get_has_printing, SystemCapabilities::Printing);
+capabilities_func!(get_has_printing, SystemCapabilities::PRINTING);
 capabilities_func!(
     get_has_screen_broadcast,
-    SystemCapabilities::ScreenBroadcast
+    SystemCapabilities::SCREEN_BROADCAST
 );
-capabilities_func!(get_has_screen_playback, SystemCapabilities::ScreenPlayback);
-capabilities_func!(get_has_streaming_audio, SystemCapabilities::StreamingAudio);
-capabilities_func!(get_has_streaming_video, SystemCapabilities::StreamingVideo);
-capabilities_func!(get_has_video_encoder, SystemCapabilities::VideoEncoder);
-capabilities_func!(get_is_debugger, SystemCapabilities::Debugger);
+capabilities_func!(get_has_screen_playback, SystemCapabilities::SCREEN_PLAYBACK);
+capabilities_func!(get_has_streaming_audio, SystemCapabilities::STREAMING_AUDIO);
+capabilities_func!(get_has_streaming_video, SystemCapabilities::STREAMING_VIDEO);
+capabilities_func!(get_has_video_encoder, SystemCapabilities::VIDEO_ENCODER);
+capabilities_func!(get_is_debugger, SystemCapabilities::DEBUGGER);
 inverse_capabilities_func!(
     get_is_local_file_read_disabled,
-    SystemCapabilities::LocalFileRead
+    SystemCapabilities::LOCAL_FILE_READ
 );
-inverse_capabilities_func!(get_is_av_hardware_disabled, SystemCapabilities::AvHardware);
-inverse_capabilities_func!(get_is_windowless_disabled, SystemCapabilities::WindowLess);
+inverse_capabilities_func!(get_is_av_hardware_disabled, SystemCapabilities::AV_HARDWARE);
+inverse_capabilities_func!(get_is_windowless_disabled, SystemCapabilities::WINDOW_LESS);
 
 pub fn get_player_type<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -78,41 +78,56 @@ pub fn create<'gc>(
         gc_context,
         "ALPHANUMERIC_FULL",
         "ALPHANUMERIC_FULL".into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     ime.define_value(
         gc_context,
         "ALPHANUMERIC_HALF",
         "ALPHANUMERIC_HALF".into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
-    ime.define_value(gc_context, "CHINESE", "CHINESE".into(), Attribute::all());
+    ime.define_value(
+        gc_context,
+        "CHINESE",
+        "CHINESE".into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
 
     ime.define_value(
         gc_context,
         "JAPANESE_HIRAGANA",
         "JAPANESE_HIRAGANA".into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     ime.define_value(
         gc_context,
         "JAPANESE_KATAKANA_FULL",
         "JAPANESE_KATAKANA_FULL".into(),
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
-    ime.define_value(gc_context, "KOREAN", "KOREAN".into(), Attribute::all());
+    ime.define_value(
+        gc_context,
+        "KOREAN",
+        "KOREAN".into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
 
-    ime.define_value(gc_context, "UNKNOWN", "UNKNOWN".into(), Attribute::all());
+    ime.define_value(
+        gc_context,
+        "UNKNOWN",
+        "UNKNOWN".into(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
+    );
 
     ime.force_set_function(
         "onIMEComposition",
         on_ime_composition,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -120,7 +135,7 @@ pub fn create<'gc>(
         "doConversion",
         do_conversion,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -128,7 +143,7 @@ pub fn create<'gc>(
         "getConversionMode",
         get_conversion_mode,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -136,7 +151,7 @@ pub fn create<'gc>(
         "getEnabled",
         get_enabled,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -144,7 +159,7 @@ pub fn create<'gc>(
         "setCompositionString",
         set_composition_string,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -152,7 +167,7 @@ pub fn create<'gc>(
         "setConversionMode",
         set_conversion_mode,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 
@@ -160,7 +175,7 @@ pub fn create<'gc>(
         "setEnabled",
         set_enabled,
         gc_context,
-        Attribute::all(),
+        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
         fn_proto,
     );
 

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -3,7 +3,6 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::Object;
 use crate::avm1::property::Attribute;
-use crate::avm1::property::Attribute::{DontDelete, DontEnum, ReadOnly};
 use crate::avm1::{ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
 use std::convert::Into;
@@ -79,56 +78,41 @@ pub fn create<'gc>(
         gc_context,
         "ALPHANUMERIC_FULL",
         "ALPHANUMERIC_FULL".into(),
-        Attribute::DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     ime.define_value(
         gc_context,
         "ALPHANUMERIC_HALF",
         "ALPHANUMERIC_HALF".into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
-    ime.define_value(
-        gc_context,
-        "CHINESE",
-        "CHINESE".into(),
-        DontDelete | ReadOnly | DontEnum,
-    );
+    ime.define_value(gc_context, "CHINESE", "CHINESE".into(), Attribute::all());
 
     ime.define_value(
         gc_context,
         "JAPANESE_HIRAGANA",
         "JAPANESE_HIRAGANA".into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
     ime.define_value(
         gc_context,
         "JAPANESE_KATAKANA_FULL",
         "JAPANESE_KATAKANA_FULL".into(),
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
     );
 
-    ime.define_value(
-        gc_context,
-        "KOREAN",
-        "KOREAN".into(),
-        DontDelete | ReadOnly | DontEnum,
-    );
+    ime.define_value(gc_context, "KOREAN", "KOREAN".into(), Attribute::all());
 
-    ime.define_value(
-        gc_context,
-        "UNKNOWN",
-        "UNKNOWN".into(),
-        DontDelete | ReadOnly | DontEnum,
-    );
+    ime.define_value(gc_context, "UNKNOWN", "UNKNOWN".into(), Attribute::all());
 
     ime.force_set_function(
         "onIMEComposition",
         on_ime_composition,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -136,7 +120,7 @@ pub fn create<'gc>(
         "doConversion",
         do_conversion,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -144,7 +128,7 @@ pub fn create<'gc>(
         "getConversionMode",
         get_conversion_mode,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -152,7 +136,7 @@ pub fn create<'gc>(
         "getEnabled",
         get_enabled,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -160,7 +144,7 @@ pub fn create<'gc>(
         "setCompositionString",
         set_composition_string,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -168,7 +152,7 @@ pub fn create<'gc>(
         "setConversionMode",
         set_conversion_mode,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 
@@ -176,7 +160,7 @@ pub fn create<'gc>(
         "setEnabled",
         set_enabled,
         gc_context,
-        DontDelete | ReadOnly | DontEnum,
+        Attribute::all(),
         fn_proto,
     );
 

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -2,9 +2,9 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::Object;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, ScriptObject, TObject, Value};
 use crate::avm_warn;
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 use std::convert::Into;
 
@@ -97,7 +97,7 @@ pub fn create<'gc>(
         "PolicyFileResolver",
         policy_file_resolver,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -105,7 +105,7 @@ pub fn create<'gc>(
         "allowDomain",
         allow_domain,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -113,7 +113,7 @@ pub fn create<'gc>(
         "allowInsecureDomain",
         allow_insecure_domain,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -121,7 +121,7 @@ pub fn create<'gc>(
         "loadPolicyFile",
         load_policy_file,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -129,7 +129,7 @@ pub fn create<'gc>(
         "escapeDomain",
         escape_domain,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 
@@ -143,7 +143,7 @@ pub fn create<'gc>(
             fn_proto,
         ),
         None,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     security.add_property(
@@ -156,7 +156,7 @@ pub fn create<'gc>(
             fn_proto,
         ),
         None,
-        EnumSet::empty(),
+        Attribute::empty(),
     );
 
     security.into()

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -23,7 +23,7 @@ macro_rules! with_text_field {
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                Attribute::all(),
+                Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
                 $fn_proto
             );
         )*

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -2,7 +2,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::display_object;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::avm_error;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject, TextSelection};
@@ -23,7 +23,7 @@ macro_rules! with_text_field {
                     Ok(Value::Undefined)
                 } as crate::avm1::function::NativeFunction<'gc>,
                 $gc_context,
-                DontDelete | ReadOnly | DontEnum,
+                Attribute::all(),
                 $fn_proto
             );
         )*
@@ -38,7 +38,7 @@ macro_rules! with_text_field_props {
                 $name,
                 with_text_field_props!(getter $gc, $fn_proto, $get),
                 with_text_field_props!(setter $gc, $fn_proto, $($set),*),
-                Default::default()
+                Attribute::empty()
             );
         )*
     };

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -5,9 +5,9 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::{color_transform, matrix};
 use crate::avm1::object::transform_object::TransformObject;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, TObject, Value};
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 
 macro_rules! with_transform_props {
@@ -18,7 +18,7 @@ macro_rules! with_transform_props {
                 $name,
                 with_transform_props!(getter $gc, $fn_proto, $get),
                 with_transform_props!(setter $gc, $fn_proto, $($set),*),
-                EnumSet::empty(),
+                Attribute::empty(),
             );
         )*
     };

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -5,13 +5,12 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::script_object::ScriptObject;
 use crate::avm1::object::xml_object::XMLObject;
-use crate::avm1::property::Attribute::*;
+use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::RequestOptions;
 use crate::xml;
 use crate::xml::{XMLDocument, XMLNode};
-use enumset::EnumSet;
 use gc_arena::MutationContext;
 use quick_xml::Error as ParseError;
 
@@ -550,7 +549,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -562,7 +561,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -574,7 +573,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -586,7 +585,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -598,7 +597,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -610,7 +609,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -622,7 +621,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -634,7 +633,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -646,7 +645,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -658,7 +657,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -670,7 +669,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -682,7 +681,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -694,7 +693,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xmlnode_proto
         .as_script_object()
@@ -703,7 +702,7 @@ pub fn create_xmlnode_proto<'gc>(
             "appendChild",
             xmlnode_append_child,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -713,7 +712,7 @@ pub fn create_xmlnode_proto<'gc>(
             "insertBefore",
             xmlnode_insert_before,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -723,7 +722,7 @@ pub fn create_xmlnode_proto<'gc>(
             "cloneNode",
             xmlnode_clone_node,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -733,7 +732,7 @@ pub fn create_xmlnode_proto<'gc>(
             "getNamespaceForPrefix",
             xmlnode_get_namespace_for_prefix,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -743,7 +742,7 @@ pub fn create_xmlnode_proto<'gc>(
             "getPrefixForNamespace",
             xmlnode_get_prefix_for_namespace,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -753,7 +752,7 @@ pub fn create_xmlnode_proto<'gc>(
             "hasChildNodes",
             xmlnode_has_child_nodes,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -763,7 +762,7 @@ pub fn create_xmlnode_proto<'gc>(
             "removeNode",
             xmlnode_remove_node,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
     xmlnode_proto
@@ -773,7 +772,7 @@ pub fn create_xmlnode_proto<'gc>(
             "toString",
             xmlnode_to_string,
             gc_context,
-            EnumSet::empty(),
+            Attribute::empty(),
             Some(fn_proto),
         );
 
@@ -1091,9 +1090,9 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
-    xml_proto.define_value(gc_context, "ignoreWhite", false.into(), EnumSet::empty());
+    xml_proto.define_value(gc_context, "ignoreWhite", false.into(), Attribute::empty());
     xml_proto.add_property(
         gc_context,
         "xmlDecl",
@@ -1104,7 +1103,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xml_proto.add_property(
         gc_context,
@@ -1116,7 +1115,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xml_proto.add_property(
         gc_context,
@@ -1128,41 +1127,41 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        ReadOnly.into(),
+        Attribute::READ_ONLY,
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "createElement",
         xml_create_element,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "createTextNode",
         xml_create_text_node,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "parseXML",
         xml_parse_xml,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "load",
         xml_load,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "onData",
         xml_on_data,
         gc_context,
-        EnumSet::empty(),
+        Attribute::empty(),
         Some(fn_proto),
     );
 

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -549,7 +549,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -561,7 +561,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -573,7 +573,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -585,7 +585,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -597,7 +597,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -609,7 +609,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -621,7 +621,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -633,7 +633,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -645,7 +645,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -657,7 +657,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -669,7 +669,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -681,7 +681,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -693,7 +693,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xmlnode_proto
         .as_script_object()
@@ -1090,7 +1090,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xml_proto.define_value(gc_context, "ignoreWhite", false.into(), Attribute::empty());
     xml_proto.add_property(
@@ -1103,7 +1103,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xml_proto.add_property(
         gc_context,
@@ -1115,7 +1115,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xml_proto.add_property(
         gc_context,
@@ -1127,7 +1127,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+        Attribute::READ_ONLY,
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "createElement",

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -549,7 +549,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -561,7 +561,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -573,7 +573,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -585,7 +585,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -597,7 +597,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -609,7 +609,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -621,7 +621,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -633,7 +633,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -645,7 +645,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -657,7 +657,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -669,7 +669,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -681,7 +681,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto.add_property(
         gc_context,
@@ -693,7 +693,7 @@ pub fn create_xmlnode_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xmlnode_proto
         .as_script_object()
@@ -1090,7 +1090,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xml_proto.define_value(gc_context, "ignoreWhite", false.into(), Attribute::empty());
     xml_proto.add_property(
@@ -1103,7 +1103,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xml_proto.add_property(
         gc_context,
@@ -1115,7 +1115,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xml_proto.add_property(
         gc_context,
@@ -1127,7 +1127,7 @@ pub fn create_xml_proto<'gc>(
             fn_proto,
         ),
         None,
-        Attribute::READ_ONLY,
+        AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
     );
     xml_proto.as_script_object().unwrap().force_set_function(
         "createElement",

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -28,7 +28,6 @@ use crate::avm1::{ScriptObject, SoundObject, StageObject, Value};
 use crate::avm_warn;
 use crate::display_object::DisplayObject;
 use crate::xml::XMLNode;
-use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
 use ruffle_macros::enum_trait_object;
 use std::borrow::Cow;
@@ -249,7 +248,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     );
 
     /// Set the attributes of a given property.
@@ -263,8 +262,8 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
-        set_attributes: EnumSet<Attribute>,
-        clear_attributes: EnumSet<Attribute>,
+        set_attributes: Attribute,
+        clear_attributes: Attribute,
     );
 
     /// Define a virtual property onto a given object.
@@ -283,7 +282,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     );
 
     /// Define a virtual property onto a given object.
@@ -303,7 +302,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     );
 
     /// Set the 'watcher' of a given property.

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -58,7 +58,7 @@ macro_rules! impl_custom_object_without_set {
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: &str,
             value: crate::avm1::Value<'gc>,
-            attributes: enumset::EnumSet<crate::avm1::property::Attribute>,
+            attributes: crate::avm1::property::Attribute,
         ) {
             self.0
                 .read()
@@ -70,8 +70,8 @@ macro_rules! impl_custom_object_without_set {
             &self,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             name: Option<&str>,
-            set_attributes: enumset::EnumSet<crate::avm1::property::Attribute>,
-            clear_attributes: enumset::EnumSet<crate::avm1::property::Attribute>,
+            set_attributes: crate::avm1::property::Attribute,
+            clear_attributes: crate::avm1::property::Attribute,
         ) {
             self.0.write(gc_context).$field.set_attributes(
                 gc_context,
@@ -87,7 +87,7 @@ macro_rules! impl_custom_object_without_set {
             name: &str,
             get: crate::avm1::object::Object<'gc>,
             set: Option<crate::avm1::object::Object<'gc>>,
-            attributes: enumset::EnumSet<crate::avm1::property::Attribute>,
+            attributes: crate::avm1::property::Attribute,
         ) {
             self.0
                 .read()
@@ -102,7 +102,7 @@ macro_rules! impl_custom_object_without_set {
             name: &str,
             get: crate::avm1::object::Object<'gc>,
             set: Option<crate::avm1::object::Object<'gc>>,
-            attributes: enumset::EnumSet<crate::avm1::property::Attribute>,
+            attributes: crate::avm1::property::Attribute,
         ) {
             self.0
                 .read()
@@ -267,7 +267,6 @@ macro_rules! add_field_accessors {
             $([$var, $type_, set => $set_ident, get => $get_ident],)*
         );
     };
-
 
     ($([$var: ident, $type_: ty $(, set => $set_ident: ident)? $(, get => $get_ident: ident)?],)*) => {
         $(

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -974,7 +974,7 @@ mod tests {
                 activation.context.gc_context,
                 "readonly",
                 "initial".into(),
-                AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                Attribute::READ_ONLY,
             );
 
             object.set("normal", "replaced".into(), activation).unwrap();

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -974,7 +974,7 @@ mod tests {
                 activation.context.gc_context,
                 "readonly",
                 "initial".into(),
-                Attribute::READ_ONLY,
+                AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
             );
 
             object.set("normal", "replaced".into(), activation).unwrap();

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -11,7 +11,6 @@ use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, EditText, MovieClip, TDisplayObjectContainer};
 use crate::property_map::PropertyMap;
 use crate::types::Percent;
-use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
@@ -268,7 +267,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.0
             .read()
@@ -280,8 +279,8 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
-        set_attributes: EnumSet<Attribute>,
-        clear_attributes: EnumSet<Attribute>,
+        set_attributes: Attribute,
+        clear_attributes: Attribute,
     ) {
         self.0.write(gc_context).base.set_attributes(
             gc_context,
@@ -297,7 +296,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.0
             .read()
@@ -312,7 +311,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.0
             .read()

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -9,7 +9,6 @@ use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ObjectPtr, ScriptObject, TObject, Value};
 use crate::avm_warn;
 use crate::display_object::DisplayObject;
-use enumset::EnumSet;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::borrow::Cow;
 
@@ -181,7 +180,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         _gc_context: MutationContext<'gc, '_>,
         _name: &str,
         _value: Value<'gc>,
-        _attributes: EnumSet<Attribute>,
+        _attributes: Attribute,
     ) {
         //`super` cannot have values defined on it
     }
@@ -190,8 +189,8 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         &self,
         _gc_context: MutationContext<'gc, '_>,
         _name: Option<&str>,
-        _set_attributes: EnumSet<Attribute>,
-        _clear_attributes: EnumSet<Attribute>,
+        _set_attributes: Attribute,
+        _clear_attributes: Attribute,
     ) {
         //TODO: Does ASSetPropFlags work on `super`? What would it even work on?
     }
@@ -202,7 +201,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         _name: &str,
         _get: Object<'gc>,
         _set: Option<Object<'gc>>,
-        _attributes: EnumSet<Attribute>,
+        _attributes: Attribute,
     ) {
         //`super` cannot have properties defined on it
     }
@@ -214,7 +213,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         _name: &str,
         _get: Object<'gc>,
         _set: Option<Object<'gc>>,
-        _attributes: EnumSet<Attribute>,
+        _attributes: Attribute,
     ) {
         //`super` cannot have properties defined on it
     }

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -6,7 +6,6 @@ use crate::avm1::object::{ObjectPtr, TObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, Value};
 use crate::xml::{XMLName, XMLNode};
-use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
@@ -126,7 +125,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base()
             .add_property(gc_context, name, get, set, attributes)
@@ -139,7 +138,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base()
             .add_property_with_case(activation, gc_context, name, get, set, attributes)
@@ -171,7 +170,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base()
             .define_value(gc_context, name, value, attributes)
@@ -181,8 +180,8 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
-        set_attributes: EnumSet<Attribute>,
-        clear_attributes: EnumSet<Attribute>,
+        set_attributes: Attribute,
+        clear_attributes: Attribute,
     ) {
         self.base()
             .set_attributes(gc_context, name, set_attributes, clear_attributes)

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -7,7 +7,6 @@ use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm_warn;
 use crate::xml::{XMLDocument, XMLNode};
-use enumset::EnumSet;
 use gc_arena::{Collect, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
@@ -124,7 +123,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base()
             .add_property(gc_context, name, get, set, attributes)
@@ -137,7 +136,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base()
             .add_property_with_case(activation, gc_context, name, get, set, attributes)
@@ -169,7 +168,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         name: &str,
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     ) {
         self.base()
             .define_value(gc_context, name, value, attributes)
@@ -179,8 +178,8 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         &self,
         gc_context: MutationContext<'gc, '_>,
         name: Option<&str>,
-        set_attributes: EnumSet<Attribute>,
-        clear_attributes: EnumSet<Attribute>,
+        set_attributes: Attribute,
+        clear_attributes: Attribute,
     ) {
         self.base()
             .set_attributes(gc_context, name, set_attributes, clear_attributes)

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -7,7 +7,7 @@ use core::fmt;
 
 bitflags! {
     /// Attributes of properties in the AVM runtime.
-    /// The order is significant and should match the order used by `object::as_set_prop_flags`.
+    /// The values are significant and should match the order used by `object::as_set_prop_flags`.
     pub struct Attribute: u8 {
         const DONT_ENUM   = 1 << 0;
         const DONT_DELETE = 1 << 1;
@@ -47,7 +47,9 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(Attribute::READ_ONLY) {
+                if !attributes.contains(
+                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                ) {
                     *value = new_value.into();
                 }
 
@@ -95,8 +97,13 @@ impl<'gc> Property<'gc> {
         match self {
             Property::Virtual {
                 attributes, set, ..
-            } => !attributes.contains(Attribute::READ_ONLY) && !set.is_none(),
-            Property::Stored { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
+            } => {
+                !attributes.contains(
+                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                ) && !set.is_none()
+            }
+            Property::Stored { attributes, .. } => !attributes
+                .contains(AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY),
         }
     }
 

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -47,9 +47,7 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(
-                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
-                ) {
+                if !attributes.contains(Attribute::READ_ONLY) {
                     *value = new_value.into();
                 }
 
@@ -97,13 +95,8 @@ impl<'gc> Property<'gc> {
         match self {
             Property::Virtual {
                 attributes, set, ..
-            } => {
-                !attributes.contains(
-                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
-                ) && !set.is_none()
-            }
-            Property::Stored { attributes, .. } => !attributes
-                .contains(AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY),
+            } => !attributes.contains(Attribute::READ_ONLY) && !set.is_none(),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
         }
     }
 

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -1,18 +1,18 @@
 //! User-defined properties
 
-use self::Attribute::*;
 use crate::avm1::object::Object;
 use crate::avm1::Value;
+use bitflags::bitflags;
 use core::fmt;
-use enumset::{EnumSet, EnumSetType};
 
-/// Attributes of properties in the AVM runtime.
-/// The order is significant and should match the order used by `object::as_set_prop_flags`.
-#[derive(EnumSetType, Debug)]
-pub enum Attribute {
-    DontEnum,
-    DontDelete,
-    ReadOnly,
+bitflags! {
+    /// Attributes of properties in the AVM runtime.
+    /// The order is significant and should match the order used by `object::as_set_prop_flags`.
+    pub struct Attribute: u8 {
+        const DONT_ENUM   = 1 << 0;
+        const DONT_DELETE = 1 << 1;
+        const READ_ONLY   = 1 << 2;
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -21,11 +21,11 @@ pub enum Property<'gc> {
     Virtual {
         get: Object<'gc>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     },
     Stored {
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     },
 }
 
@@ -47,7 +47,7 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(ReadOnly) {
+                if !attributes.contains(Attribute::READ_ONLY) {
                     *value = new_value.into();
                 }
 
@@ -57,7 +57,7 @@ impl<'gc> Property<'gc> {
     }
 
     /// List this property's attributes.
-    pub fn attributes(&self) -> EnumSet<Attribute> {
+    pub fn attributes(&self) -> Attribute {
         match self {
             Property::Virtual { attributes, .. } => *attributes,
             Property::Stored { attributes, .. } => *attributes,
@@ -65,7 +65,7 @@ impl<'gc> Property<'gc> {
     }
 
     /// Re-define this property's attributes.
-    pub fn set_attributes(&mut self, new_attributes: EnumSet<Attribute>) {
+    pub fn set_attributes(&mut self, new_attributes: Attribute) {
         match self {
             Property::Virtual {
                 ref mut attributes, ..
@@ -78,15 +78,15 @@ impl<'gc> Property<'gc> {
 
     pub fn can_delete(&self) -> bool {
         match self {
-            Property::Virtual { attributes, .. } => !attributes.contains(DontDelete),
-            Property::Stored { attributes, .. } => !attributes.contains(DontDelete),
+            Property::Virtual { attributes, .. } => !attributes.contains(Attribute::DONT_DELETE),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::DONT_DELETE),
         }
     }
 
     pub fn is_enumerable(&self) -> bool {
         match self {
-            Property::Virtual { attributes, .. } => !attributes.contains(DontEnum),
-            Property::Stored { attributes, .. } => !attributes.contains(DontEnum),
+            Property::Virtual { attributes, .. } => !attributes.contains(Attribute::DONT_ENUM),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::DONT_ENUM),
         }
     }
 
@@ -95,8 +95,8 @@ impl<'gc> Property<'gc> {
         match self {
             Property::Virtual {
                 attributes, set, ..
-            } => !attributes.contains(ReadOnly) && !set.is_none(),
-            Property::Stored { attributes, .. } => !attributes.contains(ReadOnly),
+            } => !attributes.contains(Attribute::READ_ONLY) && !set.is_none(),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
         }
     }
 

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -3,8 +3,8 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::callable_value::CallableValue;
 use crate::avm1::error::Error;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use enumset::EnumSet;
 use gc_arena::{GcCell, MutationContext};
 use std::cell::Ref;
 
@@ -307,7 +307,7 @@ impl<'gc> Scope<'gc> {
     /// local object and does not traverse the scope chain.
     pub fn define(&self, name: &str, value: impl Into<Value<'gc>>, mc: MutationContext<'gc, '_>) {
         self.locals()
-            .define_value(mc, name, value.into(), EnumSet::empty());
+            .define_value(mc, name, value.into(), Attribute::empty());
     }
 
     /// Delete a value from scope

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -503,9 +503,10 @@ mod test {
     use crate::avm1::globals::create_globals;
     use crate::avm1::object::script_object::ScriptObject;
     use crate::avm1::object::{Object, TObject};
+    use crate::avm1::property::Attribute;
     use crate::avm1::test_utils::with_avm;
     use crate::avm1::{AvmString, Value};
-    use enumset::EnumSet;
+
     use std::f64::{INFINITY, NAN, NEG_INFINITY};
 
     #[test]
@@ -549,7 +550,7 @@ mod test {
                 activation.context.gc_context,
                 "valueOf",
                 valueof.into(),
-                EnumSet::empty(),
+                Attribute::empty(),
             );
 
             assert_eq!(

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -7,23 +7,24 @@ use crate::avm2::string::AvmString;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::{Avm2, Error};
 use crate::collect::CollectWrapper;
-use enumset::{EnumSet, EnumSetType};
+use bitflags::bitflags;
 use gc_arena::{Collect, GcCell, MutationContext};
 use swf::avm2::types::{Class as AbcClass, Instance as AbcInstance};
 
-/// All possible attributes for a given class.
-#[derive(EnumSetType, Debug)]
-pub enum ClassAttributes {
-    /// Class is sealed, attempts to set or init dynamic properties on an
-    /// object will generate a runtime error.
-    Sealed,
+bitflags! {
+    /// All possible attributes for a given class.
+    pub struct ClassAttributes: u8 {
+        /// Class is sealed, attempts to set or init dynamic properties on an
+        /// object will generate a runtime error.
+        const SEALED    = 1 << 0;
 
-    /// Class is final, attempts to construct child classes from it will
-    /// generate a verification error.
-    Final,
+        /// Class is final, attempts to construct child classes from it will
+        /// generate a verification error.
+        const FINAL     = 1 << 1;
 
-    /// Class is an interface.
-    Interface,
+        /// Class is an interface.
+        const INTERFACE = 1 << 2;
+    }
 }
 
 /// A loaded ABC Class which can be used to construct objects with.
@@ -37,7 +38,7 @@ pub struct Class<'gc> {
     super_class: Option<Multiname<'gc>>,
 
     /// Attributes of the given class.
-    attributes: CollectWrapper<EnumSet<ClassAttributes>>,
+    attributes: CollectWrapper<ClassAttributes>,
 
     /// The namespace that protected traits of this class are stored into.
     protected_namespace: Option<Namespace<'gc>>,
@@ -128,7 +129,7 @@ impl<'gc> Class<'gc> {
             Self {
                 name,
                 super_class,
-                attributes: CollectWrapper(EnumSet::empty()),
+                attributes: CollectWrapper(ClassAttributes::empty()),
                 protected_namespace: None,
                 interfaces: Vec::new(),
                 instance_init,
@@ -141,7 +142,7 @@ impl<'gc> Class<'gc> {
     }
 
     /// Set the attributes of the class (sealed/final/interface status).
-    pub fn set_attributes(&mut self, attributes: EnumSet<ClassAttributes>) {
+    pub fn set_attributes(&mut self, attributes: ClassAttributes) {
         self.attributes = CollectWrapper(attributes);
     }
 
@@ -202,17 +203,17 @@ impl<'gc> Class<'gc> {
         let instance_init = unit.load_method(abc_instance.init_method.0, mc)?;
         let class_init = unit.load_method(abc_class.init_method.0, mc)?;
 
-        let mut attributes = EnumSet::new();
+        let mut attributes = ClassAttributes::empty();
         if abc_instance.is_sealed {
-            attributes |= ClassAttributes::Sealed;
+            attributes |= ClassAttributes::SEALED;
         }
 
         if abc_instance.is_final {
-            attributes |= ClassAttributes::Final;
+            attributes |= ClassAttributes::FINAL;
         }
 
         if abc_instance.is_interface {
-            attributes |= ClassAttributes::Interface;
+            attributes |= ClassAttributes::INTERFACE;
         }
 
         Ok(GcCell::allocate(
@@ -410,6 +411,6 @@ impl<'gc> Class<'gc> {
 
     /// Determine if this class is sealed (no dynamic properties)
     pub fn is_sealed(&self) -> bool {
-        self.attributes.0.contains(ClassAttributes::Sealed)
+        self.attributes.0.contains(ClassAttributes::SEALED)
     }
 }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -204,17 +204,9 @@ impl<'gc> Class<'gc> {
         let class_init = unit.load_method(abc_class.init_method.0, mc)?;
 
         let mut attributes = ClassAttributes::empty();
-        if abc_instance.is_sealed {
-            attributes |= ClassAttributes::SEALED;
-        }
-
-        if abc_instance.is_final {
-            attributes |= ClassAttributes::FINAL;
-        }
-
-        if abc_instance.is_interface {
-            attributes |= ClassAttributes::INTERFACE;
-        }
+        attributes.set(ClassAttributes::SEALED, abc_instance.is_sealed);
+        attributes.set(ClassAttributes::FINAL, abc_instance.is_final);
+        attributes.set(ClassAttributes::INTERFACE, abc_instance.is_interface);
 
         Ok(GcCell::allocate(
             mc,

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1102,13 +1102,13 @@ fn extract_maybe_array_strings<'gc>(
     Ok(out)
 }
 
-/// Given a value, extract its array values and coerce them to bitflags.
+/// Given a value, extract its array values and coerce them to SortOptions.
 ///
 /// If the value is not an array, it will be returned as if it was present in a
 /// one-element array containing itself. This is intended for use with parsing
 /// parameters which are optionally arrays. The returned value will still be
 /// coerced into a string in this case.
-fn extract_maybe_array_enumsets<'gc>(
+fn extract_maybe_array_sort_options<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     value: Value<'gc>,
 ) -> Result<Vec<SortOptions>, Error> {
@@ -1132,7 +1132,7 @@ pub fn sort_on<'gc>(
     if let Some(this) = this {
         if let Some(field_names_value) = args.get(0).cloned() {
             let field_names = extract_maybe_array_strings(activation, field_names_value)?;
-            let mut options = extract_maybe_array_enumsets(
+            let mut options = extract_maybe_array_sort_options(
                 activation,
                 args.get(1).cloned().unwrap_or_else(|| 0.into()),
             )?;

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -10,7 +10,7 @@ use crate::avm2::string::AvmString;
 use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use enumset::{EnumSet, EnumSetType};
+use bitflags::bitflags;
 use gc_arena::{GcCell, MutationContext};
 use std::cmp::{min, Ordering};
 use std::mem::swap;
@@ -775,25 +775,26 @@ pub fn splice<'gc>(
     Ok(Value::Undefined)
 }
 
-/// The array options that a given sort operation may use.
-///
-/// These are provided as a number by the VM and converted into an enumset.
-#[derive(EnumSetType)]
-enum SortOptions {
-    /// Request case-insensitive string value sort.
-    CaseInsensitive,
+bitflags! {
+    /// The array options that a given sort operation may use.
+    ///
+    /// These are provided as a number by the VM and converted into bitflags.
+    struct SortOptions: u8 {
+        /// Request case-insensitive string value sort.
+        const CASE_INSENSITIVE     = 1 << 0;
 
-    /// Reverse the order of sorting.
-    Descending,
+        /// Reverse the order of sorting.
+        const DESCENDING           = 1 << 1;
 
-    /// Reject sorting on arrays with multiple equivalent values.
-    UniqueSort,
+        /// Reject sorting on arrays with multiple equivalent values.
+        const UNIQUE_SORT          = 1 << 2;
 
-    /// Yield a list of indices rather than sorting the array in-place.
-    ReturnIndexedArray,
+        /// Yield a list of indices rather than sorting the array in-place.
+        const RETURN_INDEXED_ARRAY = 1 << 3;
 
-    /// Request numeric value sort.
-    Numeric,
+        /// Request numeric value sort.
+        const NUMERIC              = 1 << 4;
+    }
 }
 
 /// Identity closure shim which exists purely to decorate closure types with
@@ -821,7 +822,7 @@ where
 fn sort_inner<'a, 'gc, 'ctxt, C>(
     activation: &mut Activation<'a, 'gc, 'ctxt>,
     values: &mut [(usize, Value<'gc>)],
-    options: EnumSet<SortOptions>,
+    options: SortOptions,
     mut sort_func: C,
 ) -> Result<bool, Error>
 where
@@ -848,7 +849,7 @@ where
                 unique_sort_satisfied = false;
                 Ordering::Equal
             }
-            Ok(v) if options.contains(SortOptions::Descending) => v.reverse(),
+            Ok(v) if options.contains(SortOptions::DESCENDING) => v.reverse(),
             Ok(v) => v,
             Err(e) => {
                 error_signal = Err(e);
@@ -859,7 +860,7 @@ where
 
     error_signal?;
 
-    Ok(!options.contains(SortOptions::UniqueSort) || unique_sort_satisfied)
+    Ok(!options.contains(SortOptions::UNIQUE_SORT) || unique_sort_satisfied)
 }
 
 fn compare_string_case_sensitive<'gc>(
@@ -907,12 +908,12 @@ fn compare_numeric<'gc>(
 fn sort_postprocess<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
-    options: EnumSet<SortOptions>,
+    options: SortOptions,
     unique_satisfied: bool,
     values: Vec<(usize, Value<'gc>)>,
 ) -> Result<Value<'gc>, Error> {
     if unique_satisfied {
-        if options.contains(SortOptions::ReturnIndexedArray) {
+        if options.contains(SortOptions::RETURN_INDEXED_ARRAY) {
             return build_array(
                 activation,
                 ArrayStorage::from_storage(
@@ -998,18 +999,22 @@ pub fn sort<'gc>(
                         .unwrap_or(Value::Undefined)
                         .coerce_to_object(activation)?,
                 ),
-                args.get(1)
-                    .cloned()
-                    .unwrap_or_else(|| 0.into())
-                    .coerce_to_enumset(activation)?,
+                SortOptions::from_bits_truncate(
+                    args.get(1)
+                        .cloned()
+                        .unwrap_or_else(|| 0.into())
+                        .coerce_to_u32(activation)? as u8,
+                ),
             )
         } else {
             (
                 None,
-                args.get(0)
-                    .cloned()
-                    .unwrap_or_else(|| 0.into())
-                    .coerce_to_enumset(activation)?,
+                SortOptions::from_bits_truncate(
+                    args.get(0)
+                        .cloned()
+                        .unwrap_or_else(|| 0.into())
+                        .coerce_to_u32(activation)? as u8,
+                ),
             )
         };
 
@@ -1042,9 +1047,9 @@ pub fn sort<'gc>(
                     }
                 }),
             )?
-        } else if options.contains(SortOptions::Numeric) {
+        } else if options.contains(SortOptions::NUMERIC) {
             sort_inner(activation, &mut values, options, compare_numeric)?
-        } else if options.contains(SortOptions::CaseInsensitive) {
+        } else if options.contains(SortOptions::CASE_INSENSITIVE) {
             sort_inner(
                 activation,
                 &mut values,
@@ -1097,23 +1102,22 @@ fn extract_maybe_array_strings<'gc>(
     Ok(out)
 }
 
-/// Given a value, extract its array values and coerce them to enumsets.
+/// Given a value, extract its array values and coerce them to bitflags.
 ///
 /// If the value is not an array, it will be returned as if it was present in a
 /// one-element array containing itself. This is intended for use with parsing
 /// parameters which are optionally arrays. The returned value will still be
 /// coerced into a string in this case.
-fn extract_maybe_array_enumsets<'gc, E>(
+fn extract_maybe_array_enumsets<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     value: Value<'gc>,
-) -> Result<Vec<EnumSet<E>>, Error>
-where
-    E: EnumSetType,
-{
+) -> Result<Vec<SortOptions>, Error> {
     let mut out = Vec::new();
 
     for value in extract_maybe_array_values(activation, value)? {
-        out.push(value.coerce_to_enumset(activation)?);
+        out.push(SortOptions::from_bits_truncate(
+            value.coerce_to_u32(activation)? as u8,
+        ));
     }
 
     Ok(out)
@@ -1133,11 +1137,8 @@ pub fn sort_on<'gc>(
                 args.get(1).cloned().unwrap_or_else(|| 0.into()),
             )?;
 
-            let first_option = options
-                .get(0)
-                .cloned()
-                .unwrap_or_else(EnumSet::empty)
-                .intersection(SortOptions::UniqueSort | SortOptions::ReturnIndexedArray);
+            let first_option = options.get(0).cloned().unwrap_or_else(SortOptions::empty)
+                & (SortOptions::UNIQUE_SORT | SortOptions::RETURN_INDEXED_ARRAY);
             let mut values = if let Some(values) = extract_array_values(activation, this.into())? {
                 values
                     .iter()
@@ -1151,7 +1152,7 @@ pub fn sort_on<'gc>(
             if options.len() < field_names.len() {
                 options.resize(
                     field_names.len(),
-                    options.last().cloned().unwrap_or_else(EnumSet::empty),
+                    options.last().cloned().unwrap_or_else(SortOptions::empty),
                 );
             }
 
@@ -1175,9 +1176,9 @@ pub fn sort_on<'gc>(
                             activation,
                         )?;
 
-                        let ord = if options.contains(SortOptions::Numeric) {
+                        let ord = if options.contains(SortOptions::NUMERIC) {
                             compare_numeric(activation, a_field, b_field)?
-                        } else if options.contains(SortOptions::CaseInsensitive) {
+                        } else if options.contains(SortOptions::CASE_INSENSITIVE) {
                             compare_string_case_insensitive(activation, a_field, b_field)?
                         } else {
                             compare_string_case_sensitive(activation, a_field, b_field)?
@@ -1187,7 +1188,7 @@ pub fn sort_on<'gc>(
                             continue;
                         }
 
-                        if options.contains(SortOptions::Descending) {
+                        if options.contains(SortOptions::DESCENDING) {
                             return Ok(ord.reverse());
                         } else {
                             return Ok(ord);
@@ -1328,35 +1329,31 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     class.write(mc).define_class_trait(Trait::from_const(
         QName::new(Namespace::public_namespace(), "CASEINSENSITIVE"),
         Multiname::from(QName::new(Namespace::public_namespace(), "uint")),
-        Some(EnumSet::from(SortOptions::CaseInsensitive).as_u32().into()),
+        Some(SortOptions::CASE_INSENSITIVE.bits().into()),
     ));
 
     class.write(mc).define_class_trait(Trait::from_const(
         QName::new(Namespace::public_namespace(), "DESCENDING"),
         Multiname::from(QName::new(Namespace::public_namespace(), "uint")),
-        Some(EnumSet::from(SortOptions::Descending).as_u32().into()),
+        Some(SortOptions::DESCENDING.bits().into()),
     ));
 
     class.write(mc).define_class_trait(Trait::from_const(
         QName::new(Namespace::public_namespace(), "NUMERIC"),
         Multiname::from(QName::new(Namespace::public_namespace(), "uint")),
-        Some(EnumSet::from(SortOptions::Numeric).as_u32().into()),
+        Some(SortOptions::NUMERIC.bits().into()),
     ));
 
     class.write(mc).define_class_trait(Trait::from_const(
         QName::new(Namespace::public_namespace(), "RETURNINDEXEDARRAY"),
         Multiname::from(QName::new(Namespace::public_namespace(), "uint")),
-        Some(
-            EnumSet::from(SortOptions::ReturnIndexedArray)
-                .as_u32()
-                .into(),
-        ),
+        Some(SortOptions::RETURN_INDEXED_ARRAY.bits().into()),
     ));
 
     class.write(mc).define_class_trait(Trait::from_const(
         QName::new(Namespace::public_namespace(), "UNIQUESORT"),
         Multiname::from(QName::new(Namespace::public_namespace(), "uint")),
-        Some(EnumSet::from(SortOptions::UniqueSort).as_u32().into()),
+        Some(SortOptions::UNIQUE_SORT.bits().into()),
     ));
 
     class

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -9,8 +9,7 @@ use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::context::UpdateContext;
-use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
-use enumset::EnumSet;
+use crate::display_object::{DisplayObject, Lists, TDisplayObject, TDisplayObjectContainer};
 use gc_arena::{GcCell, MutationContext};
 use std::cmp::min;
 
@@ -100,7 +99,7 @@ fn remove_child_from_displaylist<'gc>(
 ) {
     if let Some(parent) = child.parent() {
         if let Some(mut ctr) = parent.as_container() {
-            ctr.remove_child(context, child, EnumSet::all());
+            ctr.remove_child(context, child, Lists::all());
         }
     }
 }
@@ -353,7 +352,7 @@ pub fn remove_child_at<'gc>(
 
             let child = ctr.child_by_index(target_child as usize).unwrap();
 
-            ctr.remove_child(&mut activation.context, child, EnumSet::all());
+            ctr.remove_child(&mut activation.context, child, Lists::all());
 
             return Ok(child.object2());
         }

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -272,7 +272,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.set_attributes(ClassAttributes::Sealed.into());
+    write.set_attributes(ClassAttributes::SEALED);
 
     write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public_namespace(), "bubbles"),

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -375,7 +375,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.set_attributes(ClassAttributes::Sealed.into());
+    write.set_attributes(ClassAttributes::SEALED);
 
     write.implements(QName::new(Namespace::package("flash.events"), "IEventDispatcher").into());
 

--- a/core/src/avm2/globals/flash/events/ieventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/ieventdispatcher.rs
@@ -40,7 +40,7 @@ pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<
 
     let mut write = class.write(mc);
 
-    write.set_attributes(ClassAttributes::Interface.into());
+    write.set_attributes(ClassAttributes::INTERFACE);
     write.define_instance_trait(Trait::from_method(
         QName::dynamic_name("addEventListener"),
         Method::from_builtin(bodiless_method),

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -84,7 +84,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     );
 
     let mut write = class.write(mc);
-    write.set_attributes(ClassAttributes::Final | ClassAttributes::Sealed);
+    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
     use std::f64::consts::*;
     math_constants! {

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -1,20 +1,20 @@
 //! Property data structures
 
-use self::Attribute::*;
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::return_value::ReturnValue;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use enumset::{EnumSet, EnumSetType};
+use bitflags::bitflags;
 use gc_arena::{Collect, CollectionContext};
 
-/// Attributes of properties in the AVM runtime.
-///
-/// TODO: Replace with AVM2 properties for traits
-#[derive(EnumSetType, Debug)]
-pub enum Attribute {
-    DontDelete,
-    ReadOnly,
+bitflags! {
+    /// Attributes of properties in the AVM runtime.
+    ///
+    /// TODO: Replace with AVM2 properties for traits
+    pub struct Attribute: u8 {
+        const DONT_DELETE = 1 << 0;
+        const READ_ONLY   = 1 << 1;
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -23,15 +23,15 @@ pub enum Property<'gc> {
     Virtual {
         get: Option<Object<'gc>>,
         set: Option<Object<'gc>>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     },
     Stored {
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     },
     Slot {
         slot_id: u32,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     },
 }
 
@@ -53,7 +53,7 @@ impl<'gc> Property<'gc> {
     pub fn new_stored(value: impl Into<Value<'gc>>) -> Self {
         Property::Stored {
             value: value.into(),
-            attributes: EnumSet::from(Attribute::DontDelete),
+            attributes: Attribute::DONT_DELETE,
         }
     }
 
@@ -61,7 +61,7 @@ impl<'gc> Property<'gc> {
     pub fn new_const(value: impl Into<Value<'gc>>) -> Self {
         Property::Stored {
             value: value.into(),
-            attributes: Attribute::ReadOnly | Attribute::DontDelete,
+            attributes: Attribute::all(),
         }
     }
 
@@ -69,17 +69,17 @@ impl<'gc> Property<'gc> {
     pub fn new_dynamic_property(value: impl Into<Value<'gc>>) -> Self {
         Property::Stored {
             value: value.into(),
-            attributes: EnumSet::empty(),
+            attributes: Attribute::empty(),
         }
     }
 
     /// Convert a function into a method.
     ///
-    /// This applies ReadOnly/DontDelete to the property.
+    /// This applies ReadOnly/DONT_DELETE to the property.
     pub fn new_method(fn_obj: Object<'gc>) -> Self {
         Property::Stored {
             value: fn_obj.into(),
-            attributes: Attribute::ReadOnly | Attribute::DontDelete,
+            attributes: Attribute::all(),
         }
     }
 
@@ -88,7 +88,7 @@ impl<'gc> Property<'gc> {
         Property::Virtual {
             get: None,
             set: None,
-            attributes: Attribute::ReadOnly | Attribute::DontDelete,
+            attributes: Attribute::all(),
         }
     }
 
@@ -96,7 +96,7 @@ impl<'gc> Property<'gc> {
     pub fn new_slot(slot_id: u32) -> Self {
         Property::Slot {
             slot_id,
-            attributes: EnumSet::from(Attribute::DontDelete),
+            attributes: Attribute::DONT_DELETE,
         }
     }
 
@@ -185,7 +185,7 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(ReadOnly) {
+                if !attributes.contains(Attribute::READ_ONLY) {
                     *value = new_value.into();
                 }
 
@@ -247,9 +247,9 @@ impl<'gc> Property<'gc> {
 
     pub fn can_delete(&self) -> bool {
         match self {
-            Property::Virtual { attributes, .. } => !attributes.contains(DontDelete),
-            Property::Stored { attributes, .. } => !attributes.contains(DontDelete),
-            Property::Slot { attributes, .. } => !attributes.contains(DontDelete),
+            Property::Virtual { attributes, .. } => !attributes.contains(Attribute::DONT_DELETE),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::DONT_DELETE),
+            Property::Slot { attributes, .. } => !attributes.contains(Attribute::DONT_DELETE),
         }
     }
 
@@ -257,9 +257,9 @@ impl<'gc> Property<'gc> {
         match self {
             Property::Virtual {
                 attributes, set, ..
-            } => !attributes.contains(ReadOnly) && !set.is_none(),
-            Property::Stored { attributes, .. } => !attributes.contains(ReadOnly),
-            Property::Slot { attributes, .. } => !attributes.contains(ReadOnly),
+            } => !attributes.contains(Attribute::READ_ONLY) && !set.is_none(),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
+            Property::Slot { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
         }
     }
 }

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -185,7 +185,9 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(Attribute::READ_ONLY) {
+                if !attributes.contains(
+                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                ) {
                     *value = new_value.into();
                 }
 
@@ -257,9 +259,15 @@ impl<'gc> Property<'gc> {
         match self {
             Property::Virtual {
                 attributes, set, ..
-            } => !attributes.contains(Attribute::READ_ONLY) && !set.is_none(),
-            Property::Stored { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
-            Property::Slot { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
+            } => {
+                !attributes.contains(
+                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                ) && !set.is_none()
+            }
+            Property::Stored { attributes, .. } => !attributes
+                .contains(AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY),
+            Property::Slot { attributes, .. } => !attributes
+                .contains(AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY),
         }
     }
 }

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -185,9 +185,7 @@ impl<'gc> Property<'gc> {
             Property::Stored {
                 value, attributes, ..
             } => {
-                if !attributes.contains(
-                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
-                ) {
+                if !attributes.contains(Attribute::READ_ONLY) {
                     *value = new_value.into();
                 }
 
@@ -259,15 +257,9 @@ impl<'gc> Property<'gc> {
         match self {
             Property::Virtual {
                 attributes, set, ..
-            } => {
-                !attributes.contains(
-                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
-                ) && !set.is_none()
-            }
-            Property::Stored { attributes, .. } => !attributes
-                .contains(AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY),
-            Property::Slot { attributes, .. } => !attributes
-                .contains(AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY),
+            } => !attributes.contains(Attribute::READ_ONLY) && !set.is_none(),
+            Property::Stored { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
+            Property::Slot { attributes, .. } => !attributes.contains(Attribute::READ_ONLY),
         }
     }
 }

--- a/core/src/avm2/slot.rs
+++ b/core/src/avm2/slot.rs
@@ -3,7 +3,6 @@
 use crate::avm2::property::Attribute;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use enumset::EnumSet;
 use gc_arena::{Collect, CollectionContext};
 
 /// Represents a single slot on an object.
@@ -20,7 +19,7 @@ pub enum Slot<'gc> {
     /// TODO: For some reason, rustc believes this variant is unused.
     Occupied {
         value: Value<'gc>,
-        attributes: EnumSet<Attribute>,
+        attributes: Attribute,
     },
 }
 
@@ -44,7 +43,7 @@ impl<'gc> Slot<'gc> {
     pub fn new(value: impl Into<Value<'gc>>) -> Self {
         Self::Occupied {
             value: value.into(),
-            attributes: EnumSet::empty(),
+            attributes: Attribute::empty(),
         }
     }
 
@@ -52,7 +51,7 @@ impl<'gc> Slot<'gc> {
     pub fn new_const(value: impl Into<Value<'gc>>) -> Self {
         Self::Occupied {
             value: value.into(),
-            attributes: EnumSet::from(Attribute::ReadOnly),
+            attributes: Attribute::READ_ONLY,
         }
     }
 
@@ -69,7 +68,7 @@ impl<'gc> Slot<'gc> {
         match self {
             Self::Unoccupied => Err("Cannot overwrite unoccupied slot".into()),
             Self::Occupied { value, attributes } => {
-                if attributes.contains(Attribute::ReadOnly) {
+                if attributes.contains(Attribute::READ_ONLY) {
                     return Err("Cannot overwrite const slot".into());
                 }
 

--- a/core/src/avm2/slot.rs
+++ b/core/src/avm2/slot.rs
@@ -51,7 +51,7 @@ impl<'gc> Slot<'gc> {
     pub fn new_const(value: impl Into<Value<'gc>>) -> Self {
         Self::Occupied {
             value: value.into(),
-            attributes: Attribute::READ_ONLY,
+            attributes: AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
         }
     }
 
@@ -68,7 +68,9 @@ impl<'gc> Slot<'gc> {
         match self {
             Self::Unoccupied => Err("Cannot overwrite unoccupied slot".into()),
             Self::Occupied { value, attributes } => {
-                if attributes.contains(Attribute::READ_ONLY) {
+                if attributes.contains(
+                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+                ) {
                     return Err("Cannot overwrite const slot".into());
                 }
 

--- a/core/src/avm2/slot.rs
+++ b/core/src/avm2/slot.rs
@@ -51,7 +51,7 @@ impl<'gc> Slot<'gc> {
     pub fn new_const(value: impl Into<Value<'gc>>) -> Self {
         Self::Occupied {
             value: value.into(),
-            attributes: AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
+            attributes: Attribute::READ_ONLY,
         }
     }
 
@@ -68,9 +68,7 @@ impl<'gc> Slot<'gc> {
         match self {
             Self::Unoccupied => Err("Cannot overwrite unoccupied slot".into()),
             Self::Occupied { value, attributes } => {
-                if attributes.contains(
-                    AttrAttribute::DONT_ENUM | Attribute::DONT_DELETE | Attribute::READ_ONLY,
-                ) {
+                if attributes.contains(Attribute::READ_ONLY) {
                     return Err("Cannot overwrite const slot".into());
                 }
 

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -48,12 +48,10 @@ pub struct Trait<'gc> {
 }
 
 fn trait_attribs_from_abc_traits(abc_trait: &AbcTrait) -> CollectWrapper<TraitAttributes> {
-    CollectWrapper(match (abc_trait.is_final, abc_trait.is_override) {
-        (true, true) => TraitAttributes::all(),
-        (true, false) => TraitAttributes::FINAL,
-        (false, true) => TraitAttributes::OVERRIDE,
-        (false, false) => TraitAttributes::empty(),
-    })
+    let mut attributes = TraitAttributes::empty();
+    attributes.set(TraitAttributes::FINAL, abc_trait.is_final);
+    attributes.set(TraitAttributes::OVERRIDE, abc_trait.is_override);
+    CollectWrapper(attributes)
 }
 
 /// The fields for a particular kind of trait.

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -7,20 +7,21 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::value::{abc_default_value, Value};
 use crate::avm2::{Avm2, Error};
 use crate::collect::CollectWrapper;
-use enumset::{EnumSet, EnumSetType};
+use bitflags::bitflags;
 use gc_arena::{Collect, GcCell, MutationContext};
 use swf::avm2::types::{Trait as AbcTrait, TraitKind as AbcTraitKind};
 
-/// All attributes a trait can have.
-#[derive(Debug, EnumSetType)]
-pub enum TraitAttributes {
-    /// Whether or not traits in downstream classes are allowed to override
-    /// this trait.
-    Final,
+bitflags! {
+    /// All attributes a trait can have.
+    pub struct  TraitAttributes: u8 {
+        /// Whether or not traits in downstream classes are allowed to override
+        /// this trait.
+        const FINAL    = 1 << 0;
 
-    /// Whether or not this trait is intended to override an upstream class's
-    /// trait.
-    Override,
+        /// Whether or not this trait is intended to override an upstream class's
+        /// trait.
+        const OVERRIDE = 1 << 1;
+    }
 }
 
 /// Represents a trait as loaded into the VM.
@@ -40,18 +41,18 @@ pub struct Trait<'gc> {
     name: QName<'gc>,
 
     /// The attributes set on this trait.
-    attributes: CollectWrapper<EnumSet<TraitAttributes>>,
+    attributes: CollectWrapper<TraitAttributes>,
 
     /// The kind of trait in use.
     kind: TraitKind<'gc>,
 }
 
-fn trait_attribs_from_abc_traits(abc_trait: &AbcTrait) -> CollectWrapper<EnumSet<TraitAttributes>> {
+fn trait_attribs_from_abc_traits(abc_trait: &AbcTrait) -> CollectWrapper<TraitAttributes> {
     CollectWrapper(match (abc_trait.is_final, abc_trait.is_override) {
-        (true, true) => TraitAttributes::Final | TraitAttributes::Override,
-        (true, false) => TraitAttributes::Final.into(),
-        (false, true) => TraitAttributes::Override.into(),
-        (false, false) => EnumSet::empty(),
+        (true, true) => TraitAttributes::all(),
+        (true, false) => TraitAttributes::FINAL,
+        (false, true) => TraitAttributes::OVERRIDE,
+        (false, false) => TraitAttributes::empty(),
     })
 }
 
@@ -104,7 +105,7 @@ impl<'gc> Trait<'gc> {
 
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Class { slot_id: 0, class },
         }
     }
@@ -112,7 +113,7 @@ impl<'gc> Trait<'gc> {
     pub fn from_method(name: QName<'gc>, method: Method<'gc>) -> Self {
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Method { disp_id: 0, method },
         }
     }
@@ -120,7 +121,7 @@ impl<'gc> Trait<'gc> {
     pub fn from_getter(name: QName<'gc>, method: Method<'gc>) -> Self {
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Getter { disp_id: 0, method },
         }
     }
@@ -128,7 +129,7 @@ impl<'gc> Trait<'gc> {
     pub fn from_setter(name: QName<'gc>, method: Method<'gc>) -> Self {
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Setter { disp_id: 0, method },
         }
     }
@@ -136,7 +137,7 @@ impl<'gc> Trait<'gc> {
     pub fn from_function(name: QName<'gc>, function: Method<'gc>) -> Self {
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Function {
                 slot_id: 0,
                 function,
@@ -151,7 +152,7 @@ impl<'gc> Trait<'gc> {
     ) -> Self {
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Slot {
                 slot_id: 0,
                 type_name,
@@ -167,7 +168,7 @@ impl<'gc> Trait<'gc> {
     ) -> Self {
         Trait {
             name,
-            attributes: CollectWrapper(EnumSet::empty()),
+            attributes: CollectWrapper(TraitAttributes::empty()),
             kind: TraitKind::Slot {
                 slot_id: 0,
                 type_name,
@@ -280,14 +281,14 @@ impl<'gc> Trait<'gc> {
     }
 
     pub fn is_final(&self) -> bool {
-        self.attributes.0.contains(TraitAttributes::Final)
+        self.attributes.0.contains(TraitAttributes::FINAL)
     }
 
     pub fn is_override(&self) -> bool {
-        self.attributes.0.contains(TraitAttributes::Override)
+        self.attributes.0.contains(TraitAttributes::OVERRIDE)
     }
 
-    pub fn set_attributes(&mut self, attribs: EnumSet<TraitAttributes>) {
+    pub fn set_attributes(&mut self, attribs: TraitAttributes) {
         self.attributes.0 = attribs;
     }
 

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -8,7 +8,6 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::string::AvmString;
 use crate::avm2::{Avm2, Error};
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
-use enumset::{EnumSet, EnumSetType};
 use gc_arena::{Collect, MutationContext};
 use std::cell::Ref;
 use std::f64::NAN;
@@ -444,20 +443,6 @@ impl<'gc> Value<'gc> {
     /// ToInt32 algorithm which appears to match AVM2.
     pub fn coerce_to_i32(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<i32, Error> {
         Ok(f64_to_wrapping_i32(self.coerce_to_number(activation)?))
-    }
-
-    /// Coerce the value to an EnumSet of a particular type.
-    ///
-    /// This function will ignore invalid bits of the value when interpreting
-    /// the enum.
-    pub fn coerce_to_enumset<E>(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<EnumSet<E>, Error>
-    where
-        E: EnumSetType,
-    {
-        Ok(EnumSet::from_u32_truncated(self.coerce_to_u32(activation)?))
     }
 
     /// Minimum number of digits after which numbers are formatted as

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -181,7 +181,7 @@ impl<'gc> Button<'gc> {
         // Kill children that no longer exist in this state.
         for depth in removed_depths {
             if let Some(child) = self.child_by_depth(depth) {
-                self.remove_child(context, child, EnumSet::all());
+                self.remove_child(context, child, Lists::all());
             }
         }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3116,7 +3116,7 @@ impl ClipAction {
             if (flags & bit) != 0 {
                 events.push(ClipEventFlag::from_bits_truncate(bit));
             }
-            bit = bit << 1;
+            bit <<= 1;
         }
         events.into_iter().map(move |event| Self {
             event: match event {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3108,13 +3108,17 @@ impl ClipAction {
         let action_data = SwfSlice::from(movie)
             .to_unbounded_subslice(other.action_data)
             .unwrap();
-        let mut x = Vec::new();
-        for i in 0..32 {
-            x.push(ClipEventFlag::from_bits_truncate(
-                other.events.bits() & (1 << i),
-            ));
+
+        let mut events = Vec::new();
+        let flags = other.events.bits();
+        let mut bit = 1u32;
+        while flags & !(bit - 1) != 0 {
+            if (flags & bit) != 0 {
+                events.push(ClipEventFlag::from_bits_truncate(bit));
+            }
+            bit = bit << 1;
         }
-        x.into_iter().map(move |event| Self {
+        events.into_iter().map(move |event| Self {
             event: match event {
                 ClipEventFlag::CONSTRUCT => ClipEvent::Construct,
                 ClipEventFlag::DATA => ClipEvent::Data,
@@ -3139,6 +3143,7 @@ impl ClipAction {
                 ClipEventFlag::RELEASE => ClipEvent::Release,
                 ClipEventFlag::RELEASE_OUTSIDE => ClipEvent::ReleaseOutside,
                 ClipEventFlag::UNLOAD => ClipEvent::Unload,
+                _ => unreachable!(),
             },
             action_data: action_data.clone(),
         })

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -8,6 +8,7 @@ use crate::avm2::{
     StageObject as Avm2StageObject, TObject as Avm2TObject, Value as Avm2Value,
 };
 use crate::backend::audio::AudioStreamHandle;
+use bitflags::bitflags;
 
 use crate::avm1::activation::{Activation as Avm1Activation, ActivationIdentifier};
 use crate::character::Character;
@@ -24,7 +25,6 @@ use crate::shape_utils::DrawCommand;
 use crate::tag_utils::{self, DecodeResult, SwfMovie, SwfSlice, SwfStream};
 use crate::types::{Degrees, Percent};
 use crate::vminterface::{AvmObject, AvmType, Instantiator};
-use enumset::{EnumSet, EnumSetType};
 use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use smallvec::SmallVec;
 use std::cell::{Ref, RefCell};
@@ -57,7 +57,7 @@ pub struct MovieClipData<'gc> {
     clip_actions: Vec<ClipAction>,
     frame_scripts: Vec<Avm2FrameScript<'gc>>,
     has_button_clip_event: bool,
-    flags: EnumSet<MovieClipFlags>,
+    flags: MovieClipFlags,
     avm2_constructor: Option<Avm2Object<'gc>>,
     drawing: Drawing,
     is_focusable: bool,
@@ -93,7 +93,7 @@ impl<'gc> MovieClip<'gc> {
                 clip_actions: Vec::new(),
                 frame_scripts: Vec::new(),
                 has_button_clip_event: false,
-                flags: EnumSet::empty(),
+                flags: MovieClipFlags::empty(),
                 avm2_constructor: None,
                 drawing: Drawing::new(),
                 is_focusable: false,
@@ -125,7 +125,7 @@ impl<'gc> MovieClip<'gc> {
                 clip_actions: Vec::new(),
                 frame_scripts: Vec::new(),
                 has_button_clip_event: false,
-                flags: MovieClipFlags::Playing.into(),
+                flags: MovieClipFlags::PLAYING,
                 avm2_constructor: None,
                 drawing: Drawing::new(),
                 is_focusable: false,
@@ -1159,9 +1159,9 @@ impl<'gc> MovieClip<'gc> {
                 .collect();
             for (_depth, child) in children {
                 if !child.placed_by_script() {
-                    self.remove_child(context, child, EnumSet::all());
+                    self.remove_child(context, child, Lists::all());
                 } else {
-                    self.remove_child(context, child, Lists::Depth.into());
+                    self.remove_child(context, child, Lists::DEPTH);
                 }
             }
             true
@@ -1533,10 +1533,10 @@ impl<'gc> MovieClip<'gc> {
             if let Some(child) = read.container.get_depth(depth) {
                 if !child.placed_by_script() {
                     drop(read);
-                    self.remove_child(context, child, EnumSet::all());
+                    self.remove_child(context, child, Lists::all());
                 } else {
                     drop(read);
-                    self.remove_child(context, child, Lists::Depth.into());
+                    self.remove_child(context, child, Lists::DEPTH);
                 }
             }
         }
@@ -1826,7 +1826,7 @@ impl<'gc> MovieClipData<'gc> {
             MovieClipStatic::with_data(0, movie.into(), total_frames),
         );
         self.tag_stream_pos = 0;
-        self.flags = MovieClipFlags::Playing.into();
+        self.flags = MovieClipFlags::PLAYING;
         self.current_frame = 0;
         self.audio_stream = None;
         self.container = ChildContainer::new();
@@ -1845,23 +1845,23 @@ impl<'gc> MovieClipData<'gc> {
     }
 
     fn playing(&self) -> bool {
-        self.flags.contains(MovieClipFlags::Playing)
+        self.flags.contains(MovieClipFlags::PLAYING)
     }
 
     fn set_playing(&mut self, value: bool) {
         if value {
-            self.flags.insert(MovieClipFlags::Playing);
+            self.flags |= MovieClipFlags::PLAYING;
         } else {
-            self.flags.remove(MovieClipFlags::Playing);
+            self.flags -= MovieClipFlags::PLAYING;
         }
     }
 
     fn programmatically_played(&self) -> bool {
-        self.flags.contains(MovieClipFlags::ProgrammaticallyPlayed)
+        self.flags.contains(MovieClipFlags::PROGRAMMATICALLY_PLAYED)
     }
 
     fn set_programmatically_played(&mut self) {
-        self.flags.insert(MovieClipFlags::ProgrammaticallyPlayed);
+        self.flags |= MovieClipFlags::PROGRAMMATICALLY_PLAYED;
     }
 
     fn play(&mut self) {
@@ -2000,15 +2000,17 @@ impl<'gc> MovieClipData<'gc> {
     }
 
     fn initialized(&self) -> bool {
-        self.flags.contains(MovieClipFlags::Initialized)
+        self.flags.contains(MovieClipFlags::INITIALIZED)
     }
 
     fn set_initialized(&mut self, value: bool) -> bool {
+        let ret = self.flags.contains(MovieClipFlags::INITIALIZED);
         if value {
-            self.flags.insert(MovieClipFlags::Initialized)
+            self.flags |= MovieClipFlags::INITIALIZED;
         } else {
-            self.flags.remove(MovieClipFlags::Initialized)
+            self.flags -= MovieClipFlags::INITIALIZED;
         }
+        !ret
     }
 
     /// Stops the audio stream if one is playing.
@@ -2808,9 +2810,9 @@ impl<'gc, 'a> MovieClip<'gc> {
 
         if let Some(child) = self.child_by_depth(remove_object.depth.into()) {
             if !child.placed_by_script() {
-                self.remove_child(context, child, EnumSet::all());
+                self.remove_child(context, child, Lists::all());
             } else {
-                self.remove_child(context, child, Lists::Depth.into());
+                self.remove_child(context, child, Lists::DEPTH);
             }
         }
 
@@ -3061,20 +3063,21 @@ impl<'a> GotoPlaceObject<'a> {
     }
 }
 
-/// Boolean state flags used by `MovieClip`.
-#[derive(Debug, EnumSetType)]
-enum MovieClipFlags {
-    /// Whether this `MovieClip` has run its initial frame.
-    Initialized,
+bitflags! {
+    /// Boolean state flags used by `MovieClip`.
+    struct MovieClipFlags: u8 {
+        /// Whether this `MovieClip` has run its initial frame.
+        const INITIALIZED             = 1 << 0;
 
-    /// Whether this `MovieClip` is playing or stopped.
-    Playing,
+        /// Whether this `MovieClip` is playing or stopped.
+        const PLAYING                 = 1 << 1;
 
-    /// Whether this `MovieClip` has been played as a result of an AS3 command.
-    ///
-    /// The AS3 `isPlaying` property is broken and yields false until you first
-    /// call `play` to unbreak it. This flag tracks that bug.
-    ProgrammaticallyPlayed,
+        /// Whether this `MovieClip` has been played as a result of an AS3 command.
+        ///
+        /// The AS3 `isPlaying` property is broken and yields false until you first
+        /// call `play` to unbreak it. This flag tracks that bug.
+        const PROGRAMMATICALLY_PLAYED = 1 << 2;
+    }
 }
 
 /// Actions that are attached to a `MovieClip` event in
@@ -3105,31 +3108,37 @@ impl ClipAction {
         let action_data = SwfSlice::from(movie)
             .to_unbounded_subslice(other.action_data)
             .unwrap();
-        other.events.into_iter().map(move |event| Self {
+        let mut x = Vec::new();
+        for i in 0..32 {
+            x.push(ClipEventFlag::from_bits_truncate(
+                other.events.bits() & (1 << i),
+            ));
+        }
+        x.into_iter().map(move |event| Self {
             event: match event {
-                ClipEventFlag::Construct => ClipEvent::Construct,
-                ClipEventFlag::Data => ClipEvent::Data,
-                ClipEventFlag::DragOut => ClipEvent::DragOut,
-                ClipEventFlag::DragOver => ClipEvent::DragOver,
-                ClipEventFlag::EnterFrame => ClipEvent::EnterFrame,
-                ClipEventFlag::Initialize => ClipEvent::Initialize,
-                ClipEventFlag::KeyUp => ClipEvent::KeyUp,
-                ClipEventFlag::KeyDown => ClipEvent::KeyDown,
-                ClipEventFlag::KeyPress => ClipEvent::KeyPress {
+                ClipEventFlag::CONSTRUCT => ClipEvent::Construct,
+                ClipEventFlag::DATA => ClipEvent::Data,
+                ClipEventFlag::DRAG_OUT => ClipEvent::DragOut,
+                ClipEventFlag::DRAG_OVER => ClipEvent::DragOver,
+                ClipEventFlag::ENTER_FRAME => ClipEvent::EnterFrame,
+                ClipEventFlag::INITIALIZE => ClipEvent::Initialize,
+                ClipEventFlag::KEY_UP => ClipEvent::KeyUp,
+                ClipEventFlag::KEY_DOWN => ClipEvent::KeyDown,
+                ClipEventFlag::KEY_PRESS => ClipEvent::KeyPress {
                     key_code: key_code
                         .and_then(|k| ButtonKeyCode::try_from(k).ok())
                         .unwrap_or(ButtonKeyCode::Unknown),
                 },
-                ClipEventFlag::Load => ClipEvent::Load,
-                ClipEventFlag::MouseUp => ClipEvent::MouseUp,
-                ClipEventFlag::MouseDown => ClipEvent::MouseDown,
-                ClipEventFlag::MouseMove => ClipEvent::MouseMove,
-                ClipEventFlag::Press => ClipEvent::Press,
-                ClipEventFlag::RollOut => ClipEvent::RollOut,
-                ClipEventFlag::RollOver => ClipEvent::RollOver,
-                ClipEventFlag::Release => ClipEvent::Release,
-                ClipEventFlag::ReleaseOutside => ClipEvent::ReleaseOutside,
-                ClipEventFlag::Unload => ClipEvent::Unload,
+                ClipEventFlag::LOAD => ClipEvent::Load,
+                ClipEventFlag::MOUSE_UP => ClipEvent::MouseUp,
+                ClipEventFlag::MOUSE_DOWN => ClipEvent::MouseDown,
+                ClipEventFlag::MOUSE_MOVE => ClipEvent::MouseMove,
+                ClipEventFlag::PRESS => ClipEvent::Press,
+                ClipEventFlag::ROLL_OUT => ClipEvent::RollOut,
+                ClipEventFlag::ROLL_OVER => ClipEvent::RollOver,
+                ClipEventFlag::RELEASE => ClipEvent::Release,
+                ClipEventFlag::RELEASE_OUTSIDE => ClipEvent::ReleaseOutside,
+                ClipEventFlag::UNLOAD => ClipEvent::Unload,
             },
             action_data: action_data.clone(),
         })

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2,6 +2,7 @@ use crate::avm1::activation::{Activation, ActivationIdentifier};
 use crate::avm1::debug::VariableDumper;
 use crate::avm1::globals::system::SystemProperties;
 use crate::avm1::object::Object;
+use crate::avm1::property::Attribute;
 use crate::avm1::{Avm1, AvmString, ScriptObject, TObject, Timers, Value};
 use crate::avm2::{Avm2, Domain as Avm2Domain};
 use crate::backend::input::{InputBackend, MouseCursor};
@@ -23,7 +24,6 @@ use crate::property_map::PropertyMap;
 use crate::tag_utils::SwfMovie;
 use crate::transform::TransformStack;
 use crate::vminterface::{AvmType, Instantiator};
-use enumset::EnumSet;
 use gc_arena::{make_arena, ArenaParameters, Collect, GcCell};
 use instant::Instant;
 use log::info;
@@ -388,7 +388,7 @@ impl Player {
                         context.gc_context,
                         key,
                         AvmString::new(context.gc_context, value).into(),
-                        EnumSet::empty(),
+                        Attribute::empty(),
                     );
                 }
                 Some(object.into())
@@ -426,7 +426,7 @@ impl Player {
                 activation.context.gc_context,
                 "$version",
                 AvmString::new(activation.context.gc_context, version_string).into(),
-                EnumSet::empty(),
+                Attribute::empty(),
             );
         });
 

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -7,7 +7,6 @@ pub use crate::display_object::{
 pub use crate::{
     impl_display_object, impl_display_object_container, impl_display_object_sansbounds,
 };
-pub use enumset::EnumSet;
 pub use log::{error, info, trace, warn};
 pub use std::ops::{Bound, RangeBounds};
 pub use swf::Matrix;

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 description = "Read and write the Adobe Flash SWF file format."
 
 [dependencies]
+bitflags = "1.2.1"
 bitstream-io = "1.0.0"
 byteorder = "1.4"
 encoding_rs = "0.8.26"
-enumset = "1.0.1"
 num-derive = "0.3"
 num-traits = "0.2"
 libflate = {version = "1.0", optional = true}

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use bitstream_io::BitRead;
 use byteorder::{LittleEndian, ReadBytesExt};
-use enumset::EnumSet;
 use std::collections::HashSet;
 use std::io::{self, Read};
 
@@ -2208,7 +2207,7 @@ impl<'a> Reader<'a> {
             Ok(None)
         } else {
             let mut length = self.read_u32()?;
-            let key_code = if events.contains(ClipEventFlag::KeyPress) {
+            let key_code = if events.contains(ClipEventFlag::KEY_PRESS) {
                 // ActionData length includes the 1 byte key code.
                 length -= 1;
                 Some(self.read_u8()?)
@@ -2225,33 +2224,33 @@ impl<'a> Reader<'a> {
         }
     }
 
-    fn read_clip_event_flags(&mut self) -> Result<EnumSet<ClipEventFlag>> {
+    fn read_clip_event_flags(&mut self) -> Result<ClipEventFlag> {
         // TODO: Switch to a bitset.
-        let mut event_list = EnumSet::new();
+        let mut event_list = ClipEventFlag::empty();
         let flags = self.read_u8()?;
         if flags & 0b1000_0000 != 0 {
-            event_list.insert(ClipEventFlag::KeyUp);
+            event_list.insert(ClipEventFlag::KEY_UP);
         }
         if flags & 0b0100_0000 != 0 {
-            event_list.insert(ClipEventFlag::KeyDown);
+            event_list.insert(ClipEventFlag::KEY_DOWN);
         }
         if flags & 0b0010_0000 != 0 {
-            event_list.insert(ClipEventFlag::MouseUp);
+            event_list.insert(ClipEventFlag::MOUSE_UP);
         }
         if flags & 0b0001_0000 != 0 {
-            event_list.insert(ClipEventFlag::MouseDown);
+            event_list.insert(ClipEventFlag::MOUSE_DOWN);
         }
         if flags & 0b0000_1000 != 0 {
-            event_list.insert(ClipEventFlag::MouseMove);
+            event_list.insert(ClipEventFlag::MOUSE_MOVE);
         }
         if flags & 0b0000_0100 != 0 {
-            event_list.insert(ClipEventFlag::Unload);
+            event_list.insert(ClipEventFlag::UNLOAD);
         }
         if flags & 0b0000_0010 != 0 {
-            event_list.insert(ClipEventFlag::EnterFrame);
+            event_list.insert(ClipEventFlag::ENTER_FRAME);
         }
         if flags & 0b0000_0001 != 0 {
-            event_list.insert(ClipEventFlag::Load);
+            event_list.insert(ClipEventFlag::LOAD);
         }
         if self.version < 6 {
             // SWF19 pp. 48-50: For SWFv5, the ClipEventFlags only had 2 bytes of flags,
@@ -2261,28 +2260,28 @@ impl<'a> Reader<'a> {
         } else {
             let flags = self.read_u8()?;
             if flags & 0b1000_0000 != 0 {
-                event_list.insert(ClipEventFlag::DragOver);
+                event_list.insert(ClipEventFlag::DRAG_OVER);
             }
             if flags & 0b0100_0000 != 0 {
-                event_list.insert(ClipEventFlag::RollOut);
+                event_list.insert(ClipEventFlag::ROLL_OUT);
             }
             if flags & 0b0010_0000 != 0 {
-                event_list.insert(ClipEventFlag::RollOver);
+                event_list.insert(ClipEventFlag::ROLL_OVER);
             }
             if flags & 0b0001_0000 != 0 {
-                event_list.insert(ClipEventFlag::ReleaseOutside);
+                event_list.insert(ClipEventFlag::RELEASE_OUTSIDE);
             }
             if flags & 0b0000_1000 != 0 {
-                event_list.insert(ClipEventFlag::Release);
+                event_list.insert(ClipEventFlag::RELEASE);
             }
             if flags & 0b0000_0100 != 0 {
-                event_list.insert(ClipEventFlag::Press);
+                event_list.insert(ClipEventFlag::PRESS);
             }
             if flags & 0b0000_0010 != 0 {
-                event_list.insert(ClipEventFlag::Initialize);
+                event_list.insert(ClipEventFlag::INITIALIZE);
             }
             if flags & 0b0000_0001 != 0 {
-                event_list.insert(ClipEventFlag::Data);
+                event_list.insert(ClipEventFlag::DATA);
             }
             if self.version < 6 {
                 self.read_u16()?;
@@ -2291,13 +2290,13 @@ impl<'a> Reader<'a> {
                 if flags & 0b0000_0100 != 0 {
                     // Construct was only added in SWF7, but it's not version-gated;
                     // Construct events will still fire in SWF6 in a v7+ player. (#1424)
-                    event_list.insert(ClipEventFlag::Construct);
+                    event_list.insert(ClipEventFlag::CONSTRUCT);
                 }
                 if flags & 0b0000_0010 != 0 {
-                    event_list.insert(ClipEventFlag::KeyPress);
+                    event_list.insert(ClipEventFlag::KEY_PRESS);
                 }
                 if flags & 0b0000_0001 != 0 {
-                    event_list.insert(ClipEventFlag::DragOut);
+                    event_list.insert(ClipEventFlag::DRAG_OUT);
                 }
                 self.read_u8()?;
             }

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -2125,7 +2125,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 background_color: None,
                 blend_mode: None,
                 clip_actions: Some(vec![ClipAction {
-                    events: ClipEventFlag::EnterFrame.into(),
+                    events: ClipEventFlag::ENTER_FRAME,
                     key_code: None,
                     action_data: &[150, 6, 0, 0, 99, 108, 105, 112, 0, 38, 0],
                 }]),
@@ -2156,17 +2156,17 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 blend_mode: None,
                 clip_actions: Some(vec![
                     ClipAction {
-                        events: ClipEventFlag::Press | ClipEventFlag::Release,
+                        events: ClipEventFlag::PRESS | ClipEventFlag::RELEASE,
                         key_code: None,
                         action_data: &[150, 3, 0, 0, 65, 0, 38, 0],
                     },
                     ClipAction {
-                        events: ClipEventFlag::KeyPress.into(),
+                        events: ClipEventFlag::KEY_PRESS,
                         key_code: Some(99),
                         action_data: &[150, 3, 0, 0, 66, 0, 38, 0],
                     },
                     ClipAction {
-                        events: ClipEventFlag::EnterFrame.into(),
+                        events: ClipEventFlag::ENTER_FRAME,
                         key_code: None,
                         action_data: &[150, 3, 0, 0, 67, 0, 38, 0],
                     },
@@ -2326,12 +2326,12 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 blend_mode: Some(BlendMode::Difference),
                 clip_actions: Some(vec![
                     ClipAction {
-                        events: ClipEventFlag::ReleaseOutside | ClipEventFlag::RollOver,
+                        events: ClipEventFlag::RELEASE_OUTSIDE | ClipEventFlag::ROLL_OVER,
                         key_code: None,
                         action_data: &[0],
                     },
                     ClipAction {
-                        events: ClipEventFlag::Data.into(),
+                        events: ClipEventFlag::DATA,
                         key_code: None,
                         action_data: &[150, 3, 0, 0, 66, 0, 38, 0],
                     },

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -3,8 +3,8 @@
 //! These structures are documented in the Adobe SWF File Format Specification
 //! version 19 (henceforth SWF19):
 //! https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf
-use bitflags::bitflags;
 use crate::string::SwfStr;
+use bitflags::bitflags;
 use std::collections::HashSet;
 
 mod matrix;

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -3,8 +3,8 @@
 //! These structures are documented in the Adobe SWF File Format Specification
 //! version 19 (henceforth SWF19):
 //! https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf
+use bitflags::bitflags;
 use crate::string::SwfStr;
-use enumset::{EnumSet, EnumSetType};
 use std::collections::HashSet;
 
 mod matrix;
@@ -418,39 +418,40 @@ pub enum BlendMode {
 /// An clip action (a.k.a. clip event) placed on a movieclip instance.
 /// Created in the Flash IDE using `onClipEvent` or `on` blocks.
 ///
-/// [SWF19 pp.37-38 ClipActionRecord](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=37)
+/// [SWF19 pp.37-38 ClipActionRecord](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=39)
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClipAction<'a> {
-    pub events: EnumSet<ClipEventFlag>,
+    pub events: ClipEventFlag,
     pub key_code: Option<KeyCode>,
     pub action_data: &'a [u8],
 }
 
-/// An event that can be attached to a movieclip instance using
-/// an `onClipEvent` or `on` block.
-///
-/// [SWF19 pp.48-50 ClipEvent](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=38)
-#[derive(Debug, EnumSetType)]
-pub enum ClipEventFlag {
-    Construct,
-    Data,
-    DragOut,
-    DragOver,
-    EnterFrame,
-    Initialize,
-    KeyUp,
-    KeyDown,
-    KeyPress,
-    Load,
-    MouseUp,
-    MouseDown,
-    MouseMove,
-    Press,
-    RollOut,
-    RollOver,
-    Release,
-    ReleaseOutside,
-    Unload,
+bitflags! {
+    /// An event that can be attached to a movieclip instance using
+    /// an `onClipEvent` or `on` block.
+    ///
+    /// [SWF19 pp.48-50 ClipEvent](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=50)
+    pub struct ClipEventFlag: u32 {
+        const CONSTRUCT       = 1 << 0;
+        const DATA            = 1 << 1;
+        const DRAG_OUT        = 1 << 2;
+        const DRAG_OVER       = 1 << 3;
+        const ENTER_FRAME     = 1 << 4;
+        const INITIALIZE      = 1 << 5;
+        const KEY_UP          = 1 << 6;
+        const KEY_DOWN        = 1 << 7;
+        const KEY_PRESS       = 1 << 8;
+        const LOAD            = 1 << 9;
+        const MOUSE_UP        = 1 << 10;
+        const MOUSE_DOWN      = 1 << 11;
+        const MOUSE_MOVE      = 1 << 12;
+        const PRESS           = 1 << 13;
+        const ROLL_OUT        = 1 << 14;
+        const ROLL_OVER       = 1 << 15;
+        const RELEASE         = 1 << 16;
+        const RELEASE_OUTSIDE = 1 << 17;
+        const UNLOAD          = 1 << 18;
+    }
 }
 
 /// A key code used in `ButtonAction` and `ClipAction` key press events.

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use bitstream_io::BitWrite;
 use byteorder::{LittleEndian, WriteBytesExt};
-use enumset::EnumSet;
 use std::cmp::max;
 use std::io::{self, Write};
 
@@ -2195,7 +2194,7 @@ impl<W: Write> Writer<W> {
     fn write_clip_actions(&mut self, clip_actions: &[ClipAction]) -> Result<()> {
         self.write_u16(0)?; // Reserved
         {
-            let mut all_events = EnumSet::new();
+            let mut all_events = ClipEventFlag::empty();
             for action in clip_actions {
                 all_events |= action.events;
             }
@@ -2219,31 +2218,31 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn write_clip_event_flags(&mut self, clip_events: EnumSet<ClipEventFlag>) -> Result<()> {
+    fn write_clip_event_flags(&mut self, clip_events: ClipEventFlag) -> Result<()> {
         // TODO: Assert proper version.
         let version = self.version;
         let mut bits = self.bits();
-        bits.write_bit(clip_events.contains(ClipEventFlag::KeyUp))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::KeyDown))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::MouseUp))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::MouseDown))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::MouseMove))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::Unload))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::EnterFrame))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::Load))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::DragOver))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::RollOut))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::RollOver))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::ReleaseOutside))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::Release))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::Press))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::Initialize))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::Data))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::KEY_UP))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::KEY_DOWN))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::MOUSE_UP))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::MOUSE_DOWN))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::MOUSE_MOVE))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::UNLOAD))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::ENTER_FRAME))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::LOAD))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::DRAG_OVER))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::ROLL_OUT))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::ROLL_OVER))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::RELEASE_OUTSIDE))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::RELEASE))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::PRESS))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::INITIALIZE))?;
+        bits.write_bit(clip_events.contains(ClipEventFlag::DATA))?;
         if version >= 6 {
             bits.write_ubits(5, 0)?;
-            bits.write_bit(clip_events.contains(ClipEventFlag::Construct))?;
-            bits.write_bit(clip_events.contains(ClipEventFlag::KeyPress))?;
-            bits.write_bit(clip_events.contains(ClipEventFlag::DragOut))?;
+            bits.write_bit(clip_events.contains(ClipEventFlag::CONSTRUCT))?;
+            bits.write_bit(clip_events.contains(ClipEventFlag::KEY_PRESS))?;
+            bits.write_bit(clip_events.contains(ClipEventFlag::DRAG_OUT))?;
             bits.write_ubits(8, 0)?;
         }
         Ok(())


### PR DESCRIPTION
This PR replaces the [`enumset`](https://github.com/Lymia/enumset) dependency with [`bitflags`](https://github.com/bitflags/bitflags), which is more maintained and elegant.
Also, the last update of [`syn`](https://github.com/dtolnay/syn) broke `enumset` and prevents merging #2298, so this PR would allow to merge it.