### PR TITLE
Don't stop audio streams in `run_frame_internal` to prevent audio stutter. Close #3817

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1049,7 +1049,6 @@ impl<'gc> MovieClip<'gc> {
         let tag_stream_start = mc.static_data.swf.as_ref().as_ptr() as u64;
         let data = mc.static_data.swf.clone();
         let mut reader = data.read_from(mc.tag_stream_pos);
-        let mut has_stream_block = false;
         drop(mc);
 
         let vm_type = self.vm_type(context);
@@ -1073,21 +1072,13 @@ impl<'gc> MovieClip<'gc> {
             TagCode::RemoveObject2 if run_display_actions => self.remove_object(context, reader, 2),
             TagCode::SetBackgroundColor => self.set_background_color(context, reader),
             TagCode::StartSound => self.start_sound_1(context, reader),
-            TagCode::SoundStreamBlock => {
-                has_stream_block = true;
-                self.sound_stream_block(context, reader)
-            }
+            TagCode::SoundStreamBlock => self.sound_stream_block(context, reader),
             _ => Ok(()),
         };
         let _ = tag_utils::decode_tags(&mut reader, tag_callback, TagCode::ShowFrame);
 
         self.0.write(context.gc_context).tag_stream_pos =
             reader.get_ref().as_ptr() as u64 - tag_stream_start;
-
-        // If we are playing a streaming sound, there should(?) be a `SoundStreamBlock` on each frame.
-        if !has_stream_block {
-            self.0.write(context.gc_context).stop_audio_stream(context);
-        }
 
         let frame_id = self.0.read().current_frame;
         self.0.write(context.gc_context).queued_script_frame = Some(frame_id);


### PR DESCRIPTION
Related issue #3817

This seems safe to do since sound instances will still get pruned normally by the audio manager once they have finished playing, as far as I understand.