### PR TITLE
canvas: Update_texture should update in-place, not insert

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -765,15 +765,12 @@ impl RenderBackend for WebCanvasRenderBackend {
         let image = HtmlImageElement::new().unwrap();
         image.set_src(&png);
 
-        self.bitmaps.insert(
-            handle.0,
-            BitmapData {
-                image,
-                width,
-                height,
-                data: png,
-            },
-        );
+        self.bitmaps[handle.0] = BitmapData {
+            image,
+            width,
+            height,
+            data: png,
+        };
 
         Ok(handle)
     }


### PR DESCRIPTION
This sounds common-sense correct, and it does fix https://github.com/ruffle-rs/ruffle/issues/2403 , but I didn't check if it breaks/fixes anything else.