### PR TITLE
POC: Navigator: disallow requests to some domains (currently mochiads.com)

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -389,3 +389,14 @@ impl NavigatorBackend for NullNavigatorBackend {
         url
     }
 }
+
+pub fn is_fetch_domain_banned(url: &str) -> bool {
+    if let Ok(parsed_url) = Url::parse(url) {
+        if let Some(domain) = parsed_url.domain() {
+            if domain.ends_with("mochiads.com") {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -1,7 +1,8 @@
 //! Navigator backend for web
 use js_sys::{Array, ArrayBuffer, Uint8Array};
 use ruffle_core::backend::navigator::{
-    url_from_relative_url, NavigationMethod, NavigatorBackend, OwnedFuture, RequestOptions,
+    is_fetch_domain_banned, url_from_relative_url, NavigationMethod, NavigatorBackend, OwnedFuture,
+    RequestOptions,
 };
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
@@ -162,6 +163,14 @@ impl NavigatorBackend for WebNavigatorBackend {
         };
 
         Box::pin(async move {
+            if is_fetch_domain_banned(&url) {
+                log::error!("Request to {} was blocked by Ruffle.", url);
+                return Err(Error::FetchError(format!(
+                    "Request to {} was blocked by Ruffle.",
+                    url
+                )));
+            }
+
             let mut init = RequestInit::new();
 
             init.method(match options.method() {


### PR DESCRIPTION
Requested on discord, no GH issue :(

mochiads.com was used by some flash games for distributing ads (and other uses?) - currently the domain was taken over by what looks like malware distributor.

PR design questions:
- disable flag in options? (needed for MVP?)
- list of banned domains in options? (needed for MVP?)
- what logging level (browsers usually log blocked requests by default)?
- currently the error message is duplicated, because the Err() variant contents are pretty much just ignored. Maybe some better way to write this?
