### PR TITLE
desktop: Fix windows cross compilation of assets

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -29,7 +29,7 @@ tinyfiledialogs = {git ="https://github.com/jdm/tinyfiledialogs-rs", rev="1a235d
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"
 
-[target.'cfg(windows)'.build-dependencies]
+[build-dependencies]
 embed-resource = "1"
 
 [features]

--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -14,12 +14,10 @@ fn main() {
         println!("cargo:rerun-if-changed=.git/HEAD");
     }
 
-    #[cfg(windows)]
-    {
-        // Embed resource file w/ icon.
-        println!("cargo:rerun-if-changed=assets/ruffle_desktop.rc");
-        embed_resource::compile("assets/ruffle_desktop.rc")
-    }
+    // Embed resource file w/ icon on windows
+    // To allow for cross-compilation, this must not be behind cfg(windows)!
+    println!("cargo:rerun-if-changed=assets/ruffle_desktop.rc");
+    embed_resource::compile("assets/ruffle_desktop.rc");
 
     println!("cargo:rerun-if-env-changed=CFG_RELEASE_CHANNEL");
     if option_env!("CFG_RELEASE_CHANNEL").map_or(true, |c| c == "nightly" || c == "dev") {


### PR DESCRIPTION
`embed-resource` is designed to run on all machines and only include the binary when the end binary is for Windows