### PR TITLE
web/build: Make successful wasm-opt invocation mandatory on GitHub Actions

### DIFF
--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -12,8 +12,8 @@
         "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
         "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
         "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name ruffle_web",
-        "build:wasm-opt": "wasm-opt ./pkg/ruffle_web_bg.wasm -O -g --output ./pkg/ruffle_web_bg.opt.wasm && move-file ./pkg/ruffle_web_bg.opt.wasm ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-note",
-        "build:wasm-opt-note": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.'",
+        "build:wasm-opt": "wasm-opt ./pkg/ruffle_web_bg.wasm -O -g --output ./pkg/ruffle_web_bg.opt.wasm && move-file ./pkg/ruffle_web_bg.opt.wasm ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",
+        "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && [[ $GITHUB_ACTIONS != true ]]",
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
         "test": "mocha -r esm -r ts-node/register test/**.ts"


### PR DESCRIPTION
This might be highly `bash`-specific.
I don't know how many people make web builds from other, incompatible shells...
If anyone has a more universal solution, feel free to adjust this.
The logic in this is that after the note about unsuccessful invocation is printed, the script checks if the `GITHUB_ACTIONS` environment variable is _not_ set to `true`, and only succeeds (letting the build continue) then.