### PR TITLE
Revert "build(deps): bump quick-xml from 0.20.0 to 0.21.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.21.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0452695941410a58c8ce4391707ba9bad26a247173bd9886a05a5e8a8babec75"
+checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
 dependencies = [
  "memchr",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,7 +23,7 @@ swf = { path = "../swf" }
 bitflags = "1.2.1"
 smallvec = "1.6.1"
 num_enum = "0.5.1"
-quick-xml = "0.21.0"
+quick-xml = "0.20.0"
 downcast-rs = "1.2.0"
 url = "2.2.0"
 weak-table = "0.3.0"


### PR DESCRIPTION
See https://github.com/tafia/quick-xml/issues/255