### PR TITLE
core: Fix build without default features

### DIFF
--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -1,11 +1,13 @@
 //! Audio decoders.
 
 mod adpcm;
+#[cfg(any(feature = "puremp3", feature = "minimp3"))]
 mod mp3;
 mod nellymoser;
 mod pcm;
 
 pub use adpcm::AdpcmDecoder;
+#[cfg(any(feature = "puremp3", feature = "minimp3"))]
 pub use mp3::Mp3Decoder;
 pub use nellymoser::NellymoserDecoder;
 pub use pcm::PcmDecoder;
@@ -53,6 +55,7 @@ pub fn make_decoder<'a, R: 'a + Send + Read>(
             format.is_stereo,
             format.sample_rate,
         )),
+        #[cfg(any(feature = "puremp3", feature = "minimp3"))]
         AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
             if format.is_stereo { 2 } else { 1 },
             format.sample_rate.into(),

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -2,7 +2,6 @@ use super::{Decoder, SeekableDecoder};
 use std::io::{Cursor, Read};
 
 #[cfg(feature = "minimp3")]
-#[allow(dead_code)]
 pub struct Mp3Decoder<R: Read> {
     decoder: minimp3::Decoder<R>,
     sample_rate: u32,


### PR DESCRIPTION
Previously `cargo build --no-default-features` failed because then neither implementation of `Mp3Decoder` is chosen.
Fix that by not handling mp3 sounds at all in that case.