### PR TITLE
desktop: Improve ruffle_desktop.rc

### DIFF
--- a/desktop/assets/ruffle_desktop.rc
+++ b/desktop/assets/ruffle_desktop.rc
@@ -1,17 +1,22 @@
 #include "winres.h"
 
-#define IDI_ICON 0x101
-IDI_ICON ICON "assets/favicon.ico"
+#define VER_FILEVERSION 0,1,0,0
+#define VER_FILEVERSION_STR "0.1.0.0\0"
+
+#define VER_PRODUCTVERSION 0,1,0,0
+#define VER_PRODUCTVERSION_STR "0.1.0\0"
+
+#ifdef DEBUG // TODO: Actually define DEBUG
+#define VER_DEBUG VS_FF_DEBUG
+#else
+#define VER_DEBUG 0
+#endif
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 1,0,0,1
-PRODUCTVERSION 1,0,0,1
+FILEVERSION VER_FILEVERSION
+PRODUCTVERSION VER_PRODUCTVERSION
 FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
-#ifdef _DEBUG
-FILEFLAGS VS_FF_DEBUG
-#else
-FILEFLAGS 0
-#endif
+FILEFLAGS VER_DEBUG
 FILEOS VOS__WINDOWS32
 FILETYPE VFT_APP
 FILESUBTYPE VFT2_UNKNOWN
@@ -21,13 +26,13 @@ FILESUBTYPE VFT2_UNKNOWN
         BLOCK "040904b0"
         {
             VALUE "CompanyName", "Ruffle"
-            VALUE "FileDescription", "Ruffle"
-            VALUE "FileVersion", "1.0.0.1"
+            VALUE "FileDescription", "A Flash Player emulator written in Rust"
+            VALUE "FileVersion", VER_FILEVERSION_STR
             VALUE "InternalName", "ruffle_desktop.exe"
             VALUE "LegalCopyright", "Copyright (C) 2021"
             VALUE "OriginalFilename", "ruffle_desktop.exe"
             VALUE "ProductName", "Ruffle"
-            VALUE "ProductVersion", "1.0.0.1"
+            VALUE "ProductVersion", VER_PRODUCTVERSION_STR
         }
     }
 
@@ -36,3 +41,6 @@ FILESUBTYPE VFT2_UNKNOWN
         VALUE "Translation", 0x409, 1200
     }
 }
+
+#define IDI_ICON 0x101
+IDI_ICON ICON "assets/favicon.ico"

--- a/desktop/assets/ruffle_desktop.rc
+++ b/desktop/assets/ruffle_desktop.rc
@@ -1,4 +1,4 @@
-#include "winres.h"
+#include <winres.h>
 
 #define VER_FILEVERSION 0,1,0,0
 #define VER_FILEVERSION_STR "0.1.0.0\0"

--- a/desktop/assets/ruffle_desktop.rc
+++ b/desktop/assets/ruffle_desktop.rc
@@ -1,3 +1,38 @@
-#define IDI_ICON 0x101
+#include "winres.h"
 
+#define IDI_ICON 0x101
 IDI_ICON ICON "assets/favicon.ico"
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION 1,0,0,1
+PRODUCTVERSION 1,0,0,1
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+FILEFLAGS VS_FF_DEBUG
+#else
+FILEFLAGS 0
+#endif
+FILEOS VOS__WINDOWS32
+FILETYPE VFT_APP
+FILESUBTYPE VFT2_UNKNOWN
+{
+    BLOCK "StringFileInfo"
+    {
+        BLOCK "040904b0"
+        {
+            VALUE "CompanyName", "Ruffle"
+            VALUE "FileDescription", "Ruffle"
+            VALUE "FileVersion", "1.0.0.1"
+            VALUE "InternalName", "ruffle_desktop.exe"
+            VALUE "LegalCopyright", "Copyright (C) 2021"
+            VALUE "OriginalFilename", "ruffle_desktop.exe"
+            VALUE "ProductName", "Ruffle"
+            VALUE "ProductVersion", "1.0.0.1"
+        }
+    }
+
+    BLOCK "VarFileInfo"
+    {
+        VALUE "Translation", 0x409, 1200
+    }
+}

--- a/desktop/assets/ruffle_desktop.rc
+++ b/desktop/assets/ruffle_desktop.rc
@@ -26,7 +26,7 @@ FILESUBTYPE VFT2_UNKNOWN
         BLOCK "040904b0"
         {
             VALUE "CompanyName", "Ruffle"
-            VALUE "FileDescription", "A Flash Player emulator written in Rust"
+            VALUE "FileDescription", "Ruffle"
             VALUE "FileVersion", VER_FILEVERSION_STR
             VALUE "InternalName", "ruffle_desktop.exe"
             VALUE "LegalCopyright", "Copyright (C) 2021"

--- a/desktop/assets/ruffle_desktop.rc
+++ b/desktop/assets/ruffle_desktop.rc
@@ -1,4 +1,9 @@
-#include <winres.h>
+// winres.h cannot be included, so define manually
+#define VS_FF_DEBUG 0x1L
+#define VS_FFI_FILEFLAGSMASK 0x17L
+#define VOS__WINDOWS32 0x4L
+#define VFT_APP 0x1L
+#define VFT2_UNKNOWN 0x0L
 
 #define VER_FILEVERSION 0,1,0,0
 #define VER_FILEVERSION_STR "0.1.0.0\0"


### PR DESCRIPTION
This PR adds some nice resources to [`desktop/assets/ruffle_desktop.rc`](https://github.com/ruffle-rs/ruffle/blob/master/desktop/assets/ruffle_desktop.rc), including [version information](https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource) and copyright notice.
Based on Windows docs and Chromium's [`chrome_version.rc.version`](https://chromium.googlesource.com/chromium/src/+/master/chrome/app/chrome_version.rc.version).