### PR TITLE
ci: Add Mozilla add-on variables

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -1,8 +1,12 @@
 name: Release Nightly
 
 on:
+  # Run nightly
   schedule:
     - cron: "0 0 * * *"
+
+  # Allow for manual dispatch on GitHub
+  workflow_dispatch:
 
 jobs:
   create-nightly-release:
@@ -26,7 +30,7 @@ jobs:
           rm -f $HOME/commit.json
           echo "Repository activity: $timestamp $author $url"
           alive=0
-          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+          if [ "${{ github.event_name }}" == "repository_dispatch" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "[WARNING] Ignoring activity check: workflow triggered manually."
             alive=1
           elif [[ $days < 1 ]]; then

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -110,6 +110,10 @@ jobs:
 
       - name: Build web
         if: matrix.os == 'ubuntu-latest'
+        env:
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          MOZILLA_API_KEY: ${{ secrets.MOZILLA_API_KEY }}
+          MOZILLA_API_SECRET: ${{ secrets.MOZILLA_API_SECRET }}
         working-directory: web
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Missed this part the first time around. Ensure the workflow has access to the environment variables for signing the Mozilla extension.
Add the "workflow_dispatch" event to the exceptions of the activity check (so I can manually run the nightly build!).