### PR TITLE
avm1: Fix #3298

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -953,7 +953,7 @@ fn set_mask<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mask = args
         .get(0)
-        .unwrap()
+        .unwrap_or(&Value::Undefined)
         .coerce_to_object(activation)
         .as_display_object();
     let mc = DisplayObject::MovieClip(movie_clip);


### PR DESCRIPTION
Prevent panic when no arguments are passed to MovieClip.setMask, fixes #3298, #3348