### PR TITLE
web: Bypass maximum active WebGL contexts limit

### DIFF
--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -27,4 +27,4 @@ default-features = false
 version = "0.3.45"
 features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebglDebugRendererInfo",
             "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGl2RenderingContext",
-            "WebGlShader", "WebGlTexture", "WebGlUniformLocation", "WebGlVertexArrayObject"]
+            "WebGlShader", "WebGlTexture", "WebGlUniformLocation", "WebGlVertexArrayObject", "OffscreenCanvas", "ImageBitmapRenderingContext", "ImageBitmap"]

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -103,8 +103,7 @@ pub struct WebGlRenderBackend {
 const MAX_GRADIENT_COLORS: usize = 15;
 
 impl WebGlRenderBackend {
-    pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, Error> {
-        let offscreen = OffscreenCanvas::new(canvas.width(), canvas.height()).unwrap();
+    pub fn new(canvas: &HtmlCanvasElement, offscreen: &OffscreenCanvas) -> Result<Self, Error> {
         let bitmaprenderer = canvas.get_context("bitmaprenderer").unwrap().unwrap().dyn_into::<ImageBitmapRenderingContext>().unwrap();
 
         // Create WebGL context.
@@ -248,7 +247,7 @@ impl WebGlRenderBackend {
             add_color: None,
             bitmap_registry: HashMap::new(),
 
-            offscreen,
+            offscreen: offscreen.clone(),
             bitmaprenderer,
         };
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -100,6 +100,8 @@ function sanitizeParameters(
     return output;
 }
 
+var offscreen = new OffscreenCanvas(100, 100);
+
 /**
  * The ruffle player element that should be inserted onto the page.
  *
@@ -371,7 +373,7 @@ export class RufflePlayer extends HTMLElement {
             throw e;
         });
 
-        this.instance = new ruffleConstructor(this.container, this, config);
+        this.instance = new ruffleConstructor(this.container, this, config, offscreen);
         console.log("New Ruffle instance created.");
 
         // In Firefox, AudioContext.state is always "suspended" when the object has just been created.


### PR DESCRIPTION
Chrome (and other browsers I guess) limit the maximum number of active WebGL contexts per renderer process up to 16 (or 8 on Android). This limit can be overridden in Chrome using the `--max-active-webgl-contexts` command-line flag.
When it's reached, a console message: `WARNING: Too many active WebGL contexts. Oldest context will be lost.` appears, and as it suggests, the oldest context is lost. This makes Ruffle panic when there are more than 16 players in the page with the "Unable to create VAO" error message. Currently [many issues](https://github.com/ruffle-rs/ruffle/issues?q=is%3Aissue+is%3Aopen+unable+to+create+vao) are caused by this problem.

This solution is inspired by the second point in https://stackoverflow.com/questions/59140439/allowing-more-webgl-contexts#answer-59148816.
Use a single `OffscreenCanvas` across all Ruffle instances in the page. That way an arbitrary amount of players can be created with a single WebGL context, thus never reaching the limit.
Note: `OffscreenCanvas` is implemented only on Chrome. Using a 2D context should be a fine alternative on Firefox and Safari.