### PR TITLE
Remove `Collect` impls from `Activation` and `UpdateContext`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -14,7 +14,7 @@ use crate::ecma_conversions::f64_to_wrapping_u32;
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
-use gc_arena::{Collect, Gc, GcCell, MutationContext};
+use gc_arena::{Gc, GcCell, MutationContext};
 use indexmap::IndexMap;
 use rand::Rng;
 use smallvec::SmallVec;
@@ -179,8 +179,6 @@ unsafe impl<'gc> gc_arena::Collect for ActivationIdentifier<'gc> {
     fn trace(&self, _cc: gc_arena::CollectionContext) {}
 }
 
-#[derive(Collect)]
-#[collect(unsafe_drop)]
 pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     /// Represents the SWF version of a given function.
     ///

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -13,7 +13,7 @@ use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::{value, Avm2, Error};
 use crate::context::UpdateContext;
-use gc_arena::{Collect, Gc, GcCell, MutationContext};
+use gc_arena::{Gc, GcCell, MutationContext};
 use smallvec::SmallVec;
 use std::io::Cursor;
 use swf::avm2::read::Reader;
@@ -63,13 +63,13 @@ enum FrameControl<'gc> {
 }
 
 /// Represents a single activation of a given AVM2 function or keyframe.
-#[derive(Collect)]
-#[collect(no_drop)]
 pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     /// The immutable value of `this`.
+    #[allow(dead_code)]
     this: Option<Object<'gc>>,
 
     /// The arguments this function was called by.
+    #[allow(dead_code)]
     arguments: Option<Object<'gc>>,
 
     /// Flags that the current activation frame is being executed and has a
@@ -87,9 +87,11 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     ///
     /// A return value of `None` indicates that the called function is still
     /// executing. Functions that do not return instead return `Undefined`.
+    #[allow(dead_code)]
     return_value: Option<Value<'gc>>,
 
     /// The current local scope, implemented as a bare object.
+    #[allow(dead_code)]
     local_scope: Object<'gc>,
 
     /// The current scope stack.

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -22,7 +22,7 @@ use crate::prelude::*;
 use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::transform::TransformStack;
 use core::fmt;
-use gc_arena::{Collect, CollectionContext, MutationContext};
+use gc_arena::{Collect, MutationContext};
 use instant::Instant;
 use rand::rngs::SmallRng;
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -229,37 +229,6 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
 
     pub fn set_sound_transforms_dirty(&mut self) {
         self.audio_manager.set_sound_transforms_dirty()
-    }
-}
-
-unsafe impl<'a, 'gc, 'gc_context> Collect for UpdateContext<'a, 'gc, 'gc_context> {
-    fn trace(&self, cc: CollectionContext) {
-        self.action_queue.trace(cc);
-        self.background_color.trace(cc);
-        self.library.trace(cc);
-        self.player_version.trace(cc);
-        self.needs_render.trace(cc);
-        self.swf.trace(cc);
-        self.audio.trace(cc);
-        self.audio_manager.trace(cc);
-        self.navigator.trace(cc);
-        self.renderer.trace(cc);
-        self.ui.trace(cc);
-        self.storage.trace(cc);
-        self.rng.trace(cc);
-        self.levels.trace(cc);
-        self.mouse_hovered_object.trace(cc);
-        self.mouse_position.trace(cc);
-        self.drag_object.trace(cc);
-        self.load_manager.trace(cc);
-        self.system.trace(cc);
-        self.instance_counter.trace(cc);
-        self.shared_objects.trace(cc);
-        self.unbound_text_fields.trace(cc);
-        self.timers.trace(cc);
-        self.avm1.trace(cc);
-        self.avm2.trace(cc);
-        self.focus_tracker.trace(cc);
     }
 }
 


### PR DESCRIPTION
Neither of these impls are actually used.

As a result of this change, several fields in `avm2::Activation` became
unused. I assumed that these fields will become used as more of avm2 is
implemented, so I suppressed the warnings for now