### PR TITLE
chore: Lock wasm-bindgen and wasm-bindgen-cli to 0.2.69

### DIFF
--- a/.github/workflows/release_nightlies.yml
+++ b/.github/workflows/release_nightlies.yml
@@ -88,8 +88,9 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
+      # wasm-bindgen-cli version must match wasm-bindgen crate version
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.69
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -39,8 +39,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get -y install libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
+    # wasm-bindgen-cli version must match wasm-bindgen crate version
     - name: Install wasm-bindgen
-      run: cargo install wasm-bindgen-cli
+      run: cargo install wasm-bindgen-cli --version 0.2.69
 
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v2

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -17,7 +17,7 @@ ruffle_web_common = { path = "../../web/common" }
 svg = "0.8.2"
 percent-encoding = "2.1.0"
 png = "0.16.8"
-wasm-bindgen = "0.2.69"
+wasm-bindgen = "=0.2.69"
 
 [dependencies.jpeg-decoder]
 version = "0.1.21"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -13,7 +13,7 @@ percent-encoding = "2.1.0"
 png = "0.16.8"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "0.2.69"
+wasm-bindgen = "=0.2.69"
 
 [dependencies.jpeg-decoder]
 version = "0.1.21"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -32,7 +32,7 @@ ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 url = "2.2.0"
-wasm-bindgen = { version = "0.2.69", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.69", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.19"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 js-sys = "0.3.46"
 log = "0.4"
-wasm-bindgen = "0.2.69"
+wasm-bindgen = "=0.2.69"
 
 [dependencies.web-sys]
 version = "0.3.41"


### PR DESCRIPTION
wasm-bindgen released a new version 0.2.70, but this caused CI to choke because the wasm-bindgen and wasm-bindgen-cli verisons must match exactly (https://github.com/ruffle-rs/ruffle/pull/2845/checks?check_run_id=1764454473). wgpu-rs has a dependency on =0.2.69, so the wasm-bindgen version couldn't be used.

Given that the versions must match exactly, let's depend on the exact version itself both for wasm-bindgen in Cargo.toml, and cargo install wasm-bindgen-cli on CI so that this doesn't break randomly as versions get bumped. When we want to update wasm-bindgen, we must explicitly do so and update the version in these places.