### PR TITLE
docs: Update some documentation in the swf library

### DIFF
--- a/swf/src/string.rs
+++ b/swf/src/string.rs
@@ -3,14 +3,15 @@
 pub use encoding_rs::{Encoding, SHIFT_JIS, UTF_8, WINDOWS_1252};
 use std::{borrow::Cow, fmt};
 
-/// `SwfStr` is the string type returned by SWF parsing functions.
-/// `SwfStr` is a bstr-like type analogous to `str`:
+/// A bstr-like string type analogous to [`str`] that's returned by SWF parsing functions:
+///
 /// * The encoding depends on the SWF version (UTF-8 for SWF6 and higher).
-///   Use `Reader::encoding` or `SwfStr::encoding_for_version` to get the
+///   Use `Reader::encoding` or [`SwfStr::encoding_for_version`] to get the
 ///   proper encoding.
 /// * Invalid data for any particular encoding is allowed;
 ///   any conversions to std::String will be lossy for invalid data.
-/// To convert this to a standard Rust string, use `SwfStr::to_str_lossy`.
+///
+/// To convert this to a standard Rust string, use [`SwfStr::to_str_lossy`].
 #[derive(Eq, PartialEq)]
 #[repr(transparent)]
 pub struct SwfStr {
@@ -19,8 +20,16 @@ pub struct SwfStr {
 }
 
 impl SwfStr {
-    /// Create a new `SwfStr` from a byte slice.
+    /// Creates a new `SwfStr` from a byte slice.
     /// The data is not required to be valid for the given encoding.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_bytes(b"Hello, World!");
+    /// ```
     #[inline]
     pub fn from_bytes(string: &[u8]) -> &Self {
         // SAFETY: Casting is safe because internal representations are
@@ -28,8 +37,20 @@ impl SwfStr {
         unsafe { &*(string as *const [u8] as *const Self) }
     }
 
-    /// Read a `SwfStr` from a byte slice until a NULL byte is encountered.
+    /// Creates a `SwfStr` from a byte slice by reading until a NULL byte (`0`) is encountered.
     /// Returns `None` if no NULL byte was found.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_bytes_null_terminated(b"I'm null-terminated!\0");
+    /// assert!(s.is_some());
+    ///
+    /// let s = SwfStr::from_bytes_null_terminated(b"I'm not terminated...");
+    /// assert!(s.is_none());
+    /// ```
     #[inline]
     pub fn from_bytes_null_terminated(string: &[u8]) -> Option<&Self> {
         // If investigations show that the bounds check is not elided,
@@ -41,23 +62,55 @@ impl SwfStr {
             .map(|i| Self::from_bytes(&string[..i]))
     }
 
-    /// Create a new UTF-8 `SwfStr` from a Rust `str`.
+    /// Creates a new UTF-8 `SwfStr` from a Rust [`str`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_utf8_str("Hello, 🌏!");
+    /// ```
     #[inline]
     pub fn from_utf8_str(string: &str) -> &Self {
         Self::from_bytes(string.as_bytes())
     }
 
-    /// Create a new UTF-8 `SwfStr` from a Rust `str`.
+    /// Creates a new UTF-8 `SwfStr` from a Rust [`str`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_utf8_str_null_terminated("I'm null-terminated!\0");
+    /// assert!(s.is_some());
+    ///
+    /// let s = SwfStr::from_utf8_str_null_terminated("I'm not terminated...");
+    /// assert!(s.is_none());
+    /// ```
     #[inline]
     pub fn from_utf8_str_null_terminated(string: &str) -> Option<&Self> {
         Self::from_bytes_null_terminated(string.as_bytes())
     }
 
-    /// Create a new `SwfStr` with the given encoding from a Rust `str`.
+    /// Creates a new `SwfStr` with the given encoding from a Rust [`str`].
+    /// Returns `None` if the encoding is not lossless.
+    ///
     /// The string will be re-encoded with the given encoding.
-    /// The string will be truncated if a null byte is encountered.
-    /// `None` is returned if the encoding is not lossless.
+    /// The string will be truncated if a NULL byte (`0`) is encountered.
+    ///
     /// Intended for tests.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    /// use encoding_rs::WINDOWS_1252;
+    ///
+    /// let s = SwfStr::from_str_with_encoding("Hello, World!", WINDOWS_1252);
+    /// assert!(s.is_some());
+    /// ```
     pub fn from_str_with_encoding<'a>(
         string: &'a str,
         encoding: &'static Encoding,
@@ -70,9 +123,20 @@ impl SwfStr {
     }
 
     /// Returns the suggested string encoding for the given SWF version.
+    ///
     /// For SWF version 6 and higher, this is always UTF-8.
     /// For SWF version 5 and lower, this is locale-dependent,
     /// and we default to WINDOWS-1252.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    /// use encoding_rs::{UTF_8, WINDOWS_1252};
+    ///
+    /// assert_eq!(SwfStr::encoding_for_version(9), UTF_8);
+    /// assert_eq!(SwfStr::encoding_for_version(3), WINDOWS_1252);
+    /// ```
     #[inline]
     pub fn encoding_for_version(swf_version: u8) -> &'static Encoding {
         if swf_version >= 6 {
@@ -83,32 +147,89 @@ impl SwfStr {
     }
 
     /// Returns the byte slice of this string.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_utf8_str("💖");
+    /// assert_eq!(s.as_bytes(), [0xF0, 0x9F, 0x92, 0x96]);
+    /// ```
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.string
     }
 
     /// Returns `true` if the string has a length of zero, and `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_bytes(&[]);
+    /// assert!(s.is_empty());
+    ///
+    /// let s = SwfStr::from_utf8_str("💖");
+    /// assert!(!s.is_empty());
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.string.is_empty()
     }
 
-    /// Returns the `len` of the string in bytes.
+    /// Returns the length of the string in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    ///
+    /// let s = SwfStr::from_utf8_str("");
+    /// assert_eq!(s.len(), 0);
+    ///
+    /// let s = SwfStr::from_utf8_str("Hi!");
+    /// assert_eq!(s.len(), 3);
+    ///
+    /// let s = SwfStr::from_utf8_str("💖");
+    /// assert_eq!(s.len(), 4);
+    /// ```
     #[inline]
     pub fn len(&self) -> usize {
         self.string.len()
     }
 
-    /// Decodes the string into a Rust UTF-8 `str`.
-    /// The UTF-8 replacement character will be uses for any invalid data.
+    /// Decodes the string into a Rust UTF-8 [`str`].
+    ///
+    /// The UTF-8 replacement character will be used for any invalid data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    /// use encoding_rs::UTF_8;
+    ///
+    /// let s = SwfStr::from_bytes(&[0xF0, 0x9F, 0x92, 0x96]);
+    /// assert_eq!(s.to_str_lossy(UTF_8), "💖");
+    /// ```
     #[inline]
     pub fn to_str_lossy(&self, encoding: &'static Encoding) -> Cow<'_, str> {
         encoding.decode_without_bom_handling(&self.string).0
     }
 
-    /// Decodes the string into a Rust UTF-8 `String`.
-    /// The UTF-8 replacement character will be uses for any invalid data.
+    /// Decodes the string into a Rust UTF-8 [`String`].
+    ///
+    /// The UTF-8 replacement character will be used for any invalid data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::SwfStr;
+    /// use encoding_rs::UTF_8;
+    ///
+    /// let s = SwfStr::from_bytes(&[0xF0, 0x9F, 0x92, 0x96]);
+    /// assert_eq!(s.to_string_lossy(UTF_8), "💖");
+    /// ```
     #[inline]
     pub fn to_string_lossy(&self, encoding: &'static Encoding) -> String {
         self.to_str_lossy(encoding).into_owned()
@@ -134,9 +255,11 @@ impl<'a, T: ?Sized + AsRef<str>> PartialEq<T> for SwfStr {
 }
 
 impl fmt::Debug for SwfStr {
+    /// Formats the `SwfStr` using the given formatter.
+    ///
+    /// Note: this method assumes UTF-8 encoding;
+    /// other encodings like Shift-JIS will output gibberish.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Note that this assumes UTF-8 encoding;
-        // other encodings like Shift-JIS will output gibberish.
         f.write_str(&self.to_str_lossy(UTF_8))
     }
 }

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -233,11 +233,21 @@ impl std::fmt::Display for Twips {
     }
 }
 
+/// A rectangular region defined by minimum
+/// and maximum x- and y-coordinate positions
+/// measured in [`Twips`].
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Rectangle {
+    /// The minimum x-position of the rectangle.
     pub x_min: Twips,
+
+    /// The maximum x-position of the rectangle.
     pub x_max: Twips,
+
+    /// The minimum y-position of the rectangle.
     pub y_min: Twips,
+
+    /// The maximum y-position of the rectangle.
     pub y_max: Twips,
 }
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -241,15 +241,42 @@ pub struct Rectangle {
     pub y_max: Twips,
 }
 
+/// An RGBA (red, green, blue, alpha) color.
+///
+/// All components are stored as [`u8`] and have a color range of 0-255.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Color {
+    /// The red component value.
     pub r: u8,
+
+    /// The green component value.
     pub g: u8,
+
+    /// The blue component value.
     pub b: u8,
+
+    /// The alpha component value.
     pub a: u8,
 }
 
 impl Color {
+    /// Creates a `Color` from a 32-bit `rgb` value and an `alpha` value.
+    ///
+    /// The byte-ordering of the 32-bit `rgb` value is XXRRGGBB.
+    /// The most significant byte, represented by XX, is ignored;
+    /// the `alpha` value is provided separately.
+    /// This is followed by the the red (RR), green (GG), and blue (BB) components values,
+    /// respectively.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Color;
+    ///
+    /// let red = Color::from_rgb(0xFF0000, 255);
+    /// let green = Color::from_rgb(0x00FF00, 255);
+    /// let blue = Color::from_rgb(0x0000FF, 255);
+    /// ```
     pub fn from_rgb(rgb: u32, alpha: u8) -> Self {
         Self {
             r: ((rgb & 0xFF_0000) >> 16) as u8,
@@ -258,6 +285,29 @@ impl Color {
             a: alpha,
         }
     }
+
+    /// Converts the color to a 32-bit RGB value.
+    ///
+    /// The alpha value does not get stored.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```rust
+    /// use swf::Color;
+    ///
+    /// let color = Color::from_rgb(0xFF00FF, 255);
+    /// assert_eq!(color.to_rgb(), 0xFF00FF);
+    /// ```
+    ///
+    /// Alpha values do not get stored:
+    /// ```rust
+    /// use swf::Color;
+    ///
+    /// let color1 = Color::from_rgb(0xFF00FF, 255);
+    /// let color2 = Color::from_rgb(0xFF00FF, 0);
+    /// assert_eq!(color1.to_rgb(), color2.to_rgb());
+    /// ```
     pub fn to_rgb(&self) -> u32 {
         ((self.r as u32) << 16) | ((self.g as u32) << 8) | (self.b as u32)
     }

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -54,14 +54,17 @@ pub enum Compression {
     Lzma,
 }
 
-/// Most coordinates in an SWF file are represented in "twips".
-/// A twip is 1/20th of a pixel.
-///
-/// `Twips` is a type-safe wrapper type documenting where Twips are used
+/// A type-safe wrapper type documenting where "twips" are used
 /// in the SWF format.
 ///
-/// Use `Twips::from_pixels` and `Twips::to_pixels` to convert to and from
+/// A twip is 1/20th of a pixel.
+/// Most coordinates in an SWF file are represented in twips.
+///
+/// Use the [`from_pixels`] and [`to_pixels`] methods to convert to and from
 /// pixel values.
+///
+/// [`from_pixels`]: Twips::from_pixels
+/// [`to_pixels`]: Twips::to_pixels
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default, PartialOrd, Ord)]
 pub struct Twips(i32);
 
@@ -70,24 +73,66 @@ impl Twips {
     pub const TWIPS_PER_PIXEL: f64 = 20.0;
 
     /// Creates a new `Twips` object. Note that the `twips` value is in twips,
-    /// not pixels. Use `from_pixels` to convert from pixel units.
+    /// not pixels. Use the [`from_pixels`] method to convert from pixel units.
+    ///
+    /// [`from_pixels`]: Twips::from_pixels
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Twips;
+    ///
+    /// let twips = Twips::new(40);
+    /// ```
     pub fn new<T: Into<i32>>(twips: T) -> Self {
         Self(twips.into())
     }
 
-    /// Creates a new `Twips` object set to the value of 0.
+    /// Creates a new `Twips` object with a value of `0`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Twips;
+    ///
+    /// let twips = Twips::zero();
+    /// assert_eq!(twips.get(), 0);
+    /// ```
     pub fn zero() -> Self {
         Self(0)
     }
 
     /// Returns the number of twips.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Twips;
+    ///
+    /// let twips = Twips::new(47);
+    /// assert_eq!(twips.get(), 47);
+    /// ```
     pub fn get(self) -> i32 {
         self.0
     }
 
-    /// Converts the number of pixels into twips.
+    /// Converts the given number of `pixels` into twips.
     ///
-    /// This may be a lossy conversion; any precision less than a twip (1/20 pixels) is truncated.
+    /// This may be a lossy conversion; any precision more than a twip (1/20 pixels) is truncated.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Twips;
+    ///
+    /// // 40 pixels is equivalent to 800 twips.
+    /// let twips = Twips::from_pixels(40.0);
+    /// assert_eq!(twips.get(), 800);
+    ///
+    /// // Output is truncated if more precise than a twip (1/20 pixels).
+    /// let twips = Twips::from_pixels(40.018);
+    /// assert_eq!(twips.get(), 800);
+    /// ```
     pub fn from_pixels(pixels: f64) -> Self {
         Self((pixels * Self::TWIPS_PER_PIXEL) as i32)
     }
@@ -95,10 +140,36 @@ impl Twips {
     /// Converts this twips value into pixel units.
     ///
     /// This is a lossless operation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Twips;
+    ///
+    /// // 800 twips is equivalent to 40 pixels.
+    /// let twips = Twips::new(800);
+    /// assert_eq!(twips.to_pixels(), 40.0);
+    ///
+    /// // Twips are sub-pixel: 713 twips represent 35.65 pixels.
+    /// let twips = Twips::new(713);
+    /// assert_eq!(twips.to_pixels(), 35.65);
+    /// ```
     pub fn to_pixels(self) -> f64 {
         f64::from(self.0) / Self::TWIPS_PER_PIXEL
     }
 
+    /// Saturating integer subtraction. Computes `self - rhs`, saturating at the numeric bounds
+    /// of [`i32`] instead of overflowing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use swf::Twips;
+    ///
+    /// assert_eq!(Twips::new(40).saturating_sub(Twips::new(20)), Twips::new(20));
+    /// assert_eq!(Twips::new(i32::MIN).saturating_sub(Twips::new(5)), Twips::new(i32::MIN));
+    /// assert_eq!(Twips::new(i32::MAX).saturating_sub(Twips::new(-100)), Twips::new(i32::MAX));
+    /// ```
     pub fn saturating_sub(self, rhs: Self) -> Self {
         Self(self.0.saturating_sub(rhs.0))
     }


### PR DESCRIPTION
Updated the documentation for SwfStr, Twips, Color, and Rectangle. It's only a couple of types, but this should bring the relevant docs more in line with what Rust recommends (e.g., code examples for everything, even if trivial).

I'll probably try to beef up the documentation of other areas as well in future pull requests.