### PR TITLE
avm1: Migrate to primitive prototypes (step 2)

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -709,12 +709,12 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.base.delete(activation, name)
     }
 
-    fn proto(&self) -> Option<Object<'gc>> {
-        self.base.proto()
+    fn proto_value(&self) -> Value<'gc> {
+        self.base.proto_value()
     }
 
-    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Option<Object<'gc>>) {
-        self.base.set_proto(gc_context, prototype);
+    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.base.set_proto_value(gc_context, prototype);
     }
 
     fn define_value(

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -709,12 +709,12 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.base.delete(activation, name)
     }
 
-    fn proto_value(&self) -> Value<'gc> {
-        self.base.proto_value()
+    fn proto(&self) -> Value<'gc> {
+        self.base.proto()
     }
 
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
-        self.base.set_proto_value(gc_context, prototype);
+    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.base.set_proto(gc_context, prototype);
     }
 
     fn define_value(

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -226,38 +226,14 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// The proto is another object used to resolve methods across a class of
     /// multiple objects. It should also be accessible as `__proto__` from
     /// `get`.
-    fn proto(&self) -> Option<Object<'gc>> {
-        match self.proto_value() {
-            Value::Object(o) => Some(o),
-            _ => None,
-        }
-    }
-
-    fn proto_value(&self) -> Value<'gc> {
-        self.proto().map_or(Value::Undefined, Value::Object)
-    }
+    fn proto_value(&self) -> Value<'gc>;
 
     /// Sets the `__proto__` of a given object.
     ///
     /// The proto is another object used to resolve methods across a class of
     /// multiple objects. It should also be accessible as `__proto__` in
     /// `set`.
-    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Option<Object<'gc>>) {
-        self.set_proto_value(
-            gc_context,
-            prototype.map_or(Value::Undefined, Value::Object),
-        );
-    }
-
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
-        self.set_proto(
-            gc_context,
-            match prototype {
-                Value::Object(o) => Some(o),
-                _ => None,
-            },
-        );
-    }
+    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>);
 
     /// Define a value on an object.
     ///

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -41,16 +41,16 @@ macro_rules! impl_custom_object_without_set {
             self.0.read().$field.delete(activation, name)
         }
 
-        fn proto(&self) -> Option<crate::avm1::Object<'gc>> {
-            self.0.read().$field.proto()
+        fn proto_value(&self) -> crate::avm1::Value<'gc> {
+            self.0.read().$field.proto_value()
         }
 
-        fn set_proto(
+        fn set_proto_value(
             &self,
             gc_context: gc_arena::MutationContext<'gc, '_>,
-            prototype: Option<crate::avm1::Object<'gc>>,
+            prototype: crate::avm1::Value<'gc>,
         ) {
-            self.0.read().$field.set_proto(gc_context, prototype);
+            self.0.read().$field.set_proto_value(gc_context, prototype);
         }
 
         fn define_value(

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -41,16 +41,16 @@ macro_rules! impl_custom_object_without_set {
             self.0.read().$field.delete(activation, name)
         }
 
-        fn proto_value(&self) -> crate::avm1::Value<'gc> {
-            self.0.read().$field.proto_value()
+        fn proto(&self) -> crate::avm1::Value<'gc> {
+            self.0.read().$field.proto()
         }
 
-        fn set_proto_value(
+        fn set_proto(
             &self,
             gc_context: gc_arena::MutationContext<'gc, '_>,
             prototype: crate::avm1::Value<'gc>,
         ) {
-            self.0.read().$field.set_proto_value(gc_context, prototype);
+            self.0.read().$field.set_proto(gc_context, prototype);
         }
 
         fn define_value(

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -281,7 +281,7 @@ impl<'gc> ScriptObject<'gc> {
                         break;
                     }
 
-                    proto = this_proto.proto_value();
+                    proto = this_proto.proto();
                 }
 
                 if let Value::Object(this_proto) = proto {
@@ -381,7 +381,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         this: Object<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if name == "__proto__" {
-            return Ok(self.proto_value());
+            return Ok(self.proto());
         }
 
         let mut getter = None;
@@ -610,18 +610,18 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         }
     }
 
-    fn proto_value(&self) -> Value<'gc> {
+    fn proto(&self) -> Value<'gc> {
         self.0.read().prototype
     }
 
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
         self.0.write(gc_context).prototype = prototype;
     }
 
     /// Checks if the object has a given named property.
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {
         self.has_own_property(activation, name)
-            || if let Value::Object(proto) = self.proto_value() {
+            || if let Value::Object(proto) = self.proto() {
                 proto.has_property(activation, name)
             } else {
                 false
@@ -669,7 +669,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 
     /// Enumerate the object.
     fn get_keys(&self, activation: &mut Activation<'_, 'gc, '_>) -> Vec<String> {
-        let proto_keys = if let Value::Object(proto) = self.proto_value() {
+        let proto_keys = if let Value::Object(proto) = self.proto() {
             proto.get_keys(activation)
         } else {
             Vec::new()

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -159,7 +159,11 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
             Ok(level.object())
         } else {
             // 5) Prototype
-            Ok(search_prototype(self.proto(), name, activation, (*self).into())?.0)
+            let prototype = match self.proto_value() {
+                Value::Object(o) => Some(o),
+                _ => None,
+            };
+            Ok(search_prototype(prototype, name, activation, (*self).into())?.0)
         }
         // 6) TODO: __resolve?
     }
@@ -260,12 +264,12 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0.read().base.delete(activation, name)
     }
 
-    fn proto(&self) -> Option<Object<'gc>> {
-        self.0.read().base.proto()
+    fn proto_value(&self) -> Value<'gc> {
+        self.0.read().base.proto_value()
     }
 
-    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Option<Object<'gc>>) {
-        self.0.read().base.set_proto(gc_context, prototype);
+    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.0.read().base.set_proto_value(gc_context, prototype);
     }
 
     fn define_value(

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -159,7 +159,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
             Ok(level.object())
         } else {
             // 5) Prototype
-            let prototype = match self.proto_value() {
+            let prototype = match self.proto() {
                 Value::Object(o) => Some(o),
                 _ => None,
             };
@@ -264,12 +264,12 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0.read().base.delete(activation, name)
     }
 
-    fn proto_value(&self) -> Value<'gc> {
-        self.0.read().base.proto_value()
+    fn proto(&self) -> Value<'gc> {
+        self.0.read().base.proto()
     }
 
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
-        self.0.read().base.set_proto_value(gc_context, prototype);
+    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.0.read().base.set_proto(gc_context, prototype);
     }
 
     fn define_value(

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -56,8 +56,8 @@ impl<'gc> SuperObject<'gc> {
     }
 
     /// Retrieve the prototype that `super` should be pulling from.
-    fn super_proto(self) -> Option<Object<'gc>> {
-        self.0.read().base_proto.proto()
+    fn super_proto(self) -> Value<'gc> {
+        self.0.read().base_proto.proto_value()
     }
 
     /// Retrieve the constructor associated with the super proto.
@@ -65,7 +65,7 @@ impl<'gc> SuperObject<'gc> {
         self,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Option<Object<'gc>>, Error<'gc>> {
-        if let Some(super_proto) = self.super_proto() {
+        if let Value::Object(super_proto) = self.super_proto() {
             Ok(Some(
                 super_proto
                     .get("__constructor__", activation)?
@@ -105,13 +105,11 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
         if let Some(constr) = self.super_constr(activation)? {
-            constr.call(
-                name,
-                activation,
-                self.0.read().child,
-                self.super_proto(),
-                args,
-            )
+            let super_proto = match self.super_proto() {
+                Value::Object(o) => Some(o),
+                _ => None,
+            };
+            constr.call(name, activation, self.0.read().child, super_proto, args)
         } else {
             Ok(Value::Undefined)
         }
@@ -124,7 +122,10 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let child = self.0.read().child;
-        let super_proto = self.super_proto();
+        let super_proto = match self.super_proto() {
+            Value::Object(o) => Some(o),
+            _ => None,
+        };
         let (method, base_proto) = search_prototype(super_proto, name, activation, child)?;
 
         if let Value::Object(_) = method {
@@ -150,7 +151,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        if let Some(proto) = self.proto() {
+        if let Value::Object(proto) = self.proto_value() {
             proto.create_bare_object(activation, this)
         } else {
             // TODO: What happens when you `new super` but there's no
@@ -164,12 +165,12 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         false
     }
 
-    fn proto(&self) -> Option<Object<'gc>> {
+    fn proto_value(&self) -> Value<'gc> {
         self.super_proto()
     }
 
-    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Option<Object<'gc>>) {
-        if let Some(prototype) = prototype {
+    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        if let Value::Object(prototype) = prototype {
             self.0.write(gc_context).base_proto = prototype;
         }
     }

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -57,7 +57,7 @@ impl<'gc> SuperObject<'gc> {
 
     /// Retrieve the prototype that `super` should be pulling from.
     fn super_proto(self) -> Value<'gc> {
-        self.0.read().base_proto.proto_value()
+        self.0.read().base_proto.proto()
     }
 
     /// Retrieve the constructor associated with the super proto.
@@ -151,7 +151,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        if let Value::Object(proto) = self.proto_value() {
+        if let Value::Object(proto) = self.proto() {
             proto.create_bare_object(activation, this)
         } else {
             // TODO: What happens when you `new super` but there's no
@@ -165,11 +165,11 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         false
     }
 
-    fn proto_value(&self) -> Value<'gc> {
+    fn proto(&self) -> Value<'gc> {
         self.super_proto()
     }
 
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
         if let Value::Object(prototype) = prototype {
             self.0.write(gc_context).base_proto = prototype;
         }

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -187,12 +187,12 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
             .set_attributes(gc_context, name, set_attributes, clear_attributes)
     }
 
-    fn proto_value(&self) -> Value<'gc> {
-        self.base().proto_value()
+    fn proto(&self) -> Value<'gc> {
+        self.base().proto()
     }
 
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
-        self.base().set_proto_value(gc_context, prototype);
+    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.base().set_proto(gc_context, prototype);
     }
 
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -187,12 +187,12 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
             .set_attributes(gc_context, name, set_attributes, clear_attributes)
     }
 
-    fn proto(&self) -> Option<Object<'gc>> {
-        self.base().proto()
+    fn proto_value(&self) -> Value<'gc> {
+        self.base().proto_value()
     }
 
-    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Option<Object<'gc>>) {
-        self.base().set_proto(gc_context, prototype);
+    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.base().set_proto_value(gc_context, prototype);
     }
 
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -185,12 +185,12 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
             .set_attributes(gc_context, name, set_attributes, clear_attributes)
     }
 
-    fn proto(&self) -> Option<Object<'gc>> {
-        self.base().proto()
+    fn proto_value(&self) -> Value<'gc> {
+        self.base().proto_value()
     }
 
-    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Option<Object<'gc>>) {
-        self.base().set_proto(gc_context, prototype);
+    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.base().set_proto_value(gc_context, prototype);
     }
 
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -185,12 +185,12 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
             .set_attributes(gc_context, name, set_attributes, clear_attributes)
     }
 
-    fn proto_value(&self) -> Value<'gc> {
-        self.base().proto_value()
+    fn proto(&self) -> Value<'gc> {
+        self.base().proto()
     }
 
-    fn set_proto_value(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
-        self.base().set_proto_value(gc_context, prototype);
+    fn set_proto(&self, gc_context: MutationContext<'gc, '_>, prototype: Value<'gc>) {
+        self.base().set_proto(gc_context, prototype);
     }
 
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1100,7 +1100,7 @@ impl Player {
                     );
                     if let Ok(prototype) = constructor.get("prototype", &mut activation) {
                         if let Value::Object(object) = actions.clip.object() {
-                            object.set_proto_value(activation.context.gc_context, prototype);
+                            object.set_proto(activation.context.gc_context, prototype);
                             for event in events {
                                 let _ = activation.run_child_frame_for_action(
                                     "[Actions]",

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1098,12 +1098,9 @@ impl Player {
                         globals,
                         actions.clip,
                     );
-                    if let Ok(prototype) = constructor
-                        .get("prototype", &mut activation)
-                        .map(|v| v.coerce_to_object(&mut activation))
-                    {
+                    if let Ok(prototype) = constructor.get("prototype", &mut activation) {
                         if let Value::Object(object) = actions.clip.object() {
-                            object.set_proto(activation.context.gc_context, Some(prototype));
+                            object.set_proto_value(activation.context.gc_context, prototype);
                             for event in events {
                                 let _ = activation.run_child_frame_for_action(
                                     "[Actions]",


### PR DESCRIPTION
Follow-up for #3860.
1. Replace all old `proto`/`set_proto` implementations by the new `proto_value`/`set_proto_value` in all `TObject` implementations on a one-by-one basis.
2. Delete `proto`/`set_proto` and rename `proto_value`/`set_proto_value` to `proto`/`set_proto` for more concise code.

This brings us close to a complete migration. Remaining changes are `ScriptObject::object`, `ScriptObject::array`, `ScriptObject::object_cell` etc.