### PR TITLE
Fix regression in AVM1 seeking

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1460,7 +1460,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let val = self.context.avm1.pop();
         if val.as_bool(self.current_swf_version()) {
-            reader.seek(data.as_ref(), jump_offset);
+            reader.seek(data.movie.data(), jump_offset);
         }
         Ok(FrameControl::Continue)
     }
@@ -1543,7 +1543,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         reader: &mut Reader<'b>,
         data: &'b SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        reader.seek(data.as_ref(), jump_offset);
+        reader.seek(data.movie.data(), jump_offset);
         Ok(FrameControl::Continue)
     }
 


### PR DESCRIPTION
These are the changes from https://github.com/ruffle-rs/ruffle/issues/3525#issuecomment-791077972.
Fixes #3501 and #3525, and perhaps #3532 too.

I haven't found any AVM2 content in the reports about this regression. I looked through the AVM2 part of the changes in dad21d43, and found no similar mistake at a first glance.

The problem was most likely with negative relative offsets, as the "rest" of the slice was always there. And these might not be very common.
