### PR TITLE
web/desktop: Check the HTTP status code of requests

### DIFF
--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -149,7 +149,12 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                     .map_err(|e| Error::FetchError(e.to_string()))?;
 
                 if !response.status().is_success() {
-                    return Err(Error::FetchError("HTTP status is not ok".to_string()));
+                    return Err(Error::FetchError(format!(
+                        "HTTP status is not ok, got {}",
+                        response.status().canonical_reason().unwrap_or(
+                            format!("unknown status {}", response.status().as_u16()).as_str()
+                        )
+                    )));
                 }
 
                 let mut buffer = vec![];

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -151,9 +151,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                 if !response.status().is_success() {
                     return Err(Error::FetchError(format!(
                         "HTTP status is not ok, got {}",
-                        response.status().canonical_reason().unwrap_or(
-                            format!("unknown status {}", response.status().as_u16()).as_str()
-                        )
+                        response.status()
                     )));
                 }
 

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -148,6 +148,10 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                     .await
                     .map_err(|e| Error::FetchError(e.to_string()))?;
 
+                if !response.status().is_success() {
+                    return Err(Error::FetchError("HTTP status is not ok".to_string()));
+                }
+
                 let mut buffer = vec![];
                 response
                     .copy_to(&mut buffer)

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -176,6 +176,9 @@ impl NavigatorBackend for WebNavigatorBackend {
             }
 
             let resp: Response = fetchval.unwrap().dyn_into().unwrap();
+            if !resp.ok() {
+                return Err(Error::FetchError("HTTP status is not ok".to_string()));
+            }
             let data: ArrayBuffer = JsFuture::from(resp.array_buffer().unwrap())
                 .await
                 .unwrap()

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -176,9 +176,14 @@ impl NavigatorBackend for WebNavigatorBackend {
             }
 
             let resp: Response = fetchval.unwrap().dyn_into().unwrap();
+
             if !resp.ok() {
-                return Err(Error::FetchError("HTTP status is not ok".to_string()));
+                return Err(Error::FetchError(format!(
+                    "HTTP status is not ok, got {}",
+                    resp.status_text()
+                )));
             }
+
             let data: ArrayBuffer = JsFuture::from(resp.array_buffer().unwrap())
                 .await
                 .unwrap()


### PR DESCRIPTION
This PR fixes a bug where Ruffle does not actually check the status code of the files it fetches, the correct behavior is for Ruffle to only return "Ok" if the status code is in the range of 200-299. Fixes #2787 