### PR TITLE
extension: Avoid script injection in XML documents

### DIFF
--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -90,17 +90,19 @@ function checkPageOptout(): boolean {
     return false;
 }
 
-declare global {
-    interface Document {
-        xmlVersion: string | null;
-    }
+/**
+ * @returns {boolean} Whether the current page is an XML document or not.
+ */
+function isXMLDocument(): boolean {
+    // Based on https://developer.mozilla.org/en-US/docs/Web/API/Document/xmlVersion
+    return document.createElement("foo").tagName !== "FOO";
 }
 
 (async () => {
     const options = await utils.getOptions(["ruffleEnable", "ignoreOptout"]);
     const pageOptout = checkPageOptout();
     const shouldLoad =
-        !document.xmlVersion &&
+        !isXMLDocument() &&
         options.ruffleEnable &&
         !window.RufflePlayer &&
         (options.ignoreOptout || !pageOptout);


### PR DESCRIPTION
#4092 was not proper because `document.xmlVersion` doesn't exist in Firefox.
So use another method to detect XML documents as described in [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/xmlVersion).

Really fixes #4090.