### PR TITLE
web: crash out of infinite loop if not NotSupportedError

### DIFF
--- a/web/packages/core/src/register-element.ts
+++ b/web/packages/core/src/register-element.ts
@@ -75,31 +75,32 @@ export function registerElement(
 
     let tries = 0;
 
-    while (tries < MAX_TRIES) {
-        let externalName = elementName;
-        if (tries > 0) {
-            externalName = externalName + "-" + tries;
-        }
-
-        try {
-            window.customElements.define(externalName, elementClass);
-        } catch (e) {
-            if (e.name === "NotSupportedError") {
-                tries += 1;
-                continue;
-            } else {
-                // window.customElements undefined, for example
-                throw e;
+    if (window.customElements !== undefined) {
+        while (tries < MAX_TRIES) {
+            let externalName = elementName;
+            if (tries > 0) {
+                externalName = externalName + "-" + tries;
             }
+
+            try {
+                window.customElements.define(externalName, elementClass);
+            } catch (e) {
+                if (e.name === "NotSupportedError") {
+                    tries += 1;
+                    continue;
+                } else {
+                    throw e;
+                }
+            }
+
+            privateRegistry[elementName] = {
+                class: elementClass,
+                name: externalName,
+                internalName: elementName,
+            };
+
+            return externalName;
         }
-
-        privateRegistry[elementName] = {
-            class: elementClass,
-            name: externalName,
-            internalName: elementName,
-        };
-
-        return externalName;
     }
 
     throw new Error("Failed to assign custom element " + elementName);

--- a/web/packages/core/src/register-element.ts
+++ b/web/packages/core/src/register-element.ts
@@ -71,24 +71,29 @@ export function registerElement(
     let tries = 0;
 
     while (true) {
+        let externalName = elementName;
+        if (tries > 0) {
+            externalName = externalName + "-" + tries;
+        }
+
         try {
-            let externalName = elementName;
-            if (tries > 0) {
-                externalName = externalName + "-" + tries;
-            }
-
             window.customElements.define(externalName, elementClass);
-            privateRegistry[elementName] = {
-                class: elementClass,
-                name: externalName,
-                internalName: elementName,
-            };
-
-            return externalName;
         } catch (e) {
             if (e.name === "NotSupportedError") {
                 tries += 1;
+                continue;
+            } else {
+                // window.customElements undefined, for example
+                throw e;
             }
         }
+
+        privateRegistry[elementName] = {
+            class: elementClass,
+            name: externalName,
+            internalName: elementName,
+        };
+
+        return externalName;
     }
 }

--- a/web/packages/core/src/register-element.ts
+++ b/web/packages/core/src/register-element.ts
@@ -82,15 +82,11 @@ export function registerElement(
                 externalName = externalName + "-" + tries;
             }
 
-            try {
+            if (window.customElements.get(externalName) !== undefined) {
+                tries += 1;
+                continue;
+            } else {
                 window.customElements.define(externalName, elementClass);
-            } catch (e) {
-                if (e.name === "NotSupportedError") {
-                    tries += 1;
-                    continue;
-                } else {
-                    throw e;
-                }
             }
 
             privateRegistry[elementName] = {

--- a/web/packages/core/src/register-element.ts
+++ b/web/packages/core/src/register-element.ts
@@ -1,4 +1,9 @@
 /**
+ * Number of times to try defining a custom element.
+ */
+const MAX_TRIES = 999;
+
+/**
  * A mapping between internal element IDs and DOM element IDs.
  */
 const privateRegistry: Record<string, Registration> = {};
@@ -70,7 +75,7 @@ export function registerElement(
 
     let tries = 0;
 
-    while (true) {
+    while (tries < MAX_TRIES) {
         let externalName = elementName;
         if (tries > 0) {
             externalName = externalName + "-" + tries;
@@ -96,4 +101,6 @@ export function registerElement(
 
         return externalName;
     }
+
+    throw new Error("Failed to assign custom element " + elementName);
 }


### PR DESCRIPTION
Related to #3729.

This changes the infinite loop to
- only catch errors coming from `window.customElements.define`
- throw any errors that aren't `NotSupportedError`

I assumed that if the custom elements don't get registered Ruffle doesn't work so throwing the error is about the only sensible thing, but I may be mistaken.

One other possibility is changing `while (true)` to `while (tries < 999)` (or some other large number) to remove the possibility of an infinite loop.

One other possibility might be to avoid the try-catch by using `customElements.get` instead. That would keep the infinite loop, but avoid the try-catch that caught unwanted errors.