### PR TITLE
core: Introduce BoundsMode enum

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -135,7 +135,7 @@ pub fn hit_test<'gc>(
             let ret = if shape {
                 movie_clip.hit_test_shape(&mut activation.context, point)
             } else {
-                movie_clip.hit_test_bounds(point)
+                movie_clip.hit_test_bounds(point, &BoundsMode::Script)
             };
             return Ok(ret.into());
         }
@@ -1150,7 +1150,7 @@ fn get_bounds<'gc>(
     };
 
     if let Some(target) = target {
-        let bounds = movie_clip.bounds();
+        let bounds = movie_clip.bounds(&BoundsMode::Script);
         let out_bounds = if DisplayObject::ptr_eq(movie_clip.into(), target) {
             // Getting the clips bounds in its own coordinate space; no AABB transform needed.
             bounds

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -8,6 +8,7 @@ use crate::avm1::object::transform_object::TransformObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, TObject, Value};
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject};
+use crate::prelude::*;
 use gc_arena::MutationContext;
 
 macro_rules! with_transform_props {
@@ -187,7 +188,7 @@ fn pixel_bounds<'gc>(
     clip: MovieClip<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     // This is equivalent to `clip.getBounds()`.
-    let bounds = clip.world_bounds();
+    let bounds = clip.world_bounds(&BoundsMode::Script);
 
     // Return Rectangle object.
     let args = [

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -10,6 +10,7 @@ use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::{DisplayObject, TDisplayObject};
+use crate::prelude::*;
 use crate::types::{Degrees, Percent};
 use gc_arena::{GcCell, MutationContext};
 use swf::Twips;
@@ -466,7 +467,7 @@ pub fn hit_test_point<'gc>(
         if shape_flag {
             return Ok(dobj.hit_test_shape(&mut activation.context, (x, y)).into());
         } else {
-            return Ok(dobj.hit_test_bounds((x, y)).into());
+            return Ok(dobj.hit_test_bounds((x, y), &BoundsMode::Script).into());
         }
     }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -423,6 +423,19 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 }
 
+/// Indicates `bounds`, `local_bounds`, and `world_bounds` which kind of bounds
+/// should be returned.
+/// In most cases it's ignored and `BoundsMode::Engine` should be used.
+pub enum BoundsMode {
+    /// The bounds visible on the stage (e.g. takes MorphShape ratio into
+    /// account).
+    Engine,
+
+    /// The bounds used internally and returned by ActionScript (e.g. doesn't
+    /// take MorphShape ratio into account).
+    Script,
+}
+
 #[enum_trait_object(
     #[derive(Clone, Collect, Debug, Copy)]
     #[collect(no_drop)]
@@ -444,44 +457,44 @@ pub trait TDisplayObject<'gc>:
     fn depth(&self) -> Depth;
     fn set_depth(&self, gc_context: MutationContext<'gc, '_>, depth: Depth);
 
-    /// The untransformed inherent bounding box of this object.
-    /// These bounds do **not** include child DisplayObjects.
-    /// To get the bounds including children, use `bounds`, `local_bounds`, or `world_bounds`.
-    ///
-    /// Implementors must override this method.
-    /// Leaf DisplayObjects should return their bounds.
-    /// Composite DisplayObjects that only contain children should return `&Default::default()`
-    fn self_bounds(&self) -> BoundingBox;
-
     /// The untransformed bounding box of this object including children.
-    fn bounds(&self) -> BoundingBox {
-        self.bounds_with_transform(&Matrix::default())
+    fn bounds(&self, mode: &BoundsMode) -> BoundingBox {
+        self.bounds_with_transform(&Matrix::default(), mode)
     }
 
     /// The local bounding box of this object including children, in its parent's coordinate system.
-    fn local_bounds(&self) -> BoundingBox {
-        self.bounds_with_transform(&self.matrix())
+    fn local_bounds(&self, mode: &BoundsMode) -> BoundingBox {
+        self.bounds_with_transform(&self.matrix(), mode)
     }
 
     /// The world bounding box of this object including children, relative to the stage.
-    fn world_bounds(&self) -> BoundingBox {
-        self.bounds_with_transform(&self.local_to_global_matrix())
+    fn world_bounds(&self, mode: &BoundsMode) -> BoundingBox {
+        self.bounds_with_transform(&self.local_to_global_matrix(), mode)
     }
+
+    /// The untransformed inherent bounding box of this object.
+    /// These bounds do *not* include child DisplayObjects.
+    /// To get the bounds including children, use `bounds`, `local_bounds`, or `world_bounds`.
+    ///
+    /// Composite DisplayObjects that only contain children should return `&Default::default()`.
+    ///
+    /// Do not use directly, use `bounds`, `local_bounds`, or `world_bounds`.
+    fn self_bounds(&self, mode: &BoundsMode) -> BoundingBox;
 
     /// Gets the bounds of this object and all children, transformed by a given matrix.
     /// This function recurses down and transforms the AABB each child before adding
     /// it to the bounding box. This gives a tighter AABB then if we simply transformed
     /// the overall AABB.
-    fn bounds_with_transform(&self, matrix: &Matrix) -> BoundingBox {
-        let mut bounds = self.self_bounds().transform(matrix);
-
+    ///
+    /// Do not use directly, use `bounds`, `local_bounds`, or `world_bounds`.
+    fn bounds_with_transform(&self, matrix: &Matrix, mode: &BoundsMode) -> BoundingBox {
+        let mut bounds = self.self_bounds(&mode).transform(matrix);
         if let Some(ctr) = self.as_container() {
             for child in ctr.iter_execution_list() {
                 let matrix = *matrix * *child.matrix();
-                bounds.union(&child.bounds_with_transform(&matrix));
+                bounds.union(&child.bounds_with_transform(&matrix, &mode));
             }
         }
-
         bounds
     }
 
@@ -572,20 +585,18 @@ pub trait TDisplayObject<'gc>:
     /// Returned by the `_yscale`/`scaleY` ActionScript properties.
     fn set_scale_y(&self, gc_context: MutationContext<'gc, '_>, value: Percent);
 
-    /// Sets the pixel width of this display object in local space.
-    /// The width is based on the AABB of the object.
-    /// Returned by the ActionScript `_width`/`width` properties.
+    /// Gets the pixel width of this display object in local space.
+    /// Returned by the `_width`/`width` ActionScript properties.
     fn width(&self) -> f64 {
-        let bounds = self.local_bounds();
+        let bounds = self.local_bounds(&BoundsMode::Script);
         (bounds.x_max.saturating_sub(bounds.x_min)).to_pixels()
     }
 
     /// Sets the pixel width of this display object in local space.
-    /// The width is based on the AABB of the object.
-    /// Set by the ActionScript `_width`/`width` properties.
+    /// Set by the `_width`/`width` ActionScript properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
     fn set_width(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
-        let object_bounds = self.bounds();
+        let object_bounds = self.bounds(&BoundsMode::Script);
         let object_width = (object_bounds.x_max - object_bounds.x_min).to_pixels();
         let object_height = (object_bounds.y_max - object_bounds.y_min).to_pixels();
         let aspect_ratio = object_height / object_width;
@@ -622,18 +633,18 @@ pub trait TDisplayObject<'gc>:
         self.set_scale_y(gc_context, Percent::from_unit(new_scale_y));
     }
 
-    /// Gets the pixel height of the AABB containing this display object in local space.
-    /// Returned by the ActionScript `_height`/`height` properties.
+    /// Gets the pixel height of this display object in local space.
+    /// Returned by the `_height`/`height` ActionScript properties.
     fn height(&self) -> f64 {
-        let bounds = self.local_bounds();
+        let bounds = self.local_bounds(&BoundsMode::Script);
         (bounds.y_max.saturating_sub(bounds.y_min)).to_pixels()
     }
 
     /// Sets the pixel height of this display object in local space.
-    /// Set by the ActionScript `_height`/`height` properties.
+    /// Set by the `_height`/`height` ActionScript properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
     fn set_height(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
-        let object_bounds = self.bounds();
+        let object_bounds = self.bounds(&BoundsMode::Script);
         let object_width = (object_bounds.x_max - object_bounds.x_min).to_pixels();
         let object_height = (object_bounds.y_max - object_bounds.y_min).to_pixels();
         let aspect_ratio = object_width / object_height;
@@ -1020,7 +1031,7 @@ pub trait TDisplayObject<'gc>:
         placing_movie: Option<Arc<SwfMovie>>,
         place_object: &swf::PlaceObject,
     ) {
-        // PlaceObject tags only apply if this onject has not been dynamically moved by AS code.
+        // PlaceObject tags only apply if this object has not been dynamically moved by AS code.
         if !self.transformed_by_script() {
             if let Some(matrix) = &place_object.matrix {
                 self.set_matrix(context.gc_context, &matrix);
@@ -1098,14 +1109,15 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Tests if a given stage position point intersects with the world bounds of this object.
-    fn hit_test_bounds(&self, pos: (Twips, Twips)) -> bool {
-        self.world_bounds().contains(pos)
+    fn hit_test_bounds(&self, pos: (Twips, Twips), mode: &BoundsMode) -> bool {
+        self.world_bounds(mode).contains(pos)
     }
 
     /// Tests if a given object's world bounds intersects with the world bounds
     /// of this object.
     fn hit_test_object(&self, other: DisplayObject<'gc>) -> bool {
-        self.world_bounds().intersects(&other.world_bounds())
+        self.world_bounds(&BoundsMode::Script)
+            .intersects(&other.world_bounds(&BoundsMode::Script))
     }
 
     /// Tests if a given stage position point intersects within this object, considering the art.
@@ -1115,7 +1127,7 @@ pub trait TDisplayObject<'gc>:
         pos: (Twips, Twips),
     ) -> bool {
         // Default to using bounding box.
-        self.hit_test_bounds(pos)
+        self.hit_test_bounds(pos, &BoundsMode::Engine)
     }
 
     fn mouse_pick(

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -87,7 +87,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         self.0.read().static_data.id
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         BoundingBox {
             x_min: Twips::zero(),
             y_min: Twips::zero(),
@@ -114,7 +114,10 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
     }
 
     fn render_self(&self, context: &mut RenderContext) {
-        if !self.world_bounds().intersects(&context.view_bounds) {
+        if !self
+            .world_bounds(&BoundsMode::Engine)
+            .intersects(&context.view_bounds)
+        {
             // Off-screen; culled
             return;
         }

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -328,7 +328,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
         self.render_children(context);
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         // No inherent bounds; contains child DisplayObjects.
         BoundingBox::default()
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1407,7 +1407,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             .unwrap_or(Avm2Value::Undefined)
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         self.0.read().bounds.clone()
     }
 
@@ -1476,7 +1476,10 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
-        if !self.world_bounds().intersects(&context.view_bounds) {
+        if !self
+            .world_bounds(&BoundsMode::Engine)
+            .intersects(&context.view_bounds)
+        {
             // Off-screen; culled
             return;
         }

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -106,7 +106,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         self.0.read().static_data.id
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         if let Some(drawing) = &self.0.read().drawing {
             drawing.self_bounds()
         } else {
@@ -119,7 +119,10 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn render_self(&self, context: &mut RenderContext) {
-        if !self.world_bounds().intersects(&context.view_bounds) {
+        if !self
+            .world_bounds(&BoundsMode::Engine)
+            .intersects(&context.view_bounds)
+        {
             // Off-screen; culled
             return;
         }
@@ -139,7 +142,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         point: (Twips, Twips),
     ) -> bool {
         // Transform point to local coordinates and test.
-        if self.world_bounds().contains(point) {
+        if self.world_bounds(&BoundsMode::Engine).contains(point) {
             let local_matrix = self.global_to_local_matrix();
             let point = local_matrix * point;
             if let Some(drawing) = &self.0.read().drawing {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1796,7 +1796,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         self.render_children(context);
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         self.0.read().drawing.self_bounds()
     }
 
@@ -1805,7 +1805,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         point: (Twips, Twips),
     ) -> bool {
-        if self.world_bounds().contains(point) {
+        if self.world_bounds(&BoundsMode::Engine).contains(point) {
             for child in self.iter_execution_list() {
                 if child.hit_test_shape(context, point) {
                     return true;
@@ -1829,7 +1829,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         point: (Twips, Twips),
     ) -> Option<DisplayObject<'gc>> {
         if self.visible() {
-            if self.world_bounds().contains(point) {
+            if self.world_bounds(&BoundsMode::Engine).contains(point) {
                 // This movieclip operates in "button mode" if it has a mouse handler,
                 // either via on(..) or via property mc.onRelease, etc.
                 let is_button_mode = {

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -123,7 +123,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         context.transform_stack.pop();
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         self.0.read().static_data.bounds.clone()
     }
 
@@ -132,7 +132,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
         mut point: (Twips, Twips),
     ) -> bool {
-        if self.world_bounds().contains(point) {
+        if self.world_bounds(&BoundsMode::Engine).contains(point) {
             // Texts using the "Advanced text rendering" always hit test using their bounding box.
             if self.0.read().render_settings.is_advanced() {
                 return true;

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -388,7 +388,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         }
     }
 
-    fn self_bounds(&self) -> BoundingBox {
+    fn self_bounds(&self, _mode: &BoundsMode) -> BoundingBox {
         let mut bounding_box = BoundingBox::default();
 
         match (*self.0.read().source.read()).borrow() {
@@ -402,7 +402,10 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     }
 
     fn render(&self, context: &mut RenderContext) {
-        if !self.world_bounds().intersects(&context.view_bounds) {
+        if !self
+            .world_bounds(&BoundsMode::Engine)
+            .intersects(&context.view_bounds)
+        {
             // Off-screen; culled
             return;
         }

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -2,7 +2,8 @@ pub use crate::avm2::Value as Avm2Value;
 pub use crate::bounding_box::BoundingBox;
 pub use crate::color_transform::ColorTransform;
 pub use crate::display_object::{
-    DisplayObject, DisplayObjectContainer, Lists, TDisplayObject, TDisplayObjectContainer,
+    BoundsMode, DisplayObject, DisplayObjectContainer, Lists, TDisplayObject,
+    TDisplayObjectContainer,
 };
 pub use crate::{
     impl_display_object, impl_display_object_container, impl_display_object_sansbounds,


### PR DESCRIPTION
This is useful for cases where bounds returned by ActionScript don't match the actual visual bounds of the object.
Inspired by https://github.com/ruffle-rs/ruffle/pull/3214#issuecomment-791685468.

Fixes #1915.