### PR TITLE
avm2: Generate class traits from const arrays

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -1,6 +1,6 @@
 //! AVM2 classes
 
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Multiname, Namespace, QName};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::string::AvmString;
@@ -378,7 +378,7 @@ impl<'gc> Class<'gc> {
     #[inline(never)]
     pub fn define_public_builtin_instance_methods(
         &mut self,
-        items: &[(&'static str, GenericNativeMethod)],
+        items: &[(&'static str, NativeMethod)],
     ) {
         for &(name, value) in items {
             self.define_instance_trait(Trait::from_method(
@@ -388,10 +388,7 @@ impl<'gc> Class<'gc> {
         }
     }
     #[inline(never)]
-    pub fn define_as3_builtin_instance_methods(
-        &mut self,
-        items: &[(&'static str, GenericNativeMethod)],
-    ) {
+    pub fn define_as3_builtin_instance_methods(&mut self, items: &[(&'static str, NativeMethod)]) {
         for &(name, value) in items {
             self.define_instance_trait(Trait::from_method(
                 QName::new(Namespace::as3_namespace(), name),
@@ -400,10 +397,7 @@ impl<'gc> Class<'gc> {
         }
     }
     #[inline(never)]
-    pub fn define_public_builtin_class_methods(
-        &mut self,
-        items: &[(&'static str, GenericNativeMethod)],
-    ) {
+    pub fn define_public_builtin_class_methods(&mut self, items: &[(&'static str, NativeMethod)]) {
         for &(name, value) in items {
             self.define_class_trait(Trait::from_method(
                 QName::new(Namespace::public(), name),
@@ -414,11 +408,7 @@ impl<'gc> Class<'gc> {
     #[inline(never)]
     pub fn define_public_builtin_instance_properties(
         &mut self,
-        items: &[(
-            &'static str,
-            Option<GenericNativeMethod>,
-            Option<GenericNativeMethod>,
-        )],
+        items: &[(&'static str, Option<NativeMethod>, Option<NativeMethod>)],
     ) {
         for &(name, getter, setter) in items {
             if let Some(getter) = getter {
@@ -443,7 +433,6 @@ impl<'gc> Class<'gc> {
     pub fn define_class_trait(&mut self, my_trait: Trait<'gc>) {
         self.class_traits.push(my_trait);
     }
-
 
     /// Given a name, append class traits matching the name to a list of known
     /// traits.

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -1,6 +1,6 @@
 //! AVM2 classes
 
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Multiname, Namespace, QName};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::string::AvmString;
@@ -342,6 +342,100 @@ impl<'gc> Class<'gc> {
         &self.super_class
     }
 
+    #[inline(never)]
+    pub fn define_public_constant_string_class_traits(
+        &mut self,
+        items: &[(&'static str, &'static str)],
+    ) {
+        for &(name, value) in items {
+            self.define_class_trait(Trait::from_const(
+                QName::new(Namespace::public(), name),
+                QName::new(Namespace::public(), "String").into(),
+                Some(value.into()),
+            ));
+        }
+    }
+    #[inline(never)]
+    pub fn define_public_constant_number_class_traits(&mut self, items: &[(&'static str, f64)]) {
+        for &(name, value) in items {
+            self.define_class_trait(Trait::from_const(
+                QName::new(Namespace::public(), name),
+                QName::new(Namespace::public(), "Number").into(),
+                Some(value.into()),
+            ));
+        }
+    }
+    #[inline(never)]
+    pub fn define_public_constant_uint_class_traits(&mut self, items: &[(&'static str, u32)]) {
+        for &(name, value) in items {
+            self.define_class_trait(Trait::from_const(
+                QName::new(Namespace::public(), name),
+                QName::new(Namespace::public(), "uint").into(),
+                Some(value.into()),
+            ));
+        }
+    }
+    #[inline(never)]
+    pub fn define_public_builtin_instance_methods(
+        &mut self,
+        items: &[(&'static str, GenericNativeMethod)],
+    ) {
+        for &(name, value) in items {
+            self.define_instance_trait(Trait::from_method(
+                QName::new(Namespace::public(), name),
+                Method::from_builtin(value),
+            ));
+        }
+    }
+    #[inline(never)]
+    pub fn define_as3_builtin_instance_methods(
+        &mut self,
+        items: &[(&'static str, GenericNativeMethod)],
+    ) {
+        for &(name, value) in items {
+            self.define_instance_trait(Trait::from_method(
+                QName::new(Namespace::as3_namespace(), name),
+                Method::from_builtin(value),
+            ));
+        }
+    }
+    #[inline(never)]
+    pub fn define_public_builtin_class_methods(
+        &mut self,
+        items: &[(&'static str, GenericNativeMethod)],
+    ) {
+        for &(name, value) in items {
+            self.define_class_trait(Trait::from_method(
+                QName::new(Namespace::public(), name),
+                Method::from_builtin(value),
+            ));
+        }
+    }
+    #[inline(never)]
+    pub fn define_public_builtin_instance_properties(
+        &mut self,
+        items: &[(
+            &'static str,
+            Option<GenericNativeMethod>,
+            Option<GenericNativeMethod>,
+        )],
+    ) {
+        for &(name, getter, setter) in items {
+            if let Some(getter) = getter {
+                self.define_instance_trait(Trait::from_getter(
+                    QName::new(Namespace::public(), name),
+                    Method::from_builtin(getter),
+                ));
+            }
+            if let Some(setter) = setter {
+                self.define_instance_trait(Trait::from_setter(
+                    QName::new(Namespace::public(), name),
+                    Method::from_builtin(setter),
+                ));
+            }
+        }
+    }
+
     /// Define a trait on the class.
     ///
     /// Class traits will be accessible as properties on the class constructor
@@ -349,6 +443,7 @@ impl<'gc> Class<'gc> {
     pub fn define_class_trait(&mut self, my_trait: Trait<'gc>) {
         self.class_traits.push(my_trait);
     }
+
 
     /// Given a name, append class traits matching the name to a list of known
     /// traits.

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -33,7 +33,7 @@ pub enum Executable<'gc> {
     /// Code defined in Ruffle's binary.
     ///
     /// The second parameter stores the bound receiver for this function.
-    Native(NativeMethod<'gc>, Option<Object<'gc>>),
+    Native(NativeMethod, Option<Object<'gc>>),
 
     /// Code defined in a loaded ABC file.
     Action(Gc<'gc, BytecodeExecutable<'gc>>),

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -164,7 +164,7 @@ fn function<'gc>(
     mc: MutationContext<'gc, '_>,
     package: impl Into<AvmString<'gc>>,
     name: impl Into<AvmString<'gc>>,
-    nf: NativeMethod<'gc>,
+    nf: NativeMethod,
     fn_proto: Object<'gc>,
     mut domain: Domain<'gc>,
     script: Script<'gc>,

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::array::ArrayStorage;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{ArrayObject, Object, TObject};
 use crate::avm2::string::AvmString;
@@ -1229,7 +1229,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("toString", to_string),
         ("toLocaleString", to_locale_string),
         ("valueOf", value_of),
@@ -1238,12 +1238,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("length", Some(length), Some(set_length))];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const AS3_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const AS3_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("concat", concat),
         ("join", join),
         ("forEach", for_each),

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1228,145 +1228,147 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         mc,
     );
 
-    class.write(mc).define_instance_trait(Trait::from_getter(
+    let mut write = class.write(mc);
+
+    write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public(), "length"),
         Method::from_builtin(length),
     ));
-    class.write(mc).define_instance_trait(Trait::from_setter(
+    write.define_instance_trait(Trait::from_setter(
         QName::new(Namespace::public(), "length"),
         Method::from_builtin(set_length),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "concat"),
         Method::from_builtin(concat),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "join"),
         Method::from_builtin(join),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "toString"),
         Method::from_builtin(to_string),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "toLocaleString"),
         Method::from_builtin(to_locale_string),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "valueOf"),
         Method::from_builtin(value_of),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "forEach"),
         Method::from_builtin(for_each),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "map"),
         Method::from_builtin(map),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "filter"),
         Method::from_builtin(filter),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "every"),
         Method::from_builtin(every),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "some"),
         Method::from_builtin(some),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "indexOf"),
         Method::from_builtin(index_of),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "lastIndexOf"),
         Method::from_builtin(last_index_of),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "pop"),
         Method::from_builtin(pop),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "push"),
         Method::from_builtin(push),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "reverse"),
         Method::from_builtin(reverse),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "shift"),
         Method::from_builtin(shift),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "unshift"),
         Method::from_builtin(unshift),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "slice"),
         Method::from_builtin(slice),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "splice"),
         Method::from_builtin(splice),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "sort"),
         Method::from_builtin(sort),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::as3_namespace(), "sortOn"),
         Method::from_builtin(sort_on),
     ));
 
-    class.write(mc).define_class_trait(Trait::from_const(
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "CASEINSENSITIVE"),
         Multiname::from(QName::new(Namespace::public(), "uint")),
         Some(SortOptions::CASE_INSENSITIVE.bits().into()),
     ));
 
-    class.write(mc).define_class_trait(Trait::from_const(
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "DESCENDING"),
         Multiname::from(QName::new(Namespace::public(), "uint")),
         Some(SortOptions::DESCENDING.bits().into()),
     ));
 
-    class.write(mc).define_class_trait(Trait::from_const(
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "NUMERIC"),
         Multiname::from(QName::new(Namespace::public(), "uint")),
         Some(SortOptions::NUMERIC.bits().into()),
     ));
 
-    class.write(mc).define_class_trait(Trait::from_const(
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "RETURNINDEXEDARRAY"),
         Multiname::from(QName::new(Namespace::public(), "uint")),
         Some(SortOptions::RETURN_INDEXED_ARRAY.bits().into()),
     ));
 
-    class.write(mc).define_class_trait(Trait::from_const(
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "UNIQUESORT"),
         Multiname::from(QName::new(Namespace::public(), "uint")),
         Some(SortOptions::UNIQUE_SORT.bits().into()),

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1229,21 +1229,18 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("toString", to_string),
         ("toLocaleString", to_locale_string),
         ("valueOf", value_of),
     ];
     write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("length", Some(length), Some(set_length))];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("length", Some(length), Some(set_length))];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const AS3_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const AS3_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("concat", concat),
         ("join", join),
         ("forEach", for_each),
@@ -1265,7 +1262,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 
-    const CONSTANTS: &[(&'static str, u32)] = &[
+    const CONSTANTS: &[(&str, u32)] = &[
         (
             "CASEINSENSITIVE",
             SortOptions::CASE_INSENSITIVE.bits() as u32,

--- a/core/src/avm2/globals/flash/display/actionscriptversion.rs
+++ b/core/src/avm2/globals/flash/display/actionscriptversion.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, u32)] = &[("ACTIONSCRIPT2", 2), ("ACTIONSCRIPT3", 3)];
+    const CONSTANTS: &[(&str, u32)] = &[("ACTIONSCRIPT2", 2), ("ACTIONSCRIPT3", 3)];
     write.define_public_constant_uint_class_traits(CONSTANTS);
 
     class

--- a/core/src/avm2/globals/flash/display/actionscriptversion.rs
+++ b/core/src/avm2/globals/flash/display/actionscriptversion.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,16 +45,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ACTIONSCRIPT2"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(2.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ACTIONSCRIPT3"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(3.into()),
-    ));
+    const CONSTANTS: &[(&'static str, u32)] = &[("ACTIONSCRIPT2", 2), ("ACTIONSCRIPT3", 3)];
+    write.define_public_constant_uint_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/capsstyle.rs
+++ b/core/src/avm2/globals/flash/display/capsstyle.rs
@@ -44,7 +44,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
 
     write.set_attributes(ClassAttributes::SEALED);
-    const CONSTANTS: &[(&'static str, &'static str)] =
+    const CONSTANTS: &[(&str, &str)] =
         &[("NONE", "none"), ("ROUND", "round"), ("SQUARE", "square")];
     write.define_public_constant_string_class_traits(CONSTANTS);
 

--- a/core/src/avm2/globals/flash/display/capsstyle.rs
+++ b/core/src/avm2/globals/flash/display/capsstyle.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -45,22 +44,9 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
 
     write.set_attributes(ClassAttributes::SEALED);
-
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NONE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("none".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ROUND"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("round".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SQUARE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("square".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] =
+        &[("NONE", "none"), ("ROUND", "round"), ("SQUARE", "square")];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -597,11 +597,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("alpha", Some(alpha), Some(set_alpha)),
         ("height", Some(height), Some(set_height)),
         ("scaleY", Some(scale_y), Some(set_scale_y)),
@@ -621,7 +617,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("hitTestPoint", hit_test_point),
         ("hitTestObject", hit_test_object),
     ];

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{LoaderInfoObject, Object, TObject};
 use crate::avm2::string::AvmString;
@@ -599,8 +599,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("alpha", Some(alpha), Some(set_alpha)),
         ("height", Some(height), Some(set_height)),
@@ -621,7 +621,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("hitTestPoint", hit_test_point),
         ("hitTestObject", hit_test_object),
     ];

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -2,11 +2,10 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{LoaderInfoObject, Object, TObject};
 use crate::avm2::string::AvmString;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::{DisplayObject, HitTestOptions, TDisplayObject};
@@ -598,118 +597,35 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "alpha"),
-        Method::from_builtin(alpha),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "alpha"),
-        Method::from_builtin(set_alpha),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "height"),
-        Method::from_builtin(height),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "height"),
-        Method::from_builtin(set_height),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "scaleY"),
-        Method::from_builtin(scale_y),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "scaleY"),
-        Method::from_builtin(set_scale_y),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "width"),
-        Method::from_builtin(width),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "width"),
-        Method::from_builtin(set_width),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "scaleX"),
-        Method::from_builtin(scale_x),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "scaleX"),
-        Method::from_builtin(set_scale_x),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "x"),
-        Method::from_builtin(x),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "x"),
-        Method::from_builtin(set_x),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "y"),
-        Method::from_builtin(y),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "y"),
-        Method::from_builtin(set_y),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "rotation"),
-        Method::from_builtin(rotation),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "rotation"),
-        Method::from_builtin(set_rotation),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "name"),
-        Method::from_builtin(name),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "name"),
-        Method::from_builtin(set_name),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "parent"),
-        Method::from_builtin(parent),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "root"),
-        Method::from_builtin(root),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "stage"),
-        Method::from_builtin(stage),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "visible"),
-        Method::from_builtin(visible),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "visible"),
-        Method::from_builtin(set_visible),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "mouseX"),
-        Method::from_builtin(mouse_x),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "mouseY"),
-        Method::from_builtin(mouse_y),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "hitTestPoint"),
-        Method::from_builtin(hit_test_point),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "hitTestObject"),
-        Method::from_builtin(hit_test_object),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "loaderInfo"),
-        Method::from_builtin(loader_info),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("alpha", Some(alpha), Some(set_alpha)),
+        ("height", Some(height), Some(set_height)),
+        ("scaleY", Some(scale_y), Some(set_scale_y)),
+        ("width", Some(width), Some(set_width)),
+        ("scaleX", Some(scale_x), Some(set_scale_x)),
+        ("x", Some(x), Some(set_x)),
+        ("y", Some(y), Some(set_y)),
+        ("rotation", Some(rotation), Some(set_rotation)),
+        ("name", Some(name), Some(set_name)),
+        ("parent", Some(parent), None),
+        ("root", Some(root), None),
+        ("stage", Some(stage), None),
+        ("visible", Some(visible), Some(set_visible)),
+        ("mouseX", Some(mouse_x), None),
+        ("mouseY", Some(mouse_y), None),
+        ("loaderInfo", Some(loader_info), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
+
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("hitTestPoint", hit_test_point),
+        ("hitTestObject", hit_test_object),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::context::UpdateContext;
@@ -586,70 +585,34 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "getChildAt"),
-        Method::from_builtin(get_child_at),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "getChildByName"),
-        Method::from_builtin(get_child_by_name),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "numChildren"),
-        Method::from_builtin(num_children),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "addChild"),
-        Method::from_builtin(add_child),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "addChildAt"),
-        Method::from_builtin(add_child_at),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "removeChild"),
-        Method::from_builtin(remove_child),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "contains"),
-        Method::from_builtin(contains),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "getChildIndex"),
-        Method::from_builtin(get_child_index),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "removeChildAt"),
-        Method::from_builtin(remove_child_at),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "removeChildren"),
-        Method::from_builtin(remove_children),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "setChildIndex"),
-        Method::from_builtin(set_child_index),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "swapChildrenAt"),
-        Method::from_builtin(swap_children_at),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "swapChildren"),
-        Method::from_builtin(swap_children),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "stopAllMovieClips"),
-        Method::from_builtin(stop_all_movie_clips),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "getObjectsUnderPoint"),
-        Method::from_builtin(get_objects_under_point),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "areInaccessibleObjectsUnderPoint"),
-        Method::from_builtin(are_inaccessible_objects_under_point),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("numChildren", Some(num_children), None)];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
+
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("getChildAt", get_child_at),
+        ("getChildByName", get_child_by_name),
+        ("addChild", add_child),
+        ("addChildAt", add_child_at),
+        ("removeChild", remove_child),
+        ("contains", contains),
+        ("getChildIndex", get_child_index),
+        ("removeChildAt", remove_child_at),
+        ("removeChildren", remove_children),
+        ("setChildIndex", set_child_index),
+        ("swapChildrenAt", swap_children_at),
+        ("swapChildren", swap_children),
+        ("stopAllMovieClips", stop_all_movie_clips),
+        ("getObjectsUnderPoint", get_objects_under_point),
+        (
+            "areInaccessibleObjectsUnderPoint",
+            are_inaccessible_objects_under_point,
+        ),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -585,14 +585,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("numChildren", Some(num_children), None)];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("numChildren", Some(num_children), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("getChildAt", get_child_at),
         ("getChildByName", get_child_by_name),
         ("addChild", add_child),

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
@@ -587,12 +587,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("numChildren", Some(num_children), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("getChildAt", get_child_at),
         ("getChildByName", get_child_by_name),
         ("addChild", add_child),

--- a/core/src/avm2/globals/flash/display/framelabel.rs
+++ b/core/src/avm2/globals/flash/display/framelabel.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -102,15 +101,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "name"),
-        Method::from_builtin(name),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "frame"),
-        Method::from_builtin(frame),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("name", Some(name), None), ("frame", Some(frame), None)];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/framelabel.rs
+++ b/core/src/avm2/globals/flash/display/framelabel.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
@@ -103,8 +103,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("name", Some(name), None), ("frame", Some(frame), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/framelabel.rs
+++ b/core/src/avm2/globals/flash/display/framelabel.rs
@@ -101,11 +101,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("name", Some(name), None), ("frame", Some(frame), None)];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("name", Some(name), None), ("frame", Some(frame), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -365,7 +365,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("beginFill", begin_fill),
         ("clear", clear),
         ("curveTo", curve_to),

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
@@ -365,7 +365,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("beginFill", begin_fill),
         ("clear", clear),
         ("curveTo", curve_to),

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::TDisplayObject;
@@ -366,38 +365,17 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "beginFill"),
-        Method::from_builtin(begin_fill),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "clear"),
-        Method::from_builtin(clear),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "curveTo"),
-        Method::from_builtin(curve_to),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "endFill"),
-        Method::from_builtin(end_fill),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "lineStyle"),
-        Method::from_builtin(line_style),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "lineTo"),
-        Method::from_builtin(line_to),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "moveTo"),
-        Method::from_builtin(move_to),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "drawRect"),
-        Method::from_builtin(draw_rect),
-    ));
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("beginFill", begin_fill),
+        ("clear", clear),
+        ("curveTo", curve_to),
+        ("endFill", end_fill),
+        ("lineStyle", line_style),
+        ("lineTo", line_to),
+        ("moveTo", move_to),
+        ("drawRect", draw_rect),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/jointstyle.rs
+++ b/core/src/avm2/globals/flash/display/jointstyle.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,21 +45,9 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BEVEL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("bevel".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "MITER"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("miter".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ROUND"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("round".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] =
+        &[("BEVEL", "bevel"), ("MITER", "miter"), ("ROUND", "round")];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/jointstyle.rs
+++ b/core/src/avm2/globals/flash/display/jointstyle.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, &'static str)] =
+    const CONSTANTS: &[(&str, &str)] =
         &[("BEVEL", "bevel"), ("MITER", "miter"), ("ROUND", "round")];
     write.define_public_constant_string_class_traits(CONSTANTS);
 

--- a/core/src/avm2/globals/flash/display/linescalemode.rs
+++ b/core/src/avm2/globals/flash/display/linescalemode.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("HORIZONTAL", "horizontal"),
         ("NONE", "none"),
         ("NORMAL", "normal"),

--- a/core/src/avm2/globals/flash/display/linescalemode.rs
+++ b/core/src/avm2/globals/flash/display/linescalemode.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,26 +45,13 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HORIZONTAL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("horizontal".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NONE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("none".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NORMAL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("normal".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "VERTICAL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("vertical".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("HORIZONTAL", "horizontal"),
+        ("NONE", "none"),
+        ("NORMAL", "normal"),
+        ("VERTICAL", "vertical"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::bytearray::Endian;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{
     ByteArrayObject, DomainObject, LoaderInfoObject, LoaderStream, Object, ScriptObject, TObject,
@@ -435,8 +435,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("actionScriptVersion", Some(action_script_version), None),
         ("applicationDomain", Some(application_domain), None),

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -3,13 +3,12 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::bytearray::Endian;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{
     ByteArrayObject, DomainObject, LoaderInfoObject, LoaderStream, Object, ScriptObject, TObject,
 };
 use crate::avm2::scope::Scope;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::{AvmString, Error};
 use crate::display_object::TDisplayObject;
@@ -434,66 +433,28 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "actionScriptVersion"),
-        Method::from_builtin(action_script_version),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "applicationDomain"),
-        Method::from_builtin(application_domain),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "bytesLoaded"),
-        Method::from_builtin(bytes_total),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "bytesTotal"),
-        Method::from_builtin(bytes_total),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "content"),
-        Method::from_builtin(content),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "contentType"),
-        Method::from_builtin(content_type),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "frameRate"),
-        Method::from_builtin(frame_rate),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "height"),
-        Method::from_builtin(height),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "isURLInaccessible"),
-        Method::from_builtin(is_url_inaccessible),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "swfVersion"),
-        Method::from_builtin(swf_version),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "url"),
-        Method::from_builtin(url),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "width"),
-        Method::from_builtin(width),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "bytes"),
-        Method::from_builtin(bytes),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "loaderUrl"),
-        Method::from_builtin(loader_url),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "parameters"),
-        Method::from_builtin(parameters),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("actionScriptVersion", Some(action_script_version), None),
+        ("applicationDomain", Some(application_domain), None),
+        ("bytesLoaded", Some(bytes_total), None),
+        ("bytesTotal", Some(bytes_total), None),
+        ("content", Some(content), None),
+        ("contentType", Some(content_type), None),
+        ("frameRate", Some(frame_rate), None),
+        ("height", Some(height), None),
+        ("isURLInaccessible", Some(is_url_inaccessible), None),
+        ("swfVersion", Some(swf_version), None),
+        ("url", Some(url), None),
+        ("width", Some(width), None),
+        ("bytes", Some(bytes), None),
+        ("loaderUrl", Some(loader_url), None),
+        ("parameters", Some(parameters), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -433,11 +433,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("actionScriptVersion", Some(action_script_version), None),
         ("applicationDomain", Some(application_domain), None),
         ("bytesLoaded", Some(bytes_total), None),

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -4,11 +4,10 @@ use crate::avm2::activation::Activation;
 use crate::avm2::array::ArrayStorage;
 use crate::avm2::class::Class;
 use crate::avm2::globals::flash::display::{framelabel, scene};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{ArrayObject, Object, TObject};
 use crate::avm2::string::AvmString;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::{MovieClip, Scene, TDisplayObject};
@@ -547,95 +546,35 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "addFrameScript"),
-        Method::from_builtin(add_frame_script),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("currentFrame", Some(current_frame), None),
+        ("currentFrameLabel", Some(current_frame_label), None),
+        ("currentLabel", Some(current_label), None),
+        ("currentLabels", Some(current_labels), None),
+        ("currentScene", Some(current_scene), None),
+        ("scenes", Some(scenes), None),
+        ("framesLoaded", Some(frames_loaded), None),
+        ("isPlaying", Some(is_playing), None),
+        ("totalFrames", Some(total_frames), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentFrame"),
-        Method::from_builtin(current_frame),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentFrameLabel"),
-        Method::from_builtin(current_frame_label),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentLabel"),
-        Method::from_builtin(current_label),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentLabels"),
-        Method::from_builtin(current_labels),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentScene"),
-        Method::from_builtin(current_scene),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "scenes"),
-        Method::from_builtin(scenes),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "framesLoaded"),
-        Method::from_builtin(frames_loaded),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "isPlaying"),
-        Method::from_builtin(is_playing),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "totalFrames"),
-        Method::from_builtin(total_frames),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "gotoAndPlay"),
-        Method::from_builtin(goto_and_play),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "gotoAndStop"),
-        Method::from_builtin(goto_and_stop),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "stop"),
-        Method::from_builtin(stop),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "play"),
-        Method::from_builtin(play),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "prevFrame"),
-        Method::from_builtin(prev_frame),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "nextFrame"),
-        Method::from_builtin(next_frame),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "prevScene"),
-        Method::from_builtin(prev_scene),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "nextScene"),
-        Method::from_builtin(next_scene),
-    ));
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("addFrameScript", add_frame_script),
+        ("gotoAndPlay", goto_and_play),
+        ("gotoAndStop", goto_and_stop),
+        ("stop", stop),
+        ("play", play),
+        ("prevFrame", prev_frame),
+        ("nextFrame", next_frame),
+        ("prevScene", prev_scene),
+        ("nextScene", next_scene),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -4,7 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::array::ArrayStorage;
 use crate::avm2::class::Class;
 use crate::avm2::globals::flash::display::{framelabel, scene};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{ArrayObject, Object, TObject};
 use crate::avm2::string::AvmString;
@@ -548,8 +548,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("currentFrame", Some(current_frame), None),
         ("currentFrameLabel", Some(current_frame_label), None),
@@ -563,7 +563,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("addFrameScript", add_frame_script),
         ("gotoAndPlay", goto_and_play),
         ("gotoAndStop", goto_and_stop),

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -546,11 +546,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("currentFrame", Some(current_frame), None),
         ("currentFrameLabel", Some(current_frame_label), None),
         ("currentLabel", Some(current_label), None),
@@ -563,7 +559,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("addFrameScript", add_frame_script),
         ("gotoAndPlay", goto_and_play),
         ("gotoAndStop", goto_and_stop),

--- a/core/src/avm2/globals/flash/display/scene.rs
+++ b/core/src/avm2/globals/flash/display/scene.rs
@@ -125,11 +125,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("labels", Some(labels), None),
         ("name", Some(name), None),
         ("numFrames", Some(num_frames), None),

--- a/core/src/avm2/globals/flash/display/scene.rs
+++ b/core/src/avm2/globals/flash/display/scene.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
@@ -127,8 +127,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("labels", Some(labels), None),
         ("name", Some(name), None),

--- a/core/src/avm2/globals/flash/display/scene.rs
+++ b/core/src/avm2/globals/flash/display/scene.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -126,20 +125,16 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "labels"),
-        Method::from_builtin(labels),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "name"),
-        Method::from_builtin(name),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "numFrames"),
-        Method::from_builtin(num_frames),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("labels", Some(labels), None),
+        ("name", Some(name), None),
+        ("numFrames", Some(num_frames), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, StageObject, TObject};
 use crate::avm2::traits::Trait;
@@ -97,10 +97,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "graphics"),
-        Method::from_builtin(graphics),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("graphics", Some(graphics), None)];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     // Slot for lazy-initialized Graphics object.
     write.define_instance_trait(Trait::from_slot(

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -97,11 +97,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("graphics", Some(graphics), None)];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("graphics", Some(graphics), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     // Slot for lazy-initialized Graphics object.

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, StageObject, TObject};
 use crate::avm2::traits::Trait;
@@ -99,8 +99,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("graphics", Some(graphics), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, StageObject, TObject};
 use crate::avm2::traits::Trait;
@@ -91,11 +91,14 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "graphics"),
-        Method::from_builtin(graphics),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("graphics", Some(graphics), None)];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
+    // Slot for lazy-initialized Graphics object.
     write.define_instance_trait(Trait::from_slot(
         QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
         QName::new(Namespace::package("flash.display"), "Graphics").into(),

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, StageObject, TObject};
 use crate::avm2::traits::Trait;
@@ -93,8 +93,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("graphics", Some(graphics), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -91,11 +91,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("graphics", Some(graphics), None)];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("graphics", Some(graphics), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     // Slot for lazy-initialized Graphics object.

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -615,7 +615,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_attributes(ClassAttributes::SEALED);
 
     const PUBLIC_OVERRIDE_INSTANCE_PROPERTIES: &[(
-        &'static str,
+        &str,
         Option<NativeMethod>,
         Option<NativeMethod>,
     )] = &[
@@ -668,11 +668,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         }
     }
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("align", Some(align), Some(set_align)),
         ("browserZoomFactor", Some(browser_zoom_factor), None),
         ("color", Some(color), Some(set_color)),

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
@@ -614,265 +614,89 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "accessibilityProperties"),
-            Method::from_builtin(set_accessibility_properties),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "alpha"),
-            Method::from_builtin(set_alpha),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "blendMode"),
-            Method::from_builtin(set_blend_mode),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "cacheAsBitmap"),
-            Method::from_builtin(set_cache_as_bitmap),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "contextMenu"),
-            Method::from_builtin(set_context_menu),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "filters"),
-            Method::from_builtin(set_filters),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "focusRect"),
-            Method::from_builtin(set_focus_rect),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "loaderInfo"),
-            Method::from_builtin(set_loader_info),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "mask"),
-            Method::from_builtin(set_mask),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "mouseEnabled"),
-            Method::from_builtin(set_mouse_enabled),
-        )
-        .with_override(),
-    );
+    const PUBLIC_OVERRIDE_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        (
+            "accessibilityProperties",
+            None,
+            Some(set_accessibility_properties),
+        ),
+        ("alpha", None, Some(set_alpha)),
+        ("blendMode", None, Some(set_blend_mode)),
+        ("cacheAsBitmap", None, Some(set_cache_as_bitmap)),
+        ("contextMenu", None, Some(set_context_menu)),
+        ("filters", None, Some(set_filters)),
+        ("focusRect", None, Some(set_focus_rect)),
+        ("loaderInfo", None, Some(set_loader_info)),
+        ("mask", None, Some(set_mask)),
+        ("mouseEnabled", None, Some(set_mouse_enabled)),
+        ("name", Some(name), Some(set_name)),
+        ("opaqueBackground", None, Some(set_opaque_background)),
+        ("rotation", None, Some(set_rotation)),
+        ("scale9Grid", None, Some(set_scale_nine_grid)),
+        ("scaleX", None, Some(set_scale_x)),
+        ("scaleY", None, Some(set_scale_y)),
+        ("scrollRect", None, Some(set_scroll_rect)),
+        ("tabEnabled", None, Some(set_tab_enabled)),
+        ("tabIndex", None, Some(set_tab_index)),
+        ("transform", None, Some(set_transform)),
+        ("visible", None, Some(set_visible)),
+        ("x", None, Some(set_x)),
+        ("y", None, Some(set_y)),
+    ];
+    for &(name, getter, setter) in PUBLIC_OVERRIDE_INSTANCE_PROPERTIES {
+        if let Some(getter) = getter {
+            write.define_instance_trait(
+                Trait::from_getter(
+                    QName::new(Namespace::public(), name),
+                    Method::from_builtin(getter),
+                )
+                .with_override(),
+            );
+        }
+        if let Some(setter) = setter {
+            write.define_instance_trait(
+                Trait::from_setter(
+                    QName::new(Namespace::public(), name),
+                    Method::from_builtin(setter),
+                )
+                .with_override(),
+            );
+        }
+    }
 
-    write.define_instance_trait(
-        Trait::from_getter(
-            QName::new(Namespace::public(), "name"),
-            Method::from_builtin(name),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "name"),
-            Method::from_builtin(set_name),
-        )
-        .with_override(),
-    );
-
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "opaqueBackground"),
-            Method::from_builtin(set_opaque_background),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "rotation"),
-            Method::from_builtin(set_rotation),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "scale9Grid"),
-            Method::from_builtin(set_scale_nine_grid),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "scaleX"),
-            Method::from_builtin(set_scale_x),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "scaleY"),
-            Method::from_builtin(set_scale_y),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "scrollRect"),
-            Method::from_builtin(set_scroll_rect),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "tabEnabled"),
-            Method::from_builtin(set_tab_enabled),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "tabIndex"),
-            Method::from_builtin(set_tab_index),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "transform"),
-            Method::from_builtin(set_transform),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "visible"),
-            Method::from_builtin(set_visible),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "x"),
-            Method::from_builtin(set_x),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(
-        Trait::from_setter(
-            QName::new(Namespace::public(), "y"),
-            Method::from_builtin(set_y),
-        )
-        .with_override(),
-    );
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "align"),
-        Method::from_builtin(align),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "align"),
-        Method::from_builtin(set_align),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "browserZoomFactor"),
-        Method::from_builtin(browser_zoom_factor),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "color"),
-        Method::from_builtin(color),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "color"),
-        Method::from_builtin(set_color),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "contentsScaleFactor"),
-        Method::from_builtin(contents_scale_factor),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "displayState"),
-        Method::from_builtin(display_state),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "focus"),
-        Method::from_builtin(focus),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "focus"),
-        Method::from_builtin(set_focus),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "frameRate"),
-        Method::from_builtin(frame_rate),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "frameRate"),
-        Method::from_builtin(set_frame_rate),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "scaleMode"),
-        Method::from_builtin(scale_mode),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "scaleMode"),
-        Method::from_builtin(set_scale_mode),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "showDefaultContextMenu"),
-        Method::from_builtin(show_default_context_menu),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "showDefaultContextMenu"),
-        Method::from_builtin(set_show_default_context_menu),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "stageWidth"),
-        Method::from_builtin(stage_width),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "stageWidth"),
-        Method::from_builtin(set_stage_width),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "stageHeight"),
-        Method::from_builtin(stage_height),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "stageHeight"),
-        Method::from_builtin(set_stage_height),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "allowsFullScreen"),
-        Method::from_builtin(allows_full_screen),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "allowsFullScreenInteractive"),
-        Method::from_builtin(allows_full_screen_interactive),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "quality"),
-        Method::from_builtin(quality),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("align", Some(align), Some(set_align)),
+        ("browserZoomFactor", Some(browser_zoom_factor), None),
+        ("color", Some(color), Some(set_color)),
+        ("contentsScaleFactor", Some(contents_scale_factor), None),
+        ("displayState", Some(display_state), None),
+        ("focus", Some(focus), Some(set_focus)),
+        ("frameRate", Some(frame_rate), Some(set_frame_rate)),
+        ("scaleMode", Some(scale_mode), Some(set_scale_mode)),
+        (
+            "showDefaultContextMenu",
+            Some(show_default_context_menu),
+            Some(set_show_default_context_menu),
+        ),
+        ("stageWidth", Some(stage_width), Some(set_stage_width)),
+        ("stageHeight", Some(stage_height), Some(set_stage_height)),
+        ("allowsFullScreen", Some(allows_full_screen), None),
+        (
+            "allowsFullScreenInteractive",
+            Some(allows_full_screen_interactive),
+            None,
+        ),
+        ("quality", Some(quality), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
@@ -616,8 +616,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_OVERRIDE_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         (
             "accessibilityProperties",
@@ -670,8 +670,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("align", Some(align), Some(set_align)),
         ("browserZoomFactor", Some(browser_zoom_factor), None),

--- a/core/src/avm2/globals/flash/display/stagealign.rs
+++ b/core/src/avm2/globals/flash/display/stagealign.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,46 +45,17 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BOTTOM"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("B".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BOTTOM_LEFT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("BL".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BOTTOM_RIGHT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("BR".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "LEFT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("L".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "RIGHT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("R".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TOP"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("T".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TOP_LEFT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("TL".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TOP_RIGHT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("TR".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("BOTTOM", "B"),
+        ("BOTTOM_LEFT", "BL"),
+        ("BOTTOM_RIGHT", "BR"),
+        ("LEFT", "L"),
+        ("RIGHT", "R"),
+        ("TOP", "T"),
+        ("TOP_LEFT", "TL"),
+        ("TOP_RIGHT", "TR"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/stagealign.rs
+++ b/core/src/avm2/globals/flash/display/stagealign.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("BOTTOM", "B"),
         ("BOTTOM_LEFT", "BL"),
         ("BOTTOM_RIGHT", "BR"),

--- a/core/src/avm2/globals/flash/display/stagedisplaystate.rs
+++ b/core/src/avm2/globals/flash/display/stagedisplaystate.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,21 +45,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FULL_SCREEN"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("fullScreen".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FULL_SCREEN_INTERACTIVE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("fullScreenInteractive".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NORMAL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("normal".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("FULL_SCREEN", "fullScreen"),
+        ("FULL_SCREEN_INTERACTIVE", "fullScreenInteractive"),
+        ("NORMAL", "normal"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/stagedisplaystate.rs
+++ b/core/src/avm2/globals/flash/display/stagedisplaystate.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("FULL_SCREEN", "fullScreen"),
         ("FULL_SCREEN_INTERACTIVE", "fullScreenInteractive"),
         ("NORMAL", "normal"),

--- a/core/src/avm2/globals/flash/display/stagequality.rs
+++ b/core/src/avm2/globals/flash/display/stagequality.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("BEST", "best"),
         ("HIGH", "high"),
         ("HIGH_16X16", "16x16"),

--- a/core/src/avm2/globals/flash/display/stagequality.rs
+++ b/core/src/avm2/globals/flash/display/stagequality.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,46 +45,17 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BEST"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("best".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HIGH"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("high".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HIGH_16X16"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("16x16".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HIGH_16x16_LINEAR"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("16x16linear".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HIGH_8X8"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("8x8".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HIGH_8x8_LINEAR"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("8x8linear".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "LOW"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("low".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "MEDIUM"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("medium".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("BEST", "best"),
+        ("HIGH", "high"),
+        ("HIGH_16X16", "16x16"),
+        ("HIGH_16x16_LINEAR", "16x16linear"),
+        ("HIGH_8X8", "8x8"),
+        ("HIGH_8x8_LINEAR", "8x8linear"),
+        ("LOW", "low"),
+        ("MEDIUM", "medium"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/stagescalemode.rs
+++ b/core/src/avm2/globals/flash/display/stagescalemode.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("EXACT_FIT", "exactFit"),
         ("NO_BORDER", "noBorder"),
         ("NO_SCALE", "noScale"),

--- a/core/src/avm2/globals/flash/display/stagescalemode.rs
+++ b/core/src/avm2/globals/flash/display/stagescalemode.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,26 +45,13 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "EXACT_FIT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("exactFit".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NO_BORDER"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("noBorder".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NO_SCALE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("noScale".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SHOW_ALL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("showAll".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("EXACT_FIT", "exactFit"),
+        ("NO_BORDER", "noBorder"),
+        ("NO_SCALE", "noScale"),
+        ("SHOW_ALL", "showAll"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/swfversion.rs
+++ b/core/src/avm2/globals/flash/display/swfversion.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, u32)] = &[
+    const CONSTANTS: &[(&str, u32)] = &[
         ("FLASH1", 1),
         ("FLASH2", 2),
         ("FLASH3", 3),

--- a/core/src/avm2/globals/flash/display/swfversion.rs
+++ b/core/src/avm2/globals/flash/display/swfversion.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,66 +45,21 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH1"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(1.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH2"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(2.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH3"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(3.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH4"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(4.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH5"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(5.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH6"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(6.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH7"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(7.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH8"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(8.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH9"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(9.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH10"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(10.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH11"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(11.into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FLASH12"),
-        QName::new(Namespace::public(), "uint").into(),
-        Some(12.into()),
-    ));
+    const CONSTANTS: &[(&'static str, u32)] = &[
+        ("FLASH1", 1),
+        ("FLASH2", 2),
+        ("FLASH3", 3),
+        ("FLASH4", 4),
+        ("FLASH5", 5),
+        ("FLASH6", 6),
+        ("FLASH7", 7),
+        ("FLASH8", 8),
+        ("FLASH9", 9),
+        ("FLASH10", 10),
+        ("FLASH11", 11),
+        ("FLASH12", 12),
+    ];
+    write.define_public_constant_uint_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{EventObject, Object, TObject};
 use crate::avm2::scope::Scope;
@@ -275,8 +275,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("bubbles", Some(bubbles), None),
         ("cancelable", Some(cancelable), None),
@@ -287,7 +287,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("clone", clone),
         ("formatToString", format_to_string),
         ("isDefaultPrevented", is_default_prevented),

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -2,12 +2,11 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{EventObject, Object, TObject};
 use crate::avm2::scope::Scope;
 use crate::avm2::string::AvmString;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -274,344 +273,91 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "bubbles"),
-        Method::from_builtin(bubbles),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "cancelable"),
-        Method::from_builtin(cancelable),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "type"),
-        Method::from_builtin(get_type),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "target"),
-        Method::from_builtin(target),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentTarget"),
-        Method::from_builtin(current_target),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "eventPhase"),
-        Method::from_builtin(event_phase),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "clone"),
-        Method::from_builtin(clone),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "formatToString"),
-        Method::from_builtin(format_to_string),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "isDefaultPrevented"),
-        Method::from_builtin(is_default_prevented),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "preventDefault"),
-        Method::from_builtin(prevent_default),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "stopPropagation"),
-        Method::from_builtin(stop_propagation),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "stopImmediatePropagation"),
-        Method::from_builtin(stop_immediate_propagation),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "toString"),
-        Method::from_builtin(to_string),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("bubbles", Some(bubbles), None),
+        ("cancelable", Some(cancelable), None),
+        ("type", Some(get_type), None),
+        ("target", Some(target), None),
+        ("currentTarget", Some(current_target), None),
+        ("eventPhase", Some(event_phase), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ACTIVATE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("activate".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ADDED"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("added".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ADDED_TO_STAGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("addedToStage".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BROWSER_ZOOM_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("browserZoomChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CANCEL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("cancel".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("change".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CHANNEL_MESSAGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("channelMessage".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CHANNEL_STATE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("channelState".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CLEAR"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("clear".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CLOSE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("close".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CLOSING"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("closing".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "COMPLETE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("complete".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CONNECT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("connect".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CONTEXT3D_CREATE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("context3DCreate".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "COPY"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("copy".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CUT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("cut".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "DEACTIVATE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("deactivate".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "DISPLAYING"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("displaying".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ENTER_FRAME"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("enterFrame".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "EXIT_FRAME"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("exitFrame".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "EXITING"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("exiting".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FRAME_CONSTRUCTED"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("frameConstructed".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FRAME_LABEL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("frameLabel".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "FULLSCREEN"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("fullScreen".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HTML_BOUNDS_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("htmlBoundsChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HTML_DOM_INITIALIZE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("htmlDOMInitialize".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "HTML_RENDER"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("htmlRender".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "ID3"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("id3".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "INIT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("init".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "LOCATION_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("locationChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "MOUSE_LEAVE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("mouseLeave".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NETWORK_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("networkChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "OPEN"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("open".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "PASTE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("paste".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "PREPARING"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("preparing".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "REMOVED"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("removed".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "REMOVED_FROM_STAGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("removedFromStage".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "RENDER"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("render".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "RESIZE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("resize".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SCROLL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("scroll".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SELECT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("select".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SELECT_ALL"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("selectAll".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SOUND_COMPLETE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("soundComplete".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "STANDARD_ERROR_CLOSE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("standardErrorClose".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "STANDARD_INPUT_CLOSE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("standardInputClose".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "STANDARD_OUTPUT_CLOSE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("standardOutputClose".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "SUSPEND"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("suspend".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TAB_CHILDREN_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("tabChildrenChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TAB_ENABLED_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("tabEnabledChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TAB_INDEX_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("tabIndexChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TEXT_INTERACTION_MODE_CHANGE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("textInteractionModeChange".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "TEXTURE_READY"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("textureReady".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "UNLOAD"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("unload".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "USER_IDLE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("userIdle".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "USER_PRESENT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("userPresent".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "VIDEO_FRAME"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("videoFrame".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "WORKER_STATE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("workerState".into()),
-    ));
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("clone", clone),
+        ("formatToString", format_to_string),
+        ("isDefaultPrevented", is_default_prevented),
+        ("preventDefault", prevent_default),
+        ("stopPropagation", stop_propagation),
+        ("stopImmediatePropagation", stop_immediate_propagation),
+        ("toString", to_string),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
+
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("ACTIVATE", "activate"),
+        ("ADDED", "added"),
+        ("ADDED_TO_STAGE", "addedToStage"),
+        ("BROWSER_ZOOM_CHANGE", "browserZoomChange"),
+        ("CANCEL", "cancel"),
+        ("CHANGE", "change"),
+        ("CHANNEL_MESSAGE", "channelMessage"),
+        ("CHANNEL_STATE", "channelState"),
+        ("CLEAR", "clear"),
+        ("CLOSE", "close"),
+        ("CLOSING", "closing"),
+        ("COMPLETE", "complete"),
+        ("CONNECT", "connect"),
+        ("CONTEXT3D_CREATE", "context3DCreate"),
+        ("COPY", "copy"),
+        ("CUT", "cut"),
+        ("DEACTIVATE", "deactivate"),
+        ("DISPLAYING", "displaying"),
+        ("ENTER_FRAME", "enterFrame"),
+        ("EXIT_FRAME", "exitFrame"),
+        ("EXITING", "exiting"),
+        ("FRAME_CONSTRUCTED", "frameConstructed"),
+        ("FRAME_LABEL", "frameLabel"),
+        ("FULLSCREEN", "fullScreen"),
+        ("HTML_BOUNDS_CHANGE", "htmlBoundsChange"),
+        ("HTML_DOM_INITIALIZE", "htmlDOMInitialize"),
+        ("HTML_RENDER", "htmlRender"),
+        ("ID3", "id3"),
+        ("INIT", "init"),
+        ("LOCATION_CHANGE", "locationChange"),
+        ("MOUSE_LEAVE", "mouseLeave"),
+        ("NETWORK_CHANGE", "networkChange"),
+        ("OPEN", "open"),
+        ("PASTE", "paste"),
+        ("PREPARING", "preparing"),
+        ("REMOVED", "removed"),
+        ("REMOVED_FROM_STAGE", "removedFromStage"),
+        ("RENDER", "render"),
+        ("RESIZE", "resize"),
+        ("SCROLL", "scroll"),
+        ("SELECT", "select"),
+        ("SELECT_ALL", "selectAll"),
+        ("SOUND_COMPLETE", "soundComplete"),
+        ("STANDARD_ERROR_CLOSE", "standardErrorClose"),
+        ("STANDARD_INPUT_CLOSE", "standardInputClose"),
+        ("STANDARD_OUTPUT_CLOSE", "standardOutputClose"),
+        ("SUSPEND", "suspend"),
+        ("TAB_CHILDREN_CHANGE", "tabChildrenChange"),
+        ("TAB_ENABLED_CHANGE", "tabEnabledChange"),
+        ("TAB_INDEX_CHANGE", "tabIndexChange"),
+        ("TEXT_INTERACTION_MODE_CHANGE", "textInteractionModeChange"),
+        ("TEXTURE_READY", "textureReady"),
+        ("UNLOAD", "unload"),
+        ("USER_IDLE", "userIdle"),
+        ("USER_PRESENT", "userPresent"),
+        ("VIDEO_FRAME", "videoFrame"),
+        ("WORKER_STATE", "workerState"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -273,11 +273,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("bubbles", Some(bubbles), None),
         ("cancelable", Some(cancelable), None),
         ("type", Some(get_type), None),
@@ -287,7 +283,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("clone", clone),
         ("formatToString", format_to_string),
         ("isDefaultPrevented", is_default_prevented),
@@ -298,7 +294,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("ACTIVATE", "activate"),
         ("ADDED", "added"),
         ("ADDED_TO_STAGE", "addedToStage"),

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -6,7 +6,7 @@ use crate::avm2::events::{
     dispatch_event as dispatch_event_internal, parent_of, NS_EVENT_DISPATCHER,
 };
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{DispatchObject, Object, TObject};
 use crate::avm2::traits::Trait;
@@ -253,7 +253,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.implements(QName::new(Namespace::package("flash.events"), "IEventDispatcher").into());
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("addEventListener", add_event_listener),
         ("removeEventListener", remove_event_listener),
         ("hasEventListener", has_event_listener),

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -253,7 +253,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.implements(QName::new(Namespace::package("flash.events"), "IEventDispatcher").into());
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("addEventListener", add_event_listener),
         ("removeEventListener", remove_event_listener),
         ("hasEventListener", has_event_listener),

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -6,7 +6,7 @@ use crate::avm2::events::{
     dispatch_event as dispatch_event_internal, parent_of, NS_EVENT_DISPATCHER,
 };
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{DispatchObject, Object, TObject};
 use crate::avm2::traits::Trait;
@@ -253,26 +253,14 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.implements(QName::new(Namespace::package("flash.events"), "IEventDispatcher").into());
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "addEventListener"),
-        Method::from_builtin(add_event_listener),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "removeEventListener"),
-        Method::from_builtin(remove_event_listener),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "hasEventListener"),
-        Method::from_builtin(has_event_listener),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "willTrigger"),
-        Method::from_builtin(will_trigger),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "dispatchEvent"),
-        Method::from_builtin(dispatch_event),
-    ));
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("addEventListener", add_event_listener),
+        ("removeEventListener", remove_event_listener),
+        ("hasEventListener", has_event_listener),
+        ("willTrigger", will_trigger),
+        ("dispatchEvent", dispatch_event),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     write.define_instance_trait(Trait::from_slot(
         QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target"),

--- a/core/src/avm2/globals/flash/events/ieventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/ieventdispatcher.rs
@@ -41,7 +41,7 @@ pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<
 
     write.set_attributes(ClassAttributes::INTERFACE);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("addEventListener", bodiless_method),
         ("dispatchEvent", bodiless_method),
         ("hasEventListener", bodiless_method),

--- a/core/src/avm2/globals/flash/events/ieventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/ieventdispatcher.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -41,26 +40,15 @@ pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<
     let mut write = class.write(mc);
 
     write.set_attributes(ClassAttributes::INTERFACE);
-    write.define_instance_trait(Trait::from_method(
-        QName::dynamic_name("addEventListener"),
-        Method::from_builtin(bodiless_method),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::dynamic_name("dispatchEvent"),
-        Method::from_builtin(bodiless_method),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::dynamic_name("hasEventListener"),
-        Method::from_builtin(bodiless_method),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::dynamic_name("removeEventListener"),
-        Method::from_builtin(bodiless_method),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::dynamic_name("willTrigger"),
-        Method::from_builtin(bodiless_method),
-    ));
+
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("addEventListener", bodiless_method),
+        ("dispatchEvent", bodiless_method),
+        ("hasEventListener", bodiless_method),
+        ("removeEventListener", bodiless_method),
+        ("willTrigger", bodiless_method),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/events/ieventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/ieventdispatcher.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
@@ -41,7 +41,7 @@ pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<
 
     write.set_attributes(ClassAttributes::INTERFACE);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("addEventListener", bodiless_method),
         ("dispatchEvent", bodiless_method),
         ("hasEventListener", bodiless_method),

--- a/core/src/avm2/globals/flash/geom/point.rs
+++ b/core/src/avm2/globals/flash/geom/point.rs
@@ -2,8 +2,7 @@
 
 use crate::avm1::AvmString;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
-use crate::avm2::traits::Trait;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::{Activation, Error, Namespace, Object, QName, TObject, Value};
 use gc_arena::{GcCell, MutationContext};
 
@@ -342,58 +341,31 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "length"),
-        Method::from_builtin(length),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "add"),
-        Method::from_builtin(add),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "clone"),
-        Method::from_builtin(clone),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "copyFrom"),
-        Method::from_builtin(copy_from),
-    ));
-    write.define_class_trait(Trait::from_method(
-        QName::new(Namespace::public(), "distance"),
-        Method::from_builtin(distance),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "equals"),
-        Method::from_builtin(equals),
-    ));
-    write.define_class_trait(Trait::from_method(
-        QName::new(Namespace::public(), "interpolate"),
-        Method::from_builtin(interpolate),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "normalize"),
-        Method::from_builtin(normalize),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "offset"),
-        Method::from_builtin(offset),
-    ));
-    write.define_class_trait(Trait::from_method(
-        QName::new(Namespace::public(), "polar"),
-        Method::from_builtin(polar),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "setTo"),
-        Method::from_builtin(set_to),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "subtract"),
-        Method::from_builtin(subtract),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "toString"),
-        Method::from_builtin(to_string),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("length", Some(length), None)];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
+    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("distance", distance),
+        ("interpolate", interpolate),
+        ("polar", polar),
+    ];
+    write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
+
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("add", add),
+        ("clone", clone),
+        ("copyFrom", copy_from),
+        ("equals", equals),
+        ("normalize", normalize),
+        ("offset", offset),
+        ("setTo", set_to),
+        ("subtract", subtract),
+        ("toString", to_string),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
     class
 }

--- a/core/src/avm2/globals/flash/geom/point.rs
+++ b/core/src/avm2/globals/flash/geom/point.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::AvmString;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::{Activation, Error, Namespace, Object, QName, TObject, Value};
 use gc_arena::{GcCell, MutationContext};
 
@@ -343,19 +343,19 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("length", Some(length), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[
         ("distance", distance),
         ("interpolate", interpolate),
         ("polar", polar),
     ];
     write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("add", add),
         ("clone", clone),
         ("copyFrom", copy_from),

--- a/core/src/avm2/globals/flash/geom/point.rs
+++ b/core/src/avm2/globals/flash/geom/point.rs
@@ -341,21 +341,18 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("length", Some(length), None)];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("length", Some(length), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethod)] = &[
         ("distance", distance),
         ("interpolate", interpolate),
         ("polar", polar),
     ];
     write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("add", add),
         ("clone", clone),
         ("copyFrom", copy_from),

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{DomainObject, Object, TObject};
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -161,31 +160,20 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_class_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "currentDomain"),
-        Method::from_builtin(current_domain),
-    ));
-    write.define_class_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "parentDomain"),
-        Method::from_builtin(parent_domain),
-    ));
-    write.define_class_trait(Trait::from_method(
-        QName::new(Namespace::public(), "getDefinition"),
-        Method::from_builtin(get_definition),
-    ));
-    write.define_class_trait(Trait::from_method(
-        QName::new(Namespace::public(), "hasDefinition"),
-        Method::from_builtin(has_definition),
-    ));
+    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("currentDomain", current_domain),
+        ("parentDomain", parent_domain),
+        ("getDefinition", get_definition),
+        ("hasDefinition", has_definition),
+    ];
+    write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "domainMemory"),
-        Method::from_builtin(set_domain_memory),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "domainMemory"),
-        Method::from_builtin(domain_memory),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("domainMemory", Some(domain_memory), Some(set_domain_memory))];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class
 }

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -160,7 +160,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethod)] = &[
         ("currentDomain", current_domain),
         ("parentDomain", parent_domain),
         ("getDefinition", get_definition),
@@ -168,11 +168,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("domainMemory", Some(domain_memory), Some(set_domain_memory))];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("domainMemory", Some(domain_memory), Some(set_domain_memory))];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{DomainObject, Object, TObject};
 use crate::avm2::value::Value;
@@ -160,7 +160,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[
         ("currentDomain", current_domain),
         ("parentDomain", parent_domain),
         ("getDefinition", get_definition),
@@ -170,8 +170,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("domainMemory", Some(domain_memory), Some(set_domain_memory))];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -52,7 +52,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[("gc", gc)];
+    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethod)] = &[("gc", gc)];
     write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
     class

--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -2,10 +2,9 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -53,10 +52,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_class_trait(Trait::from_method(
-        QName::new(Namespace::public(), "gc"),
-        Method::from_builtin(gc),
-    ));
+    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[("gc", gc)];
+    write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
@@ -52,7 +52,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[("gc", gc)];
+    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[("gc", gc)];
     write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
     class

--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -2,11 +2,10 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject, TextSelection};
@@ -866,155 +865,52 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "autoSize"),
-        Method::from_builtin(autosize),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "autoSize"),
-        Method::from_builtin(set_autosize),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "backgroundColor"),
-        Method::from_builtin(background_color),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "backgroundColor"),
-        Method::from_builtin(set_background_color),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "border"),
-        Method::from_builtin(border),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "border"),
-        Method::from_builtin(set_border),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "borderColor"),
-        Method::from_builtin(border_color),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "borderColor"),
-        Method::from_builtin(set_border_color),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "defaultTextFormat"),
-        Method::from_builtin(default_text_format),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "defaultTextFormat"),
-        Method::from_builtin(set_default_text_format),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "displayAsPassword"),
-        Method::from_builtin(display_as_password),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "displayAsPassword"),
-        Method::from_builtin(set_display_as_password),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "embedFonts"),
-        Method::from_builtin(embed_fonts),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "embedFonts"),
-        Method::from_builtin(set_embed_fonts),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "htmlText"),
-        Method::from_builtin(html_text),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "htmlText"),
-        Method::from_builtin(set_html_text),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "length"),
-        Method::from_builtin(length),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "multiline"),
-        Method::from_builtin(multiline),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "multiline"),
-        Method::from_builtin(set_multiline),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "selectable"),
-        Method::from_builtin(selectable),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "selectable"),
-        Method::from_builtin(set_selectable),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "text"),
-        Method::from_builtin(text),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "text"),
-        Method::from_builtin(set_text),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "textColor"),
-        Method::from_builtin(text_color),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "textColor"),
-        Method::from_builtin(set_text_color),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "textHeight"),
-        Method::from_builtin(text_height),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "textWidth"),
-        Method::from_builtin(text_width),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "type"),
-        Method::from_builtin(get_type),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "type"),
-        Method::from_builtin(set_type),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "wordWrap"),
-        Method::from_builtin(word_wrap),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "wordWrap"),
-        Method::from_builtin(set_word_wrap),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("autoSize", Some(autosize), Some(set_autosize)),
+        (
+            "backgroundColor",
+            Some(background_color),
+            Some(set_background_color),
+        ),
+        ("border", Some(border), Some(set_border)),
+        ("borderColor", Some(border_color), Some(set_border_color)),
+        (
+            "defaultTextFormat",
+            Some(default_text_format),
+            Some(set_default_text_format),
+        ),
+        (
+            "displayAsPassword",
+            Some(display_as_password),
+            Some(set_display_as_password),
+        ),
+        ("embedFonts", Some(embed_fonts), Some(set_embed_fonts)),
+        ("htmlText", Some(html_text), Some(set_html_text)),
+        ("length", Some(length), None),
+        ("multiline", Some(multiline), Some(set_multiline)),
+        ("selectable", Some(selectable), Some(set_selectable)),
+        ("text", Some(text), Some(set_text)),
+        ("textColor", Some(text_color), Some(set_text_color)),
+        ("textHeight", Some(text_height), None),
+        ("textWidth", Some(text_width), None),
+        ("type", Some(get_type), Some(set_type)),
+        ("wordWrap", Some(word_wrap), Some(set_word_wrap)),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "appendText"),
-        Method::from_builtin(append_text),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "getTextFormat"),
-        Method::from_builtin(get_text_format),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "replaceSelectedText"),
-        Method::from_builtin(replace_selected_text),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "replaceText"),
-        Method::from_builtin(replace_text),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "setSelection"),
-        Method::from_builtin(set_selection),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "setTextFormat"),
-        Method::from_builtin(set_text_format),
-    ));
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("appendText", append_text),
+        ("getTextFormat", get_text_format),
+        ("replaceSelectedText", replace_selected_text),
+        ("replaceText", replace_text),
+        ("setSelection", set_selection),
+        ("setTextFormat", set_text_format),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -865,11 +865,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("autoSize", Some(autosize), Some(set_autosize)),
         (
             "backgroundColor",
@@ -902,7 +898,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("appendText", append_text),
         ("getTextFormat", get_text_format),
         ("replaceSelectedText", replace_selected_text),

--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
@@ -867,8 +867,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("autoSize", Some(autosize), Some(set_autosize)),
         (
@@ -902,7 +902,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("appendText", append_text),
         ("getTextFormat", get_text_format),
         ("replaceSelectedText", replace_selected_text),

--- a/core/src/avm2/globals/flash/text/textfieldautosize.rs
+++ b/core/src/avm2/globals/flash/text/textfieldautosize.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("CENTER", "center"),
         ("LEFT", "left"),
         ("NONE", "none"),

--- a/core/src/avm2/globals/flash/text/textfieldautosize.rs
+++ b/core/src/avm2/globals/flash/text/textfieldautosize.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,26 +45,13 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CENTER"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("center".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "LEFT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("left".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "NONE"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("none".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "RIGHT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("right".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("CENTER", "center"),
+        ("LEFT", "left"),
+        ("NONE", "none"),
+        ("RIGHT", "right"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/text/textfieldtype.rs
+++ b/core/src/avm2/globals/flash/text/textfieldtype.rs
@@ -45,8 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, &'static str)] =
-        &[("DYNAMIC", "dynamic"), ("INPUT", "input")];
+    const CONSTANTS: &[(&str, &str)] = &[("DYNAMIC", "dynamic"), ("INPUT", "input")];
     write.define_public_constant_string_class_traits(CONSTANTS);
 
     class

--- a/core/src/avm2/globals/flash/text/textfieldtype.rs
+++ b/core/src/avm2/globals/flash/text/textfieldtype.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,16 +45,9 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "DYNAMIC"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("dynamic".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "INPUT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("input".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] =
+        &[("DYNAMIC", "dynamic"), ("INPUT", "input")];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/text/textformat.rs
+++ b/core/src/avm2/globals/flash/text/textformat.rs
@@ -125,7 +125,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const ITEMS: &[(&'static str, &'static str)] = &[
+    const ITEMS: &[(&str, &str)] = &[
         ("align", "String"),
         ("blockIndent", "Object"),
         ("bold", "Object"),

--- a/core/src/avm2/globals/flash/text/textformat.rs
+++ b/core/src/avm2/globals/flash/text/textformat.rs
@@ -125,96 +125,33 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "align"),
-        QName::new(Namespace::public(), "String").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "blockIndent"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "bold"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "bullet"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "color"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "font"),
-        QName::new(Namespace::public(), "String").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "indent"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "italic"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "kerning"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "leading"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "leftMargin"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "letterSpacing"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "rightMargin"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "size"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "tabStops"),
-        QName::new(Namespace::public(), "Array").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "target"),
-        QName::new(Namespace::public(), "String").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "underline"),
-        QName::new(Namespace::public(), "Object").into(),
-        None,
-    ));
-    write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::public(), "url"),
-        QName::new(Namespace::public(), "String").into(),
-        None,
-    ));
+    const ITEMS: &[(&'static str, &'static str)] = &[
+        ("align", "String"),
+        ("blockIndent", "Object"),
+        ("bold", "Object"),
+        ("bullet", "Object"),
+        ("color", "Object"),
+        ("font", "String"),
+        ("indent", "Object"),
+        ("italic", "Object"),
+        ("kerning", "Object"),
+        ("leading", "Object"),
+        ("leftMargin", "Object"),
+        ("letterSpacing", "Object"),
+        ("rightMargin", "Object"),
+        ("size", "Object"),
+        ("tabStops", "Array"),
+        ("target", "String"),
+        ("underline", "Object"),
+        ("url", "String"),
+    ];
+    for &(name, type_name) in ITEMS {
+        write.define_instance_trait(Trait::from_slot(
+            QName::new(Namespace::public(), name),
+            QName::new(Namespace::public(), type_name).into(),
+            None,
+        ));
+    }
 
     class
 }

--- a/core/src/avm2/globals/flash/text/textformatalign.rs
+++ b/core/src/avm2/globals/flash/text/textformatalign.rs
@@ -45,7 +45,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("CENTER", "center"),
         ("END", "end"),
         ("JUSTIFY", "justify"),

--- a/core/src/avm2/globals/flash/text/textformatalign.rs
+++ b/core/src/avm2/globals/flash/text/textformatalign.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -46,36 +45,15 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "CENTER"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("center".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "END"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("end".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "JUSTIFY"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("justify".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "LEFT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("left".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "RIGHT"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("right".into()),
-    ));
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "START"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("start".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("CENTER", "center"),
+        ("END", "end"),
+        ("JUSTIFY", "justify"),
+        ("LEFT", "left"),
+        ("RIGHT", "right"),
+        ("START", "start"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/utils/bytearray.rs
+++ b/core/src/avm2/globals/flash/utils/bytearray.rs
@@ -740,188 +740,190 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         mc,
     );
 
-    class.write(mc).set_attributes(ClassAttributes::SEALED);
+    let mut write = class.write(mc);
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.set_attributes(ClassAttributes::SEALED);
+
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeByte"),
         Method::from_builtin(write_byte),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeBytes"),
         Method::from_builtin(write_bytes),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readBytes"),
         Method::from_builtin(read_bytes),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "toString"),
         Method::from_builtin(to_string),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readShort"),
         Method::from_builtin(read_short),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeShort"),
         Method::from_builtin(write_short),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readUnsignedShort"),
         Method::from_builtin(read_unsigned_short),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readDouble"),
         Method::from_builtin(read_double),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeDouble"),
         Method::from_builtin(write_double),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readFloat"),
         Method::from_builtin(read_float),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeFloat"),
         Method::from_builtin(write_float),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readInt"),
         Method::from_builtin(read_int),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeInt"),
         Method::from_builtin(write_int),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readUnsignedInt"),
         Method::from_builtin(read_unsigned_int),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeUnsignedInt"),
         Method::from_builtin(write_unsigned_int),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readBoolean"),
         Method::from_builtin(read_boolean),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeBoolean"),
         Method::from_builtin(write_boolean),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readByte"),
         Method::from_builtin(read_byte),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readUnsignedByte"),
         Method::from_builtin(read_unsigned_byte),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeUTF"),
         Method::from_builtin(write_utf),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readUTF"),
         Method::from_builtin(read_utf),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "clear"),
         Method::from_builtin(clear),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "compress"),
         Method::from_builtin(compress),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "uncompress"),
         Method::from_builtin(uncompress),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "inflate"),
         Method::from_builtin(inflate),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "deflate"),
         Method::from_builtin(deflate),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeMultiByte"),
         Method::from_builtin(write_multibyte),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readMultiByte"),
         Method::from_builtin(read_multibyte),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "writeUTFBytes"),
         Method::from_builtin(write_utf_bytes),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_method(
+    write.define_instance_trait(Trait::from_method(
         QName::new(Namespace::public(), "readUTFBytes"),
         Method::from_builtin(read_utf_bytes),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_getter(
+    write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public(), "bytesAvailable"),
         Method::from_builtin(bytes_available),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_getter(
+    write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public(), "length"),
         Method::from_builtin(length),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_setter(
+    write.define_instance_trait(Trait::from_setter(
         QName::new(Namespace::public(), "length"),
         Method::from_builtin(set_length),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_getter(
+    write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public(), "position"),
         Method::from_builtin(position),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_setter(
+    write.define_instance_trait(Trait::from_setter(
         QName::new(Namespace::public(), "position"),
         Method::from_builtin(set_position),
     ));
 
-    class.write(mc).define_instance_trait(Trait::from_getter(
+    write.define_instance_trait(Trait::from_getter(
         QName::new(Namespace::public(), "endian"),
         Method::from_builtin(endian),
     ));
-    class.write(mc).define_instance_trait(Trait::from_setter(
+    write.define_instance_trait(Trait::from_setter(
         QName::new(Namespace::public(), "endian"),
         Method::from_builtin(set_endian),
     ));

--- a/core/src/avm2/globals/flash/utils/bytearray.rs
+++ b/core/src/avm2/globals/flash/utils/bytearray.rs
@@ -1,11 +1,10 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::bytearray::Endian;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use encoding_rs::Encoding;
@@ -744,189 +743,51 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeByte"),
-        Method::from_builtin(write_byte),
-    ));
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("writeByte", write_byte),
+        ("writeBytes", write_bytes),
+        ("readBytes", read_bytes),
+        ("toString", to_string),
+        ("readShort", read_short),
+        ("writeShort", write_short),
+        ("readUnsignedShort", read_unsigned_short),
+        ("readDouble", read_double),
+        ("writeDouble", write_double),
+        ("readFloat", read_float),
+        ("writeFloat", write_float),
+        ("readInt", read_int),
+        ("writeInt", write_int),
+        ("readUnsignedInt", read_unsigned_int),
+        ("writeUnsignedInt", write_unsigned_int),
+        ("readBoolean", read_boolean),
+        ("writeBoolean", write_boolean),
+        ("readByte", read_byte),
+        ("readUnsignedByte", read_unsigned_byte),
+        ("writeUTF", write_utf),
+        ("readUTF", read_utf),
+        ("clear", clear),
+        ("compress", compress),
+        ("uncompress", uncompress),
+        ("inflate", inflate),
+        ("deflate", deflate),
+        ("writeMultiByte", write_multibyte),
+        ("readMultiByte", read_multibyte),
+        ("writeUTFBytes", write_utf_bytes),
+        ("readUTFBytes", read_utf_bytes),
+    ];
+    write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeBytes"),
-        Method::from_builtin(write_bytes),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readBytes"),
-        Method::from_builtin(read_bytes),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "toString"),
-        Method::from_builtin(to_string),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readShort"),
-        Method::from_builtin(read_short),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeShort"),
-        Method::from_builtin(write_short),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readUnsignedShort"),
-        Method::from_builtin(read_unsigned_short),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readDouble"),
-        Method::from_builtin(read_double),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeDouble"),
-        Method::from_builtin(write_double),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readFloat"),
-        Method::from_builtin(read_float),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeFloat"),
-        Method::from_builtin(write_float),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readInt"),
-        Method::from_builtin(read_int),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeInt"),
-        Method::from_builtin(write_int),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readUnsignedInt"),
-        Method::from_builtin(read_unsigned_int),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeUnsignedInt"),
-        Method::from_builtin(write_unsigned_int),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readBoolean"),
-        Method::from_builtin(read_boolean),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeBoolean"),
-        Method::from_builtin(write_boolean),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readByte"),
-        Method::from_builtin(read_byte),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readUnsignedByte"),
-        Method::from_builtin(read_unsigned_byte),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeUTF"),
-        Method::from_builtin(write_utf),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readUTF"),
-        Method::from_builtin(read_utf),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "clear"),
-        Method::from_builtin(clear),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "compress"),
-        Method::from_builtin(compress),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "uncompress"),
-        Method::from_builtin(uncompress),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "inflate"),
-        Method::from_builtin(inflate),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "deflate"),
-        Method::from_builtin(deflate),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeMultiByte"),
-        Method::from_builtin(write_multibyte),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readMultiByte"),
-        Method::from_builtin(read_multibyte),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "writeUTFBytes"),
-        Method::from_builtin(write_utf_bytes),
-    ));
-
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::public(), "readUTFBytes"),
-        Method::from_builtin(read_utf_bytes),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "bytesAvailable"),
-        Method::from_builtin(bytes_available),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "length"),
-        Method::from_builtin(length),
-    ));
-
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "length"),
-        Method::from_builtin(set_length),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "position"),
-        Method::from_builtin(position),
-    ));
-
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "position"),
-        Method::from_builtin(set_position),
-    ));
-
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "endian"),
-        Method::from_builtin(endian),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "endian"),
-        Method::from_builtin(set_endian),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("bytesAvailable", Some(bytes_available), None),
+        ("length", Some(length), Some(set_length)),
+        ("position", Some(position), Some(set_position)),
+        ("endian", Some(endian), Some(set_endian)),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
     class
 }

--- a/core/src/avm2/globals/flash/utils/bytearray.rs
+++ b/core/src/avm2/globals/flash/utils/bytearray.rs
@@ -1,7 +1,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::bytearray::Endian;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
@@ -743,7 +743,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
         ("writeByte", write_byte),
         ("writeBytes", write_bytes),
         ("readBytes", read_bytes),
@@ -779,8 +779,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("bytesAvailable", Some(bytes_available), None),
         ("length", Some(length), Some(set_length)),

--- a/core/src/avm2/globals/flash/utils/bytearray.rs
+++ b/core/src/avm2/globals/flash/utils/bytearray.rs
@@ -743,7 +743,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[
         ("writeByte", write_byte),
         ("writeBytes", write_bytes),
         ("readBytes", read_bytes),
@@ -777,11 +777,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_methods(PUBLIC_INSTANCE_METHODS);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("bytesAvailable", Some(bytes_available), None),
         ("length", Some(length), Some(set_length)),
         ("position", Some(position), Some(set_position)),

--- a/core/src/avm2/globals/flash/utils/endian.rs
+++ b/core/src/avm2/globals/flash/utils/endian.rs
@@ -38,7 +38,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&'static str, &'static str)] = &[
+    const CONSTANTS: &[(&str, &str)] = &[
         ("LITTLE_ENDIAN", "littleEndian"),
         ("BIG_ENDIAN", "bigEndian"),
     ];

--- a/core/src/avm2/globals/flash/utils/endian.rs
+++ b/core/src/avm2/globals/flash/utils/endian.rs
@@ -3,7 +3,6 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
@@ -38,16 +37,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
 
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "LITTLE_ENDIAN"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("littleEndian".into()),
-    ));
 
-    write.define_class_trait(Trait::from_const(
-        QName::new(Namespace::public(), "BIG_ENDIAN"),
-        QName::new(Namespace::public(), "String").into(),
-        Some("bigEndian".into()),
-    ));
+    const CONSTANTS: &[(&'static str, &'static str)] = &[
+        ("LITTLE_ENDIAN", "littleEndian"),
+        ("BIG_ENDIAN", "bigEndian"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
+
     class
 }

--- a/core/src/avm2/globals/flash/utils/endian.rs
+++ b/core/src/avm2/globals/flash/utils/endian.rs
@@ -35,16 +35,16 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         mc,
     );
 
-    class
-        .write(mc)
-        .set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
-    class.write(mc).define_class_trait(Trait::from_const(
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "LITTLE_ENDIAN"),
         QName::new(Namespace::public(), "String").into(),
         Some("littleEndian".into()),
     ));
 
-    class.write(mc).define_class_trait(Trait::from_const(
+    write.define_class_trait(Trait::from_const(
         QName::new(Namespace::public(), "BIG_ENDIAN"),
         QName::new(Namespace::public(), "String").into(),
         Some("bigEndian".into()),

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -55,7 +55,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
     use std::f64::consts::*;
-    const CONSTANTS: &[(&'static str, f64)] = &[
+    const CONSTANTS: &[(&str, f64)] = &[
         ("E", E),
         ("LN10", LN_10),
         ("LN2", LN_2),
@@ -67,7 +67,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_constant_number_class_traits(CONSTANTS);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[
+    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethod)] = &[
         ("atan2", atan2),
         ("max", max),
         ("min", min),

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
@@ -67,7 +67,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_constant_number_class_traits(CONSTANTS);
 
-    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+    const PUBLIC_CLASS_METHODS: &[(&'static str, NativeMethod)] = &[
         ("atan2", atan2),
         ("max", max),
         ("min", min),

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -2,55 +2,24 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
-use crate::avm2::names::{Multiname, Namespace, QName};
+use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
 use rand::Rng;
 
-macro_rules! math_constants {
-    ($class:ident, $($name:expr => $value:expr),*) => {{
-        $(
-            $class.define_class_trait(Trait::from_const(
-                QName::new(Namespace::public(), $name),
-                Multiname::from(QName::new(Namespace::public(), "Number")),
-                Some($value.into()),
-            ));
-        )*
-    }};
-}
-
-macro_rules! math_method {
-    ($class:ident, $($name:expr => $f:expr),*) => {{
-        $(
-            $class.define_class_trait(Trait::from_method(
-                QName::new(Namespace::public(), $name),
-                Method::from_builtin($f),
-            ));
-        )*
-    }};
-}
-
 macro_rules! math_wrap_std {
-    ($class:ident, $($name:expr => $std:expr),*) => {{
-        $(
-            $class.define_class_trait(Trait::from_method(
-                QName::new(Namespace::public(), $name),
-                Method::from_builtin(
-                    |activation, _this, args| -> Result<Value<'gc>, Error> {
-                        if let Some(input) = args.get(0) {
-                            Ok($std(input.coerce_to_number(activation)?).into())
-                        } else {
-                            Ok(f64::NAN.into())
-                        }
-                    }
-                ),
-            ));
-        )*
-    }};
+    ($std:expr) => {
+        |activation, _this, args| -> Result<Value<'_>, Error> {
+            if let Some(input) = args.get(0) {
+                Ok($std(input.coerce_to_number(activation)?).into())
+            } else {
+                Ok(f64::NAN.into())
+            }
+        }
+    };
 }
 
 /// Implements `Math`'s instance initializer.
@@ -86,43 +55,39 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
     use std::f64::consts::*;
-    math_constants! {
-        write,
-        "E" => E,
-        "LN10" => LN_10,
-        "LN2" => LN_2,
-        "LOG10E" => LOG10_E,
-        "LOG2E" => LOG2_E,
-        "PI" => PI,
-        "SQRT1_2" => FRAC_1_SQRT_2,
-        "SQRT2" => SQRT_2
-    }
+    const CONSTANTS: &[(&'static str, f64)] = &[
+        ("E", E),
+        ("LN10", LN_10),
+        ("LN2", LN_2),
+        ("LOG10E", LOG10_E),
+        ("LOG2E", LOG2_E),
+        ("PI", PI),
+        ("SQRT1_2", FRAC_1_SQRT_2),
+        ("SQRT2", SQRT_2),
+    ];
+    write.define_public_constant_number_class_traits(CONSTANTS);
 
-    math_wrap_std! {
-        write,
-        "abs" => f64::abs,
-        "acos" => f64::acos,
-        "asin" => f64::asin,
-        "atan" => f64::atan,
-        "ceil" => f64::ceil,
-        "cos" => f64::cos,
-        "exp" => f64::exp,
-        "floor" => f64::floor,
-        "log" => f64::ln,
-        "sin" => f64::sin,
-        "sqrt" => f64::sqrt,
-        "tan" => f64::tan
-    }
-
-    math_method! {
-        write,
-        "atan2" => atan2,
-        "max" => max,
-        "min" => min,
-        "pow" => pow,
-        "random" => random,
-        "round" => round
-    }
+    const PUBLIC_CLASS_METHODS: &[(&'static str, GenericNativeMethod)] = &[
+        ("atan2", atan2),
+        ("max", max),
+        ("min", min),
+        ("pow", pow),
+        ("random", random),
+        ("round", round),
+        ("abs", math_wrap_std!(f64::abs)),
+        ("acos", math_wrap_std!(f64::acos)),
+        ("asin", math_wrap_std!(f64::asin)),
+        ("atan", math_wrap_std!(f64::atan)),
+        ("ceil", math_wrap_std!(f64::ceil)),
+        ("cos", math_wrap_std!(f64::cos)),
+        ("exp", math_wrap_std!(f64::exp)),
+        ("floor", math_wrap_std!(f64::floor)),
+        ("log", math_wrap_std!(f64::ln)),
+        ("sin", math_wrap_std!(f64::sin)),
+        ("sqrt", math_wrap_std!(f64::sqrt)),
+        ("tan", math_wrap_std!(f64::tan)),
+    ];
+    write.define_public_builtin_class_methods(PUBLIC_CLASS_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/regexp.rs
+++ b/core/src/avm2/globals/regexp.rs
@@ -1,12 +1,11 @@
 //! `RegExp` impl
 
 use crate::avm2::class::Class;
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{ArrayObject, Object, RegExpObject, TObject};
 use crate::avm2::scope::Scope;
 use crate::avm2::string::AvmString;
-use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::{activation::Activation, array::ArrayStorage};
@@ -275,47 +274,24 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "dotall"),
-        Method::from_builtin(dotall),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "extended"),
-        Method::from_builtin(extended),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "global"),
-        Method::from_builtin(global),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "ignoreCase"),
-        Method::from_builtin(ignore_case),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "multiline"),
-        Method::from_builtin(multiline),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "lastIndex"),
-        Method::from_builtin(last_index),
-    ));
-    write.define_instance_trait(Trait::from_setter(
-        QName::new(Namespace::public(), "lastIndex"),
-        Method::from_builtin(set_last_index),
-    ));
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "source"),
-        Method::from_builtin(source),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[
+        ("dotall", Some(dotall), None),
+        ("extended", Some(extended), None),
+        ("global", Some(global), None),
+        ("ignoreCase", Some(ignore_case), None),
+        ("multiline", Some(multiline), None),
+        ("lastIndex", Some(last_index), Some(set_last_index)),
+        ("source", Some(source), None),
+    ];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::as3_namespace(), "exec"),
-        Method::from_builtin(exec),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::as3_namespace(), "test"),
-        Method::from_builtin(test),
-    ));
+    const AS3_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] =
+        &[("exec", exec), ("test", test)];
+    write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/regexp.rs
+++ b/core/src/avm2/globals/regexp.rs
@@ -274,11 +274,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] = &[
         ("dotall", Some(dotall), None),
         ("extended", Some(extended), None),
         ("global", Some(global), None),
@@ -289,7 +285,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const AS3_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[("exec", exec), ("test", test)];
+    const AS3_INSTANCE_METHODS: &[(&str, NativeMethod)] = &[("exec", exec), ("test", test)];
     write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 
     class

--- a/core/src/avm2/globals/regexp.rs
+++ b/core/src/avm2/globals/regexp.rs
@@ -1,7 +1,7 @@
 //! `RegExp` impl
 
 use crate::avm2::class::Class;
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{ArrayObject, Object, RegExpObject, TObject};
 use crate::avm2::scope::Scope;
@@ -276,8 +276,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[
         ("dotall", Some(dotall), None),
         ("extended", Some(extended), None),
@@ -289,8 +289,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const AS3_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] =
-        &[("exec", exec), ("test", test)];
+    const AS3_INSTANCE_METHODS: &[(&'static str, NativeMethod)] = &[("exec", exec), ("test", test)];
     write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 
     class

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -129,14 +129,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &'static str,
-        Option<NativeMethod>,
-        Option<NativeMethod>,
-    )] = &[("length", Some(length), None)];
+    const PUBLIC_INSTANCE_PROPERTIES: &[(&str, Option<NativeMethod>, Option<NativeMethod>)] =
+        &[("length", Some(length), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const AS3_INSTANCE_METHODS: &[(&'static str, NativeMethod)] =
+    const AS3_INSTANCE_METHODS: &[(&str, NativeMethod)] =
         &[("charAt", char_at), ("charCodeAt", char_code_at)];
     write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -1,13 +1,13 @@
 //! `String` impl
 
+use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::Method;
+use crate::avm2::method::{GenericNativeMethod, Method};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::avm2::{activation::Activation, traits::Trait};
 use crate::string_utils;
 use gc_arena::{GcCell, MutationContext};
 
@@ -129,19 +129,16 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     let mut write = class.write(mc);
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
-    write.define_instance_trait(Trait::from_getter(
-        QName::new(Namespace::public(), "length"),
-        Method::from_builtin(length),
-    ));
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &'static str,
+        Option<GenericNativeMethod>,
+        Option<GenericNativeMethod>,
+    )] = &[("length", Some(length), None)];
+    write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::as3_namespace(), "charAt"),
-        Method::from_builtin(char_at),
-    ));
-    write.define_instance_trait(Trait::from_method(
-        QName::new(Namespace::as3_namespace(), "charCodeAt"),
-        Method::from_builtin(char_code_at),
-    ));
+    const AS3_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] =
+        &[("charAt", char_at), ("charCodeAt", char_code_at)];
+    write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 
     class
 }

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{GenericNativeMethod, Method};
+use crate::avm2::method::{Method, NativeMethod};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::string::AvmString;
@@ -131,12 +131,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &'static str,
-        Option<GenericNativeMethod>,
-        Option<GenericNativeMethod>,
+        Option<NativeMethod>,
+        Option<NativeMethod>,
     )] = &[("length", Some(length), None)];
     write.define_public_builtin_instance_properties(PUBLIC_INSTANCE_PROPERTIES);
 
-    const AS3_INSTANCE_METHODS: &[(&'static str, GenericNativeMethod)] =
+    const AS3_INSTANCE_METHODS: &[(&'static str, NativeMethod)] =
         &[("charAt", char_at), ("charCodeAt", char_code_at)];
     write.define_as3_builtin_instance_methods(AS3_INSTANCE_METHODS);
 

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -25,13 +25,8 @@ use swf::avm2::types::{AbcFile, Index, Method as AbcMethod, MethodBody as AbcMet
 /// resolve on the AVM stack, as if you had called a non-native function. If
 /// your function yields `None`, you must ensure that the top-most activation
 /// in the AVM1 runtime will return with the value of this function.
-pub type NativeMethod<'gc> = fn(
-    &mut Activation<'_, 'gc, '_>,
-    Option<Object<'gc>>,
-    &[Value<'gc>],
-) -> Result<Value<'gc>, Error>;
 
-pub type GenericNativeMethod = for<'gc> fn(
+pub type NativeMethod = for<'gc> fn(
     &mut Activation<'_, 'gc, '_>,
     Option<Object<'gc>>,
     &[Value<'gc>],
@@ -125,7 +120,7 @@ impl<'gc> BytecodeMethod<'gc> {
 #[derive(Clone)]
 pub enum Method<'gc> {
     /// A native method.
-    Native(NativeMethod<'gc>),
+    Native(NativeMethod),
 
     /// An ABC-provided method entry.
     Entry(Gc<'gc, BytecodeMethod<'gc>>),
@@ -152,8 +147,8 @@ impl<'gc> fmt::Debug for Method<'gc> {
     }
 }
 
-impl<'gc> From<NativeMethod<'gc>> for Method<'gc> {
-    fn from(nf: NativeMethod<'gc>) -> Self {
+impl<'gc> From<NativeMethod> for Method<'gc> {
+    fn from(nf: NativeMethod) -> Self {
         Self::Native(nf)
     }
 }
@@ -167,7 +162,7 @@ impl<'gc> From<Gc<'gc, BytecodeMethod<'gc>>> for Method<'gc> {
 impl<'gc> Method<'gc> {
     /// Builtin method constructor, because for some reason `nf.into()` just
     /// causes odd lifetime mismatches.
-    pub fn from_builtin(nf: NativeMethod<'gc>) -> Self {
+    pub fn from_builtin(nf: NativeMethod) -> Self {
         Self::Native(nf)
     }
 

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -31,6 +31,12 @@ pub type NativeMethod<'gc> = fn(
     &[Value<'gc>],
 ) -> Result<Value<'gc>, Error>;
 
+pub type GenericNativeMethod = for<'gc> fn(
+    &mut Activation<'_, 'gc, '_>,
+    Option<Object<'gc>>,
+    &[Value<'gc>],
+) -> Result<Value<'gc>, Error>;
+
 /// Represents a reference to an AVM2 method and body.
 #[derive(Collect, Clone, Debug)]
 #[collect(no_drop)]

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -227,7 +227,7 @@ impl<'gc> FunctionObject<'gc> {
     /// Construct a builtin function object from a Rust function.
     pub fn from_builtin(
         mc: MutationContext<'gc, '_>,
-        nf: NativeMethod<'gc>,
+        nf: NativeMethod,
         fn_proto: Object<'gc>,
     ) -> Object<'gc> {
         FunctionObject(GcCell::allocate(
@@ -243,7 +243,7 @@ impl<'gc> FunctionObject<'gc> {
     /// Construct a builtin type from a Rust constructor and prototype.
     pub fn from_builtin_constr(
         mc: MutationContext<'gc, '_>,
-        constr: NativeMethod<'gc>,
+        constr: NativeMethod,
         mut prototype: Object<'gc>,
         fn_proto: Object<'gc>,
     ) -> Result<Object<'gc>, Error> {


### PR DESCRIPTION
This was a rough first pass at deduplicating AVM2 globals' class creation code. The two major benefits are:

- Smaller final binary due to boilerplate deduplication
- Makes the future steps of auto-generating bindings a bit less painful
- Removing boilerplate reduced length of some source files by half, which helps readability

It technically can slow down initialization a little bit as this effectively "un-unrolled" the code back into loops, but I wouldn't expect it to be a noticeable factor (and smaller code size counters that).

One thing I wasn't sure about was how far to generalize vs specialize the code; for example `define_as3_builtin_instance_methods` is only there to use `Namespace::as3_namespace()` instead of public namespace; but instead of a separate function, there could have been one `define_builtin_instance_methods` function that takes a namespace as argument; or the namespace could have been part of the const array (well, it currently can't, as Namespace needs `'gc` lifetime :( ).

I don't expect to get it perfect the first time, I'm assuming the future "stubs generation from .swc" work would clean this up. In fact, long term I'd hope for the entire class declarations to be defined declaratively, as Rust constants.

As for size differences:

70kB decrease on .wasm:
```
    FILE SIZE
 --------------
  +1.1% +7.17Ki    Data
  +0.8% +4.06Ki    name
  +0.8%     +48    Function
  +0.7%      +6    Type
  -0.0%      -2    Element
  -1.9% -80.4Ki    Code
  -1.3% -69.1Ki    TOTAL
```

Small increase on x64, but only because of not-stripped symbols; with stripping, it'd also be a ~60kB decrease.
```
    FILE SIZE        VM SIZE    
 --------------  -------------- 
  +6.1% +53.8Ki  [ = ]       0    .strtab
  +6.8% +20.6Ki  +6.8% +20.6Ki    .rela.dyn
  +5.9% +16.2Ki  [ = ]       0    .symtab
  +4.8% +11.8Ki  +4.8% +11.8Ki    .data.rel.ro
  +0.1%    +720  +0.1%    +720    .rodata
  +1.4%    +160  +1.5%    +160    .got
  +0.5%    +152  +0.5%    +152    .eh_frame_hdr
  -0.0%     -16  -0.0%     -16    .eh_frame
  -6.8%     -48  -6.8%     -48    [LOAD #2 [RX]]
 -76.3% -2.57Ki  [ = ]       0    [Unmapped]
  -2.5% -86.8Ki  -2.5% -86.8Ki    .text
  +0.2% +14.0Ki  -1.1% -53.4Ki    TOTAL
```
  
70kB doesn't feel like a lot now, but remember that we only have a small % of AS3 API surface done; this would quickly increase over time.
  
(BTW, something similar could be also done for AVM1, though it feels less consistent there)
  
Also, the general approach, like using `Option<NativeMethod>, Option<NativeMethod>` for getters/setters, was inspired from Firefox's JS binding constants, like: https://searchfox.org/mozilla-central/source/__GENERATED__/dom/bindings/CSSRuleBinding.cpp#221
