### PR TITLE
ci: Fix publish AUR package job

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -294,6 +294,7 @@ jobs:
           force: true
 
   publish-aur-package:
+    name: Publish AUR package
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -315,7 +316,7 @@ jobs:
         run: sed -e "s/@VERSION@/${{ steps.current_time_dots.outputs.formattedTime }}/" -i ./PKGBUILD
 
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v2
+        uses: KSXGitHub/github-actions-deploy-aur@v2.2.3
         with:
           pkgname: ruffle-nightly-bin
           pkgbuild: ./PKGBUILD


### PR DESCRIPTION
I was mistakenly thought that `KSXGitHub/github-actions-deploy-aur@v2` is equivalent to `KSXGitHub/github-actions-deploy-aur@v2.2.3`.