### PR TITLE
Call the super initializer of LoaderInfo after construction

### DIFF
--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -515,13 +515,16 @@ pub fn loader_info<'gc>(
                 let movie = dobj.movie();
 
                 if let Some(movie) = movie {
-                    return Ok(LoaderInfoObject::from_movie(
+                    let obj = LoaderInfoObject::from_movie(
                         movie,
                         root,
                         activation.context.avm2.prototypes().loaderinfo,
                         activation.context.gc_context,
-                    )?
-                    .into());
+                    )?;
+
+                    activation.super_init(obj, &[])?;
+
+                    return Ok(obj.into());
                 }
             }
         }


### PR DESCRIPTION
It feels like this would be in a better place inside `::from_movie`, but then I'd have to pass in the entire `activation`, and I haven't seen similar anywhere else.
Should I still move it in there?

I also tried to check for any other instance of the same mistake, but don't know enough of this part of the project to really recognize any.

This resolves an error in https://z0r.de/3068 ([SWF](https://z0r.de/L/z0r-de_3068.swf)), that happens when a frame script calls `addEventListener` on `root.loaderInfo`, which then finds the `dispatch_list` property inherited from `EventDispatcher` to be `Undefined`.