### PR TITLE
core: Global execution order

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2816,8 +2816,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             .into();
 
             level.set_depth(self.context.gc_context, level_id as i32);
+            level.set_level(self.context.gc_context, level_id);
             level.set_default_root_name(&mut self.context);
             self.context.levels.insert(level_id, level);
+            self.context.add_node(level);
             level.post_instantiation(&mut self.context, level, None, Instantiator::Movie, false);
 
             level

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -9,7 +9,7 @@ use crate::avm1::{
 };
 use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use crate::context::UpdateContext;
-use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer, Level};
+use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
 use crate::ecma_conversions::f64_to_wrapping_u32;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
@@ -343,7 +343,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ) -> Self {
         let version = context.swf.version();
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.get(0).unwrap();
+        let level0 = *context.levels.get(0).unwrap();
 
         Self::from_nothing(context, id, version, globals, level0)
     }
@@ -2807,7 +2807,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     /// with a script object.
     pub fn resolve_level(&mut self, level_id: u32) -> DisplayObject<'gc> {
         if let Some(level) = self.context.levels.get(level_id) {
-            level
+            *level
         } else {
             let level: DisplayObject<'_> = MovieClip::new(
                 SwfSlice::empty(self.base_clip().movie().unwrap()),
@@ -2817,7 +2817,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
             level.set_depth(self.context.gc_context, level_id as i32);
             level.set_default_root_name(&mut self.context);
-            self.context.levels.insert(level_id, Level::new(level));
+            self.context.levels.insert(level_id, level);
             level.post_instantiation(&mut self.context, level, None, Instantiator::Movie, false);
 
             level

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2820,9 +2820,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             root.set_depth(self.context.gc_context, level_id as Depth);
             root.set_level_id(self.context.gc_context, level_id);
             root.set_default_root_name(&mut self.context);
-            self.context
-                .levels
-                .insert(self.context.gc_context, root);
+            self.context.levels.insert(self.context.gc_context, root);
             root.post_instantiation(&mut self.context, root, None, Instantiator::Movie, false);
 
             root

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -11,6 +11,7 @@ use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
 use crate::ecma_conversions::f64_to_wrapping_u32;
+use crate::prelude::Depth;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
@@ -2815,11 +2816,11 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             )
             .into();
 
-            level.set_depth(self.context.gc_context, level_id as i32);
+            level.set_depth(self.context.gc_context, level_id as Depth);
             level.set_level(self.context.gc_context, level_id);
             level.set_default_root_name(&mut self.context);
             self.context.levels.insert(level_id, level);
-            self.context.add_node(level);
+            self.context.add_to_execution_list(level);
             level.post_instantiation(&mut self.context, level, None, Instantiator::Movie, false);
 
             level

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -345,7 +345,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ) -> Self {
         let version = context.swf.version();
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.at(0).unwrap();
+        let level0 = context.levels.get(0).unwrap();
 
         Self::from_nothing(context, id, version, globals, level0)
     }
@@ -2808,7 +2808,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     /// If the level does not exist, then it will be created and instantiated
     /// with a script object.
     pub fn resolve_level(&mut self, level_id: LevelId) -> DisplayObject<'gc> {
-        if let Some(level) = self.context.levels.at(level_id) {
+        if let Some(level) = self.context.levels.get(level_id) {
             level
         } else {
             let root: DisplayObject<'_> = MovieClip::new(

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -9,11 +9,9 @@ use crate::avm1::{
 };
 use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use crate::context::UpdateContext;
-use crate::display_object::{
-    DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer,
-};
-use crate::levels::{Level, LevelId};
+use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
 use crate::ecma_conversions::f64_to_wrapping_u32;
+use crate::levels::{Level, LevelId};
 use crate::prelude::Depth;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
@@ -347,7 +345,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ) -> Self {
         let version = context.swf.version();
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.level_at(0).unwrap();
+        let level0 = context.levels.at(0).unwrap();
 
         Self::from_nothing(context, id, version, globals, level0)
     }
@@ -2810,7 +2808,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     /// If the level does not exist, then it will be created and instantiated
     /// with a script object.
     pub fn resolve_level(&mut self, level_id: LevelId) -> DisplayObject<'gc> {
-        if let Some(level) = self.context.levels.level_at(level_id) {
+        if let Some(level) = self.context.levels.at(level_id) {
             level
         } else {
             let root: DisplayObject<'_> = MovieClip::new(
@@ -2820,10 +2818,11 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             .into();
 
             root.set_depth(self.context.gc_context, level_id as Depth);
-            root.set_level(self.context.gc_context, level_id);
+            root.set_level_id(self.context.gc_context, level_id);
             root.set_default_root_name(&mut self.context);
-            self.context.levels.push(self.context.gc_context, &mut Level::new(root));
-            self.context.add_to_execution_list(root);
+            self.context
+                .levels
+                .insert(self.context.gc_context, Level::new(root));
             root.post_instantiation(&mut self.context, root, None, Instantiator::Movie, false);
 
             root

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -9,7 +9,7 @@ use crate::avm1::{
 };
 use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use crate::context::UpdateContext;
-use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
+use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer, Level};
 use crate::ecma_conversions::f64_to_wrapping_u32;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
@@ -343,7 +343,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ) -> Self {
         let version = context.swf.version();
         let globals = context.avm1.global_object_cell();
-        let level0 = *context.levels.get(&0).unwrap();
+        let level0 = context.levels.get(0).unwrap();
 
         Self::from_nothing(context, id, version, globals, level0)
     }
@@ -2806,8 +2806,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     /// If the level does not exist, then it will be created and instantiated
     /// with a script object.
     pub fn resolve_level(&mut self, level_id: u32) -> DisplayObject<'gc> {
-        if let Some(level) = self.context.levels.get(&level_id) {
-            *level
+        if let Some(level) = self.context.levels.get(level_id) {
+            level
         } else {
             let level: DisplayObject<'_> = MovieClip::new(
                 SwfSlice::empty(self.base_clip().movie().unwrap()),
@@ -2817,7 +2817,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
             level.set_depth(self.context.gc_context, level_id as i32);
             level.set_default_root_name(&mut self.context);
-            self.context.levels.insert(level_id, level);
+            self.context.levels.insert(level_id, Level::new(level));
             level.post_instantiation(&mut self.context, level, None, Instantiator::Movie, false);
 
             level

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -11,7 +11,7 @@ use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
 use crate::ecma_conversions::f64_to_wrapping_u32;
-use crate::levels::{Level, LevelId};
+use crate::levels::LevelId;
 use crate::prelude::Depth;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
@@ -2822,7 +2822,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             root.set_default_root_name(&mut self.context);
             self.context
                 .levels
-                .insert(self.context.gc_context, Level::new(root));
+                .insert(self.context.gc_context, root);
             root.post_instantiation(&mut self.context, root, None, Instantiator::Movie, false);
 
             root

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.get(0).clone()) // TODO: copied?
+            .or_else(|| activation.context.levels.get(0).copied()) // TODO: copied?
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.get(0).clone()) // TODO: copied?
+                .or_else(|| activation.context.levels.get(0).copied()) // TODO: copied?
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.get(0).copied()) // TODO: copied?
+            .or_else(|| activation.context.levels.get(0).copied())
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.get(0).copied()) // TODO: copied?
+                .or_else(|| activation.context.levels.get(0).copied())
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.get(&0).map(|&l| l.root()))
+            .or_else(|| activation.context.levels.level_at(0))
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.get(&0).map(|&l| l.root()))
+                .or_else(|| activation.context.levels.level_at(0))
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.level_at(0))
+            .or_else(|| activation.context.levels.at(0))
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.level_at(0))
+                .or_else(|| activation.context.levels.at(0))
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.get(0).copied())
+            .or_else(|| activation.context.levels.get(&0).map(|&l| l.root()))
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.get(0).copied())
+                .or_else(|| activation.context.levels.get(&0).map(|&l| l.root()))
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.get(&0).copied())
+            .or_else(|| activation.context.levels.get(0).clone()) // TODO: copied?
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.get(&0).copied())
+                .or_else(|| activation.context.levels.get(0).clone()) // TODO: copied?
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.at(0))
+            .or_else(|| activation.context.levels.get(0))
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.at(0))
+                .or_else(|| activation.context.levels.get(0))
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -836,7 +836,7 @@ mod tests {
     use crate::backend::ui::NullUiBackend;
     use crate::backend::video::NullVideoBackend;
     use crate::context::UpdateContext;
-    use crate::display_object::{Levels, MovieClip};
+    use crate::display_object::{Level, MovieClip};
     use crate::focus_tracker::FocusTracker;
     use crate::library::Library;
     use crate::loader::LoadManager;
@@ -846,7 +846,7 @@ mod tests {
     use gc_arena::rootless_arena;
     use instant::Instant;
     use rand::{rngs::SmallRng, SeedableRng};
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -861,8 +861,8 @@ mod tests {
             let root: DisplayObject<'_> =
                 MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
             root.set_depth(gc_context, 0);
-            let mut levels = Levels::new();
-            levels.insert(0, root);
+            let mut levels = BTreeMap::new();
+            levels.insert(0, Level::new(root));
 
             let object = ScriptObject::object(gc_context, Some(avm1.prototypes().object)).into();
             let globals = avm1.global_object_cell();
@@ -910,7 +910,7 @@ mod tests {
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");
 
-            let base_clip = *context.levels.get(0).unwrap();
+            let base_clip = context.levels.get(&0).unwrap().root();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
                 context,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -836,7 +836,7 @@ mod tests {
     use crate::backend::ui::NullUiBackend;
     use crate::backend::video::NullVideoBackend;
     use crate::context::UpdateContext;
-    use crate::display_object::{Level, Levels, MovieClip};
+    use crate::display_object::{Levels, MovieClip};
     use crate::focus_tracker::FocusTracker;
     use crate::library::Library;
     use crate::loader::LoadManager;

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -836,7 +836,7 @@ mod tests {
     use crate::backend::ui::NullUiBackend;
     use crate::backend::video::NullVideoBackend;
     use crate::context::UpdateContext;
-    use crate::display_object::MovieClip;
+    use crate::display_object::{Level, Levels, MovieClip};
     use crate::focus_tracker::FocusTracker;
     use crate::library::Library;
     use crate::loader::LoadManager;
@@ -846,7 +846,7 @@ mod tests {
     use gc_arena::rootless_arena;
     use instant::Instant;
     use rand::{rngs::SmallRng, SeedableRng};
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -861,14 +861,13 @@ mod tests {
             let root: DisplayObject<'_> =
                 MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
             root.set_depth(gc_context, 0);
-            let mut levels = BTreeMap::new();
+            let mut levels = Levels::new();
             levels.insert(0, root);
 
             let object = ScriptObject::object(gc_context, Some(avm1.prototypes().object)).into();
             let globals = avm1.global_object_cell();
 
             let mut context = UpdateContext {
-                exec_list: &mut GlobalExecList::default(),
                 gc_context,
                 player_version: 32,
                 swf: &swf,
@@ -911,7 +910,7 @@ mod tests {
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");
 
-            let base_clip = *context.levels.get(&0).unwrap();
+            let base_clip = *context.levels.get(0).unwrap();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
                 context,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -838,7 +838,7 @@ mod tests {
     use crate::context::UpdateContext;
     use crate::display_object::MovieClip;
     use crate::focus_tracker::FocusTracker;
-    use crate::levels::{Level, LevelsData};
+    use crate::levels::LevelsData;
     use crate::library::Library;
     use crate::loader::LoadManager;
     use crate::prelude::*;
@@ -863,7 +863,7 @@ mod tests {
                 MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
             root.set_depth(gc_context, 0);
             let mut levels = LevelsData::default();
-            levels.insert(gc_context, Level::new(root));
+            levels.insert(gc_context, root);
 
             let object = ScriptObject::object(gc_context, Some(avm1.prototypes().object)).into();
             let globals = avm1.global_object_cell();
@@ -911,7 +911,7 @@ mod tests {
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");
 
-            let base_clip = context.levels.get(0).unwrap().root();
+            let base_clip = context.levels.at(0).unwrap();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
                 context,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -836,8 +836,9 @@ mod tests {
     use crate::backend::ui::NullUiBackend;
     use crate::backend::video::NullVideoBackend;
     use crate::context::UpdateContext;
-    use crate::display_object::{Level, MovieClip};
+    use crate::display_object::MovieClip;
     use crate::focus_tracker::FocusTracker;
+    use crate::levels::{Level, LevelsData};
     use crate::library::Library;
     use crate::loader::LoadManager;
     use crate::prelude::*;
@@ -846,7 +847,7 @@ mod tests {
     use gc_arena::rootless_arena;
     use instant::Instant;
     use rand::{rngs::SmallRng, SeedableRng};
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -861,8 +862,8 @@ mod tests {
             let root: DisplayObject<'_> =
                 MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
             root.set_depth(gc_context, 0);
-            let mut levels = BTreeMap::new();
-            levels.insert(0, Level::new(root));
+            let mut levels = LevelsData::default();
+            levels.insert(gc_context, Level::new(root));
 
             let object = ScriptObject::object(gc_context, Some(avm1.prototypes().object)).into();
             let globals = avm1.global_object_cell();
@@ -910,7 +911,7 @@ mod tests {
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");
 
-            let base_clip = context.levels.get(&0).unwrap().root();
+            let base_clip = context.levels.get(0).unwrap().root();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
                 context,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -868,6 +868,7 @@ mod tests {
             let globals = avm1.global_object_cell();
 
             let mut context = UpdateContext {
+                exec_list: &mut GlobalExecList::default(),
                 gc_context,
                 player_version: 32,
                 swf: &swf,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -838,7 +838,7 @@ mod tests {
     use crate::context::UpdateContext;
     use crate::display_object::MovieClip;
     use crate::focus_tracker::FocusTracker;
-    use crate::levels::LevelsData;
+    use crate::levels::Levels;
     use crate::library::Library;
     use crate::loader::LoadManager;
     use crate::prelude::*;
@@ -862,7 +862,7 @@ mod tests {
             let root: DisplayObject<'_> =
                 MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
             root.set_depth(gc_context, 0);
-            let mut levels = LevelsData::default();
+            let mut levels = Levels::default();
             levels.insert(gc_context, root);
 
             let object = ScriptObject::object(gc_context, Some(avm1.prototypes().object)).into();

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -911,7 +911,7 @@ mod tests {
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");
 
-            let base_clip = context.levels.at(0).unwrap();
+            let base_clip = context.levels.get(0).unwrap();
             let swf_version = context.swf.version();
             let mut activation = Activation::from_nothing(
                 context,

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -409,8 +409,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         let mut keys = obj.base.get_keys(activation);
 
         if let Some(ctr) = obj.display_object.as_container() {
-            // TODO: fix order?
-            keys.extend(ctr.iter_render_list().map(|child| child.name().to_string()));
+            keys.extend(ctr.iter_children_by_depth().map(|(_, child)| child.name().to_string()));
         }
 
         keys

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -409,10 +409,8 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         let mut keys = obj.base.get_keys(activation);
 
         if let Some(ctr) = obj.display_object.as_container() {
-            keys.extend(
-                ctr.iter_execution_list()
-                    .map(|child| child.name().to_string()),
-            );
+            // TODO: fix order?
+            keys.extend(ctr.iter_render_list().map(|child| child.name().to_string()));
         }
 
         keys

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -409,7 +409,10 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         let mut keys = obj.base.get_keys(activation);
 
         if let Some(ctr) = obj.display_object.as_container() {
-            keys.extend(ctr.iter_children_by_depth().map(|(_, child)| child.name().to_string()));
+            keys.extend(
+                ctr.iter_children_by_depth()
+                    .map(|(_, child)| child.name().to_string()),
+            );
         }
 
         keys

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -12,7 +12,7 @@ use crate::backend::storage::MemoryStorageBackend;
 use crate::backend::ui::NullUiBackend;
 use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
-use crate::display_object::{MovieClip, TDisplayObject};
+use crate::display_object::{Level, Levels, MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
 use crate::library::Library;
 use crate::loader::LoadManager;
@@ -22,7 +22,7 @@ use crate::vminterface::Instantiator;
 use gc_arena::{rootless_arena, MutationContext};
 use instant::Instant;
 use rand::{rngs::SmallRng, SeedableRng};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,13 +40,12 @@ where
         let root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
         root.set_depth(gc_context, 0);
-        let mut levels = BTreeMap::new();
+        let mut levels = Levels::new();
         levels.insert(0, root);
 
         let globals = avm1.global_object_cell();
 
         let mut context = UpdateContext {
-            exec_list: &mut GlobalExecList::default(),
             gc_context,
             player_version: 32,
             swf: &swf,
@@ -102,7 +101,7 @@ where
             }
         }
 
-        let base_clip = *context.levels.get(&0).unwrap();
+        let base_clip = *context.levels.get(0).unwrap();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
             context,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -12,7 +12,7 @@ use crate::backend::storage::MemoryStorageBackend;
 use crate::backend::ui::NullUiBackend;
 use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
-use crate::display_object::{Levels, MovieClip, TDisplayObject};
+use crate::display_object::{Level, MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
 use crate::library::Library;
 use crate::loader::LoadManager;
@@ -22,7 +22,7 @@ use crate::vminterface::Instantiator;
 use gc_arena::{rootless_arena, MutationContext};
 use instant::Instant;
 use rand::{rngs::SmallRng, SeedableRng};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,8 +40,8 @@ where
         let root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
         root.set_depth(gc_context, 0);
-        let mut levels = Levels::new();
-        levels.insert(0, root);
+        let mut levels = BTreeMap::new();
+        levels.insert(0, Level::new(root));
 
         let globals = avm1.global_object_cell();
 
@@ -101,7 +101,7 @@ where
             }
         }
 
-        let base_clip = *context.levels.get(0).unwrap();
+        let base_clip = context.levels.get(&0).unwrap().root();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
             context,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -12,7 +12,7 @@ use crate::backend::storage::MemoryStorageBackend;
 use crate::backend::ui::NullUiBackend;
 use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
-use crate::display_object::{Level, Levels, MovieClip, TDisplayObject};
+use crate::display_object::{Levels, MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
 use crate::library::Library;
 use crate::loader::LoadManager;

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -12,8 +12,9 @@ use crate::backend::storage::MemoryStorageBackend;
 use crate::backend::ui::NullUiBackend;
 use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
-use crate::display_object::{Level, MovieClip, TDisplayObject};
+use crate::display_object::{MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
+use crate::levels::{Level, LevelsData};
 use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::prelude::*;
@@ -22,7 +23,7 @@ use crate::vminterface::Instantiator;
 use gc_arena::{rootless_arena, MutationContext};
 use instant::Instant;
 use rand::{rngs::SmallRng, SeedableRng};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,8 +41,8 @@ where
         let root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
         root.set_depth(gc_context, 0);
-        let mut levels = BTreeMap::new();
-        levels.insert(0, Level::new(root));
+        let mut levels = LevelsData::default();
+        levels.insert(gc_context, Level::new(root));
 
         let globals = avm1.global_object_cell();
 
@@ -101,7 +102,7 @@ where
             }
         }
 
-        let base_clip = context.levels.get(&0).unwrap().root();
+        let base_clip = context.levels.get(0).unwrap().root();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
             context,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -46,6 +46,7 @@ where
         let globals = avm1.global_object_cell();
 
         let mut context = UpdateContext {
+            exec_list: &mut GlobalExecList::default(),
             gc_context,
             player_version: 32,
             swf: &swf,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -14,7 +14,7 @@ use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
 use crate::display_object::{MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
-use crate::levels::{Level, LevelsData};
+use crate::levels::LevelsData;
 use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::prelude::*;
@@ -42,7 +42,7 @@ where
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
         root.set_depth(gc_context, 0);
         let mut levels = LevelsData::default();
-        levels.insert(gc_context, Level::new(root));
+        levels.insert(gc_context, root);
 
         let globals = avm1.global_object_cell();
 
@@ -102,7 +102,7 @@ where
             }
         }
 
-        let base_clip = context.levels.get(0).unwrap().root();
+        let base_clip = context.levels.at(0).unwrap();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
             context,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -102,7 +102,7 @@ where
             }
         }
 
-        let base_clip = context.levels.at(0).unwrap();
+        let base_clip = context.levels.get(0).unwrap();
         let swf_version = context.swf.version();
         let mut activation = Activation::from_nothing(
             context,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -14,7 +14,7 @@ use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
 use crate::display_object::{MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
-use crate::levels::LevelsData;
+use crate::levels::Levels;
 use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::prelude::*;
@@ -41,7 +41,7 @@ where
         let root: DisplayObject<'gc> =
             MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
         root.set_depth(gc_context, 0);
-        let mut levels = LevelsData::default();
+        let mut levels = Levels::default();
         levels.insert(gc_context, root);
 
         let globals = avm1.global_object_cell();

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.level_at(0).unwrap(); // copied?
+        let level0 = context.levels.at(0).unwrap(); // copied?
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.get(0).copied().unwrap();
+        let level0 = context.levels.get(&0).copied().unwrap().root();
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.get(0).unwrap().clone(); // TODO: copied?
+        let level0 = context.levels.get(0).copied().unwrap(); // TODO: copied?
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.get(0).copied().unwrap(); // TODO: copied?
+        let level0 = context.levels.get(0).copied().unwrap();
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.get(&0).copied().unwrap();
+        let level0 = context.levels.get(0).unwrap().clone(); // TODO: copied?
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.get(&0).copied().unwrap().root();
+        let level0 = context.levels.level_at(0).unwrap(); // copied?
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -39,7 +39,7 @@ impl<'gc> Timers<'gc> {
 
         let version = context.swf.header().version;
         let globals = context.avm1.global_object_cell();
-        let level0 = context.levels.at(0).unwrap(); // copied?
+        let level0 = context.levels.get(0).unwrap(); // copied?
 
         let mut activation = Activation::from_nothing(
             context.reborrow(),

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -83,7 +83,7 @@ fn validate_remove_operation<'gc>(
         .as_container()
         .ok_or("ArgumentError: Parent is not a DisplayObjectContainer")?;
 
-    for child in old_ctr.iter_execution_list() {
+    for child in old_ctr.iter_render_list() {
         if DisplayObject::ptr_eq(child, proposed_child) {
             return Ok(());
         }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -235,7 +235,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
         self.audio_manager.set_sound_transforms_dirty()
     }
 
-    pub fn remove_node(&mut self, node: DisplayObject<'gc>) -> bool {
+    pub fn remove_from_execution_list(&mut self, node: DisplayObject<'gc>) -> bool {
         // Remove from linked list.
         let prev = node.prev_global();
         let next = node.next_global();
@@ -264,7 +264,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
         present_on_execution_list
     }
 
-    pub fn add_node(&mut self, node: DisplayObject<'gc>) {
+    pub fn add_to_execution_list(&mut self, node: DisplayObject<'gc>) {
         let level = node.level();
         if let Some(head) = self.levels.get_exec_list(level) {
             head.set_prev_global(self.gc_context, Some(node));

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -235,12 +235,12 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
         self.audio_manager.set_sound_transforms_dirty()
     }
 
-    /// Methods to add/remove nodes from the global execution list.
+    /// Methods to add/remove nodes to/from the global execution list.
     pub fn add_to_execution_list(&mut self, node: DisplayObject<'gc>) {
         if let Some(level) = self.levels.get_mut(&node.level()) {
             if let Some(head) = level.exec_list() {
-                head.set_prev_global(self.gc_context, Some(node));
-                node.set_next_global(self.gc_context, Some(head));
+                head.set_prev_exec(self.gc_context, Some(node));
+                node.set_next_exec(self.gc_context, Some(head));
             }
             level.set_exec_list(Some(node));
         } else {
@@ -255,18 +255,18 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             }
         }
 
-        let prev = node.prev_global();
-        let next = node.next_global();
+        let prev = node.prev_exec();
+        let next = node.next_exec();
 
         if let Some(prev) = prev {
-            prev.set_next_global(self.gc_context, next);
+            prev.set_next_exec(self.gc_context, next);
         }
         if let Some(next) = next {
-            next.set_prev_global(self.gc_context, prev);
+            next.set_prev_exec(self.gc_context, prev);
         }
 
-        node.set_prev_global(self.gc_context, None);
-        node.set_next_global(self.gc_context, None);
+        node.set_prev_exec(self.gc_context, None);
+        node.set_next_exec(self.gc_context, None);
 
         if let Some(level) = self.levels.get_mut(&node.level()) {
             if let Some(head) = level.exec_list() {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -249,6 +249,12 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
     }
 
     pub fn remove_from_execution_list(&mut self, node: DisplayObject<'gc>) -> bool {
+        if let Some(ctr) = node.as_container() {
+            for child in ctr.iter_render_list() {
+                self.remove_from_execution_list(child);
+            }
+        }
+
         let prev = node.prev_global();
         let next = node.next_global();
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -248,7 +248,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
         }
     }
 
-    pub fn remove_from_execution_list(&mut self, node: DisplayObject<'gc>) -> bool {
+    pub fn remove_from_execution_list(&mut self, node: DisplayObject<'gc>) {
         if let Some(ctr) = node.as_container() {
             for child in ctr.iter_render_list() {
                 self.remove_from_execution_list(child);
@@ -272,12 +272,9 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             if let Some(head) = level.exec_list() {
                 if DisplayObject::ptr_eq(head, node) {
                     level.set_exec_list(next);
-                    return true;
                 }
             }
         }
-
-        prev.is_some() || next.is_some()
     }
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -240,6 +240,10 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
     pub fn add_to_execution_list(&mut self, node: DisplayObject<'gc>) {
         if let Some(level) = self.levels.get_mut(node.level_id()) {
             let head = level.last_child();
+            if let Some(prev) = head.prev_exec() {
+                prev.set_next_exec(self.gc_context, Some(node));
+                node.set_prev_exec(self.gc_context, Some(prev));
+            }
             head.set_prev_exec(self.gc_context, Some(node));
             node.set_next_exec(self.gc_context, Some(head));
             level.set_last_child(node);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -239,8 +239,8 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
         // Remove from linked list.
         let prev = node.prev_global();
         let next = node.next_global();
-        let depth = node.depth() as u32; // TODO: cast depth?
-        let exec_list = self.levels.get_exec_list(depth);
+        let level = node.level();
+        let exec_list = self.levels.get_exec_list(level);
         let present_on_execution_list = prev.is_some()
             || next.is_some()
             || (exec_list.is_some() && DisplayObject::ptr_eq(exec_list.unwrap(), node));
@@ -257,7 +257,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
 
         if let Some(head) = exec_list {
             if DisplayObject::ptr_eq(head, node) {
-                self.levels.set_exec_list(depth, next);
+                self.levels.set_exec_list(level, next);
             }
         }
 
@@ -265,12 +265,13 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
     }
 
     pub fn add_node(&mut self, node: DisplayObject<'gc>) {
-        let depth = node.depth() as u32; // TODO: cast depth?
-        if let Some(head) = self.levels.get_exec_list(depth) {
+        let level = node.level();
+        println!("[add_node] level: {}", level);
+        if let Some(head) = self.levels.get_exec_list(level) {
             head.set_prev_global(self.gc_context, Some(node));
             node.set_next_global(self.gc_context, Some(head));
         }
-        self.levels.set_exec_list(depth, Some(node));
+        self.levels.set_exec_list(level, Some(node));
     }
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -266,7 +266,6 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
 
     pub fn add_node(&mut self, node: DisplayObject<'gc>) {
         let level = node.level();
-        println!("[add_node] level: {}", level);
         if let Some(head) = self.levels.get_exec_list(level) {
             head.set_prev_global(self.gc_context, Some(node));
             node.set_next_global(self.gc_context, Some(head));

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -16,7 +16,7 @@ use crate::backend::{
 use crate::display_object::{EditText, MovieClip, SoundTransform};
 use crate::external::ExternalInterface;
 use crate::focus_tracker::FocusTracker;
-use crate::levels::LevelsData;
+use crate::levels::Levels;
 use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::player::Player;
@@ -94,7 +94,7 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     pub rng: &'a mut SmallRng,
 
     /// All loaded levels of the current player.
-    pub levels: &'a mut LevelsData<'gc>,
+    pub levels: &'a mut Levels<'gc>,
 
     /// The display object that the mouse is currently hovering over.
     pub mouse_hovered_object: Option<DisplayObject<'gc>>,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -168,7 +168,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             self.audio,
             self.gc_context,
             self.action_queue,
-            self.levels.at(0).unwrap(),
+            self.levels.get(0).unwrap(),
         );
     }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -90,9 +90,7 @@ impl<'gc> Iterator for ExecIter<'gc> {
     fn next(&mut self) -> Option<Self::Item> {
         let cur = self.head;
 
-        self.head = self
-            .head
-            .and_then(|display_cell| display_cell.next_exec());
+        self.head = self.head.and_then(|display_cell| display_cell.next_exec());
 
         cur
     }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -193,7 +193,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.level
     }
 
-    fn set_level(&mut self, _context: MutationContext<'gc, '_>, level: u32) {
+    fn set_level(&mut self, level: u32) {
         self.level = level;
     }
 
@@ -1354,7 +1354,7 @@ macro_rules! impl_display_object_sansbounds {
             self.0.read().$field.level()
         }
         fn set_level(&self, gc_context: gc_arena::MutationContext<'gc, '_>, level: u32) {
-            self.0.write(gc_context).$field.set_level(gc_context, level)
+            self.0.write(gc_context).$field.set_level(level)
         }
         fn place_frame(&self) -> u16 {
             self.0.read().$field.place_frame()

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -48,7 +48,7 @@ pub struct DisplayObjectBase<'gc> {
     parent: Option<DisplayObject<'gc>>,
     place_frame: u16,
     depth: Depth,
-    level: LevelId,
+    level_id: LevelId,
     transform: Transform,
     name: String,
     clip_depth: Depth,
@@ -90,7 +90,7 @@ impl<'gc> Default for DisplayObjectBase<'gc> {
             parent: Default::default(),
             place_frame: Default::default(),
             depth: Default::default(),
-            level: Default::default(),
+            level_id: Default::default(),
             transform: Default::default(),
             name: Default::default(),
             clip_depth: Default::default(),
@@ -124,12 +124,12 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.depth = depth;
     }
 
-    fn level(&self) -> LevelId {
-        self.level
+    fn level_id(&self) -> LevelId {
+        self.level_id
     }
 
-    fn set_level(&mut self, level: LevelId) {
-        self.level = level;
+    fn set_level_id(&mut self, id: LevelId) {
+        self.level_id = id;
     }
 
     fn place_frame(&self) -> u16 {
@@ -456,8 +456,8 @@ pub trait TDisplayObject<'gc>:
     fn id(&self) -> CharacterId;
     fn depth(&self) -> Depth;
     fn set_depth(&self, gc_context: MutationContext<'gc, '_>, depth: Depth);
-    fn level(&self) -> LevelId;
-    fn set_level(&self, gc_context: MutationContext<'gc, '_>, level: LevelId);
+    fn level_id(&self) -> LevelId;
+    fn set_level_id(&self, gc_context: MutationContext<'gc, '_>, id: LevelId);
 
     /// The untransformed inherent bounding box of this object.
     /// These bounds do **not** include child DisplayObjects.
@@ -762,7 +762,7 @@ pub trait TDisplayObject<'gc>:
             };
             if is_level {
                 if let Some(level_id) = name.get(6..).and_then(|v| v.parse::<LevelId>().ok()) {
-                    return context.levels.level_at(level_id);
+                    return context.levels.at(level_id);
                 }
             }
         }
@@ -1285,11 +1285,11 @@ macro_rules! impl_display_object_sansbounds {
         fn set_depth(&self, gc_context: gc_arena::MutationContext<'gc, '_>, depth: Depth) {
             self.0.write(gc_context).$field.set_depth(depth)
         }
-        fn level(&self) -> LevelId {
-            self.0.read().$field.level()
+        fn level_id(&self) -> LevelId {
+            self.0.read().$field.level_id()
         }
-        fn set_level(&self, gc_context: gc_arena::MutationContext<'gc, '_>, level: LevelId) {
-            self.0.write(gc_context).$field.set_level(level)
+        fn set_level_id(&self, gc_context: gc_arena::MutationContext<'gc, '_>, id: LevelId) {
+            self.0.write(gc_context).$field.set_level_id(id)
         }
         fn place_frame(&self) -> u16 {
             self.0.read().$field.place_frame()

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -186,12 +186,6 @@ pub struct DisplayObjectBase<'gc> {
     prev_global: Option<DisplayObject<'gc>>,
     next_global: Option<DisplayObject<'gc>>,
 
-    /// The previous sibling of this display object in order of execution.
-    prev_sibling: Option<DisplayObject<'gc>>,
-
-    /// The next sibling of this display object in order of execution.
-    next_sibling: Option<DisplayObject<'gc>>,
-
     /// The sound transform of sounds playing via this display object.
     sound_transform: SoundTransform,
 
@@ -221,8 +215,6 @@ impl<'gc> Default for DisplayObjectBase<'gc> {
             skew: 0.0,
             prev_global: None,
             next_global: None,
-            prev_sibling: None,
-            next_sibling: None,
             masker: None,
             maskee: None,
             sound_transform: Default::default(),
@@ -454,22 +446,6 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.parent = parent;
     }
 
-    fn prev_sibling(&self) -> Option<DisplayObject<'gc>> {
-        self.prev_sibling
-    }
-
-    fn set_prev_sibling(&mut self, node: Option<DisplayObject<'gc>>) {
-        self.prev_sibling = node;
-    }
-
-    fn next_sibling(&self) -> Option<DisplayObject<'gc>> {
-        self.next_sibling
-    }
-
-    fn set_next_sibling(&mut self, node: Option<DisplayObject<'gc>>) {
-        self.next_sibling = node;
-    }
-
     fn prev_global(&self) -> Option<DisplayObject<'gc>> {
         self.prev_global
     }
@@ -634,7 +610,7 @@ pub trait TDisplayObject<'gc>:
         let mut bounds = self.self_bounds().transform(matrix);
 
         if let Some(ctr) = self.as_container() {
-            for child in ctr.iter_execution_list() {
+            for child in ctr.iter_render_list() {
                 let matrix = *matrix * *child.matrix();
                 bounds.union(&child.bounds_with_transform(&matrix));
             }
@@ -868,16 +844,6 @@ pub trait TDisplayObject<'gc>:
     fn set_clip_depth(&self, gc_context: MutationContext<'gc, '_>, depth: Depth);
     fn parent(&self) -> Option<DisplayObject<'gc>>;
     fn set_parent(&self, gc_context: MutationContext<'gc, '_>, parent: Option<DisplayObject<'gc>>);
-    fn prev_sibling(&self) -> Option<DisplayObject<'gc>>;
-    fn set_prev_sibling(
-        &self,
-        gc_context: MutationContext<'gc, '_>,
-        node: Option<DisplayObject<'gc>>,
-    );
-    fn next_sibling(&self) -> Option<DisplayObject<'gc>>;
-    fn set_next_sibling(&self, gc_context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>);
-    fn global_exec_list(&self) -> Option<DisplayObject<'gc>>;
-    fn set_global_exec_list(&self, context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>);
     fn prev_global(&self) -> Option<DisplayObject<'gc>>;
     fn set_prev_global(&self, context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>);
     fn next_global(&self) -> Option<DisplayObject<'gc>>;
@@ -1113,7 +1079,8 @@ pub trait TDisplayObject<'gc>:
     fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Unload children.
         if let Some(ctr) = self.as_container() {
-            for child in ctr.iter_execution_list() {
+            // TODO: fix order?
+            for child in ctr.iter_render_list() {
                 child.unload(context);
             }
         }
@@ -1529,26 +1496,6 @@ macro_rules! impl_display_object_sansbounds {
             parent: Option<crate::display_object::DisplayObject<'gc>>,
         ) {
             self.0.write(context).$field.set_parent(parent)
-        }
-        fn prev_sibling(&self) -> Option<DisplayObject<'gc>> {
-            self.0.read().$field.prev_sibling()
-        }
-        fn set_prev_sibling(
-            &self,
-            context: gc_arena::MutationContext<'gc, '_>,
-            node: Option<DisplayObject<'gc>>,
-        ) {
-            self.0.write(context).$field.set_prev_sibling(node);
-        }
-        fn next_sibling(&self) -> Option<DisplayObject<'gc>> {
-            self.0.read().$field.next_sibling()
-        }
-        fn set_next_sibling(
-            &self,
-            context: gc_arena::MutationContext<'gc, '_>,
-            node: Option<DisplayObject<'gc>>,
-        ) {
-            self.0.write(context).$field.set_next_sibling(node);
         }
         fn prev_global(&self) -> Option<DisplayObject<'gc>> {
             self.0.read().$field.prev_global()

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -72,10 +72,11 @@ impl<'gc> Levels<'gc> {
 
     pub fn insert(&mut self, depth: u32, level: DisplayObject<'gc>) {
         let exec_list = self.get_exec_list(depth);
+        self.0.insert(depth, Level::new(level));
+        // TODO: remove?
         if exec_list.is_some() {
             self.set_exec_list(depth, exec_list);
         }
-        self.0.insert(depth, Level::new(level));
     }
 
     pub fn iter(&self) -> Values<u32, Level<'gc>> {
@@ -233,11 +234,7 @@ impl<'gc> Default for DisplayObjectBase<'gc> {
 #[allow(dead_code)]
 impl<'gc> DisplayObjectBase<'gc> {
     fn level(&self) -> u32 {
-        if let Some(parent) = self.parent {
-            parent.level()
-        } else {
-            self.level
-        }
+        self.level
     }
 
     fn set_level(&mut self, _context: MutationContext<'gc, '_>, level: u32) {
@@ -918,7 +915,7 @@ pub trait TDisplayObject<'gc>:
             };
             if is_level {
                 if let Some(level_id) = name.get(6..).and_then(|v| v.parse::<u32>().ok()) {
-                    return context.levels.get(level_id).copied(); // TODO: copied?
+                    return context.levels.get(level_id).copied();
                 }
             }
         }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -900,7 +900,8 @@ pub trait TDisplayObject<'gc>:
     /// Run any frame scripts (if they exist and this object needs to run them).
     fn run_frame_scripts(self, context: &mut UpdateContext<'_, 'gc, '_>) {
         if let Some(container) = self.as_container() {
-            for child in container.iter_execution_list() {
+            // TODO: in what order?
+            for child in container.iter_render_list() {
                 child.run_frame_scripts(context);
             }
         }
@@ -1216,8 +1217,8 @@ pub trait TDisplayObject<'gc>:
         let ancestor = ancestor.unwrap_or_else(|| self.into());
         context
             .levels
-            .values()
-            .any(|o| DisplayObject::ptr_eq(*o, ancestor))
+            .iter_roots()
+            .any(|o| DisplayObject::ptr_eq(o, ancestor))
     }
 
     /// Obtain the top-most parent of the display tree hierarchy, or some kind

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -960,7 +960,7 @@ pub trait TDisplayObject<'gc>:
     fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Unload children.
         if let Some(ctr) = self.as_container() {
-            // TODO: fix order?
+            // TODO: in what order?
             for child in ctr.iter_render_list() {
                 child.unload(context);
             }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -762,7 +762,7 @@ pub trait TDisplayObject<'gc>:
             };
             if is_level {
                 if let Some(level_id) = name.get(6..).and_then(|v| v.parse::<LevelId>().ok()) {
-                    return context.levels.at(level_id);
+                    return context.levels.get(level_id);
                 }
             }
         }

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -337,7 +337,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         point: (Twips, Twips),
     ) -> bool {
-        for child in self.iter_execution_list() {
+        for child in self.iter_render_list() {
             if child.hit_test_shape(context, point) {
                 return true;
             }
@@ -415,7 +415,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         }
 
         if event.propagates() {
-            for child in self.iter_execution_list() {
+            for child in self.iter_render_list() {
                 if child.handle_clip_event(context, event) == ClipEventResult::Handled {
                     return ClipEventResult::Handled;
                 }

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -137,7 +137,7 @@ impl<'gc> Button<'gc> {
             self.iter_render_list().map(|o| o.depth()).collect();
 
         let movie = self.movie().unwrap();
-        let level = self.level();
+        let level_id = self.level_id();
         let mut write = self.0.write(context.gc_context);
         write.state = state;
         let swf_state = match state {
@@ -170,7 +170,7 @@ impl<'gc> Button<'gc> {
                         {
                             // New child that did not previously exist, create it.
                             child.set_parent(context.gc_context, Some(self.into()));
-                            child.set_level(context.gc_context, level);
+                            child.set_level_id(context.gc_context, level_id);
                             child.set_depth(context.gc_context, record.depth.into());
 
                             children.push((child, record.depth));
@@ -295,7 +295,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
                         Ok(child) => {
                             child.set_matrix(context.gc_context, &record.matrix);
                             child.set_parent(context.gc_context, Some(self_display_object));
-                            child.set_level(context.gc_context, self_display_object.level());
+                            child.set_level_id(context.gc_context, self_display_object.level_id());
                             child.set_depth(context.gc_context, record.depth.into());
                             new_children.push((child, record.depth.into()));
                         }

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -354,6 +354,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
     ) -> Option<DisplayObject<'gc>> {
         // The button is hovered if the mouse is over any child nodes.
         if self.visible() {
+            // TODO: in what order?
             for child in self.iter_render_list().rev() {
                 let result = child.mouse_pick(context, child, point);
                 if result.is_some() {
@@ -415,6 +416,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         }
 
         if event.propagates() {
+            // TODO: in what order?
             for child in self.iter_render_list() {
                 if child.handle_clip_event(context, event) == ClipEventResult::Handled {
                     return ClipEventResult::Handled;

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -137,6 +137,7 @@ impl<'gc> Button<'gc> {
             self.iter_render_list().map(|o| o.depth()).collect();
 
         let movie = self.movie().unwrap();
+        let level = self.level();
         let mut write = self.0.write(context.gc_context);
         write.state = state;
         let swf_state = match state {
@@ -169,6 +170,7 @@ impl<'gc> Button<'gc> {
                         {
                             // New child that did not previously exist, create it.
                             child.set_parent(context.gc_context, Some(self.into()));
+                            child.set_level(context.gc_context, level);
                             child.set_depth(context.gc_context, record.depth.into());
 
                             children.push((child, record.depth));
@@ -293,6 +295,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
                         Ok(child) => {
                             child.set_matrix(context.gc_context, &record.matrix);
                             child.set_parent(context.gc_context, Some(self_display_object));
+                            child.set_level(context.gc_context, self_display_object.level());
                             child.set_depth(context.gc_context, record.depth.into());
                             new_children.push((child, record.depth.into()));
                         }

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -318,10 +318,6 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
                     .insert(depth, child);
             }
         }
-
-        for child in self.iter_execution_list() {
-            child.run_frame(context);
-        }
     }
 
     fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -157,19 +157,19 @@ bitflags! {
 pub trait TDisplayObjectContainer<'gc>:
     'gc + Clone + Copy + Collect + Debug + Into<DisplayObjectContainer<'gc>>
 {
-    /// Get a child display object by it's position in the render list.
+    /// Get a child display object by its position in the render list.
     ///
     /// The `index` provided here should not be confused with the `Depth`s used
     /// to index the depth list.
     fn child_by_index(self, index: usize) -> Option<DisplayObject<'gc>>;
 
-    /// Get a child display object by it's position in the depth list.
+    /// Get a child display object by its position in the depth list.
     ///
     /// The `Depth` provided here should not be confused with the `index`s used
     /// to index the render list.
     fn child_by_depth(self, depth: Depth) -> Option<DisplayObject<'gc>>;
 
-    /// Get a child display object by it's instance/timeline name.
+    /// Get a child display object by its instance/timeline name.
     ///
     /// The `case_sensitive` parameter determines if we should consider
     /// children with different capitalizations as being distinct names.
@@ -181,6 +181,10 @@ pub trait TDisplayObjectContainer<'gc>:
 
     /// Returns the number of children on the render list.
     fn num_children(self) -> usize;
+
+    /// Returns the lowest depth on the render list, or `None` if no children
+    /// exist on the depth list.
+    fn lowest_depth(self) -> Option<Depth>;
 
     /// Returns the highest depth on the render list, or `None` if no children
     /// exist on the depth list.
@@ -251,7 +255,7 @@ pub trait TDisplayObjectContainer<'gc>:
     /// You can control which lists a child should be removed from with the
     /// `from_lists` parameter. If a list is omitted from `from_lists`, then
     /// not only will the child remain, but the return code will also not take
-    /// it's presence in the list into account.
+    /// its presence in the list into account.
     fn remove_child(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
@@ -282,6 +286,10 @@ pub trait TDisplayObjectContainer<'gc>:
     /// limitations.
     fn iter_render_list(self) -> RenderIter<'gc> {
         RenderIter::from_container(self.into())
+    }
+
+    fn iter_children_by_depth(self) -> DepthIter<'gc> {
+        DepthIter::from_container(self.into())
     }
 
     /// Renders the children of this container in render list order.
@@ -347,6 +355,10 @@ macro_rules! impl_display_object_container {
 
         fn num_children(self) -> usize {
             self.0.read().$field.num_children()
+        }
+
+        fn lowest_depth(self) -> Option<Depth> {
+            self.0.read().$field.lowest_depth()
         }
 
         fn highest_depth(self) -> Option<Depth> {
@@ -683,6 +695,12 @@ impl<'gc> ChildContainer<'gc> {
         }
     }
 
+    /// Returns the lowest depth in use by this container, or `None` if there
+    /// are no children.
+    pub fn lowest_depth(&self) -> Option<Depth> {
+        self.depth_list.keys().copied().next()
+    }
+
     /// Returns the highest depth in use by this container, or `None` if there
     /// are no children.
     pub fn highest_depth(&self) -> Option<Depth> {
@@ -699,7 +717,7 @@ impl<'gc> ChildContainer<'gc> {
         self.depth_list.get(&depth).copied()
     }
 
-    /// Get a child by it's instance/timeline name.
+    /// Get a child by its instance/timeline name.
     ///
     /// The `case_sensitive` parameter determines if we should consider
     /// children with different capitalizations as being distinct names.
@@ -723,7 +741,7 @@ impl<'gc> ChildContainer<'gc> {
         }
     }
 
-    /// Get a child by it's render list position (ID).
+    /// Get a child by its render list position (ID).
     pub fn get_id(&self, id: usize) -> Option<DisplayObject<'gc>> {
         self.render_list.get(id).copied()
     }
@@ -905,7 +923,7 @@ impl<'gc> RenderIter<'gc> {
 impl<'gc> Iterator for RenderIter<'gc> {
     type Item = DisplayObject<'gc>;
 
-    fn next(&mut self) -> Option<DisplayObject<'gc>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.i == self.neg_i {
             return None;
         }
@@ -929,5 +947,39 @@ impl<'gc> DoubleEndedIterator for RenderIter<'gc> {
         self.neg_i -= 1;
 
         this
+    }
+}
+
+pub struct DepthIter<'gc> {
+    container: DisplayObjectContainer<'gc>,
+    depth: Option<Depth>,
+    lowest_depth: Option<Depth>,
+}
+
+impl<'gc> DepthIter<'gc> {
+    fn from_container(container: DisplayObjectContainer<'gc>) -> Self {
+        Self {
+            container,
+            depth: container.highest_depth(),
+            lowest_depth: container.lowest_depth(),
+        }
+    }
+}
+
+impl<'gc> Iterator for DepthIter<'gc> {
+    type Item = (Depth, DisplayObject<'gc>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut depth = self.depth?;
+        loop {
+            if depth < self.lowest_depth.unwrap() {
+                return None;
+            }
+            if let Some(child) = self.container.child_by_depth(depth) {
+                self.depth = Some(depth - 1);
+                return Some((depth, child));
+            }
+            depth -= 1;
+        }
     }
 }

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -448,6 +448,7 @@ macro_rules! impl_display_object_container {
             context.add_node(child);
 
             child.set_parent(context.gc_context, Some(self.into()));
+            child.set_level(context.gc_context, self.level());
             child.set_place_frame(context.gc_context, 0);
             child.set_depth(context.gc_context, depth);
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -371,6 +371,11 @@ macro_rules! impl_display_object_container {
             child: DisplayObject<'gc>,
             depth: Depth,
         ) -> Option<DisplayObject<'gc>> {
+            child.set_parent(context.gc_context, Some(self.into()));
+            child.set_depth(context.gc_context, depth);
+            child.set_level_id(context.gc_context, self.level_id());
+            child.set_place_frame(context.gc_context, 0);
+
             let mut write = self.0.write(context.gc_context);
 
             let prev_child = write.$field.insert_child_into_depth_list(depth, child);
@@ -418,12 +423,6 @@ macro_rules! impl_display_object_container {
                 context.remove_from_execution_list(removed_child);
             }
             context.add_to_execution_list(child);
-
-            child.set_parent(context.gc_context, Some(self.into()));
-            child.set_level_id(context.gc_context, self.level_id());
-            child.set_place_frame(context.gc_context, 0);
-            child.set_depth(context.gc_context, depth);
-
             if let Some(removed_child) = removed_child {
                 removed_child.unload(context);
                 removed_child.set_parent(context.gc_context, None);

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -442,11 +442,11 @@ macro_rules! impl_display_object_container {
 
             drop(write);
 
-            let mut level0 = context.levels.get_mut(&0).copied().unwrap();
             if let Some(removed_child) = removed_child {
-                level0.remove_child_from_global_exec_list(context, removed_child);
+                context
+                    .remove_node(removed_child);
             }
-            level0.add_child_to_global_exec_list(context.gc_context, child);
+            context.add_node(child);
 
             child.set_parent(context.gc_context, Some(self.into()));
             child.set_place_frame(context.gc_context, 0);
@@ -561,8 +561,7 @@ macro_rules! impl_display_object_container {
             drop(write);
 
             if from_lists.contains(Lists::EXECUTION) {
-                let mut level0 = context.levels.get_mut(&0).copied().unwrap();
-                level0.remove_child_from_global_exec_list(context, child);
+                context.remove_node(child);
             }
 
             if removed_from_execution_list {
@@ -604,11 +603,9 @@ macro_rules! impl_display_object_container {
                 write.$field.remove_child_from_render_list(removed);
                 write.$field.remove_child_from_depth_list(removed);
                 write.$field.remove_child_from_exec_list(context, removed);
-
                 drop(write);
 
-                let mut level0 = context.levels.get_mut(&0).copied().unwrap();
-                level0.remove_child_from_global_exec_list(context, removed);
+                context.remove_node(removed);
 
                 removed.unload(context);
 
@@ -873,8 +870,6 @@ impl<'gc> ChildContainer<'gc> {
     /// position will be shifted back by one, which must be taken into account
     /// when calculating future insertion IDs.
     ///
-    /// `parent` should be the display object that owns this container.
-    ///
     /// All children at or after the given ID will be shifted down in the
     /// render list. The child will *not* be put onto the depth list.
     pub fn insert_at_id(
@@ -902,8 +897,7 @@ impl<'gc> ChildContainer<'gc> {
         } else {
             self.render_list.insert(id, child);
             self.add_child_to_exec_list(context.gc_context, child);
-            let mut level0 = context.levels.get_mut(&0).copied().unwrap();
-            level0.add_child_to_global_exec_list(context.gc_context, child);
+            context.add_node(child);
         }
     }
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -420,9 +420,13 @@ macro_rules! impl_display_object_container {
             drop(write);
 
             if let Some(removed_child) = removed_child {
-                context.levels.remove_from_execution_list(context.gc_context, removed_child);
+                context
+                    .levels
+                    .remove_from_execution_list(context.gc_context, removed_child);
             }
-            context.levels.add_to_execution_list(context.gc_context, child);
+            context
+                .levels
+                .add_to_execution_list(context.gc_context, child);
             if let Some(removed_child) = removed_child {
                 removed_child.unload(context);
                 removed_child.set_parent(context.gc_context, None);
@@ -483,7 +487,9 @@ macro_rules! impl_display_object_container {
             let inserted = write.$field.insert_at_id(child, index);
             drop(write);
             if inserted {
-                context.levels.add_to_execution_list(context.gc_context, child);
+                context
+                    .levels
+                    .add_to_execution_list(context.gc_context, child);
             }
 
             if parent_changed {
@@ -531,7 +537,9 @@ macro_rules! impl_display_object_container {
             }
             drop(write);
             if from_lists.contains(Lists::EXECUTION) {
-                context.levels.remove_from_execution_list(context.gc_context, child);
+                context
+                    .levels
+                    .remove_from_execution_list(context.gc_context, child);
 
                 child.unload(context);
 
@@ -570,7 +578,9 @@ macro_rules! impl_display_object_container {
                 write.$field.remove_child_from_depth_list(removed);
                 drop(write);
 
-                context.levels.remove_from_execution_list(context.gc_context, removed);
+                context
+                    .levels
+                    .remove_from_execution_list(context.gc_context, removed);
 
                 removed.unload(context);
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -415,9 +415,9 @@ macro_rules! impl_display_object_container {
             drop(write);
 
             if let Some(removed_child) = removed_child {
-                context.remove_node(removed_child);
+                context.remove_from_execution_list(removed_child);
             }
-            context.add_node(child);
+            context.add_to_execution_list(child);
 
             child.set_parent(context.gc_context, Some(self.into()));
             child.set_level(context.gc_context, self.level());
@@ -531,7 +531,7 @@ macro_rules! impl_display_object_container {
             drop(write);
 
             let removed_from_execution_list =
-                from_lists.contains(Lists::EXECUTION) && context.remove_node(child);
+                from_lists.contains(Lists::EXECUTION) && context.remove_from_execution_list(child);
 
             if removed_from_execution_list {
                 child.unload(context);
@@ -573,7 +573,7 @@ macro_rules! impl_display_object_container {
                 write.$field.remove_child_from_depth_list(removed);
                 drop(write);
 
-                context.remove_node(removed);
+                context.remove_from_execution_list(removed);
 
                 removed.unload(context);
 
@@ -802,7 +802,7 @@ impl<'gc> ChildContainer<'gc> {
             }
         } else {
             self.render_list.insert(id, child);
-            context.add_node(child);
+            context.add_to_execution_list(child);
         }
     }
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -443,8 +443,7 @@ macro_rules! impl_display_object_container {
             drop(write);
 
             if let Some(removed_child) = removed_child {
-                context
-                    .remove_node(removed_child);
+                context.remove_node(removed_child);
             }
             context.add_node(child);
 
@@ -723,7 +722,7 @@ impl<'gc> ChildContainer<'gc> {
     /// unset the parent either as that's expected to happen after unloading.
     pub fn remove_child_from_exec_list(
         &mut self,
-        context: &UpdateContext<'_, 'gc, '_>,
+        context: &mut UpdateContext<'_, 'gc, '_>,
         child: DisplayObject<'gc>,
     ) -> bool {
         // Remove from children linked list.

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -420,7 +420,7 @@ macro_rules! impl_display_object_container {
             context.add_to_execution_list(child);
 
             child.set_parent(context.gc_context, Some(self.into()));
-            child.set_level(context.gc_context, self.level());
+            child.set_level_id(context.gc_context, self.level_id());
             child.set_place_frame(context.gc_context, 0);
             child.set_depth(context.gc_context, depth);
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -875,6 +875,7 @@ impl<'gc> ChildContainer<'gc> {
 
     /// Remove all children from the container's render and depth lists.
     pub fn clear(&mut self, _gc_context: MutationContext<'gc, '_>) {
+        // TODO: remove from global execution list?
         self.render_list.clear();
         self.depth_list.clear();
     }

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -420,9 +420,9 @@ macro_rules! impl_display_object_container {
             drop(write);
 
             if let Some(removed_child) = removed_child {
-                context.remove_from_execution_list(removed_child);
+                context.levels.remove_from_execution_list(context.gc_context, removed_child);
             }
-            context.add_to_execution_list(child);
+            context.levels.add_to_execution_list(context.gc_context, child);
             if let Some(removed_child) = removed_child {
                 removed_child.unload(context);
                 removed_child.set_parent(context.gc_context, None);
@@ -483,7 +483,7 @@ macro_rules! impl_display_object_container {
             let inserted = write.$field.insert_at_id(child, index);
             drop(write);
             if inserted {
-                context.add_to_execution_list(child);
+                context.levels.add_to_execution_list(context.gc_context, child);
             }
 
             if parent_changed {
@@ -531,7 +531,7 @@ macro_rules! impl_display_object_container {
             }
             drop(write);
             if from_lists.contains(Lists::EXECUTION) {
-                context.remove_from_execution_list(child);
+                context.levels.remove_from_execution_list(context.gc_context, child);
 
                 child.unload(context);
 
@@ -570,7 +570,7 @@ macro_rules! impl_display_object_container {
                 write.$field.remove_child_from_depth_list(removed);
                 drop(write);
 
-                context.remove_from_execution_list(removed);
+                context.levels.remove_from_execution_list(context.gc_context, removed);
 
                 removed.unload(context);
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -179,9 +179,6 @@ pub trait TDisplayObjectContainer<'gc>:
     /// this mechanism.
     fn child_by_name(self, name: &str, case_sensitive: bool) -> Option<DisplayObject<'gc>>;
 
-    /// Yield the head of the execution list.
-    fn first_executed_child(self) -> Option<DisplayObject<'gc>>;
-
     /// Returns the number of children on the render list.
     fn num_children(self) -> usize;
 
@@ -195,16 +192,12 @@ pub trait TDisplayObjectContainer<'gc>:
     /// After inserting the child into the depth list, we will attempt to
     /// assign it a render list position one after the previous item in the
     /// depth list. The position that children are placed into the render list
-    /// matches Flash Player behavior. The child will also be placed at the end
-    /// of the execution list.
+    /// matches Flash Player behavior.
     ///
     /// Any child removed from the depth list will also be removed from the
-    /// render and execution lists if and only if the child was not flagged as
-    /// being placed by script. If such a child was removed from said lists, it
-    /// will be returned here. Otherwise, this method returns `None`.
-    ///
-    /// Note: this method specifically does *not* dispatch events on any
-    /// children it modifies. You must do this yourself.
+    /// render list if and only if the child was not flagged as being placed by script.
+    /// If such a child was removed from said list, it will be returned here.
+    /// Otherwise, this method returns `None`.
     fn replace_at_depth(
         self,
         context: &mut UpdateContext<'_, 'gc, '_>,
@@ -216,9 +209,8 @@ pub trait TDisplayObjectContainer<'gc>:
     ///
     /// Any child already at the desired position will move back to the new
     /// child's former position. The render list positions of each child will
-    /// also be swapped, while the execution list will remain unchanged. If no
-    /// child has been displaced by the swap operation, then the render list
-    /// position of the child will be determined in the same way as
+    /// also be swapped. If no child has been displaced by the swap operation,
+    /// then the render list position of the child will be determined in the same way as
     /// `replace_at_depth`.
     fn swap_at_depth(
         &mut self,
@@ -230,10 +222,10 @@ pub trait TDisplayObjectContainer<'gc>:
     /// Insert a child display object into the container at a specific position
     /// in the render list.
     ///
-    /// This function does not adjust the depth or execution lists. Callers of
-    /// this method should be aware that reordering items onto or off of the
-    /// render list can make further depth list manipulations (e.g. from the
-    /// timeline) produce unusual results.
+    /// This function does not adjust the depth list. Callers of this method
+    /// should be aware that reordering items onto or off of the render list
+    /// can make further depth list manipulations (e.g. from the timeline)
+    /// produce unusual results.
     fn insert_at_index(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
@@ -251,8 +243,7 @@ pub trait TDisplayObjectContainer<'gc>:
         index2: usize,
     );
 
-    /// Remove a child display object from this container's render, depth, and
-    /// execution lists.
+    /// Remove a child display object from this container's render and depth lists.
     ///
     /// If the child was found on any of the container's lists, this function
     /// will return `true`.
@@ -269,7 +260,7 @@ pub trait TDisplayObjectContainer<'gc>:
     ) -> bool;
 
     /// Remove a set of children identified by their render list indicies from
-    /// this container's render, depth, and execution lists.
+    /// this container's render and depth lists.
     fn remove_range<R>(&mut self, context: &mut UpdateContext<'_, 'gc, '_>, range: R)
     where
         R: RangeBounds<usize>;
@@ -280,24 +271,7 @@ pub trait TDisplayObjectContainer<'gc>:
     /// Determine if the container is empty.
     fn is_empty(self) -> bool;
 
-    /// Iterates over the children of this display object in execution order.
-    /// This is different than render or depth order.
-    ///
-    /// This yields an iterator that does *not* lock the parent and can be
-    /// safely held in situations where display objects need to be unlocked.
-    /// This means that unexpected but legal and defined items may be yielded
-    /// due to intended or unintended list manipulation by the caller.
-    ///
-    /// The iterator's concrete type is stated here due to Rust language
-    /// limitations.
-    fn iter_execution_list(self) -> ExecIter<'gc> {
-        ExecIter {
-            cur_child: self.first_executed_child(),
-        }
-    }
-
-    /// Iterates over the children of this display object in render order. This
-    /// is different than execution or depth order.
+    /// Iterates over the children of this display object in render order.
     ///
     /// This yields an iterator that does *not* lock the parent and can be
     /// safely held in situations where display objects need to be unlocked.
@@ -371,10 +345,6 @@ macro_rules! impl_display_object_container {
             self.0.read().$field.get_name(name, case_sensitive)
         }
 
-        fn first_executed_child(self) -> Option<DisplayObject<'gc>> {
-            self.0.read().$field.first_executed_child()
-        }
-
         fn num_children(self) -> usize {
             self.0.read().$field.num_children()
         }
@@ -429,16 +399,6 @@ macro_rules! impl_display_object_container {
                     None
                 }
             };
-
-            if let Some(removed_child) = removed_child {
-                write
-                    .$field
-                    .remove_child_from_exec_list(context, removed_child);
-            }
-
-            write
-                .$field
-                .add_child_to_exec_list(context.gc_context, child);
 
             drop(write);
 
@@ -555,14 +515,11 @@ macro_rules! impl_display_object_container {
                 && write.$field.remove_child_from_depth_list(child);
             let removed_from_render_list = from_lists.contains(Lists::RENDER)
                 && write.$field.remove_child_from_render_list(child);
-            let removed_from_execution_list = from_lists.contains(Lists::EXECUTION)
-                && write.$field.remove_child_from_exec_list(context, child);
 
             drop(write);
 
-            if from_lists.contains(Lists::EXECUTION) {
-                context.remove_node(child);
-            }
+            let removed_from_execution_list =
+                from_lists.contains(Lists::EXECUTION) && context.remove_node(child);
 
             if removed_from_execution_list {
                 child.unload(context);
@@ -602,7 +559,6 @@ macro_rules! impl_display_object_container {
             for removed in removed_list {
                 write.$field.remove_child_from_render_list(removed);
                 write.$field.remove_child_from_depth_list(removed);
-                write.$field.remove_child_from_exec_list(context, removed);
                 drop(write);
 
                 context.remove_node(removed);
@@ -668,12 +624,6 @@ pub struct ChildContainer<'gc> {
     /// exclusively with the depth list. However, AS3 instead references clips
     /// by render list indexes and does not manipulate the depth list.
     depth_list: BTreeMap<Depth, DisplayObject<'gc>>,
-
-    /// The execution-order list for display objects' AVM1 scripts.
-    ///
-    /// This list is an intrusive linked list baked into all display objects.
-    /// Thus, this merely references the first item in the list.
-    exec_list: Option<DisplayObject<'gc>>,
 }
 
 impl<'gc> Default for ChildContainer<'gc> {
@@ -687,69 +637,7 @@ impl<'gc> ChildContainer<'gc> {
         ChildContainer {
             render_list: Vec::new(),
             depth_list: BTreeMap::new(),
-            exec_list: None,
         }
-    }
-
-    /// Get the head of the execution list.
-    pub fn first_executed_child(&self) -> Option<DisplayObject<'gc>> {
-        self.exec_list
-    }
-
-    /// Adds a child to the front of the execution list.
-    ///
-    /// This does not affect the render or depth lists.
-    pub fn add_child_to_exec_list(
-        &mut self,
-        gc_context: MutationContext<'gc, '_>,
-        child: DisplayObject<'gc>,
-    ) {
-        if let Some(head) = self.exec_list {
-            head.set_prev_sibling(gc_context, Some(child));
-            child.set_next_sibling(gc_context, Some(head));
-        }
-
-        self.exec_list = Some(child);
-    }
-
-    /// Removes a child from the execution list.
-    ///
-    /// This returns `true` if the child was successfully removed, and `false`
-    /// if no list alterations were made.
-    ///
-    /// This does not affect the render or depth lists, nor does it unload the
-    /// child. You must unload the child yourself in a clean stack frame, as
-    /// display objects are permitted to run code when unloading. We also don't
-    /// unset the parent either as that's expected to happen after unloading.
-    pub fn remove_child_from_exec_list(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        child: DisplayObject<'gc>,
-    ) -> bool {
-        // Remove from children linked list.
-        let prev = child.prev_sibling();
-        let next = child.next_sibling();
-        let present_on_execution_list = prev.is_some()
-            || next.is_some()
-            || (self.exec_list.is_some() && DisplayObject::ptr_eq(self.exec_list.unwrap(), child));
-
-        if let Some(prev) = prev {
-            prev.set_next_sibling(context.gc_context, next);
-        }
-        if let Some(next) = next {
-            next.set_prev_sibling(context.gc_context, prev);
-        }
-
-        child.set_prev_sibling(context.gc_context, None);
-        child.set_next_sibling(context.gc_context, None);
-
-        if let Some(head) = self.exec_list {
-            if DisplayObject::ptr_eq(head, child) {
-                self.exec_list = next;
-            }
-        }
-
-        present_on_execution_list
     }
 
     /// Add a child to the depth list.
@@ -896,7 +784,6 @@ impl<'gc> ChildContainer<'gc> {
             }
         } else {
             self.render_list.insert(id, child);
-            self.add_child_to_exec_list(context.gc_context, child);
             context.add_node(child);
         }
     }
@@ -968,21 +855,8 @@ impl<'gc> ChildContainer<'gc> {
         }
     }
 
-    /// Remove all children from the container's execution, render, and depth
-    /// lists.
-    pub fn clear(&mut self, gc_context: MutationContext<'gc, '_>) {
-        let mut head = self.exec_list;
-
-        while let Some(child) = head {
-            let next_head = child.next_sibling();
-
-            child.set_next_sibling(gc_context, None);
-            child.set_prev_sibling(gc_context, None);
-
-            head = next_head;
-        }
-
-        self.exec_list = None;
+    /// Remove all children from the container's render and depth lists.
+    pub fn clear(&mut self, _gc_context: MutationContext<'gc, '_>) {
         self.render_list.clear();
         self.depth_list.clear();
     }
@@ -1009,24 +883,6 @@ impl<'gc> ChildContainer<'gc> {
     /// Yield children in the order they are rendered.
     pub fn iter_render_list<'a>(&'a self) -> impl 'a + Iterator<Item = DisplayObject<'gc>> {
         self.render_list.iter().copied()
-    }
-}
-
-pub struct ExecIter<'gc> {
-    cur_child: Option<DisplayObject<'gc>>,
-}
-
-impl<'gc> Iterator for ExecIter<'gc> {
-    type Item = DisplayObject<'gc>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let cur = self.cur_child;
-
-        self.cur_child = self
-            .cur_child
-            .and_then(|display_cell| display_cell.next_sibling());
-
-        cur
     }
 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1141,34 +1141,31 @@ impl<'gc> MovieClip<'gc> {
             // Remove previous child from children list,
             // and add new child onto front of the list.
             let prev_child = self.replace_at_depth(context, child, depth);
-            {
-                // Set initial properties for child.
-                child.set_instantiated_by_timeline(context.gc_context, true);
-                child.set_depth(context.gc_context, depth);
-                child.set_parent(context.gc_context, Some(self_display_object));
-                child.set_level_id(context.gc_context, self_display_object.level_id());
-                if child.vm_type(context) == AvmType::Avm2 {
-                    // In AVM2 instantiation happens before frame advance so we
-                    // have to special-case that
-                    child.set_place_frame(context.gc_context, self.current_frame() + 1);
-                } else {
-                    child.set_place_frame(context.gc_context, self.current_frame());
+
+            // Set initial properties for child.
+            child.set_instantiated_by_timeline(context.gc_context, true);
+            if child.vm_type(context) == AvmType::Avm2 {
+                // In AVM2 instantiation happens before frame advance so we
+                // have to special-case that
+                child.set_place_frame(context.gc_context, self.current_frame() + 1);
+            } else {
+                child.set_place_frame(context.gc_context, self.current_frame());
+            }
+            if copy_previous_properties {
+                if let Some(prev_child) = prev_child {
+                    child.copy_display_properties_from(context.gc_context, prev_child);
                 }
-                if copy_previous_properties {
-                    if let Some(prev_child) = prev_child {
-                        child.copy_display_properties_from(context.gc_context, prev_child);
-                    }
-                }
-                // Run first frame.
-                child.apply_place_object(context, self.movie(), place_object);
-                child.construct_frame(context);
-                child.post_instantiation(context, child, None, Instantiator::Movie, false);
-                // In AVM1, children are added in `run_frame` so this is necessary.
-                // In AVM2 we add them in `construct_frame` so calling this causes
-                // duplicate frames
-                if child.vm_type(context) == AvmType::Avm1 {
-                    child.run_frame(context);
-                }
+            }
+
+            // Run first frame.
+            child.apply_place_object(context, self.movie(), place_object);
+            child.construct_frame(context);
+            child.post_instantiation(context, child, None, Instantiator::Movie, false);
+            // In AVM1, children are added in `run_frame` so this is necessary.
+            // In AVM2 we add them in `construct_frame` so calling this causes
+            // duplicate frames
+            if child.vm_type(context) == AvmType::Avm1 {
+                child.run_frame(context);
             }
 
             dispatch_added_event_only(child, context);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1087,16 +1087,16 @@ impl<'gc> MovieClip<'gc> {
         let tag_callback = |reader: &mut SwfStream<'_>, tag_code, tag_len| match tag_code {
             TagCode::DoAction => self.do_action(self_display_object, context, reader, tag_len),
             TagCode::PlaceObject if run_display_actions && vm_type == AvmType::Avm1 => {
-                self.place_object(self_display_object, context, reader, tag_len, 1)
+                self.place_object(context, reader, tag_len, 1)
             }
             TagCode::PlaceObject2 if run_display_actions && vm_type == AvmType::Avm1 => {
-                self.place_object(self_display_object, context, reader, tag_len, 2)
+                self.place_object(context, reader, tag_len, 2)
             }
             TagCode::PlaceObject3 if run_display_actions && vm_type == AvmType::Avm1 => {
-                self.place_object(self_display_object, context, reader, tag_len, 3)
+                self.place_object(context, reader, tag_len, 3)
             }
             TagCode::PlaceObject4 if run_display_actions && vm_type == AvmType::Avm1 => {
-                self.place_object(self_display_object, context, reader, tag_len, 4)
+                self.place_object(context, reader, tag_len, 4)
             }
             TagCode::RemoveObject if run_display_actions => self.remove_object(context, reader, 1),
             TagCode::RemoveObject2 if run_display_actions => self.remove_object(context, reader, 2),
@@ -1123,10 +1123,8 @@ impl<'gc> MovieClip<'gc> {
     }
 
     /// Instantiate a given child object on the timeline at a given depth.
-    #[allow(clippy::too_many_arguments)]
     fn instantiate_child(
         self,
-        self_display_object: DisplayObject<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         id: CharacterId,
         depth: Depth,
@@ -1337,7 +1335,6 @@ impl<'gc> MovieClip<'gc> {
                 }
                 _ => {
                     if let Some(child) = clip.instantiate_child(
-                        self_display_object,
                         context,
                         params.id(),
                         params.depth(),
@@ -3039,7 +3036,6 @@ impl<'gc, 'a> MovieClip<'gc> {
 
     fn place_object(
         self,
-        self_display_object: DisplayObject<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
         reader: &mut SwfStream<'a>,
         tag_len: usize,
@@ -3054,7 +3050,6 @@ impl<'gc, 'a> MovieClip<'gc> {
         match place_object.action {
             PlaceObjectAction::Place(id) | PlaceObjectAction::Replace(id) => {
                 if let Some(child) = self.instantiate_child(
-                    self_display_object,
                     context,
                     id,
                     place_object.depth.into(),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1146,6 +1146,7 @@ impl<'gc> MovieClip<'gc> {
                 child.set_instantiated_by_timeline(context.gc_context, true);
                 child.set_depth(context.gc_context, depth);
                 child.set_parent(context.gc_context, Some(self_display_object));
+                child.set_level(context.gc_context, self_display_object.level());
                 if child.vm_type(context) == AvmType::Avm2 {
                     // In AVM2 instantiation happens before frame advance so we
                     // have to special-case that

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1146,7 +1146,7 @@ impl<'gc> MovieClip<'gc> {
                 child.set_instantiated_by_timeline(context.gc_context, true);
                 child.set_depth(context.gc_context, depth);
                 child.set_parent(context.gc_context, Some(self_display_object));
-                child.set_level(context.gc_context, self_display_object.level());
+                child.set_level_id(context.gc_context, self_display_object.level_id());
                 if child.vm_type(context) == AvmType::Avm2 {
                     // In AVM2 instantiation happens before frame advance so we
                     // have to special-case that

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1873,6 +1873,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             // Maybe we could skip recursing down at all if !world_bounds.contains(point),
             // but a child button can have an invisible hit area outside the parent's bounds.
             for child in self.iter_render_list().rev() {
+                // TODO: in what order?
                 let result = child.mouse_pick(context, child, point);
                 if result.is_some() {
                     return result;
@@ -1908,7 +1909,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
 
         if event.propagates() {
-            for child in self.iter_render_list() {
+            // TODO: in what order?
+            for (_, child) in self.iter_children_by_depth() {
                 if child.handle_clip_event(context, event) == ClipEventResult::Handled {
                     return ClipEventResult::Handled;
                 }
@@ -1969,7 +1971,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        // TODO: fix order?
+        // TODO: in what order?
         for child in self.iter_render_list() {
             child.unload(context);
         }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1744,11 +1744,6 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn run_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        // Children must run first.
-        for child in self.iter_execution_list() {
-            child.run_frame(context);
-        }
-
         // Run my load/enterFrame clip event.
         let mut mc = self.0.write(context.gc_context);
         let is_load_frame = !mc.initialized();

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1829,7 +1829,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         point: (Twips, Twips),
     ) -> bool {
         if self.world_bounds().contains(point) {
-            for child in self.iter_execution_list() {
+            for child in self.iter_render_list() {
                 if child.hit_test_shape(context, point) {
                     return true;
                 }
@@ -1914,7 +1914,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
 
         if event.propagates() {
-            for child in self.iter_execution_list() {
+            for child in self.iter_render_list() {
                 if child.handle_clip_event(context, event) == ClipEventResult::Handled {
                     return ClipEventResult::Handled;
                 }
@@ -1975,7 +1975,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        for child in self.iter_execution_list() {
+        // TODO: fix order?
+        for child in self.iter_render_list() {
             child.unload(context);
         }
 

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -203,7 +203,7 @@ impl<'gc> Callback<'gc> {
     ) -> Value {
         match self {
             Callback::Avm1 { this, method } => {
-                let base_clip = *context.levels.get(0).unwrap();
+                let base_clip = context.levels.get(&0).unwrap().root();
                 let swf_version = context.swf.version();
                 let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -203,7 +203,7 @@ impl<'gc> Callback<'gc> {
     ) -> Value {
         match self {
             Callback::Avm1 { this, method } => {
-                let base_clip = context.levels.level_at(0).unwrap();
+                let base_clip = context.levels.at(0).unwrap();
                 let swf_version = context.swf.version();
                 let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -203,7 +203,7 @@ impl<'gc> Callback<'gc> {
     ) -> Value {
         match self {
             Callback::Avm1 { this, method } => {
-                let base_clip = *context.levels.get(&0).unwrap();
+                let base_clip = context.levels.get(0).unwrap();
                 let swf_version = context.swf.version();
                 let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -203,7 +203,7 @@ impl<'gc> Callback<'gc> {
     ) -> Value {
         match self {
             Callback::Avm1 { this, method } => {
-                let base_clip = context.levels.get(&0).unwrap().root();
+                let base_clip = context.levels.level_at(0).unwrap();
                 let swf_version = context.swf.version();
                 let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -203,7 +203,7 @@ impl<'gc> Callback<'gc> {
     ) -> Value {
         match self {
             Callback::Avm1 { this, method } => {
-                let base_clip = context.levels.get(0).unwrap();
+                let base_clip = *context.levels.get(0).unwrap();
                 let swf_version = context.swf.version();
                 let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -203,7 +203,7 @@ impl<'gc> Callback<'gc> {
     ) -> Value {
         match self {
             Callback::Avm1 { this, method } => {
-                let base_clip = context.levels.at(0).unwrap();
+                let base_clip = context.levels.get(0).unwrap();
                 let swf_version = context.swf.version();
                 let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.get(&0).copied().unwrap();
+        let level0 = context.levels.get(0).unwrap().clone(); // TODO: copied?
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.get(0).unwrap().clone(); // TODO: copied?
+        let level0 = context.levels.get(0).copied().unwrap(); // TODO: copied?
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.get(&0).copied().unwrap().root();
+        let level0 = context.levels.level_at(0).unwrap(); // copied?
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.level_at(0).unwrap(); // copied?
+        let level0 = context.levels.at(0).unwrap(); // copied?
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.get(0).copied().unwrap(); // TODO: copied?
+        let level0 = context.levels.get(0).copied().unwrap();
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.get(0).copied().unwrap();
+        let level0 = context.levels.get(&0).copied().unwrap().root();
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -43,7 +43,7 @@ impl<'gc> FocusTracker<'gc> {
 
         log::info!("Focus is now on {:?}", focused_element);
 
-        let level0 = context.levels.at(0).unwrap(); // copied?
+        let level0 = context.levels.get(0).unwrap(); // copied?
         Avm1::notify_system_listeners(
             level0,
             context.swf.version(),

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -1,74 +1,68 @@
-use gc_arena::{Collect, MutationContext};
 use crate::display_object::{DisplayObject, TDisplayObject};
+use gc_arena::{Collect, MutationContext};
 use std::collections::BTreeMap;
 
 pub type LevelId = u32;
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, Default)]
 #[collect(no_drop)]
-pub struct LevelsData<'gc> {
-    levels: BTreeMap<LevelId, Level<'gc>>,
-}
+pub struct LevelsData<'gc>(BTreeMap<LevelId, Level<'gc>>);
 
 impl<'gc> LevelsData<'gc> {
-    pub fn new() -> Self {
-        Self { levels: BTreeMap::new() }
-    }
+    pub fn insert(&mut self, gc_context: MutationContext<'gc, '_>, level: Level<'gc>) {
+        if let Some(level0) = self.get(0) {
+            let prev = level0.root();
+            let next = prev.next_exec();
 
-    pub fn push(&mut self, gc_context: MutationContext<'gc, '_>, level: &mut Level<'gc>) {
-        self.remove(gc_context, level.id());
-        let level0 = self.get_mut(0);
-        if let Some(level0) = level0 {
-            if let Some(next) = level0.next_level_id().and_then(|id| self.get_mut(id)) {
-                next.set_prev_level(gc_context, Some(*level));
-                level.set_next_level(gc_context, Some(*next));
+            level.last_child().set_prev_exec(gc_context, Some(prev));
+            level.root().set_next_exec(gc_context, next);
+
+            prev.set_next_exec(gc_context, Some(level.last_child()));
+            if let Some(next) = next {
+                next.set_prev_exec(gc_context, Some(level.root()));
             }
-
-            level0.set_next_level(gc_context, Some(*level));
-            level.set_prev_level(gc_context, Some(*level0));
         }
-
-        self.levels.insert(level.id(), *level);
+        self.0.insert(level.id(), level);
     }
 
     pub fn remove(&mut self, gc_context: MutationContext<'gc, '_>, id: LevelId) {
-        if let Some(level) = self.get(id) {
-            let prev = level.prev_level_id().and_then(|id| self.get_mut(id));
-            let next = level.next_level_id().and_then(|id| self.get_mut(id));
+        if let Some(level) = self.0.remove(&id) {
+            let prev = level.last_child().prev_exec();
+            let next = level.root().next_exec();
 
-            // TODO: cleanup
             if let Some(prev) = prev {
-                let next = level.next_level_id().and_then(|id| self.get(id));
-                prev.set_next_level(gc_context, next);
+                prev.set_next_exec(gc_context, next);
             }
             if let Some(next) = next {
-                let prev = level.prev_level_id().and_then(|id| self.get(id));
-                next.set_prev_level(gc_context, prev);
+                next.set_prev_exec(gc_context, prev);
             }
 
-            level.set_prev_level(gc_context, None);
-            level.set_next_level(gc_context, None);
+            level.last_child().set_prev_exec(gc_context, None);
+            level.root().set_next_exec(gc_context, None);
         }
     }
 
-    pub fn get(&self, id: LevelId) -> Option<Level<'gc>> {
-        self.levels.get(&id).copied()
+    pub fn get(&self, id: LevelId) -> Option<&Level<'gc>> {
+        self.0.get(&id)
     }
 
     pub fn get_mut(&mut self, id: LevelId) -> Option<&mut Level<'gc>> {
-        self.levels.get_mut(&id)
+        self.0.get_mut(&id)
     }
 
-    pub fn level_at(&self, id: LevelId) -> Option<DisplayObject<'gc>> {
+    // TODO: impl Index?
+    pub fn at(&self, id: LevelId) -> Option<DisplayObject<'gc>> {
         self.get(id).map(|level| level.root())
     }
 
-    pub fn iter(&self) -> LevelIter<'gc> {
-        LevelIter { head: self.get(0) }
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Level<'gc>> {
+        self.0.values()
     }
 
-    pub fn exec_iter(&self) -> ExecIter<'gc> {
-        ExecIter { head: Some(self.get(0).unwrap().last_child()) }
+    pub fn iter_exec(&self) -> ExecIter<'gc> {
+        ExecIter {
+            head: self.get(0).map(|level0| level0.last_child()),
+        }
     }
 }
 
@@ -77,8 +71,6 @@ impl<'gc> LevelsData<'gc> {
 pub struct Level<'gc> {
     root: DisplayObject<'gc>,
     last_child: DisplayObject<'gc>,
-    prev_level_id: Option<LevelId>,
-    next_level_id: Option<LevelId>,
 }
 
 impl<'gc> Level<'gc> {
@@ -86,8 +78,6 @@ impl<'gc> Level<'gc> {
         Self {
             root,
             last_child: root,
-            prev_level_id: None,
-            next_level_id: None,
         }
     }
 
@@ -95,12 +85,8 @@ impl<'gc> Level<'gc> {
         self.root
     }
 
-    fn set_root(&mut self, root: DisplayObject<'gc>) {
-        self.root = root;
-    }
-
     pub fn id(&self) -> LevelId {
-        self.root.level()
+        self.root.level_id()
     }
 
     pub fn last_child(&self) -> DisplayObject<'gc> {
@@ -109,37 +95,6 @@ impl<'gc> Level<'gc> {
 
     pub fn set_last_child(&mut self, child: DisplayObject<'gc>) {
         self.last_child = child;
-    }
-
-    fn prev_level_id(&self) -> Option<LevelId> {
-        self.prev_level_id
-    }
-
-    fn next_level_id(&self) -> Option<LevelId> {
-        self.next_level_id
-    }
-
-    fn set_prev_level(&mut self, gc_context: MutationContext<'gc, '_>, level: Option<Level<'gc>>) {
-        self.root.set_prev_exec(gc_context, level.map(|level| level.last_child));
-        self.next_level_id = level.map(|level| level.id());
-    }
-
-    fn set_next_level(&mut self, gc_context: MutationContext<'gc, '_>, level: Option<Level<'gc>>) {
-        self.last_child.set_next_exec(gc_context, level.map(|level| level.root));
-        self.next_level_id = level.map(|level| level.id());
-    }
-}
-
-pub struct LevelIter<'gc> {
-    head: Option<Level<'gc>>,
-}
-
-impl<'gc> Iterator for LevelIter<'gc> {
-    type Item = Level<'gc>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        // TODO
-        None
     }
 }
 
@@ -151,7 +106,8 @@ impl<'gc> Iterator for ExecIter<'gc> {
     type Item = DisplayObject<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO
-        None
+        let ret = self.head;
+        self.head = ret.and_then(|x| x.next_exec());
+        ret
     }
 }

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -12,15 +12,12 @@ impl<'gc> LevelsData<'gc> {
     pub fn insert(&mut self, gc_context: MutationContext<'gc, '_>, level: Level<'gc>) {
         if let Some(level0) = self.get(0) {
             let prev = level0.root();
-            let next = prev.next_exec();
-
-            level.last_child().set_prev_exec(gc_context, Some(prev));
-            level.root().set_next_exec(gc_context, next);
-
-            prev.set_next_exec(gc_context, Some(level.last_child()));
-            if let Some(next) = next {
+            if let Some(next) = prev.next_exec() {
+                level.root().set_next_exec(gc_context, Some(next));
                 next.set_prev_exec(gc_context, Some(level.root()));
             }
+            level.last_child().set_prev_exec(gc_context, Some(prev));
+            prev.set_next_exec(gc_context, Some(level.last_child()));
         }
         self.0.insert(level.id(), level);
     }

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -1,0 +1,157 @@
+use gc_arena::{Collect, MutationContext};
+use crate::display_object::{DisplayObject, TDisplayObject};
+use std::collections::BTreeMap;
+
+pub type LevelId = u32;
+
+#[derive(Clone, Collect)]
+#[collect(no_drop)]
+pub struct LevelsData<'gc> {
+    levels: BTreeMap<LevelId, Level<'gc>>,
+}
+
+impl<'gc> LevelsData<'gc> {
+    pub fn new() -> Self {
+        Self { levels: BTreeMap::new() }
+    }
+
+    pub fn push(&mut self, gc_context: MutationContext<'gc, '_>, level: &mut Level<'gc>) {
+        self.remove(gc_context, level.id());
+        let level0 = self.get_mut(0);
+        if let Some(level0) = level0 {
+            if let Some(next) = level0.next_level_id().and_then(|id| self.get_mut(id)) {
+                next.set_prev_level(gc_context, Some(*level));
+                level.set_next_level(gc_context, Some(*next));
+            }
+
+            level0.set_next_level(gc_context, Some(*level));
+            level.set_prev_level(gc_context, Some(*level0));
+        }
+
+        self.levels.insert(level.id(), *level);
+    }
+
+    pub fn remove(&mut self, gc_context: MutationContext<'gc, '_>, id: LevelId) {
+        if let Some(level) = self.get(id) {
+            let prev = level.prev_level_id().and_then(|id| self.get_mut(id));
+            let next = level.next_level_id().and_then(|id| self.get_mut(id));
+
+            // TODO: cleanup
+            if let Some(prev) = prev {
+                let next = level.next_level_id().and_then(|id| self.get(id));
+                prev.set_next_level(gc_context, next);
+            }
+            if let Some(next) = next {
+                let prev = level.prev_level_id().and_then(|id| self.get(id));
+                next.set_prev_level(gc_context, prev);
+            }
+
+            level.set_prev_level(gc_context, None);
+            level.set_next_level(gc_context, None);
+        }
+    }
+
+    pub fn get(&self, id: LevelId) -> Option<Level<'gc>> {
+        self.levels.get(&id).copied()
+    }
+
+    pub fn get_mut(&mut self, id: LevelId) -> Option<&mut Level<'gc>> {
+        self.levels.get_mut(&id)
+    }
+
+    pub fn level_at(&self, id: LevelId) -> Option<DisplayObject<'gc>> {
+        self.get(id).map(|level| level.root())
+    }
+
+    pub fn iter(&self) -> LevelIter<'gc> {
+        LevelIter { head: self.get(0) }
+    }
+
+    pub fn exec_iter(&self) -> ExecIter<'gc> {
+        ExecIter { head: Some(self.get(0).unwrap().last_child()) }
+    }
+}
+
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+pub struct Level<'gc> {
+    root: DisplayObject<'gc>,
+    last_child: DisplayObject<'gc>,
+    prev_level_id: Option<LevelId>,
+    next_level_id: Option<LevelId>,
+}
+
+impl<'gc> Level<'gc> {
+    pub fn new(root: DisplayObject<'gc>) -> Self {
+        Self {
+            root,
+            last_child: root,
+            prev_level_id: None,
+            next_level_id: None,
+        }
+    }
+
+    pub fn root(&self) -> DisplayObject<'gc> {
+        self.root
+    }
+
+    fn set_root(&mut self, root: DisplayObject<'gc>) {
+        self.root = root;
+    }
+
+    pub fn id(&self) -> LevelId {
+        self.root.level()
+    }
+
+    pub fn last_child(&self) -> DisplayObject<'gc> {
+        self.last_child
+    }
+
+    pub fn set_last_child(&mut self, child: DisplayObject<'gc>) {
+        self.last_child = child;
+    }
+
+    fn prev_level_id(&self) -> Option<LevelId> {
+        self.prev_level_id
+    }
+
+    fn next_level_id(&self) -> Option<LevelId> {
+        self.next_level_id
+    }
+
+    fn set_prev_level(&mut self, gc_context: MutationContext<'gc, '_>, level: Option<Level<'gc>>) {
+        self.root.set_prev_exec(gc_context, level.map(|level| level.last_child));
+        self.next_level_id = level.map(|level| level.id());
+    }
+
+    fn set_next_level(&mut self, gc_context: MutationContext<'gc, '_>, level: Option<Level<'gc>>) {
+        self.last_child.set_next_exec(gc_context, level.map(|level| level.root));
+        self.next_level_id = level.map(|level| level.id());
+    }
+}
+
+pub struct LevelIter<'gc> {
+    head: Option<Level<'gc>>,
+}
+
+impl<'gc> Iterator for LevelIter<'gc> {
+    type Item = Level<'gc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO
+        None
+    }
+}
+
+pub struct ExecIter<'gc> {
+    head: Option<DisplayObject<'gc>>,
+}
+
+impl<'gc> Iterator for ExecIter<'gc> {
+    type Item = DisplayObject<'gc>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO
+        None
+    }
+}

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -1,31 +1,38 @@
-use crate::display_object::{DisplayObject, TDisplayObject};
+use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use gc_arena::{Collect, MutationContext};
 use std::collections::BTreeMap;
 
 pub type LevelId = u32;
+
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+struct Level<'gc> {
+    root: DisplayObject<'gc>,
+    last_child: DisplayObject<'gc>,
+}
 
 #[derive(Clone, Collect, Default)]
 #[collect(no_drop)]
 pub struct LevelsData<'gc>(BTreeMap<LevelId, Level<'gc>>);
 
 impl<'gc> LevelsData<'gc> {
-    pub fn insert(&mut self, gc_context: MutationContext<'gc, '_>, level: Level<'gc>) {
-        if let Some(level0) = self.get(0) {
-            let prev = level0.root();
+    pub fn insert(&mut self, gc_context: MutationContext<'gc, '_>, root: DisplayObject<'gc>) {
+        if let Some(level0) = self.0.get(&0) {
+            let prev = level0.root;
             if let Some(next) = prev.next_exec() {
-                level.root().set_next_exec(gc_context, Some(next));
-                next.set_prev_exec(gc_context, Some(level.root()));
+                root.set_next_exec(gc_context, Some(next));
+                next.set_prev_exec(gc_context, Some(root));
             }
-            level.last_child().set_prev_exec(gc_context, Some(prev));
-            prev.set_next_exec(gc_context, Some(level.last_child()));
+            root.set_prev_exec(gc_context, Some(prev));
+            prev.set_next_exec(gc_context, Some(root));
         }
-        self.0.insert(level.id(), level);
+        self.0.insert(root.level_id(), Level { root, last_child: root });
     }
 
     pub fn remove(&mut self, gc_context: MutationContext<'gc, '_>, id: LevelId) {
         if let Some(level) = self.0.remove(&id) {
-            let prev = level.last_child().prev_exec();
-            let next = level.root().next_exec();
+            let prev = level.last_child.prev_exec();
+            let next = level.root.next_exec();
 
             if let Some(prev) = prev {
                 prev.set_next_exec(gc_context, next);
@@ -34,64 +41,67 @@ impl<'gc> LevelsData<'gc> {
                 next.set_prev_exec(gc_context, prev);
             }
 
-            level.last_child().set_prev_exec(gc_context, None);
-            level.root().set_next_exec(gc_context, None);
+            level.last_child.set_prev_exec(gc_context, None);
+            level.root.set_next_exec(gc_context, None);
         }
     }
 
-    pub fn get(&self, id: LevelId) -> Option<&Level<'gc>> {
-        self.0.get(&id)
+    pub fn add_to_execution_list(&mut self, gc_context: MutationContext<'gc, '_>, node: DisplayObject<'gc>) {
+        if let Some(level) = self.0.get_mut(&node.level_id()) {
+            let head = level.last_child;
+            if let Some(prev) = head.prev_exec() {
+                prev.set_next_exec(gc_context, Some(node));
+                node.set_prev_exec(gc_context, Some(prev));
+            }
+            head.set_prev_exec(gc_context, Some(node));
+            node.set_next_exec(gc_context, Some(head));
+            level.last_child = node;
+        } else {
+            self.insert(gc_context, node);
+        }
     }
 
-    pub fn get_mut(&mut self, id: LevelId) -> Option<&mut Level<'gc>> {
-        self.0.get_mut(&id)
+    pub fn remove_from_execution_list(&mut self, gc_context: MutationContext<'gc, '_>, node: DisplayObject<'gc>) {
+        if let Some(ctr) = node.as_container() {
+            for child in ctr.iter_render_list() {
+                self.remove_from_execution_list(gc_context, child);
+            }
+        }
+
+        let prev = node.prev_exec();
+        let next = node.next_exec();
+
+        if let Some(prev) = prev {
+            prev.set_next_exec(gc_context, next);
+        }
+        if let Some(next) = next {
+            next.set_prev_exec(gc_context, prev);
+        }
+
+        node.set_prev_exec(gc_context, None);
+        node.set_next_exec(gc_context, None);
+
+        if let Some(level) = self.0.get_mut(&node.level_id()) {
+            if DisplayObject::ptr_eq(level.last_child, node) {
+                // TODO: can we safely unwrap here?
+                level.last_child = next.unwrap();
+            }
+        }
     }
 
     // TODO: impl Index?
     pub fn at(&self, id: LevelId) -> Option<DisplayObject<'gc>> {
-        self.get(id).map(|level| level.root())
+        self.0.get(&id).map(|level| level.root)
     }
 
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Level<'gc>> {
-        self.0.values()
+    pub fn iter_roots<'a>(&'a self) -> impl 'a + Iterator<Item = DisplayObject<'gc>> {
+        self.0.values().map(|level| level.root)
     }
 
     pub fn iter_exec(&self) -> ExecIter<'gc> {
         ExecIter {
-            head: self.get(0).map(|level0| level0.last_child()),
+            head: self.0.get(&0).map(|level0| level0.last_child),
         }
-    }
-}
-
-#[derive(Clone, Copy, Collect)]
-#[collect(no_drop)]
-pub struct Level<'gc> {
-    root: DisplayObject<'gc>,
-    last_child: DisplayObject<'gc>,
-}
-
-impl<'gc> Level<'gc> {
-    pub fn new(root: DisplayObject<'gc>) -> Self {
-        Self {
-            root,
-            last_child: root,
-        }
-    }
-
-    pub fn root(&self) -> DisplayObject<'gc> {
-        self.root
-    }
-
-    pub fn id(&self) -> LevelId {
-        self.root.level_id()
-    }
-
-    pub fn last_child(&self) -> DisplayObject<'gc> {
-        self.last_child
-    }
-
-    pub fn set_last_child(&mut self, child: DisplayObject<'gc>) {
-        self.last_child = child;
     }
 }
 

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -26,7 +26,13 @@ impl<'gc> LevelsData<'gc> {
             root.set_prev_exec(gc_context, Some(prev));
             prev.set_next_exec(gc_context, Some(root));
         }
-        self.0.insert(root.level_id(), Level { root, last_child: root });
+        self.0.insert(
+            root.level_id(),
+            Level {
+                root,
+                last_child: root,
+            },
+        );
     }
 
     pub fn remove(&mut self, gc_context: MutationContext<'gc, '_>, id: LevelId) {
@@ -46,7 +52,11 @@ impl<'gc> LevelsData<'gc> {
         }
     }
 
-    pub fn add_to_execution_list(&mut self, gc_context: MutationContext<'gc, '_>, node: DisplayObject<'gc>) {
+    pub fn add_to_execution_list(
+        &mut self,
+        gc_context: MutationContext<'gc, '_>,
+        node: DisplayObject<'gc>,
+    ) {
         if let Some(level) = self.0.get_mut(&node.level_id()) {
             let head = level.last_child;
             if let Some(prev) = head.prev_exec() {
@@ -61,7 +71,11 @@ impl<'gc> LevelsData<'gc> {
         }
     }
 
-    pub fn remove_from_execution_list(&mut self, gc_context: MutationContext<'gc, '_>, node: DisplayObject<'gc>) {
+    pub fn remove_from_execution_list(
+        &mut self,
+        gc_context: MutationContext<'gc, '_>,
+        node: DisplayObject<'gc>,
+    ) {
         if let Some(ctr) = node.as_container() {
             for child in ctr.iter_render_list() {
                 self.remove_from_execution_list(gc_context, child);

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -89,8 +89,7 @@ impl<'gc> LevelsData<'gc> {
         }
     }
 
-    // TODO: impl Index?
-    pub fn at(&self, id: LevelId) -> Option<DisplayObject<'gc>> {
+    pub fn get(&self, id: LevelId) -> Option<DisplayObject<'gc>> {
         self.0.get(&id).map(|level| level.root)
     }
 

--- a/core/src/levels.rs
+++ b/core/src/levels.rs
@@ -13,9 +13,9 @@ struct Level<'gc> {
 
 #[derive(Clone, Collect, Default)]
 #[collect(no_drop)]
-pub struct LevelsData<'gc>(BTreeMap<LevelId, Level<'gc>>);
+pub struct Levels<'gc>(BTreeMap<LevelId, Level<'gc>>);
 
-impl<'gc> LevelsData<'gc> {
+impl<'gc> Levels<'gc> {
     pub fn insert(&mut self, gc_context: MutationContext<'gc, '_>, root: DisplayObject<'gc>) {
         if let Some(level0) = self.0.get(&0) {
             let prev = level0.root;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod events;
 pub mod focus_tracker;
 mod font;
 mod html;
+mod levels;
 mod library;
 pub mod loader;
 mod player;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -413,7 +413,7 @@ impl Player {
             root.post_instantiation(context, root, flashvars, Instantiator::Movie, false);
             root.set_default_root_name(context);
             context.levels.insert(0, root);
-            context.add_node(root);
+            context.add_to_execution_list(root);
 
             // Load and parse the device font.
             let device_font =

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -17,7 +17,8 @@ use crate::backend::{
 };
 use crate::config::Letterbox;
 use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
-use crate::display_object::{EditText, Level, MorphShape, MovieClip};
+use crate::display_object::{EditText, MorphShape, MovieClip};
+use crate::levels::{LevelsData, Level};
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, PlayerEvent};
 use crate::external::Value as ExternalValue;
 use crate::external::{ExternalInterface, ExternalInterfaceProvider};
@@ -33,7 +34,7 @@ use gc_arena::{make_arena, ArenaParameters, Collect, GcCell};
 use instant::Instant;
 use log::info;
 use rand::{rngs::SmallRng, SeedableRng};
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, Weak};
@@ -59,7 +60,7 @@ struct GcRootData<'gc> {
     /// Each level is a `_root` MovieClip that holds a particular SWF movie, also accessible via
     /// the `_levelN` property.
     /// levels[0] represents the initial SWF file that was loaded.
-    levels: BTreeMap<u32, Level<'gc>>,
+    levels: LevelsData<'gc>,
 
     mouse_hovered_object: Option<DisplayObject<'gc>>, // TODO: Remove GcCell wrapped inside GcCell.
 
@@ -103,7 +104,7 @@ impl<'gc> GcRootData<'gc> {
     fn update_context_params(
         &mut self,
     ) -> (
-        &mut BTreeMap<u32, Level<'gc>>,
+        &mut LevelsData<'gc>,
         &mut Library<'gc>,
         &mut ActionQueue<'gc>,
         &mut Avm1<'gc>,
@@ -273,7 +274,7 @@ impl Player {
                     gc_context,
                     GcRootData {
                         library: Library::empty(gc_context),
-                        levels: BTreeMap::new(),
+                        levels: LevelsData::new(),
                         mouse_hovered_object: None,
                         drag_object: None,
                         avm1: Avm1::new(gc_context, NEWEST_PLAYER_VERSION),
@@ -331,7 +332,7 @@ impl Player {
                 Instantiator::Movie,
                 false,
             );
-            context.levels.insert(0, Level::new(fake_root.into()));
+            context.levels.push(context.gc_context, &mut Level::new(fake_root.into()));
 
             Avm2::load_player_globals(context)
         })?;
@@ -412,7 +413,7 @@ impl Player {
             root.construct_frame(context);
             root.post_instantiation(context, root, flashvars, Instantiator::Movie, false);
             root.set_default_root_name(context);
-            context.levels.insert(0, Level::new(root));
+            context.levels.push(context.gc_context, &mut Level::new(root));
             context.add_to_execution_list(root);
 
             // Load and parse the device font.
@@ -644,11 +645,11 @@ impl Player {
                             &mut activation,
                         );
 
-                        for (depth, level) in levels.iter() {
+                        for level in levels.iter() {
                             let object = level.root().object().coerce_to_object(&mut activation);
                             dumper.print_variables(
-                                &format!("Level #{}:", depth),
-                                &format!("_level{}", depth),
+                                &format!("Level #{}:", level.id()),
+                                &format!("_level{}", level.id()),
                                 &object,
                                 &mut activation,
                             );
@@ -718,7 +719,7 @@ impl Player {
 
         if button_event.is_some() {
             self.mutate_with_update_context(|context| {
-                let levels: Vec<Level<'_>> = context.levels.values().copied().collect();
+                let levels: Vec<Level<'_>> = context.levels.iter().collect();
                 for level in levels {
                     if let Some(button_event) = button_event {
                         let state = level.root().handle_clip_event(context, button_event);
@@ -768,7 +769,7 @@ impl Player {
 
             // Fire clip event on all clips.
             if let Some(clip_event) = clip_event {
-                let levels: Vec<Level<'_>> = context.levels.values().copied().collect();
+                let levels: Vec<Level<'_>> = context.levels.iter().collect();
                 for level in levels {
                     level.root().handle_clip_event(context, clip_event);
                 }
@@ -777,7 +778,7 @@ impl Player {
             // Fire event listener on appropriate object
             if let Some((listener_type, event_name, args)) = listener {
                 context.action_queue.queue_actions(
-                    context.levels.get(&0).expect("root level").root(),
+                    context.levels.level_at(0).expect("root level"),
                     ActionType::NotifyListeners {
                         listener: listener_type,
                         method: event_name,
@@ -867,7 +868,8 @@ impl Player {
             // Check hovered object.
             let mut new_hovered = None;
             // TODO: don't use rev?
-            for level in context.levels.clone().values().rev() {
+            // TODO: change to values
+            for level in context.levels.clone().iter() {
                 if new_hovered.is_none() {
                     new_hovered =
                         level
@@ -921,7 +923,7 @@ impl Player {
         let mut is_action_script_3 = false;
         self.mutate_with_update_context(|context| {
             let mut morph_shapes = fnv::FnvHashMap::default();
-            let root = context.levels.get(&0).expect("root level").root();
+            let root = context.levels.level_at(0).expect("root level");
             root.as_movie_clip()
                 .unwrap()
                 .preload(context, &mut morph_shapes);
@@ -948,31 +950,29 @@ impl Player {
             // NOTE: We have to copy all the layer pointers into a separate list
             // because level updates can create more levels, which we don't
             // want to run frames on.
-            let levels: Vec<_> = update_context.levels.values().copied().collect();
+            let objects: Vec<_> = update_context.levels.exec_iter().collect();
 
-            if let Some(level) = levels.first() {
+            if let Some(level) = objects.first() {
                 level.exit_frame(update_context);
             }
 
-            if let Some(level) = levels.first() {
+            if let Some(level) = objects.first() {
                 level.enter_frame(update_context);
             }
 
-            for level in levels.iter() {
+            for level in objects.iter() {
                 level.construct_frame(update_context);
             }
 
-            if let Some(level) = levels.first() {
+            if let Some(level) = objects.first() {
                 level.frame_constructed(update_context);
             }
 
-            for level in levels {
-                for object in level.iter() {
-                    object.run_frame(update_context);
-                }
+            for object in objects {
+                object.run_frame(update_context);
             }
 
-            for level in levels.iter() {
+            for level in objects.iter() {
                 level.run_frame_scripts(update_context);
             }
 
@@ -1007,7 +1007,7 @@ impl Player {
                 allow_mask: true,
             };
 
-            for level in root_data.levels.values().copied() {
+            for level in root_data.levels.iter() {
                 level.root().render(&mut render_context);
             }
         });
@@ -1352,8 +1352,8 @@ impl Player {
 
             *current_frame = update_context
                 .levels
-                .get(&0)
-                .and_then(|level| level.root().as_movie_clip())
+                .level_at(0)
+                .and_then(|level| level.as_movie_clip())
                 .map(|clip| clip.current_frame());
 
             // Hovered object may have been updated; copy it back to the GC root.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -960,8 +960,10 @@ impl Player {
                 level.frame_constructed(update_context);
             }
 
-            for level in levels.iter() {
-                level.run_frame(update_context);
+            for level in levels {
+                for x in level.iter_global_exec_list() {
+                    x.run_frame(update_context);
+                }
             }
 
             for level in levels.iter() {
@@ -1226,7 +1228,7 @@ impl Player {
     }
 
     /// Runs the closure `f` with an `UpdateContext`.
-    /// This takes cares of populating the `UpdateContext` struct, avoiding borrow issues.
+    /// This takes care of populating the `UpdateContext` struct, avoiding borrow issues.
     fn mutate_with_update_context<F, R>(&mut self, f: F) -> R
     where
         F: for<'a, 'gc> FnOnce(&mut UpdateContext<'a, 'gc, '_>) -> R,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -332,9 +332,7 @@ impl Player {
                 Instantiator::Movie,
                 false,
             );
-            context
-                .levels
-                .insert(context.gc_context, fake_root.into());
+            context.levels.insert(context.gc_context, fake_root.into());
 
             Avm2::load_player_globals(context)
         })?;
@@ -869,8 +867,7 @@ impl Player {
             // TODO: use rev?
             for root in context.levels.clone().iter_roots() {
                 if new_hovered.is_none() {
-                    new_hovered =
-                        root.mouse_pick(context, root, (mouse_pos.0, mouse_pos.1));
+                    new_hovered = root.mouse_pick(context, root, (mouse_pos.0, mouse_pos.1));
                 } else {
                     break;
                 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -967,8 +967,8 @@ impl Player {
             }
 
             for level in levels {
-                for x in level.iter() {
-                    x.run_frame(update_context);
+                for object in level.iter() {
+                    object.run_frame(update_context);
                 }
             }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -718,15 +718,13 @@ impl Player {
             _ => None,
         };
 
-        if button_event.is_some() {
+        if let Some(button_event) = button_event {
             self.mutate_with_update_context(|context| {
                 let levels: Vec<Level<'_>> = context.levels.iter().copied().collect();
                 for level in levels {
-                    if let Some(button_event) = button_event {
-                        let state = level.root().handle_clip_event(context, button_event);
-                        if state == ClipEventResult::Handled {
-                            return;
-                        }
+                    let state = level.root().handle_clip_event(context, button_event);
+                    if state == ClipEventResult::Handled {
+                        return;
                     }
                 }
             });

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -777,7 +777,7 @@ impl Player {
             // Fire event listener on appropriate object
             if let Some((listener_type, event_name, args)) = listener {
                 context.action_queue.queue_actions(
-                    context.levels.at(0).expect("root level"),
+                    context.levels.get(0).expect("root level"),
                     ActionType::NotifyListeners {
                         listener: listener_type,
                         method: event_name,
@@ -919,7 +919,7 @@ impl Player {
         let mut is_action_script_3 = false;
         self.mutate_with_update_context(|context| {
             let mut morph_shapes = fnv::FnvHashMap::default();
-            let root = context.levels.at(0).expect("root level");
+            let root = context.levels.get(0).expect("root level");
             root.as_movie_clip()
                 .unwrap()
                 .preload(context, &mut morph_shapes);
@@ -1347,7 +1347,7 @@ impl Player {
 
             *current_frame = update_context
                 .levels
-                .at(0)
+                .get(0)
                 .and_then(|level| level.as_movie_clip())
                 .map(|clip| clip.current_frame());
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -22,7 +22,7 @@ use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, PlayerEv
 use crate::external::Value as ExternalValue;
 use crate::external::{ExternalInterface, ExternalInterfaceProvider};
 use crate::focus_tracker::FocusTracker;
-use crate::levels::LevelsData;
+use crate::levels::Levels;
 use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::prelude::*;
@@ -60,7 +60,7 @@ struct GcRootData<'gc> {
     /// Each level is a `_root` MovieClip that holds a particular SWF movie, also accessible via
     /// the `_levelN` property.
     /// levels[0] represents the initial SWF file that was loaded.
-    levels: LevelsData<'gc>,
+    levels: Levels<'gc>,
 
     mouse_hovered_object: Option<DisplayObject<'gc>>, // TODO: Remove GcCell wrapped inside GcCell.
 
@@ -104,7 +104,7 @@ impl<'gc> GcRootData<'gc> {
     fn update_context_params(
         &mut self,
     ) -> (
-        &mut LevelsData<'gc>,
+        &mut Levels<'gc>,
         &mut Library<'gc>,
         &mut ActionQueue<'gc>,
         &mut Avm1<'gc>,
@@ -274,7 +274,7 @@ impl Player {
                     gc_context,
                     GcRootData {
                         library: Library::empty(gc_context),
-                        levels: LevelsData::default(),
+                        levels: Levels::default(),
                         mouse_hovered_object: None,
                         drag_object: None,
                         avm1: Avm1::new(gc_context, NEWEST_PLAYER_VERSION),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -960,7 +960,7 @@ impl Player {
                 level.frame_constructed(update_context);
             }
 
-            for object in objects {
+            for object in objects.iter() {
                 object.run_frame(update_context);
             }
 

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,7 +2,8 @@ pub use crate::avm2::Value as Avm2Value;
 pub use crate::bounding_box::BoundingBox;
 pub use crate::color_transform::ColorTransform;
 pub use crate::display_object::{
-    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject, TDisplayObjectContainer, GlobalExecIter
+    DisplayObject, DisplayObjectContainer, GlobalExecList, Lists, TDisplayObject,
+    TDisplayObjectContainer,
 };
 pub use crate::{
     impl_display_object, impl_display_object_container, impl_display_object_sansbounds,

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -4,6 +4,7 @@ pub use crate::color_transform::ColorTransform;
 pub use crate::display_object::{
     DisplayObject, DisplayObjectContainer, Lists, TDisplayObject, TDisplayObjectContainer,
 };
+pub use crate::levels::LevelId;
 pub use crate::{
     impl_display_object, impl_display_object_container, impl_display_object_sansbounds,
 };
@@ -11,7 +12,6 @@ pub use log::{error, info, trace, warn};
 pub use std::ops::{Bound, RangeBounds};
 pub use swf::Matrix;
 pub use swf::{CharacterId, Color, Twips};
-pub use crate::levels::LevelId;
 
 /// A depth for a Flash display object in AVM1.
 /// This is different than defined in `swf`; during execution, clips

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -11,6 +11,7 @@ pub use log::{error, info, trace, warn};
 pub use std::ops::{Bound, RangeBounds};
 pub use swf::Matrix;
 pub use swf::{CharacterId, Color, Twips};
+pub use crate::levels::LevelId;
 
 /// A depth for a Flash display object in AVM1.
 /// This is different than defined in `swf`; during execution, clips

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,7 +2,7 @@ pub use crate::avm2::Value as Avm2Value;
 pub use crate::bounding_box::BoundingBox;
 pub use crate::color_transform::ColorTransform;
 pub use crate::display_object::{
-    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject, TDisplayObjectContainer,
+    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject, TDisplayObjectContainer, GlobalExecIter
 };
 pub use crate::{
     impl_display_object, impl_display_object_container, impl_display_object_sansbounds,

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,7 +2,7 @@ pub use crate::avm2::Value as Avm2Value;
 pub use crate::bounding_box::BoundingBox;
 pub use crate::color_transform::ColorTransform;
 pub use crate::display_object::{
-    DisplayObject, DisplayObjectContainer, GlobalExecList, Lists, TDisplayObject,
+    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject,
     TDisplayObjectContainer,
 };
 pub use crate::{

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,8 +2,7 @@ pub use crate::avm2::Value as Avm2Value;
 pub use crate::bounding_box::BoundingBox;
 pub use crate::color_transform::ColorTransform;
 pub use crate::display_object::{
-    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject,
-    TDisplayObjectContainer,
+    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject, TDisplayObjectContainer,
 };
 pub use crate::{
     impl_display_object, impl_display_object_container, impl_display_object_sansbounds,

--- a/core/tests/regression_tests.rs
+++ b/core/tests/regression_tests.rs
@@ -485,7 +485,7 @@ swf_tests! {
     (as3_displayobjectcontainer_setchildindex, "avm2/displayobjectcontainer_setchildindex", 1),
     (as3_displayobjectcontainer_swapchildren, "avm2/displayobjectcontainer_swapchildren", 1),
     (as3_displayobjectcontainer_swapchildrenat, "avm2/displayobjectcontainer_swapchildrenat", 1),
-    (button_order, "avm1/button_order", 1),
+    (button_order, "avm1/button_order", 2),
     (as3_displayobjectcontainer_stopallmovieclips, "avm2/displayobjectcontainer_stopallmovieclips", 2),
     (as3_displayobjectcontainer_timelineinstance, "avm2/displayobjectcontainer_timelineinstance", 6),
     (as3_displayobject_alpha, "avm2/displayobject_alpha", 1),


### PR DESCRIPTION
Use a global execution list as suggested in https://github.com/ruffle-rs/ruffle/pull/2943#issuecomment-769690222.

Fixes at least #1626 (now Sonic runs through the corkscrew loop) and #1986 (now enemies get hit).
Doesn't fix other frame-order-execution bugs such as #1164. It might or might not be related.

## TODO

- [ ] Add more documentation and comments in the code.
- [ ] Add new tests.