### PR TITLE
Implement BitmapData.perlinNoise()

### DIFF
--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -7,6 +7,7 @@ use gc_arena::{Collect, GcCell, MutationContext};
 use crate::avm1::activation::Activation;
 use crate::avm1::object::color_transform_object::ColorTransformObject;
 use crate::backend::render::{BitmapHandle, RenderBackend};
+use crate::bitmap::turbulence::Turbulence;
 use downcast_rs::__std::fmt::Formatter;
 use std::fmt;
 use std::ops::Range;
@@ -601,6 +602,110 @@ impl BitmapData {
                 }
 
                 self.set_pixel32_raw(dest_x as u32, dest_y as u32, dest_color);
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn perlin_noise(
+        &mut self,
+        base: (f64, f64),
+        num_octaves: usize,
+        random_seed: i64,
+        stitch: bool,
+        fractal_noise: bool,
+        channel_options: u8,
+        grayscale: bool,
+        offsets: Vec<(f64, f64)>, // must contain `num_octaves` values
+    ) {
+        let turb = Turbulence::from_seed(random_seed);
+
+        for y in 0..self.height() {
+            for x in 0..self.width() {
+                let px = x as f64;
+                let py = y as f64;
+
+                let mut noise = [0.0_f64; 4];
+
+                // grayscale mode is different enough to warrant its own branch
+                if grayscale {
+                    noise[0] = turb.turbulence(
+                        0,
+                        (px, py),
+                        (1.0 / base.0, 1.0 / base.1),
+                        num_octaves,
+                        fractal_noise,
+                        stitch,
+                        (0.0, 0.0),
+                        (self.width as f64, self.height as f64),
+                        &offsets,
+                    );
+
+                    noise[1] = noise[0];
+                    noise[2] = noise[0];
+
+                    noise[3] = if channel_options & 8 != 0 {
+                        turb.turbulence(
+                            1,
+                            (px, py),
+                            (1.0 / base.0, 1.0 / base.1),
+                            num_octaves,
+                            fractal_noise,
+                            stitch,
+                            (0.0, 0.0),
+                            (self.width as f64, self.height as f64),
+                            &offsets,
+                        )
+                    } else {
+                        1.0
+                    };
+                } else {
+                    // Flash seems to pass the `color_channel` parameter to `turbulence`
+                    // somewhat strangely. It's not always r=0, g=1, b=2, a=3; instead,
+                    // it skips incrementing the parameter after channels that are
+                    // not included in `channel_options`.
+                    let mut channel = 0;
+
+                    for (c, noise_c) in noise.iter_mut().enumerate() {
+                        // this will work both in fractal_sum and turbulence "modes",
+                        // because of the saturating conversion to u8
+                        *noise_c = if c == 3 { 1.0 } else { -1.0 };
+
+                        if (channel_options & (1 << c)) != 0 {
+                            *noise_c = turb.turbulence(
+                                channel,
+                                (px, py),
+                                (1.0 / base.0, 1.0 / base.1),
+                                num_octaves,
+                                fractal_noise,
+                                stitch,
+                                (0.0, 0.0),
+                                (self.width as f64, self.height as f64),
+                                &offsets,
+                            );
+                            channel += 1;
+                        }
+                    }
+                }
+
+                let mut color = [0_u8; 4];
+                for chan in 0..4 {
+                    // This is precisely how Adobe Flash converts the -1..1 or 0..1 floats to u8.
+                    // Please don't touch, it was difficult to figure out the exact method. :)
+                    color[chan] = (if fractal_noise {
+                        // Yes, the + 0.5 for correct (nearest) rounding is done before the division by 2.0,
+                        // making it technically less correct (I think), but this is how it is!
+                        ((noise[chan] * 255.0 + 255.0) + 0.5) / 2.0
+                    } else {
+                        (noise[chan] * 255.0) + 0.5
+                    }) as u8;
+                }
+
+                if !self.transparency {
+                    color[3] = 255;
+                }
+
+                self.set_pixel32_raw(x, y, Color::argb(color[3], color[0], color[1], color[2]));
             }
         }
     }

--- a/core/src/bitmap.rs
+++ b/core/src/bitmap.rs
@@ -1,0 +1,1 @@
+pub mod turbulence;

--- a/core/src/bitmap/turbulence.rs
+++ b/core/src/bitmap/turbulence.rs
@@ -1,0 +1,244 @@
+/// This file is a Rust port of the C reference implementation of the
+/// feTurbulence element in the SVG specification. It's the usual Perlin noise.
+/// See: https://www.w3.org/TR/SVG11/filters.html#feTurbulenceElement
+/// The `octave_offsets` parameter of `turbulence` was added after porting.
+
+// Copyright © 2015 W3C® (MIT, ERCIM, Keio, Beihang).
+// This software or document includes material copied from or derived
+// from https://www.w3.org/TR/SVG11/filters.html#feTurbulenceElement.
+
+/* Produces results in the range [1, 2**31 - 2].
+Algorithm is: r = (a * r) mod m
+where a = 16807 and m = 2**31 - 1 = 2147483647
+See [Park & Miller], CACM vol. 31 no. 10 p. 1195, Oct. 1988
+To test: the algorithm should produce the result 1043618065
+as the 10,000th generated number if the original seed is 1.
+*/
+const RAND_M: i64 = 2147483647; // 2**31 - 1
+const RAND_A: i64 = 16807; // 7**5; primitive root of m
+const RAND_Q: i64 = 127773; // m / a
+const RAND_R: i64 = 2836; // m % a
+fn setup_seed(mut seed: i64) -> i64 {
+    if seed <= 0 {
+        seed = -(seed % (RAND_M - 1)) + 1
+    };
+    if seed > RAND_M - 1 {
+        seed = RAND_M - 1
+    };
+    seed
+}
+
+fn random(seed: i64) -> i64 {
+    let mut result = RAND_A * (seed % RAND_Q) - RAND_R * (seed / RAND_Q);
+    if result <= 0 {
+        result += RAND_M
+    };
+    result
+}
+
+#[derive(Copy, Clone)]
+struct StitchInfo {
+    width: i32, // How much to subtract to wrap for stitching.
+    height: i32,
+    wrap_x: i32, // Minimum value to wrap.
+    wrap_y: i32,
+}
+
+fn s_curve(t: f64) -> f64 {
+    t * t * (3. - 2. * t)
+}
+
+fn lerp(t: f64, a: f64, b: f64) -> f64 {
+    a + t * (b - a)
+}
+
+const B_SIZE: usize = 0x100;
+const BM: i32 = 0xff;
+const PERLIN_N: i32 = 0x1000;
+// const NP: i32 = 12; // 2^PerlinN
+// const NM: i32 = 0xfff;
+
+pub struct Turbulence {
+    lattice_selector: [i32; B_SIZE + B_SIZE + 2],
+    gradient: [[[f64; 2]; B_SIZE + B_SIZE + 2]; 4],
+}
+
+#[allow(clippy::many_single_char_names, clippy::needless_range_loop)] // for the sake of similarity with the original
+impl Turbulence {
+    pub fn from_seed(mut seed: i64) -> Self {
+        let mut s: f64;
+        let mut lattice_selector = [0_i32; B_SIZE + B_SIZE + 2];
+        let mut gradient = [[[0.0_f64; 2]; B_SIZE + B_SIZE + 2]; 4];
+
+        seed = setup_seed(seed);
+        for k in 0..4 {
+            for i in 0..B_SIZE {
+                lattice_selector[i] = i as i32;
+                for j in 0..2 {
+                    seed = random(seed);
+                    gradient[k][i][j] =
+                        ((seed % (B_SIZE + B_SIZE) as i64) - B_SIZE as i64) as f64 / B_SIZE as f64;
+                }
+                s = f64::sqrt(
+                    gradient[k][i][0] * gradient[k][i][0] + gradient[k][i][1] * gradient[k][i][1],
+                );
+                gradient[k][i][0] /= s;
+                gradient[k][i][1] /= s;
+            }
+        }
+        for i in (1..B_SIZE).rev() {
+            let k = lattice_selector[i];
+            seed = random(seed);
+            let j = ((seed as i64) % B_SIZE as i64) as usize;
+            lattice_selector[i] = lattice_selector[j];
+            lattice_selector[j] = k;
+        }
+        for i in 0..B_SIZE + 2 {
+            lattice_selector[B_SIZE + i] = lattice_selector[i];
+            for k in 0..4 {
+                for j in 0..2 {
+                    gradient[k][B_SIZE + i][j] = gradient[k][i][j];
+                }
+            }
+        }
+
+        Turbulence {
+            gradient,
+            lattice_selector,
+        }
+    }
+
+    fn noise2(
+        &self,
+        color_channel: usize,
+        vec: (f64, f64),
+        stitch_info: Option<StitchInfo>,
+    ) -> f64 {
+        let t = vec.0 + PERLIN_N as f64;
+        let mut bx0 = t as i32;
+        let mut bx1 = bx0 + 1;
+        let rx0 = t - (t as i32) as f64;
+        let rx1 = rx0 - 1.0;
+
+        let t = vec.1 + PERLIN_N as f64;
+        let mut by0 = t as i32;
+        let mut by1 = by0 + 1;
+        let ry0 = t - (t as i32) as f64;
+        let ry1 = ry0 - 1.0;
+
+        // If stitching, adjust lattice points accordingly.
+        if let Some(stitch_info) = stitch_info {
+            if bx0 >= stitch_info.wrap_x {
+                bx0 -= stitch_info.width;
+            }
+            if bx1 >= stitch_info.wrap_x {
+                bx1 -= stitch_info.width;
+            }
+            if by0 >= stitch_info.wrap_y {
+                by0 -= stitch_info.height;
+            }
+            if by1 >= stitch_info.wrap_y {
+                by1 -= stitch_info.height;
+            }
+        }
+
+        bx0 &= BM;
+        bx1 &= BM;
+        by0 &= BM;
+        by1 &= BM;
+
+        let i = self.lattice_selector[bx0 as usize];
+        let j = self.lattice_selector[bx1 as usize];
+        let b00 = self.lattice_selector[(i + by0) as usize];
+        let b10 = self.lattice_selector[(j + by0) as usize];
+        let b01 = self.lattice_selector[(i + by1) as usize];
+        let b11 = self.lattice_selector[(j + by1) as usize];
+
+        let sx = s_curve(rx0);
+        let sy = s_curve(ry0);
+
+        let q = self.gradient[color_channel][b00 as usize];
+        let u = rx0 * q[0] + ry0 * q[1];
+        let q = self.gradient[color_channel][b10 as usize];
+        let v = rx1 * q[0] + ry0 * q[1];
+        let a = lerp(sx, u, v);
+
+        let q = self.gradient[color_channel][b01 as usize];
+        let u = rx0 * q[0] + ry1 * q[1];
+        let q = self.gradient[color_channel][b11 as usize];
+        let v = rx1 * q[0] + ry1 * q[1];
+        let b = lerp(sx, u, v);
+
+        lerp(sy, a, b)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn turbulence(
+        &self,
+        color_channel: usize,
+        point: (f64, f64),
+        mut base_freq: (f64, f64),
+        num_octaves: usize,
+        fractal_sum: bool,
+        do_stitching: bool,
+        tile_pos: (f64, f64),
+        tile_size: (f64, f64),
+        octave_offsets: &[(f64, f64)],
+    ) -> f64 {
+        let mut stitch_info: Option<StitchInfo> = None; // Not stitching when None.
+                                                        // Adjust the base frequencies if necessary for stitching.
+        if do_stitching {
+            // When stitching tiled turbulence, the frequencies must be adjusted
+            // so that the tile borders will be continuous.
+            if base_freq.0 != 0.0 {
+                let lo_freq = ((tile_size.0 * base_freq.0).floor() as f64) / tile_size.0;
+                let hi_freq = ((tile_size.0 * base_freq.0).ceil() as f64) / tile_size.0;
+                base_freq.0 = if base_freq.0 / lo_freq < hi_freq / base_freq.0 {
+                    lo_freq
+                } else {
+                    hi_freq
+                };
+            }
+            if base_freq.1 != 0.0 {
+                let lo_freq = (tile_size.1 * base_freq.0).floor() / tile_size.1;
+                let hi_freq = (tile_size.1 * base_freq.1).ceil() / tile_size.1;
+                base_freq.1 = if base_freq.1 / lo_freq < hi_freq / base_freq.1 {
+                    lo_freq
+                } else {
+                    hi_freq
+                };
+            }
+            // Set up initial stitch values.
+            let w = (tile_size.0 * base_freq.0 + 0.5) as i32;
+            let h = (tile_size.1 * base_freq.1 + 0.5) as i32;
+            stitch_info = Some(StitchInfo {
+                width: w,
+                height: h,
+                wrap_x: (tile_pos.0 * base_freq.0) as i32 + PERLIN_N + w,
+                wrap_y: (tile_pos.1 * base_freq.1) as i32 + PERLIN_N + h,
+            });
+        }
+        let mut sum = 0.0;
+        let mut ratio = 1.0;
+        for octave in 0..num_octaves {
+            let offset = octave_offsets.get(octave).unwrap();
+            let vec = (
+                (point.0 + offset.0) * base_freq.0 * ratio,
+                (point.1 + offset.1) * base_freq.1 * ratio,
+            );
+            let noise = self.noise2(color_channel, vec, stitch_info);
+            sum += if fractal_sum { noise } else { noise.abs() } / ratio;
+            ratio *= 2.0;
+            stitch_info.as_mut().map(|stitch_info| {
+                // Update stitch values. Subtracting PerlinN before the multiplication and
+                // adding it afterward simplifies to subtracting it once.
+                stitch_info.width *= 2;
+                stitch_info.wrap_x = 2 * stitch_info.wrap_x - PERLIN_N;
+                stitch_info.height *= 2;
+                stitch_info.wrap_y = 2 * stitch_info.wrap_y - PERLIN_N;
+                stitch_info
+            });
+        }
+        sum
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,6 +18,7 @@ extern crate downcast_rs;
 #[macro_use]
 mod avm1;
 mod avm2;
+pub mod bitmap;
 mod bounding_box;
 mod character;
 mod collect;


### PR DESCRIPTION
This aims to help with #2240, although that is still blocked by `BitmapData.draw` (also by `merge`, but that doesn't seem to be enough in itself).
Also should improve #2295, but without `BitmapData.paletteMap`, it actually regresses a bit - at least visually.

I tested these changes with lots of different parameter combinations, using [this ActionScript code](https://gist.github.com/torokati44/c1b5a859d7c96bb4022ac36ed493b2f4), which I compiled with `mtasc` into [this .swf](https://github.com/ruffle-rs/ruffle/files/5865428/BitmapPerlinNoise.zip).

This produces the following image:

![image](https://user-images.githubusercontent.com/288816/105685618-903fd400-5ef6-11eb-9bec-dd9023cd5be4.png)

**EDIT:**
I managed to "fix" the rounding when converting the floating point values to `u8` in all cases.
Now, when taking the example `.swf` above, and making four variations of it: Setting the `transparency` property of the `BitmapData`; and the `fractalNoise` parameter of `perlinNoise()` to be always `true`/`false` (independent of each other); every single pixel matches perfectly between Ruffle and Flash Player in all four cases.

As usual, there are some ways performance could be improved, but for now, this is more than nothing.