### PR TITLE
Don't unwrap url to file path conversion

### DIFF
--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -129,7 +129,8 @@ impl NavigatorBackend for ExternalNavigatorBackend {
 
         match processed_url.scheme() {
             "file" => Box::pin(async move {
-                fs::read(processed_url.to_file_path().unwrap()).map_err(Error::NetworkError)
+                fs::read(processed_url.to_file_path().unwrap_or_default())
+                    .map_err(Error::NetworkError)
             }),
             _ => Box::pin(async move {
                 let client = client.ok_or(Error::NetworkUnavailable)?;


### PR DESCRIPTION
It might not succeed.
This unwrap crashes the Newgrounds Meat Boy flash on desktop.

Instead, use unwrap_or_default with an empty path. This will cause
the read to fail, but it's better than crashing the whole program.

The unwrap crash is reproducible with the Meat Boy flash from Newgrounds.