### PR TITLE
Add VP6 video decoding by utilizing an external crate that bundles parts of FFmpeg

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -256,6 +256,15 @@ jobs:
         shell: bash -l {0}
         run: conda install -c conda-forge binaryen
 
+      - name: Add msys to PATH for clang
+        if: matrix.os == 'Windows'
+        shell: bash -l {0}
+        run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
+
+      - name: Setup Developer Command Prompt
+        if: matrix.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build web
         env:
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -61,6 +61,15 @@ jobs:
           sudo apt-get dist-upgrade
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev mesa-vulkan-drivers
 
+      - name: Add msys to PATH for clang
+        if: matrix.os == 'windows-latest'
+        shell: bash -l {0}
+        run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
+
+      - name: Setup Developer Command Prompt
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -68,6 +68,11 @@ jobs:
         shell: bash -l {0}
         run: conda install -c conda-forge binaryen
 
+      - name: Add msys to PATH for clang
+        if: matrix.os == 'windows-latest'
+        shell: bash -l {0}
+        run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
+
       - name: Build
         working-directory: web
         shell: bash -l {0}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,9 +1119,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embed-resource"
-version = "1.6.4"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a67531cc22d81bf92a24358a1dfa3d3b30f8d326fed8c5780eb6f2e5c784f"
+checksum = "45de30eb317b4cd3882ee16623cb3004e5fb99a8f4cd40097cadf61efbc54adc"
 dependencies = [
  "cc",
  "vswhom",
@@ -2003,9 +2003,9 @@ checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libflate"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16364af76ebb39b5869bb32c81fa93573267cd8c62bb3474e28d78fac3fb141e"
+checksum = "6d87eae36b3f680f7f01645121b782798b56ef33c53f83d1c66ba3a22b60bfe3"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -3642,18 +3642,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4221,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ dependencies = [
  "symphonia",
  "thiserror",
  "url",
+ "vp6-dec-rs",
  "weak-table",
 ]
 
@@ -3850,6 +3851,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "vp6-dec-rs"
+version = "0.1.0"
+source = "git+https://github.com/torokati44/vp6-dec-rs?branch=main#b6c1a6101c8ec0d27c00ec29aba0a757f8ea87e0"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "vswhom"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,6 +43,7 @@ json = "0.12.4"
 lzma-rs = {version = "0.2.0", optional = true }
 dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"] }
 symphonia = { version = "0.3.0", default-features = false, features = ["mp3"], optional = true }
+vp6-dec-rs = { git = "https://github.com/torokati44/vp6-dec-rs", branch = "main", features = ["allow-lgpl"], optional = true }
 
 [dependencies.jpeg-decoder]
 version = "0.1.22"
@@ -54,6 +55,7 @@ approx = "0.5.0"
 [features]
 default = ["minimp3", "serde"]
 h263 = ["h263-rs", "h263-rs-yuv"]
+vp6 = ["vp6-dec-rs"]
 lzma = ["lzma-rs", "swf/lzma"]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 avm_debug = []

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -29,12 +29,13 @@ winapi = "0.3.9"
 embed-resource = "1"
 
 [features]
-default = ["h263"]
+default = ["h263", "vp6"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]
 h263 = ["ruffle_core/h263"]
 lzma = ["ruffle_core/lzma"]
+vp6 = ["ruffle_core/vp6"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -48,7 +48,7 @@ base64 = "0.13.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["h263", "serde", "wasm-bindgen"]
+features = ["h263", "vp6", "serde", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.50"


### PR DESCRIPTION
This is very much a ~~WIP POC RFC OMG~~ PR.

_(With https://github.com/ruffle-rs/ruffle/pull/3117 merged, there aren't any "extra" commits in here anymore.)_

Because this is (I feel like) a fairly heavy change set (both in technical and legal aspects), I'd like to get some feedback about it, before fully polishing it, and hopefully together an acceptable state for merging can be achieved.
While rough around the edges, it's already complete enough that it can be seen working on z0r.de: [7055](https://z0r.de/7055), [7340](https://z0r.de/7340), [7617](https://z0r.de/7617), [7872](https://z0r.de/7872), and many others.
(I'm hoping that deploying "unofficial forks" like this in the public is not problematic?)

Most functionality is in an external crate. The rest of the description applies to the contents of that separate crate.
At the moment, that crate lives in this repository: https://github.com/torokati44/vp6-dec-rs
In the future, this will be migrated under the Ruffle organization.

The C code is built by a fairly straightforward `build.rs` using the `cc` crate, which automatically handles native compilation or targeting WASM for the extension/selfhosted variant, using a static config.
For the WASM target, instead of relying on Emscripten or something similar, a (handmade) tiny fraction of a libc is included as well, just enough to make the decoder compile and work.
~This same libc stub is also utilized on Windows - it was easier this way than supporting compilation with MSVC as well.~ - EDIT: This is no longer true.

Binding declarations are based on those generated by `bindgen`, but in the end, only a tiny portion of those were kept - and some other parts didn't work well then targeting WASM.
This adds clang as an additional dev dependency, which hopefully isn't too big an issue. Version 7 is for sure too old, 11 is confirmed recent enough - but at least not a whole Emscripten SDK is required.
I opted not to use any of the already available ffmpeg binding crates, because they all seemed to have issues with cross-compilation, and doing this without them wasn't that bad after all.

Some things that should be fairly straightforward to add, but aren't done yet:
 - [X] Reporting which frames are and aren't keyframes, for artifact-free seeking.
   - **EDIT:** This turned out to be really easy to do.
 - [X] Support for videos with transparency - ffmpeg has VP6A variant as well; or the two streams can be easily merged by hand.
    - **EDIT:** I have wired this up, it was fortunately only a matter of selecting a different codec, no manual merging needed. The only file I found containing VP6WithAlpha is the (slightly NSFW?) [z0r.de/3926](https://z0r.de/L/z0r-de_3926.swf), but this one doesn't look like it is actually transparent anywhere at all. And one can build a test file from [this example](https://download.macromedia.com/pub/documentation/en/flash/fl8/alpha_video.zip) from Adobe as well.
 - [X] ~~Trimming the "padding pixels" off from the right and bottom edges, they are needed only for compression.~~
   - **EDIT:** When noting this, I mistakenly looked at the FLV tag spec instead of the SWF one. In the SWF tag header, the `HorizontalAdjustment` and `VerticalAdjustment` fields are not present. ~Also, I've checked, and even if the size in the header is not an integer multiple of 8 or 16 (the block sizes), the results already match that of Flash Player nicely. Most likely, the actual frame size is also part of the frame data fed to the decoder in FFmpeg, which then handles it properly.~
   - **UPDATE**: I was wrong with the edit above, and it was only a coincidence that all the videos I looked at were fullscreen, so they were in fact cropped by the player window itself. #4154 exposed this issue, and made the garbage pixels visible. These are now cropped manually, for reasons explained in 2ac4acf3f18d0699e8596f847b8922e8804aa667.
 - [X] Supporting the different post-processing (deblocking/deringing/smoothing) options
   - **EDIT:** Judging by the header parsing code, I believe that at least the deblocking filter is also configured by the encoded data itself, and FFmpeg applies it as requested.
 - [ ] Triple-checking that nothing in the countless `unsafe` blocks can crash or leak or do anything nasty.