### PR TITLE
web: Handle direct SWF links

### DIFF
--- a/web/packages/extension/assets/css/player.css
+++ b/web/packages/extension/assets/css/player.css
@@ -1,0 +1,9 @@
+#player {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: auto;
+    height: auto;
+}

--- a/web/packages/extension/assets/player.html
+++ b/web/packages/extension/assets/player.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Ruffle</title>
+        <link rel="stylesheet" href="css/player.css" />
+    </head>
+    <body>
+        <div id="main"></div>
+        <script src="dist/player.js"></script>
+    </body>
+</html>

--- a/web/packages/extension/manifest.json
+++ b/web/packages/extension/manifest.json
@@ -10,6 +10,10 @@
         "default_popup": "popup.html",
         "browser_style": true
     },
+    "background": {
+        "scripts": ["dist/background.js"],
+        "persistent": true
+    },
     "content_scripts": [
         {
             "matches": ["<all_urls>"],
@@ -18,7 +22,7 @@
             "run_at": "document_start"
         }
     ],
-    "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline';",
+    "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'; connect-src *;",
     "icons": {
         "16": "images/icon16.png",
         "32": "images/icon32.png",
@@ -30,6 +34,11 @@
         "page": "options.html",
         "open_in_tab": true
     },
-    "permissions": ["storage"],
-    "web_accessible_resources": ["dist/*"]
+    "permissions": [
+        "storage",
+        "<all_urls>",
+        "webRequest",
+        "webRequestBlocking"
+    ],
+    "web_accessible_resources": ["*"]
 }

--- a/web/packages/extension/src/background.js
+++ b/web/packages/extension/src/background.js
@@ -1,0 +1,39 @@
+function isSwf(details) {
+    const typeHeader = details.responseHeaders.find(({name}) => name.toLowerCase() === "content-type");
+    if (!typeHeader) {
+        return false;
+    }
+
+    const mime = typeHeader.value.toLowerCase().match(/^\s*(.*?)\s*(?:;.*)?$/)[1];
+
+    // Some sites (e.g. swfchan.net) might (wrongly?) send octet-stream, so check file extension too.
+    if (mime === "application/octet-stream") {
+        const url = new URL(details.url);
+        const extension = url.pathname.substring(url.pathname.lastIndexOf("."));
+        return extension.toLowerCase() === ".swf";
+    }
+
+    return mime === "application/x-shockwave-flash";
+}
+
+function onHeadersReceived(details) {
+    if (!isSwf(details)) {
+        return;
+    }
+
+    const baseUrl = chrome.runtime.getURL("player.html");
+    return { redirectUrl: `${baseUrl}?url=${details.url}` };
+}
+
+// TODO: Support Firefox.
+// TODO: Only if configured.
+chrome.webRequest.onHeadersReceived.addListener(
+    onHeadersReceived,
+    {
+        urls: ["<all_urls>"],
+        types: ["main_frame"],
+    },
+    ["blocking", "responseHeaders"]
+);
+
+// TODO: chrome.webRequest.onHeadersReceived.removeListener(onHeadersReceived);

--- a/web/packages/extension/src/player.js
+++ b/web/packages/extension/src/player.js
@@ -23,6 +23,13 @@ window.addEventListener("DOMContentLoaded", () => {
         return;
     }
 
+    try {
+        const pathname = new URL(swfUrl).pathname;
+        document.title = pathname.substring(pathname.lastIndexOf("/") + 1);
+    } catch (_) {
+        // Ignore URL parsing errors.
+    }
+
     player = ruffle.createPlayer();
     player.id = "player";
     document.getElementById("main").append(player);

--- a/web/packages/extension/src/player.js
+++ b/web/packages/extension/src/player.js
@@ -1,6 +1,13 @@
 import { PublicAPI, SourceAPI, publicPath } from "ruffle-core";
 
-let ruffle;
+window.RufflePlayer = PublicAPI.negotiate(
+    window.RufflePlayer,
+    "local",
+    new SourceAPI("local")
+);
+__webpack_public_path__ = publicPath(window.RufflePlayer.config, "local");
+const ruffle = window.RufflePlayer.newest();
+
 let player;
 
 // Default config used by the player.
@@ -9,13 +16,6 @@ const config = {
     logLevel: "warn",
 };
 
-window.RufflePlayer = PublicAPI.negotiate(
-    window.RufflePlayer,
-    "local",
-    new SourceAPI("local")
-);
-__webpack_public_path__ = publicPath(window.RufflePlayer.config, "local");
-
 window.addEventListener("DOMContentLoaded", () => {
     const url = new URL(window.location);
     const swfUrl = url.searchParams.get("url");
@@ -23,7 +23,6 @@ window.addEventListener("DOMContentLoaded", () => {
         return;
     }
 
-    ruffle = window.RufflePlayer.newest();
     player = ruffle.createPlayer();
     player.id = "player";
     document.getElementById("main").append(player);

--- a/web/packages/extension/src/player.js
+++ b/web/packages/extension/src/player.js
@@ -1,0 +1,32 @@
+import { PublicAPI, SourceAPI, publicPath } from "ruffle-core";
+
+let ruffle;
+let player;
+
+// Default config used by the player.
+const config = {
+    letterbox: "on",
+    logLevel: "warn",
+};
+
+window.RufflePlayer = PublicAPI.negotiate(
+    window.RufflePlayer,
+    "local",
+    new SourceAPI("local")
+);
+__webpack_public_path__ = publicPath(window.RufflePlayer.config, "local");
+
+window.addEventListener("DOMContentLoaded", () => {
+    const url = new URL(window.location);
+    const swfUrl = url.searchParams.get("url");
+    if (!swfUrl) {
+        return;
+    }
+
+    ruffle = window.RufflePlayer.newest();
+    player = ruffle.createPlayer();
+    player.id = "player";
+    document.getElementById("main").append(player);
+
+    player.load({ url: swfUrl, ...config });
+});

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = (env, argv) => {
             options: path.resolve(__dirname, "src/options.js"),
             content: path.resolve(__dirname, "src/content.js"),
             ruffle: path.resolve(__dirname, "src/ruffle.js"),
+            background: path.resolve(__dirname, "src/background.js"),
+            player: path.resolve(__dirname, "src/player.js"),
         },
         output: {
             path: path.resolve(__dirname, "assets/dist/"),


### PR DESCRIPTION
Fixes #2167.
Tested on Chrome and Firefox.
TODO: Currently saving the page (e.g. using Ctrl+S) downloads the HTML page instead of the playing SWF. After some experiments with the [`chrome.downloads`](https://developer.chrome.com/docs/extensions/reference/downloads/) API, it seems to be somewhat possible to download the SWF instead, but under some limitations (e.g. The "Save As..." dialog still suggests the name of the HTML page, saving the SWF outside of the Downloads directory might not be possible). Also I didn't check if/how it's possible on Firefox and Safari.