### PR TITLE
Video base/stub impls

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -705,6 +705,7 @@ pub fn create_globals<'gc>(
     let video = FunctionObject::constructor(
         gc_context,
         Executable::Native(video::constructor),
+        constructor_to_fn!(video::constructor),
         Some(function_proto),
         video_proto,
     );

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -55,6 +55,7 @@ pub(crate) mod system_security;
 pub(crate) mod text_field;
 mod text_format;
 mod transform;
+mod video;
 mod xml;
 
 pub fn random<'gc>(
@@ -506,6 +507,8 @@ pub struct SystemPrototypes<'gc> {
     pub date: Object<'gc>,
     pub bitmap_data: Object<'gc>,
     pub bitmap_data_constructor: Object<'gc>,
+    pub video: Object<'gc>,
+    pub video_constructor: Object<'gc>,
 }
 
 /// Initialize default global scope and builtins for an AVM1 instance.
@@ -581,6 +584,8 @@ pub fn create_globals<'gc>(
         movie_clip_loader_proto,
     );
     let date_proto: Object<'gc> = date::create_proto(gc_context, object_proto, function_proto);
+
+    let video_proto: Object<'gc> = video::create_proto(gc_context, object_proto, function_proto);
 
     //TODO: These need to be constructors and should also set `.prototype` on each one
     let object = object::create_object_object(gc_context, object_proto, function_proto);
@@ -696,6 +701,12 @@ pub fn create_globals<'gc>(
         constructor_to_fn!(transform::constructor),
         Some(function_proto),
         transform_proto,
+    );
+    let video = FunctionObject::constructor(
+        gc_context,
+        Executable::Native(video::constructor),
+        Some(function_proto),
+        video_proto,
     );
 
     flash.define_value(gc_context, "geom", geom.into(), Attribute::empty());
@@ -1255,6 +1266,8 @@ pub fn create_globals<'gc>(
             date: date_proto,
             bitmap_data: bitmap_data_proto,
             bitmap_data_constructor: bitmap_data,
+            video: video_proto,
+            video_constructor: video,
         },
         globals.into(),
         broadcaster_functions,

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -1,0 +1,30 @@
+//! Video class
+
+use crate::avm1::activation::Activation;
+use crate::avm1::error::Error;
+use crate::avm1::globals::display_object;
+use crate::avm1::object::Object;
+use crate::avm1::value::Value;
+use crate::avm1::ScriptObject;
+use gc_arena::MutationContext;
+
+/// Implements `Video`
+pub fn constructor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_proto<'gc>(
+    gc_context: MutationContext<'gc, '_>,
+    proto: Object<'gc>,
+    fn_proto: Object<'gc>,
+) -> Object<'gc> {
+    let object = ScriptObject::object(gc_context, Some(proto));
+
+    display_object::define_display_object_proto(gc_context, object, fn_proto);
+
+    object.into()
+}

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -842,6 +842,7 @@ mod tests {
     use crate::backend::render::NullRenderer;
     use crate::backend::storage::MemoryStorageBackend;
     use crate::backend::ui::NullUiBackend;
+    use crate::backend::video::NullVideoBackend;
     use crate::context::UpdateContext;
     use crate::display_object::MovieClip;
     use crate::focus_tracker::FocusTracker;
@@ -890,6 +891,7 @@ mod tests {
                 renderer: &mut NullRenderer::new(),
                 locale: &mut NullLocaleBackend::new(),
                 log: &mut NullLogBackend::new(),
+                video: &mut NullVideoBackend::new(),
                 mouse_hovered_object: None,
                 mouse_position: &(Twips::new(0), Twips::new(0)),
                 drag_object: &mut None,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -10,6 +10,7 @@ use crate::backend::navigator::NullNavigatorBackend;
 use crate::backend::render::NullRenderer;
 use crate::backend::storage::MemoryStorageBackend;
 use crate::backend::ui::NullUiBackend;
+use crate::backend::video::NullVideoBackend;
 use crate::context::ActionQueue;
 use crate::display_object::{MovieClip, TDisplayObject};
 use crate::focus_tracker::FocusTracker;
@@ -59,6 +60,7 @@ where
             renderer: &mut NullRenderer::new(),
             locale: &mut NullLocaleBackend::new(),
             log: &mut NullLogBackend::new(),
+            video: &mut NullVideoBackend::new(),
             mouse_hovered_object: None,
             mouse_position: &(Twips::new(0), Twips::new(0)),
             drag_object: &mut None,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -95,6 +95,7 @@ pub struct SystemPrototypes<'gc> {
     pub scene: Object<'gc>,
     pub application_domain: Object<'gc>,
     pub event: Object<'gc>,
+    pub video: Object<'gc>,
 }
 
 impl<'gc> SystemPrototypes<'gc> {
@@ -128,6 +129,7 @@ impl<'gc> SystemPrototypes<'gc> {
             scene: empty,
             application_domain: empty,
             event: empty,
+            video: empty,
         }
     }
 }
@@ -549,6 +551,21 @@ pub fn load_player_globals<'gc>(
         .scene = class(
         activation,
         flash::display::scene::create_class(mc),
+        implicit_deriver,
+        domain,
+        script,
+    )?;
+
+    // package `flash.media`
+    activation
+        .context
+        .avm2
+        .system_prototypes
+        .as_mut()
+        .unwrap()
+        .video = class(
+        activation,
+        flash::media::video::create_class(mc),
         implicit_deriver,
         domain,
         script,

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -2,4 +2,5 @@
 
 pub mod display;
 pub mod events;
+pub mod media;
 pub mod system;

--- a/core/src/avm2/globals/flash/media.rs
+++ b/core/src/avm2/globals/flash/media.rs
@@ -1,0 +1,3 @@
+//! `flash.media` namespace
+
+pub mod video;

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -1,0 +1,43 @@
+//! `flash.media.Video` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.media.Video`'s instance constructor.
+pub fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        activation.super_init(this, &[])?;
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.media.Video`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `Video`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    Class::new(
+        QName::new(Namespace::package("flash.media"), "Video"),
+        Some(QName::new(Namespace::package("flash.media"), "DisplayObject").into()),
+        Method::from_builtin(instance_init),
+        Method::from_builtin(class_init),
+        mc,
+    )
+}

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -1,7 +1,7 @@
 //! `flash.media.Video` builtin/prototype
 
 use crate::avm2::activation::Activation;
-use crate::avm2::class::Class;
+use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
@@ -33,11 +33,17 @@ pub fn class_init<'gc>(
 
 /// Construct `Video`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
-    Class::new(
+    let class = Class::new(
         QName::new(Namespace::package("flash.media"), "Video"),
         Some(QName::new(Namespace::package("flash.media"), "DisplayObject").into()),
         Method::from_builtin(instance_init),
         Method::from_builtin(class_init),
         mc,
-    )
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED);
+
+    class
 }

--- a/core/src/backend.rs
+++ b/core/src/backend.rs
@@ -5,3 +5,4 @@ pub mod navigator;
 pub mod render;
 pub mod storage;
 pub mod ui;
+pub mod video;

--- a/core/src/backend/video.rs
+++ b/core/src/backend/video.rs
@@ -111,10 +111,10 @@ pub struct NullVideoBackend {
 ///
 /// Specifically:
 ///
-///  * Registering a video stream fails silently
+///  * Registering a video stream succeeds but does nothing
 ///  * All video frames are silently marked as keyframes
-///  * Video stream decoding fails (since we can't pump arbitrary bitmaps into
-///    arbitrary renderers)
+///  * Video stream decoding fails with an error that video decoding is
+///    unimplemented
 impl NullVideoBackend {
     pub fn new() -> Self {
         Self {

--- a/core/src/backend/video.rs
+++ b/core/src/backend/video.rs
@@ -4,6 +4,10 @@ use crate::backend::render::{BitmapInfo, RenderBackend};
 use generational_arena::{Arena, Index};
 use swf::{VideoCodec, VideoDeblocking};
 
+mod software;
+
+pub use crate::backend::video::software::SoftwareVideoBackend;
+
 pub type VideoStreamHandle = Index;
 
 pub type Error = Box<dyn std::error::Error>;

--- a/core/src/backend/video.rs
+++ b/core/src/backend/video.rs
@@ -1,0 +1,140 @@
+//! Video decoder backends
+
+use crate::backend::render::{BitmapInfo, RenderBackend};
+use generational_arena::{Arena, Index};
+use swf::{VideoCodec, VideoDeblocking};
+
+pub type VideoStreamHandle = Index;
+
+type Error = Box<dyn std::error::Error>;
+
+/// An encoded video frame of some video codec.
+pub struct EncodedFrame<'a> {
+    /// The codec used to encode the frame.
+    codec: VideoCodec,
+
+    /// The raw bitstream data to funnel into the codec.
+    data: &'a [u8],
+
+    /// A caller-specified frame ID. Frame IDs must be consistent between
+    frame_id: u32,
+}
+
+/// What dependencies a given video frame has on any previous frames.
+pub enum FrameDependency {
+    /// This frame has no reference frames and can be seeked to at any time.
+    Keyframe,
+
+    /// This frame has one reference frame which must be completely decoded
+    /// before this frame can be decoded.
+    ///
+    /// The given frame identifier is relative to those provided by the caller
+    /// and not
+    OneRef(u32),
+}
+
+/// A backend that provides access to some number of video decoders.
+///
+/// Implementations of `VideoBackend` are not required to actually support
+/// decoding any video formats. However, they must interoperate with at least
+/// one `RenderBackend` so that renderable video frames may be passed from the
+/// decoder to the renderer.
+pub trait VideoBackend {
+    /// Register a new video stream.
+    ///
+    /// Most of the parameters provided to this function are advisory: the
+    /// actual video data stream provided to the decoder may vary in size or
+    /// number of frames. This function should return an `Error` if it is not
+    /// possible to decode video with the given parameters.
+    fn register_video_stream(
+        &mut self,
+        num_frames: u32,
+        size: (u16, u16),
+        codec: VideoCodec,
+        filter: VideoDeblocking,
+    ) -> Result<VideoStreamHandle, Error>;
+
+    /// Preload a frame of a given video stream.
+    ///
+    /// No decoding is intended to happen at this point in time. Instead, the
+    /// video data should be inspected to determine inter-frame dependencies
+    /// between this and any previous frames in the stream.
+    ///
+    /// Frames should be preloaded in the order that they are recieved.
+    ///
+    /// Any dependencies listed here are inherent to the video bitstream. The
+    /// containing video stream is also permitted to introduce additional
+    /// interframe dependencies.
+    fn preload_video_stream_frame(
+        &mut self,
+        stream: VideoStreamHandle,
+        encoded_frame: EncodedFrame<'_>,
+    ) -> Result<FrameDependency, Error>;
+
+    /// Decode a frame of a given video stream.
+    ///
+    /// This function is provided the external index of the frame, the codec
+    /// used to decode the data, and what codec to decode it with. The codec
+    /// provided here must match the one used to register the video stream.
+    ///
+    /// Frames may be decoded in any order that does not violate the frame
+    /// dependencies declared by the output of `preload_video_stream_frame`.
+    ///
+    /// The resulting `BitmapInfo` will be renderable only on the given
+    /// `RenderBackend`. `VideoBackend` implementations are allowed to return
+    /// an error if a drawable bitmap cannot be produced for the given
+    /// renderer.
+    fn decode_video_stream_frame(
+        &mut self,
+        stream: VideoStreamHandle,
+        encoded_frame: EncodedFrame<'_>,
+        renderer: &mut dyn RenderBackend,
+    ) -> Result<BitmapInfo, Error>;
+}
+
+pub struct NullVideoBackend {
+    streams: Arena<()>,
+}
+
+impl NullVideoBackend {
+    pub fn new() -> Self {
+        Self {
+            streams: Arena::new(),
+        }
+    }
+}
+
+impl Default for NullVideoBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VideoBackend for NullVideoBackend {
+    fn register_video_stream(
+        &mut self,
+        _num_frames: u32,
+        _size: (u16, u16),
+        _codec: VideoCodec,
+        _filter: VideoDeblocking,
+    ) -> Result<VideoStreamHandle, Error> {
+        Ok(self.streams.insert(()))
+    }
+
+    fn preload_video_stream_frame(
+        &mut self,
+        _stream: VideoStreamHandle,
+        _encoded_frame: EncodedFrame<'_>,
+    ) -> Result<FrameDependency, Error> {
+        Ok(FrameDependency::Keyframe)
+    }
+
+    fn decode_video_stream_frame(
+        &mut self,
+        _stream: VideoStreamHandle,
+        _encoded_frame: EncodedFrame<'_>,
+        _renderer: &mut dyn RenderBackend,
+    ) -> Result<BitmapInfo, Error> {
+        Err("Video decoding not implemented".into())
+    }
+}

--- a/core/src/backend/video.rs
+++ b/core/src/backend/video.rs
@@ -15,14 +15,14 @@ pub type Error = Box<dyn std::error::Error>;
 /// An encoded video frame of some video codec.
 pub struct EncodedFrame<'a> {
     /// The codec used to encode the frame.
-    codec: VideoCodec,
+    pub codec: VideoCodec,
 
     /// The raw bitstream data to funnel into the codec.
-    data: &'a [u8],
+    pub data: &'a [u8],
 
     /// A caller-specified frame ID. Frame IDs must be consistent between
     /// subsequent uses of the same data stream.
-    frame_id: u32,
+    pub frame_id: u32,
 }
 
 impl<'a> EncodedFrame<'a> {

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -10,11 +10,8 @@ use swf::{VideoCodec, VideoDeblocking};
 /// A single preloaded video stream.
 pub enum VideoStream {}
 
-/// Desktop video backend.
-///
-/// TODO: Currently, this just proxies out to `ruffle_h263`, in the future it
-/// should support desktop media playback APIs so we can take advantage of
-/// hardware-accelerated video decoding.
+/// Software video backend that proxies to CPU-only codec implementations that
+/// ship with Ruffle.
 pub struct SoftwareVideoBackend {
     streams: Arena<VideoStream>,
 }

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -1,0 +1,79 @@
+//! Pure software video decoding backend.
+
+use crate::backend::render::{BitmapInfo, RenderBackend};
+use crate::backend::video::{
+    EncodedFrame, Error, FrameDependency, VideoBackend, VideoStreamHandle,
+};
+use generational_arena::Arena;
+use swf::{VideoCodec, VideoDeblocking};
+
+/// A single preloaded video stream.
+pub enum VideoStream {}
+
+/// Desktop video backend.
+///
+/// TODO: Currently, this just proxies out to `ruffle_h263`, in the future it
+/// should support desktop media playback APIs so we can take advantage of
+/// hardware-accelerated video decoding.
+pub struct SoftwareVideoBackend {
+    streams: Arena<VideoStream>,
+}
+
+impl Default for SoftwareVideoBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SoftwareVideoBackend {
+    pub fn new() -> Self {
+        Self {
+            streams: Arena::new(),
+        }
+    }
+}
+
+impl VideoBackend for SoftwareVideoBackend {
+    fn register_video_stream(
+        &mut self,
+        _num_frames: u32,
+        _size: (u16, u16),
+        codec: VideoCodec,
+        _filter: VideoDeblocking,
+    ) -> Result<VideoStreamHandle, Error> {
+        match codec {
+            _ => Err(format!("Unsupported video codec type {:?}", codec).into()),
+        }
+    }
+
+    fn preload_video_stream_frame(
+        &mut self,
+        stream: VideoStreamHandle,
+        encoded_frame: EncodedFrame<'_>,
+    ) -> Result<FrameDependency, Error> {
+        let stream = self
+            .streams
+            .get_mut(stream)
+            .ok_or("Unregistered video stream")?;
+
+        match stream {
+            _ => unreachable!(),
+        }
+    }
+
+    fn decode_video_stream_frame(
+        &mut self,
+        stream: VideoStreamHandle,
+        encoded_frame: EncodedFrame<'_>,
+        renderer: &mut dyn RenderBackend,
+    ) -> Result<BitmapInfo, Error> {
+        let stream = self
+            .streams
+            .get_mut(stream)
+            .ok_or("Unregistered video stream")?;
+
+        match stream {
+            _ => unreachable!(),
+        }
+    }
+}

--- a/core/src/backend/video/software.rs
+++ b/core/src/backend/video/software.rs
@@ -41,39 +41,33 @@ impl VideoBackend for SoftwareVideoBackend {
         codec: VideoCodec,
         _filter: VideoDeblocking,
     ) -> Result<VideoStreamHandle, Error> {
-        match codec {
-            _ => Err(format!("Unsupported video codec type {:?}", codec).into()),
-        }
+        Err(format!("Unsupported video codec type {:?}", codec).into())
     }
 
     fn preload_video_stream_frame(
         &mut self,
         stream: VideoStreamHandle,
-        encoded_frame: EncodedFrame<'_>,
+        _encoded_frame: EncodedFrame<'_>,
     ) -> Result<FrameDependency, Error> {
-        let stream = self
+        let _stream = self
             .streams
             .get_mut(stream)
             .ok_or("Unregistered video stream")?;
 
-        match stream {
-            _ => unreachable!(),
-        }
+        unreachable!()
     }
 
     fn decode_video_stream_frame(
         &mut self,
         stream: VideoStreamHandle,
-        encoded_frame: EncodedFrame<'_>,
-        renderer: &mut dyn RenderBackend,
+        _encoded_frame: EncodedFrame<'_>,
+        _renderer: &mut dyn RenderBackend,
     ) -> Result<BitmapInfo, Error> {
-        let stream = self
+        let _stream = self
             .streams
             .get_mut(stream)
             .ok_or("Unregistered video stream")?;
 
-        match stream {
-            _ => unreachable!(),
-        }
+        unreachable!()
     }
 }

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -1,5 +1,7 @@
 use crate::backend::audio::SoundHandle;
-use crate::display_object::{Bitmap, Button, EditText, Graphic, MorphShape, MovieClip, Text};
+use crate::display_object::{
+    Bitmap, Button, EditText, Graphic, MorphShape, MovieClip, Text, Video,
+};
 use crate::font::Font;
 
 #[derive(Clone)]
@@ -13,6 +15,7 @@ pub enum Character<'gc> {
     MorphShape(MorphShape<'gc>),
     Text(Text<'gc>),
     Sound(SoundHandle),
+    Video(Video<'gc>),
 }
 
 unsafe impl<'gc> gc_arena::Collect for Character<'gc> {
@@ -28,6 +31,7 @@ unsafe impl<'gc> gc_arena::Collect for Character<'gc> {
             Character::MorphShape(c) => c.trace(cc),
             Character::Text(c) => c.trace(cc),
             Character::Sound(c) => c.trace(cc),
+            Character::Video(c) => c.trace(cc),
         }
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -11,6 +11,7 @@ use crate::backend::{
     render::RenderBackend,
     storage::StorageBackend,
     ui::UiBackend,
+    video::VideoBackend,
 };
 use crate::display_object::{EditText, MovieClip, SoundTransform};
 use crate::external::ExternalInterface;
@@ -84,6 +85,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The logging backend, used for trace output capturing
     pub log: &'a mut dyn LogBackend,
+
+    /// The video backend, used for video decoding
+    pub video: &'a mut dyn VideoBackend,
 
     /// The RNG, used by the AVM `RandomNumber` opcode,  `Math.random(),` and `random()`.
     pub rng: &'a mut SmallRng,
@@ -290,6 +294,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             locale: self.locale,
             log: self.log,
             ui: self.ui,
+            video: self.video,
             storage: self.storage,
             rng: self.rng,
             levels: self.levels,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -25,6 +25,7 @@ mod graphic;
 mod morph_shape;
 mod movie_clip;
 mod text;
+mod video;
 
 use crate::avm1::activation::Activation;
 use crate::backend::ui::MouseCursor;
@@ -39,6 +40,7 @@ pub use graphic::Graphic;
 pub use morph_shape::{MorphShape, MorphShapeStatic};
 pub use movie_clip::{MovieClip, Scene};
 pub use text::Text;
+use video::Video;
 
 #[derive(Clone, Debug)]
 pub struct DisplayObjectBase<'gc> {
@@ -479,6 +481,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         MorphShape(MorphShape<'gc>),
         MovieClip(MovieClip<'gc>),
         Text(Text<'gc>),
+        Video(Video<'gc>),
     }
 )]
 pub trait TDisplayObject<'gc>:

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -40,7 +40,7 @@ pub use graphic::Graphic;
 pub use morph_shape::{MorphShape, MorphShapeStatic};
 pub use movie_clip::{MovieClip, Scene};
 pub use text::Text;
-use video::Video;
+pub use video::Video;
 
 #[derive(Clone, Debug)]
 pub struct DisplayObjectBase<'gc> {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -982,8 +982,8 @@ pub trait TDisplayObject<'gc>:
             if let Some(ratio) = place_object.ratio {
                 if let Some(mut morph_shape) = self.as_morph_shape() {
                     morph_shape.set_ratio(context.gc_context, ratio);
-                } else if let Some(mut video) = self.as_video() {
-                    video.seek(context, ratio);
+                } else if let Some(video) = self.as_video() {
+                    video.seek(context, ratio.into());
                 }
             }
             // Clip events only apply to movie clips.

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1104,7 +1104,7 @@ impl<'gc> MovieClip<'gc> {
                     }
                 }
                 // Run first frame.
-                child.apply_place_object(context.gc_context, self.movie(), place_object);
+                child.apply_place_object(context, self.movie(), place_object);
                 child.post_instantiation(context, child, None, Instantiator::Movie, false);
                 child.run_frame(context);
             }
@@ -1267,11 +1267,7 @@ impl<'gc> MovieClip<'gc> {
                 // If it's a rewind, we removed any dead children above, so we always
                 // modify the previous child.
                 Some(prev_child) if params.id() == 0 || is_rewind => {
-                    prev_child.apply_place_object(
-                        context.gc_context,
-                        self.movie(),
-                        &params.place_object,
-                    );
+                    prev_child.apply_place_object(context, self.movie(), &params.place_object);
                 }
                 _ => {
                     if let Some(child) = clip.instantiate_child(
@@ -2886,7 +2882,7 @@ impl<'gc, 'a> MovieClip<'gc> {
             }
             PlaceObjectAction::Modify => {
                 if let Some(child) = self.child_by_depth(place_object.depth.into()) {
-                    child.apply_place_object(context.gc_context, self.movie(), &place_object);
+                    child.apply_place_object(context, self.movie(), &place_object);
                     child
                 } else {
                     return Ok(());

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -384,6 +384,10 @@ impl<'gc> MovieClip<'gc> {
                 &mut static_data,
                 1,
             ),
+            TagCode::VideoFrame => self
+                .0
+                .write(context.gc_context)
+                .preload_video_frame(context, reader),
             TagCode::SoundStreamHead2 => {
                 self.0.write(context.gc_context).preload_sound_stream_head(
                     context,
@@ -2234,6 +2238,32 @@ impl<'gc, 'a> MovieClipData<'gc> {
             }
         }
         Ok(())
+    }
+
+    #[inline]
+    fn preload_video_frame(
+        &mut self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        reader: &mut SwfStream,
+    ) -> DecodeResult {
+        match reader.read_video_frame()? {
+            Tag::VideoFrame(vframe) => {
+                let library = context.library.library_for_movie_mut(self.movie());
+                match library.character_by_id(vframe.stream_id) {
+                    Some(Character::Video(mut v)) => {
+                        v.preload_swf_frame(vframe, context);
+
+                        Ok(())
+                    }
+                    _ => Err(format!(
+                        "Attempted to preload video frames into non-video character {}",
+                        vframe.stream_id
+                    )
+                    .into()),
+                }
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[inline]

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -16,6 +16,7 @@ use crate::context::{ActionType, RenderContext, UpdateContext};
 use crate::display_object::container::{ChildContainer, TDisplayObjectContainer};
 use crate::display_object::{
     Bitmap, Button, DisplayObjectBase, EditText, Graphic, MorphShapeStatic, TDisplayObject, Text,
+    Video,
 };
 use crate::drawing::Drawing;
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult};
@@ -32,7 +33,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use swf::read::SwfReadExt;
-use swf::{FillStyle, FrameLabelData, LineStyle};
+use swf::{FillStyle, FrameLabelData, LineStyle, Tag};
 
 type FrameNumber = u16;
 
@@ -288,6 +289,10 @@ impl<'gc> MovieClip<'gc> {
                 .0
                 .write(context.gc_context)
                 .define_sound(context, reader),
+            TagCode::DefineVideoStream => self
+                .0
+                .write(context.gc_context)
+                .define_video_stream(context, reader),
             TagCode::DefineSprite => self.0.write(context.gc_context).define_sprite(
                 context,
                 reader,
@@ -2603,6 +2608,27 @@ impl<'gc, 'a> MovieClipData<'gc> {
                 sound.id
             );
         }
+        Ok(())
+    }
+
+    #[inline]
+    fn define_video_stream(
+        &mut self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        reader: &mut SwfStream,
+    ) -> DecodeResult {
+        match reader.read_define_video_stream()? {
+            Tag::DefineVideoStream(streamdef) => {
+                let id = streamdef.id;
+                let video = Video::from_swf_tag(self.movie(), streamdef, context.gc_context);
+                context
+                    .library
+                    .library_for_movie_mut(self.movie())
+                    .register_character(id, Character::Video(video));
+            }
+            _ => unreachable!(),
+        };
+
         Ok(())
     }
 

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -57,6 +57,7 @@ pub struct VideoData<'gc> {
 #[derive(Clone, Debug, Collect)]
 #[collect(require_static)]
 pub enum VideoSource {
+    /// A video bitstream embedded inside of a SWF movie.
     SWF {
         /// The movie that defined this video stream.
         movie: Arc<SwfMovie>,
@@ -64,7 +65,7 @@ pub enum VideoSource {
         /// The video stream definition.
         streamdef: DefineVideoStream,
 
-        /// The H.263 bitstream indexed by video frame ID.
+        /// The locations of each embedded sub-bitstream for each video frame.
         ///
         /// Each frame consists of a start and end parameter which can be used
         /// to reconstruct a reference to the embedded bitstream.

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -1,6 +1,7 @@
 //! Video player display object
 
 use crate::avm1::{Object as Avm1Object, StageObject as Avm1StageObject};
+use crate::avm2::{Object as Avm2Object, StageObject as Avm2StageObject};
 use crate::backend::render::BitmapHandle;
 use crate::backend::video::{EncodedFrame, VideoStreamHandle};
 use crate::bounding_box::BoundingBox;
@@ -215,7 +216,13 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
             let library = context.library.library_for_movie_mut(movie);
             let vm_type = library.avm_type();
             if vm_type == AvmType::Avm2 {
-                //TODO: AVM2 me, cap'n.
+                let object: Avm2Object<'_> = Avm2StageObject::for_display_object(
+                    context.gc_context,
+                    display_object,
+                    context.avm2.prototypes().video,
+                )
+                .into();
+                write.object = Some(object.into());
             } else if vm_type == AvmType::Avm1 {
                 let object: Avm1Object<'_> = Avm1StageObject::for_display_object(
                     context.gc_context,

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -58,7 +58,7 @@ pub struct VideoData<'gc> {
 #[derive(Clone, Debug, Collect)]
 #[collect(require_static)]
 pub enum VideoStream {
-    /// An uninstanted video stream.
+    /// An uninstantiated video stream.
     ///
     /// The stream index parameter is what frame we should seek to once the
     /// stream is instantiated.

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -202,6 +202,8 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         write.stream = stream;
         drop(write);
 
+        self.seek(context, 0);
+
         if run_frame {
             self.run_frame(context);
         }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -149,7 +149,7 @@ impl<'gc> Video<'gc> {
     }
 
     /// Seek to a particular frame in the video stream.
-    pub fn seek(self, context: &mut UpdateContext<'_, 'gc, '_>, frame_id: u32) {
+    pub fn seek(self, context: &mut UpdateContext<'_, 'gc, '_>, mut frame_id: u32) {
         let read = self.0.read();
         if let VideoStream::Uninstantiated(_) = &read.stream {
             drop(read);
@@ -159,6 +159,11 @@ impl<'gc> Video<'gc> {
 
             return;
         };
+
+        {
+            let VideoSource::SWF { movie: _, streamdef, frames: _ } = &*read.source.read();
+            frame_id = frame_id % streamdef.num_frames as u32;
+        }
 
         let last_frame = read.decoded_frame.as_ref().map(|(lf, _)| *lf);
 

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -106,6 +106,10 @@ impl<'gc> Video<'gc> {
             } => {
                 let subslice = SwfSlice::from(movie.clone()).to_unbounded_subslice(tag.data);
 
+                if frames.contains_key(&tag.frame_num.into()) {
+                    log::warn!("Duplicate frame {}", tag.frame_num);
+                }
+
                 if let Some(subslice) = subslice {
                     frames.insert(tag.frame_num.into(), (subslice.start, subslice.end));
                 } else {

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -160,9 +160,12 @@ impl<'gc> Video<'gc> {
             return;
         };
 
-        {
-            let VideoSource::SWF { movie: _, streamdef, frames: _ } = &*read.source.read();
-            frame_id = frame_id % streamdef.num_frames as u32;
+        let num_frames = match &*read.source.read() {
+            VideoSource::Swf { streamdef, .. } => Some(streamdef.num_frames),
+        };
+
+        if let Some(num_frames) = num_frames {
+            frame_id %= num_frames as u32;
         }
 
         let last_frame = read.decoded_frame.as_ref().map(|(lf, _)| *lf);

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -72,7 +72,7 @@ pub enum VideoStream {
 #[collect(require_static)]
 pub enum VideoSource {
     /// A video bitstream embedded inside of a SWF movie.
-    SWF {
+    Swf {
         /// The movie that defined this video stream.
         movie: Arc<SwfMovie>,
 
@@ -96,7 +96,7 @@ impl<'gc> Video<'gc> {
     ) -> Self {
         let source = GcCell::allocate(
             mc,
-            VideoSource::SWF {
+            VideoSource::Swf {
                 movie,
                 streamdef,
                 frames: BTreeMap::new(),
@@ -128,7 +128,7 @@ impl<'gc> Video<'gc> {
             .write(context.gc_context))
         .borrow_mut()
         {
-            VideoSource::SWF {
+            VideoSource::Swf {
                 movie,
                 streamdef: _streamdef,
                 frames,
@@ -175,7 +175,7 @@ impl<'gc> Video<'gc> {
         }
 
         let res = match &*source.read() {
-            VideoSource::SWF {
+            VideoSource::Swf {
                 movie,
                 streamdef,
                 frames,
@@ -234,7 +234,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         let mut write = self.0.write(context.gc_context);
 
         let (stream, movie, keyframes) = match &*write.source.read() {
-            VideoSource::SWF {
+            VideoSource::Swf {
                 streamdef,
                 movie,
                 frames,
@@ -325,7 +325,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
 
     fn id(&self) -> CharacterId {
         match (*self.0.read().source.read()).borrow() {
-            VideoSource::SWF { streamdef, .. } => streamdef.id,
+            VideoSource::Swf { streamdef, .. } => streamdef.id,
         }
     }
 
@@ -333,7 +333,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         let mut bounding_box = BoundingBox::default();
 
         match (*self.0.read().source.read()).borrow() {
-            VideoSource::SWF { streamdef, .. } => {
+            VideoSource::Swf { streamdef, .. } => {
                 bounding_box.set_width(Twips::from_pixels(streamdef.width as f64));
                 bounding_box.set_height(Twips::from_pixels(streamdef.height as f64));
             }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -3,7 +3,7 @@
 use crate::avm1::{Object as Avm1Object, StageObject as Avm1StageObject};
 use crate::avm2::{Object as Avm2Object, StageObject as Avm2StageObject};
 use crate::backend::render::BitmapHandle;
-use crate::backend::video::{EncodedFrame, FrameDependency, VideoStreamHandle};
+use crate::backend::video::{EncodedFrame, VideoStreamHandle};
 use crate::bounding_box::BoundingBox;
 use crate::collect::CollectWrapper;
 use crate::context::{RenderContext, UpdateContext};
@@ -267,7 +267,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
                     );
 
                     match dep {
-                        Ok(FrameDependency::Keyframe) => {
+                        Ok(d) if d.is_keyframe() => {
                             keyframes.insert(*frame_id);
                         }
                         Ok(_) => {}

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -99,10 +99,17 @@ impl<'gc> Video<'gc> {
             }
         }
     }
+
+    /// Seek to a particular frame in the video stream.
+    pub fn seek(&self, _context: &mut UpdateContext<'_, 'gc, '_>, _frame: u16) {}
 }
 
 impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     impl_display_object!(base);
+
+    fn as_video(self) -> Option<Video<'gc>> {
+        Some(self)
+    }
 
     fn id(&self) -> CharacterId {
         match (*self.0.read().source_stream.read()).borrow() {

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -240,6 +240,8 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
             context
                 .renderer
                 .render_bitmap(bitmap.0, context.transform_stack.transform(), false);
+        } else {
+            log::warn!("Video has no decoded frame to render.");
         }
 
         context.transform_stack.pop();

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -157,7 +157,7 @@ impl<'gc> Video<'gc> {
 
                 self.0.write(context.gc_context).decoded_frame = Some(CollectWrapper(bitmap))
             }
-            Err(e) => log::error!("Got error when seeking video: {}", e),
+            Err(e) => log::error!("Got error when seeking to video frame {}: {}", frame_id, e),
         }
     }
 }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -1,0 +1,52 @@
+//! Video player display object
+
+use crate::bounding_box::BoundingBox;
+use crate::display_object::{DisplayObjectBase, TDisplayObject};
+use crate::prelude::*;
+use crate::tag_utils::SwfMovie;
+use crate::types::{Degrees, Percent};
+use gc_arena::{Collect, Gc, GcCell};
+use swf::CharacterId;
+
+/// A Video display object is a high-level interface to a video player.
+///
+/// Video data may be embedded within a variety of container formats, including
+/// a host SWF, or an externally-loaded FLV or F4V file. In the latter form,
+/// video framerates are (supposedly) permitted to differ from the stage
+/// framerate.
+#[derive(Clone, Debug, Collect, Copy)]
+#[collect(no_drop)]
+pub struct Video<'gc>(GcCell<'gc, VideoData<'gc>>);
+
+#[derive(Clone, Debug, Collect)]
+#[collect(no_drop)]
+pub struct VideoData<'gc> {
+    base: DisplayObjectBase<'gc>,
+    static_data: Gc<'gc, VideoStatic>,
+}
+
+#[derive(Clone, Debug, Collect)]
+#[collect(require_static)]
+pub struct VideoStatic {
+    movie: SwfMovie,
+    id: CharacterId,
+    width: Twips,
+    height: Twips,
+}
+
+impl<'gc> TDisplayObject<'gc> for Video<'gc> {
+    impl_display_object!(base);
+
+    fn id(&self) -> CharacterId {
+        self.0.read().static_data.id
+    }
+
+    fn self_bounds(&self) -> BoundingBox {
+        let mut bounding_box = BoundingBox::default();
+
+        bounding_box.set_width(self.0.read().static_data.width);
+        bounding_box.set_height(self.0.read().static_data.height);
+
+        bounding_box
+    }
+}

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -1,11 +1,16 @@
 //! Video player display object
 
+use crate::avm1::Object as Avm1Object;
+use crate::backend::render::BitmapHandle;
+use crate::backend::video::{EncodedFrame, VideoStreamHandle};
 use crate::bounding_box::BoundingBox;
-use crate::context::UpdateContext;
+use crate::collect::CollectWrapper;
+use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, TDisplayObject};
 use crate::prelude::*;
 use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::types::{Degrees, Percent};
+use crate::vminterface::Instantiator;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::borrow::{Borrow, BorrowMut};
 use std::collections::BTreeMap;
@@ -26,7 +31,15 @@ pub struct Video<'gc>(GcCell<'gc, VideoData<'gc>>);
 #[collect(no_drop)]
 pub struct VideoData<'gc> {
     base: DisplayObjectBase<'gc>,
-    source_stream: GcCell<'gc, VideoSource>,
+
+    /// The source of the video data (e.g. an external file, a SWF bitstream)
+    source: GcCell<'gc, VideoSource>,
+
+    /// The decoder stream that this video source is associated to.
+    stream: Option<CollectWrapper<VideoStreamHandle>>,
+
+    /// The last decoded frame in the video stream.
+    decoded_frame: Option<CollectWrapper<BitmapHandle>>,
 }
 
 #[derive(Clone, Debug, Collect)]
@@ -43,7 +56,7 @@ pub enum VideoSource {
         ///
         /// Each frame consists of a start and end parameter which can be used
         /// to reconstruct a reference to the embedded bitstream.
-        frames: BTreeMap<u16, (usize, usize)>,
+        frames: BTreeMap<u32, (usize, usize)>,
     },
 }
 
@@ -54,7 +67,7 @@ impl<'gc> Video<'gc> {
         streamdef: DefineVideoStream,
         mc: MutationContext<'gc, '_>,
     ) -> Self {
-        let source_stream = GcCell::allocate(
+        let source = GcCell::allocate(
             mc,
             VideoSource::SWF {
                 movie,
@@ -67,7 +80,9 @@ impl<'gc> Video<'gc> {
             mc,
             VideoData {
                 base: Default::default(),
-                source_stream,
+                source,
+                stream: None,
+                decoded_frame: None,
             },
         ))
     }
@@ -80,7 +95,7 @@ impl<'gc> Video<'gc> {
         match (*self
             .0
             .write(context.gc_context)
-            .source_stream
+            .source
             .write(context.gc_context))
         .borrow_mut()
         {
@@ -92,7 +107,7 @@ impl<'gc> Video<'gc> {
                 let subslice = SwfSlice::from(movie.clone()).to_unbounded_subslice(tag.data);
 
                 if let Some(subslice) = subslice {
-                    frames.insert(tag.frame_num, (subslice.start, subslice.end));
+                    frames.insert(tag.frame_num.into(), (subslice.start, subslice.end));
                 } else {
                     log::warn!("Invalid bitstream subslice on frame {}", tag.frame_num);
                 }
@@ -101,7 +116,50 @@ impl<'gc> Video<'gc> {
     }
 
     /// Seek to a particular frame in the video stream.
-    pub fn seek(&self, _context: &mut UpdateContext<'_, 'gc, '_>, _frame: u16) {}
+    pub fn seek(self, context: &mut UpdateContext<'_, 'gc, '_>, frame_id: u32) {
+        let read = self.0.read();
+        let source = read.source;
+        let stream = if let Some(stream) = &read.stream {
+            stream
+        } else {
+            log::error!("Attempted to sync uninstantiated video stream!");
+            return;
+        };
+
+        let res = match &*source.read() {
+            VideoSource::SWF {
+                movie,
+                streamdef,
+                frames,
+            } => match frames.get(&frame_id) {
+                Some((slice_start, slice_end)) => {
+                    let encframe = EncodedFrame {
+                        codec: streamdef.codec,
+                        data: &movie.data()[*slice_start..*slice_end],
+                        frame_id,
+                    };
+                    context
+                        .video
+                        .decode_video_stream_frame(stream.0, encframe, context.renderer)
+                }
+                None => Err(Box::from(format!(
+                    "Attempted to seek to unknown frame {}",
+                    frame_id
+                ))),
+            },
+        };
+
+        drop(read);
+
+        match res {
+            Ok(bitmapinfo) => {
+                let bitmap = bitmapinfo.handle;
+
+                self.0.write(context.gc_context).decoded_frame = Some(CollectWrapper(bitmap))
+            }
+            Err(e) => log::error!("Got error when seeking video: {}", e),
+        }
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for Video<'gc> {
@@ -111,8 +169,46 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         Some(self)
     }
 
+    fn post_instantiation(
+        &self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        _display_object: DisplayObject<'gc>,
+        _init_object: Option<Avm1Object<'gc>>,
+        _instantiated_by: Instantiator,
+        run_frame: bool,
+    ) {
+        let mut write = self.0.write(context.gc_context);
+
+        let stream = match &*write.source.read() {
+            VideoSource::SWF { streamdef, .. } => {
+                let stream = context.video.register_video_stream(
+                    streamdef.num_frames.into(),
+                    (streamdef.width, streamdef.height),
+                    streamdef.codec,
+                    streamdef.deblocking,
+                );
+                if stream.is_err() {
+                    log::error!(
+                        "Got error when post-instantiating video: {}",
+                        stream.unwrap_err()
+                    );
+                    return;
+                }
+
+                Some(CollectWrapper(stream.unwrap()))
+            }
+        };
+
+        write.stream = stream;
+        drop(write);
+
+        if run_frame {
+            self.run_frame(context);
+        }
+    }
+
     fn id(&self) -> CharacterId {
-        match (*self.0.read().source_stream.read()).borrow() {
+        match (*self.0.read().source.read()).borrow() {
             VideoSource::SWF { streamdef, .. } => streamdef.id,
         }
     }
@@ -120,7 +216,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     fn self_bounds(&self) -> BoundingBox {
         let mut bounding_box = BoundingBox::default();
 
-        match (*self.0.read().source_stream.read()).borrow() {
+        match (*self.0.read().source.read()).borrow() {
             VideoSource::SWF { streamdef, .. } => {
                 bounding_box.set_width(Twips::from_pixels(streamdef.width as f64));
                 bounding_box.set_height(Twips::from_pixels(streamdef.height as f64));
@@ -128,5 +224,22 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
 
         bounding_box
+    }
+
+    fn render(&self, context: &mut RenderContext) {
+        if !self.world_bounds().intersects(&context.view_bounds) {
+            // Off-screen; culled
+            return;
+        }
+
+        context.transform_stack.push(&*self.transform());
+
+        if let Some(ref bitmap) = self.0.read().decoded_frame {
+            context
+                .renderer
+                .render_bitmap(bitmap.0, context.transform_stack.transform(), false);
+        }
+
+        context.transform_stack.pop();
     }
 }

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -181,6 +181,7 @@ impl<'gc> MovieLibrary<'gc> {
             Character::MovieClip(movie_clip) => Ok(movie_clip.instantiate(gc_context)),
             Character::Button(button) => Ok(button.instantiate(gc_context)),
             Character::Text(text) => Ok(text.instantiate(gc_context)),
+            Character::Video(video) => Ok(video.instantiate(gc_context)),
             _ => Err("Not a DisplayObject".into()),
         }
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -13,6 +13,7 @@ use crate::backend::{
     render::RenderBackend,
     storage::StorageBackend,
     ui::{MouseCursor, UiBackend},
+    video::VideoBackend,
 };
 use crate::config::Letterbox;
 use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
@@ -142,6 +143,7 @@ type Storage = Box<dyn StorageBackend>;
 type Locale = Box<dyn LocaleBackend>;
 type Log = Box<dyn LogBackend>;
 type Ui = Box<dyn UiBackend>;
+type Video = Box<dyn VideoBackend>;
 
 pub struct Player {
     /// The version of the player we're emulating.
@@ -170,6 +172,7 @@ pub struct Player {
     locale: Locale,
     log: Log,
     ui: Ui,
+    video: Video,
 
     transform_stack: TransformStack,
     view_matrix: Matrix,
@@ -231,12 +234,14 @@ pub struct Player {
 
 #[allow(clippy::too_many_arguments)]
 impl Player {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         renderer: Renderer,
         audio: Audio,
         navigator: Navigator,
         storage: Storage,
         locale: Locale,
+        video: Video,
         log: Log,
         ui: Ui,
     ) -> Result<Arc<Mutex<Self>>, Error> {
@@ -306,6 +311,7 @@ impl Player {
             locale,
             log,
             ui,
+            video,
             self_reference: None,
             system: SystemProperties::default(),
             instance_counter: 0,
@@ -1224,6 +1230,7 @@ impl Player {
             storage,
             locale,
             logging,
+            video,
             needs_render,
             max_execution_duration,
             current_frame,
@@ -1246,6 +1253,7 @@ impl Player {
             self.storage.deref_mut(),
             self.locale.deref_mut(),
             self.log.deref_mut(),
+            self.video.deref_mut(),
             &mut self.needs_render,
             self.max_execution_duration,
             &mut self.current_frame,
@@ -1295,6 +1303,7 @@ impl Player {
                 storage,
                 locale,
                 log: logging,
+                video,
                 shared_objects,
                 unbound_text_fields,
                 timers,

--- a/core/tests/regression_tests.rs
+++ b/core/tests/regression_tests.rs
@@ -11,6 +11,7 @@ use ruffle_core::backend::{
     render::NullRenderer,
     storage::{MemoryStorageBackend, StorageBackend},
     ui::NullUiBackend,
+    video::NullVideoBackend,
 };
 use ruffle_core::context::UpdateContext;
 use ruffle_core::external::Value as ExternalValue;
@@ -767,6 +768,7 @@ fn run_swf(
         Box::new(NullNavigatorBackend::with_base_path(base_path, channel)),
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
+        Box::new(NullVideoBackend::new()),
         Box::new(TestLogBackend::new(trace_output.clone())),
         Box::new(NullUiBackend::new()),
     )?;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -28,6 +28,7 @@ use std::time::Instant;
 use tinyfiledialogs::open_file_dialog;
 use url::Url;
 
+use ruffle_core::backend::video;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use std::io::Read;
@@ -243,7 +244,7 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     )); //TODO: actually implement this backend type
     let storage = Box::new(storage::DiskStorageBackend::new());
     let locale = Box::new(locale::DesktopLocaleBackend::new());
-    let video = Box::new(NullVideoBackend::new());
+    let video = Box::new(video::SoftwareVideoBackend::new());
     let log = Box::new(ruffle_core::backend::log::NullLogBackend::new());
     let ui = Box::new(ui::DesktopUiBackend::new(window.clone()));
     let player = Player::new(renderer, audio, navigator, storage, locale, video, log, ui)?;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -18,7 +18,9 @@ use crate::custom_event::RuffleEvent;
 use crate::executor::GlutinAsyncExecutor;
 use clap::Clap;
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
-use ruffle_core::{backend::audio::AudioBackend, config::Letterbox, Player};
+use ruffle_core::{
+    backend::audio::AudioBackend, backend::video::NullVideoBackend, config::Letterbox, Player,
+};
 use ruffle_render_wgpu::WgpuRenderBackend;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -241,9 +243,10 @@ fn run_player(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     )); //TODO: actually implement this backend type
     let storage = Box::new(storage::DiskStorageBackend::new());
     let locale = Box::new(locale::DesktopLocaleBackend::new());
+    let video = Box::new(NullVideoBackend::new());
     let log = Box::new(ruffle_core::backend::log::NullLogBackend::new());
     let ui = Box::new(ui::DesktopUiBackend::new(window.clone()));
-    let player = Player::new(renderer, audio, navigator, storage, locale, log, ui)?;
+    let player = Player::new(renderer, audio, navigator, storage, locale, video, log, ui)?;
     {
         let mut player = player.lock().unwrap();
         player.set_root_movie(Arc::new(movie));
@@ -462,9 +465,10 @@ fn run_timedemo(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
     let navigator = Box::new(ruffle_core::backend::navigator::NullNavigatorBackend::new());
     let storage = Box::new(ruffle_core::backend::storage::MemoryStorageBackend::default());
     let locale = Box::new(locale::DesktopLocaleBackend::new());
+    let video = Box::new(NullVideoBackend::new());
     let log = Box::new(ruffle_core::backend::log::NullLogBackend::new());
     let ui = Box::new(ruffle_core::backend::ui::NullUiBackend::new());
-    let player = Player::new(renderer, audio, navigator, storage, locale, log, ui)?;
+    let player = Player::new(renderer, audio, navigator, storage, locale, video, log, ui)?;
     player.lock().unwrap().set_root_movie(Arc::new(movie));
     player.lock().unwrap().set_is_playing(true);
 

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -7,6 +7,7 @@ use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::backend::navigator::NullNavigatorBackend;
 use ruffle_core::backend::storage::MemoryStorageBackend;
 use ruffle_core::backend::ui::NullUiBackend;
+use ruffle_core::backend::video::NullVideoBackend;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::Player;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
@@ -108,6 +109,7 @@ fn take_screenshot(
         Box::new(NullNavigatorBackend::new()),
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
+        Box::new(NullVideoBackend::new()),
         Box::new(NullLogBackend::new()),
         Box::new(NullUiBackend::new()),
     )?;

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -7,7 +7,7 @@ use ruffle_core::backend::log::NullLogBackend;
 use ruffle_core::backend::navigator::NullNavigatorBackend;
 use ruffle_core::backend::storage::MemoryStorageBackend;
 use ruffle_core::backend::ui::NullUiBackend;
-use ruffle_core::backend::video::NullVideoBackend;
+use ruffle_core::backend::video::SoftwareVideoBackend;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::Player;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
@@ -109,7 +109,7 @@ fn take_screenshot(
         Box::new(NullNavigatorBackend::new()),
         Box::new(MemoryStorageBackend::default()),
         Box::new(NullLocaleBackend::new()),
-        Box::new(NullVideoBackend::new()),
+        Box::new(SoftwareVideoBackend::new()),
         Box::new(NullLogBackend::new()),
         Box::new(NullUiBackend::new()),
     )?;

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2615,7 +2615,7 @@ impl<'a> Reader<'a> {
         })
     }
 
-    fn read_define_video_stream(&mut self) -> Result<Tag<'a>> {
+    pub fn read_define_video_stream(&mut self) -> Result<Tag<'a>> {
         let id = self.read_character_id()?;
         let num_frames = self.read_u16()?;
         let width = self.read_u16()?;
@@ -2649,7 +2649,7 @@ impl<'a> Reader<'a> {
         }))
     }
 
-    fn read_video_frame(&mut self) -> Result<Tag<'a>> {
+    pub fn read_video_frame(&mut self) -> Result<Tag<'a>> {
         let stream_id = self.read_character_id()?;
         let frame_num = self.read_u16()?;
         let data = self.read_slice_to_end();

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -19,6 +19,7 @@ use ruffle_core::backend::{
     render::RenderBackend,
     storage::{MemoryStorageBackend, StorageBackend},
     ui::UiBackend,
+    video::NullVideoBackend,
 };
 use ruffle_core::config::Letterbox;
 use ruffle_core::context::UpdateContext;
@@ -457,9 +458,11 @@ impl Ruffle {
         };
         let locale = Box::new(locale::WebLocaleBackend::new());
         let trace_observer = Arc::new(RefCell::new(JsValue::UNDEFINED));
+        let video = Box::new(NullVideoBackend::new());
         let log = Box::new(log_adapter::WebLogBackend::new(trace_observer.clone()));
         let ui = Box::new(ui::WebUiBackend::new(js_player.clone(), &canvas));
-        let core = ruffle_core::Player::new(renderer, audio, navigator, storage, locale, log, ui)?;
+        let core =
+            ruffle_core::Player::new(renderer, audio, navigator, storage, locale, video, log, ui)?;
         {
             let mut core = core.lock().unwrap();
             if let Some(color) = config.background_color.and_then(parse_html_color) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -19,7 +19,7 @@ use ruffle_core::backend::{
     render::RenderBackend,
     storage::{MemoryStorageBackend, StorageBackend},
     ui::UiBackend,
-    video::NullVideoBackend,
+    video::SoftwareVideoBackend,
 };
 use ruffle_core::config::Letterbox;
 use ruffle_core::context::UpdateContext;
@@ -458,7 +458,7 @@ impl Ruffle {
         };
         let locale = Box::new(locale::WebLocaleBackend::new());
         let trace_observer = Arc::new(RefCell::new(JsValue::UNDEFINED));
-        let video = Box::new(NullVideoBackend::new());
+        let video = Box::new(SoftwareVideoBackend::new());
         let log = Box::new(log_adapter::WebLogBackend::new(trace_observer.clone()));
         let ui = Box::new(ui::WebUiBackend::new(js_player.clone(), &canvas));
         let core =


### PR DESCRIPTION
As requested I have extracted all of the non-codec Video support - a fresh display object, associated AVM stubs, and so on. This PR will recognize video tracks in an SWF, store them, and then generate errors as it has no codecs to work with. I've also reorganized the H.263 PR to be downstream of this one. Merging that PR will also merge this one.

I expect the person working on libav VP6 integration (szooloo on Discord but I don't know their Github username) to also make use of this base PR.

As this contains no codecs there should be no patent exposure from merging it.