### PR TITLE
Publish nightly builds to the AUR

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -292,3 +292,34 @@ jobs:
           github_token: ${{ secrets.RUFFLE_BUILD_TOKEN }}
           directory: js-docs
           force: true
+
+  publish-aur-package:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get current time with dashes
+        uses: 1466587594/get-current-time@v2
+        id: current_time_dashes
+        with:
+          format: YYYY-MM-DD
+
+      - name: Get current time with dots
+        uses: 1466587594/get-current-time@v2
+        id: current_time_dots
+        with:
+          format: YYYY.MM.DD
+
+      - name: Update PKGBUILD
+        run: sed -e "s/@VERSION@/${{ steps.current_time_dots.outputs.formattedTime }}/" -i ./PKGBUILD
+
+      - name: Publish AUR package
+        uses: KSXGitHub/github-actions-deploy-aur@v2
+        with:
+          pkgname: ruffle-nightly-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: RuffleBuild
+          commit_email: ruffle@ruffle.rs
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update to Nightly ${{ steps.current_time_dashes.outputs.formattedTime }}

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -36,7 +36,7 @@ jobs:
         target: wasm32-unknown-unknown
 
     # wasm-bindgen-cli version must match wasm-bindgen crate version
-    # Be sure to update in release_nightlies.yml, web/Cargo.toml, web/README.md
+    # Be sure to update in release_nightly.yml, web/Cargo.toml, web/README.md
     - name: Install wasm-bindgen
       run: cargo install wasm-bindgen-cli --version 0.2.69
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: relrel <relrelbachar@gmail.com>
+pkgname=ruffle-nightly-bin
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="A Flash Player emulator written in Rust"
+arch=('x86_64')
+url="https://ruffle.rs/"
+license=('Apache' 'MIT')
+depends=(openssl zlib libxcb alsa-lib)
+provides=(ruffle)
+conflicts=(ruffle-git)
+source=("https://github.com/ruffle-rs/ruffle/releases/download/nightly-${pkgver//./-}/ruffle_nightly_${pkgver//./_}_linux.tar.gz")
+sha512sums=('SKIP')
+
+package() {
+	cd "$srcdir/"
+	install -Dm755 -t "$pkgdir/usr/bin/" ruffle
+	install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
+	install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE_*
+}


### PR DESCRIPTION
Resolves #2246.

- [x] Need to add the `AUR_SSH_PRIVATE_KEY` secret.
@Herschel I think the best way is that you generate a new private/public key pair, then add the private key as a secret and send me the public key so I can add it in the AUR.
- [x] Also it might be worthy to move the [`ruffle-nightly-bin`](https://aur.archlinux.org/packages/ruffle-nightly-bin) package to a more official owner, rather than my personal AUR account.