### PR TITLE
core: Fix stroke artifacts when using drawing API

### DIFF
--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -73,29 +73,36 @@ pub fn point(x: Twips, y: Twips) -> lyon::math::Point {
 
 pub fn ruffle_path_to_lyon_path(commands: Vec<DrawCommand>, is_closed: bool) -> Path {
     let mut builder = Path::builder();
-    let mut cmds = commands.into_iter().peekable();
-    while let Some(cmd) = cmds.next() {
+    let mut move_to = Some((Twips::default(), Twips::default()));
+    for cmd in commands {
         match cmd {
             DrawCommand::MoveTo { x, y } => {
-                builder.begin(point(x, y));
+                if move_to.is_none() {
+                    builder.end(false);
+                }
+                move_to = Some((x, y));
             }
             DrawCommand::LineTo { x, y } => {
+                if let Some((x, y)) = move_to.take() {
+                    builder.begin(point(x, y));
+                }
                 builder.line_to(point(x, y));
             }
             DrawCommand::CurveTo { x1, y1, x2, y2 } => {
+                if let Some((x, y)) = move_to.take() {
+                    builder.begin(point(x, y));
+                }
                 builder.quadratic_bezier_to(point(x1, y1), point(x2, y2));
             }
         }
-
-        if let Some(DrawCommand::MoveTo { .. }) = cmds.peek() {
-            builder.end(false);
-        }
     }
 
-    if is_closed {
-        builder.close();
-    } else {
-        builder.end(false);
+    if move_to.is_none() {
+        if is_closed {
+            builder.close();
+        } else {
+            builder.end(false);
+        }
     }
 
     builder.build()


### PR DESCRIPTION
Some recent changes with lyon's API could cause Ruffle to draw extra
strokes when it sees two Move commands in a row -- an extra zero-length
stroke would appear. Let's merge adjacent Move commands in the
tessellator to avoid this issue.

(TODO: Add an example to visual_tests).

For example:
```
mc.lineStyle(10, 0);
mc.moveTo(10, 10);
mc.lineTo(10.5, 10);
mc.lineStyle(10, 0xff0000);
mc.moveTo(10, 30);
mc.lineTo(10.5, 30);
```
Previously:
![image](https://user-images.githubusercontent.com/36278/107086685-34efca80-67af-11eb-93d6-69ab1f67a213.png)

Correct:
![image](https://user-images.githubusercontent.com/36278/107086666-2f928000-67af-11eb-9968-7e48ea3ff23c.png)


