### PR TITLE
web: Use publicPath() instead of ruffleRuntimePath

### DIFF
--- a/web/packages/core/src/globals.d.ts
+++ b/web/packages/core/src/globals.d.ts
@@ -1,9 +1,7 @@
 /* eslint @typescript-eslint/naming-convention:off */
 
 declare let __webpack_public_path__: string;
-declare let ruffleRuntimePath: string;
 
 interface Error {
-    ruffleIsExtension?: boolean;
     ruffleIndexError?: number;
 }

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -22,36 +22,13 @@ async function fetchRuffle(): Promise<{ new (...args: any[]): Ruffle }> {
     // libraries, if needed.
     setPolyfillsOnLoad();
 
-    let isExtension = true;
-
-    try {
-        // If ruffleRuntimePath is defined then we are executing inside the extension
-        // closure. In that case, we configure our local Webpack instance.
-        __webpack_public_path__ = ruffleRuntimePath + "dist/";
-    } catch (e) {
-        // Checking an undefined closure variable usually throws ReferenceError,
-        // so we need to catch it here and continue onward.
-        if (!(e instanceof ReferenceError)) {
-            throw e;
-        }
-        isExtension = false;
-    }
-
-    // We currently assume that if we are not executing inside the extension,
-    // then we can use webpack to get Ruffle.
-
-    try {
-        // wasm files are set to use file-loader,
-        // so this package will resolve to the URL of the wasm file.
-        const ruffleWasm = await import(
-            /* webpackMode: "eager" */
-            "../pkg/ruffle_web_bg.wasm"
-        );
-        await init(ruffleWasm.default);
-    } catch (e) {
-        e.ruffleIsExtension = isExtension;
-        throw e;
-    }
+    // wasm files are set to use file-loader,
+    // so this package will resolve to the URL of the wasm file.
+    const ruffleWasm = await import(
+        /* webpackMode: "eager" */
+        "../pkg/ruffle_web_bg.wasm"
+    );
+    await init(ruffleWasm.default);
 
     return Ruffle;
 }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -346,7 +346,7 @@ export class RufflePlayer extends HTMLElement {
             // Serious duck typing. In error conditions, let's not make assumptions.
             if (window.location.protocol === "file:") {
                 e.ruffleIndexError = PanicError.FileProtocol;
-            } else if (!e.ruffleIsExtension) {
+            } else {
                 e.ruffleIndexError = PanicError.WasmNotFound;
                 const message = String(e.message).toLowerCase();
                 if (message.includes("mime")) {

--- a/web/packages/extension/.eslintrc.json
+++ b/web/packages/extension/.eslintrc.json
@@ -4,6 +4,7 @@
         "webextensions": true
     },
     "globals": {
+        "__webpack_public_path__": true,
         "obfuscatedEventPrefix": true
     }
 }

--- a/web/packages/extension/js/index.js
+++ b/web/packages/extension/js/index.js
@@ -7,6 +7,25 @@ window.RufflePlayer = PublicAPI.negotiate(
 );
 __webpack_public_path__ = publicPath(window.RufflePlayer.config, "extension");
 
+function getObfuscatedEventPrefix() {
+    if (
+        document.currentScript !== undefined &&
+        document.currentScript !== null &&
+        "src" in document.currentScript &&
+        document.currentScript.src !== ""
+    ) {
+        // Default to the directory where this script resides.
+        try {
+            return new URL(document.currentScript.src).searchParams.get(
+                "obfuscatedEventPrefix"
+            );
+        } catch (e) {
+            return null;
+        }
+    }
+}
+
+const obfuscatedEventPrefix = getObfuscatedEventPrefix();
 if (obfuscatedEventPrefix) {
     document.addEventListener(obfuscatedEventPrefix + "_request", function (e) {
         let body = JSON.parse(e.detail);

--- a/web/packages/extension/js/index.js
+++ b/web/packages/extension/js/index.js
@@ -1,10 +1,11 @@
-import { PublicAPI, SourceAPI } from "ruffle-core";
+import { PublicAPI, SourceAPI, publicPath } from "ruffle-core";
 
 window.RufflePlayer = PublicAPI.negotiate(
     window.RufflePlayer,
     "extension",
     new SourceAPI("extension")
 );
+__webpack_public_path__ = publicPath(window.RufflePlayer.config, "extension");
 
 if (obfuscatedEventPrefix) {
     document.addEventListener(obfuscatedEventPrefix + "_request", function (e) {

--- a/web/packages/extension/js/lv0.js
+++ b/web/packages/extension/js/lv0.js
@@ -139,8 +139,6 @@ getSyncStorage(["ruffleEnable", "ignoreOptout"], function (data) {
         }
     });
 
-    const extPath = getExtensionUrl();
-
     if (shouldLoadUntrustedWorld) {
         // We must run the plugin polyfill before any flash detection scripts.
         // Unfortunately, this might still be too late for some websites when using Chrome (issue #969).
@@ -151,22 +149,13 @@ getSyncStorage(["ruffleEnable", "ignoreOptout"], function (data) {
 
         // Load Ruffle script asynchronously. By doing so, we can inject extra variables and isolate them from the global scope.
         (async function () {
-            let ruffleSrcResp = await fetch(extPath + "dist/ruffle.js");
-            if (ruffleSrcResp.ok) {
-                let ruffleSource =
-                    '(function () { var obfuscatedEventPrefix = "' +
-                    obfuscatedEventPrefix +
-                    '";\n' +
-                    (await ruffleSrcResp.text()) +
-                    "}())";
-                let ruffleScript = document.createElement("script");
-                ruffleScript.appendChild(document.createTextNode(ruffleSource));
-                (document.head || document.documentElement).appendChild(
-                    ruffleScript
-                );
-            } else {
-                console.error("Critical error loading Ruffle into page");
-            }
+            const ruffleScript = document.createElement("script");
+            ruffleScript.src = getExtensionUrl(
+                `dist/ruffle.js?obfuscatedEventPrefix=${obfuscatedEventPrefix}`
+            );
+            (document.head || document.documentElement).appendChild(
+                ruffleScript
+            );
         })();
     }
 });

--- a/web/packages/extension/js/lv0.js
+++ b/web/packages/extension/js/lv0.js
@@ -154,9 +154,7 @@ getSyncStorage(["ruffleEnable", "ignoreOptout"], function (data) {
             let ruffleSrcResp = await fetch(extPath + "dist/ruffle.js");
             if (ruffleSrcResp.ok) {
                 let ruffleSource =
-                    '(function () { var ruffleRuntimePath = "' +
-                    extPath +
-                    '";\nvar obfuscatedEventPrefix = "' +
+                    '(function () { var obfuscatedEventPrefix = "' +
                     obfuscatedEventPrefix +
                     '";\n' +
                     (await ruffleSrcResp.text()) +

--- a/web/packages/extension/js/util.js
+++ b/web/packages/extension/js/util.js
@@ -213,15 +213,11 @@ function setMessageListener(listener) {
     }
 }
 
-function getExtensionUrl() {
+function getExtensionUrl(path) {
     if (chrome && chrome.extension && chrome.extension.getURL) {
-        return chrome.extension
-            .getURL("dist/ruffle.js")
-            .replace("dist/ruffle.js", "");
+        return chrome.extension.getURL(path);
     } else if (browser && browser.runtime && browser.runtime.getURL) {
-        return browser.runtime
-            .getURL("dist/ruffle.js")
-            .replace("dist/ruffle.js", "");
+        return browser.runtime.getURL(path);
     } else {
         console.error("Couldn't get extension URL");
     }


### PR DESCRIPTION
Pulled out from #3426.
Define `__webpack_public_path__` in injected extension script and use `publicPath()` similarly to how selfhosted currently does.
The only behavioral effect should be as mentioned in https://github.com/ruffle-rs/ruffle/issues/3426#issuecomment-787480902, but I don't see it much a problem because none of the errors should really happen in the extension.