### PR TITLE
web: Use case-insensitive check for detecting javascript scheme

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -172,9 +172,6 @@ pub trait NavigatorBackend {
         vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     );
 
-    /// Execute a JavaScript code.
-    fn run_script(&self, js_code: &str);
-
     /// Fetch data at a given URL and return it some time in the future.
     fn fetch(&self, url: &str, request_options: RequestOptions) -> OwnedFuture<Vec<u8>, Error>;
 
@@ -361,8 +358,6 @@ impl NavigatorBackend for NullNavigatorBackend {
         _vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     ) {
     }
-
-    fn run_script(&self, _js_code: &str) {}
 
     fn fetch(&self, url: &str, _opts: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
         let mut path = self.relative_base_path.clone();

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -111,8 +111,6 @@ impl NavigatorBackend for ExternalNavigatorBackend {
         };
     }
 
-    fn run_script(&self, _js_code: &str) {}
-
     fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
         // TODO: honor sandbox type (local-with-filesystem, local-with-network, remote, ...)
         let full_url = match self.movie_url.clone().join(url) {


### PR DESCRIPTION
Do a case-insensitive check for the `javascript:` scheme when allowScriptAccess is false. Fixes #3132.

Also move `run_script` to be a method directly on `WebNavigatorBackend` since it will be unused by desktop.

TODO: Definitely should have a web test for all `allowScriptAccess` affected APIs.
