### PR TITLE
chore: Avoid deprecated constants

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -787,7 +787,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         };
 
         if let Some((clip, frame)) = call_frame {
-            if frame <= u32::from(std::u16::MAX) {
+            if frame <= u32::from(u16::MAX) {
                 for action in clip.actions_on_frame(&mut self.context, frame as u16) {
                     let _ = self.run_child_frame_for_action(
                         "[Frame Call]",

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -6,9 +6,7 @@ use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::Collect;
 use gc_arena::MutationContext;
 use rand::Rng;
-use std::f64;
 use std::str;
-use std::u8;
 
 mod array;
 pub(crate) mod as_broadcaster;
@@ -1279,8 +1277,8 @@ mod tests {
             [10.0] => true,
             [-10.0] => true,
             [0.0] => false,
-            [std::f64::INFINITY] => true,
-            [std::f64::NAN] => false,
+            [f64::INFINITY] => true,
+            [f64::NAN] => false,
             [""] => false,
             ["Hello"] => true,
             [" "] => true,
@@ -1296,8 +1294,8 @@ mod tests {
             [10.0] => true,
             [-10.0] => true,
             [0.0] => false,
-            [std::f64::INFINITY] => true,
-            [std::f64::NAN] => false,
+            [f64::INFINITY] => true,
+            [f64::NAN] => false,
             [""] => false,
             ["Hello"] => false,
             [" "] => false,
@@ -1316,8 +1314,8 @@ mod tests {
             [10.0] => false,
             [-10.0] => false,
             [0.0] => false,
-            [std::f64::INFINITY] => false,
-            [std::f64::NAN] => true,
+            [f64::INFINITY] => false,
+            [f64::NAN] => true,
             [""] => true,
             ["Hello"] => true,
             [" "] => true,
@@ -1342,9 +1340,9 @@ mod tests {
             [10.0] => true,
             [-10.0] => true,
             [0.0] => true,
-            [std::f64::INFINITY] => false,
-            [std::f64::NEG_INFINITY] => false,
-            [std::f64::NAN] => false,
+            [f64::INFINITY] => false,
+            [f64::NEG_INFINITY] => false,
+            [f64::NAN] => false,
             [""] => false,
             ["Hello"] => false,
             [" "] => false,
@@ -1371,39 +1369,39 @@ mod tests {
             [false] => 0.0,
             [10.0] => 10.0,
             [-10.0] => -10.0,
-            ["true"] => std::f64::NAN,
-            ["false"] => std::f64::NAN,
+            ["true"] => f64::NAN,
+            ["false"] => f64::NAN,
             [1.0] => 1.0,
             [0.0] => 0.0,
             [0.000] => 0.0,
             ["0.000"] => 0.0,
-            ["True"] => std::f64::NAN,
-            ["False"] => std::f64::NAN,
-            [std::f64::NAN] => std::f64::NAN,
-            [std::f64::INFINITY] => std::f64::INFINITY,
-            [std::f64::NEG_INFINITY] => std::f64::NEG_INFINITY,
+            ["True"] => f64::NAN,
+            ["False"] => f64::NAN,
+            [f64::NAN] => f64::NAN,
+            [f64::INFINITY] => f64::INFINITY,
+            [f64::NEG_INFINITY] => f64::NEG_INFINITY,
             [" 12"] => 12.0,
             [" \t\r\n12"] => 12.0,
-            ["\u{A0}12"] => std::f64::NAN,
-            [" 0x12"] => std::f64::NAN,
+            ["\u{A0}12"] => f64::NAN,
+            [" 0x12"] => f64::NAN,
             ["01.2"] => 1.2,
-            [""] => std::f64::NAN,
-            ["Hello"] => std::f64::NAN,
-            [" "] => std::f64::NAN,
-            ["  5  "] => std::f64::NAN,
+            [""] => f64::NAN,
+            ["Hello"] => f64::NAN,
+            [" "] => f64::NAN,
+            ["  5  "] => f64::NAN,
             ["0"] => 0.0,
             ["1"] => 1.0,
-            ["Infinity"] => std::f64::NAN,
-            ["100a"] => std::f64::NAN,
-            ["0xhello"] => std::f64::NAN,
+            ["Infinity"] => f64::NAN,
+            ["100a"] => f64::NAN,
+            ["0xhello"] => f64::NAN,
             ["123e-1"] => 12.3,
-            ["0xUIXUIDFKHJDF012345678"] => std::f64::NAN,
+            ["0xUIXUIDFKHJDF012345678"] => f64::NAN,
             [] => 0.0
         },
         [5] => {
-            ["0x12"] => std::f64::NAN,
-            ["0x10"] => std::f64::NAN,
-            ["0x1999999981ffffff"] => std::f64::NAN,
+            ["0x12"] => f64::NAN,
+            ["0x10"] => f64::NAN,
+            ["0x1999999981ffffff"] => f64::NAN,
             ["010"] => 10,
             ["-010"] => -10,
             ["+010"] => 10,
@@ -1416,7 +1414,7 @@ mod tests {
         [6, 7] => {
             ["0x12"] => 18.0,
             ["0x10"] => 16.0,
-            ["-0x10"] => std::f64::NAN,
+            ["-0x10"] => f64::NAN,
             ["0x1999999981ffffff"] => -2113929217.0,
             ["010"] => 8,
             ["-010"] => -8,
@@ -1432,8 +1430,8 @@ mod tests {
             [Value::Null] => 0.0
         },
         [7] => {
-            [Value::Undefined] => std::f64::NAN,
-            [Value::Null] => std::f64::NAN
+            [Value::Undefined] => f64::NAN,
+            [Value::Null] => f64::NAN
         }
     );
 }

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -7,7 +7,6 @@ use crate::avm1::{AvmString, Object, TObject, Value};
 use chrono::{DateTime, Datelike, Duration, FixedOffset, LocalResult, TimeZone, Timelike, Utc};
 use gc_arena::{Collect, MutationContext};
 use num_traits::ToPrimitive;
-use std::f64::NAN;
 
 macro_rules! implement_local_getters {
     ($gc_context: ident, $object:ident, $fn_proto: expr, $($name:expr => $fn:expr),*) => {
@@ -20,7 +19,7 @@ macro_rules! implement_local_getters {
                             let local = date.with_timezone(&activation.context.locale.get_timezone());
                             Ok($fn(&local).into())
                         } else {
-                            Ok(NAN.into())
+                            Ok(f64::NAN.into())
                         }
                     } else {
                         Ok(Value::Undefined)
@@ -64,7 +63,7 @@ macro_rules! implement_utc_getters {
                         if let Some(date) = this.date_time() {
                             Ok($fn(&date).into())
                         } else {
-                            Ok(NAN.into())
+                            Ok(f64::NAN.into())
                         }
                     } else {
                         Ok(Value::Undefined)
@@ -546,7 +545,7 @@ impl<'builder, 'activation_a, 'gc, 'gc_context, T: TimeZone>
         if let Some(date) = date {
             date.timestamp_millis() as f64
         } else {
-            NAN
+            f64::NAN
         }
     }
 }
@@ -662,7 +661,7 @@ fn get_timezone_offset<'gc>(
     let date = if let Some(date) = this.date_time() {
         date.with_timezone(&activation.context.locale.get_timezone())
     } else {
-        return Ok(NAN.into());
+        return Ok(f64::NAN.into());
     };
 
     let seconds = date.offset().utc_minus_local() as f32;
@@ -677,7 +676,7 @@ fn set_date<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.is_empty() {
         this.set_date_time(activation.context.gc_context, None);
-        Ok(NAN.into())
+        Ok(f64::NAN.into())
     } else {
         let timezone = activation.context.locale.get_timezone();
         let timestamp = DateAdjustment::new(activation, &timezone)
@@ -694,7 +693,7 @@ fn set_utc_date<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.is_empty() {
         this.set_date_time(activation.context.gc_context, None);
-        Ok(NAN.into())
+        Ok(f64::NAN.into())
     } else {
         let timestamp = DateAdjustment::new(activation, &Utc)
             .day(args.get(0))?
@@ -862,7 +861,7 @@ fn set_time<'gc>(
     }
 
     this.set_date_time(activation.context.gc_context, None);
-    Ok(NAN.into())
+    Ok(f64::NAN.into())
 }
 
 fn set_full_year<'gc>(

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -5,7 +5,6 @@ use crate::avm1::property::Attribute;
 use crate::avm1::{ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
 use rand::Rng;
-use std::f64::{INFINITY, NAN, NEG_INFINITY};
 
 macro_rules! wrap_std {
     ( $object: ident, $gc_context: ident, $proto: ident, $($name:expr => $std:path),* ) => {{
@@ -16,7 +15,7 @@ macro_rules! wrap_std {
                     if let Some(input) = args.get(0) {
                         Ok($std(input.coerce_to_f64(activation)?).into())
                     } else {
-                        Ok(NAN.into())
+                        Ok(f64::NAN.into())
                     }
                 },
                 $gc_context,
@@ -42,7 +41,7 @@ fn atan2<'gc>(
             return Ok(y.coerce_to_f64(activation)?.atan2(0.0).into());
         }
     }
-    Ok(NAN.into())
+    Ok(f64::NAN.into())
 }
 
 fn pow<'gc>(
@@ -54,12 +53,12 @@ fn pow<'gc>(
         if let Some(x) = args.get(1) {
             let x = x.coerce_to_f64(activation)?;
             if x.is_nan() {
-                return Ok(NAN.into());
+                return Ok(f64::NAN.into());
             }
             return Ok(y.coerce_to_f64(activation)?.powf(x).into());
         }
     }
-    Ok(NAN.into())
+    Ok(f64::NAN.into())
 }
 
 fn round<'gc>(
@@ -74,7 +73,7 @@ fn round<'gc>(
         let ret = (x + 0.5).floor();
         return Ok(ret.into());
     }
-    Ok(NAN.into())
+    Ok(f64::NAN.into())
 }
 
 fn max<'gc>(
@@ -92,13 +91,13 @@ fn max<'gc>(
                         Ok(a.coerce_to_f64(activation)?.into())
                     }
                 }
-                _ => Ok(NAN.into()),
+                _ => Ok(f64::NAN.into()),
             }
         } else {
-            Ok(NAN.into())
+            Ok(f64::NAN.into())
         };
     }
-    Ok(NEG_INFINITY.into())
+    Ok(f64::NEG_INFINITY.into())
 }
 
 fn min<'gc>(
@@ -116,13 +115,13 @@ fn min<'gc>(
                         Ok(b.coerce_to_f64(activation)?.into())
                     }
                 }
-                _ => Ok(NAN.into()),
+                _ => Ok(f64::NAN.into()),
             }
         } else {
-            Ok(NAN.into())
+            Ok(f64::NAN.into())
         };
     }
-    Ok(INFINITY.into())
+    Ok(f64::INFINITY.into())
 }
 
 pub fn random<'gc>(
@@ -265,8 +264,8 @@ mod tests {
 
     test_method!(test_abs, "abs", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [-50.0] => 50.0,
             [25.0] => 25.0
         }
@@ -274,8 +273,8 @@ mod tests {
 
     test_method!(test_acos, "acos", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [-1.0] => f64::acos(-1.0),
             [0.0] => f64::acos(0.0),
             [1.0] => f64::acos(1.0)
@@ -284,8 +283,8 @@ mod tests {
 
     test_method!(test_asin, "asin", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [-1.0] => f64::asin(-1.0),
             [0.0] => f64::asin(0.0),
             [1.0] => f64::asin(1.0)
@@ -294,8 +293,8 @@ mod tests {
 
     test_method!(test_atan, "atan", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [-1.0] => f64::atan(-1.0),
             [0.0] => f64::atan(0.0),
             [1.0] => f64::atan(1.0)
@@ -304,16 +303,16 @@ mod tests {
 
     test_method!(test_ceil, "ceil", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [12.5] => 13.0
         }
     );
 
     test_method!(test_cos, "cos", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [0.0] => 1.0,
             [std::f64::consts::PI] => f64::cos(std::f64::consts::PI)
         }
@@ -321,8 +320,8 @@ mod tests {
 
     test_method!(test_exp, "exp", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [1.0] => f64::exp(1.0),
             [2.0] => f64::exp(2.0)
         }
@@ -330,15 +329,15 @@ mod tests {
 
     test_method!(test_floor, "floor", setup,
         [19] => {
-            [] => NAN,
-            [Value::Undefined] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Undefined] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [Value::Bool(false)] => 0.0,
             [Value::Bool(true)] => 1.0,
             [12.5] => 12.0
         },
         [6] => {
-            [] => NAN,
+            [] => f64::NAN,
             [Value::Undefined] => 0.0,
             [Value::Null] => 0.0,
             [Value::Bool(false)] => 0.0,
@@ -349,9 +348,9 @@ mod tests {
 
     test_method!(test_round, "round", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
-            [Value::Undefined] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
+            [Value::Undefined] => f64::NAN,
             [12.5] => 13.0,
             [23.2] => 23.0,
             [23.5] => 24.0,
@@ -359,22 +358,22 @@ mod tests {
             [-23.2] => -23.0,
             [-23.5] => -23.0,
             [-23.7] => -24.0,
-            [std::f64::NAN] => std::f64::NAN,
-            [std::f64::INFINITY] => std::f64::INFINITY,
-            [std::f64::NEG_INFINITY] => std::f64::NEG_INFINITY
+            [f64::NAN] => f64::NAN,
+            [f64::INFINITY] => f64::INFINITY,
+            [f64::NEG_INFINITY] => f64::NEG_INFINITY
         },
         [5, 6] => {
-            [] => NAN,
+            [] => f64::NAN,
             [Value::Null] => 0.0,
             [Value::Undefined] => 0.0,
-            [std::f64::NAN] => std::f64::NAN
+            [f64::NAN] => f64::NAN
         }
     );
 
     test_method!(test_sin, "sin", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [0.0] => f64::sin(0.0),
             [std::f64::consts::PI / 2.0] => f64::sin(std::f64::consts::PI / 2.0)
         }
@@ -382,8 +381,8 @@ mod tests {
 
     test_method!(test_sqrt, "sqrt", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [0.0] => f64::sqrt(0.0),
             [5.0] => f64::sqrt(5.0)
         }
@@ -391,8 +390,8 @@ mod tests {
 
     test_method!(test_tan, "tan", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [0.0] => f64::tan(0.0),
             [1.0] => f64::tan(1.0)
         }
@@ -400,12 +399,12 @@ mod tests {
 
     test_method!(test_pow, "pow", setup,
         [5, 6, 7, 8] => {
-            [] => NAN,
-            [1.0] => NAN,
-            [NAN] => NAN,
-            [Value::Null] => NAN,
-            [Value::Undefined] => NAN,
-            ["5"] => NAN,
+            [] => f64::NAN,
+            [1.0] => f64::NAN,
+            [f64::NAN] => f64::NAN,
+            [Value::Null] => f64::NAN,
+            [Value::Undefined] => f64::NAN,
+            ["5"] => f64::NAN,
             [1.0, 2.0] => 1.0,
             [3.0, 2.0, 1.0] => 9.0
         },
@@ -414,15 +413,15 @@ mod tests {
             [Value::Undefined, 3.0] => 0.0
         },
         [7, 8] => {
-            [1.0, Value::Null] => NAN,
-            [Value::Undefined, 3.0] => NAN
+            [1.0, Value::Null] => f64::NAN,
+            [Value::Undefined, 3.0] => f64::NAN
         }
     );
 
     test_method!(test_log, "log", setup,
         [19] => {
-            [] => NAN,
-            [Value::Null] => NAN,
+            [] => f64::NAN,
+            [Value::Null] => f64::NAN,
             [2.0] => f64::ln(2.0),
             [0.0] => f64::ln(0.0),
             [1.0] => f64::ln(1.0)
@@ -431,12 +430,12 @@ mod tests {
 
     test_method!(test_max, "max", setup,
         [5, 6, 7, 8] => {
-            [] => NEG_INFINITY,
-            [1.0] => NAN,
-            [NAN] => NAN,
-            [Value::Null] => NAN,
-            [Value::Undefined] => NAN,
-            ["5"] => NAN,
+            [] => f64::NEG_INFINITY,
+            [1.0] => f64::NAN,
+            [f64::NAN] => f64::NAN,
+            [Value::Null] => f64::NAN,
+            [Value::Undefined] => f64::NAN,
+            ["5"] => f64::NAN,
             [1.0, 2.0] => 2.0,
             [3.0, 2.0, 1.0] => 3.0
         },
@@ -445,19 +444,19 @@ mod tests {
             [Value::Undefined, 3.0] => 3.0
         },
         [7, 8] => {
-            [1.0, Value::Null] => NAN,
-            [Value::Undefined, 3.0] => NAN
+            [1.0, Value::Null] => f64::NAN,
+            [Value::Undefined, 3.0] => f64::NAN
         }
     );
 
     test_method!(test_min, "min", setup,
         [5, 6, 7, 8] => {
-            [] => INFINITY,
-            [1.0] => NAN,
-            [NAN] => NAN,
-            [Value::Null] => NAN,
-            [Value::Undefined] => NAN,
-            ["5"] => NAN,
+            [] => f64::INFINITY,
+            [1.0] => f64::NAN,
+            [f64::NAN] => f64::NAN,
+            [Value::Null] => f64::NAN,
+            [Value::Undefined] => f64::NAN,
+            ["5"] => f64::NAN,
             [1.0, 2.0] => 1.0,
             [3.0, 2.0, 1.0] => 2.0
         },
@@ -466,8 +465,8 @@ mod tests {
             [Value::Undefined, 3.0] => 0.0
         },
         [7, 8] => {
-            [1.0, Value::Null] => NAN,
-            [Value::Undefined, 3.0] => NAN
+            [1.0, Value::Null] => f64::NAN,
+            [Value::Undefined, 3.0] => f64::NAN
         }
     );
 
@@ -480,18 +479,18 @@ mod tests {
                 Some(activation.context.avm1.prototypes().function),
             );
 
-            assert_eq!(atan2(activation, math, &[]).unwrap(), NAN.into());
+            assert_eq!(atan2(activation, math, &[]).unwrap(), f64::NAN.into());
             assert_eq!(
                 atan2(activation, math, &[1.0.into(), Value::Null]).unwrap(),
-                NAN.into()
+                f64::NAN.into()
             );
             assert_eq!(
                 atan2(activation, math, &[1.0.into(), Value::Undefined]).unwrap(),
-                NAN.into()
+                f64::NAN.into()
             );
             assert_eq!(
                 atan2(activation, math, &[Value::Undefined, 1.0.into()]).unwrap(),
-                NAN.into()
+                f64::NAN.into()
             );
             Ok(())
         });

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -61,7 +61,7 @@ pub fn create_number_object<'gc>(
     object.define_value(
         gc_context,
         "MAX_VALUE",
-        std::f64::MAX.into(),
+        f64::MAX.into(),
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
@@ -77,21 +77,21 @@ pub fn create_number_object<'gc>(
     object.define_value(
         gc_context,
         "NaN",
-        std::f64::NAN.into(),
+        f64::NAN.into(),
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.define_value(
         gc_context,
         "NEGATIVE_INFINITY",
-        std::f64::NEG_INFINITY.into(),
+        f64::NEG_INFINITY.into(),
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 
     object.define_value(
         gc_context,
         "POSITIVE_INFINITY",
-        std::f64::INFINITY.into(),
+        f64::INFINITY.into(),
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -6,7 +6,6 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
-use std::f64::NAN;
 
 pub fn point_to_object<'gc>(
     point: (f64, f64),
@@ -138,7 +137,7 @@ fn distance<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.len() < 2 {
-        return Ok(NAN.into());
+        return Ok(f64::NAN.into());
     }
 
     let a = args
@@ -173,7 +172,7 @@ fn interpolate<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.len() < 3 {
-        return point_to_object((NAN, NAN), activation);
+        return point_to_object((f64::NAN, f64::NAN), activation);
     }
 
     let a = value_to_point(args.get(0).unwrap().to_owned(), activation)?;

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -7,7 +7,6 @@ use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
-use std::f64::NAN;
 
 fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -249,7 +248,7 @@ fn union<'gc>(
                 other.get("height", activation)?.coerce_to_f64(activation)?,
             )
         } else {
-            (NAN, NAN, NAN, NAN)
+            (f64::NAN, f64::NAN, f64::NAN, f64::NAN)
         };
     let other_right = other_left + other_width;
     let other_bottom = other_top + other_height;
@@ -405,7 +404,7 @@ fn intersection<'gc>(
                 other.get("height", activation)?.coerce_to_f64(activation)?,
             )
         } else {
-            (NAN, NAN, NAN, NAN)
+            (f64::NAN, f64::NAN, f64::NAN, f64::NAN)
         };
     let other_right = other_left + other_width;
     let other_bottom = other_top + other_height;
@@ -542,7 +541,7 @@ fn set_right<'gc>(
     let right = if let Some(arg) = args.get(0) {
         arg.coerce_to_f64(activation)?
     } else {
-        NAN
+        f64::NAN
     };
     let x = this.get("x", activation)?.coerce_to_f64(activation)?;
 
@@ -569,7 +568,7 @@ fn set_bottom<'gc>(
     let bottom = if let Some(arg) = args.get(0) {
         arg.coerce_to_f64(activation)?
     } else {
-        NAN
+        f64::NAN
     };
     let y = this.get("y", activation)?.coerce_to_f64(activation)?;
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -478,7 +478,7 @@ fn start<'gc>(
         .unwrap_or(&Value::Number(1.0))
         .coerce_to_f64(activation)?;
 
-    // TODO: Handle loops > std::u16::MAX.
+    // TODO: Handle loops > u16::MAX.
     let loops = (loops as u16).max(1);
 
     use swf::{SoundEvent, SoundInfo};

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -223,9 +223,9 @@ fn char_code_at<'gc>(
         this.encode_utf16()
             .nth(i as usize)
             .map(f64::from)
-            .unwrap_or(std::f64::NAN)
+            .unwrap_or(f64::NAN)
     } else {
-        std::f64::NAN
+        f64::NAN
     };
     Ok(ret.into())
 }
@@ -392,7 +392,7 @@ fn split<'gc>(
     let delimiter_val = args.get(0).unwrap_or(&Value::Undefined);
     let delimiter = delimiter_val.coerce_to_string(activation)?;
     let limit = match args.get(1) {
-        None | Some(Value::Undefined) => std::usize::MAX,
+        None | Some(Value::Undefined) => usize::MAX,
         Some(n) => std::cmp::max(0, n.coerce_to_i32(activation)?) as usize,
     };
     let array = ScriptObject::array(

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -7,7 +7,6 @@ use crate::ecma_conversions::{
     f64_to_wrapping_u32,
 };
 use std::borrow::Cow;
-use std::f64::NAN;
 
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
@@ -141,8 +140,8 @@ impl<'gc> Value<'gc> {
         match self {
             Value::Undefined if activation.current_swf_version() < 7 => 0.0,
             Value::Null if activation.current_swf_version() < 7 => 0.0,
-            Value::Undefined => NAN,
-            Value::Null => NAN,
+            Value::Undefined => f64::NAN,
+            Value::Null => f64::NAN,
             Value::Bool(false) => 0.0,
             Value::Bool(true) => 1.0,
             Value::Number(v) => *v,
@@ -168,7 +167,7 @@ impl<'gc> Value<'gc> {
                             b'd' | b'D' => 13,
                             b'e' | b'E' => 14,
                             b'f' | b'F' => 15,
-                            _ => return NAN,
+                            _ => return f64::NAN,
                         }
                     }
                     f64::from(n as i32)
@@ -188,13 +187,13 @@ impl<'gc> Value<'gc> {
                     }
                     f64::from(n as i32)
                 }
-                "" => NAN,
+                "" => f64::NAN,
                 _ => v
                     .trim_start_matches(|c| c == '\t' || c == '\n' || c == '\r' || c == ' ')
                     .parse()
-                    .unwrap_or(NAN),
+                    .unwrap_or(f64::NAN),
             },
-            Value::Object(_) => NAN,
+            Value::Object(_) => f64::NAN,
         }
     }
 
@@ -507,8 +506,6 @@ mod test {
     use crate::avm1::test_utils::with_avm;
     use crate::avm1::{AvmString, Value};
 
-    use std::f64::{INFINITY, NAN, NEG_INFINITY};
-
     #[test]
     fn to_primitive_num() {
         with_avm(6, |activation, _this| -> Result<(), Error> {
@@ -614,13 +611,13 @@ mod test {
 
             assert_eq!(a.abstract_lt(b, activation).unwrap(), Value::Bool(true));
 
-            let nan = Value::Number(NAN);
+            let nan = Value::Number(f64::NAN);
             assert_eq!(a.abstract_lt(nan, activation).unwrap(), Value::Undefined);
 
-            let inf = Value::Number(INFINITY);
+            let inf = Value::Number(f64::INFINITY);
             assert_eq!(a.abstract_lt(inf, activation).unwrap(), Value::Bool(true));
 
-            let neg_inf = Value::Number(NEG_INFINITY);
+            let neg_inf = Value::Number(f64::NEG_INFINITY);
             assert_eq!(
                 a.abstract_lt(neg_inf, activation).unwrap(),
                 Value::Bool(false)
@@ -641,13 +638,13 @@ mod test {
 
             assert_eq!(b.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 
-            let nan = Value::Number(NAN);
+            let nan = Value::Number(f64::NAN);
             assert_eq!(nan.abstract_lt(a, activation).unwrap(), Value::Undefined);
 
-            let inf = Value::Number(INFINITY);
+            let inf = Value::Number(f64::INFINITY);
             assert_eq!(inf.abstract_lt(a, activation).unwrap(), Value::Bool(false));
 
-            let neg_inf = Value::Number(NEG_INFINITY);
+            let neg_inf = Value::Number(f64::NEG_INFINITY);
             assert_eq!(
                 neg_inf.abstract_lt(a, activation).unwrap(),
                 Value::Bool(true)
@@ -708,9 +705,9 @@ mod test {
         assert_eq!(f64_to_wrapping_u16(66535.9), 999);
         assert_eq!(f64_to_wrapping_u16(-9980.7), 55556);
         assert_eq!(f64_to_wrapping_u16(-196608.0), 0);
-        assert_eq!(f64_to_wrapping_u16(std::f64::NAN), 0);
-        assert_eq!(f64_to_wrapping_u16(std::f64::INFINITY), 0);
-        assert_eq!(f64_to_wrapping_u16(std::f64::NEG_INFINITY), 0);
+        assert_eq!(f64_to_wrapping_u16(f64::NAN), 0);
+        assert_eq!(f64_to_wrapping_u16(f64::INFINITY), 0);
+        assert_eq!(f64_to_wrapping_u16(f64::NEG_INFINITY), 0);
     }
 
     #[test]
@@ -726,9 +723,9 @@ mod test {
         assert_eq!(f64_to_wrapping_i16(-32769.9), 32767);
         assert_eq!(f64_to_wrapping_i16(-33268.1), 32268);
         assert_eq!(f64_to_wrapping_i16(-196608.0), 0);
-        assert_eq!(f64_to_wrapping_i16(std::f64::NAN), 0);
-        assert_eq!(f64_to_wrapping_i16(std::f64::INFINITY), 0);
-        assert_eq!(f64_to_wrapping_i16(std::f64::NEG_INFINITY), 0);
+        assert_eq!(f64_to_wrapping_i16(f64::NAN), 0);
+        assert_eq!(f64_to_wrapping_i16(f64::INFINITY), 0);
+        assert_eq!(f64_to_wrapping_i16(f64::NEG_INFINITY), 0);
     }
 
     #[test]
@@ -742,9 +739,9 @@ mod test {
         assert_eq!(f64_to_wrapping_u32(4294968295.9), 999);
         assert_eq!(f64_to_wrapping_u32(-4289411740.3), 5555556);
         assert_eq!(f64_to_wrapping_u32(-12884901888.0), 0);
-        assert_eq!(f64_to_wrapping_u32(std::f64::NAN), 0);
-        assert_eq!(f64_to_wrapping_u32(std::f64::INFINITY), 0);
-        assert_eq!(f64_to_wrapping_u32(std::f64::NEG_INFINITY), 0);
+        assert_eq!(f64_to_wrapping_u32(f64::NAN), 0);
+        assert_eq!(f64_to_wrapping_u32(f64::INFINITY), 0);
+        assert_eq!(f64_to_wrapping_u32(f64::NEG_INFINITY), 0);
     }
 
     #[test]
@@ -759,9 +756,9 @@ mod test {
         assert_eq!(f64_to_wrapping_i32(2147484648.3), -2147482648);
         assert_eq!(f64_to_wrapping_i32(-8589934591.2), 1);
         assert_eq!(f64_to_wrapping_i32(4294966896.1), -400);
-        assert_eq!(f64_to_wrapping_i32(std::f64::NAN), 0);
-        assert_eq!(f64_to_wrapping_i32(std::f64::INFINITY), 0);
-        assert_eq!(f64_to_wrapping_i32(std::f64::NEG_INFINITY), 0);
+        assert_eq!(f64_to_wrapping_i32(f64::NAN), 0);
+        assert_eq!(f64_to_wrapping_i32(f64::INFINITY), 0);
+        assert_eq!(f64_to_wrapping_i32(f64::NEG_INFINITY), 0);
     }
 
     #[test]
@@ -772,9 +769,9 @@ mod test {
         assert_eq!(f64_to_string(1.0), "1");
         assert_eq!(f64_to_string(1.4), "1.4");
         assert_eq!(f64_to_string(-990.123), "-990.123");
-        assert_eq!(f64_to_string(std::f64::NAN), "NaN");
-        assert_eq!(f64_to_string(std::f64::INFINITY), "Infinity");
-        assert_eq!(f64_to_string(std::f64::NEG_INFINITY), "-Infinity");
+        assert_eq!(f64_to_string(f64::NAN), "NaN");
+        assert_eq!(f64_to_string(f64::INFINITY), "Infinity");
+        assert_eq!(f64_to_string(f64::NEG_INFINITY), "-Infinity");
         assert_eq!(f64_to_string(9.9999e14), "999990000000000");
         assert_eq!(f64_to_string(-9.9999e14), "-999990000000000");
         assert_eq!(f64_to_string(1e15), "1e+15");

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -743,7 +743,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn op_push_nan(&mut self) -> Result<FrameControl<'gc>, Error> {
-        self.context.avm2.push(std::f64::NAN);
+        self.context.avm2.push(f64::NAN);
         Ok(FrameControl::Continue)
     }
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -15,7 +15,6 @@ use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{Collect, GcCell, MutationContext};
-use std::f64::NAN;
 
 mod array;
 mod boolean;
@@ -431,7 +430,7 @@ pub fn load_player_globals<'gc>(
     function(mc, "", "isNaN", is_nan, fn_proto, domain, script)?;
     constant(mc, "", "undefined", Value::Undefined, domain, script)?;
     constant(mc, "", "null", Value::Null, domain, script)?;
-    constant(mc, "", "NaN", NAN.into(), domain, script)?;
+    constant(mc, "", "NaN", f64::NAN.into(), domain, script)?;
     constant(mc, "", "Infinity", f64::INFINITY.into(), domain, script)?;
 
     class(

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -10,7 +10,6 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
 use rand::Rng;
-use std::f64::{INFINITY, NAN, NEG_INFINITY};
 
 macro_rules! math_constants {
     ($class:ident, $($name:expr => $value:expr),*) => {{
@@ -45,7 +44,7 @@ macro_rules! math_wrap_std {
                         if let Some(input) = args.get(0) {
                             Ok($std(input.coerce_to_number(activation)?).into())
                         } else {
-                            Ok(std::f64::NAN.into())
+                            Ok(f64::NAN.into())
                         }
                     }
                 ),
@@ -140,7 +139,7 @@ fn round<'gc>(
         let ret = (x + 0.5).floor();
         return Ok(ret.into());
     }
-    Ok(NAN.into())
+    Ok(f64::NAN.into())
 }
 
 fn atan2<'gc>(
@@ -164,11 +163,11 @@ fn max<'gc>(
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
-    let mut cur_max = NEG_INFINITY;
+    let mut cur_max = f64::NEG_INFINITY;
     for arg in args {
         let val = arg.coerce_to_number(activation)?;
         if val.is_nan() {
-            return Ok(NAN.into());
+            return Ok(f64::NAN.into());
         } else if val > cur_max {
             cur_max = val;
         };
@@ -181,11 +180,11 @@ fn min<'gc>(
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
-    let mut cur_min = INFINITY;
+    let mut cur_min = f64::INFINITY;
     for arg in args {
         let val = arg.coerce_to_number(activation)?;
         if val.is_nan() {
-            return Ok(NAN.into());
+            return Ok(f64::NAN.into());
         } else if val < cur_min {
             cur_min = val;
         }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -10,7 +10,6 @@ use crate::avm2::{Avm2, Error};
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use gc_arena::{Collect, MutationContext};
 use std::cell::Ref;
-use std::f64::NAN;
 use swf::avm2::types::{DefaultValue as AbcDefaultValue, Index};
 
 /// Indicate what kind of primitive coercion would be preferred when coercing
@@ -169,7 +168,7 @@ pub fn abc_uint(translation_unit: TranslationUnit<'_>, index: Index<u32>) -> Res
 
 pub fn abc_double(translation_unit: TranslationUnit<'_>, index: Index<f64>) -> Result<f64, Error> {
     if index.0 == 0 {
-        return Ok(NAN);
+        return Ok(f64::NAN);
     }
 
     translation_unit

--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -7,9 +7,9 @@ use std::borrow::Cow;
 pub fn f64_to_string(n: f64) -> Cow<'static, str> {
     if n.is_nan() {
         Cow::Borrowed("NaN")
-    } else if n == std::f64::INFINITY {
+    } else if n == f64::INFINITY {
         Cow::Borrowed("Infinity")
-    } else if n == std::f64::NEG_INFINITY {
+    } else if n == f64::NEG_INFINITY {
         Cow::Borrowed("-Infinity")
     } else if n != 0.0 && (n.abs() >= 1e15 || n.abs() < 1e-5) {
         // Exponential notation.

--- a/core/src/shape_utils.rs
+++ b/core/src/shape_utils.rs
@@ -6,10 +6,10 @@ use swf::{CharacterId, FillStyle, LineStyle, Matrix, Shape, ShapeRecord, Twips};
 
 pub fn calculate_shape_bounds(shape_records: &[swf::ShapeRecord]) -> swf::Rectangle {
     let mut bounds = swf::Rectangle {
-        x_min: Twips::new(std::i32::MAX),
-        y_min: Twips::new(std::i32::MAX),
-        x_max: Twips::new(std::i32::MIN),
-        y_max: Twips::new(std::i32::MIN),
+        x_min: Twips::new(i32::MAX),
+        y_min: Twips::new(i32::MAX),
+        x_max: Twips::new(i32::MIN),
+        y_max: Twips::new(i32::MIN),
     };
     let mut x = Twips::new(0);
     let mut y = Twips::new(0);

--- a/core/tests/regression_tests.rs
+++ b/core/tests/regression_tests.rs
@@ -519,16 +519,16 @@ swf_tests_approx! {
     (stage_object_properties, "avm1/stage_object_properties", 6, epsilon = 0.051),
     (stage_object_properties_swf6, "avm1/stage_object_properties_swf6", 4, epsilon = 0.051),
     (movieclip_getbounds, "avm1/movieclip_getbounds", 1, epsilon = 0.051),
-    (parse_float, "avm1/parse_float", 1, max_relative = 5.0 * std::f64::EPSILON),
+    (parse_float, "avm1/parse_float", 1, max_relative = 5.0 * f64::EPSILON),
     (edittext_letter_spacing, "avm1/edittext_letter_spacing", 1, epsilon = 15.0), // TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
     (edittext_align, "avm1/edittext_align", 1, epsilon = 3.0),
     (edittext_margins, "avm1/edittext_margins", 1, epsilon = 5.0), // TODO: Discrepancy in wrapping.
     (edittext_tab_stops, "avm1/edittext_tab_stops", 1, epsilon = 5.0),
     (edittext_bullet, "avm1/edittext_bullet", 1, epsilon = 3.0),
     (edittext_underline, "avm1/edittext_underline", 1, epsilon = 4.0),
-    (as3_coerce_string_precision, "avm2/coerce_string_precision", 1, max_relative = 30.0 * std::f64::EPSILON),
+    (as3_coerce_string_precision, "avm2/coerce_string_precision", 1, max_relative = 30.0 * f64::EPSILON),
     (as3_divide, "avm2/divide", 1, epsilon = 0.0), // TODO: Discrepancy in float formatting.
-    (as3_math, "avm2/math", 1, max_relative = 30.0 * std::f64::EPSILON),
+    (as3_math, "avm2/math", 1, max_relative = 30.0 * f64::EPSILON),
     (as3_displayobject_height, "avm2/displayobject_height", 7, epsilon = 0.06), // TODO: height/width appears to be off by 1 twip sometimes
     (as3_displayobject_width, "avm2/displayobject_width", 7, epsilon = 0.06),
     (as3_displayobject_rotation, "avm2/displayobject_rotation", 1, epsilon = 0.0000000001),

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -626,7 +626,7 @@ impl dasp::signal::Signal for EnvelopeSignal {
                 .next()
                 .clone()
                 .unwrap_or(swf::SoundEnvelopePoint {
-                    sample: std::u32::MAX,
+                    sample: u32::MAX,
                     left_volume: self.prev_point.left_volume,
                     right_volume: self.prev_point.right_volume,
                 });

--- a/swf/src/types/matrix.rs
+++ b/swf/src/types/matrix.rs
@@ -768,15 +768,15 @@ fn round_to_i32(f: f32) -> i32 {
     if f.is_finite() {
         let a = f.abs();
         if f < 2_147_483_648.0_f32 {
-            let k = 1.0 / std::f32::EPSILON;
+            let k = 1.0 / f32::EPSILON;
             let out = if a < k { ((a + k) - k).copysign(f) } else { f };
             out as i32
         } else {
             // Out-of-range clamps to MIN.
-            std::i32::MIN
+            i32::MIN
         }
     } else {
-        // NAN/Infinity goes to 0.
+        // NaN/Infinity goes to 0.
         0
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -863,7 +863,7 @@ impl Ruffle {
                 if instance.borrow().canvas_width != canvas_width
                     || instance.borrow().canvas_height != canvas_height
                     || (instance.borrow().device_pixel_ratio - device_pixel_ratio).abs()
-                        >= std::f64::EPSILON
+                        >= f64::EPSILON
                 {
                     let mut mut_instance = instance.borrow_mut();
                     // If a canvas resizes, its drawing context will get scaled. You must reset


### PR DESCRIPTION
The Rust documentation considers numeric constants prefixed with `std::` as deprecated.
For example: https://doc.rust-lang.org/std/u16/constant.MAX.html.