### PR TITLE
Preallocate AVM1 constant pool values

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -82,7 +82,7 @@ pub struct Avm1<'gc> {
 
     /// The constant pool to use for new activations from code sources that
     /// don't close over the constant pool they were defined with.
-    constant_pool: GcCell<'gc, Vec<String>>,
+    constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
 
     /// The global object.
     globals: Object<'gc>,

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1300,7 +1300,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 target.as_display_object()
             } else {
                 let start = self.target_clip_or_root()?;
-                self.resolve_target_display_object(start, target.clone(), true)?
+                self.resolve_target_display_object(start, target, true)?
             }
         } else {
             Some(self.target_clip_or_root()?)
@@ -1792,7 +1792,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 SwfValue::Register(v) => self.current_register(*v),
                 SwfValue::ConstantPool(i) => {
                     if let Some(value) = self.constant_pool().read().get(*i as usize) {
-                        value.clone()
+                        *value
                     } else {
                         avm_warn!(
                             self,
@@ -1811,7 +1811,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
     fn action_push_duplicate(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let val = self.context.avm1.pop();
-        self.context.avm1.push(val.clone());
+        self.context.avm1.push(val);
         self.context.avm1.push(val);
         Ok(FrameControl::Continue)
     }
@@ -2028,7 +2028,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     fn action_store_register(&mut self, register: u8) -> Result<FrameControl<'gc>, Error<'gc>> {
         // The value must remain on the stack.
         let val = self.context.avm1.pop();
-        self.context.avm1.push(val.clone());
+        self.context.avm1.push(val);
         self.set_current_register(register, val);
 
         Ok(FrameControl::Continue)

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -77,7 +77,7 @@ pub struct Avm1Function<'gc> {
     scope: GcCell<'gc, Scope<'gc>>,
 
     /// The constant pool the function executes with.
-    constant_pool: GcCell<'gc, Vec<String>>,
+    constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
 
     /// The base movie clip that the function was defined on.
     /// This is the movie clip that contains the bytecode.
@@ -95,7 +95,7 @@ impl<'gc> Avm1Function<'gc> {
         name: &str,
         params: &[&'_ SwfStr],
         scope: GcCell<'gc, Scope<'gc>>,
-        constant_pool: GcCell<'gc, Vec<String>>,
+        constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
         let name = if name.is_empty() {
@@ -139,7 +139,7 @@ impl<'gc> Avm1Function<'gc> {
         actions: SwfSlice,
         swf_function: &swf::avm1::types::Function,
         scope: GcCell<'gc, Scope<'gc>>,
-        constant_pool: GcCell<'gc, Vec<String>>,
+        constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
         let name = if swf_function.name.is_empty() {

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -282,7 +282,7 @@ impl<'gc> Executable<'gc> {
                     for i in 0..args.len() {
                         arguments.set_array_element(
                             i,
-                            args.get(i).unwrap().clone(),
+                            *args.get(i).unwrap(),
                             activation.context.gc_context,
                         );
                     }

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -455,7 +455,7 @@ pub fn concat<'gc>(
         }
 
         if !added {
-            array.set_array_element(length, arg.clone(), activation.context.gc_context);
+            array.set_array_element(length, *arg, activation.context.gc_context);
             length += 1;
         }
     }
@@ -792,8 +792,8 @@ fn sort_compare_fields<'a, 'gc: 'a>(
     use crate::avm1::object::value_object::ValueObject;
     move |activation, a, b| {
         for (field_name, compare_fn) in field_names.iter().zip(compare_fns.iter_mut()) {
-            let a_object = ValueObject::boxed(activation, a.clone());
-            let b_object = ValueObject::boxed(activation, b.clone());
+            let a_object = ValueObject::boxed(activation, *a);
+            let b_object = ValueObject::boxed(activation, *b);
             let a_prop = a_object.get(field_name, activation).unwrap();
             let b_prop = b_object.get(field_name, activation).unwrap();
 
@@ -816,7 +816,7 @@ fn sort_compare_custom<'gc>(
     compare_fn: &Value<'gc>,
 ) -> Ordering {
     // TODO: Handle errors.
-    let args = [a.clone(), b.clone()];
+    let args = [*a, *b];
     let ret = compare_fn
         .call("[Compare]", activation, this, None, &args)
         .unwrap_or(Value::Undefined);

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -189,7 +189,7 @@ fn on_data<'gc>(
     let success = match args.get(0) {
         None | Some(Value::Undefined) | Some(Value::Null) => false,
         Some(val) => {
-            this.call_method(&"decode", &[val.clone()], activation)?;
+            this.call_method(&"decode", &[*val], activation)?;
             this.set("loaded", true.into(), activation)?;
             true
         }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -126,22 +126,22 @@ fn constructor<'gc>(
         apply_matrix_to_object(Matrix::identity(), this, activation)?;
     } else {
         if let Some(a) = args.get(0) {
-            this.set("a", a.clone(), activation)?;
+            this.set("a", *a, activation)?;
         }
         if let Some(b) = args.get(1) {
-            this.set("b", b.clone(), activation)?;
+            this.set("b", *b, activation)?;
         }
         if let Some(c) = args.get(2) {
-            this.set("c", c.clone(), activation)?;
+            this.set("c", *c, activation)?;
         }
         if let Some(d) = args.get(3) {
-            this.set("d", d.clone(), activation)?;
+            this.set("d", *d, activation)?;
         }
         if let Some(tx) = args.get(4) {
-            this.set("tx", tx.clone(), activation)?;
+            this.set("tx", *tx, activation)?;
         }
         if let Some(ty) = args.get(5) {
-            this.set("ty", ty.clone(), activation)?;
+            this.set("ty", *ty, activation)?;
         }
     }
 
@@ -240,7 +240,7 @@ fn concat<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut matrix = object_to_matrix(this, activation)?;
-    let other = value_to_matrix(args.get(0).unwrap_or(&Value::Undefined).clone(), activation)?;
+    let other = value_to_matrix(*args.get(0).unwrap_or(&Value::Undefined), activation)?;
     matrix = other * matrix;
     apply_matrix_to_object(matrix, this, activation)?;
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -142,7 +142,7 @@ pub fn hit_test<'gc>(
     } else if args.len() == 1 {
         let other = activation.resolve_target_display_object(
             movie_clip.into(),
-            args.get(0).unwrap().clone(),
+            *args.get(0).unwrap(),
             false,
         )?;
         if let Some(other) = other {

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -490,7 +490,7 @@ fn set_left<'gc>(
     let new_left = args.get(0).unwrap_or(&Value::Undefined).to_owned();
     let old_left = this.get("x", activation)?.coerce_to_f64(activation)?;
     let width = this.get("width", activation)?.coerce_to_f64(activation)?;
-    this.set("x", new_left.clone(), activation)?;
+    this.set("x", new_left, activation)?;
     this.set(
         "width",
         Value::Number(width + (old_left - new_left.coerce_to_f64(activation)?)),
@@ -515,7 +515,7 @@ fn set_top<'gc>(
     let new_top = args.get(0).unwrap_or(&Value::Undefined).to_owned();
     let old_top = this.get("y", activation)?.coerce_to_f64(activation)?;
     let height = this.get("height", activation)?.coerce_to_f64(activation)?;
-    this.set("y", new_top.clone(), activation)?;
+    this.set("y", new_top, activation)?;
     this.set(
         "height",
         Value::Number(height + (old_top - new_top.coerce_to_f64(activation)?)),
@@ -632,8 +632,8 @@ fn set_top_left<'gc>(
     let old_top = this.get("y", activation)?.coerce_to_f64(activation)?;
     let height = this.get("height", activation)?.coerce_to_f64(activation)?;
 
-    this.set("x", new_left.clone(), activation)?;
-    this.set("y", new_top.clone(), activation)?;
+    this.set("x", new_left, activation)?;
+    this.set("y", new_top, activation)?;
     this.set(
         "width",
         Value::Number(width + (old_left - new_left.coerce_to_f64(activation)?)),

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -94,7 +94,7 @@ impl<'gc> ValueObject<'gc> {
 
     /// Retrieve the boxed value.
     pub fn unbox(self) -> Value<'gc> {
-        self.0.read().value.clone()
+        self.0.read().value
     }
 
     /// Change the value in the box.

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -9,7 +9,7 @@ use crate::ecma_conversions::{
 use std::borrow::Cow;
 use std::f64::NAN;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 pub enum Value<'gc> {
     Undefined,
@@ -639,26 +639,17 @@ mod test {
             let a = Value::Number(1.0);
             let b = Value::Number(2.0);
 
-            assert_eq!(
-                b.abstract_lt(a.clone(), activation).unwrap(),
-                Value::Bool(false)
-            );
+            assert_eq!(b.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 
             let nan = Value::Number(NAN);
-            assert_eq!(
-                nan.abstract_lt(a.clone(), activation).unwrap(),
-                Value::Undefined
-            );
+            assert_eq!(nan.abstract_lt(a, activation).unwrap(), Value::Undefined);
 
             let inf = Value::Number(INFINITY);
-            assert_eq!(
-                inf.abstract_lt(a.clone(), activation).unwrap(),
-                Value::Bool(false)
-            );
+            assert_eq!(inf.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 
             let neg_inf = Value::Number(NEG_INFINITY);
             assert_eq!(
-                neg_inf.abstract_lt(a.clone(), activation).unwrap(),
+                neg_inf.abstract_lt(a, activation).unwrap(),
                 Value::Bool(true)
             );
 


### PR DESCRIPTION
AFAIK this change shouldn't change any observable behaviors?

This seems reasonable in general (now these objects are _actually_ pooled, and removes a bunch of work from `action_push`), and is another step towards pre-hashing constant strings like property names in the future.

What positively surprised me, is that apparently `AvmString::new` called on nearly every ActionPush was a major source of `gc-arena` GC pressure in some games. For example, in Meat Boy on FF wasm, this change reduced time spent in `gc_arena.collect_debt()` by 2-3x and - on my PC - improved the game from "slightly choppy most of the time" to "smooth most of the time" :)

Second commit makes `avm1::Value` `Copy`, as all its fields are `Copy`. This generates better code, but I'm not sure if you like the less explicit API.