### PR TITLE
chore: Appease clippy

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2397,15 +2397,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     .finish();
 
                 match method {
-                    NavigationMethod::GET if url.find('?').is_none() => (
+                    NavigationMethod::Get if url.find('?').is_none() => (
                         Cow::Owned(format!("{}?{}", url, qstring)),
                         RequestOptions::get(),
                     ),
-                    NavigationMethod::GET => (
+                    NavigationMethod::Get => (
                         Cow::Owned(format!("{}&{}", url, qstring)),
                         RequestOptions::get(),
                     ),
-                    NavigationMethod::POST => (
+                    NavigationMethod::Post => (
                         url,
                         RequestOptions::post(Some((
                             qstring.as_bytes().to_owned(),

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -229,7 +229,7 @@ fn send<'gc>(
         .get(1)
         .unwrap_or(&Value::Undefined)
         .coerce_to_string(activation)?;
-    let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::POST);
+    let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::Post);
 
     use indexmap::IndexMap;
 
@@ -276,7 +276,7 @@ fn send_and_load<'gc>(
         .get(2)
         .unwrap_or(&Value::Undefined)
         .coerce_to_string(activation)?;
-    let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::POST);
+    let method = NavigationMethod::from_method_str(&method_name).unwrap_or(NavigationMethod::Post);
 
     spawn_load_var_fetch(activation, target, &url, Some((this, method)))?;
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -431,8 +431,8 @@ fn begin_gradient_fill<'gc>(
             .and_then(|v| v.coerce_to_string(activation).ok())
             .as_deref()
         {
-            Some("linearRGB") => GradientInterpolation::LinearRGB,
-            _ => GradientInterpolation::RGB,
+            Some("linearRGB") => GradientInterpolation::LinearRgb,
+            _ => GradientInterpolation::Rgb,
         };
 
         let gradient = Gradient {
@@ -1162,8 +1162,8 @@ pub fn get_url<'gc>(
             None
         };
         let method = match args.get(2) {
-            Some(Value::String(s)) if *s == "GET" => Some(NavigationMethod::GET),
-            Some(Value::String(s)) if *s == "POST" => Some(NavigationMethod::POST),
+            Some(Value::String(s)) if *s == "GET" => Some(NavigationMethod::Get),
+            Some(Value::String(s)) if *s == "POST" => Some(NavigationMethod::Post),
             _ => None,
         };
         let vars_method = method.map(|m| (m, activation.locals_into_form_values()));

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -13,19 +13,19 @@ use std::convert::TryFrom;
 
 /// Available cpu architectures
 pub enum CpuArchitecture {
-    PowerPC,
+    PowerPc,
     X86,
-    SPARC,
-    ARM,
+    Sparc,
+    Arm,
 }
 
 impl fmt::Display for CpuArchitecture {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            CpuArchitecture::PowerPC => "PowerPC",
+            CpuArchitecture::PowerPc => "PowerPC",
             CpuArchitecture::X86 => "x86",
-            CpuArchitecture::SPARC => "SPARC",
-            CpuArchitecture::ARM => "ARM",
+            CpuArchitecture::Sparc => "SPARC",
+            CpuArchitecture::Arm => "ARM",
         })
     }
 }
@@ -56,10 +56,10 @@ pub enum OperatingSystem {
     WindowsNt,
     Windows98,
     Windows95,
-    WindowsCE,
+    WindowsCe,
     WindowsUnknown,
     Linux,
-    MacOS,
+    MacOs,
 }
 
 impl fmt::Display for OperatingSystem {
@@ -70,10 +70,10 @@ impl fmt::Display for OperatingSystem {
             OperatingSystem::WindowsNt => "Windows NT",
             OperatingSystem::Windows98 => "Windows 98/ME",
             OperatingSystem::Windows95 => "Windows 95",
-            OperatingSystem::WindowsCE => "Windows CE",
+            OperatingSystem::WindowsCe => "Windows CE",
             OperatingSystem::WindowsUnknown => "Windows",
             OperatingSystem::Linux => "Linux",
-            OperatingSystem::MacOS => "MacOS",
+            OperatingSystem::MacOs => "MacOS",
         })
     }
 }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -4,13 +4,13 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::script_object::ScriptObject;
-use crate::avm1::object::xml_object::XMLObject;
+use crate::avm1::object::xml_object::XmlObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::RequestOptions;
 use crate::xml;
-use crate::xml::{XMLDocument, XMLNode};
+use crate::xml::{XmlDocument, XmlNode};
 use gc_arena::MutationContext;
 use quick_xml::Error as ParseError;
 
@@ -35,7 +35,7 @@ pub const XML_MISMATCHED_END: f64 = -10.0;
 /// not. Those nodes are filtered from all attributes that return XML nodes to
 /// act as if those nodes did not exist. For example, `prevSibling` skips
 /// past incompatible nodes, etc.
-fn is_as2_compatible(node: XMLNode<'_>) -> bool {
+fn is_as2_compatible(node: XmlNode<'_>) -> bool {
     node.is_document_root() || node.is_element() || node.is_text()
 }
 
@@ -45,7 +45,7 @@ pub fn xmlnode_constructor<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let blank_document = XMLDocument::new(activation.context.gc_context);
+    let blank_document = XmlDocument::new(activation.context.gc_context);
 
     match (
         args.get(0)
@@ -55,13 +55,13 @@ pub fn xmlnode_constructor<'gc>(
     ) {
         (Some(Ok(1)), Some(Ok(ref strval)), Some(ref mut this_node)) => {
             let mut xmlelement =
-                XMLNode::new_element(activation.context.gc_context, strval, blank_document);
+                XmlNode::new_element(activation.context.gc_context, strval, blank_document);
             xmlelement.introduce_script_object(activation.context.gc_context, this);
             this_node.swap(activation.context.gc_context, xmlelement);
         }
         (Some(Ok(3)), Some(Ok(ref strval)), Some(ref mut this_node)) => {
             let mut xmlelement =
-                XMLNode::new_text(activation.context.gc_context, strval, blank_document);
+                XmlNode::new_text(activation.context.gc_context, strval, blank_document);
             xmlelement.introduce_script_object(activation.context.gc_context, this);
             this_node.swap(activation.context.gc_context, xmlelement);
         }
@@ -537,7 +537,7 @@ pub fn create_xmlnode_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xmlnode_proto = XMLObject::empty_node(gc_context, Some(proto));
+    let xmlnode_proto = XmlObject::empty_node(gc_context, Some(proto));
 
     xmlnode_proto.add_property(
         gc_context,
@@ -790,7 +790,7 @@ pub fn xml_constructor<'gc>(
         this.as_xml_node(),
     ) {
         (Some(Ok(ref string)), Some(ref mut this_node)) => {
-            let xmldoc = XMLDocument::new(activation.context.gc_context);
+            let xmldoc = XmlDocument::new(activation.context.gc_context);
             let mut xmlnode = xmldoc.as_node();
             xmlnode.introduce_script_object(activation.context.gc_context, this);
             this_node.swap(activation.context.gc_context, xmlnode);
@@ -812,7 +812,7 @@ pub fn xml_constructor<'gc>(
             }
         }
         (None, Some(ref mut this_node)) => {
-            let xmldoc = XMLDocument::new(activation.context.gc_context);
+            let xmldoc = XmlDocument::new(activation.context.gc_context);
             let mut xmlnode = xmldoc.as_node();
             xmlnode.introduce_script_object(activation.context.gc_context, this);
             this_node.swap(activation.context.gc_context, xmlnode);
@@ -832,15 +832,15 @@ pub fn xml_create_element<'gc>(
     let document = if let Some(node) = this.as_xml_node() {
         node.document()
     } else {
-        XMLDocument::new(activation.context.gc_context)
+        XmlDocument::new(activation.context.gc_context)
     };
 
     let nodename = args
         .get(0)
         .map(|v| v.coerce_to_string(activation).unwrap_or_default())
         .unwrap_or_default();
-    let mut xml_node = XMLNode::new_element(activation.context.gc_context, &nodename, document);
-    let object = XMLObject::from_xml_node(
+    let mut xml_node = XmlNode::new_element(activation.context.gc_context, &nodename, document);
+    let object = XmlObject::from_xml_node(
         activation.context.gc_context,
         xml_node,
         Some(activation.context.avm1.prototypes().xml_node),
@@ -859,15 +859,15 @@ pub fn xml_create_text_node<'gc>(
     let document = if let Some(node) = this.as_xml_node() {
         node.document()
     } else {
-        XMLDocument::new(activation.context.gc_context)
+        XmlDocument::new(activation.context.gc_context)
     };
 
     let text_node = args
         .get(0)
         .map(|v| v.coerce_to_string(activation).unwrap_or_default())
         .unwrap_or_default();
-    let mut xml_node = XMLNode::new_text(activation.context.gc_context, &text_node, document);
-    let object = XMLObject::from_xml_node(
+    let mut xml_node = XmlNode::new_text(activation.context.gc_context, &text_node, document);
+    let object = XmlObject::from_xml_node(
         activation.context.gc_context,
         xml_node,
         Some(activation.context.avm1.prototypes().xml_node),
@@ -1078,7 +1078,7 @@ pub fn create_xml_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_proto = XMLObject::empty_node(gc_context, Some(proto));
+    let xml_proto = XmlObject::empty_node(gc_context, Some(proto));
 
     xml_proto.add_property(
         gc_context,

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -21,13 +21,13 @@ use crate::avm1::object::glow_filter::GlowFilterObject;
 use crate::avm1::object::gradient_bevel_filter::GradientBevelFilterObject;
 use crate::avm1::object::gradient_glow_filter::GradientGlowFilterObject;
 use crate::avm1::object::transform_object::TransformObject;
-use crate::avm1::object::xml_attributes_object::XMLAttributesObject;
-use crate::avm1::object::xml_idmap_object::XMLIDMapObject;
-use crate::avm1::object::xml_object::XMLObject;
+use crate::avm1::object::xml_attributes_object::XmlAttributesObject;
+use crate::avm1::object::xml_idmap_object::XmlIdMapObject;
+use crate::avm1::object::xml_object::XmlObject;
 use crate::avm1::{ScriptObject, SoundObject, StageObject, Value};
 use crate::avm_warn;
 use crate::display_object::DisplayObject;
-use crate::xml::XMLNode;
+use crate::xml::XmlNode;
 use gc_arena::{Collect, MutationContext};
 use ruffle_macros::enum_trait_object;
 use std::borrow::Cow;
@@ -67,9 +67,9 @@ pub mod xml_object;
         SoundObject(SoundObject<'gc>),
         StageObject(StageObject<'gc>),
         SuperObject(SuperObject<'gc>),
-        XMLObject(XMLObject<'gc>),
-        XMLAttributesObject(XMLAttributesObject<'gc>),
-        XMLIDMapObject(XMLIDMapObject<'gc>),
+        XmlObject(XmlObject<'gc>),
+        XmlAttributesObject(XmlAttributesObject<'gc>),
+        XmlIdMapObject(XmlIdMapObject<'gc>),
         ValueObject(ValueObject<'gc>),
         FunctionObject(FunctionObject<'gc>),
         SharedObject(SharedObject<'gc>),
@@ -432,7 +432,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     }
 
     /// Get the underlying XML node for this object, if it exists.
-    fn as_xml_node(&self) -> Option<XMLNode<'gc>> {
+    fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
         None
     }
 

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -14,11 +14,11 @@ use std::ops::Range;
 
 /// An implementation of the Lehmer/Park-Miller random number generator
 /// Uses the fixed parameters m = 2,147,483,647 and a = 16,807
-pub struct LehmerRNG {
+pub struct LehmerRng {
     x: u32,
 }
 
-impl LehmerRNG {
+impl LehmerRng {
     pub fn with_seed(seed: u32) -> Self {
         Self { x: seed }
     }
@@ -333,7 +333,7 @@ impl BitmapData {
             seed as u32
         };
 
-        let mut rng = LehmerRNG::with_seed(true_seed);
+        let mut rng = LehmerRng::with_seed(true_seed);
 
         for y in 0..self.height() {
             for x in 0..self.width() {

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -17,12 +17,12 @@ use std::borrow::Cow;
 /// A `SuperObject` references all data from another object, but with one layer
 /// of prototyping removed. It's as if the given object had been constructed
 /// with its parent class.
-#[collect(no_drop)]
 #[derive(Copy, Clone, Collect, Debug)]
+#[collect(no_drop)]
 pub struct SuperObject<'gc>(GcCell<'gc, SuperObjectData<'gc>>);
 
-#[collect(no_drop)]
 #[derive(Clone, Collect, Debug)]
+#[collect(no_drop)]
 pub struct SuperObjectData<'gc> {
     /// The object present as `this` throughout the superchain.
     child: Object<'gc>,

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::{ObjectPtr, TObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, Value};
-use crate::xml::{XMLName, XMLNode};
+use crate::xml::{XmlName, XmlNode};
 use gc_arena::{Collect, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
@@ -18,36 +18,36 @@ use crate::avm_warn;
 /// separately.
 #[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
-pub struct XMLAttributesObject<'gc>(ScriptObject<'gc>, XMLNode<'gc>);
+pub struct XmlAttributesObject<'gc>(ScriptObject<'gc>, XmlNode<'gc>);
 
-impl<'gc> XMLAttributesObject<'gc> {
-    /// Construct an XMLAttributesObject for an already existing node's
+impl<'gc> XmlAttributesObject<'gc> {
+    /// Construct an XmlAttributesObject for an already existing node's
     /// attributes.
     pub fn from_xml_node(
         gc_context: MutationContext<'gc, '_>,
-        xml_node: XMLNode<'gc>,
+        xml_node: XmlNode<'gc>,
     ) -> Object<'gc> {
-        XMLAttributesObject(ScriptObject::object(gc_context, None), xml_node).into()
+        XmlAttributesObject(ScriptObject::object(gc_context, None), xml_node).into()
     }
 
     fn base(&self) -> ScriptObject<'gc> {
         match self {
-            XMLAttributesObject(base, ..) => *base,
+            XmlAttributesObject(base, ..) => *base,
         }
     }
 
-    fn node(&self) -> XMLNode<'gc> {
+    fn node(&self) -> XmlNode<'gc> {
         match self {
-            XMLAttributesObject(_, node) => *node,
+            XmlAttributesObject(_, node) => *node,
         }
     }
 }
 
-impl fmt::Debug for XMLAttributesObject<'_> {
+impl fmt::Debug for XmlAttributesObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            XMLAttributesObject(base, node) => f
-                .debug_tuple("XMLAttributesObject")
+            XmlAttributesObject(base, node) => f
+                .debug_tuple("XmlAttributesObject")
                 .field(base)
                 .field(node)
                 .finish(),
@@ -55,7 +55,7 @@ impl fmt::Debug for XMLAttributesObject<'_> {
     }
 }
 
-impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
+impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
     fn get_local(
         &self,
         name: &str,
@@ -64,7 +64,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     ) -> Result<Value<'gc>, Error<'gc>> {
         Ok(self
             .node()
-            .attribute_value(&XMLName::from_str(name))
+            .attribute_value(&XmlName::from_str(name))
             .map(|s| AvmString::new(activation.context.gc_context, s).into())
             .unwrap_or_else(|| Value::Undefined))
     }
@@ -77,7 +77,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
     ) -> Result<(), Error<'gc>> {
         self.node().set_attribute_value(
             activation.context.gc_context,
-            &XMLName::from_str(name),
+            &XmlName::from_str(name),
             &value.coerce_to_string(activation)?,
         );
         self.base().set(name, value, activation)
@@ -115,7 +115,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.node()
-            .delete_attribute(activation.context.gc_context, &XMLName::from_str(name));
+            .delete_attribute(activation.context.gc_context, &XmlName::from_str(name));
         self.base().delete(activation, name)
     }
 
@@ -201,7 +201,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
 
     fn has_own_property(&self, _activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.node()
-            .attribute_value(&XMLName::from_str(name))
+            .attribute_value(&XmlName::from_str(name))
             .is_some()
     }
 
@@ -239,7 +239,7 @@ impl<'gc> TObject<'gc> for XMLAttributesObject<'gc> {
         Some(self.base())
     }
 
-    fn as_xml_node(&self) -> Option<XMLNode<'gc>> {
+    fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
         Some(self.node())
     }
 

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::{ObjectPtr, TObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm_warn;
-use crate::xml::{XMLDocument, XMLNode};
+use crate::xml::{XmlDocument, XmlNode};
 use gc_arena::{Collect, MutationContext};
 use std::borrow::Cow;
 use std::fmt;
@@ -18,36 +18,36 @@ use std::fmt;
 /// document.
 #[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
-pub struct XMLIDMapObject<'gc>(ScriptObject<'gc>, XMLDocument<'gc>);
+pub struct XmlIdMapObject<'gc>(ScriptObject<'gc>, XmlDocument<'gc>);
 
-impl<'gc> XMLIDMapObject<'gc> {
-    /// Construct an XMLIDMapObject for an already existing node's
+impl<'gc> XmlIdMapObject<'gc> {
+    /// Construct an XmlIdMapObject for an already existing node's
     /// attributes.
     pub fn from_xml_document(
         gc_context: MutationContext<'gc, '_>,
-        xml_doc: XMLDocument<'gc>,
+        xml_doc: XmlDocument<'gc>,
     ) -> Object<'gc> {
-        XMLIDMapObject(ScriptObject::object(gc_context, None), xml_doc).into()
+        XmlIdMapObject(ScriptObject::object(gc_context, None), xml_doc).into()
     }
 
     fn base(&self) -> ScriptObject<'gc> {
         match self {
-            XMLIDMapObject(base, ..) => *base,
+            XmlIdMapObject(base, ..) => *base,
         }
     }
 
-    fn document(&self) -> XMLDocument<'gc> {
+    fn document(&self) -> XmlDocument<'gc> {
         match self {
-            XMLIDMapObject(_, document) => *document,
+            XmlIdMapObject(_, document) => *document,
         }
     }
 }
 
-impl fmt::Debug for XMLIDMapObject<'_> {
+impl fmt::Debug for XmlIdMapObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            XMLIDMapObject(base, document) => f
-                .debug_tuple("XMLIDMapObject")
+            XmlIdMapObject(base, document) => f
+                .debug_tuple("XmlIdMapObject")
                 .field(base)
                 .field(document)
                 .finish(),
@@ -55,7 +55,7 @@ impl fmt::Debug for XMLIDMapObject<'_> {
     }
 }
 
-impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
+impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
     fn get_local(
         &self,
         name: &str,
@@ -236,7 +236,7 @@ impl<'gc> TObject<'gc> for XMLIDMapObject<'gc> {
         Some(self.base())
     }
 
-    fn as_xml_node(&self) -> Option<XMLNode<'gc>> {
+    fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
         None
     }
 

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -5,34 +5,34 @@ use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
 use crate::avm1::{Object, ScriptObject};
 use crate::impl_custom_object;
-use crate::xml::{XMLDocument, XMLNode};
+use crate::xml::{XmlDocument, XmlNode};
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
 
 /// A ScriptObject that is inherently tied to an XML node.
 #[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
-pub struct XMLObject<'gc>(GcCell<'gc, XMLObjectData<'gc>>);
+pub struct XmlObject<'gc>(GcCell<'gc, XmlObjectData<'gc>>);
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-pub struct XMLObjectData<'gc> {
+pub struct XmlObjectData<'gc> {
     base: ScriptObject<'gc>,
-    node: XMLNode<'gc>,
+    node: XmlNode<'gc>,
 }
 
-impl<'gc> XMLObject<'gc> {
+impl<'gc> XmlObject<'gc> {
     /// Construct a new XML node and object pair.
     pub fn empty_node(
         gc_context: MutationContext<'gc, '_>,
         proto: Option<Object<'gc>>,
     ) -> Object<'gc> {
-        let empty_document = XMLDocument::new(gc_context);
-        let mut xml_node = XMLNode::new_text(gc_context, "", empty_document);
+        let empty_document = XmlDocument::new(gc_context);
+        let mut xml_node = XmlNode::new_text(gc_context, "", empty_document);
         let base_object = ScriptObject::object(gc_context, proto);
-        let object = XMLObject(GcCell::allocate(
+        let object = XmlObject(GcCell::allocate(
             gc_context,
-            XMLObjectData {
+            XmlObjectData {
                 base: base_object,
                 node: xml_node,
             },
@@ -44,15 +44,15 @@ impl<'gc> XMLObject<'gc> {
         object
     }
 
-    /// Construct an XMLObject for an already existing node.
+    /// Construct an XmlObject for an already existing node.
     pub fn from_xml_node(
         gc_context: MutationContext<'gc, '_>,
-        xml_node: XMLNode<'gc>,
+        xml_node: XmlNode<'gc>,
         proto: Option<Object<'gc>>,
     ) -> Object<'gc> {
-        XMLObject(GcCell::allocate(
+        XmlObject(GcCell::allocate(
             gc_context,
-            XMLObjectData {
+            XmlObjectData {
                 base: ScriptObject::object(gc_context, proto),
                 node: xml_node,
             },
@@ -61,17 +61,17 @@ impl<'gc> XMLObject<'gc> {
     }
 }
 
-impl fmt::Debug for XMLObject<'_> {
+impl fmt::Debug for XmlObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let this = self.0.read();
-        f.debug_struct("XMLObject")
+        f.debug_struct("XmlObject")
             .field("base", &this.base)
             .field("node", &this.node)
             .finish()
     }
 }
 
-impl<'gc> TObject<'gc> for XMLObject<'gc> {
+impl<'gc> TObject<'gc> for XmlObject<'gc> {
     impl_custom_object!(base);
 
     #[allow(clippy::new_ret_no_self)]
@@ -80,13 +80,13 @@ impl<'gc> TObject<'gc> for XMLObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(XMLObject::empty_node(
+        Ok(XmlObject::empty_node(
             activation.context.gc_context,
             Some(this),
         ))
     }
 
-    fn as_xml_node(&self) -> Option<XMLNode<'gc>> {
+    fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
         Some(self.0.read().node)
     }
 }

--- a/core/src/avm1/string.rs
+++ b/core/src/avm1/string.rs
@@ -114,7 +114,7 @@ impl<'gc> Hash for AvmString<'gc> {
 
 macro_rules! impl_eq {
     ($lhs:ty, $rhs: ty) => {
-        #[allow(unused_lifetimes)]
+        #[allow(unused_lifetimes, clippy::redundant_slicing)]
         impl<'a, 'b> PartialEq<$rhs> for $lhs {
             #[inline]
             fn eq(&self, other: &$rhs) -> bool {
@@ -122,7 +122,7 @@ macro_rules! impl_eq {
             }
         }
 
-        #[allow(unused_lifetimes)]
+        #[allow(unused_lifetimes, clippy::redundant_slicing)]
         impl<'a, 'b> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -72,10 +72,10 @@ pub fn url_from_relative_url(base: &str, relative: &str) -> Result<Url, ParseErr
 #[derive(Copy, Clone)]
 pub enum NavigationMethod {
     /// Indicates that navigation should generate a GET request.
-    GET,
+    Get,
 
     /// Indicates that navigation should generate a POST request.
-    POST,
+    Post,
 }
 
 impl NavigationMethod {
@@ -83,15 +83,15 @@ impl NavigationMethod {
     pub fn from_send_vars_method(s: SendVarsMethod) -> Option<Self> {
         match s {
             SendVarsMethod::None => None,
-            SendVarsMethod::Get => Some(Self::GET),
-            SendVarsMethod::Post => Some(Self::POST),
+            SendVarsMethod::Get => Some(Self::Get),
+            SendVarsMethod::Post => Some(Self::Post),
         }
     }
 
     pub fn from_method_str(method: &str) -> Option<Self> {
         match method {
-            "GET" => Some(Self::GET),
-            "POST" => Some(Self::POST),
+            "GET" => Some(Self::Get),
+            "POST" => Some(Self::Post),
             _ => None,
         }
     }
@@ -113,7 +113,7 @@ impl RequestOptions {
     /// Construct request options for a GET request.
     pub fn get() -> Self {
         Self {
-            method: NavigationMethod::GET,
+            method: NavigationMethod::Get,
             body: None,
         }
     }
@@ -121,7 +121,7 @@ impl RequestOptions {
     /// Construct request options for a POST request.
     pub fn post(body: Option<(Vec<u8>, String)>) -> Self {
         Self {
-            method: NavigationMethod::POST,
+            method: NavigationMethod::Post,
             body,
         }
     }

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -395,7 +395,7 @@ pub fn decode_define_bits_lossless(
     swf_tag: &swf::DefineBitsLossless,
 ) -> Result<Bitmap, Box<dyn std::error::Error>> {
     // Decompress the image data (DEFLATE compression).
-    let mut decoded_data = decompress_zlib(&swf_tag.data[..])?;
+    let mut decoded_data = decompress_zlib(swf_tag.data)?;
 
     // Swizzle/de-palettize the bitmap.
     let out_data = match (swf_tag.version, swf_tag.format) {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -16,7 +16,7 @@ use crate::tag_utils::SwfMovie;
 use crate::transform::Transform;
 use crate::types::{Degrees, Percent};
 use crate::vminterface::Instantiator;
-use crate::xml::XMLDocument;
+use crate::xml::XmlDocument;
 use chrono::Utc;
 use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use std::{cell::Ref, sync::Arc};
@@ -63,7 +63,7 @@ pub struct EditTextData<'gc> {
     /// appropriate set of format spans, which is used for actual rendering.
     /// The HTML is only retained if there is also a stylesheet already defined
     /// on the `EditText`, else it is discarded during the lowering process.
-    document: XMLDocument<'gc>,
+    document: XmlDocument<'gc>,
 
     /// The underlying text format spans of the `EditText`.
     ///
@@ -157,7 +157,7 @@ impl<'gc> EditText<'gc> {
         let is_password = swf_tag.is_password;
         let is_editable = !swf_tag.is_read_only;
         let is_html = swf_tag.is_html;
-        let document = XMLDocument::new(context.gc_context);
+        let document = XmlDocument::new(context.gc_context);
         let text = swf_tag.initial_text.clone().unwrap_or_default();
         let default_format = TextFormat::from_swf_tag(swf_tag.clone(), swf_movie.clone(), context);
         let encoding = swf_movie.encoding();
@@ -384,7 +384,7 @@ impl<'gc> EditText<'gc> {
     ) -> Result<(), Error> {
         if self.is_html() {
             let html_string = text.replace("<sbr>", "\n").replace("<br>", "\n");
-            let document = XMLDocument::new(context.gc_context);
+            let document = XmlDocument::new(context.gc_context);
 
             if let Err(err) =
                 document
@@ -401,7 +401,7 @@ impl<'gc> EditText<'gc> {
         Ok(())
     }
 
-    pub fn html_tree(self, context: &mut UpdateContext<'_, 'gc, '_>) -> XMLDocument<'gc> {
+    pub fn html_tree(self, context: &mut UpdateContext<'_, 'gc, '_>) -> XmlDocument<'gc> {
         self.0.read().text_spans.raise_to_html(context.gc_context)
     }
 
@@ -415,7 +415,7 @@ impl<'gc> EditText<'gc> {
     /// In stylesheet mode, the opposite is true: text spans are an
     /// intermediate, user-facing text span APIs don't work, and the document
     /// is retained.
-    pub fn set_html_tree(self, doc: XMLDocument<'gc>, context: &mut UpdateContext<'_, 'gc, '_>) {
+    pub fn set_html_tree(self, doc: XmlDocument<'gc>, context: &mut UpdateContext<'_, 'gc, '_>) {
         let mut write = self.0.write(context.gc_context);
 
         write.document = doc;

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -3,8 +3,8 @@ use crate::context::UpdateContext;
 pub use crate::display_object::{DisplayObject, TDisplayObject};
 use gc_arena::{Collect, GcCell, MutationContext};
 
-#[collect(no_drop)]
 #[derive(Clone, Copy, Collect, Debug)]
+#[collect(no_drop)]
 pub struct FocusTracker<'gc>(GcCell<'gc, Option<DisplayObject<'gc>>>);
 
 impl<'gc> FocusTracker<'gc> {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -5,7 +5,7 @@ use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::context::UpdateContext;
 use crate::html::iterators::TextSpanIter;
 use crate::tag_utils::SwfMovie;
-use crate::xml::{Step, XMLDocument, XMLName, XMLNode};
+use crate::xml::{Step, XmlDocument, XmlName, XmlNode};
 use gc_arena::{Collect, MutationContext};
 use std::borrow::Cow;
 use std::cmp::{min, Ordering};
@@ -280,11 +280,11 @@ impl TextFormat {
     /// loaded with all of the *currently existing* styles at this point in the
     /// lowering process. Any property not implied by markup will be retained
     /// in this format.
-    pub fn from_presentational_markup(node: XMLNode<'_>, mut tf: TextFormat) -> Self {
+    pub fn from_presentational_markup(node: XmlNode<'_>, mut tf: TextFormat) -> Self {
         match node.tag_name() {
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("p")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("p")) => {
                 match node
-                    .attribute_value_ignore_ascii_case(&XMLName::from_str("align"))
+                    .attribute_value_ignore_ascii_case(&XmlName::from_str("align"))
                     .as_deref()
                 {
                     Some("left") => tf.align = Some(swf::TextAlign::Left),
@@ -293,34 +293,34 @@ impl TextFormat {
                     _ => {}
                 }
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("a")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("a")) => {
                 if let Some(href) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("href"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("href"))
                 {
                     tf.url = Some(href);
                 }
 
                 if let Some(target) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("target"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("target"))
                 {
                     tf.target = Some(target);
                 }
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("font")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("font")) => {
                 if let Some(face) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("face"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("face"))
                 {
                     tf.font = Some(face);
                 }
 
                 if let Some(size) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("size"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("size"))
                 {
                     tf.size = size.parse().ok();
                 }
 
                 if let Some(color) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("color"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("color"))
                 {
                     if color.starts_with('#') {
                         let rval = color.get(1..3).and_then(|v| u8::from_str_radix(v, 16).ok());
@@ -334,13 +334,13 @@ impl TextFormat {
                 }
 
                 if let Some(letter_spacing) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("letterSpacing"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("letterSpacing"))
                 {
                     tf.letter_spacing = letter_spacing.parse().ok();
                 }
 
                 tf.kerning = match node
-                    .attribute_value_ignore_ascii_case(&XMLName::from_str("kerning"))
+                    .attribute_value_ignore_ascii_case(&XmlName::from_str("kerning"))
                     .as_deref()
                 {
                     Some("1") => Some(true),
@@ -348,53 +348,53 @@ impl TextFormat {
                     _ => tf.kerning,
                 }
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("b")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("b")) => {
                 tf.bold = Some(true);
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("i")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("i")) => {
                 tf.italic = Some(true);
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("u")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("u")) => {
                 tf.underline = Some(true);
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("li")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("li")) => {
                 tf.bullet = Some(true);
             }
-            Some(name) if name.eq_ignore_ascii_case(&XMLName::from_str("textformat")) => {
+            Some(name) if name.eq_ignore_ascii_case(&XmlName::from_str("textformat")) => {
                 //TODO: Spec says these are all in twips. That doesn't seem to
                 //match Flash 8.
                 if let Some(left_margin) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("leftmargin"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("leftmargin"))
                 {
                     tf.left_margin = left_margin.parse().ok();
                 }
 
                 if let Some(right_margin) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("rightmargin"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("rightmargin"))
                 {
                     tf.right_margin = right_margin.parse().ok();
                 }
 
                 if let Some(indent) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("indent"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("indent"))
                 {
                     tf.indent = indent.parse().ok();
                 }
 
                 if let Some(blockindent) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("blockindent"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("blockindent"))
                 {
                     tf.block_indent = blockindent.parse().ok();
                 }
 
                 if let Some(leading) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("leading"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("leading"))
                 {
                     tf.leading = leading.parse().ok();
                 }
 
                 if let Some(tabstops) =
-                    node.attribute_value_ignore_ascii_case(&XMLName::from_str("tabstops"))
+                    node.attribute_value_ignore_ascii_case(&XmlName::from_str("tabstops"))
                 {
                     tf.tab_stops = Some(
                         tabstops
@@ -1265,7 +1265,7 @@ impl FormatSpans {
     /// a handful of presentational attributes in the HTML tree to generate
     /// styling. There's also a `lower_from_css` that respects both
     /// presentational markup and CSS stylesheets.
-    pub fn lower_from_html(&mut self, tree: XMLDocument<'_>) {
+    pub fn lower_from_html(&mut self, tree: XmlDocument<'_>) {
         let mut format_stack = vec![self.default_format.clone()];
         let mut last_successful_format = None;
 
@@ -1349,8 +1349,8 @@ impl FormatSpans {
     }
 
     #[allow(clippy::float_cmp)]
-    pub fn raise_to_html<'gc>(&self, mc: MutationContext<'gc, '_>) -> XMLDocument<'gc> {
-        let document = XMLDocument::new(mc);
+    pub fn raise_to_html<'gc>(&self, mc: MutationContext<'gc, '_>) -> XmlDocument<'gc> {
+        let document = XmlDocument::new(mc);
         let mut root = document.as_node();
 
         let mut last_span = self.span(0);
@@ -1378,12 +1378,12 @@ impl FormatSpans {
                 || ls.tab_stops != span.tab_stops
                 || last_text_format_element.is_none()
             {
-                let new_tf = XMLNode::new_element(mc, "TEXTFORMAT", document);
+                let new_tf = XmlNode::new_element(mc, "TEXTFORMAT", document);
 
                 if ls.left_margin != 0.0 {
                     new_tf.set_attribute_value(
                         mc,
-                        &XMLName::from_str("LEFTMARGIN"),
+                        &XmlName::from_str("LEFTMARGIN"),
                         &format!("{}", span.left_margin),
                     );
                 }
@@ -1391,7 +1391,7 @@ impl FormatSpans {
                 if ls.right_margin != 0.0 {
                     new_tf.set_attribute_value(
                         mc,
-                        &XMLName::from_str("RIGHTMARGIN"),
+                        &XmlName::from_str("RIGHTMARGIN"),
                         &format!("{}", span.right_margin),
                     );
                 }
@@ -1399,7 +1399,7 @@ impl FormatSpans {
                 if ls.indent != 0.0 {
                     new_tf.set_attribute_value(
                         mc,
-                        &XMLName::from_str("INDENT"),
+                        &XmlName::from_str("INDENT"),
                         &format!("{}", span.indent),
                     );
                 }
@@ -1407,7 +1407,7 @@ impl FormatSpans {
                 if ls.block_indent != 0.0 {
                     new_tf.set_attribute_value(
                         mc,
-                        &XMLName::from_str("BLOCKINDENT"),
+                        &XmlName::from_str("BLOCKINDENT"),
                         &format!("{}", span.block_indent),
                     );
                 }
@@ -1415,7 +1415,7 @@ impl FormatSpans {
                 if ls.leading != 0.0 {
                     new_tf.set_attribute_value(
                         mc,
-                        &XMLName::from_str("LEADING"),
+                        &XmlName::from_str("LEADING"),
                         &format!("{}", span.leading),
                     );
                 }
@@ -1423,7 +1423,7 @@ impl FormatSpans {
                 if !ls.tab_stops.is_empty() {
                     new_tf.set_attribute_value(
                         mc,
-                        &XMLName::from_str("TABSTOPS"),
+                        &XmlName::from_str("TABSTOPS"),
                         &span
                             .tab_stops
                             .iter()
@@ -1450,7 +1450,7 @@ impl FormatSpans {
                 if can_span_create_bullets && span.bullet
                     || !can_span_create_bullets && last_span.map(|ls| ls.bullet).unwrap_or(false)
                 {
-                    let new_li = XMLNode::new_element(mc, "LI", document);
+                    let new_li = XmlNode::new_element(mc, "LI", document);
 
                     last_bullet = Some(new_li);
                     last_paragraph = None;
@@ -1467,11 +1467,11 @@ impl FormatSpans {
                 }
 
                 if ls.align != span.align || last_paragraph.is_none() {
-                    let new_p = XMLNode::new_element(mc, "P", document);
+                    let new_p = XmlNode::new_element(mc, "P", document);
 
                     new_p.set_attribute_value(
                         mc,
-                        &XMLName::from_str("ALIGN"),
+                        &XmlName::from_str("ALIGN"),
                         match span.align {
                             swf::TextAlign::Left => "LEFT",
                             swf::TextAlign::Center => "CENTER",
@@ -1500,16 +1500,16 @@ impl FormatSpans {
                     || ls.kerning != span.kerning
                     || last_font.is_none()
                 {
-                    let new_font = XMLNode::new_element(mc, "FONT", document);
+                    let new_font = XmlNode::new_element(mc, "FONT", document);
 
                     if ls.font != span.font || last_font.is_none() {
-                        new_font.set_attribute_value(mc, &XMLName::from_str("FACE"), &span.font);
+                        new_font.set_attribute_value(mc, &XmlName::from_str("FACE"), &span.font);
                     }
 
                     if ls.size != span.size || last_font.is_none() {
                         new_font.set_attribute_value(
                             mc,
-                            &XMLName::from_str("SIZE"),
+                            &XmlName::from_str("SIZE"),
                             &format!("{}", span.size),
                         );
                     }
@@ -1517,7 +1517,7 @@ impl FormatSpans {
                     if ls.color != span.color || last_font.is_none() {
                         new_font.set_attribute_value(
                             mc,
-                            &XMLName::from_str("COLOR"),
+                            &XmlName::from_str("COLOR"),
                             &format!(
                                 "#{:0>2X}{:0>2X}{:0>2X}",
                                 span.color.r, span.color.g, span.color.b
@@ -1528,7 +1528,7 @@ impl FormatSpans {
                     if ls.letter_spacing != span.letter_spacing || last_font.is_none() {
                         new_font.set_attribute_value(
                             mc,
-                            &XMLName::from_str("LETTERSPACING"),
+                            &XmlName::from_str("LETTERSPACING"),
                             &format!("{}", span.letter_spacing),
                         );
                     }
@@ -1536,7 +1536,7 @@ impl FormatSpans {
                     if ls.kerning != span.kerning || last_font.is_none() {
                         new_font.set_attribute_value(
                             mc,
-                            &XMLName::from_str("KERNING"),
+                            &XmlName::from_str("KERNING"),
                             if span.kerning { "1" } else { "0" },
                         );
                     }
@@ -1557,12 +1557,12 @@ impl FormatSpans {
                 }
 
                 if !span.url.is_empty() && (ls.url != span.url || last_a.is_none()) {
-                    let new_a = XMLNode::new_element(mc, "A", document);
+                    let new_a = XmlNode::new_element(mc, "A", document);
 
-                    new_a.set_attribute_value(mc, &XMLName::from_str("HREF"), &span.url);
+                    new_a.set_attribute_value(mc, &XmlName::from_str("HREF"), &span.url);
 
                     if !span.target.is_empty() {
-                        new_a.set_attribute_value(mc, &XMLName::from_str("TARGET"), &span.target);
+                        new_a.set_attribute_value(mc, &XmlName::from_str("TARGET"), &span.target);
                     }
 
                     last_font
@@ -1584,7 +1584,7 @@ impl FormatSpans {
                 }
 
                 if span.bold && last_b.is_none() {
-                    let new_b = XMLNode::new_element(mc, "B", document);
+                    let new_b = XmlNode::new_element(mc, "B", document);
 
                     last_a
                         .or(last_font)
@@ -1605,7 +1605,7 @@ impl FormatSpans {
                 }
 
                 if span.italic && last_i.is_none() {
-                    let new_i = XMLNode::new_element(mc, "I", document);
+                    let new_i = XmlNode::new_element(mc, "I", document);
 
                     last_b
                         .or(last_a)
@@ -1625,7 +1625,7 @@ impl FormatSpans {
                 }
 
                 if span.underline && last_u.is_none() {
-                    let new_u = XMLNode::new_element(mc, "U", document);
+                    let new_u = XmlNode::new_element(mc, "U", document);
 
                     last_i
                         .or(last_b)
@@ -1644,7 +1644,7 @@ impl FormatSpans {
                 }
 
                 let span_text = if last_bullet.is_some() {
-                    XMLNode::new_text(mc, line, document)
+                    XmlNode::new_text(mc, line, document)
                 } else {
                     let line_start = line.as_ptr() as usize - text.as_ptr() as usize;
                     let line_with_newline = if line_start > 0 {
@@ -1654,7 +1654,7 @@ impl FormatSpans {
                         line
                     };
 
-                    XMLNode::new_text(mc, line_with_newline, document)
+                    XmlNode::new_text(mc, line_with_newline, document)
                 };
 
                 last_u

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -141,7 +141,7 @@ type Renderer = Box<dyn RenderBackend>;
 type Storage = Box<dyn StorageBackend>;
 type Locale = Box<dyn LocaleBackend>;
 type Log = Box<dyn LogBackend>;
-type UI = Box<dyn UiBackend>;
+type Ui = Box<dyn UiBackend>;
 
 pub struct Player {
     /// The version of the player we're emulating.
@@ -169,7 +169,7 @@ pub struct Player {
     storage: Storage,
     locale: Locale,
     log: Log,
-    ui: UI,
+    ui: Ui,
 
     transform_stack: TransformStack,
     view_matrix: Matrix,
@@ -238,7 +238,7 @@ impl Player {
         storage: Storage,
         locale: Locale,
         log: Log,
-        ui: UI,
+        ui: Ui,
     ) -> Result<Arc<Mutex<Self>>, Error> {
         let fake_movie = Arc::new(SwfMovie::empty(NEWEST_PLAYER_VERSION));
         let movie_width = 550;
@@ -1025,11 +1025,11 @@ impl Player {
         self.renderer
     }
 
-    pub fn ui(&self) -> &UI {
+    pub fn ui(&self) -> &Ui {
         &self.ui
     }
 
-    pub fn ui_mut(&mut self) -> &mut UI {
+    pub fn ui_mut(&mut self) -> &mut Ui {
         &mut self.ui
     }
 

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -78,7 +78,7 @@ impl SwfMovie {
 
     /// Construct a movie based on the contents of the SWF datastream.
     pub fn from_data(swf_data: &[u8], url: Option<String>) -> Result<Self, Error> {
-        let swf_buf = swf::read::decompress_swf(&swf_data[..])?;
+        let swf_buf = swf::read::decompress_swf(swf_data)?;
         let encoding = swf::SwfStr::encoding_for_version(swf_buf.header.version);
         Ok(Self {
             header: swf_buf.header,

--- a/core/src/xml.rs
+++ b/core/src/xml.rs
@@ -9,12 +9,12 @@ mod tree;
 #[cfg(test)]
 mod tests;
 
-pub use document::XMLDocument;
+pub use document::XmlDocument;
 pub use error::Error;
 pub use error::ParseError;
 pub use iterators::Step;
-pub use namespace::XMLName;
-pub use tree::XMLNode;
+pub use namespace::XmlName;
+pub use tree::XmlNode;
 
 pub const ELEMENT_NODE: u8 = 1;
 pub const TEXT_NODE: u8 = 3;

--- a/core/src/xml/iterators.rs
+++ b/core/src/xml/iterators.rs
@@ -1,17 +1,17 @@
 //! Iterator types for XML trees
 
-use crate::xml::XMLNode;
+use crate::xml::XmlNode;
 
 /// Iterator that yields direct children of an XML node.
 pub struct ChildIter<'gc> {
-    base: XMLNode<'gc>,
+    base: XmlNode<'gc>,
     index: usize,
     back_index: usize,
 }
 
 impl<'gc> ChildIter<'gc> {
     /// Construct a new `ChildIter` that lists the children of an XML node.
-    pub fn for_node(base: XMLNode<'gc>) -> Self {
+    pub fn for_node(base: XmlNode<'gc>) -> Self {
         Self {
             base,
             index: 0,
@@ -20,13 +20,13 @@ impl<'gc> ChildIter<'gc> {
     }
 
     /// Yield the base element whose children are being read out of.
-    pub fn base(&self) -> XMLNode<'gc> {
+    pub fn base(&self) -> XmlNode<'gc> {
         self.base
     }
 }
 
 impl<'gc> Iterator for ChildIter<'gc> {
-    type Item = XMLNode<'gc>;
+    type Item = XmlNode<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index < self.back_index {
@@ -59,23 +59,23 @@ impl<'gc> DoubleEndedIterator for ChildIter<'gc> {
 pub enum Step<'gc> {
     /// `WalkIter` has discovered a new element and will begin to yield its
     /// children's steps.
-    In(XMLNode<'gc>),
+    In(XmlNode<'gc>),
 
     /// `WalkIter` has discovered a non-element node that cannot have children.
     ///
     /// Note that elements will never be stepped around, even if they are
     /// empty. They will be stepped in and out.
-    Around(XMLNode<'gc>),
+    Around(XmlNode<'gc>),
 
     /// `WalkIter` has exhausted the children of an element, stepping out of
     /// it.
-    Out(XMLNode<'gc>),
+    Out(XmlNode<'gc>),
 }
 
 impl<'gc> Step<'gc> {
     /// Discard the information regarding how we approached a given node, and
     /// just return the underlying `XMLNode`.
-    pub fn unwrap(self) -> XMLNode<'gc> {
+    pub fn unwrap(self) -> XmlNode<'gc> {
         match self {
             Self::In(node) | Self::Around(node) | Self::Out(node) => node,
         }
@@ -114,7 +114,7 @@ pub struct WalkIter<'gc> {
 
 impl<'gc> WalkIter<'gc> {
     /// Construct a new `WalkIter` that lists a tree out in `Step`s.
-    pub fn for_node(base: XMLNode<'gc>) -> Self {
+    pub fn for_node(base: XmlNode<'gc>) -> Self {
         Self {
             stack: vec![ChildIter::for_node(base)],
         }
@@ -144,7 +144,7 @@ impl<'gc> Iterator for WalkIter<'gc> {
 
 /// Iterator that yields indirect descendents of an XML node.
 pub struct AnscIter<'gc> {
-    next: Option<XMLNode<'gc>>,
+    next: Option<XmlNode<'gc>>,
 }
 
 impl<'gc> AnscIter<'gc> {
@@ -152,13 +152,13 @@ impl<'gc> AnscIter<'gc> {
     ///
     /// This function should be called with the parent of the node being
     /// iterated.
-    pub fn for_node(next: Option<XMLNode<'gc>>) -> Self {
+    pub fn for_node(next: Option<XmlNode<'gc>>) -> Self {
         Self { next }
     }
 }
 
 impl<'gc> Iterator for AnscIter<'gc> {
-    type Item = XMLNode<'gc>;
+    type Item = XmlNode<'gc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let parent = self.next;

--- a/core/src/xml/namespace.rs
+++ b/core/src/xml/namespace.rs
@@ -14,7 +14,7 @@ use std::fmt;
 /// should not be used for user-specified namespaces.
 #[derive(Clone, Collect, PartialEq, Eq, PartialOrd, Ord)]
 #[collect(no_drop)]
-pub struct XMLName {
+pub struct XmlName {
     /// The name of the XML namespace this name is scoped to.
     ///
     /// Names without a namespace use the default namespace.
@@ -25,10 +25,10 @@ pub struct XMLName {
     name: String,
 }
 
-impl XMLName {
+impl XmlName {
     /// Construct an XML name from its parts (name and namespace).
     pub fn from_parts(namespace: Option<&str>, name: &str) -> Self {
-        XMLName {
+        XmlName {
             namespace: namespace.map(|s| s.to_string()),
             name: name.to_string(),
         }
@@ -88,7 +88,7 @@ impl XMLName {
 
     /// Compares both names as case-insensitve ASCII (for use in HTML parsing).
     /// TODO: We shouldn't need this when we have a proper HTML parser.
-    pub fn eq_ignore_ascii_case(&self, other: &XMLName) -> bool {
+    pub fn eq_ignore_ascii_case(&self, other: &XmlName) -> bool {
         if !self.name.eq_ignore_ascii_case(&other.name) {
             return false;
         }
@@ -101,9 +101,9 @@ impl XMLName {
     }
 }
 
-impl fmt::Debug for XMLName {
+impl fmt::Debug for XmlName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("XMLName")
+        f.debug_struct("XmlName")
             .field("namespace", &self.namespace)
             .field("name", &self.name)
             .finish()

--- a/core/src/xml/tests.rs
+++ b/core/src/xml/tests.rs
@@ -1,14 +1,14 @@
 //! XML tests
 
 use crate::xml;
-use crate::xml::{XMLDocument, XMLName};
+use crate::xml::{XmlDocument, XmlName};
 use gc_arena::rootless_arena;
 
 /// Tests very basic parsing of a single-element document.
 #[test]
 fn parse_single_element() {
     rootless_arena(|mc| {
-        let xml = XMLDocument::new(mc);
+        let xml = XmlDocument::new(mc);
         xml.as_node()
             .replace_with_str(mc, "<test></test>", true, false)
             .expect("Parsed document");
@@ -19,7 +19,7 @@ fn parse_single_element() {
 
         let root = roots.next().expect("Parsed document should have a root");
         assert_eq!(root.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.tag_name(), Some(XMLName::from_str("test")));
+        assert_eq!(root.tag_name(), Some(XmlName::from_str("test")));
 
         let mut root_children = root.children().unwrap();
         assert!(root_children.next().is_none());
@@ -32,7 +32,7 @@ fn parse_single_element() {
 #[test]
 fn double_ended_children() {
     rootless_arena(|mc| {
-        let xml = XMLDocument::new(mc);
+        let xml = XmlDocument::new(mc);
         xml.as_node()
             .replace_with_str(
                 mc,
@@ -49,23 +49,23 @@ fn double_ended_children() {
 
         let root = roots.next().expect("Should have first root");
         assert_eq!(root.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.tag_name(), Some(XMLName::from_str("test")));
+        assert_eq!(root.tag_name(), Some(XmlName::from_str("test")));
 
         let root = roots.next_back().expect("Should have last root");
         assert_eq!(root.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.tag_name(), Some(XMLName::from_str("test5")));
+        assert_eq!(root.tag_name(), Some(XmlName::from_str("test5")));
 
         let root = roots.next().expect("Should have next root");
         assert_eq!(root.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.tag_name(), Some(XMLName::from_str("test2")));
+        assert_eq!(root.tag_name(), Some(XmlName::from_str("test2")));
 
         let root = roots.next_back().expect("Should have second-to-last root");
         assert_eq!(root.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.tag_name(), Some(XMLName::from_str("test4")));
+        assert_eq!(root.tag_name(), Some(XmlName::from_str("test4")));
 
         let root = roots.next().expect("Should have next root");
         assert_eq!(root.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.tag_name(), Some(XMLName::from_str("test3")));
+        assert_eq!(root.tag_name(), Some(XmlName::from_str("test3")));
 
         assert!(roots.next().is_none());
         assert!(roots.next_back().is_none());
@@ -77,7 +77,7 @@ fn double_ended_children() {
 #[allow(clippy::cognitive_complexity)]
 fn walk() {
     rootless_arena(|mc| {
-        let xml = XMLDocument::new(mc);
+        let xml = XmlDocument::new(mc);
         xml.as_node()
             .replace_with_str(
                 mc,
@@ -95,29 +95,29 @@ fn walk() {
         let root = roots.next().expect("Should have first root");
         assert!(root.stepped_in());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test")));
 
         let root = roots.next().expect("Should have first root's child");
         assert!(root.stepped_in());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test2")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test2")));
 
         let root = roots
             .next()
             .expect("Should have first root's child step-out");
         assert!(root.stepped_out());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test2")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test2")));
 
         let root = roots.next().expect("Should have first root step-out");
         assert!(root.stepped_out());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test")));
 
         let root = roots.next().expect("Should have second root");
         assert!(root.stepped_in());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test3")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test3")));
 
         let root = roots
             .next()
@@ -129,29 +129,29 @@ fn walk() {
         let root = roots.next().expect("Should have second root");
         assert!(root.stepped_out());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test3")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test3")));
 
         let root = roots.next().expect("Should have last root");
         assert!(root.stepped_in());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test4")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test4")));
 
         let root = roots.next().expect("Should have last root's child");
         assert!(root.stepped_in());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test5")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test5")));
 
         let root = roots
             .next()
             .expect("Should have last root's child step-out");
         assert!(root.stepped_out());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test5")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test5")));
 
         let root = roots.next().expect("Should have last root step-out");
         assert!(root.stepped_out());
         assert_eq!(root.unwrap().node_type(), xml::ELEMENT_NODE);
-        assert_eq!(root.unwrap().tag_name(), Some(XMLName::from_str("test4")));
+        assert_eq!(root.unwrap().tag_name(), Some(XmlName::from_str("test4")));
 
         assert!(roots.next().is_none());
     })
@@ -163,7 +163,7 @@ fn round_trip_tostring() {
     let test_string = "<test><!-- Comment -->This is a text node</test>";
 
     rootless_arena(|mc| {
-        let xml = XMLDocument::new(mc);
+        let xml = XmlDocument::new(mc);
         xml.as_node()
             .replace_with_str(mc, test_string, true, false)
             .expect("Parsed document");
@@ -183,7 +183,7 @@ fn round_trip_filtered_tostring() {
     let test_string = "<test><!-- Comment -->This is a text node</test>";
 
     rootless_arena(|mc| {
-        let xml = XMLDocument::new(mc);
+        let xml = XmlDocument::new(mc);
         xml.as_node()
             .replace_with_str(mc, test_string, true, false)
             .expect("Parsed document");
@@ -201,7 +201,7 @@ fn round_trip_filtered_tostring() {
 #[test]
 fn ignore_white() {
     rootless_arena(|mc| {
-        let xml = XMLDocument::new(mc);
+        let xml = XmlDocument::new(mc);
         xml.as_node()
             .replace_with_str(
                 mc,
@@ -218,7 +218,7 @@ fn ignore_white() {
 
         let mut node = root.next().expect("Should have root");
         assert_eq!(node.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(node.tag_name(), Some(XMLName::from_str("test")));
+        assert_eq!(node.tag_name(), Some(XmlName::from_str("test")));
 
         node = node
             .children()
@@ -226,7 +226,7 @@ fn ignore_white() {
             .next()
             .expect("Should have children");
         assert_eq!(node.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(node.tag_name(), Some(XMLName::from_str("test2")));
+        assert_eq!(node.tag_name(), Some(XmlName::from_str("test2")));
 
         node = node
             .children()
@@ -234,7 +234,7 @@ fn ignore_white() {
             .next()
             .expect("Should have children");
         assert_eq!(node.node_type(), xml::ELEMENT_NODE);
-        assert_eq!(node.tag_name(), Some(XMLName::from_str("test3")));
+        assert_eq!(node.tag_name(), Some(XmlName::from_str("test3")));
 
         node = node
             .children()

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -324,7 +324,7 @@ impl AudioBackend for CpalAudioBackend {
                 u16::from(swf_sound.data[0]) | (u16::from(swf_sound.data[1]) << 8);
             (skip_sample_frames, &swf_sound.data[2..])
         } else {
-            (0, &swf_sound.data[..])
+            (0, swf_sound.data)
         };
 
         let sound = Sound {

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -134,8 +134,8 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                 let client = client.ok_or(Error::NetworkUnavailable)?;
 
                 let request = match options.method() {
-                    NavigationMethod::GET => Request::get(processed_url.to_string()),
-                    NavigationMethod::POST => Request::post(processed_url.to_string()),
+                    NavigationMethod::Get => Request::get(processed_url.to_string()),
+                    NavigationMethod::Post => Request::post(processed_url.to_string()),
                 };
 
                 let (body_data, _) = options.body().clone().unwrap_or_default();

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -873,13 +873,13 @@ fn swf_shape_to_svg(
                             GradientSpread::Reflect => svg_gradient.set("spreadMethod", "reflect"),
                             GradientSpread::Repeat => svg_gradient.set("spreadMethod", "repeat"),
                         };
-                        if gradient.interpolation == GradientInterpolation::LinearRGB {
+                        if gradient.interpolation == GradientInterpolation::LinearRgb {
                             has_linear_rgb_gradient = true;
                             svg_path = svg_path.set("filter", "url('#_linearrgb')");
                         }
                         for record in &gradient.records {
                             let color =
-                                if gradient.interpolation == GradientInterpolation::LinearRGB {
+                                if gradient.interpolation == GradientInterpolation::LinearRgb {
                                     srgb_to_linear(record.color.clone())
                                 } else {
                                     record.color.clone()
@@ -935,13 +935,13 @@ fn swf_shape_to_svg(
                             GradientSpread::Reflect => svg_gradient.set("spreadMethod", "reflect"),
                             GradientSpread::Repeat => svg_gradient.set("spreadMethod", "repeat"),
                         };
-                        if gradient.interpolation == GradientInterpolation::LinearRGB {
+                        if gradient.interpolation == GradientInterpolation::LinearRgb {
                             has_linear_rgb_gradient = true;
                             svg_path = svg_path.set("filter", "url('#_linearrgb')");
                         }
                         for record in &gradient.records {
                             let color =
-                                if gradient.interpolation == GradientInterpolation::LinearRGB {
+                                if gradient.interpolation == GradientInterpolation::LinearRgb {
                                     srgb_to_linear(record.color.clone())
                                 } else {
                                     record.color.clone()
@@ -1001,13 +1001,13 @@ fn swf_shape_to_svg(
                             GradientSpread::Reflect => svg_gradient.set("spreadMethod", "reflect"),
                             GradientSpread::Repeat => svg_gradient.set("spreadMethod", "repeat"),
                         };
-                        if gradient.interpolation == GradientInterpolation::LinearRGB {
+                        if gradient.interpolation == GradientInterpolation::LinearRgb {
                             has_linear_rgb_gradient = true;
                             svg_path = svg_path.set("filter", "url('#_linearrgb')");
                         }
                         for record in &gradient.records {
                             let color =
-                                if gradient.interpolation == GradientInterpolation::LinearRGB {
+                                if gradient.interpolation == GradientInterpolation::LinearRgb {
                                     srgb_to_linear(record.color.clone())
                                 } else {
                                     record.color.clone()

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -532,7 +532,7 @@ impl WebGlRenderBackend {
                     ratios[..num_colors].copy_from_slice(&gradient.ratios[..num_colors]);
                     colors[..num_colors].copy_from_slice(&gradient.colors[..num_colors]);
                     // Convert to linear color space if this is a linear-interpolated gradient.
-                    if gradient.interpolation == swf::GradientInterpolation::LinearRGB {
+                    if gradient.interpolation == swf::GradientInterpolation::LinearRgb {
                         for color in &mut colors[..num_colors] {
                             *color = srgb_to_linear(*color);
                         }
@@ -1177,7 +1177,7 @@ impl RenderBackend for WebGlRenderBackend {
                     program.uniform1i(
                         &self.gl,
                         ShaderUniform::GradientInterpolation,
-                        (gradient.interpolation == swf::GradientInterpolation::LinearRGB) as i32,
+                        (gradient.interpolation == swf::GradientInterpolation::LinearRgb) as i32,
                     );
                 }
                 DrawType::Bitmap(bitmap) => {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -175,13 +175,13 @@ unsafe impl Zeroable for ColorAdjustments {}
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-struct GPUVertex {
+struct GpuVertex {
     position: [f32; 2],
     color: [f32; 4],
 }
 
-unsafe impl Pod for GPUVertex {}
-unsafe impl Zeroable for GPUVertex {}
+unsafe impl Pod for GpuVertex {}
+unsafe impl Zeroable for GpuVertex {}
 
 impl WgpuRenderBackend<SwapChainTarget> {
     pub fn for_window<W: HasRawWindowHandle>(
@@ -349,7 +349,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
             shape_id: CharacterId,
             draw: IncompleteDrawType,
             draws: &mut Vec<Draw>,
-            lyon_mesh: &mut VertexBuffers<GPUVertex, u32>,
+            lyon_mesh: &mut VertexBuffers<GpuVertex, u32>,
             device: &wgpu::Device,
             pipelines: &Pipelines,
         ) {
@@ -1328,19 +1328,19 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
 fn create_quad_buffers(device: &wgpu::Device) -> (wgpu::Buffer, wgpu::Buffer, wgpu::Buffer) {
     let vertices = [
-        GPUVertex {
+        GpuVertex {
             position: [0.0, 0.0],
             color: [1.0, 1.0, 1.0, 1.0],
         },
-        GPUVertex {
+        GpuVertex {
             position: [1.0, 0.0],
             color: [1.0, 1.0, 1.0, 1.0],
         },
-        GPUVertex {
+        GpuVertex {
             position: [1.0, 1.0],
             color: [1.0, 1.0, 1.0, 1.0],
         },
-        GPUVertex {
+        GpuVertex {
             position: [0.0, 1.0],
             color: [1.0, 1.0, 1.0, 1.0],
         },
@@ -1401,7 +1401,7 @@ fn swf_gradient_to_uniforms(
     }
 
     // Convert colors from sRGB to linear space if necessary.
-    if gradient.interpolation == GradientInterpolation::LinearRGB {
+    if gradient.interpolation == GradientInterpolation::LinearRgb {
         for color in &mut colors[0..gradient.records.len()] {
             *color = srgb_to_linear(*color);
         }
@@ -1411,7 +1411,7 @@ fn swf_gradient_to_uniforms(
         gradient_type,
         ratios,
         colors,
-        interpolation: (gradient.interpolation == GradientInterpolation::LinearRGB) as i32,
+        interpolation: (gradient.interpolation == GradientInterpolation::LinearRgb) as i32,
         num_colors: gradient.records.len() as u32,
         repeat_mode: gradient_spread_mode_index(gradient.spread),
         focal_point,
@@ -1430,18 +1430,18 @@ struct RuffleVertexCtor {
     color: [f32; 4],
 }
 
-impl FillVertexConstructor<GPUVertex> for RuffleVertexCtor {
-    fn new_vertex(&mut self, vertex: FillVertex) -> GPUVertex {
-        GPUVertex {
+impl FillVertexConstructor<GpuVertex> for RuffleVertexCtor {
+    fn new_vertex(&mut self, vertex: FillVertex) -> GpuVertex {
+        GpuVertex {
             position: [vertex.position().x, vertex.position().y],
             color: self.color,
         }
     }
 }
 
-impl StrokeVertexConstructor<GPUVertex> for RuffleVertexCtor {
-    fn new_vertex(&mut self, vertex: StrokeVertex) -> GPUVertex {
-        GPUVertex {
+impl StrokeVertexConstructor<GpuVertex> for RuffleVertexCtor {
+    fn new_vertex(&mut self, vertex: StrokeVertex) -> GpuVertex {
+        GpuVertex {
             position: [vertex.position().x, vertex.position().y],
             color: self.color,
         }

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -1,4 +1,4 @@
-use crate::{Error, GPUVertex, MaskState};
+use crate::{Error, GpuVertex, MaskState};
 use enum_map::{enum_map, EnumMap};
 use wgpu::vertex_attr_array;
 
@@ -43,7 +43,7 @@ impl Pipelines {
             device.create_shader_module(&wgpu::include_spirv!("../shaders/bitmap.frag.spv"));
 
         let vertex_buffers_description = [wgpu::VertexBufferDescriptor {
-            stride: std::mem::size_of::<GPUVertex>() as u64,
+            stride: std::mem::size_of::<GpuVertex>() as u64,
             step_mode: wgpu::InputStepMode::Vertex,
             attributes: &vertex_attr_array![
                 0 => Float2,

--- a/swf/src/avm1/opcode.rs
+++ b/swf/src/avm1/opcode.rs
@@ -1,6 +1,4 @@
-#![allow(clippy::useless_attribute)]
-
-#[allow(dead_code)]
+#[allow(dead_code, clippy::useless_attribute)]
 #[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
 pub enum OpCode {
     End = 0x00,

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -6,7 +6,12 @@
 //!
 //! This library consists of a `read` module for decoding SWF data, and a `write` library for
 //! writing SWF data.
-#![allow(clippy::unusual_byte_groupings)]
+#![allow(
+    renamed_and_removed_lints,
+    clippy::unknown_clippy_lints,
+    clippy::unusual_byte_groupings,
+    clippy::upper_case_acronyms
+)]
 
 extern crate byteorder;
 #[cfg(feature = "flate2")]

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1817,8 +1817,8 @@ impl<'a> Reader<'a> {
             _ => return Err(Error::invalid_data("Invalid gradient spread mode")),
         };
         let interpolation = match flags & 0b11_0000 {
-            0b00_0000 => GradientInterpolation::RGB,
-            0b01_0000 => GradientInterpolation::LinearRGB,
+            0b00_0000 => GradientInterpolation::Rgb,
+            0b01_0000 => GradientInterpolation::LinearRgb,
             _ => return Err(Error::invalid_data("Invalid gradient interpolation mode")),
         };
         let num_records = usize::from(flags & 0b1111);
@@ -2625,8 +2625,8 @@ impl<'a> Reader<'a> {
         let codec = match self.read_u8()? {
             2 => VideoCodec::H263,
             3 => VideoCodec::ScreenVideo,
-            4 => VideoCodec::VP6,
-            5 => VideoCodec::VP6WithAlpha,
+            4 => VideoCodec::Vp6,
+            5 => VideoCodec::Vp6WithAlpha,
             6 => VideoCodec::ScreenVideoV2,
             _ => return Err(Error::invalid_data("Invalid video codec.")),
         };
@@ -3063,8 +3063,8 @@ pub mod tests {
             assert_eq!(reader.read_string().unwrap(), "");
         }
         {
-            let buf = "12🤖12\0".as_bytes();
-            let mut reader = Reader::new(&buf[..], 1);
+            let buf = "12🤖12\0";
+            let mut reader = Reader::new(buf.as_bytes(), 1);
             assert_eq!(reader.read_string().unwrap(), "12🤖12");
         }
     }

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -737,7 +737,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             c: -0.024429321,
                         },
                         spread: GradientSpread::Pad,
-                        interpolation: GradientInterpolation::RGB,
+                        interpolation: GradientInterpolation::Rgb,
                         records: vec![
                             GradientRecord {
                                 ratio: 0,
@@ -840,7 +840,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             c: 0.0,
                         },
                         spread: GradientSpread::Pad,
-                        interpolation: GradientInterpolation::RGB,
+                        interpolation: GradientInterpolation::Rgb,
                         records: vec![
                             GradientRecord {
                                 ratio: 56,
@@ -958,7 +958,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                                 c: 0.0,
                             },
                             spread: GradientSpread::Pad,
-                            interpolation: GradientInterpolation::RGB,
+                            interpolation: GradientInterpolation::Rgb,
                             records: vec![
                                 GradientRecord {
                                     ratio: 0,
@@ -1081,7 +1081,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                                 c: -0.15675354,
                             },
                             spread: GradientSpread::Pad,
-                            interpolation: GradientInterpolation::RGB,
+                            interpolation: GradientInterpolation::Rgb,
                             records: vec![
                                 GradientRecord {
                                     ratio: 0,
@@ -1217,7 +1217,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             c: 0.0,
                         },
                         spread: GradientSpread::Reflect,
-                        interpolation: GradientInterpolation::LinearRGB,
+                        interpolation: GradientInterpolation::LinearRgb,
                         records: vec![
                             GradientRecord {
                                 ratio: 0,
@@ -1305,7 +1305,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             c: -0.084503174,
                         },
                         spread: GradientSpread::Reflect,
-                        interpolation: GradientInterpolation::LinearRGB,
+                        interpolation: GradientInterpolation::LinearRgb,
                         records: vec![
                             GradientRecord {
                                 ratio: 0,
@@ -1514,7 +1514,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             c: 0f32,
                         },
                         spread: GradientSpread::Pad,
-                        interpolation: GradientInterpolation::RGB,
+                        interpolation: GradientInterpolation::Rgb,
                         records: vec![
                             GradientRecord {
                                 ratio: 0,
@@ -1637,7 +1637,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                                     c: 0f32,
                                 },
                                 spread: GradientSpread::Pad,
-                                interpolation: GradientInterpolation::LinearRGB,
+                                interpolation: GradientInterpolation::LinearRgb,
                                 records: vec![
                                     GradientRecord {
                                         ratio: 0,
@@ -1701,7 +1701,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                                     c: 0f32,
                                 },
                                 spread: GradientSpread::Pad,
-                                interpolation: GradientInterpolation::RGB,
+                                interpolation: GradientInterpolation::Rgb,
                                 records: vec![
                                     GradientRecord {
                                         ratio: 0,

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -849,8 +849,8 @@ pub enum GradientSpread {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum GradientInterpolation {
-    RGB,
-    LinearRGB,
+    Rgb,
+    LinearRgb,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -1227,8 +1227,8 @@ pub enum VideoDeblocking {
 pub enum VideoCodec {
     H263,
     ScreenVideo,
-    VP6,
-    VP6WithAlpha,
+    Vp6,
+    Vp6WithAlpha,
     ScreenVideoV2,
 }
 

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1781,8 +1781,8 @@ impl<W: Write> Writer<W> {
         };
 
         flags |= match &gradient.interpolation {
-            GradientInterpolation::RGB => 0b00_0000,
-            GradientInterpolation::LinearRGB => 0b_01_0000,
+            GradientInterpolation::Rgb => 0b00_0000,
+            GradientInterpolation::LinearRgb => 0b_01_0000,
         };
 
         flags |= (gradient.records.len() as u8) & 0b1111;
@@ -2565,8 +2565,8 @@ impl<W: Write> Writer<W> {
         self.write_u8(match video.codec {
             VideoCodec::H263 => 2,
             VideoCodec::ScreenVideo => 3,
-            VideoCodec::VP6 => 4,
-            VideoCodec::VP6WithAlpha => 5,
+            VideoCodec::Vp6 => 4,
+            VideoCodec::Vp6WithAlpha => 5,
             VideoCodec::ScreenVideoV2 => 6,
         })?;
         Ok(())

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -803,7 +803,7 @@ impl AudioBackend for WebAudioBackend {
             let skip_sample_frames = u16::from(sound.data[0]) | (u16::from(sound.data[1]) << 8);
             (skip_sample_frames, &sound.data[2..])
         } else {
-            (0, &sound.data[..])
+            (0, sound.data)
         };
 
         let sound = Sound {

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -111,8 +111,8 @@ impl NavigatorBackend for WebNavigatorBackend {
                     let _ = form.set_attribute(
                         "method",
                         match navmethod {
-                            NavigationMethod::GET => "get",
-                            NavigationMethod::POST => "post",
+                            NavigationMethod::Get => "get",
+                            NavigationMethod::Post => "post",
                         },
                     );
 
@@ -165,8 +165,8 @@ impl NavigatorBackend for WebNavigatorBackend {
             let mut init = RequestInit::new();
 
             init.method(match options.method() {
-                NavigationMethod::GET => "GET",
-                NavigationMethod::POST => "POST",
+                NavigationMethod::Get => "GET",
+                NavigationMethod::Post => "POST",
             });
 
             if let Some((data, mime)) = options.body() {


### PR DESCRIPTION
 * #[derive(Collect)] should be before #[collect]
 * Replace redunant `&buf[..]` with `buf`
 * Changes most cases of UPPERCase to UpperCase
 * Allow upper_case_acronym on most SWF types, as they are from
   SWF spec/more annoying to change.