### PR TITLE
Change "ActionScript 3 not supported" message

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -20,6 +20,10 @@ pub trait UiBackend: Downcast {
 
     fn is_fullscreen(&self) -> bool;
 
+    /// Displays a warning about unsupported content in Ruffle.
+    /// The user can still click an "OK" or "run anyway" message to dismiss the warning.
+    fn display_unsupported_message(&self);
+    // Unused, but kept in case we need it later
     fn message(&self, message: &str);
 }
 impl_downcast!(UiBackend);
@@ -80,6 +84,8 @@ impl UiBackend for NullUiBackend {
     fn is_fullscreen(&self) -> bool {
         false
     }
+
+    fn display_unsupported_message(&self) {}
 
     fn message(&self, _message: &str) {}
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -883,7 +883,7 @@ impl Player {
             }
         });
         if is_action_script_3 && self.warn_on_unsupported_content {
-            self.ui.message("This SWF contains ActionScript 3 which is not yet supported by Ruffle. The movie may not work as intended.");
+            self.ui.display_unsupported_message();
         }
     }
 

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -70,6 +70,13 @@ impl DesktopUiBackend {
     }
 }
 
+// TODO: Move link to https://ruffle.rs/faq or similar
+const UNSUPPORTED_CONTENT_MESSAGE: &str = "\
+This content is not yet supported by Ruffle and will likely not run as intended.
+
+See the following link for more info:
+https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users";
+
 impl UiBackend for DesktopUiBackend {
     fn is_key_down(&self, key: KeyCode) -> bool {
         match key {
@@ -214,6 +221,14 @@ impl UiBackend for DesktopUiBackend {
 
     fn is_fullscreen(&self) -> bool {
         self.window.fullscreen().is_some()
+    }
+
+    fn display_unsupported_message(&self) {
+        message_box_ok(
+            "Ruffle - Unsupported content",
+            UNSUPPORTED_CONTENT_MESSAGE,
+            MessageBoxIcon::Warning,
+        );
     }
 
     fn message(&self, message: &str) {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1008,17 +1008,36 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
+    displayUnsupportedMessage(): void {
+        const div = document.createElement("div");
+        div.id = "message_overlay";
+        // TODO: Change link to https://ruffle.rs/faq or similar
+        // TODO: Pause content until message is dismissed
+        div.innerHTML = `<div class="message">
+            <p>Flash Player has been removed from browsers in 2021.</p>
+            <p>This content is not yet supported by the Ruffle emulator and will likely not run as intended.</p>
+            <div>
+                <a class="more-info-link" href="https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users">More info</a>
+                <button id="run-anyway-btn">Run anyway</button>
+            </div>
+        </div>`;
+        this.container.prepend(div);
+        const button = <HTMLButtonElement>div.querySelector("#run-anyway-btn");
+        button.onclick = () => {
+            div.remove();
+        };
+    }
+
     displayMessage(message: string): void {
         // Show a dismissible message in front of the player
         const div = document.createElement("div");
         div.id = "message_overlay";
         div.innerHTML = `<div class="message">
-            <div>
-                <p>${message}</p>
-            </div>
+            <p>${message}</p>
             <div>
                 <button id="continue-btn">continue</button>
-            </div>`;
+            </div>
+        </div>`;
         this.container.prepend(div);
         (<HTMLButtonElement>(
             this.container.querySelector("#continue-btn")

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -129,30 +129,44 @@ ruffleShadowTemplate.innerHTML = `
             color: #FFAD33;
             opacity: 1.0;
             z-index: 2;
-            text-align: center;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: auto;
         }
 
         #message_overlay .message {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            width: 100%;
-            padding: 20px;
-            transform: translate(-50%, -50%);
+            text-align: center;
+            max-height: 100%;
+            max-width: 100%;
+            padding: 5%;
         }
 
-        #continue-btn {
-             cursor: pointer;
-             background-color: #37528C;
-             color: #FFAD33;
-             border: 2px solid #FFAD33;
-             font-weight: bold;
-             font-size: 20px;
-             border-radius: 20px;
-             padding: 10px;
+        #message_overlay p {
+            margin: 0.5em 0;
         }
 
-        #continue-btn:hover {
+        #message_overlay .message div {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            column-gap: 1em;
+        }
+
+        #message_overlay a, #message_overlay button {
+            cursor: pointer;
+            background-color: #37528C;
+            color: #FFAD33;
+            border: 2px solid #FFAD33;
+            font-weight: bold;
+            font-size: 1.25em;
+            border-radius: 0.6em;
+            padding: 10px;
+            text-decoration: none;
+            margin: 2% 0;
+        }
+
+        #message_overlay a:hover, #message_overlay button:hover {
             background-color: rgba(255, 255, 255, 0.3);
         }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -102,6 +102,9 @@ extern "C" {
     #[wasm_bindgen(method)]
     fn panic(this: &JavascriptPlayer, error: &JsError);
 
+    #[wasm_bindgen(method, js_name = "displayUnsupportedMessage")]
+    fn display_unsupported_message(this: &JavascriptPlayer);
+
     #[wasm_bindgen(method, js_name = "displayMessage")]
     fn display_message(this: &JavascriptPlayer, message: &str);
 

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -201,6 +201,10 @@ impl UiBackend for WebUiBackend {
         self.js_player.is_fullscreen()
     }
 
+    fn display_unsupported_message(&self) {
+        self.js_player.display_unsupported_message()
+    }
+
     fn message(&self, message: &str) {
         self.js_player.display_message(message);
     }


### PR DESCRIPTION
Proposed on Discord, seems like a lot of users are having trouble with this message: `This SWF contains ActionScript 3 which is not yet supported by Ruffle. The movie may not work as intended.`

A few alternatives, some mine, some from Discord, please suggest more / better wording!
- Shortened: `This content is not yet supported by Ruffle.`
- Catering to new users: `Flash Player has been removed from browsers starting 2021. This content is not yet supported by the Ruffle emulator.`
- With timeframe: `This content contains ActionScript 3 which is not yet supported by Ruffle, and will take at least several months.`
- Extended information: `[...]. This just means that it's not done yet, the devs are working on it, it will take some time.`
- Very verbose: `Flash Player has been removed from browsers starting 2021. You can try to emulate this content by clicking "ok", but please be aware that it very likely WONT WORK! Support is being worked on, please see the Ruffle Project`

We could also change the message depending on whether the user has the extension installed or not (a little hard to do, but possible)? And it could easily include a link to more information?

I don't think we need to change the warning message in [movie_clip.rs](https://github.com/ruffle-rs/ruffle/blob/206ac43703fb51439a160bb5284a30b16ee56976/core/src/display_object/movie_clip.rs#L181). Will rebase the PR with the chosen message once we agree on that.