### PR TITLE
Redesign the web context menu a bit

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -569,7 +569,13 @@ export class RufflePlayer extends HTMLElement {
             }
         }
         items.push({
-            text: `Ruffle %VERSION_NAME%`,
+            text: "SEPARATOR",
+            onClick() {
+                // do nothing.
+            },
+        });
+        items.push({
+            text: `About Ruffle (%VERSION_NAME%)`,
             onClick() {
                 window.open(RUFFLE_ORIGIN, "_blank");
             },
@@ -593,11 +599,19 @@ export class RufflePlayer extends HTMLElement {
 
         // Populate context menu items.
         for (const { text, onClick } of this.contextMenuItems()) {
-            const element = document.createElement("li");
-            element.className = "menu_item active";
-            element.textContent = text;
-            element.addEventListener("click", onClick);
-            this.contextMenuElement.appendChild(element);
+            if (text == "SEPARATOR") {
+                const element = document.createElement("li");
+                element.className = "menu_separator";
+                const hr = document.createElement("hr");
+                element.appendChild(hr);
+                this.contextMenuElement.appendChild(element);
+            } else {
+                const element = document.createElement("li");
+                element.className = "menu_item active";
+                element.textContent = text;
+                element.addEventListener("click", onClick);
+                this.contextMenuElement.appendChild(element);
+            }
         }
 
         // Place a context menu in the top-left corner, so

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -157,13 +157,12 @@ ruffleShadowTemplate.innerHTML = `
         }
 
         #context-menu {
-            display: none;
-            color: #FFAD33;
-            background-color: #37528c;
-            border-radius: 5px;
-            box-shadow: 0px 5px 15px -5px #000;
+            color: black;
+            background-color: #FAFAFA;
+            border: 1px solid gray;
+            box-shadow: 0px 5px 10px -5px black;
             position: absolute;
-            font-size: 16px;
+            font-size: 14px;
             text-align: left;
             list-style: none;
             padding: 0;
@@ -174,36 +173,25 @@ ruffleShadowTemplate.innerHTML = `
             padding: 5px 10px;
         }
 
-        #context-menu .menu_separator {
-            padding: 5px 5px;
-        }
 
         #context-menu .active {
             cursor: pointer;
-            color: #FFAD33;
+            color: black;
         }
 
         #context-menu .disabled {
             cursor: default;
-            color: #94672F;
+            color: gray;
         }
 
         #context-menu .active:hover {
-            background-color: #184778;
+            background-color: lightgray;
         }
 
-        #context-menu hr {
-            color: #FFAD33;
-        }
-
-        #context-menu > :first-child {
-            border-top-right-radius: 5px;
-            border-top-left-radius: 5px;
-        }
-
-        #context-menu > :last-child {
-            border-bottom-right-radius: 5px;
-            border-bottom-left-radius: 5px;
+        #context-menu .menu_separator hr {
+            border: none;
+            border-bottom: 1px solid lightgray;
+            margin: 2px;
         }
     </style>
     <style id="dynamic_styles"></style>


### PR DESCRIPTION
I'm not claiming to be anywhere near good at design :) But after several questions on Discord, it feels to me like the simulated context menu should look a bit closer to native ones, to be less jarring to users used to Flash.

Separator support code may be ugly, but I imagine this all will need to be refactored for ActionScript context menus anyway.

Before vs after on light and dark backgrounds:
![2021-01-24_17-04-02](https://user-images.githubusercontent.com/4729533/105636189-81f6a700-5e67-11eb-909a-b6fabcde23fd.png)
![2021-01-24_17-05-12](https://user-images.githubusercontent.com/4729533/105636191-858a2e00-5e67-11eb-93bf-628c473bdc1d.png)

Comparison with browsers' context menus:
![2021-01-24_17-05-59](https://user-images.githubusercontent.com/4729533/105636200-8f139600-5e67-11eb-93e9-59b40dc0395b.png)
![2021-01-24_17-06-35](https://user-images.githubusercontent.com/4729533/105636203-90dd5980-5e67-11eb-9c5a-68c80ef68a1b.png)
