### PR TITLE
web: Pause player when tab is inactive (close #347)

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -104,6 +104,7 @@ export class RufflePlayer extends HTMLElement {
     private swfUrl?: string;
     private instance: Ruffle | null;
     private _trace_observer: ((message: string) => void) | null;
+    private lastActivePlayingState: boolean;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private ruffleConstructor: Promise<{ new (...args: any[]): Ruffle }>;
@@ -165,7 +166,40 @@ export class RufflePlayer extends HTMLElement {
 
         this.ruffleConstructor = loadRuffle();
 
+        this.lastActivePlayingState = false;
+        this.setupPauseOnTabHidden();
+
         return this;
+    }
+
+    /**
+     * Setup event listener to detect when tab is not active to pause instance playback.
+     * this.instance.play() is called when the tab becomes visible only if the
+     * the instance was not paused before tab became hidden.
+     *
+     * See:
+     *      https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
+     * @ignore
+     * @internal
+     */
+    setupPauseOnTabHidden(): void {
+        document.addEventListener(
+            "visibilitychange",
+            () => {
+                if (!this.instance) return;
+
+                // Tab just changed to be inactive. Record whether instance was playing.
+                if (document.hidden) {
+                    this.lastActivePlayingState = this.instance.is_playing();
+                    this.instance.pause();
+                }
+                // Play only if instance was playing originally.
+                if (!document.hidden && this.lastActivePlayingState === true) {
+                    this.instance.play();
+                }
+            },
+            false
+        );
     }
 
     /**

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -215,7 +215,6 @@ impl Ruffle {
     }
 
     pub fn play(&mut self) {
-        // Remove instance from the active list.
         INSTANCES.with(|instances| {
             let instances = instances.borrow();
             let instance = instances.get(self.0).unwrap();
@@ -224,12 +223,20 @@ impl Ruffle {
     }
 
     pub fn pause(&mut self) {
-        // Remove instance from the active list.
         INSTANCES.with(|instances| {
             let instances = instances.borrow();
             let instance = instances.get(self.0).unwrap();
             instance.borrow().core.lock().unwrap().set_is_playing(false);
         });
+    }
+
+    pub fn is_playing(&mut self) -> bool {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            let is_playing = instance.borrow().core.lock().unwrap().is_playing();
+            is_playing
+        })
     }
 
     pub fn destroy(&mut self) {


### PR DESCRIPTION
This resolves https://github.com/ruffle-rs/ruffle/issues/347. It modifies `ruffle-player.ts` to detect when the tab is inactive using the browser's [visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API). It also adds a `is_playing()` function to the public API in `web/src/lib.rs`. This is to allow the player to only resume playback if the animation wasn't already paused.

I considered whether there should be an option on the player to turn off this pausing, but since it is not currently possible to continue playing the frames in the background, and catching up may not be feasible, disabling this would produce incorrect behavior. 

It may make sense to revisit toggling this behavior when frame playback is controlled on a worker as mentioned here: https://github.com/ruffle-rs/ruffle/issues/347#issuecomment-763024001

> Possibly this can be done as we switch over to web workers, but I suspect this will be problematic on e.g. Safari which has no AudioWorklet.

### How I tested this

* Dragged and dropped an SWF into the `web/packages/demo` project using this branch
* Confirmed switching tab pauses it and audio stays in sync with animation
* Confirmed pausing the player directly will not unpause when switching tabs unless the user clicks the big play button.
* Tested in Chrome & Firefox on Windows 10
