### PR TITLE
Fixes duplicating player issue on website demo page

### DIFF
--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -107,7 +107,9 @@ function sampleFileSelected() {
         localFileInput.value = null;
         player.load({ url: swfData.location, ...config });
     } else {
-        container.children[0].remove();
+        if (player) {
+            player.remove();
+        }
         player = ruffle.createPlayer();
         player.id = "player";
         container.append(player);


### PR DESCRIPTION
The fix in https://github.com/ruffle-rs/ruffle/issues/2416 now causes the player to duplicate to 2 instances, because `container.children[0]` seems to select some sort of 'overlay' element, and not the player that it should be deleting. `container.querySelector('#player')` should however select the first player instance, to correctly remove it from the page.