### PR TITLE
Basic context menu playback control items MVP

### DIFF
--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -7,7 +7,6 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property::Attribute;
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
-use crate::avm_warn;
 use gc_arena::MutationContext;
 
 pub fn create_stage_object<'gc>(
@@ -193,16 +192,23 @@ fn show_menu<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "Stage.showMenu: unimplemented");
-    Ok(true.into())
+    Ok(activation.context.stage.show_menu().into())
 }
 
 fn set_show_menu<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: Object<'gc>,
-    _args: &[Value<'gc>],
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "Stage.showMenu: unimplemented");
+    let show_menu = args
+        .get(0)
+        .unwrap_or(&true.into())
+        .to_owned()
+        .as_bool(activation.swf_version());
+    activation
+        .context
+        .stage
+        .set_show_menu(&mut activation.context, show_menu);
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -450,6 +450,27 @@ pub fn set_frame_rate<'gc>(
     Ok(Value::Undefined)
 }
 
+pub fn show_default_context_menu<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(activation.context.stage.show_menu().into())
+}
+
+pub fn set_show_default_context_menu<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    let show_default_context_menu = args.get(0).unwrap_or(&Value::Undefined).coerce_to_boolean();
+    activation
+        .context
+        .stage
+        .set_show_menu(&mut activation.context, show_default_context_menu);
+    Ok(Value::Undefined)
+}
+
 /// Implement `scaleMode`'s getter
 pub fn scale_mode<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -814,6 +835,14 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.define_instance_trait(Trait::from_setter(
         QName::new(Namespace::public(), "scaleMode"),
         Method::from_builtin(set_scale_mode),
+    ));
+    write.define_instance_trait(Trait::from_getter(
+        QName::new(Namespace::public(), "showDefaultContextMenu"),
+        Method::from_builtin(show_default_context_menu),
+    ));
+    write.define_instance_trait(Trait::from_setter(
+        QName::new(Namespace::public(), "showDefaultContextMenu"),
+        Method::from_builtin(set_show_default_context_menu),
     ));
     write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public(), "stageWidth"),

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -76,6 +76,9 @@ pub struct StageData<'gc> {
     /// The bounds of the current viewport in twips, used for culling.
     view_bounds: BoundingBox,
 
+    /// Whether to show default context menu items
+    show_menu: bool,
+
     /// The AVM2 view of this stage object.
     avm2_object: Avm2Object<'gc>,
 }
@@ -96,6 +99,7 @@ impl<'gc> Stage<'gc> {
                 viewport_size: (width, height),
                 viewport_scale_factor: 1.0,
                 view_bounds: Default::default(),
+                show_menu: true,
                 avm2_object: Avm2ScriptObject::bare_object(gc_context),
             },
         ))
@@ -202,6 +206,15 @@ impl<'gc> Stage<'gc> {
 
     pub fn view_bounds(self) -> BoundingBox {
         self.0.read().view_bounds.clone()
+    }
+
+    pub fn show_menu(self) -> bool {
+        self.0.read().show_menu
+    }
+
+    pub fn set_show_menu(self, context: &mut UpdateContext<'_, 'gc, '_>, show_menu: bool) {
+        let mut write = self.0.write(context.gc_context);
+        write.show_menu = show_menu;
     }
 
     /// Determine if we should letterbox the stage content.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -556,6 +556,51 @@ impl Player {
         self.is_playing
     }
 
+    pub fn is_playing_root_movie(&mut self) -> bool {
+        self.gc_arena.mutate(|_gc_context, gc_root| {
+            let root_data = gc_root.0.read();
+            if let Some(mc) = root_data.stage.root_clip().as_movie_clip() {
+                mc.playing()
+            } else {
+                false
+            }
+        })
+    }
+
+    pub fn toggle_play_root_movie(&mut self) {
+        self.mutate_with_update_context(|context| {
+            if let Some(mc) = context.stage.root_clip().as_movie_clip() {
+                // TODO: no clue if we handle audio properly here?
+                if mc.playing() {
+                    mc.stop(context);
+                } else {
+                    mc.play(context);
+                }
+            }
+        });
+    }
+    pub fn rewind_root_movie(&mut self) {
+        self.mutate_with_update_context(|context| {
+            if let Some(mc) = context.stage.root_clip().as_movie_clip() {
+                mc.goto_frame(context, 1, true)
+            }
+        });
+    }
+    pub fn forward_root_movie(&mut self) {
+        self.mutate_with_update_context(|context| {
+            if let Some(mc) = context.stage.root_clip().as_movie_clip() {
+                mc.next_frame(context);
+            }
+        });
+    }
+    pub fn back_root_movie(&mut self) {
+        self.mutate_with_update_context(|context| {
+            if let Some(mc) = context.stage.root_clip().as_movie_clip() {
+                mc.prev_frame(context);
+            }
+        });
+    }
+
     pub fn set_is_playing(&mut self, v: bool) {
         if v {
             // Allow auto-play after user gesture for web backends.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -556,6 +556,13 @@ impl Player {
         self.is_playing
     }
 
+    pub fn can_show_default_menu_items(&mut self) -> bool {
+        self.gc_arena.mutate(|_gc_context, gc_root| {
+            let root_data = gc_root.0.read();
+            root_data.stage.show_menu()
+        })
+    }
+
     pub fn is_playing_root_movie(&mut self) -> bool {
         self.gc_arena.mutate(|_gc_context, gc_root| {
             let root_data = gc_root.0.read();

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -561,23 +561,28 @@ impl Player {
             if !context.stage.show_menu() {
                 return vec![];
             }
-            let mut names = vec![
-                "zoom",
-                "quality",
-                "play",
-                "loop",
-                "rewind",
-                "forward_back",
-                "print",
-            ];
 
             let mut activation = Activation::from_stub(
                 context.reborrow(),
                 ActivationIdentifier::root("[ContextMenu]"),
             );
 
-            let dobj = activation.context.stage.root_clip();
+            let is_multiframe_movie = activation.context.swf.header().num_frames > 1;
+            let mut names = if is_multiframe_movie {
+                vec![
+                    "zoom",
+                    "quality",
+                    "play",
+                    "loop",
+                    "rewind",
+                    "forward_back",
+                    "print",
+                ]
+            } else {
+                vec!["zoom", "quality", "print"]
+            };
 
+            let dobj = activation.context.stage.root_clip();
             if let Value::Object(obj) = dobj.object() {
                 if let Ok(Value::Object(menu)) = obj.get("menu", &mut activation) {
                     if let Ok(Value::Object(menu)) = menu.get("builtInItems", &mut activation) {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -663,7 +663,6 @@ export class RufflePlayer extends HTMLElement {
     }
 
     private contextMenuItems(): ContextMenuItem[] {
-
         const items = [];
         if (this.fullscreenEnabled) {
             if (this.isFullscreen) {
@@ -679,11 +678,11 @@ export class RufflePlayer extends HTMLElement {
             }
         }
         if (this.instance) {
-            let can_show_default_menu_items = this.instance.can_show_default_menu_items();
-            if (can_show_default_menu_items) {
-                let is_playing_root_movie = this.instance.is_playing_root_movie();
+            const canShowDefaultMenuItems = this.instance.can_show_default_menu_items();
+            if (canShowDefaultMenuItems) {
+                const isPlayingRootMovie = this.instance.is_playing_root_movie();
                 items.push({
-                    text: is_playing_root_movie ? `Play (☑)` : `Play (☐)`,
+                    text: isPlayingRootMovie ? `Play (☑)` : `Play (☐)`,
                     onClick: () => this.instance?.toggle_play_root_movie(),
                 });
                 items.push({

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -678,27 +678,31 @@ export class RufflePlayer extends HTMLElement {
             }
         }
         if (this.instance) {
-            const canShowDefaultMenuItems = this.instance.can_show_default_menu_items();
-            if (canShowDefaultMenuItems) {
-                const isPlayingRootMovie = this.instance.is_playing_root_movie();
-                items.push({
-                    text: isPlayingRootMovie ? `Play (☑)` : `Play (☐)`,
-                    onClick: () => this.instance?.toggle_play_root_movie(),
-                });
-                items.push({
-                    text: `Rewind`,
-                    onClick: () => this.instance?.rewind_root_movie(),
-                    separator: false,
-                });
-                items.push({
-                    text: `Forward`,
-                    onClick: () => this.instance?.forward_root_movie(),
-                    separator: false,
-                });
-                items.push({
-                    text: `Back`,
-                    onClick: () => this.instance?.back_root_movie(),
-                });
+            const builtinMenuItems = this.instance.get_builtin_menu_items();
+            for (const item of builtinMenuItems) {
+                if (item == "play") {
+                    const isPlayingRootMovie = this.instance.is_playing_root_movie();
+                    items.push({
+                        text: isPlayingRootMovie ? `Play (☑)` : `Play (☐)`,
+                        onClick: () => this.instance?.toggle_play_root_movie(),
+                    });
+                } else if (item == "rewind") {
+                    items.push({
+                        text: `Rewind`,
+                        onClick: () => this.instance?.rewind_root_movie(),
+                        separator: false,
+                    });
+                } else if (item == "forward_back") {
+                    items.push({
+                        text: `Forward`,
+                        onClick: () => this.instance?.forward_root_movie(),
+                        separator: false,
+                    });
+                    items.push({
+                        text: `Back`,
+                        onClick: () => this.instance?.back_root_movie(),
+                    });
+                }
             }
         }
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -679,25 +679,28 @@ export class RufflePlayer extends HTMLElement {
             }
         }
         if (this.instance) {
-            let is_playing_root_movie = this.instance.is_playing_root_movie();
-            items.push({
-                text: is_playing_root_movie ? `Play (☑)` : `Play (☐)`,
-                onClick: () => this.instance?.toggle_play_root_movie(),
-            });
-            items.push({
-                text: `Rewind`,
-                onClick: () => this.instance?.rewind_root_movie(),
-                separator: false,
-            });
-            items.push({
-                text: `Forward`,
-                onClick: () => this.instance?.forward_root_movie(),
-                separator: false,
-            });
-            items.push({
-                text: `Back`,
-                onClick: () => this.instance?.back_root_movie(),
-            });
+            let can_show_default_menu_items = this.instance.can_show_default_menu_items();
+            if (can_show_default_menu_items) {
+                let is_playing_root_movie = this.instance.is_playing_root_movie();
+                items.push({
+                    text: is_playing_root_movie ? `Play (☑)` : `Play (☐)`,
+                    onClick: () => this.instance?.toggle_play_root_movie(),
+                });
+                items.push({
+                    text: `Rewind`,
+                    onClick: () => this.instance?.rewind_root_movie(),
+                    separator: false,
+                });
+                items.push({
+                    text: `Forward`,
+                    onClick: () => this.instance?.forward_root_movie(),
+                    separator: false,
+                });
+                items.push({
+                    text: `Back`,
+                    onClick: () => this.instance?.back_root_movie(),
+                });
+            }
         }
 
         items.push({

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -663,6 +663,7 @@ export class RufflePlayer extends HTMLElement {
     }
 
     private contextMenuItems(): ContextMenuItem[] {
+
         const items = [];
         if (this.fullscreenEnabled) {
             if (this.isFullscreen) {
@@ -677,6 +678,28 @@ export class RufflePlayer extends HTMLElement {
                 });
             }
         }
+        if (this.instance) {
+            let is_playing_root_movie = this.instance.is_playing_root_movie();
+            items.push({
+                text: is_playing_root_movie ? `Play (☑)` : `Play (☐)`,
+                onClick: () => this.instance?.toggle_play_root_movie(),
+            });
+            items.push({
+                text: `Rewind`,
+                onClick: () => this.instance?.rewind_root_movie(),
+                separator: false,
+            });
+            items.push({
+                text: `Forward`,
+                onClick: () => this.instance?.forward_root_movie(),
+                separator: false,
+            });
+            items.push({
+                text: `Back`,
+                onClick: () => this.instance?.back_root_movie(),
+            });
+        }
+
         items.push({
             text: `About Ruffle (%VERSION_NAME%)`,
             onClick() {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -272,6 +272,20 @@ impl Ruffle {
         })
     }
 
+    pub fn can_show_default_menu_items(&mut self) -> bool {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            let can_show_default_menu_items = instance
+                .borrow()
+                .core
+                .lock()
+                .unwrap()
+                .can_show_default_menu_items();
+            can_show_default_menu_items
+        })
+    }
+
     pub fn is_playing_root_movie(&mut self) -> bool {
         INSTANCES.with(|instances| {
             let instances = instances.borrow();

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -272,17 +272,20 @@ impl Ruffle {
         })
     }
 
-    pub fn can_show_default_menu_items(&mut self) -> bool {
+    pub fn get_builtin_menu_items(&mut self) -> Vec<JsValue> {
         INSTANCES.with(|instances| {
             let instances = instances.borrow();
             let instance = instances.get(self.0).unwrap();
-            let can_show_default_menu_items = instance
+            let builtin_menu_items = instance
                 .borrow()
                 .core
                 .lock()
                 .unwrap()
-                .can_show_default_menu_items();
-            can_show_default_menu_items
+                .get_builtin_menu_items();
+            builtin_menu_items
+                .into_iter()
+                .map(JsValue::from_str)
+                .collect()
         })
     }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -272,6 +272,57 @@ impl Ruffle {
         })
     }
 
+    pub fn is_playing_root_movie(&mut self) -> bool {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            let is_playing_root_movie = instance
+                .borrow()
+                .core
+                .lock()
+                .unwrap()
+                .is_playing_root_movie();
+            is_playing_root_movie
+        })
+    }
+
+    pub fn toggle_play_root_movie(&mut self) {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            instance
+                .borrow()
+                .core
+                .lock()
+                .unwrap()
+                .toggle_play_root_movie();
+        });
+    }
+
+    pub fn rewind_root_movie(&mut self) {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            instance.borrow().core.lock().unwrap().rewind_root_movie();
+        });
+    }
+
+    pub fn forward_root_movie(&mut self) {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            instance.borrow().core.lock().unwrap().forward_root_movie();
+        });
+    }
+
+    pub fn back_root_movie(&mut self) {
+        INSTANCES.with(|instances| {
+            let instances = instances.borrow();
+            let instance = instances.get(self.0).unwrap();
+            instance.borrow().core.lock().unwrap().back_root_movie();
+        });
+    }
+
     pub fn destroy(&mut self) {
         // Remove instance from the active list.
         if let Some(instance) = INSTANCES.with(|instances| {


### PR DESCRIPTION
Supported:

- [x] `Play` (with a checkbox signifying whether the root movie is playing, same as FP)
- [x] `Rewind`
- [x] `Forward`
- [x] `Back`
- [x] Display them in web context menu
- [x] Partial support for hiding these:
- - [x] `Stage.showMenu` in AVM1
- - [x] `Stage.showDefaultContextMenu` in AVM2 (note: didn't check if this shares the underlying flag with AVM1)
- - [x] partial `ContextMenu.builtInItems` support (see below)

Not supported, out of MVP scope:

- [ ] `Loop`
- [ ] Desktop context menu
- [ ] ~~Support for weird cases where root display object is not a MovieClip (didn't even test this)~~ The playback controls are now hidden for non-movies. Still didn't test if they _should_ be supported in cases like this though.
- [ ] Fixing frame playback-related bugs
- [ ] Regarding `ContextMenu.builtInItems`:
- - [ ] only supported on top-level movie clip (supporting .menu on arbitrary InteractiveObjects would require bigger rework of finding hovered items)
- - [ ] currently AVM1 only
- - [ ] "menu" property is read as an ordinary AS property lookup, while it should probably be retrieved from the Rust object directly via trait method. I think this might as well be done after InteractiveObject refactor? (as that's where menu property resides)
- - [ ] generally the code looks kinda ugly

Also no tests.

Playing with this PR exposes some bugs when moving across frames that the movie didn't intend - I'll post videos in the comment under PR. At least I'm assuming these are bugs and not me using the API incorrectly ;)