### PR TITLE
chore: Random cleanups

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -495,47 +495,52 @@ impl<'gc> FunctionObject<'gc> {
     /// `prototype` refers to the explicit prototype of the function.
     /// The function and its prototype will be linked to each other.
     fn allocate_function(
-        context: MutationContext<'gc, '_>,
+        gc_context: MutationContext<'gc, '_>,
         function: Option<impl Into<Executable<'gc>>>,
         constructor: Option<impl Into<Executable<'gc>>>,
         fn_proto: Option<Object<'gc>>,
         prototype: Object<'gc>,
     ) -> Object<'gc> {
-        let function = Self::bare_function(context, function, constructor, fn_proto).into();
+        let function = Self::bare_function(gc_context, function, constructor, fn_proto).into();
 
         prototype.define_value(
-            context,
+            gc_context,
             "constructor",
             Value::Object(function),
             Attribute::DONT_ENUM,
         );
-        function.define_value(context, "prototype", prototype.into(), Attribute::empty());
+        function.define_value(
+            gc_context,
+            "prototype",
+            prototype.into(),
+            Attribute::empty(),
+        );
 
         function
     }
 
     /// Construct a regular function from an executable and associated protos.
     pub fn function(
-        context: MutationContext<'gc, '_>,
+        gc_context: MutationContext<'gc, '_>,
         function: impl Into<Executable<'gc>>,
         fn_proto: Option<Object<'gc>>,
         prototype: Object<'gc>,
     ) -> Object<'gc> {
         // Avoid type inference issues
         let none: Option<Executable> = None;
-        Self::allocate_function(context, Some(function), none, fn_proto, prototype)
+        Self::allocate_function(gc_context, Some(function), none, fn_proto, prototype)
     }
 
     /// Construct a regular and constructor function from an executable and associated protos.
     pub fn constructor(
-        context: MutationContext<'gc, '_>,
+        gc_context: MutationContext<'gc, '_>,
         constructor: impl Into<Executable<'gc>>,
         function: impl Into<Executable<'gc>>,
         fn_proto: Option<Object<'gc>>,
         prototype: Object<'gc>,
     ) -> Object<'gc> {
         Self::allocate_function(
-            context,
+            gc_context,
             Some(function),
             Some(constructor),
             fn_proto,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -706,8 +706,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         self.0.read().interfaces.clone()
     }
 
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
-        self.0.write(context).interfaces = iface_list;
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+        self.0.write(gc_context).interfaces = iface_list;
     }
 
     fn as_script_object(&self) -> Option<ScriptObject<'gc>> {

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -454,11 +454,11 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0.read().base.interfaces()
     }
 
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
         self.0
-            .write(context)
+            .write(gc_context)
             .base
-            .set_interfaces(context, iface_list)
+            .set_interfaces(gc_context, iface_list)
     }
 
     fn as_string(&self) -> Cow<str> {

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -231,8 +231,8 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
         self.base().interfaces()
     }
 
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
-        self.base().set_interfaces(context, iface_list)
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+        self.base().set_interfaces(gc_context, iface_list)
     }
 
     fn as_script_object(&self) -> Option<ScriptObject<'gc>> {

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -228,8 +228,8 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
         self.base().interfaces()
     }
 
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
-        self.base().set_interfaces(context, iface_list)
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+        self.base().set_interfaces(gc_context, iface_list)
     }
 
     fn as_script_object(&self) -> Option<ScriptObject<'gc>> {

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -750,7 +750,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn interfaces(&self) -> Vec<Object<'gc>>;
 
     /// Set the interface list for this object.
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>);
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>);
 
     /// Determine if this object is an instance of a given type.
     ///

--- a/core/src/avm2/object/custom_object.rs
+++ b/core/src/avm2/object/custom_object.rs
@@ -267,8 +267,12 @@ macro_rules! impl_avm2_custom_object {
             self.0.read().$field.interfaces()
         }
 
-        fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
-            self.0.write(context).$field.set_interfaces(iface_list)
+        fn set_interfaces(
+            &self,
+            gc_context: MutationContext<'gc, '_>,
+            iface_list: Vec<Object<'gc>>,
+        ) {
+            self.0.write(gc_context).$field.set_interfaces(iface_list)
         }
     };
 }

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -341,8 +341,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         self.0.read().interfaces()
     }
 
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
-        self.0.write(context).set_interfaces(iface_list)
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+        self.0.write(gc_context).set_interfaces(iface_list)
     }
 
     fn as_class(&self) -> Option<GcCell<'gc, Class<'gc>>> {

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -386,7 +386,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0.read().base.interfaces()
     }
 
-    fn set_interfaces(&self, context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
-        self.0.write(context).base.set_interfaces(iface_list)
+    fn set_interfaces(&self, gc_context: MutationContext<'gc, '_>, iface_list: Vec<Object<'gc>>) {
+        self.0.write(gc_context).base.set_interfaces(iface_list)
     }
 }

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -60,11 +60,7 @@ impl<'gc> RegExp<'gc> {
     }
 
     pub fn set_dotall(&mut self, value: bool) {
-        if value {
-            self.flags.0 |= RegExpFlags::DOTALL;
-        } else {
-            self.flags.0 -= RegExpFlags::DOTALL;
-        }
+        self.flags.0.set(RegExpFlags::DOTALL, value);
     }
 
     pub fn extended(&self) -> bool {
@@ -72,11 +68,7 @@ impl<'gc> RegExp<'gc> {
     }
 
     pub fn set_extended(&mut self, value: bool) {
-        if value {
-            self.flags.0 |= RegExpFlags::EXTENDED;
-        } else {
-            self.flags.0 -= RegExpFlags::EXTENDED;
-        }
+        self.flags.0.set(RegExpFlags::EXTENDED, value);
     }
 
     pub fn global(&self) -> bool {
@@ -84,11 +76,7 @@ impl<'gc> RegExp<'gc> {
     }
 
     pub fn set_global(&mut self, value: bool) {
-        if value {
-            self.flags.0 |= RegExpFlags::GLOBAL;
-        } else {
-            self.flags.0 -= RegExpFlags::GLOBAL;
-        }
+        self.flags.0.set(RegExpFlags::GLOBAL, value);
     }
 
     pub fn ignore_case(&self) -> bool {
@@ -96,11 +84,7 @@ impl<'gc> RegExp<'gc> {
     }
 
     pub fn set_ignore_case(&mut self, value: bool) {
-        if value {
-            self.flags.0 |= RegExpFlags::IGNORE_CASE;
-        } else {
-            self.flags.0 -= RegExpFlags::IGNORE_CASE;
-        }
+        self.flags.0.set(RegExpFlags::IGNORE_CASE, value);
     }
 
     pub fn multiline(&self) -> bool {
@@ -108,11 +92,7 @@ impl<'gc> RegExp<'gc> {
     }
 
     pub fn set_multiline(&mut self, value: bool) {
-        if value {
-            self.flags.0 |= RegExpFlags::MULTILINE;
-        } else {
-            self.flags.0 -= RegExpFlags::MULTILINE;
-        }
+        self.flags.0.set(RegExpFlags::MULTILINE, value);
     }
 
     pub fn test(&mut self, text: &str) -> bool {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -358,11 +358,7 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_removed(&mut self, value: bool) {
-        if value {
-            self.flags |= DisplayObjectFlags::REMOVED;
-        } else {
-            self.flags -= DisplayObjectFlags::REMOVED;
-        }
+        self.flags.set(DisplayObjectFlags::REMOVED, value);
     }
 
     fn sound_transform(&self) -> &SoundTransform {
@@ -378,11 +374,7 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_visible(&mut self, value: bool) {
-        if value {
-            self.flags |= DisplayObjectFlags::VISIBLE;
-        } else {
-            self.flags -= DisplayObjectFlags::VISIBLE;
-        }
+        self.flags.set(DisplayObjectFlags::VISIBLE, value);
     }
 
     fn lock_root(&self) -> bool {
@@ -390,11 +382,7 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_lock_root(&mut self, value: bool) {
-        if value {
-            self.flags |= DisplayObjectFlags::LOCK_ROOT;
-        } else {
-            self.flags -= DisplayObjectFlags::LOCK_ROOT;
-        }
+        self.flags.set(DisplayObjectFlags::LOCK_ROOT, value);
     }
 
     fn transformed_by_script(&self) -> bool {
@@ -403,11 +391,8 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_transformed_by_script(&mut self, value: bool) {
-        if value {
-            self.flags |= DisplayObjectFlags::TRANSFORMED_BY_SCRIPT;
-        } else {
-            self.flags -= DisplayObjectFlags::TRANSFORMED_BY_SCRIPT;
-        }
+        self.flags
+            .set(DisplayObjectFlags::TRANSFORMED_BY_SCRIPT, value);
     }
 
     fn placed_by_script(&self) -> bool {
@@ -415,11 +400,7 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_placed_by_script(&mut self, value: bool) {
-        if value {
-            self.flags |= DisplayObjectFlags::PLACED_BY_SCRIPT;
-        } else {
-            self.flags -= DisplayObjectFlags::PLACED_BY_SCRIPT;
-        }
+        self.flags.set(DisplayObjectFlags::PLACED_BY_SCRIPT, value);
     }
 
     fn instantiated_by_timeline(&self) -> bool {
@@ -428,11 +409,8 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_instantiated_by_timeline(&mut self, value: bool) {
-        if value {
-            self.flags |= DisplayObjectFlags::INSTANTIATED_BY_TIMELINE;
-        } else {
-            self.flags -= DisplayObjectFlags::INSTANTIATED_BY_TIMELINE;
-        }
+        self.flags
+            .set(DisplayObjectFlags::INSTANTIATED_BY_TIMELINE, value);
     }
 
     fn swf_version(&self) -> u8 {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -130,7 +130,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.place_frame
     }
 
-    fn set_place_frame(&mut self, _context: MutationContext<'gc, '_>, frame: u16) {
+    fn set_place_frame(&mut self, frame: u16) {
         self.place_frame = frame;
     }
 
@@ -142,11 +142,11 @@ impl<'gc> DisplayObjectBase<'gc> {
         &self.transform.matrix
     }
 
-    fn matrix_mut(&mut self, _context: MutationContext<'gc, '_>) -> &mut Matrix {
+    fn matrix_mut(&mut self) -> &mut Matrix {
         &mut self.transform.matrix
     }
 
-    fn set_matrix(&mut self, _context: MutationContext<'gc, '_>, matrix: &Matrix) {
+    fn set_matrix(&mut self, matrix: &Matrix) {
         self.transform.matrix = *matrix;
         self.flags -= DisplayObjectFlags::SCALE_ROTATION_CACHED;
     }
@@ -159,11 +159,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         &mut self.transform.color_transform
     }
 
-    fn set_color_transform(
-        &mut self,
-        _context: MutationContext<'gc, '_>,
-        color_transform: &ColorTransform,
-    ) {
+    fn set_color_transform(&mut self, color_transform: &ColorTransform) {
         self.transform.color_transform = *color_transform;
     }
 
@@ -296,7 +292,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         &self.name
     }
 
-    fn set_name(&mut self, _context: MutationContext<'gc, '_>, name: &str) {
+    fn set_name(&mut self, name: &str) {
         self.name = name.to_string();
     }
 
@@ -313,7 +309,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.clip_depth
     }
 
-    fn set_clip_depth(&mut self, _context: MutationContext<'gc, '_>, depth: Depth) {
+    fn set_clip_depth(&mut self, depth: Depth) {
         self.clip_depth = depth;
     }
 
@@ -321,11 +317,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.parent
     }
 
-    fn set_parent(
-        &mut self,
-        _context: MutationContext<'gc, '_>,
-        parent: Option<DisplayObject<'gc>>,
-    ) {
+    fn set_parent(&mut self, parent: Option<DisplayObject<'gc>>) {
         self.parent = parent;
     }
 
@@ -333,11 +325,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.prev_sibling
     }
 
-    fn set_prev_sibling(
-        &mut self,
-        _context: MutationContext<'gc, '_>,
-        node: Option<DisplayObject<'gc>>,
-    ) {
+    fn set_prev_sibling(&mut self, node: Option<DisplayObject<'gc>>) {
         self.prev_sibling = node;
     }
 
@@ -345,11 +333,7 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.next_sibling
     }
 
-    fn set_next_sibling(
-        &mut self,
-        _context: MutationContext<'gc, '_>,
-        node: Option<DisplayObject<'gc>>,
-    ) {
+    fn set_next_sibling(&mut self, node: Option<DisplayObject<'gc>>) {
         self.next_sibling = node;
     }
 
@@ -426,14 +410,14 @@ impl<'gc> DisplayObjectBase<'gc> {
     fn masker(&self) -> Option<DisplayObject<'gc>> {
         self.masker
     }
-    fn set_masker(&mut self, _context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>) {
+    fn set_masker(&mut self, node: Option<DisplayObject<'gc>>) {
         self.masker = node;
     }
 
     fn maskee(&self) -> Option<DisplayObject<'gc>> {
         self.maskee
     }
-    fn set_maskee(&mut self, _context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>) {
+    fn set_maskee(&mut self, node: Option<DisplayObject<'gc>>) {
         self.maskee = node;
     }
 }
@@ -1291,7 +1275,7 @@ macro_rules! impl_display_object_sansbounds {
             self.0.read().$field.place_frame()
         }
         fn set_place_frame(&self, context: gc_arena::MutationContext<'gc, '_>, frame: u16) {
-            self.0.write(context).$field.set_place_frame(context, frame)
+            self.0.write(context).$field.set_place_frame(frame)
         }
         fn transform(&self) -> std::cell::Ref<crate::transform::Transform> {
             std::cell::Ref::map(self.0.read(), |o| o.$field.transform())
@@ -1303,7 +1287,7 @@ macro_rules! impl_display_object_sansbounds {
             &self,
             context: gc_arena::MutationContext<'gc, '_>,
         ) -> std::cell::RefMut<swf::Matrix> {
-            std::cell::RefMut::map(self.0.write(context), |o| o.$field.matrix_mut(context))
+            std::cell::RefMut::map(self.0.write(context), |o| o.$field.matrix_mut())
         }
         fn color_transform(&self) -> std::cell::Ref<crate::color_transform::ColorTransform> {
             std::cell::Ref::map(self.0.read(), |o| o.$field.color_transform())
@@ -1322,7 +1306,7 @@ macro_rules! impl_display_object_sansbounds {
             self.0
                 .write(context)
                 .$field
-                .set_color_transform(context, color_transform)
+                .set_color_transform(color_transform)
         }
         fn rotation(&self, gc_context: gc_arena::MutationContext<'gc, '_>) -> Degrees {
             self.0.write(gc_context).$field.rotation()
@@ -1352,7 +1336,7 @@ macro_rules! impl_display_object_sansbounds {
             std::cell::Ref::map(self.0.read(), |o| o.$field.name())
         }
         fn set_name(&self, context: gc_arena::MutationContext<'gc, '_>, name: &str) {
-            self.0.write(context).$field.set_name(context, name)
+            self.0.write(context).$field.set_name(name)
         }
         fn clip_depth(&self) -> crate::prelude::Depth {
             self.0.read().$field.clip_depth()
@@ -1362,7 +1346,7 @@ macro_rules! impl_display_object_sansbounds {
             context: gc_arena::MutationContext<'gc, '_>,
             depth: crate::prelude::Depth,
         ) {
-            self.0.write(context).$field.set_clip_depth(context, depth)
+            self.0.write(context).$field.set_clip_depth(depth)
         }
         fn parent(&self) -> Option<crate::display_object::DisplayObject<'gc>> {
             self.0.read().$field.parent()
@@ -1372,7 +1356,7 @@ macro_rules! impl_display_object_sansbounds {
             context: gc_arena::MutationContext<'gc, '_>,
             parent: Option<crate::display_object::DisplayObject<'gc>>,
         ) {
-            self.0.write(context).$field.set_parent(context, parent)
+            self.0.write(context).$field.set_parent(parent)
         }
         fn prev_sibling(&self) -> Option<DisplayObject<'gc>> {
             self.0.read().$field.prev_sibling()
@@ -1382,7 +1366,7 @@ macro_rules! impl_display_object_sansbounds {
             context: gc_arena::MutationContext<'gc, '_>,
             node: Option<DisplayObject<'gc>>,
         ) {
-            self.0.write(context).$field.set_prev_sibling(context, node);
+            self.0.write(context).$field.set_prev_sibling(node);
         }
         fn next_sibling(&self) -> Option<DisplayObject<'gc>> {
             self.0.read().$field.next_sibling()
@@ -1392,7 +1376,7 @@ macro_rules! impl_display_object_sansbounds {
             context: gc_arena::MutationContext<'gc, '_>,
             node: Option<DisplayObject<'gc>>,
         ) {
-            self.0.write(context).$field.set_next_sibling(context, node);
+            self.0.write(context).$field.set_next_sibling(node);
         }
         fn masker(&self) -> Option<DisplayObject<'gc>> {
             self.0.read().$field.masker()
@@ -1408,7 +1392,7 @@ macro_rules! impl_display_object_sansbounds {
                     old_masker.set_maskee(context, None, false);
                 }
             }
-            self.0.write(context).$field.set_masker(context, node);
+            self.0.write(context).$field.set_masker(node);
         }
         fn maskee(&self) -> Option<DisplayObject<'gc>> {
             self.0.read().$field.maskee()
@@ -1424,7 +1408,7 @@ macro_rules! impl_display_object_sansbounds {
                     old_maskee.set_masker(context, None, false);
                 }
             }
-            self.0.write(context).$field.set_maskee(context, node);
+            self.0.write(context).$field.set_maskee(node);
         }
         fn removed(&self) -> bool {
             self.0.read().$field.removed()
@@ -1525,7 +1509,7 @@ macro_rules! impl_display_object {
             self.0.write(gc_context).$field.set_y(value)
         }
         fn set_matrix(&self, context: gc_arena::MutationContext<'gc, '_>, matrix: &swf::Matrix) {
-            self.0.write(context).$field.set_matrix(context, matrix)
+            self.0.write(context).$field.set_matrix(matrix)
         }
     };
 }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -485,17 +485,17 @@ pub trait TDisplayObject<'gc>:
     }
 
     fn place_frame(&self) -> u16;
-    fn set_place_frame(&self, context: MutationContext<'gc, '_>, frame: u16);
+    fn set_place_frame(&self, gc_context: MutationContext<'gc, '_>, frame: u16);
 
     fn transform(&self) -> Ref<Transform>;
     fn matrix(&self) -> Ref<Matrix>;
-    fn matrix_mut(&self, context: MutationContext<'gc, '_>) -> RefMut<Matrix>;
-    fn set_matrix(&self, context: MutationContext<'gc, '_>, matrix: &Matrix);
+    fn matrix_mut(&self, gc_context: MutationContext<'gc, '_>) -> RefMut<Matrix>;
+    fn set_matrix(&self, gc_context: MutationContext<'gc, '_>, matrix: &Matrix);
     fn color_transform(&self) -> Ref<ColorTransform>;
-    fn color_transform_mut(&self, context: MutationContext<'gc, '_>) -> RefMut<ColorTransform>;
+    fn color_transform_mut(&self, gc_context: MutationContext<'gc, '_>) -> RefMut<ColorTransform>;
     fn set_color_transform(
         &self,
-        context: MutationContext<'gc, '_>,
+        gc_context: MutationContext<'gc, '_>,
         color_transform: &ColorTransform,
     );
 
@@ -618,12 +618,14 @@ pub trait TDisplayObject<'gc>:
         self.set_scale_x(gc_context, Percent::from_unit(new_scale_x));
         self.set_scale_y(gc_context, Percent::from_unit(new_scale_y));
     }
+
     /// Gets the pixel height of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_height`/`height` properties.
     fn height(&self) -> f64 {
         let bounds = self.local_bounds();
         (bounds.y_max.saturating_sub(bounds.y_min)).to_pixels()
     }
+
     /// Sets the pixel height of this display object in local space.
     /// Set by the ActionScript `_height`/`height` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
@@ -655,6 +657,7 @@ pub trait TDisplayObject<'gc>:
         self.set_scale_x(gc_context, Percent::from_unit(new_scale_x));
         self.set_scale_y(gc_context, Percent::from_unit(new_scale_y));
     }
+
     /// The opacity of this display object.
     /// 1 is fully opaque.
     /// Returned by the `_alpha`/`alpha` ActionScript properties.
@@ -664,8 +667,9 @@ pub trait TDisplayObject<'gc>:
     /// 1 is fully opaque.
     /// Set by the `_alpha`/`alpha` ActionScript properties.
     fn set_alpha(&self, gc_context: MutationContext<'gc, '_>, value: f64);
+
     fn name(&self) -> Ref<str>;
-    fn set_name(&self, context: MutationContext<'gc, '_>, name: &str);
+    fn set_name(&self, gc_context: MutationContext<'gc, '_>, name: &str);
 
     /// Returns the dot-syntax path to this display object, e.g. `_level0.foo.clip`
     fn path(&self) -> String {
@@ -709,24 +713,32 @@ pub trait TDisplayObject<'gc>:
     }
 
     fn clip_depth(&self) -> Depth;
-    fn set_clip_depth(&self, context: MutationContext<'gc, '_>, depth: Depth);
+    fn set_clip_depth(&self, gc_context: MutationContext<'gc, '_>, depth: Depth);
     fn parent(&self) -> Option<DisplayObject<'gc>>;
-    fn set_parent(&self, context: MutationContext<'gc, '_>, parent: Option<DisplayObject<'gc>>);
+    fn set_parent(&self, gc_context: MutationContext<'gc, '_>, parent: Option<DisplayObject<'gc>>);
     fn prev_sibling(&self) -> Option<DisplayObject<'gc>>;
-    fn set_prev_sibling(&self, context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>);
+    fn set_prev_sibling(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+        node: Option<DisplayObject<'gc>>,
+    );
     fn next_sibling(&self) -> Option<DisplayObject<'gc>>;
-    fn set_next_sibling(&self, context: MutationContext<'gc, '_>, node: Option<DisplayObject<'gc>>);
+    fn set_next_sibling(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+        node: Option<DisplayObject<'gc>>,
+    );
     fn masker(&self) -> Option<DisplayObject<'gc>>;
     fn set_masker(
         &self,
-        context: MutationContext<'gc, '_>,
+        gc_context: MutationContext<'gc, '_>,
         node: Option<DisplayObject<'gc>>,
         remove_old_link: bool,
     );
     fn maskee(&self) -> Option<DisplayObject<'gc>>;
     fn set_maskee(
         &self,
-        context: MutationContext<'gc, '_>,
+        gc_context: MutationContext<'gc, '_>,
         node: Option<DisplayObject<'gc>>,
         remove_old_link: bool,
     );
@@ -757,7 +769,7 @@ pub trait TDisplayObject<'gc>:
         None
     }
     fn removed(&self) -> bool;
-    fn set_removed(&self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_removed(&self, gc_context: MutationContext<'gc, '_>, value: bool);
 
     /// Whether this display object is visible.
     /// Invisible objects are not rendered, but otherwise continue to exist normally.
@@ -767,7 +779,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets whether this display object will be visible.
     /// Invisible objects are not rendered, but otherwise continue to exist normally.
     /// Returned by the `_visible`/`visible` ActionScript properties.
-    fn set_visible(&self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_visible(&self, gc_context: MutationContext<'gc, '_>, value: bool);
 
     /// The sound transform for sounds played inside this display object.
     fn sound_transform(&self) -> Ref<SoundTransform>;
@@ -785,7 +797,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Sets whether this display object is used as the _root of itself and its children.
     /// Returned by the `_lockroot` ActionScript property.
-    fn set_lock_root(&self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_lock_root(&self, gc_context: MutationContext<'gc, '_>, value: bool);
 
     /// Whether this display object has been transformed by ActionScript.
     /// When this flag is set, changes from SWF `PlaceObject` tags are ignored.
@@ -793,12 +805,12 @@ pub trait TDisplayObject<'gc>:
 
     /// Sets whether this display object has been transformed by ActionScript.
     /// When this flag is set, changes from SWF `PlaceObject` tags are ignored.
-    fn set_transformed_by_script(&self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_transformed_by_script(&self, gc_context: MutationContext<'gc, '_>, value: bool);
 
     /// Called whenever the focus tracker has deemed this display object worthy, or no longer worthy,
     /// of being the currently focused object.
     /// This should only be called by the focus manager. To change a focus, go through that.
-    fn on_focus_changed(&self, _context: MutationContext<'gc, '_>, _focused: bool) {}
+    fn on_focus_changed(&self, _gc_context: MutationContext<'gc, '_>, _focused: bool) {}
 
     /// Whether or not this clip may be focusable for keyboard input.
     fn is_focusable(&self) -> bool {
@@ -813,7 +825,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets whether this display object has been created by ActionScript 3.
     /// When this flag is set, changes from SWF `RemoveObject` tags are
     /// ignored.
-    fn set_placed_by_script(&self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_placed_by_script(&self, gc_context: MutationContext<'gc, '_>, value: bool);
 
     /// Whether this display object has been instantiated by the timeline.
     /// When this flag is set, attempts to change the object's name from AVM2
@@ -823,7 +835,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets whether this display object has been instantiated by the timeline.
     /// When this flag is set, attempts to change the object's name from AVM2
     /// throw an exception.
-    fn set_instantiated_by_timeline(&self, context: MutationContext<'gc, '_>, value: bool);
+    fn set_instantiated_by_timeline(&self, gc_context: MutationContext<'gc, '_>, value: bool);
 
     /// Executes and propagates the given clip event.
     /// Events execute inside-out; the deepest child will react first, followed by its parent, and

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -507,8 +507,8 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         true
     }
 
-    fn on_focus_changed(&self, context: MutationContext<'gc, '_>, focused: bool) {
-        self.0.write(context).has_focus = focused;
+    fn on_focus_changed(&self, gc_context: MutationContext<'gc, '_>, focused: bool) {
+        self.0.write(gc_context).has_focus = focused;
     }
 
     fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -206,8 +206,8 @@ impl<'gc> EditText<'gc> {
 
         let mut base = DisplayObjectBase::default();
 
-        base.matrix_mut(context.gc_context).tx = bounds.x_min;
-        base.matrix_mut(context.gc_context).ty = bounds.y_min;
+        base.matrix_mut().tx = bounds.x_min;
+        base.matrix_mut().ty = bounds.y_min;
 
         let variable = if !swf_tag.variable_name.is_empty() {
             Some(swf_tag.variable_name)
@@ -1400,7 +1400,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn set_matrix(&self, context: MutationContext<'gc, '_>, matrix: &Matrix) {
-        self.0.write(context).base.set_matrix(context, matrix);
+        self.0.write(context).base.set_matrix(matrix);
         self.redraw_border(context);
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -522,36 +522,36 @@ impl<'gc> EditText<'gc> {
         self.0.read().has_background
     }
 
-    pub fn set_has_background(self, context: MutationContext<'gc, '_>, has_background: bool) {
-        self.0.write(context).has_background = has_background;
-        self.redraw_border(context);
+    pub fn set_has_background(self, gc_context: MutationContext<'gc, '_>, has_background: bool) {
+        self.0.write(gc_context).has_background = has_background;
+        self.redraw_border(gc_context);
     }
 
     pub fn background_color(self) -> u32 {
         self.0.read().background_color
     }
 
-    pub fn set_background_color(self, context: MutationContext<'gc, '_>, background_color: u32) {
-        self.0.write(context).background_color = background_color;
-        self.redraw_border(context);
+    pub fn set_background_color(self, gc_context: MutationContext<'gc, '_>, background_color: u32) {
+        self.0.write(gc_context).background_color = background_color;
+        self.redraw_border(gc_context);
     }
 
     pub fn has_border(self) -> bool {
         self.0.read().has_border
     }
 
-    pub fn set_has_border(self, context: MutationContext<'gc, '_>, has_border: bool) {
-        self.0.write(context).has_border = has_border;
-        self.redraw_border(context);
+    pub fn set_has_border(self, gc_context: MutationContext<'gc, '_>, has_border: bool) {
+        self.0.write(gc_context).has_border = has_border;
+        self.redraw_border(gc_context);
     }
 
     pub fn border_color(self) -> u32 {
         self.0.read().border_color
     }
 
-    pub fn set_border_color(self, context: MutationContext<'gc, '_>, border_color: u32) {
-        self.0.write(context).border_color = border_color;
-        self.redraw_border(context);
+    pub fn set_border_color(self, gc_context: MutationContext<'gc, '_>, border_color: u32) {
+        self.0.write(gc_context).border_color = border_color;
+        self.redraw_border(gc_context);
     }
 
     pub fn is_device_font(self) -> bool {
@@ -673,8 +673,8 @@ impl<'gc> EditText<'gc> {
     /// written into.
 
     /// Redraw the border of this `EditText`.
-    fn redraw_border(self, context: MutationContext<'gc, '_>) {
-        let mut write = self.0.write(context);
+    fn redraw_border(self, gc_context: MutationContext<'gc, '_>) {
+        let mut write = self.0.write(gc_context);
 
         write.drawing.clear();
 
@@ -1399,9 +1399,9 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn set_matrix(&self, context: MutationContext<'gc, '_>, matrix: &Matrix) {
-        self.0.write(context).base.set_matrix(matrix);
-        self.redraw_border(context);
+    fn set_matrix(&self, gc_context: MutationContext<'gc, '_>, matrix: &Matrix) {
+        self.0.write(gc_context).base.set_matrix(matrix);
+        self.redraw_border(gc_context);
     }
 
     fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
@@ -1544,8 +1544,8 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         MouseCursor::IBeam
     }
 
-    fn on_focus_changed(&self, context: MutationContext<'gc, '_>, focused: bool) {
-        let mut text = self.0.write(context);
+    fn on_focus_changed(&self, gc_context: MutationContext<'gc, '_>, focused: bool) {
+        let mut text = self.0.write(gc_context);
         text.has_focus = focused;
         if !focused {
             text.selection = None;

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2210,7 +2210,6 @@ impl<'gc> MovieClipData<'gc> {
                 //TODO: This should have an AVM2 onload path.
                 self.object.and_then(|o| o.as_avm1_object().ok()),
                 context.action_queue,
-                context.gc_context,
             );
         }
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2022,8 +2022,8 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         self.0.read().is_focusable
     }
 
-    fn on_focus_changed(&self, context: MutationContext<'gc, '_>, focused: bool) {
-        self.0.write(context).has_focus = focused;
+    fn on_focus_changed(&self, gc_context: MutationContext<'gc, '_>, focused: bool) {
+        self.0.write(gc_context).has_focus = focused;
     }
 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2077,11 +2077,7 @@ impl<'gc> MovieClipData<'gc> {
     }
 
     fn set_playing(&mut self, value: bool) {
-        if value {
-            self.flags |= MovieClipFlags::PLAYING;
-        } else {
-            self.flags -= MovieClipFlags::PLAYING;
-        }
+        self.flags.set(MovieClipFlags::PLAYING, value);
     }
 
     fn programmatically_played(&self) -> bool {
@@ -2233,11 +2229,7 @@ impl<'gc> MovieClipData<'gc> {
 
     fn set_initialized(&mut self, value: bool) -> bool {
         let ret = self.flags.contains(MovieClipFlags::INITIALIZED);
-        if value {
-            self.flags |= MovieClipFlags::INITIALIZED;
-        } else {
-            self.flags -= MovieClipFlags::INITIALIZED;
-        }
+        self.flags.set(MovieClipFlags::INITIALIZED, value);
         !ret
     }
 

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -828,9 +828,9 @@ impl<'gc> LayoutBox<'gc> {
     }
 
     /// Construct a duplicate layout box structure.
-    pub fn duplicate(&self, context: MutationContext<'gc, '_>) -> GcCell<'gc, Self> {
+    pub fn duplicate(&self, gc_context: MutationContext<'gc, '_>) -> GcCell<'gc, Self> {
         GcCell::allocate(
-            context,
+            gc_context,
             Self {
                 bounds: self.bounds,
                 content: self.content.clone(),

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -12,7 +12,7 @@ use crate::tag_utils::SwfMovie;
 use crate::vminterface::Instantiator;
 use crate::xml::XmlNode;
 use encoding_rs::UTF_8;
-use gc_arena::{Collect, CollectionContext, MutationContext};
+use gc_arena::{Collect, CollectionContext};
 use generational_arena::{Arena, Index};
 use std::string::FromUtf8Error;
 use std::sync::{Arc, Mutex, Weak};
@@ -171,12 +171,11 @@ impl<'gc> LoadManager<'gc> {
         loaded_clip: DisplayObject<'gc>,
         clip_object: Option<Object<'gc>>,
         queue: &mut ActionQueue<'gc>,
-        gc_context: MutationContext<'gc, '_>,
     ) {
         let mut invalidated_loaders = vec![];
 
         for (index, loader) in self.0.iter_mut() {
-            if loader.movie_clip_loaded(loaded_clip, clip_object, queue, gc_context) {
+            if loader.movie_clip_loaded(loaded_clip, clip_object, queue) {
                 invalidated_loaders.push(index);
             }
         }
@@ -702,7 +701,6 @@ impl<'gc> Loader<'gc> {
         loaded_clip: DisplayObject<'gc>,
         clip_object: Option<Object<'gc>>,
         queue: &mut ActionQueue<'gc>,
-        _gc_context: MutationContext<'gc, '_>,
     ) -> bool {
         let (clip, broadcaster, loader_status) = match self {
             Loader::Movie {


### PR DESCRIPTION
These are pure mechanical changes:

1. Take advantage of the `set` method that `bitflags` offers. For example:

```rust
if value {
    flags |= Flags::FOO;
} else {
    flags -= Flags::FOO;
}
```

Becomes:

```rust
flags.set(Flags::FOO, value);
```

2. Remove unused `MutationContext` parameters.
3. Rename remaining `MutationContext` parameters from `context` to `gc_context`.