### PR TITLE
Support grayscale JPEGs

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -331,6 +331,23 @@ pub fn decode_jpeg(
     let metadata = decoder.info().ok_or("Unable to get image info")?;
     let decoded_data = decoder.decode()?;
 
+    let decoded_data = match metadata.pixel_format {
+        jpeg_decoder::PixelFormat::RGB24 => decoded_data,
+        jpeg_decoder::PixelFormat::CMYK32 => {
+            log::warn!("Unimplemented CMYK32 JPEG pixel format");
+            decoded_data
+        }
+        jpeg_decoder::PixelFormat::L8 => {
+            let mut rgb = Vec::with_capacity(decoded_data.len() * 3);
+            for elem in decoded_data {
+                rgb.push(elem);
+                rgb.push(elem);
+                rgb.push(elem);
+            }
+            rgb
+        }
+    };
+
     // Decompress the alpha data (DEFLATE compression).
     if let Some(alpha_data) = alpha_data {
         let alpha_data = decompress_zlib(alpha_data)?;


### PR DESCRIPTION
Fixes z0r 4167 and 6009.

Technically it would be slightly more efficient to store them as grayscale, something like:

```rust
pub enum BitmapFormat {
    L8(Vec<u8>), // grayscale
    L8a(Vec<u8>), // grayscale + alpha
    Rgb(Vec<u8>),
    Rgba(Vec<u8>),
}
```
But IMO that'd be a lot of extra logic in decoding and all render backends, for a relatively minor case. But let me know if you want it that way instead.