### PR TITLE
web: Move `allowScriptAccess` to `BaseLoadOptions`

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -81,6 +81,16 @@ export enum LogLevel {
  */
 export interface BaseLoadOptions {
     /**
+     * If set to true, the movie is allowed to interact with the page through
+     * JavaScript, using a flash concept called `ExternalInterface`.
+     *
+     * This should only be enabled for movies you trust.
+     *
+     * @default false
+     */
+    allowScriptAccess?: boolean;
+
+    /**
      * Also known as "flashvars" - these are values that may be passed to
      * and loaded by the movie.
      *

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -40,12 +40,13 @@ export class RuffleEmbed extends RufflePlayer {
                 this.attributes.getNamedItem("allowScriptAccess")?.value ??
                 null;
 
-            this.allowScriptAccess = isScriptAccessAllowed(
-                allowScriptAccess,
-                src.value
-            );
+            // Kick off the SWF download.
             this.load({
                 url: src.value,
+                allowScriptAccess: isScriptAccessAllowed(
+                    allowScriptAccess,
+                    src.value
+                ),
                 parameters: this.attributes.getNamedItem("flashvars")?.value,
                 backgroundColor: this.attributes.getNamedItem("bgcolor")?.value,
             });

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -87,18 +87,18 @@ export class RuffleObject extends RufflePlayer {
 
         this.params = paramsOf(this);
 
-        const allowScriptAccess = findCaseInsensitive(
-            this.params,
-            "allowScriptAccess",
-            null
-        );
         let url = null;
-
         if (this.attributes.getNamedItem("data")) {
             url = this.attributes.getNamedItem("data")?.value;
         } else if (this.params.movie) {
             url = this.params.movie;
         }
+
+        const allowScriptAccess = findCaseInsensitive(
+            this.params,
+            "allowScriptAccess",
+            null
+        );
 
         const parameters = findCaseInsensitive(
             this.params,
@@ -113,19 +113,19 @@ export class RuffleObject extends RufflePlayer {
         );
 
         if (url) {
-            this.allowScriptAccess = isScriptAccessAllowed(
+            const options: URLLoadOptions = { url };
+            options.allowScriptAccess = isScriptAccessAllowed(
                 allowScriptAccess,
                 url
             );
-
-            // Kick off the SWF download.
-            const options: URLLoadOptions = { url };
             if (parameters) {
                 options.parameters = parameters;
             }
             if (backgroundColor) {
                 options.backgroundColor = backgroundColor;
             }
+
+            // Kick off the SWF download.
             this.load(options);
         }
     }

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -293,9 +293,7 @@ type Error = Box<dyn std::error::Error>;
 
 impl WebAudioBackend {
     pub fn new() -> Result<Self, Error> {
-        log::error!("A");
         let context = AudioContext::new().map_err(|_| "Unable to create AudioContext")?;
-        log::error!("B");
 
         // Deduce the minimum sample rate for this browser.
         let mut min_sample_rate = 44100;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -120,6 +120,9 @@ struct JavascriptInterface {
 #[derive(Serialize, Deserialize)]
 #[serde(default = "Default::default")]
 pub struct Config {
+    #[serde(rename = "allowScriptAccess")]
+    allow_script_access: bool,
+
     #[serde(rename = "backgroundColor")]
     background_color: Option<String>,
 
@@ -138,6 +141,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            allow_script_access: false,
             background_color: Default::default(),
             letterbox: Default::default(),
             upgrade_to_https: true,
@@ -160,7 +164,6 @@ impl Ruffle {
     pub fn new(
         parent: HtmlElement,
         js_player: JavascriptPlayer,
-        allow_script_access: bool,
         config: &JsValue,
     ) -> Result<Ruffle, JsValue> {
         if RUFFLE_GLOBAL_PANIC.is_completed() {
@@ -172,8 +175,7 @@ impl Ruffle {
 
         let config: Config = config.into_serde().unwrap_or_default();
 
-        Ruffle::new_internal(parent, js_player, allow_script_access, config)
-            .map_err(|_| "Error creating player".into())
+        Ruffle::new_internal(parent, js_player, config).map_err(|_| "Error creating player".into())
     }
 
     /// Stream an arbitrary movie file from (presumably) the Internet.
@@ -423,10 +425,10 @@ impl Ruffle {
     fn new_internal(
         parent: HtmlElement,
         js_player: JavascriptPlayer,
-        allow_script_access: bool,
         config: Config,
     ) -> Result<Ruffle, Box<dyn Error>> {
         let _ = console_log::init_with_level(config.log_level);
+        let allow_script_access = config.allow_script_access;
 
         let window = web_sys::window().ok_or("Expected window")?;
         let document = window.document().ok_or("Expected document")?;


### PR DESCRIPTION
When using the JavaScript API, `allowScriptAccess` can only be defined this way:
```
let player = ruffle.createPlayer();
player.allowScriptAccess = true;
player.load({
	url: "file.swf",
	parameters: "myflashvar=blahblah",
};
```
This doesn't seem really consistent considering the options in the `load()` method.
This PR allows `allowScriptAccess` to be set like this:


```
let player = ruffle.createPlayer();
player.load({
	url: "file.swf",
	parameters: "myflashvar=blahblah",
	allowScriptAccess: true,
};
```

The default value remains unchanged (always false on the JS API).