### PR TITLE
avm1: XML sendAndLoad

### DIFF
--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -86,7 +86,7 @@ pub fn create_proto<'gc>(
     object.define_value(
         gc_context,
         "contentType",
-        "application/x-www-form-url-encoded".into(),
+        "application/x-www-form-urlencoded".into(),
         Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
     );
 

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -1087,6 +1087,12 @@ pub fn create_xml_proto<'gc>(
         Attribute::READ_ONLY,
     );
     xml_proto.define_value(gc_context, "ignoreWhite", false.into(), Attribute::empty());
+    xml_proto.define_value(
+        gc_context,
+        "contentType",
+        "application/x-www-form-urlencoded".into(),
+        Attribute::empty(),
+    );
     xml_proto.add_property(
         gc_context,
         "xmlDecl",

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -935,7 +935,7 @@ pub fn xml_send_and_load<'gc>(
 
     if let Some(node) = this.as_xml_node() {
         let url = url_val.coerce_to_string(activation)?;
-        spawn_xml_fetch(activation, this, target, &url, Some(node));
+        spawn_xml_fetch(activation, this, target, &url, Some(node))?;
     }
     Ok(Value::Undefined)
 }
@@ -951,9 +951,9 @@ pub fn xml_load<'gc>(
         return Ok(false.into());
     }
 
-    if let Some(node) = this.as_xml_node() {
+    if let Some(_node) = this.as_xml_node() {
         let url = url_val.coerce_to_string(activation)?;
-        spawn_xml_fetch(activation, this, this, &url, None);
+        spawn_xml_fetch(activation, this, this, &url, None)?;
 
         Ok(true.into())
     } else {
@@ -1083,9 +1083,6 @@ fn spawn_xml_fetch<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let request_options = if let Some(node) = send_object {
         // Send `node` as string
-        let content_type = this
-            .get("contentType", activation)?
-            .coerce_to_string(activation)?;
         RequestOptions::post(Some((
             node.into_string(&mut is_as2_compatible).unwrap_or_default().into_bytes(),
             this.get("contentType", activation)?.coerce_to_string(activation)?.to_string(),

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -1087,9 +1087,7 @@ fn spawn_xml_fetch<'gc>(
             node.into_string(&mut is_as2_compatible)
                 .unwrap_or_default()
                 .into_bytes(),
-            this.get("contentType", activation)?
-                .coerce_to_string(activation)?
-                .to_string(),
+            "application/x-www-form-urlencoded".to_string(),
         )))
     } else {
         // Not sending any parameters.

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -1084,8 +1084,12 @@ fn spawn_xml_fetch<'gc>(
     let request_options = if let Some(node) = send_object {
         // Send `node` as string
         RequestOptions::post(Some((
-            node.into_string(&mut is_as2_compatible).unwrap_or_default().into_bytes(),
-            this.get("contentType", activation)?.coerce_to_string(activation)?.to_string(),
+            node.into_string(&mut is_as2_compatible)
+                .unwrap_or_default()
+                .into_bytes(),
+            this.get("contentType", activation)?
+                .coerce_to_string(activation)?
+                .to_string(),
         )))
     } else {
         // Not sending any parameters.
@@ -1094,10 +1098,7 @@ fn spawn_xml_fetch<'gc>(
 
     this.set("loaded", false.into(), activation)?;
 
-    let fetch = activation
-        .context
-        .navigator
-        .fetch(&url, request_options);
+    let fetch = activation.context.navigator.fetch(&url, request_options);
     let target_clip = activation.target_clip_or_root()?;
     // given any defined loader object, sends the request. Will load into LoadVars if given.
     let process = if let Some(node) = loader_object.as_xml_node() {


### PR DESCRIPTION
Should fix #3942, progresses on #2986.

Heavily inspired by the corresponding behaviour in LoadVars.

The spec says that `contentType` is used as the `content-type` header; I found it was ignored and `application/x-www-form-urlencoded` used no matter what.

Flash sends particular headers by default; I just left it doing whatever the current implementation does. The XML sent isn't byte-for-byte identical to Flash but I figured that is probably a Ruffle bug.

Examples of a request: request, headers, body

Flash:
```
HTTP 1.1 POST /xml/send_and_load
{
  referer: 'http://localhost:8080/xml/send_and_load',
  'content-type': 'application/x-www-form-urlencoded',
  'content-length': '34',
  'user-agent': 'Shockwave Flash',
  host: 'localhost:8080',
  'cache-control': 'no-cache'
}
<translate text="Hello, world!" />
```

Ruffle:
```
HTTP 1.1 POST /xml/send_and_load
{
  host: 'localhost:8080',
  accept: '*/*',
  'accept-encoding': 'deflate, gzip',
  'user-agent': 'curl/7.75.0-DEV isahc/1.3.0',
  'content-length': '34',
  'content-type': 'application/x-www-form-urlencoded'
}
<translate  text="Hello, world!"/>
```