### PR TITLE
swf: Convert HashSet to bitflags

### DIFF
--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -129,9 +129,9 @@ impl<'gc> Button<'gc> {
         let mut write = self.0.write(context.gc_context);
         write.state = state;
         let swf_state = match state {
-            ButtonState::Up => swf::ButtonState::Up,
-            ButtonState::Over => swf::ButtonState::Over,
-            ButtonState::Down => swf::ButtonState::Down,
+            ButtonState::Up => swf::ButtonState::UP,
+            ButtonState::Over => swf::ButtonState::OVER,
+            ButtonState::Down => swf::ButtonState::DOWN,
         };
 
         // Create any new children that exist in this state, and remove children
@@ -141,7 +141,7 @@ impl<'gc> Button<'gc> {
         let mut children = Vec::new();
 
         for record in &write.static_data.read().records {
-            if record.states.contains(&swf_state) {
+            if record.states.contains(swf_state) {
                 // State contains this depth, so we don't have to remove it.
                 removed_depths.remove(&record.depth.into());
 
@@ -257,7 +257,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
             let read = self.0.read();
 
             for record in &read.static_data.read().records {
-                if record.states.contains(&swf::ButtonState::HitTest) {
+                if record.states.contains(swf::ButtonState::HIT_TEST) {
                     match context
                         .library
                         .library_for_movie_mut(read.static_data.read().swf.clone())

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3108,10 +3108,10 @@ impl ClipAction {
             .unwrap();
 
         let mut events = Vec::new();
-        let flags = other.events.bits();
+        let bits = other.events.bits();
         let mut bit = 1u32;
-        while flags & !(bit - 1) != 0 {
-            if (flags & bit) != 0 {
+        while bits & !(bit - 1) != 0 {
+            if bits & bit != 0 {
                 events.push(ClipEventFlag::from_bits_truncate(bit));
             }
             bit <<= 1;

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -902,19 +902,7 @@ impl<'a> Reader<'a> {
         if flags == 0 {
             return Ok(None);
         }
-        let mut states = HashSet::with_capacity(4);
-        if (flags & 0b1) != 0 {
-            states.insert(ButtonState::Up);
-        }
-        if (flags & 0b10) != 0 {
-            states.insert(ButtonState::Over);
-        }
-        if (flags & 0b100) != 0 {
-            states.insert(ButtonState::Down);
-        }
-        if (flags & 0b1000) != 0 {
-            states.insert(ButtonState::HitTest);
-        }
+        let states = ButtonState::from_bits_truncate(flags);
         let id = self.read_u16()?;
         let depth = self.read_u16()?;
         let matrix = self.read_matrix()?;

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -201,9 +201,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 records: vec![
                     ButtonRecord {
                         id: 1,
-                        states: vec![ButtonState::Up, ButtonState::Over]
-                            .into_iter()
-                            .collect(),
+                        states: ButtonState::UP | ButtonState::OVER,
                         depth: 1,
                         matrix: Matrix::identity(),
                         color_transform: ColorTransform::new(),
@@ -212,9 +210,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                     },
                     ButtonRecord {
                         id: 2,
-                        states: vec![ButtonState::Down, ButtonState::HitTest]
-                            .into_iter()
-                            .collect(),
+                        states: ButtonState::DOWN | ButtonState::HIT_TEST,
                         depth: 1,
                         matrix: Matrix::identity(),
                         color_transform: ColorTransform::new(),
@@ -223,9 +219,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                     },
                 ],
                 actions: vec![ButtonAction {
-                    conditions: vec![ButtonActionCondition::OverDownToOverUp]
-                        .into_iter()
-                        .collect(),
+                    conditions: ButtonActionCondition::OVER_DOWN_TO_OVER_UP,
                     key_code: None,
                     action_data: &[0],
                 }],
@@ -240,9 +234,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 records: vec![
                     ButtonRecord {
                         id: 2,
-                        states: vec![ButtonState::Up, ButtonState::Over]
-                            .into_iter()
-                            .collect(),
+                        states: ButtonState::UP | ButtonState::OVER,
                         depth: 1,
                         matrix: Matrix::identity(),
                         color_transform: ColorTransform {
@@ -264,9 +256,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                     },
                     ButtonRecord {
                         id: 3,
-                        states: vec![ButtonState::Down, ButtonState::HitTest]
-                            .into_iter()
-                            .collect(),
+                        states: ButtonState::DOWN | ButtonState::HIT_TEST,
                         depth: 1,
                         matrix: Matrix::identity(),
                         color_transform: ColorTransform {
@@ -285,14 +275,12 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 ],
                 actions: vec![
                     ButtonAction {
-                        conditions: vec![ButtonActionCondition::OverDownToOverUp]
-                            .into_iter()
-                            .collect(),
+                        conditions: ButtonActionCondition::OVER_DOWN_TO_OVER_UP,
                         key_code: None,
                         action_data: &[150, 3, 0, 0, 65, 0, 38, 0], // trace("A");
                     },
                     ButtonAction {
-                        conditions: vec![ButtonActionCondition::KeyPress].into_iter().collect(),
+                        conditions: ButtonActionCondition::KEY_PRESS,
                         key_code: Some(3),                          // Home
                         action_data: &[150, 3, 0, 0, 66, 0, 38, 0], // trace("B");
                     },

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -5,7 +5,6 @@
 //! https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf
 use crate::string::SwfStr;
 use bitflags::bitflags;
-use std::collections::HashSet;
 
 mod matrix;
 
@@ -851,23 +850,24 @@ pub type ButtonSound = (CharacterId, SoundInfo);
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ButtonAction<'a> {
-    pub conditions: HashSet<ButtonActionCondition>,
+    pub conditions: ButtonActionCondition,
     pub key_code: Option<u8>,
     pub action_data: &'a [u8],
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub enum ButtonActionCondition {
-    IdleToOverDown,
-    OutDownToIdle,
-    OutDownToOverDown,
-    OverDownToOutDown,
-    OverDownToOverUp,
-    OverUpToOverDown,
-    OverUpToIdle,
-    IdleToOverUp,
-    OverDownToIdle,
-    KeyPress,
+bitflags! {
+    pub struct ButtonActionCondition: u16 {
+        const IDLE_TO_OVER_UP       = 1 << 0;
+        const OVER_UP_TO_IDLE       = 1 << 1;
+        const OVER_UP_TO_OVER_DOWN  = 1 << 2;
+        const OVER_DOWN_TO_OVER_UP  = 1 << 3;
+        const OVER_DOWN_TO_OUT_DOWN = 1 << 4;
+        const OUT_DOWN_TO_OVER_DOWN = 1 << 5;
+        const OUT_DOWN_TO_IDLE      = 1 << 6;
+        const IDLE_TO_OVER_DOWN     = 1 << 7;
+        const OVER_DOWN_TO_IDLE     = 1 << 8;
+        const KEY_PRESS             = 1 << 9;
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -814,7 +814,7 @@ pub struct Button<'a> {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct ButtonRecord {
-    pub states: HashSet<ButtonState>,
+    pub states: ButtonState,
     pub id: CharacterId,
     pub depth: Depth,
     pub matrix: Matrix,
@@ -823,12 +823,13 @@ pub struct ButtonRecord {
     pub blend_mode: BlendMode,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub enum ButtonState {
-    Up,
-    Over,
-    Down,
-    HitTest,
+bitflags! {
+    pub struct ButtonState: u8 {
+        const UP       = 1 << 0;
+        const OVER     = 1 << 1;
+        const DOWN     = 1 << 2;
+        const HIT_TEST = 1 << 3;
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1064,79 +1064,13 @@ impl<W: Write> Writer<W> {
                 } else {
                     writer.write_u16(0)?;
                 }
-                writer.write_u8(
-                    if action
-                        .conditions
-                        .contains(&ButtonActionCondition::IdleToOverDown)
-                    {
-                        0b1000_0000
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::OutDownToIdle)
-                    {
-                        0b100_0000
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::OutDownToOverDown)
-                    {
-                        0b10_0000
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::OverDownToOutDown)
-                    {
-                        0b1_0000
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::OverDownToOverUp)
-                    {
-                        0b1000
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::OverUpToOverDown)
-                    {
-                        0b100
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::OverUpToIdle)
-                    {
-                        0b10
-                    } else {
-                        0
-                    } | if action
-                        .conditions
-                        .contains(&ButtonActionCondition::IdleToOverUp)
-                    {
-                        0b1
-                    } else {
-                        0
-                    },
-                )?;
-                let mut flags = if action
-                    .conditions
-                    .contains(&ButtonActionCondition::OverDownToIdle)
-                {
-                    0b1
-                } else {
-                    0
-                };
-                if action.conditions.contains(&ButtonActionCondition::KeyPress) {
+                let mut flags = action.conditions.bits();
+                if action.conditions.contains(ButtonActionCondition::KEY_PRESS) {
                     if let Some(key_code) = action.key_code {
-                        flags |= key_code << 1;
+                        flags |= (key_code as u16) << 9;
                     }
                 }
-                writer.write_u8(flags)?;
+                writer.write_u16(flags)?;
                 writer.output.write_all(&action.action_data)?;
             }
         }

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1560,23 +1560,7 @@ impl<W: Write> Writer<W> {
             0b1_0000
         } else {
             0
-        } | if record.states.contains(&ButtonState::HitTest) {
-            0b1000
-        } else {
-            0
-        } | if record.states.contains(&ButtonState::Down) {
-            0b100
-        } else {
-            0
-        } | if record.states.contains(&ButtonState::Over) {
-            0b10
-        } else {
-            0
-        } | if record.states.contains(&ButtonState::Up) {
-            0b1
-        } else {
-            0
-        };
+        } | record.states.bits();
         self.write_u8(flags)?;
         self.write_u16(record.id)?;
         self.write_u16(record.depth)?;


### PR DESCRIPTION
Now that we depend on `bitflags`, we can take advantage of it to convert some `HashSet` of enums to bit fields.
This eliminates the need to convert from/to their binary representation, as `bitflags` does this by itself.