### PR TITLE
web: Fix repeating bitmap textures rendering

### DIFF
--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1209,9 +1209,9 @@ impl RenderBackend for WebGlRenderBackend {
                         .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, filter);
                     self.gl
                         .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MIN_FILTER, filter);
-                    // On WebGL1, you are unable to change the wrapping parameter causes non-power-of-2 textures.
+                    // On WebGL1, you are unable to change the wrapping parameter of non-power-of-2 textures.
                     let wrap = if self.gl2.is_some() && bitmap.is_repeating {
-                        Gl::MIRRORED_REPEAT as i32
+                        Gl::REPEAT as i32
                     } else {
                         Gl::CLAMP_TO_EDGE as i32
                     };


### PR DESCRIPTION
Change `Gl::MIRRORED_REPEAT` to `Gl::REPEAT` for the wrapping parameter in repeating bitmaps. Fixes #3591.

I'm not sure this is the right fix, but from what I've seen, this is correct.
Here's an example that now renders correctly in the WebGL backend: [repeating_bitmap.zip](https://github.com/ruffle-rs/ruffle/files/6118096/repeating_bitmap.zip)
