### PR TITLE
core: Fix missing synchronization of video with sound (close #3020)

### DIFF
--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -905,7 +905,9 @@ mod tests {
                 focus_tracker: FocusTracker::new(gc_context),
                 times_get_time_called: 0,
                 time_offset: &mut 0,
-            };
+                frame_rate: &mut None,
+            	root_frame_rate: &mut 1.0,
+           };
 
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -906,8 +906,8 @@ mod tests {
                 times_get_time_called: 0,
                 time_offset: &mut 0,
                 frame_rate: &mut None,
-            	root_frame_rate: &mut 1.0,
-           };
+                root_frame_rate: &mut 1.0,
+            };
 
             root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "");

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -83,6 +83,8 @@ where
             times_get_time_called: 0,
             time_offset: &mut 0,
             audio_manager: &mut AudioManager::new(),
+            frame_rate: &mut None,
+            root_frame_rate: &mut 1.0,
         };
         root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
         root.set_name(context.gc_context, "");

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -190,6 +190,12 @@ impl<'gc> AudioManager<'gc> {
         }
     }
 
+	/// Get the number of sound instances.
+	pub fn sounds_count(&mut self,
+	)-> usize {
+		self.sounds.len()
+	}
+	
     /// Update state of active sounds. Should be called once per frame.
     pub fn update_sounds(
         &mut self,

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -190,12 +190,11 @@ impl<'gc> AudioManager<'gc> {
         }
     }
 
-	/// Get the number of sound instances.
-	pub fn sounds_count(&mut self,
-	)-> usize {
-		self.sounds.len()
-	}
-	
+    /// Get the number of sound instances.
+    pub fn sounds_count(&mut self) -> usize {
+        self.sounds.len()
+    }
+
     /// Update state of active sounds. Should be called once per frame.
     pub fn update_sounds(
         &mut self,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -158,6 +158,13 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// This frame's current fake time offset, used to pretend passage of time in time functions
     pub time_offset: &'a mut u32,
+
+    /// The current frame rate. Is set when frame is modified.
+    pub frame_rate: &'a mut Option<f64>,
+
+    /// The root_frame rate. Is set when the root movie is loaded.
+    pub root_frame_rate: &'a mut f64,
+
 }
 
 /// Convenience methods for controlling audio.
@@ -286,6 +293,8 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             focus_tracker: self.focus_tracker,
             times_get_time_called: self.times_get_time_called,
             time_offset: self.time_offset,
+            frame_rate: self.frame_rate,
+            root_frame_rate: self.root_frame_rate,
         }
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -164,7 +164,6 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The root_frame rate. Is set when the root movie is loaded.
     pub root_frame_rate: &'a mut f64,
-
 }
 
 /// Convenience methods for controlling audio.

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2308,12 +2308,12 @@ impl<'gc> MovieClipData<'gc> {
     fn stop_audio_stream(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
         if let Some(audio_stream) = self.audio_stream.take() {
             context.stop_sound(audio_stream);
-			if context.audio_manager.sounds_count() == 0 {
-       			if let Some(_frame_rate) = context.frame_rate {
-					*context.frame_rate = Some(*context.root_frame_rate);
-				}
-			}
-         }
+            if context.audio_manager.sounds_count() == 0 {
+                if let Some(_frame_rate) = context.frame_rate {
+                    *context.frame_rate = Some(*context.root_frame_rate);
+                }
+            }
+        }
     }
 
     /// Fetch the avm1 constructor associated with this MovieClip by `Object.registerClass`.
@@ -3228,8 +3228,8 @@ impl<'gc, 'a> MovieClip<'gc> {
                             "Invalid slice generated when constructing sound stream block",
                         )
                     })?;
-				*context.frame_rate = Some(mc.static_data.swf.movie.header().frame_rate.into()); 
-               	let audio_stream = context.start_stream(
+                *context.frame_rate = Some(mc.static_data.swf.movie.header().frame_rate.into());
+                let audio_stream = context.start_stream(
                     mc.static_data.audio_stream_handle,
                     self,
                     mc.current_frame() + 1,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2308,7 +2308,12 @@ impl<'gc> MovieClipData<'gc> {
     fn stop_audio_stream(&mut self, context: &mut UpdateContext<'_, 'gc, '_>) {
         if let Some(audio_stream) = self.audio_stream.take() {
             context.stop_sound(audio_stream);
-        }
+			if context.audio_manager.sounds_count() == 0 {
+       			if let Some(_frame_rate) = context.frame_rate {
+					*context.frame_rate = Some(*context.root_frame_rate);
+				}
+			}
+         }
     }
 
     /// Fetch the avm1 constructor associated with this MovieClip by `Object.registerClass`.
@@ -3223,7 +3228,8 @@ impl<'gc, 'a> MovieClip<'gc> {
                             "Invalid slice generated when constructing sound stream block",
                         )
                     })?;
-                let audio_stream = context.start_stream(
+				*context.frame_rate = Some(mc.static_data.swf.movie.header().frame_rate.into()); 
+               	let audio_stream = context.start_stream(
                     mc.static_data.audio_stream_handle,
                     self,
                     mc.current_frame() + 1,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2309,9 +2309,7 @@ impl<'gc> MovieClipData<'gc> {
         if let Some(audio_stream) = self.audio_stream.take() {
             context.stop_sound(audio_stream);
             if context.audio_manager.sounds_count() == 0 {
-                if let Some(_frame_rate) = context.frame_rate {
-                    *context.frame_rate = Some(*context.root_frame_rate);
-                }
+                *context.frame_rate = Some(*context.root_frame_rate);
             }
         }
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -190,8 +190,8 @@ pub struct Player {
     background_color: Option<Color>,
 
     /// Current frame rate.
-	frame_rate: f64,
-	root_frame_rate: f64, 
+    frame_rate: f64,
+    root_frame_rate: f64,
 
     /// A time budget for executing frames.
     /// Gained by passage of time between host frames, spent by executing SWF frames.
@@ -255,7 +255,7 @@ impl Player {
         let fake_movie = Arc::new(SwfMovie::empty(NEWEST_PLAYER_VERSION));
         let movie_width = 550;
         let movie_height = 400;
-       	let root_frame_rate = 12.0; 
+        let root_frame_rate = 12.0;
         let frame_rate = root_frame_rate;
         // Disable script timeout in debug builds by default.
         let max_execution_duration = if cfg!(debug_assertions) { u64::MAX } else { 15 };
@@ -302,7 +302,7 @@ impl Player {
             }),
 
             frame_rate,
-			root_frame_rate,
+            root_frame_rate,
             frame_accumulator: 0.0,
             recent_run_frame_timings: VecDeque::with_capacity(10),
             time_offset: 0,
@@ -361,8 +361,8 @@ impl Player {
 
     /// Set the current frame rate
     pub fn set_frame_rate(&mut self, nframe_rate: f64) -> &mut Player {
-     	info!("Setting frame rate to {}", nframe_rate);
- 		self.frame_rate = nframe_rate;
+        info!("Setting frame rate to {}", nframe_rate);
+        self.frame_rate = nframe_rate;
         self.audio.set_frame_rate(nframe_rate);
         self
     }
@@ -1287,7 +1287,7 @@ impl Player {
             max_execution_duration,
             current_frame,
             time_offset,
-			root_frame_rate, 
+            root_frame_rate,
         ) = (
             self.player_version,
             &self.swf,
@@ -1311,7 +1311,7 @@ impl Player {
             self.max_execution_duration,
             &mut self.current_frame,
             &mut self.time_offset,
-			&mut self.root_frame_rate,
+            &mut self.root_frame_rate,
         );
 
         self.gc_arena.mutate(|gc_context, gc_root| {
@@ -1434,9 +1434,9 @@ impl Player {
         // Update frame rate if specified
         let v = self.gc_arena.root.0.read().frame_rate;
         if let Some(nframe_rate) = v {
-       		if (nframe_rate - self.frame_rate()).abs() > f64::EPSILON {
+            if (nframe_rate - self.frame_rate()).abs() > f64::EPSILON {
                 self.set_frame_rate(nframe_rate);
-			}
+            }
         };
 
         // Update mouse state (check for new hovered button, etc.)


### PR DESCRIPTION
When entering a soundstreamblock, the video frame rate is set to the frame rate specified in the file header of the soundstreamblock.
When the last sound has been played (no more sound  instances) the video frame rate is reset to the root files frame rate.
