### PR TITLE
chore: Use {from,to}_le_bytes in more places

### DIFF
--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -96,10 +96,10 @@ fn get_rgb<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(target) = target(activation, this)? {
         let color_transform = target.color_transform();
-        let r = ((color_transform.r_add * 255.0) as i32) << 16;
-        let g = ((color_transform.g_add * 255.0) as i32) << 8;
-        let b = (color_transform.b_add * 255.0) as i32;
-        Ok((r | g | b).into())
+        let r = (color_transform.r_add * 255.0) as u8;
+        let g = (color_transform.g_add * 255.0) as u8;
+        let b = (color_transform.b_add * 255.0) as u8;
+        Ok(i32::from_le_bytes([b, g, r, 0]).into())
     } else {
         Ok(Value::Undefined)
     }

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -170,19 +170,15 @@ pub fn set_rgb<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .coerce_to_u32(activation)?;
-
-    let red = ((new_rgb >> 16) & 0xFF) as f64;
-    let green = ((new_rgb >> 8) & 0xFF) as f64;
-    let blue = (new_rgb & 0xFF) as f64;
+    let [b, g, r, _] = new_rgb.to_le_bytes();
 
     if let Some(ct) = this.as_color_transform_object() {
-        ct.set_red_offset(activation.context.gc_context, red);
-        ct.set_green_offset(activation.context.gc_context, green);
-        ct.set_blue_offset(activation.context.gc_context, blue);
-
         ct.set_red_multiplier(activation.context.gc_context, 0.0);
         ct.set_green_multiplier(activation.context.gc_context, 0.0);
         ct.set_blue_multiplier(activation.context.gc_context, 0.0);
+        ct.set_red_offset(activation.context.gc_context, r as f64);
+        ct.set_green_offset(activation.context.gc_context, g as f64);
+        ct.set_blue_offset(activation.context.gc_context, b as f64);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -152,10 +152,10 @@ pub fn get_rgb<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(ct) = this.as_color_transform_object() {
-        let rgb = ((ct.get_red_offset() as u32) << 16)
-            | ((ct.get_green_offset() as u32) << 8)
-            | (ct.get_blue_offset() as u32);
-        Ok(Value::Number(rgb.into()))
+        let r = ct.get_red_offset() as u8;
+        let g = ct.get_green_offset() as u8;
+        let b = ct.get_blue_offset() as u8;
+        Ok(u32::from_le_bytes([b, g, r, 0]).into())
     } else {
         Ok(Value::Undefined)
     }
@@ -163,7 +163,6 @@ pub fn get_rgb<'gc>(
 
 pub fn set_rgb<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -81,7 +81,7 @@ impl Color {
     }
 
     pub fn argb(alpha: u8, red: u8, green: u8, blue: u8) -> Color {
-        Color(((alpha as i32) << 24) | (red as i32) << 16 | (green as i32) << 8 | (blue as i32))
+        Color(i32::from_le_bytes([blue, green, red, alpha]))
     }
 
     pub fn with_alpha(&self, alpha: u8) -> Color {
@@ -403,28 +403,28 @@ impl BitmapData {
                         .into();
 
                     let channel_shift: u32 = match source_channel {
-                        // Alpha
-                        8 => 24,
                         // red
                         1 => 16,
                         // green
                         2 => 8,
                         // blue
                         4 => 0,
+                        // alpha
+                        8 => 24,
                         _ => 0,
                     };
 
                     let source_part = (source_color >> channel_shift) & 0xFF;
 
                     let result_color: u32 = match dest_channel {
-                        // Alpha
-                        8 => (original_color & 0x00FFFFFF) | source_part << 24,
                         // red
                         1 => (original_color & 0xFF00FFFF) | source_part << 16,
                         // green
                         2 => (original_color & 0xFFFF00FF) | source_part << 8,
                         // blue
                         4 => (original_color & 0xFFFFFF00) | source_part,
+                        // alpha
+                        8 => (original_color & 0x00FFFFFF) | source_part << 24,
                         _ => original_color,
                     };
 

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -221,7 +221,7 @@ impl From<BitmapFormat> for Vec<i32> {
                     let red = chunk[0];
                     let green = chunk[1];
                     let blue = chunk[2];
-                    (0xFF << 24) | ((red as i32) << 16) | ((green as i32) << 8) | (blue as i32)
+                    i32::from_le_bytes([blue, green, red, 0xFF])
                 })
                 .collect(),
             BitmapFormat::Rgba(x) => x
@@ -231,10 +231,7 @@ impl From<BitmapFormat> for Vec<i32> {
                     let green = chunk[1];
                     let blue = chunk[2];
                     let alpha = chunk[3];
-                    ((alpha as i32) << 24)
-                        | ((red as i32) << 16)
-                        | ((green as i32) << 8)
-                        | (blue as i32)
+                    i32::from_le_bytes([blue, green, red, alpha])
                 })
                 .collect(),
         }
@@ -403,7 +400,7 @@ pub fn decode_define_bits_lossless(
             let mut out_data: Vec<u8> = Vec::with_capacity(decoded_data.len() * 2);
             let mut i = 0;
             while i < decoded_data.len() {
-                let compressed: u16 = ((decoded_data[i] as u16) << 8) | decoded_data[i + 1] as u16;
+                let compressed = u16::from_be_bytes([decoded_data[i], decoded_data[i + 1]]);
                 out_data.push(rgb5_component(compressed, 10));
                 out_data.push(rgb5_component(compressed, 5));
                 out_data.push(rgb5_component(compressed, 0));

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -494,7 +494,7 @@ fn lerp_matrix(start: &swf::Matrix, end: &swf::Matrix, a: f32, b: f32) -> swf::M
 fn lerp_gradient(start: &swf::Gradient, end: &swf::Gradient, a: f32, b: f32) -> swf::Gradient {
     use swf::{Gradient, GradientRecord};
     // Morph gradients are guaranteed to have the same number of records in the start/end gradient.
-    debug_assert!(start.records.len() == end.records.len());
+    debug_assert_eq!(start.records.len(), end.records.len());
     let records: Vec<GradientRecord> = start
         .records
         .iter()

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -437,7 +437,7 @@ impl TextFormat {
             "color",
             self.color
                 .clone()
-                .map(|v| (((v.r as u32) << 16) + ((v.g as u32) << 8) + v.b as u32).into())
+                .map(|v| v.to_rgb().into())
                 .unwrap_or(Value::Null),
             activation,
         )?;

--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -320,8 +320,7 @@ impl AudioBackend for CpalAudioBackend {
     fn register_sound(&mut self, swf_sound: &swf::Sound) -> Result<SoundHandle, Error> {
         // Slice off latency seek for MP3 data.
         let (skip_sample_frames, data) = if swf_sound.format.compression == AudioCompression::Mp3 {
-            let skip_sample_frames =
-                u16::from(swf_sound.data[0]) | (u16::from(swf_sound.data[1]) << 8);
+            let skip_sample_frames = u16::from_le_bytes([swf_sound.data[0], swf_sound.data[1]]);
             (skip_sample_frames, &swf_sound.data[2..])
         } else {
             (0, swf_sound.data)

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -49,13 +49,12 @@ impl ShapeTessellator {
             match path {
                 DrawPath::Fill { style, commands } => match style {
                     FillStyle::Color(color) => {
-                        let color = ((color.a as u32) << 24)
-                            | ((color.b as u32) << 16)
-                            | ((color.g as u32) << 8)
-                            | (color.r as u32);
-
-                        let mut buffers_builder =
-                            BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
+                        let mut buffers_builder = BuffersBuilder::new(
+                            &mut lyon_mesh,
+                            RuffleVertexCtor {
+                                color: color.to_rgba(),
+                            },
+                        );
 
                         if let Err(e) = self.fill_tess.tessellate_path(
                             &ruffle_path_to_lyon_path(commands, true),
@@ -243,13 +242,12 @@ impl ShapeTessellator {
                     commands,
                     is_closed,
                 } => {
-                    let color = ((style.color.a as u32) << 24)
-                        | ((style.color.b as u32) << 16)
-                        | ((style.color.g as u32) << 8)
-                        | (style.color.r as u32);
-
-                    let mut buffers_builder =
-                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
+                    let mut buffers_builder = BuffersBuilder::new(
+                        &mut lyon_mesh,
+                        RuffleVertexCtor {
+                            color: style.color.to_rgba(),
+                        },
+                    );
 
                     // TODO(Herschel): 0 width indicates "hairline".
                     let width = if style.width.to_pixels() >= 1.0 {

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -87,6 +87,7 @@ impl<'a> Reader<'a> {
             | (i32::from(self.read_u8()? as i8) << 8)
             | (i32::from(self.read_u8()? as i8) << 16))
     }
+
     fn read_i32(&mut self) -> Result<i32> {
         self.read_encoded_i32()
     }

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -124,12 +124,12 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    #[allow(dead_code)]
     fn write_i24(&mut self, n: i32) -> Result<()> {
-        // TODO: Verify n fits in 24-bits.
-        self.write_u8(((n >> 16) & 0xff) as u8)?;
-        self.write_u8(((n >> 8) & 0xff) as u8)?;
-        self.write_u8((n & 0xff) as u8)?;
+        let bytes = n.to_le_bytes();
+        debug_assert_eq!(bytes[3], 0);
+        self.write_u8(bytes[2])?;
+        self.write_u8(bytes[1])?;
+        self.write_u8(bytes[0])?;
         Ok(())
     }
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -319,7 +319,11 @@ impl Color {
     /// assert_eq!(color1.to_rgb(), color2.to_rgb());
     /// ```
     pub const fn to_rgb(&self) -> u32 {
-        ((self.r as u32) << 16) | ((self.g as u32) << 8) | (self.b as u32)
+        u32::from_le_bytes([self.b, self.g, self.r, 0])
+    }
+
+    pub const fn to_rgba(&self) -> u32 {
+        u32::from_le_bytes([self.b, self.g, self.r, self.a])
     }
 }
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -256,14 +256,16 @@ pub struct Rectangle {
 /// All components are stored as [`u8`] and have a color range of 0-255.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Color {
-    /// The red component value.
-    pub r: u8,
+    // The order (b, g, r, a) is important and allows better code optimizations.
+
+    /// The blue component value.
+    pub b: u8,
 
     /// The green component value.
     pub g: u8,
 
-    /// The blue component value.
-    pub b: u8,
+    /// The red component value.
+    pub r: u8,
 
     /// The alpha component value.
     pub a: u8,

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -288,12 +288,8 @@ impl Color {
     /// let blue = Color::from_rgb(0x0000FF, 255);
     /// ```
     pub const fn from_rgb(rgb: u32, alpha: u8) -> Self {
-        Self {
-            r: ((rgb & 0xFF_0000) >> 16) as u8,
-            g: ((rgb & 0x00_FF00) >> 8) as u8,
-            b: (rgb & 0x00_00FF) as u8,
-            a: alpha,
-        }
+        let [b, g, r, _] = rgb.to_le_bytes();
+        Self { r, g, b, a: alpha }
     }
 
     /// Converts the color to a 32-bit RGB value.

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -800,7 +800,7 @@ impl AudioBackend for WebAudioBackend {
     fn register_sound(&mut self, sound: &swf::Sound) -> Result<SoundHandle, Error> {
         // Slice off latency seek for MP3 data.
         let (skip_sample_frames, data) = if sound.format.compression == AudioCompression::Mp3 {
-            let skip_sample_frames = u16::from(sound.data[0]) | (u16::from(sound.data[1]) << 8);
+            let skip_sample_frames = u16::from_le_bytes([sound.data[0], sound.data[1]]);
             (skip_sample_frames, &sound.data[2..])
         } else {
             (0, sound.data)
@@ -869,9 +869,8 @@ impl AudioBackend for WebAudioBackend {
                     // previous blocks had more samples than necessary, or because the stream
                     // is stopping (silence).
                     if audio_data.len() >= 4 {
-                        let num_sample_frames =
-                            u32::from(audio_data[0]) | (u32::from(audio_data[1]) << 8);
-                        stream.num_sample_frames += num_sample_frames;
+                        stream.num_sample_frames +=
+                            u16::from_le_bytes([audio_data[0], audio_data[1]]) as u32;
                         // MP3 streaming data:
                         // First two bytes = number of samples
                         // Second two bytes = 'latency seek' (amount to skip when seeking to this frame)


### PR DESCRIPTION
Not only this simplifies bytes-related code, this also has some performance benefits.