### PR TITLE
chore: Appease clippy

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(
     renamed_and_removed_lints,
+    unknown_lints,
     clippy::unknown_clippy_lints,
+    clippy::inconsistent_struct_constructor,
+    clippy::manual_map,
     clippy::manual_range_contains,
     clippy::same_item_push,
     clippy::unnecessary_wraps

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -421,12 +421,8 @@ impl AudioBackend for CpalAudioBackend {
 
     fn get_sound_position(&self, instance: SoundInstanceHandle) -> Option<u32> {
         let sound_instances = self.sound_instances.lock().unwrap();
-        if let Some(_instance) = sound_instances.get(instance) {
-            // TODO: Return actual position
-            Some(0)
-        } else {
-            None
-        }
+        // TODO: Return actual position
+        sound_instances.get(instance).map(|_| 0)
     }
 
     fn get_sound_duration(&self, sound: SoundHandle) -> Option<u32> {

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -454,9 +454,9 @@ impl WebGlRenderBackend {
         gl.bind_framebuffer(Gl2::FRAMEBUFFER, None);
 
         self.msaa_buffers = Some(MsaaBuffers {
-            render_framebuffer,
             color_renderbuffer,
             stencil_renderbuffer,
+            render_framebuffer,
             color_framebuffer,
             framebuffer_texture,
         });
@@ -744,9 +744,9 @@ impl WebGlRenderBackend {
         self.bitmap_registry.insert(handle, bitmap);
 
         self.textures.push(Texture {
-            texture,
             width,
             height,
+            texture,
         });
 
         Ok(BitmapInfo {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -749,9 +749,9 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
 
         self.bitmap_registry.insert(handle, bitmap);
         self.textures.push(Texture {
-            texture,
             width,
             height,
+            texture,
             bind_group,
         });
 

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1777,11 +1777,11 @@ impl<'a> Reader<'a> {
                 start_cap,
                 end_cap,
                 join_style,
+                fill_style,
                 allow_scale_x,
                 allow_scale_y,
                 is_pixel_hinted,
                 allow_close,
-                fill_style,
             })
         }
     }
@@ -2397,8 +2397,8 @@ impl<'a> Reader<'a> {
         Ok(SoundFormat {
             compression,
             sample_rate,
-            is_16_bit,
             is_stereo,
+            is_16_bit,
         })
     }
 
@@ -2671,8 +2671,8 @@ impl<'a> Reader<'a> {
         let data = self.read_slice(data_size)?;
         let alpha_data = self.read_slice_to_end();
         Ok(Tag::DefineBitsJpeg3(DefineBitsJpeg3 {
-            version,
             id,
+            version,
             deblocking,
             data,
             alpha_data,

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -1022,12 +1022,8 @@ impl AudioBackend for WebAudioBackend {
     fn get_sound_position(&self, instance: SoundInstanceHandle) -> Option<u32> {
         SOUND_INSTANCES.with(|instances| {
             let instances = instances.borrow();
-            if let Some(_instance) = instances.get(instance) {
-                // TODO: Return actual position
-                Some(0)
-            } else {
-                None
-            }
+            // TODO: Return actual position
+            instances.get(instance).map(|_| 0)
         })
     }
 


### PR DESCRIPTION
Mostly disable `inconsistent_struct_constructor` and `manual_map` lints.