### PR TITLE
chore: Remove puremp3 feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,12 +191,6 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitstream-io"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614aa3f2bac03707e62a84d18a48dd3d9ea6171313fd5e6a53b5054d8ae74601"
-
-[[package]]
-name = "bitstream-io"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03539c739e37dab2c322ce07b1990089ca1fc7ad14b813e1538bf11bef98fe06"
@@ -2192,7 +2186,7 @@ name = "nellymoser-rs"
 version = "0.1.0"
 source = "git+https://github.com/ruffle-rs/nellymoser?branch=main#77000f763b58021295429ca5740e3dc3b5228cbd"
 dependencies = [
- "bitstream-io 1.0.0",
+ "bitstream-io",
  "rustdct",
 ]
 
@@ -2693,16 +2687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a66d5e88679f2720126c11ee29da07a08f094eac52306b066edd7d393752d6"
 
 [[package]]
-name = "puremp3"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b7efbb39e373af70c139e0611375fa6cad751fb93d528a610b55302710d883"
-dependencies = [
- "bitstream-io 0.8.5",
- "byteorder",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,7 +2859,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "bitflags",
- "bitstream-io 1.0.0",
+ "bitstream-io",
  "chrono",
  "downcast-rs",
  "encoding_rs",
@@ -2898,7 +2882,6 @@ dependencies = [
  "percent-encoding",
  "png",
  "pretty_assertions",
- "puremp3",
  "quick-xml",
  "rand",
  "regress",
@@ -3349,7 +3332,7 @@ version = "0.1.2"
 dependencies = [
  "approx",
  "bitflags",
- "bitstream-io 1.0.0",
+ "bitstream-io",
  "byteorder",
  "encoding_rs",
  "flate2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,6 @@ indexmap = "1.6.2"
 log = "0.4"
 minimp3 = { version = "0.5.1", optional = true }
 png = { version = "0.16.8" }
-puremp3 = { version = "0.1", optional = true }
 ruffle_macros = { path = "macros" }
 swf = { path = "../swf" }
 bitflags = "1.2.1"

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -1,13 +1,13 @@
 //! Audio decoders.
 
 mod adpcm;
-#[cfg(any(feature = "puremp3", feature = "minimp3"))]
+#[cfg(feature = "minimp3")]
 mod mp3;
 mod nellymoser;
 mod pcm;
 
 pub use adpcm::AdpcmDecoder;
-#[cfg(any(feature = "puremp3", feature = "minimp3"))]
+#[cfg(feature = "minimp3")]
 pub use mp3::Mp3Decoder;
 pub use nellymoser::NellymoserDecoder;
 pub use pcm::PcmDecoder;
@@ -55,7 +55,7 @@ pub fn make_decoder<'a, R: 'a + Send + Read>(
             format.is_stereo,
             format.sample_rate,
         )),
-        #[cfg(any(feature = "puremp3", feature = "minimp3"))]
+        #[cfg(feature = "minimp3")]
         AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
             if format.is_stereo { 2 } else { 1 },
             format.sample_rate.into(),

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -82,40 +82,6 @@ impl<R: AsRef<[u8]> + Default> SeekableDecoder for Mp3Decoder<Cursor<R>> {
     }
 }
 
-#[cfg(all(feature = "puremp3", not(feature = "minimp3")))]
-pub struct Mp3Decoder<R: Read> {
-    decoder: puremp3::Mp3Decoder<R>,
-    sample_rate: u32,
-    num_channels: u16,
-    cur_frame: puremp3::Frame,
-    cur_sample: usize,
-    cur_channel: usize,
-}
-
-#[cfg(all(feature = "puremp3", not(feature = "minimp3")))]
-impl<R: Read> Mp3Decoder<R> {
-    pub fn new(num_channels: u16, sample_rate: u32, reader: R) -> Self {
-        Mp3Decoder {
-            decoder: puremp3::Mp3Decoder::new(reader),
-            num_channels,
-            sample_rate,
-            cur_frame: unsafe { std::mem::MaybeUninit::zeroed().assume_init() },
-            cur_sample: 0,
-            cur_channel: 0,
-        }
-    }
-
-    fn next_frame(&mut self) {
-        if let Ok(frame) = self.decoder.next_frame() {
-            self.cur_frame = frame;
-        } else {
-            self.cur_frame.num_samples = 0;
-        }
-        self.cur_sample = 0;
-        self.cur_channel = 0;
-    }
-}
-
 impl<R: Read> Decoder for Mp3Decoder<R> {
     #[inline]
     fn num_channels(&self) -> u8 {
@@ -125,48 +91,5 @@ impl<R: Read> Decoder for Mp3Decoder<R> {
     #[inline]
     fn sample_rate(&self) -> u16 {
         self.sample_rate as u16
-    }
-}
-
-#[cfg(all(feature = "puremp3", not(feature = "minimp3")))]
-impl<R: Read> Iterator for Mp3Decoder<R> {
-    type Item = [i16; 2];
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.cur_sample >= self.cur_frame.num_samples {
-            self.next_frame();
-        }
-
-        if self.cur_frame.num_samples > 0 {
-            let (left, right) = if self.num_channels == 1 {
-                (
-                    self.cur_frame.samples[0][self.cur_sample],
-                    self.cur_frame.samples[0][self.cur_sample],
-                )
-            } else {
-                (
-                    self.cur_frame.samples[0][self.cur_sample],
-                    self.cur_frame.samples[1][self.cur_sample],
-                )
-            };
-            self.cur_sample += 1;
-            Some([(left * 32767.0) as i16, (right * 32767.0) as i16])
-        } else {
-            None
-        }
-    }
-}
-
-#[cfg(all(feature = "puremp3", not(feature = "minimp3")))]
-impl<R: AsRef<[u8]> + Default> SeekableDecoder for Mp3Decoder<Cursor<R>> {
-    #[inline]
-    fn reset(&mut self) {
-        // TODO: This is funky.
-        // I want to reset the `BitStream` and `Cursor` to their initial positions,
-        // but have to work around the borrowing rules of Rust.
-        let mut cursor = std::mem::replace(self.decoder.get_mut(), Default::default());
-        cursor.set_position(0);
-        *self = Mp3Decoder::new(self.num_channels, self.sample_rate, cursor);
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "1.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["puremp3", "serde", "wasm-bindgen"]
+features = ["serde", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.45"

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -1,7 +1,7 @@
 use fnv::FnvHashMap;
 use generational_arena::Arena;
 use ruffle_core::backend::audio::{
-    decoders::{AdpcmDecoder, Mp3Decoder, NellymoserDecoder},
+    decoders::{AdpcmDecoder, NellymoserDecoder},
     swf::{self, AudioCompression},
     AudioBackend, PreloadStreamHandle, SoundHandle, SoundInstanceHandle, SoundTransform,
 };
@@ -446,11 +446,6 @@ impl WebAudioBackend {
                         std::io::Cursor::new(audio_data.to_vec()),
                         sound.format.is_stereo,
                         sound.format.sample_rate,
-                    )),
-                    AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
-                        if sound.format.is_stereo { 2 } else { 1 },
-                        sound.format.sample_rate.into(),
-                        std::io::Cursor::new(audio_data.to_vec()), //&sound.data[..]
                     )),
                     AudioCompression::Nellymoser => Box::new(NellymoserDecoder::new(
                         std::io::Cursor::new(audio_data.to_vec()),


### PR DESCRIPTION
Remove the unused puremp3 dependency. Possibly replace with https://github.com/pdeljanov/Symphonia if/when start actually decoding MP3 ourselves on web.

