### PR TITLE
web: Get rid of move-file-cli

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,6 @@
                 "chai": "^4.2.0",
                 "chai-html": "^1.3.0",
                 "chromedriver": "^88.0.0",
-                "clean-webpack-plugin": "^3.0.0",
                 "copy-webpack-plugin": "^7.0.0",
                 "eslint": "^7.13.0",
                 "eslint-config-prettier": "^8.1.0",
@@ -2635,12 +2634,6 @@
             "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
             "dev": true
         },
-        "node_modules/@types/anymatch": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
-            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
-            "dev": true
-        },
         "node_modules/@types/body-parser": {
             "version": "1.19.0",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -2971,12 +2964,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-            "dev": true
-        },
         "node_modules/@types/source-map": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
@@ -2997,12 +2984,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/tapable": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
-            "integrity": "sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==",
-            "dev": true
-        },
         "node_modules/@types/through": {
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
@@ -3012,72 +2993,11 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/uglify-js": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.1.tgz",
-            "integrity": "sha512-rdBIeMQyRBOXogop/EYBvSkYFn9D9yGxUa5hagBVG55KIdSUbp22EACJSHCs6kmmfunojAhf7zJH+Ds06/qLaQ==",
-            "dev": true,
-            "dependencies": {
-                "source-map": "^0.6.1"
-            }
-        },
-        "node_modules/@types/uglify-js/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
             "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
             "dev": true
-        },
-        "node_modules/@types/webpack": {
-            "version": "4.41.13",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.13.tgz",
-            "integrity": "sha512-RYmIHOWSxnTTa765N6jJBVE45pd2SYNblEYshVDduLw6RhocazNmRzE5/ytvBD8IkDMH6DI+bcrqxh8NILimBA==",
-            "dev": true,
-            "dependencies": {
-                "@types/anymatch": "*",
-                "@types/node": "*",
-                "@types/tapable": "*",
-                "@types/uglify-js": "*",
-                "@types/webpack-sources": "*",
-                "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/@types/webpack-sources": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.7.tgz",
-            "integrity": "sha512-XyaHrJILjK1VHVC4aVlKsdNN5KBTwufMb43cQs+flGxtPAf/1Qwl8+Q0tp5BwEGaI8D6XT1L+9bSWXckgkjTLw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*",
-                "@types/source-list-map": "*",
-                "source-map": "^0.6.1"
-            }
-        },
-        "node_modules/@types/webpack-sources/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@types/webpack/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/@types/yargs": {
             "version": "15.0.13",
@@ -6129,19 +6049,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/clean-webpack-plugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
-            "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
-            "dev": true,
-            "dependencies": {
-                "@types/webpack": "^4.4.31",
-                "del": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.9.0"
-            }
-        },
         "node_modules/cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -7457,24 +7364,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/del": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-            "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/glob": "^7.1.1",
-                "globby": "^6.1.0",
-                "is-path-cwd": "^2.0.0",
-                "is-path-in-cwd": "^2.0.0",
-                "p-map": "^2.0.0",
-                "pify": "^4.0.1",
-                "rimraf": "^2.6.3"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/delayed-stream": {
@@ -9886,31 +9775,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/globby/node_modules/pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/globjoin": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
@@ -10886,30 +10750,6 @@
             "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
             "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
             "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/is-path-in-cwd": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-            "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-            "dev": true,
-            "dependencies": {
-                "is-path-inside": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-            "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-            "dev": true,
-            "dependencies": {
-                "path-is-inside": "^1.0.2"
-            },
             "engines": {
                 "node": ">=6"
             }
@@ -13743,12 +13583,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-            "dev": true
         },
         "node_modules/path-key": {
             "version": "3.1.1",
@@ -20900,12 +20734,6 @@
             "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
             "dev": true
         },
-        "@types/anymatch": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
-            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
-            "dev": true
-        },
         "@types/body-parser": {
             "version": "1.19.0",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -21236,12 +21064,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-            "dev": true
-        },
         "@types/source-map": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
@@ -21262,12 +21084,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/tapable": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
-            "integrity": "sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==",
-            "dev": true
-        },
         "@types/through": {
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
@@ -21277,69 +21093,11 @@
                 "@types/node": "*"
             }
         },
-        "@types/uglify-js": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.1.tgz",
-            "integrity": "sha512-rdBIeMQyRBOXogop/EYBvSkYFn9D9yGxUa5hagBVG55KIdSUbp22EACJSHCs6kmmfunojAhf7zJH+Ds06/qLaQ==",
-            "dev": true,
-            "requires": {
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
         "@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
             "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
             "dev": true
-        },
-        "@types/webpack": {
-            "version": "4.41.13",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.13.tgz",
-            "integrity": "sha512-RYmIHOWSxnTTa765N6jJBVE45pd2SYNblEYshVDduLw6RhocazNmRzE5/ytvBD8IkDMH6DI+bcrqxh8NILimBA==",
-            "dev": true,
-            "requires": {
-                "@types/anymatch": "*",
-                "@types/node": "*",
-                "@types/tapable": "*",
-                "@types/uglify-js": "*",
-                "@types/webpack-sources": "*",
-                "source-map": "^0.6.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "@types/webpack-sources": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.7.tgz",
-            "integrity": "sha512-XyaHrJILjK1VHVC4aVlKsdNN5KBTwufMb43cQs+flGxtPAf/1Qwl8+Q0tp5BwEGaI8D6XT1L+9bSWXckgkjTLw==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/source-list-map": "*",
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
         },
         "@types/yargs": {
             "version": "15.0.13",
@@ -23753,16 +23511,6 @@
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true
         },
-        "clean-webpack-plugin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
-            "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
-            "dev": true,
-            "requires": {
-                "@types/webpack": "^4.4.31",
-                "del": "^4.1.1"
-            }
-        },
         "cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -24821,21 +24569,6 @@
                         "kind-of": "^6.0.2"
                     }
                 }
-            }
-        },
-        "del": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-            "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-            "dev": true,
-            "requires": {
-                "@types/glob": "^7.1.1",
-                "globby": "^6.1.0",
-                "is-path-cwd": "^2.0.0",
-                "is-path-in-cwd": "^2.0.0",
-                "p-map": "^2.0.0",
-                "pify": "^4.0.1",
-                "rimraf": "^2.6.3"
             }
         },
         "delayed-stream": {
@@ -26799,27 +26532,6 @@
                 "type-fest": "^0.8.1"
             }
         },
-        "globby": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-            "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-            "dev": true,
-            "requires": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
-            }
-        },
         "globjoin": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
@@ -27605,24 +27317,6 @@
             "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
             "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
             "dev": true
-        },
-        "is-path-in-cwd": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-            "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-            "dev": true,
-            "requires": {
-                "is-path-inside": "^2.1.0"
-            }
-        },
-        "is-path-inside": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-            "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-            "dev": true,
-            "requires": {
-                "path-is-inside": "^1.0.2"
-            }
         },
         "is-plain-obj": {
             "version": "1.1.0",
@@ -29982,12 +29676,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
         "path-key": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,6 @@
         "chai": "^4.2.0",
         "chai-html": "^1.3.0",
         "chromedriver": "^88.0.0",
-        "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^7.0.0",
         "eslint": "^7.13.0",
         "eslint-config-prettier": "^8.1.0",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -12,7 +12,7 @@
         "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
         "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
         "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name ruffle_web",
-        "build:wasm-opt": "wasm-opt ./pkg/ruffle_web_bg.wasm -O -g --output ./pkg/ruffle_web_bg.opt.wasm && move-file ./pkg/ruffle_web_bg.opt.wasm ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",
+        "build:wasm-opt": "wasm-opt -o ./pkg/ruffle_web_bg.wasm -O -g ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && [[ $GITHUB_ACTIONS != true ]]",
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
@@ -31,8 +31,7 @@
         "replace-in-file": "^6.1.0",
         "ts-node": "^9.0.0",
         "typedoc": "^0.20.0",
-        "typescript": "^4.0.5",
-        "move-file-cli": "^2.0.0"
+        "typescript": "^4.0.5"
     },
     "dependencies": {
         "@types/source-map": "^0.5.2"

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 
 const path = require("path");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (env, argv) => {
@@ -19,6 +18,7 @@ module.exports = (env, argv) => {
             path: path.resolve(__dirname, "dist"),
             filename: "index.js",
             publicPath: "",
+            clean: true,
         },
         module: {
             rules: [
@@ -34,7 +34,6 @@ module.exports = (env, argv) => {
         },
         devtool: "source-map",
         plugins: [
-            new CleanWebpackPlugin(),
             new CopyWebpackPlugin({
                 patterns: [
                     {

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 
 const path = require("path");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (env, argv) => {
@@ -25,6 +24,7 @@ module.exports = (env, argv) => {
             filename: "[name].js",
             publicPath: "",
             chunkFilename: "core.ruffle.js",
+            clean: true,
         },
         module: {
             rules: [
@@ -35,7 +35,6 @@ module.exports = (env, argv) => {
             ],
         },
         plugins: [
-            new CleanWebpackPlugin(),
             new CopyWebpackPlugin({
                 patterns: [{ from: "LICENSE*" }, { from: "README.md" }],
             }),

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 
 const path = require("path");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
 module.exports = (env, argv) => {
@@ -20,6 +19,7 @@ module.exports = (env, argv) => {
             filename: "ruffle.js",
             publicPath: "",
             chunkFilename: "core.ruffle.[contenthash].js",
+            clean: true,
         },
         module: {
             rules: [
@@ -31,7 +31,6 @@ module.exports = (env, argv) => {
         },
         devtool: "source-map",
         plugins: [
-            new CleanWebpackPlugin(),
             new CopyWebpackPlugin({
                 patterns: [{ from: "LICENSE*" }, { from: "README.md" }],
             }),


### PR DESCRIPTION
As of #2482, `web/packages/core/package.json` uses `move-file-cli` in its `build:wasm-opt` script. I think it's unnecessary, as it seems to work without it by letting `wasm-opt` optimize `ruffle_web_bg.wasm` in-place.
@torokati44 Am I missing something?