### PR TITLE
avm1: Migrate to primitive prototypes (step 3)

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -322,10 +322,9 @@ impl<'gc> Avm1<'gc> {
             active_clip,
         );
 
-        let search_result =
-            search_prototype(Some(obj), name, &mut activation, obj).map(|r| (r.0, r.1));
-
-        if let Ok((callback, base_proto)) = search_result {
+        if let Ok((callback, base_proto)) =
+            search_prototype(Value::Object(obj), name, &mut activation, obj)
+        {
             let _ = callback.call(name, &mut activation, obj, base_proto, args);
         }
     }

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -97,7 +97,7 @@ impl fmt::Debug for ScriptObjectData<'_> {
 impl<'gc> ScriptObject<'gc> {
     pub fn object(
         gc_context: MutationContext<'gc, '_>,
-        proto: Option<Object<'gc>>, // TODO: Change to `Value`.
+        proto: Option<Object<'gc>>,
     ) -> ScriptObject<'gc> {
         ScriptObject(GcCell::allocate(
             gc_context,
@@ -114,7 +114,7 @@ impl<'gc> ScriptObject<'gc> {
 
     pub fn array(
         gc_context: MutationContext<'gc, '_>,
-        proto: Option<Object<'gc>>, // TODO: Change to `Value`.
+        proto: Option<Object<'gc>>,
     ) -> ScriptObject<'gc> {
         let object = ScriptObject(GcCell::allocate(
             gc_context,
@@ -134,7 +134,7 @@ impl<'gc> ScriptObject<'gc> {
     /// Constructs and allocates an empty but normal object in one go.
     pub fn object_cell(
         gc_context: MutationContext<'gc, '_>,
-        proto: Option<Object<'gc>>, // TODO: Change to `Value`.
+        proto: Option<Object<'gc>>,
     ) -> Object<'gc> {
         ScriptObject(GcCell::allocate(
             gc_context,

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -159,11 +159,7 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
             Ok(level.object())
         } else {
             // 5) Prototype
-            let prototype = match self.proto() {
-                Value::Object(o) => Some(o),
-                _ => None,
-            };
-            Ok(search_prototype(prototype, name, activation, (*self).into())?.0)
+            Ok(search_prototype(self.proto(), name, activation, (*self).into())?.0)
         }
         // 6) TODO: __resolve?
     }

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -122,11 +122,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         let child = self.0.read().child;
-        let super_proto = match self.super_proto() {
-            Value::Object(o) => Some(o),
-            _ => None,
-        };
-        let (method, base_proto) = search_prototype(super_proto, name, activation, child)?;
+        let (method, base_proto) = search_prototype(self.super_proto(), name, activation, child)?;
 
         if let Value::Object(_) = method {
         } else {

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -93,7 +93,7 @@ impl<'gc> Timers<'gc> {
                 TimerCallback::Method { this, method_name } => {
                     // Fetch the callback method from the object.
                     if let Ok((f, base_proto)) =
-                        search_prototype(Some(this), &method_name, &mut activation, this)
+                        search_prototype(Value::Object(this), &method_name, &mut activation, this)
                     {
                         let f = f.coerce_to_object(&mut activation);
                         Some((this, base_proto, f))


### PR DESCRIPTION
Follow-up for #3867.

Migrate `search_prototype` to primitive prototype.

This is the last step, as I don't think migrating `ScriptObject::object`, `ScriptObject::array`, `ScriptObject::object_cell` worth it.