### PR TITLE
core: Fix execution order

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1581,9 +1581,9 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
     fn run_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Children must run first.
-        for child in self.iter_execution_list() {
-            child.run_frame(context);
-        }
+        // for child in self.iter_execution_list() {
+        //     child.run_frame(context);
+        // }
 
         // Run my load/enterFrame clip event.
         let mut mc = self.0.write(context.gc_context);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -901,23 +901,20 @@ impl Player {
 
     pub fn run_frame(&mut self) {
         self.update(|update_context| {
-            // TODO: In what order are levels run?
             // NOTE: We have to copy all the layer pointers into a separate list
             // because level updates can create more levels, which we don't
             // want to run frames on
             let levels: Vec<_> = update_context.levels.values().copied().collect();
 
+            // TODO: In what order are levels run?
             for level in levels {
-                // level.run_frame(update_context);
                 use std::collections::VecDeque;
                 let mut q = VecDeque::<DisplayObject<'_>>::new();
                 q.push_front(level);
                 let mut s = VecDeque::new();
                 while let Some(x) = q.pop_back() {
                     if let Some(x) = x.as_container() {
-                        for &c in x.iter_execution_list().collect::<Vec<DisplayObject<'_>>>().iter().rev() {
-                            q.push_front(c); // TODO: extend?
-                        }
+                        q.extend(x.iter_execution_list().rev());
                     }
                     s.push_front(x);
                 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -908,7 +908,22 @@ impl Player {
             let levels: Vec<_> = update_context.levels.values().copied().collect();
 
             for level in levels {
-                level.run_frame(update_context);
+                // level.run_frame(update_context);
+                use std::collections::VecDeque;
+                let mut q = VecDeque::<DisplayObject<'_>>::new();
+                q.push_front(level);
+                let mut s = VecDeque::new();
+                while let Some(x) = q.pop_back() {
+                    if let Some(x) = x.as_container() {
+                        for &c in x.iter_execution_list().collect::<Vec<DisplayObject<'_>>>().iter().rev() {
+                            q.push_front(c); // TODO: extend?
+                        }
+                    }
+                    s.push_front(x);
+                }
+                for x in s.iter() {
+                    x.run_frame(update_context);
+                }
             }
 
             update_context.update_sounds();


### PR DESCRIPTION
This is a prototype PR for executing actions in [BFS](https://en.wikipedia.org/wiki/Breadth-first_search) order, rather than [DFS](https://en.wikipedia.org/wiki/Depth-first_search) order.
Fixes at least #1626 (now Sonic runs through the corkscrew loop) and #1986 (now enemies get hit).
Doesn't fix other frame-order-execution bugs such as #1164 and #1915. They might or might not be related.