### PR TITLE
core: Fix wrong frame rate  issue #3020 #3663

### DIFF
--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -907,6 +907,7 @@ mod tests {
                 focus_tracker: FocusTracker::new(gc_context),
                 times_get_time_called: 0,
                 time_offset: &mut 0,
+                frame_rate: &mut None,
             };
 
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -83,6 +83,7 @@ where
             times_get_time_called: 0,
             time_offset: &mut 0,
             audio_manager: &mut AudioManager::new(),
+            frame_rate: &mut None,
         };
         root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
         root.set_name(context.gc_context, "");

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -158,6 +158,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// This frame's current fake time offset, used to pretend passage of time in time functions
     pub time_offset: &'a mut u32,
+
+    /// The frame rate.
+    pub frame_rate: &'a mut Option<f64>,
 }
 
 /// Convenience methods for controlling audio.
@@ -286,6 +289,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             focus_tracker: self.focus_tracker,
             times_get_time_called: self.times_get_time_called,
             time_offset: self.time_offset,
+            frame_rate: self.frame_rate,
         }
     }
 }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1,6 +1,7 @@
 //! Management of async loaders
 
 use crate::avm1::activation::{Activation, ActivationIdentifier};
+use crate::avm1::globals::display_object::AVM_DEPTH_BIAS;
 use crate::avm1::{Avm1, AvmString, Object, TObject, Value};
 use crate::avm2::Domain as Avm2Domain;
 use crate::backend::navigator::OwnedFuture;
@@ -506,6 +507,11 @@ impl<'gc> Loader<'gc> {
                             None => return Err(Error::Cancelled),
                             _ => unreachable!(),
                         };
+
+                        // Change the frame rate if the movie doesn't run in a new clip
+                        if clip.depth() < AVM_DEPTH_BIAS / 2 {
+                            *uc.frame_rate = Some(movie.header().frame_rate.into());
+                        }
 
                         if let Some(broadcaster) = broadcaster {
                             Avm1::run_stack_frame_for_method(

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1401,7 +1401,6 @@ impl Player {
         F: for<'a, 'gc, 'gc_context> FnOnce(&mut UpdateContext<'a, 'gc, 'gc_context>) -> R,
     {
         self.update_drag();
-
         let rval = self.mutate_with_update_context(|context| {
             let rval = func(context);
 
@@ -1413,7 +1412,9 @@ impl Player {
         // Update frame rate if specified
         let v = self.gc_arena.root.0.read().frame_rate;
         if let Some(x) = v {
-            self.set_frame_rate(x);
+            if (x - self.frame_rate()).abs() > f64::EPSILON {
+                self.set_frame_rate(x);
+            }
         };
 
         // Update mouse state (check for new hovered button, etc.)


### PR DESCRIPTION
Fixes the wrong frame rate when an other swf is referenced via GetUrl2 (issue #3020) or GetUrl (#3663).
This is done via an optional frame_rate in the players UpdateContext. The optional frame_rate is set by the loader if the depth parameter of the loaded movie is less then AVM_DEPTH_BIAS / 2. AVM_DEPTH_BIAS is the bias for the depth of a new empty movie clip, allowing for a negative depth of movies loaded into a new clip to be down to -AVM_DEPTH_BIAS / 2 to ignore the frame rate in the swf header.