### PR TITLE
Don't mutably borrow display_properties for reading

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1183,7 +1183,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let ret = if let Some(target) = self.target_clip() {
             if let Some(clip) = self.resolve_target_display_object(target, path, true)? {
                 let display_properties = self.context.avm1.display_properties;
-                let props = display_properties.write(self.context.gc_context);
+                let props = display_properties.read();
                 if let Some(property) = props.get_by_index(prop_index) {
                     property.get(self, clip)?
                 } else {


### PR DESCRIPTION
It was a bit weird, that `action_get_property` was borrowing mutably and `action_set_property` immutably :) I'm assuming it was a mistake?

Seems to fix the panic in Adobe Presenter in https://github.com/ruffle-rs/ruffle/issues/3199 .

(note: I actually still don't know where the second borrow came from.)