### PR TITLE
Reduce frequency of timeout checks by 10+ times

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -224,7 +224,7 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     target_clip: Option<DisplayObject<'gc>>,
 
     /// Amount of actions performed since the last timeout check
-    actions_since_timeout_check: u8,
+    actions_since_timeout_check: u16,
 
     /// Whether the base clip was removed when we started this frame.
     base_clip_unloaded: bool,
@@ -449,7 +449,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         reader: &mut Reader<'b>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         self.actions_since_timeout_check += 1;
-        if self.actions_since_timeout_check >= 200 {
+        if self.actions_since_timeout_check >= 2000 {
             self.actions_since_timeout_check = 0;
             if self.context.update_start.elapsed() >= self.context.max_execution_duration {
                 return Err(Error::ExecutionTimeout);


### PR DESCRIPTION
In some games (meat boy) `instant::now()` was taking 10+% of tick time (and that wasn't even the full recorded overhead of the check), so this still needed to be tuned down. In the future, if other actions become faster, this might need to be tuned down even more.

Why "10+ times"? Because if a small function runs between 200 and 2000 actions, its # of checks will drop to 0.

That raises a side question: should `actions_since_timeout_check` be stored in Context instead of Activation? In practice, I feel like this isn't an issue, as even if an inifinite loop span across a deep call stack, the outermost frame with the loop will amass 2000 actions at _some_ point, right? So the current approach of storing in Activation might even be better as it decreases the frequency of checks without making them weaker.

Alternatively, just put it in Context and bump the number even more.