### PR TITLE
swf: Add VideoCodec::ScreenVideoV2 variant

### DIFF
--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2627,6 +2627,7 @@ impl<'a> Reader<'a> {
             3 => VideoCodec::ScreenVideo,
             4 => VideoCodec::VP6,
             5 => VideoCodec::VP6WithAlpha,
+            6 => VideoCodec::ScreenVideoV2,
             _ => return Err(Error::invalid_data("Invalid video codec.")),
         };
         Ok(Tag::DefineVideoStream(DefineVideoStream {

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -1229,6 +1229,7 @@ pub enum VideoCodec {
     ScreenVideo,
     VP6,
     VP6WithAlpha,
+    ScreenVideoV2,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2567,6 +2567,7 @@ impl<W: Write> Writer<W> {
             VideoCodec::ScreenVideo => 3,
             VideoCodec::VP6 => 4,
             VideoCodec::VP6WithAlpha => 5,
+            VideoCodec::ScreenVideoV2 => 6,
         })?;
         Ok(())
     }


### PR DESCRIPTION
For completeness' sake.
The `DefineVideoStream` header format table in the SWF spec (v19) does not mention this (might be an oversight), but the one for `VideoFrame` does.