### PR TITLE
avm1: Implement BitmapData.merge()

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -521,14 +521,14 @@ pub fn color_transform<'gc>(
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_object(activation);
 
-            let x = rectangle.get("x", activation)?.coerce_to_i32(activation)?;
-            let y = rectangle.get("y", activation)?.coerce_to_i32(activation)?;
+            let x = rectangle.get("x", activation)?.coerce_to_f64(activation)? as i32;
+            let y = rectangle.get("y", activation)?.coerce_to_f64(activation)? as i32;
             let width = rectangle
                 .get("width", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let height = rectangle
                 .get("height", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
 
             let min_x = x.max(0) as u32;
             let end_x = (x + width) as u32;
@@ -689,24 +689,24 @@ pub fn copy_pixels<'gc>(
 
             let src_min_x = source_rect
                 .get("x", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_min_y = source_rect
                 .get("y", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_width = source_rect
                 .get("width", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_height = source_rect
                 .get("height", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
 
             let dest_point = args
                 .get(2)
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_object(activation);
 
-            let dest_x = dest_point.get("x", activation)?.coerce_to_i32(activation)?;
-            let dest_y = dest_point.get("y", activation)?.coerce_to_i32(activation)?;
+            let dest_x = dest_point.get("x", activation)?.coerce_to_f64(activation)? as i32;
+            let dest_y = dest_point.get("y", activation)?.coerce_to_f64(activation)? as i32;
 
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
@@ -731,11 +731,13 @@ pub fn copy_pixels<'gc>(
 
                         let alpha_x = alpha_point
                             .get("x", activation)?
-                            .coerce_to_i32(activation)?;
+                            .coerce_to_f64(activation)?
+                            as i32;
 
                         let alpha_y = alpha_point
                             .get("y", activation)?
-                            .coerce_to_i32(activation)?;
+                            .coerce_to_f64(activation)?
+                            as i32;
 
                         let alpha_bitmap = args
                             .get(3)
@@ -818,24 +820,24 @@ pub fn merge<'gc>(
 
             let src_min_x = source_rect
                 .get("x", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_min_y = source_rect
                 .get("y", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_width = source_rect
                 .get("width", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_height = source_rect
                 .get("height", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
 
             let dest_point = args
                 .get(2)
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_object(activation);
 
-            let dest_x = dest_point.get("x", activation)?.coerce_to_i32(activation)?;
-            let dest_y = dest_point.get("y", activation)?.coerce_to_i32(activation)?;
+            let dest_x = dest_point.get("x", activation)?.coerce_to_f64(activation)? as i32;
+            let dest_y = dest_point.get("y", activation)?.coerce_to_f64(activation)? as i32;
 
             let red_mult = args
                 .get(3)
@@ -910,24 +912,24 @@ pub fn palette_map<'gc>(
 
             let src_min_x = source_rect
                 .get("x", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_min_y = source_rect
                 .get("y", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_width = source_rect
                 .get("width", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
             let src_height = source_rect
                 .get("height", activation)?
-                .coerce_to_i32(activation)?;
+                .coerce_to_f64(activation)? as i32;
 
             let dest_point = args
                 .get(2)
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_object(activation);
 
-            let dest_x = dest_point.get("x", activation)?.coerce_to_i32(activation)?;
-            let dest_y = dest_point.get("y", activation)?.coerce_to_i32(activation)?;
+            let dest_x = dest_point.get("x", activation)?.coerce_to_f64(activation)? as i32;
+            let dest_y = dest_point.get("y", activation)?.coerce_to_f64(activation)? as i32;
 
             let mut get_channel = |index: usize, shift: usize| -> Result<[u32; 256], Error<'gc>> {
                 let arg = args.get(index).unwrap_or(&Value::Null);

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -840,22 +840,22 @@ pub fn merge<'gc>(
             let red_mult = args
                 .get(3)
                 .unwrap_or(&Value::Undefined)
-                .coerce_to_u16(activation)?;
+                .coerce_to_i32(activation)?;
 
             let green_mult = args
                 .get(4)
                 .unwrap_or(&Value::Undefined)
-                .coerce_to_u16(activation)?;
+                .coerce_to_i32(activation)?;
 
             let blue_mult = args
                 .get(5)
                 .unwrap_or(&Value::Undefined)
-                .coerce_to_u16(activation)?;
+                .coerce_to_i32(activation)?;
 
             let alpha_mult = args
                 .get(6)
                 .unwrap_or(&Value::Undefined)
-                .coerce_to_u16(activation)?;
+                .coerce_to_i32(activation)?;
 
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -598,6 +598,63 @@ impl BitmapData {
         }
     }
 
+    pub fn merge(
+        &mut self,
+        source_bitmap: &Self,
+        src_rect: (i32, i32, i32, i32),
+        dest_point: (i32, i32),
+        rgba_mult: (u16, u16, u16, u16),
+    ) {
+        let (src_min_x, src_min_y, src_width, src_height) = src_rect;
+        let (dest_min_x, dest_min_y) = dest_point;
+
+        for src_y in src_min_y..(src_min_y + src_height) {
+            for src_x in src_min_x..(src_min_x + src_width) {
+                let dest_x = src_x - src_min_x + dest_min_x;
+                let dest_y = src_y - src_min_y + dest_min_y;
+
+                if !self.is_point_in_bounds(dest_x, dest_y)
+                    || !source_bitmap.is_point_in_bounds(src_x, src_y)
+                {
+                    continue;
+                }
+
+                let source_color = source_bitmap
+                    .get_pixel_raw(src_x as u32, src_y as u32)
+                    .unwrap()
+                    .to_un_multiplied_alpha();
+
+                let dest_color = self
+                    .get_pixel_raw(dest_x as u32, dest_y as u32)
+                    .unwrap()
+                    .to_un_multiplied_alpha();
+
+                let (red_mult, green_mult, blue_mult, alpha_mult) = rgba_mult;
+
+                let red = (source_color.red() as u16 * red_mult
+                    + dest_color.red() as u16 * (256 - red_mult))
+                    / 256;
+                let green = (source_color.green() as u16 * green_mult
+                    + dest_color.green() as u16 * (256 - green_mult))
+                    / 256;
+                let blue = (source_color.blue() as u16 * blue_mult
+                    + dest_color.blue() as u16 * (256 - blue_mult))
+                    / 256;
+                let alpha = (source_color.alpha() as u16 * alpha_mult
+                    + dest_color.alpha() as u16 * (256 - alpha_mult))
+                    / 256;
+
+                let mix_color = Color::argb(alpha as u8, red as u8, green as u8, blue as u8);
+
+                self.set_pixel32_raw(
+                    dest_x as u32,
+                    dest_y as u32,
+                    mix_color.to_premultiplied_alpha(self.transparency),
+                );
+            }
+        }
+    }
+
     // Unlike `copy_channel` and `copy_pixels`, this function seems to
     // operate "in-place" if the source bitmap is the same object as `self`.
     // This means that we can't resolve this aliasing issue in Rust by a

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -603,7 +603,7 @@ impl BitmapData {
         source_bitmap: &Self,
         src_rect: (i32, i32, i32, i32),
         dest_point: (i32, i32),
-        rgba_mult: (u16, u16, u16, u16),
+        rgba_mult: (i32, i32, i32, i32),
     ) {
         let (src_min_x, src_min_y, src_width, src_height) = src_rect;
         let (dest_min_x, dest_min_y) = dest_point;
@@ -629,7 +629,10 @@ impl BitmapData {
                     .unwrap()
                     .to_un_multiplied_alpha();
 
-                let (red_mult, green_mult, blue_mult, alpha_mult) = rgba_mult;
+                let red_mult = rgba_mult.0.clamp(0, 256) as u16;
+                let green_mult = rgba_mult.1.clamp(0, 256) as u16;
+                let blue_mult = rgba_mult.2.clamp(0, 256) as u16;
+                let alpha_mult = rgba_mult.3.clamp(0, 256) as u16;
 
                 let red = (source_color.red() as u16 * red_mult
                     + dest_color.red() as u16 * (256 - red_mult))


### PR DESCRIPTION
This will eventually help with https://github.com/ruffle-rs/ruffle/issues/2240.

Tested visually using this code: https://gist.github.com/torokati44/a56c961788597a203edbe45ff999ce7b
Compiled into: [BitmapMerge.zip](https://github.com/ruffle-rs/ruffle/files/6340038/BitmapMerge.zip)

As well as with a few other variations of the transparency property of the source and destination bitmaps, and the `channelOptions` parameter of the `perlinNoise()` call used to fill them.

The test as linked above produces this output in Adobe Flash Player:
![image](https://user-images.githubusercontent.com/288816/115325134-63186000-a18b-11eb-9ef4-377d957779d5.png)

The difference of the output of Ruffle from that is, **remapped from 0..2 to 0..255**:
![image](https://user-images.githubusercontent.com/288816/115325238-89d69680-a18b-11eb-95fc-7537ed174320.png)

The formula used is pasted directly from the AS2 reference.
I might play around with different rounding options to get the results to match closer.
