### PR TITLE
web: General improvements

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3180,18 +3180,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@wdio/types": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.2.1.tgz",
-            "integrity": "sha512-05+nxO2I/9asQvjgTT2ZteDi7PguAruoOw1Vu8zAVqE+yP5YQxW1CX3galRost8UlQ6Vft/RgmsYLabdxJzzag==",
-            "dev": true,
-            "dependencies": {
-                "got": "^11.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/utils": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.3.1.tgz",
@@ -17540,15 +17528,6 @@
                         "got": "^11.8.1"
                     }
                 }
-            }
-        },
-        "@wdio/types": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.2.1.tgz",
-            "integrity": "sha512-05+nxO2I/9asQvjgTT2ZteDi7PguAruoOw1Vu8zAVqE+yP5YQxW1CX3galRost8UlQ6Vft/RgmsYLabdxJzzag==",
-            "dev": true,
-            "requires": {
-                "got": "^11.8.1"
             }
         },
         "@wdio/utils": {

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -22,8 +22,8 @@ async function fetchRuffle(): Promise<{ new (...args: any[]): Ruffle }> {
     // libraries, if needed.
     setPolyfillsOnLoad();
 
-    // wasm files are set to use file-loader,
-    // so this package will resolve to the URL of the wasm file.
+    // wasm files are set to be resource assets,
+    // so this import will resolve to the URL of the wasm file.
     const ruffleWasm = await import(
         /* webpackMode: "eager" */
         "../pkg/ruffle_web_bg.wasm"

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -13,7 +13,6 @@
     },
     "devDependencies": {
         "css-loader": "^5.0.1",
-        "file-loader": "^6.2.0",
         "style-loader": "^2.0.0",
         "webpack-cli": "^4.0.0"
     }

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = (env, argv) => {
                 },
                 {
                     test: /\.wasm$/i,
-                    use: ["file-loader"],
+                    type: "asset/resource",
                 },
             ],
         },

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (env, argv) => {
 
     return {
         mode,
-        entry: path.resolve(__dirname, "www/index.js"),
+        entry: "./www/index.js",
         output: {
             path: path.resolve(__dirname, "dist"),
             filename: "index.js",

--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -1,25 +1,26 @@
 {
     "manifest_version": 2,
     "name": "Ruffle",
-    "version": null,
+    "version": null, // Filled by Webpack.
+    "version_name": null, // Filled by Webpack.
     "default_locale": "en",
     "description": "__MSG_description__",
     "homepage_url": "https://ruffle.rs/",
 
     "browser_action": {
         "default_popup": "popup.html",
-        "browser_style": true
+        "browser_style": true,
     },
     "background": {
         "scripts": ["dist/background.js"],
-        "persistent": true
+        "persistent": true,
     },
     "content_scripts": [
         {
             "matches": ["<all_urls>"],
             "js": ["dist/content.js"],
             "all_frames": true,
-            "run_at": "document_start"
+            "run_at": "document_start",
         }
     ],
     "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'; connect-src *;",
@@ -28,17 +29,17 @@
         "32": "images/icon32.png",
         "48": "images/icon48.png",
         "128": "images/icon128.png",
-        "180": "images/icon180.png"
+        "180": "images/icon180.png",
     },
     "options_ui": {
         "page": "options.html",
-        "open_in_tab": true
+        "open_in_tab": true,
     },
     "permissions": [
         "storage",
         "<all_urls>",
         "webRequest",
-        "webRequestBlocking"
+        "webRequestBlocking",
     ],
-    "web_accessible_resources": ["*"]
+    "web_accessible_resources": ["*"],
 }

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -14,7 +14,6 @@
     },
     "devDependencies": {
         "archiver": "^5.2.0",
-        "file-loader": "^6.2.0",
         "sign-addon": "^3.3.0",
         "temp-dir": "^2.0.0",
         "webpack-cli": "^4.0.0"

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -14,6 +14,7 @@
     },
     "devDependencies": {
         "archiver": "^5.2.0",
+        "json5": "^2.2.0",
         "sign-addon": "^3.3.0",
         "temp-dir": "^2.0.0",
         "webpack-cli": "^4.0.0"

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -1,7 +1,41 @@
 /* eslint-env node */
 
 const path = require("path");
+const json5 = require("json5");
 const CopyPlugin = require("copy-webpack-plugin");
+
+function transformManifest(content, env) {
+    const manifest = json5.parse(content);
+
+    const packageVersion = process.env.npm_package_version;
+
+    const versionChannel = process.env.CFG_RELEASE_CHANNEL || "nightly";
+
+    const buildDate = new Date().toISOString().substring(0, 10);
+
+    // The extension marketplaces require the version to monotonically increase,
+    // so append the build date onto the end of the manifest version.
+    const version = process.env.BUILD_ID
+        ? `${packageVersion}.${process.env.BUILD_ID}`
+        : packageVersion;
+
+    const version_name =
+        versionChannel === "nightly"
+            ? `${packageVersion} nightly ${buildDate}`
+            : packageVersion;
+
+    Object.assign(manifest, { version, version_name });
+    if (env.firefox) {
+        const id = process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs";
+        Object.assign(manifest, {
+            browser_specific_settings: {
+                gecko: { id },
+            },
+        });
+    }
+
+    return JSON.stringify(manifest);
+}
 
 module.exports = (env, argv) => {
     let mode = "production";
@@ -38,42 +72,9 @@ module.exports = (env, argv) => {
             new CopyPlugin({
                 patterns: [
                     {
-                        from: "manifest.json",
-                        to: "..",
-                        transform(content) {
-                            const manifest = JSON.parse(content.toString());
-
-                            const packageVersion =
-                                process.env.npm_package_version;
-                            const versionChannel =
-                                process.env.CFG_RELEASE_CHANNEL || "nightly";
-                            const buildDate = new Date()
-                                .toISOString()
-                                .substring(0, 10);
-                            // The extension marketplaces require the version to monotonically increase,
-                            // so append the build date onto the end of the manifest version.
-                            const version = process.env.BUILD_ID
-                                ? `${packageVersion}.${process.env.BUILD_ID}`
-                                : packageVersion;
-                            const version_name =
-                                versionChannel === "nightly"
-                                    ? `${packageVersion} nightly ${buildDate}`
-                                    : packageVersion;
-
-                            Object.assign(manifest, { version, version_name });
-                            if (env.firefox) {
-                                const id =
-                                    process.env.FIREFOX_EXTENSION_ID ||
-                                    "ruffle@ruffle.rs";
-
-                                Object.assign(manifest, {
-                                    browser_specific_settings: {
-                                        gecko: { id },
-                                    },
-                                });
-                            }
-                            return JSON.stringify(manifest);
-                        },
+                        from: "manifest.json5",
+                        to: "../manifest.json",
+                        transform: (content) => transformManifest(content, env),
                     },
                     { from: "LICENSE*" },
                     { from: "README.md" },

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -14,12 +14,12 @@ module.exports = (env, argv) => {
     return {
         mode,
         entry: {
-            popup: path.resolve(__dirname, "src/popup.js"),
-            options: path.resolve(__dirname, "src/options.js"),
-            content: path.resolve(__dirname, "src/content.js"),
-            ruffle: path.resolve(__dirname, "src/ruffle.js"),
-            background: path.resolve(__dirname, "src/background.js"),
-            player: path.resolve(__dirname, "src/player.js"),
+            popup: "./src/popup.js",
+            options: "./src/options.js",
+            content: "./src/content.js",
+            ruffle: "./src/ruffle.js",
+            background: "./src/background.js",
+            player: "./src/player.js",
         },
         output: {
             path: path.resolve(__dirname, "assets/dist/"),

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = (env, argv) => {
             rules: [
                 {
                     test: /\.wasm$/i,
-                    use: ["file-loader"],
+                    type: "asset/resource",
                 },
             ],
         },

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -20,7 +20,6 @@
     },
     "devDependencies": {
         "@wdio/cli": "^7.0.7",
-        "file-loader": "^6.2.0",
         "webpack": "^5.1.3",
         "webpack-cli": "^4.0.0",
         "webpack-dev-server": "^3.11.0"

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (env, argv) => {
 
     return {
         mode,
-        entry: path.resolve(__dirname, "js/ruffle.js"),
+        entry: "./js/ruffle.js",
         output: {
             path: path.resolve(__dirname, "dist"),
             filename: "ruffle.js",

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = (env, argv) => {
             rules: [
                 {
                     test: /\.wasm$/i,
-                    use: ["file-loader"],
+                    type: "asset/resource",
                 },
             ],
         },


### PR DESCRIPTION
Key changes:
* Migrate the deprecated [`file-loader`](https://webpack.js.org/loaders/file-loader/) to [asset modules](https://webpack.js.org/guides/asset-modules/) as suggested.
* Convert the extension's `manifest.json` to [JSON5](https://json5.org/), which is a more flexible superset of JSON. It supports comments, trailing commas and more nice features that JSON doesn't support.