### PR TITLE
avm1: Clear masker/maskee properties when using removeMovieClip()

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -918,6 +918,12 @@ pub trait TDisplayObject<'gc>:
             }
         }
 
+        if let Some(node) = self.maskee() {
+            node.set_masker(context.gc_context, None, true);
+        } else if let Some(node) = self.masker() {
+            node.set_maskee(context.gc_context, None, true);
+        }
+
         // Unregister any text field variable bindings, and replace them on the unbound list.
         if let Avm1Value::Object(object) = self.object() {
             if let Some(stage_object) = object.as_stage_object() {

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -511,6 +511,11 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
             let tracker = context.focus_tracker;
             tracker.set(None, context);
         }
+        if let Some(node) = self.maskee() {
+            node.set_masker(context.gc_context, None, true);
+        } else if let Some(node) = self.masker() {
+            node.set_maskee(context.gc_context, None, true);
+        }
         self.set_removed(context.gc_context, true);
     }
 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1500,6 +1500,12 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             tracker.set(None, context);
         }
 
+        if let Some(node) = self.maskee() {
+            node.set_masker(context.gc_context, None, true);
+        } else if let Some(node) = self.masker() {
+            node.set_maskee(context.gc_context, None, true);
+        }
+
         // Unbind any display objects bound to this text.
         if let Some(stage_object) = self.0.write(context.gc_context).bound_stage_object.take() {
             stage_object.clear_text_field_binding(context.gc_context, *self);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1805,6 +1805,12 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             child.unload(context);
         }
 
+        if let Some(node) = self.maskee() {
+            node.set_masker(context.gc_context, None, true);
+        } else if let Some(node) = self.masker() {
+            node.set_maskee(context.gc_context, None, true);
+        }
+
         // Unregister any text field variable bindings.
         if let Avm1Value::Object(object) = self.object() {
             if let Some(stage_object) = object.as_stage_object() {


### PR DESCRIPTION
This should fix masks still being active after either their maskee clip or the mask itself are removed via removeMovieClip().
