### PR TITLE
Demo: Allow small screens to still upload local files

### DIFF
--- a/web/packages/demo/www/index.css
+++ b/web/packages/demo/www/index.css
@@ -123,11 +123,11 @@ body {
 
 @media only screen and (max-width: 600px) {
     #local-file-container span {
-        display: table;
+        display: block;
     }
 
     #sample-swfs-label {
-        display: table;
+        display: block;
     }
 
     #author-container {

--- a/web/packages/demo/www/index.css
+++ b/web/packages/demo/www/index.css
@@ -122,12 +122,12 @@ body {
 }
 
 @media only screen and (max-width: 600px) {
-    #local-file-container {
-        display: none;
+    #local-file-container span {
+        display: table;
     }
 
     #sample-swfs-label {
-        display: none;
+        display: table;
     }
 
     #author-container {


### PR DESCRIPTION
The upload file button was hidden on mobile phones with screens smaller than or equal to 600px. Here's how this looks on 320px (the generally agreed upon minimum width to design for).

Edit: The look is unchanged by the second commit. "display: table;" and "display: block;" were functionally identical in this case, but "display: block;" is the more logical choice.

![320px-with-changes](https://user-images.githubusercontent.com/29206584/115168156-f7010380-a087-11eb-8eb8-6084d148a831.png)
