### PR TITLE
core: Avoid panic in EditText::on_changed (fix #2809)

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1181,7 +1181,8 @@ impl<'gc> EditText<'gc> {
     }
 
     fn on_changed(&self, activation: &mut Activation<'_, 'gc, '_>) {
-        if let Some(object) = self.0.read().object {
+        let object = self.0.read().object;
+        if let Some(object) = object {
             let _ = object.call_method(
                 "broadcastMessage",
                 &["onChanged".into(), object.into()],


### PR DESCRIPTION
Don't hold on to a borrow inside `on_changed` to avoid panics if the `onChanged` handler also tried to modify the text field.

Fixes #2788, #2809.