### PR TITLE
web: Remove unwraps from Rust glue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
  "ruffle_render_webgl",
  "ruffle_web_common",
  "serde",
+ "thiserror",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -37,6 +37,7 @@ wasm-bindgen-futures = "0.4.19"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.125", features = ["derive"] }
+thiserror = "1.0"
 
 [dependencies.ruffle_core]
 path = "../core"


### PR DESCRIPTION
Start some much needed clean up of the Rust code on the web. Remove all unwraps and avoid panics in web/lib.rs.

This should help avoid many of the panics we see in issues, e.g.: #3083, #4116, #4149... The root issues still need investigation, but mostly seems to be a) Ruffle trying to execute code after an instance has been destroyed, or b) a code loop between the Ruffle web instance and core that results in a double borrow panic. We should be able to gracefully ignore these.

 * Add convenience methods for grabbing the Ruffle web instance.
   These methods make the code much nicer to read and also avoid panics/unwraps when borrowing
   `RefCell`/`Mutex`.
 * Use `warn_on_error` to avoid unwraps from web APIs.

Future PRs
 * Clean up the JS event management code on the Rust side. I picture something like an `EventListener` struct that holds a collection of the event methods. A little difficult because you can't really make a heterogenous collection of `wasm_bindgen::Closure`.
