### PR TITLE
Use proper display object

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1248,7 +1248,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     } else {
                         let process = self.context.load_manager.load_movie_into_clip(
                             self.context.player.clone().unwrap(),
-                            level,
+                            level.as_movie_clip().expect("Attempted to load movie into not movie clip"),
                             fetch,
                             url,
                             None,
@@ -1346,7 +1346,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     let fetch = self.context.navigator.fetch(&url, opts);
                     let process = self.context.load_manager.load_movie_into_clip(
                         self.context.player.clone().unwrap(),
-                        clip_target,
+                        clip_target.as_movie_clip().expect("Attempted to load movie into not movie clip"),
                         fetch,
                         url.to_string(),
                         None,
@@ -1364,7 +1364,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
                     let process = self.context.load_manager.load_movie_into_clip(
                         self.context.player.clone().unwrap(),
-                        level,
+                        level.as_movie_clip().expect("Attempted to load movie into not movie clip"),
                         fetch,
                         url.to_string(),
                         None,

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1223,7 +1223,7 @@ fn load_movie<'gc>(
     let fetch = activation.context.navigator.fetch(&url, opts);
     let process = activation.context.load_manager.load_movie_into_clip(
         activation.context.player.clone().unwrap(),
-        DisplayObject::MovieClip(target),
+        target,
         fetch,
         url.to_string(),
         None,

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -8,7 +8,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, Value};
 use crate::backend::navigator::RequestOptions;
-use crate::display_object::{DisplayObject, TDisplayObject};
+use crate::display_object::TDisplayObject;
 use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
@@ -51,7 +51,7 @@ pub fn load_clip<'gc>(
                 .fetch(&url, RequestOptions::get());
             let process = activation.context.load_manager.load_movie_into_clip(
                 activation.context.player.clone().unwrap(),
-                DisplayObject::MovieClip(movieclip),
+                movieclip,
                 fetch,
                 url.to_string(),
                 Some(this),

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -188,7 +188,7 @@ fn attach_sound<'gc>(
         let name = name.coerce_to_string(activation)?;
         let movie = sound_object
             .owner()
-            .or_else(|| activation.context.levels.get(&0).copied())
+            .or_else(|| activation.context.levels.get(&0).copied().map(|clip| clip.into()))
             .and_then(|o| o.movie());
         if let Some(movie) = movie {
             if let Some(Character::Sound(sound)) = activation
@@ -525,7 +525,7 @@ fn stop<'gc>(
             let name = name.coerce_to_string(activation)?;
             let movie = sound
                 .owner()
-                .or_else(|| activation.context.levels.get(&0).copied())
+                .or_else(|| activation.context.levels.get(&0).copied().map(|clip| clip.into()))
                 .and_then(|o| o.movie());
             if let Some(movie) = movie {
                 if let Some(Character::Sound(sound)) = activation

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -865,8 +865,7 @@ mod tests {
             let mut avm1 = Avm1::new(gc_context, swf_version);
             let mut avm2 = Avm2::new(gc_context);
             let swf = Arc::new(SwfMovie::empty(swf_version));
-            let root: DisplayObject<'_> =
-                MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
+            let root = MovieClip::new(SwfSlice::empty(swf.clone()), gc_context);
             root.set_depth(gc_context, 0);
             let mut levels = BTreeMap::new();
             levels.insert(0, root);
@@ -913,7 +912,7 @@ mod tests {
                 time_offset: &mut 0,
             };
 
-            root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
+            root.post_instantiation(&mut context, root.into(), None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");
 
             let base_clip = *context.levels.get(&0).unwrap();
@@ -923,7 +922,7 @@ mod tests {
                 ActivationIdentifier::root("[Test]"),
                 swf_version,
                 globals,
-                base_clip,
+                base_clip.into(),
             );
 
             test(&mut activation, object)

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -36,8 +36,7 @@ where
         let mut avm1 = Avm1::new(gc_context, swf_version);
         let mut avm2 = Avm2::new(gc_context);
         let swf = Arc::new(SwfMovie::empty(swf_version));
-        let root: DisplayObject<'gc> =
-            MovieClip::new(SwfSlice::empty(swf.clone()), gc_context).into();
+        let root = MovieClip::new(SwfSlice::empty(swf.clone()), gc_context);
         root.set_depth(gc_context, 0);
         let mut levels = BTreeMap::new();
         levels.insert(0, root);
@@ -82,12 +81,12 @@ where
             time_offset: &mut 0,
             audio_manager: &mut AudioManager::new(),
         };
-        root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
+        root.post_instantiation(&mut context, root.into(), None, Instantiator::Movie, false);
         root.set_name(context.gc_context, "");
 
         fn run_test<'a, 'gc: 'a, F>(
             activation: &mut Activation<'_, 'gc, '_>,
-            root: DisplayObject<'gc>,
+            root: MovieClip<'gc>,
             test: F,
         ) where
             F: FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>) -> Result<(), Error<'gc>>,
@@ -106,7 +105,7 @@ where
             ActivationIdentifier::root("[Test]"),
             swf_version,
             globals,
-            base_clip,
+            base_clip.into(),
         );
 
         run_test(&mut activation, root, test)

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -46,7 +46,7 @@ impl<'gc> Timers<'gc> {
             ActivationIdentifier::root("[Timer Callback]"),
             version,
             globals,
-            level0,
+            level0.into(),
         );
 
         // TODO: `this` is undefined for non-method timer callbacks, but our VM

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -194,7 +194,7 @@ impl<'gc> AudioManager<'gc> {
         audio: &mut dyn AudioBackend,
         gc_context: gc_arena::MutationContext<'gc, '_>,
         action_queue: &mut crate::context::ActionQueue<'gc>,
-        root: DisplayObject<'gc>,
+        root: MovieClip<'gc>,
     ) {
         // Update the position of sounds, and remove any completed sounds.
         self.sounds.retain(|sound| {
@@ -208,7 +208,7 @@ impl<'gc> AudioManager<'gc> {
                 // Sound ended; fire end event.
                 if let Some(object) = sound.avm1_object {
                     action_queue.queue_actions(
-                        root,
+                        root.into(),
                         crate::context::ActionType::Method {
                             object: object.into(),
                             name: "onSoundComplete",

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -89,7 +89,7 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     pub rng: &'a mut SmallRng,
 
     /// All loaded levels of the current player.
-    pub levels: &'a mut BTreeMap<u32, DisplayObject<'gc>>,
+    pub levels: &'a mut BTreeMap<u32, MovieClip<'gc>>,
 
     /// The display object that the mouse is currently hovering over.
     pub mouse_hovered_object: Option<DisplayObject<'gc>>,
@@ -163,7 +163,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             self.audio,
             self.gc_context,
             self.action_queue,
-            *self.levels.get(&0).unwrap(),
+            (*self.levels.get(&0).unwrap()).into(),
         );
     }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -785,7 +785,7 @@ pub trait TDisplayObject<'gc>:
         name: &str,
         context: &mut UpdateContext<'_, 'gc, '_>,
         case_sensitive: bool,
-    ) -> Option<DisplayObject<'gc>> {
+    ) -> Option<MovieClip<'gc>> {
         if let Some(slice) = name.get(0..min(name.len(), 6)) {
             let is_level = if case_sensitive {
                 slice == "_level"

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -211,7 +211,7 @@ impl<'gc> Callback<'gc> {
                     Avm1ActivationIdentifier::root("[ExternalInterface]"),
                     swf_version,
                     globals,
-                    base_clip,
+                    base_clip.into(),
                 );
                 let this = this.coerce_to_object(&mut activation);
                 let args: Vec<Avm1Value> = args

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -45,7 +45,7 @@ impl<'gc> FocusTracker<'gc> {
 
         let level0 = context.levels.get(&0).copied().unwrap();
         Avm1::notify_system_listeners(
-            level0,
+            level0.into(),
             context.swf.version(),
             context,
             "Selection",


### PR DESCRIPTION
`LoadManager::target_clip` and `UpdateContext::levels` were stored as a `DisplayObject`, but in reality they were always a `MovieClip`. This PR changes the types to reflect that.

`SoundInstance::display_object` probably suffers from the same, but I didn't change that as I was (more) unsure there.

