### PR TITLE
web: Full screen fixes for mobile and Safari

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -32,15 +32,19 @@ enum PanicError {
     WasmNotFound,
 }
 
+// Safari still requires prefixed fullscreen APIs, see:
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullScreen
+// Safari uses alternate capitalization of FullScreen in some older APIs.
 declare global {
     interface Document {
         webkitFullscreenEnabled?: boolean;
-        webkitFullscreenElement?: HTMLElement;
+        webkitFullscreenElement?: boolean;
+        webkitExitFullscreen?: () => void;
         webkitCancelFullScreen?: () => void;
     }
-
     interface HTMLElement {
-        webkitRequestFullScreen?: () => void;
+        webkitRequestFullscreen?: (arg0: unknown) => unknown;
+        webkitRequestFullScreen?: (arg0: unknown) => unknown;
     }
 }
 
@@ -578,10 +582,15 @@ export class RufflePlayer extends HTMLElement {
      * This is not guaranteed to succeed, please check [[fullscreenEnabled]] first.
      */
     enterFullscreen(): void {
+        const options = {
+            navigationUI: "hide",
+        } as const;
         if (this.requestFullscreen) {
-            this.requestFullscreen();
+            this.requestFullscreen(options);
+        } else if (this.webkitRequestFullscreen) {
+            this.webkitRequestFullscreen(options);
         } else if (this.webkitRequestFullScreen) {
-            this.webkitRequestFullScreen();
+            this.webkitRequestFullScreen(options);
         }
     }
 
@@ -591,6 +600,8 @@ export class RufflePlayer extends HTMLElement {
     exitFullscreen(): void {
         if (document.exitFullscreen) {
             document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) {
+            document.webkitExitFullscreen();
         } else if (document.webkitCancelFullScreen) {
             document.webkitCancelFullScreen();
         }

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -21,6 +21,14 @@ ruffleShadowTemplate.innerHTML = `
             -webkit-user-select: none;
             -webkit-tap-highlight-color: transparent;
         }
+        
+        /* Ruffle's width/height CSS interferes Safari fullscreen CSS. */
+        /* Ensure that Safari's fullscreen mode actually fills the screen. */
+        :host(:-webkit-full-screen) {
+            display: block;
+            width: 100% !important;
+            height: 100% !important;
+        }
 
         /* All of these use the dimensions specified by the embed. */
         #container,


### PR DESCRIPTION
Continuing from the work in #3160:
 * Hide Android navigation bar in fullscreen mode using `navigationUI: "hide"` (fixes #1698).
 * Fix content size when fullscreen on Safari (the content would not fill the screen).
