### PR TITLE
web: Add config to enable/disable context menu

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -149,6 +149,14 @@ export interface BaseLoadOptions {
      * @default LogLevel.Error
      */
     logLevel?: LogLevel;
+
+    /**
+     * Whether or not to show a context menu when right-clicking
+     * a Ruffle instance.
+     *
+     * @default true
+     */
+    showContextMenu?: boolean;
 }
 
 /**

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -156,7 +156,7 @@ export interface BaseLoadOptions {
      *
      * @default true
      */
-    showContextMenu?: boolean;
+    contextMenu?: boolean;
 }
 
 /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -100,8 +100,12 @@ export class RufflePlayer extends HTMLElement {
     private container: HTMLElement;
     private playButton: HTMLElement;
     private unmuteOverlay: HTMLElement;
-    private contextMenu: HTMLElement;
+
+    // Firefox has a read-only "contextMenu" property,
+    // so avoid shadowing it.
+    private contextMenuElement: HTMLElement;
     private hasContextMenu = false;
+
     private swfUrl?: string;
     private instance: Ruffle | null;
     private _trace_observer: ((message: string) => void) | null;
@@ -151,7 +155,7 @@ export class RufflePlayer extends HTMLElement {
             this.unmuteOverlayClicked.bind(this)
         );
 
-        this.contextMenu = this.shadow.getElementById("context-menu")!;
+        this.contextMenuElement = this.shadow.getElementById("context-menu")!;
         this.addEventListener("contextmenu", this.showContextMenu.bind(this));
         window.addEventListener("click", this.hideContextMenu.bind(this));
 
@@ -580,38 +584,42 @@ export class RufflePlayer extends HTMLElement {
             return;
         }
 
-        // Clear all `contextMenu` items.
-        while (this.contextMenu.firstChild) {
-            this.contextMenu.removeChild(this.contextMenu.firstChild);
+        // Clear all context menu items.
+        while (this.contextMenuElement.firstChild) {
+            this.contextMenuElement.removeChild(
+                this.contextMenuElement.firstChild
+            );
         }
 
-        // Populate `contextMenu` items.
+        // Populate context menu items.
         for (const { text, onClick } of this.contextMenuItems()) {
             const element = document.createElement("li");
             element.className = "menu_item active";
             element.textContent = text;
             element.addEventListener("click", onClick);
-            this.contextMenu.appendChild(element);
+            this.contextMenuElement.appendChild(element);
         }
 
-        // Place `contextMenu` in the top-left corner, so
+        // Place a context menu in the top-left corner, so
         // its `clientWidth` and `clientHeight` are not clamped.
-        this.contextMenu.style.left = "0";
-        this.contextMenu.style.top = "0";
-        this.contextMenu.style.display = "block";
+        this.contextMenuElement.style.left = "0";
+        this.contextMenuElement.style.top = "0";
+        this.contextMenuElement.style.display = "block";
 
         const rect = this.getBoundingClientRect();
         const x = e.clientX - rect.x;
         const y = e.clientY - rect.y;
-        const maxX = rect.width - this.contextMenu.clientWidth - 1;
-        const maxY = rect.height - this.contextMenu.clientHeight - 1;
+        const maxX = rect.width - this.contextMenuElement.clientWidth - 1;
+        const maxY = rect.height - this.contextMenuElement.clientHeight - 1;
 
-        this.contextMenu.style.left = Math.floor(Math.min(x, maxX)) + "px";
-        this.contextMenu.style.top = Math.floor(Math.min(y, maxY)) + "px";
+        this.contextMenuElement.style.left =
+            Math.floor(Math.min(x, maxX)) + "px";
+        this.contextMenuElement.style.top =
+            Math.floor(Math.min(y, maxY)) + "px";
     }
 
     private hideContextMenu(): void {
-        this.contextMenu.style.display = "none";
+        this.contextMenuElement.style.display = "none";
     }
 
     /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -99,7 +99,8 @@ export class RufflePlayer extends HTMLElement {
     private container: HTMLElement;
     private playButton: HTMLElement;
     private unmuteOverlay: HTMLElement;
-    private rightClickMenu: HTMLElement;
+    private contextMenu: HTMLElement;
+    private hasContextMenu = false;
     private swfUrl?: string;
     private instance: Ruffle | null;
     private _trace_observer: ((message: string) => void) | null;
@@ -107,7 +108,6 @@ export class RufflePlayer extends HTMLElement {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private ruffleConstructor: Promise<{ new (...args: any[]): Ruffle }>;
     private panicked = false;
-    private hasContextMenu = false;
 
     /**
      * If set to true, the movie is allowed to interact with the page through
@@ -144,12 +144,9 @@ export class RufflePlayer extends HTMLElement {
             this.unmuteOverlayClicked.bind(this)
         );
 
-        this.rightClickMenu = this.shadow.getElementById("right_click_menu")!;
-        this.addEventListener(
-            "contextmenu",
-            this.openRightClickMenu.bind(this)
-        );
-        window.addEventListener("click", this.hideRightClickMenu.bind(this));
+        this.contextMenu = this.shadow.getElementById("context-menu")!;
+        this.addEventListener("contextmenu", this.showContextMenu.bind(this));
+        window.addEventListener("click", this.hideContextMenu.bind(this));
 
         this.instance = null;
         this.allowScriptAccess = false;
@@ -568,45 +565,45 @@ export class RufflePlayer extends HTMLElement {
         return items;
     }
 
-    private openRightClickMenu(e: MouseEvent): void {
+    private showContextMenu(e: MouseEvent): void {
         e.preventDefault();
 
         if (!this.hasContextMenu) {
             return;
         }
 
-        // Clear all `right_click_menu` items.
-        while (this.rightClickMenu.firstChild) {
-            this.rightClickMenu.removeChild(this.rightClickMenu.firstChild);
+        // Clear all `contextMenu` items.
+        while (this.contextMenu.firstChild) {
+            this.contextMenu.removeChild(this.contextMenu.firstChild);
         }
 
-        // Populate `right_click_menu` items.
+        // Populate `contextMenu` items.
         for (const { text, onClick } of this.contextMenuItems()) {
             const element = document.createElement("li");
             element.className = "menu_item active";
             element.textContent = text;
             element.addEventListener("click", onClick);
-            this.rightClickMenu.appendChild(element);
+            this.contextMenu.appendChild(element);
         }
 
-        // Place `right_click_menu` in the top-left corner, so
+        // Place `contextMenu` in the top-left corner, so
         // its `clientWidth` and `clientHeight` are not clamped.
-        this.rightClickMenu.style.left = "0";
-        this.rightClickMenu.style.top = "0";
-        this.rightClickMenu.style.display = "block";
+        this.contextMenu.style.left = "0";
+        this.contextMenu.style.top = "0";
+        this.contextMenu.style.display = "block";
 
         const rect = this.getBoundingClientRect();
         const x = e.clientX - rect.x;
         const y = e.clientY - rect.y;
-        const maxX = rect.width - this.rightClickMenu.clientWidth - 1;
-        const maxY = rect.height - this.rightClickMenu.clientHeight - 1;
+        const maxX = rect.width - this.contextMenu.clientWidth - 1;
+        const maxY = rect.height - this.contextMenu.clientHeight - 1;
 
-        this.rightClickMenu.style.left = Math.floor(Math.min(x, maxX)) + "px";
-        this.rightClickMenu.style.top = Math.floor(Math.min(y, maxY)) + "px";
+        this.contextMenu.style.left = Math.floor(Math.min(x, maxX)) + "px";
+        this.contextMenu.style.top = Math.floor(Math.min(y, maxY)) + "px";
     }
 
-    private hideRightClickMenu(): void {
-        this.rightClickMenu.style.display = "none";
+    private hideContextMenu(): void {
+        this.contextMenu.style.display = "none";
     }
 
     /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -3,6 +3,7 @@ import { Ruffle } from "../pkg/ruffle_web";
 import { loadRuffle } from "./load-ruffle";
 import { ruffleShadowTemplate } from "./shadow-template";
 import { lookupElement } from "./register-element";
+import { Config } from "./config";
 import {
     BaseLoadOptions,
     DataLoadOptions,
@@ -116,6 +117,12 @@ export class RufflePlayer extends HTMLElement {
      * This should only be enabled for movies you trust.
      */
     allowScriptAccess: boolean;
+
+    /**
+     * Any configuration that should apply to this specific player.
+     * This will be defaulted with any global configuration.
+     */
+    config: Config = {};
 
     /**
      * Constructs a new Ruffle flash player for insertion onto the page.
@@ -434,6 +441,7 @@ export class RufflePlayer extends HTMLElement {
         try {
             const config: BaseLoadOptions = {
                 ...(window.RufflePlayer?.config ?? {}),
+                ...this.config,
                 ...options,
             };
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -437,7 +437,7 @@ export class RufflePlayer extends HTMLElement {
                 ...options,
             };
 
-            this.hasContextMenu = config.showContextMenu !== false;
+            this.hasContextMenu = config.contextMenu !== false;
 
             // Pre-emptively set background color of container while Ruffle/SWF loads.
             if (config.backgroundColor) {

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -156,7 +156,8 @@ ruffleShadowTemplate.innerHTML = `
             background-color: rgba(255, 255, 255, 0.3);
         }
 
-        #right_click_menu {
+        #context-menu {
+            display: none;
             color: #FFAD33;
             background-color: #37528c;
             border-radius: 5px;
@@ -169,38 +170,38 @@ ruffleShadowTemplate.innerHTML = `
             margin: 0;
         }
 
-        #right_click_menu .menu_item {
+        #context-menu .menu_item {
             padding: 5px 10px;
         }
 
-        #right_click_menu .menu_separator {
+        #context-menu .menu_separator {
             padding: 5px 5px;
         }
 
-        #right_click_menu .active {
+        #context-menu .active {
             cursor: pointer;
             color: #FFAD33;
         }
 
-        #right_click_menu .disabled {
+        #context-menu .disabled {
             cursor: default;
             color: #94672F;
         }
 
-        #right_click_menu .active:hover {
+        #context-menu .active:hover {
             background-color: #184778;
         }
 
-        #right_click_menu hr {
+        #context-menu hr {
             color: #FFAD33;
         }
 
-        #right_click_menu > :first-child {
+        #context-menu > :first-child {
             border-top-right-radius: 5px;
             border-top-left-radius: 5px;
         }
 
-        #right_click_menu > :last-child {
+        #context-menu > :last-child {
             border-bottom-right-radius: 5px;
             border-bottom-left-radius: 5px;
         }
@@ -212,5 +213,5 @@ ruffleShadowTemplate.innerHTML = `
         <div id="unmute_overlay"><div class="background"></div><div class="icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" viewBox="0 0 512 584" style="width:100%;height:100%;scale:0.8;"><path fill="#FFF" stroke="#FFF" d="m457.941 256 47.029-47.029c9.372-9.373 9.372-24.568 0-33.941-9.373-9.373-24.568-9.373-33.941 0l-47.029 47.029-47.029-47.029c-9.373-9.373-24.568-9.373-33.941 0-9.372 9.373-9.372 24.568 0 33.941l47.029 47.029-47.029 47.029c-9.372 9.373-9.372 24.568 0 33.941 4.686 4.687 10.827 7.03 16.97 7.03s12.284-2.343 16.971-7.029l47.029-47.03 47.029 47.029c4.687 4.687 10.828 7.03 16.971 7.03s12.284-2.343 16.971-7.029c9.372-9.373 9.372-24.568 0-33.941z"/><path fill="#FFF" stroke="#FFF" d="m99 160h-55c-24.301 0-44 19.699-44 44v104c0 24.301 19.699 44 44 44h55c2.761 0 5-2.239 5-5v-182c0-2.761-2.239-5-5-5z"/><path fill="#FFF" stroke="#FFF" d="m280 56h-24c-5.269 0-10.392 1.734-14.578 4.935l-103.459 79.116c-1.237.946-1.963 2.414-1.963 3.972v223.955c0 1.557.726 3.026 1.963 3.972l103.459 79.115c4.186 3.201 9.309 4.936 14.579 4.936h23.999c13.255 0 24-10.745 24-24v-352.001c0-13.255-10.745-24-24-24z"/><text x="256" y="560" text-anchor="middle" style="font-size:60px;fill:#FFF;stroke:#FFF;">Click to unmute</text></svg></div></div>
     </div>
 
-    <ul id="right_click_menu" style="display: none"></ul>
+    <ul id="context-menu"></ul>
 `;


### PR DESCRIPTION
Fixes #1977.
This PR adds a new config called `contextMenu` that controls whether or not to show a context menu when right-clicking a Ruffle instance.
I did some refactors along the way, <s>including removal of the unused `Ruffle.prototype.config` member</s>.
A follow-up PR needs to handle #1972 by defaulting to `false` on mobile instead of always `true`.