### PR TITLE
Fix AVM2 reader not reading variable-length numbers correctly

### DIFF
--- a/swf/src/extensions.rs
+++ b/swf/src/extensions.rs
@@ -83,6 +83,27 @@ pub trait ReadSwfExt<'a> {
     }
 
     #[inline]
+    fn read_encoded_i32(&mut self) -> Result<i32> {
+        let mut n: i32 = 0;
+        let mut i = 0;
+        for _ in 0..5 {
+            let byte: i32 = self.read_u8()?.into();
+            n |= (byte & 0b0111_1111) << i;
+            i += 7;
+
+            if byte & 0b1000_0000 == 0 {
+                if i < 32 {
+                    n <<= 32 - i;
+                    n >>= 32 - i;
+                }
+
+                break;
+            }
+        }
+        Ok(n)
+    }
+
+    #[inline]
     fn read_f64_me(&mut self) -> Result<f64> {
         // Flash weirdly stores (some?) f64 as two LE 32-bit chunks.
         // First word is the hi-word, second word is the lo-word.


### PR DESCRIPTION
Variable-length integers are defined to be encoded by up to 5 bytes. But AVM2 reader can read beyond that, if the 5th byte also happens to have a continuation bit set.

`read_encoded_u32` already reads this correctly (it's the same implementation as `read_u30`, just with the 5 bytes limit), so the best course of action is to just deduplicate them.

The tests are copied from the `read_encoded_u32()` test.

(side note: currently in AVM2 reader, `read_u30()` is used wherever u30 _or_ u32 values are being read. Not sure if there is a functional difference, but even if there isn't, it'd be nice to refactor it for clarity)

Fixes https://github.com/ruffle-rs/ruffle/issues/3605 , probably also https://github.com/ruffle-rs/ruffle/issues/2404 and others.