### PR TITLE
chore: Switch to new cargo resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "render/common_tess",
     "render/webgl",
 ]
+resolver = "2"
 
 # Don't optimize build scripts and macros.
 [profile.release.build-override]


### PR DESCRIPTION
Turn on cargo's new [feature resolver v2](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver), added in Rust 1.51.0. Don't know if this will have any effect, but it will be default in Rust 2021 edition. Let's try it a little early to see if it breaks anything.