### PR TITLE
avm1: add property_decl::Declaration for defining built-ins

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -13,13 +13,16 @@ use crate::tag_utils::SwfSlice;
 #[macro_use]
 mod test_utils;
 
+#[macro_use]
+pub mod function;
+#[macro_use]
+pub mod property_decl;
+
 pub mod activation;
 mod callable_value;
 pub mod debug;
 pub mod error;
 mod fscommand;
-#[macro_use]
-pub mod function;
 pub mod globals;
 pub mod object;
 pub mod property;

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -2,11 +2,25 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bevel_filter::{BevelFilterObject, BevelFilterType};
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "distance" => property(distance, set_distance);
+    "angle" => property(angle, set_angle);
+    "highlightColor" => property(highlight_color, set_highlight_color);
+    "highlightAlpha" => property(highlight_alpha, set_highlight_alpha);
+    "shadowColor" => property(shadow_color, set_shadow_color);
+    "shadowAlpha" => property(shadow_alpha, set_shadow_alpha);
+    "quality" => property(quality, set_quality);
+    "strength" => property(strength, set_strength);
+    "knockout" => property(knockout, set_knockout);
+    "blurX" => property(blur_x, set_blur_x);
+    "blurY" => property(blur_y, set_blur_y);
+    "type" => property(get_type, set_type);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -401,210 +415,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let object = BevelFilterObject::empty_object(gc_context, Some(proto));
     let script_object = object.as_script_object().unwrap();
-
-    script_object.add_property(
-        gc_context,
-        "distance",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(distance),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_distance),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "angle",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(angle),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_angle),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "highlightColor",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(highlight_color),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_highlight_color),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "highlightAlpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(highlight_alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_highlight_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "shadowColor",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(shadow_color),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_shadow_color),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "shadowAlpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(shadow_alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_shadow_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "quality",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(quality),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_quality),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "strength",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(strength),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_strength),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "knockout",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(knockout),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_knockout),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "blurX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "blurY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-    script_object.add_property(
-        gc_context,
-        "type",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_type),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_type),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
+    define_properties_on(PROTO_DECLS, gc_context, script_object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -3,7 +3,7 @@
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bitmap_data::{BitmapDataObject, ChannelOptions, Color};
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{activation::Activation, object::bitmap_data::BitmapData};
 use crate::avm1::{Object, TObject, Value};
 use crate::character::Character;
@@ -40,6 +40,40 @@ fn is_size_valid(swf_version: u8, width: u32, height: u32) -> bool {
     }
     true
 }
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "height" => property(height);
+    "width" => property(width);
+    "transparent" => property(get_transparent);
+    "rectangle" => property(get_rectangle);
+    "getPixel" => method(get_pixel);
+    "getPixel32" => method(get_pixel32);
+    "setPixel" => method(set_pixel);
+    "setPixel32" => method(set_pixel32);
+    "copyChannel" => method(copy_channel);
+    "fillRect" => method(fill_rect);
+    "clone" => method(clone);
+    "dispose" => method(dispose);
+    "floodFill" => method(flood_fill);
+    "noise" => method(noise);
+    "colorTransform" => method(color_transform);
+    "getColorBoundsRect" => method(get_color_bounds_rect);
+    "perlinNoise" => method(perlin_noise);
+    "applyFilter" => method(apply_filter);
+    "draw" => method(draw);
+    "hitTest" => method(hit_test);
+    "generateFilterRect" => method(generate_filter_rect);
+    "copyPixels" => method(copy_pixels);
+    "merge" => method(merge);
+    "paletteMap" => method(palette_map);
+    "pixelDissolve" => method(pixel_dissolve);
+    "scroll" => method(scroll);
+    "threshold" => method(threshold);
+};
+
+const OBJECT_DECLS: &[Declaration] = declare_properties! {
+    "loadBitmap" => method(load_bitmap);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -1071,216 +1105,8 @@ pub fn create_proto<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let bitmap_data_object = BitmapDataObject::empty_object(gc_context, Some(proto));
-    let mut object = bitmap_data_object.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "height",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(height),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "width",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(width),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "transparent",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_transparent),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "rectangle",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_rectangle),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::empty(),
-    );
-
-    object.force_set_function(
-        "getPixel",
-        get_pixel,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "getPixel32",
-        get_pixel32,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "setPixel",
-        set_pixel,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "setPixel32",
-        set_pixel32,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "copyChannel",
-        copy_channel,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "fillRect",
-        fill_rect,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "clone",
-        clone,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "dispose",
-        dispose,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "floodFill",
-        flood_fill,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "noise",
-        noise,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "colorTransform",
-        color_transform,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "getColorBoundsRect",
-        get_color_bounds_rect,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "perlinNoise",
-        perlin_noise,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "applyFilter",
-        apply_filter,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function("draw", draw, gc_context, Attribute::empty(), Some(fn_proto));
-    object.force_set_function(
-        "hitTest",
-        hit_test,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "generateFilterRect",
-        generate_filter_rect,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "copyPixels",
-        copy_pixels,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "merge",
-        merge,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "paletteMap",
-        palette_map,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "pixelDissolve",
-        pixel_dissolve,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "scroll",
-        scroll,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "threshold",
-        threshold,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
+    let object = bitmap_data_object.as_script_object().unwrap();
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     bitmap_data_object.into()
 }
 
@@ -1332,24 +1158,16 @@ pub fn load_bitmap<'gc>(
 pub fn create_bitmap_data_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     bitmap_data_proto: Object<'gc>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = FunctionObject::constructor(
+    let bitmap_data = FunctionObject::constructor(
         gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
-        fn_proto,
+        Some(fn_proto),
         bitmap_data_proto,
     );
-    let mut script_object = object.as_script_object().unwrap();
-
-    script_object.force_set_function(
-        "loadBitmap",
-        load_bitmap,
-        gc_context,
-        Attribute::empty(),
-        fn_proto,
-    );
-
-    object
+    let object = bitmap_data.as_script_object().unwrap();
+    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    bitmap_data
 }

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -2,9 +2,13 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "clone" => method(clone);
+};
 
 pub fn constructor<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
@@ -271,11 +275,9 @@ pub fn clone<'gc>(
 pub fn create_proto<'gc>(
     gc_context: MutationContext<'gc, '_>,
     proto: Object<'gc>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function("clone", clone, gc_context, Attribute::empty(), fn_proto);
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -2,11 +2,16 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::blur_filter::BlurFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "blurX" => property(blur_x, set_blur_x);
+    "blurY" => property(get_blur_y, set_blur_y);
+    "quality" => property(get_quality, set_quality);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -117,60 +122,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let blur_filter = BlurFilterObject::empty_object(gc_context, Some(proto));
     let object = blur_filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "blurX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "quality",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_quality),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_quality),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     blur_filter.into()
 }

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -4,9 +4,14 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "toString" => method(to_string);
+    "valueOf" => method(value_of);
+};
 
 /// `Boolean` constructor
 pub fn constructor<'gc>(
@@ -66,23 +71,8 @@ pub fn create_proto<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let boolean_proto = ValueObject::empty_box(gc_context, Some(proto));
-    let mut object = boolean_proto.as_script_object().unwrap();
-
-    object.force_set_function(
-        "toString",
-        to_string,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    object.force_set_function(
-        "valueOf",
-        value_of,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
+    let object = boolean_proto.as_script_object().unwrap();
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     boolean_proto
 }
 

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -6,10 +6,18 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::display_object::{DisplayObject, TDisplayObject};
 use gc_arena::MutationContext;
 use swf::Fixed8;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "getRGB" => method(get_rgb; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getTransform" => method(get_transform; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setRGB" => method(set_rgb; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setTransform" => method(set_transform; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -35,40 +43,8 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function(
-        "getRGB",
-        get_rgb,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "getTransform",
-        get_transform,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "setRGB",
-        set_rgb,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "setTransform",
-        set_transform,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -2,11 +2,14 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::color_matrix_filter::ColorMatrixFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "matrix" => property(matrix, set_matrix);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -72,24 +75,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let color_matrix_filter = ColorMatrixFilterObject::empty_object(gc_context, Some(proto));
     let object = color_matrix_filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "matrix",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(matrix),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_matrix),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     color_matrix_filter.into()
 }

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -1,12 +1,17 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
 use crate::context_menu;
 use crate::display_object::TDisplayObject;
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "copy" => method(copy; DONT_ENUM | DONT_DELETE);
+    "hideBuiltInItems" => method(hide_builtin_items; DONT_ENUM | DONT_DELETE);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -138,24 +143,8 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function(
-        "copy",
-        copy,
-        gc_context,
-        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "hideBuiltInItems",
-        hide_builtin_items,
-        gc_context,
-        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
-        Some(fn_proto),
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -1,10 +1,14 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object};
 use crate::avm1::{ScriptObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "copy" => method(copy; DONT_ENUM | DONT_DELETE);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -100,15 +104,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function(
-        "copy",
-        copy,
-        gc_context,
-        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
-        Some(fn_proto),
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -2,11 +2,22 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::convolution_filter::ConvolutionFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "alpha" => property(alpha, set_alpha);
+    "bias" => property(bias, set_bias);
+    "clamp" => property(clamp, set_clamp);
+    "color" => property(color, set_color);
+    "divisor" => property(divisor, set_divisor);
+    "matrix" => property(matrix, set_matrix);
+    "matrixX" => property(matrix_x, set_matrix_x);
+    "matrixY" => property(matrix_y, set_matrix_y);
+    "preserveAlpha" => property(preserve_alpha, set_preserve_alpha);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -321,168 +332,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let filter = ConvolutionFilterObject::empty_object(gc_context, Some(proto));
     let object = filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "alpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "bias",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(bias),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_bias),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "clamp",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(clamp),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_clamp),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "color",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(color),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_color),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "divisor",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(divisor),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_divisor),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "matrix",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(matrix),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_matrix),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "matrixX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(matrix_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_matrix_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "matrixY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(matrix_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_matrix_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "preserveAlpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(preserve_alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_preserve_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     filter.into()
 }

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -2,11 +2,22 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::displacement_map_filter::DisplacementMapFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "alpha" => property(alpha, set_alpha);
+    "color" => property(color, set_color);
+    "componentX" => property(component_x, set_component_x);
+    "componentY" => property(component_y, set_component_y);
+    "mapBitmap" => property(map_bitmap, set_map_bitmap);
+    "mapPoint" => property(map_point, set_map_point);
+    "mode" => property(mode, set_mode);
+    "scaleX" => property(scale_x, set_scale_x);
+    "scaleY" => property(scale_y, set_scale_y);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -312,168 +323,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let filter = DisplacementMapFilterObject::empty_object(gc_context, Some(proto));
     let object = filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "alpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "color",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(color),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_color),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "componentX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(component_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_component_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "componentY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(component_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_component_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "mapBitmap",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(map_bitmap),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_map_bitmap),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "mapPoint",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(map_point),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_map_point),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "mode",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(mode),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_mode),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "scaleX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(scale_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_scale_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "scaleY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(scale_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_scale_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     filter.into()
 }

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -2,11 +2,24 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::drop_shadow_filter::DropShadowFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "alpha" => property(alpha, set_alpha);
+    "angle" => property(angle, set_angle);
+    "blurX" => property(blur_x, set_blur_x);
+    "blurY" => property(blur_y, set_blur_y);
+    "color" => property(color, set_color);
+    "distance" => property(distance, set_distance);
+    "hideObject" => property(hide_object, set_hide_object);
+    "inner" => property(inner, set_inner);
+    "knockout" => property(knockout, set_knockout);
+    "quality" => property(quality, set_quality);
+    "strength" => property(strength, set_strength);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -365,204 +378,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let drop_shadow_filter = DropShadowFilterObject::empty_object(gc_context, Some(proto));
     let object = drop_shadow_filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "alpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "angle",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(angle),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_angle),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "color",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(color),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_color),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "distance",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(distance),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_distance),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "hideObject",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(hide_object),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_hide_object),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "inner",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(inner),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_inner),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "knockout",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(knockout),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_knockout),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "quality",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(quality),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_quality),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "strength",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(strength),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_strength),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     drop_shadow_filter.into()
 }

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -2,9 +2,15 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "message" => string("Error");
+    "name" => string("Error");
+    "toString" => method(to_string; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -25,19 +31,8 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.define_value(gc_context, "message", "Error".into(), Attribute::empty());
-    object.define_value(gc_context, "name", "Error".into(), Attribute::empty());
-
-    object.force_set_function(
-        "toString",
-        to_string,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -2,11 +2,21 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::glow_filter::GlowFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "alpha" => property(alpha, set_alpha);
+    "blurX" => property(blur_x, set_blur_x);
+    "blurY" => property(blur_y, set_blur_y);
+    "color" => property(color, set_color);
+    "inner" => property(inner, set_inner);
+    "knockout" => property(knockout, set_knockout);
+    "quality" => property(quality, set_quality);
+    "strength" => property(strength, set_strength);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -268,150 +278,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let glow_filter = GlowFilterObject::empty_object(gc_context, Some(proto));
     let object = glow_filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "alpha",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(alpha),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_alpha),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "color",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(color),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_color),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "inner",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(inner),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_inner),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "knockout",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(knockout),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_knockout),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "quality",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(quality),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_quality),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "strength",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(strength),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_strength),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     glow_filter.into()
 }

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -2,12 +2,25 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_bevel_filter::GradientBevelFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "distance" => property(distance, set_distance);
+    "angle" => property(angle, set_angle);
+    "colors" => property(colors, set_colors);
+    "alphas" => property(alphas, set_alphas);
+    "ratios" => property(ratios, set_ratios);
+    "blurX" => property(blur_x, set_blur_x);
+    "blurY" => property(blur_y, set_blur_y);
+    "strength" => property(strength, set_strength);
+    "quality" => property(quality, set_quality);
+    "type" => property(get_type, set_type);
+    "knockout" => property(knockout, set_knockout);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -461,204 +474,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let color_matrix_filter = GradientBevelFilterObject::empty_object(gc_context, Some(proto));
     let object = color_matrix_filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "distance",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(distance),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_distance),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "angle",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(angle),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_angle),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "colors",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(colors),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_colors),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "alphas",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(alphas),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_alphas),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "ratios",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(ratios),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_ratios),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "strength",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(strength),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_strength),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "quality",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(quality),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_quality),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "type",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_type),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_type),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "knockout",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(knockout),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_knockout),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     color_matrix_filter.into()
 }

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -2,12 +2,25 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_glow_filter::GradientGlowFilterObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "distance" => property(distance, set_distance);
+    "angle" => property(angle, set_angle);
+    "colors" => property(colors, set_colors);
+    "alphas" => property(alphas, set_alphas);
+    "ratios" => property(ratios, set_ratios);
+    "blurX" => property(blur_x, set_blur_x);
+    "blurY" => property(blur_y, set_blur_y);
+    "strength" => property(strength, set_strength);
+    "quality" => property(quality, set_quality);
+    "type" => property(get_type, set_type);
+    "knockout" => property(knockout, set_knockout);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -461,204 +474,6 @@ pub fn create_proto<'gc>(
 ) -> Object<'gc> {
     let color_matrix_filter = GradientGlowFilterObject::empty_object(gc_context, Some(proto));
     let object = color_matrix_filter.as_script_object().unwrap();
-
-    object.add_property(
-        gc_context,
-        "distance",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(distance),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_distance),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "angle",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(angle),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_angle),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "colors",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(colors),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_colors),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "alphas",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(alphas),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_alphas),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "ratios",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(ratios),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_ratios),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurX",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_x),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_x),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "blurY",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(blur_y),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_blur_y),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "strength",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(strength),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_strength),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "quality",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(quality),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_quality),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "type",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_type),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_type),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
-    object.add_property(
-        gc_context,
-        "knockout",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(knockout),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_knockout),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::empty(),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     color_matrix_filter.into()
 }

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -1,11 +1,36 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
-use crate::avm1::property::Attribute;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::{Object, ScriptObject, Value};
 use crate::events::KeyCode;
 use gc_arena::MutationContext;
 use std::convert::TryFrom;
+
+const OBJECT_DECLS: &[Declaration] = declare_properties! {
+    "ALT" => int(18; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "BACKSPACE" => int(8; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "CAPSLOCK" => int(20; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "CONTROL" => int(17; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "DELETEKEY" => int(46; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "DOWN" => int(40; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "END" => int(35; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "ENTER" => int(13; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "ESCAPE" => int(27; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "HOME" => int(36; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "INSERT" => int(45; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "LEFT" => int(37; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "PGDN" => int(34; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "PGUP" => int(33; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "RIGHT" => int(39; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "SHIFT" => int(16; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "SPACE" => int(32; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "TAB" => int(9; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "UP" => int(38; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "isDown" => method(is_down; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getAscii" => method(get_ascii; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getCode" => method(get_code; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 pub fn is_down<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -44,152 +69,12 @@ pub fn get_code<'gc>(
 pub fn create_key_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     proto: Option<Object<'gc>>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut key = ScriptObject::object(gc_context, proto);
-
+    let key = ScriptObject::object(gc_context, proto);
     broadcaster_functions.initialize(gc_context, key.into(), array_proto);
-
-    key.define_value(
-        gc_context,
-        "ALT",
-        18.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "BACKSPACE",
-        8.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "CAPSLOCK",
-        20.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "CONTROL",
-        17.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "DELETEKEY",
-        46.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "DOWN",
-        40.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "END",
-        35.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "ENTER",
-        13.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "ESCAPE",
-        27.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "HOME",
-        36.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "INSERT",
-        45.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "LEFT",
-        37.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "PGDN",
-        34.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "PGUP",
-        33.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "RIGHT",
-        39.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "SHIFT",
-        16.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "SPACE",
-        32.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "TAB",
-        9.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-    key.define_value(
-        gc_context,
-        "UP",
-        38.into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    key.force_set_function(
-        "isDown",
-        is_down,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    key.force_set_function(
-        "getAscii",
-        get_ascii,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    key.force_set_function(
-        "getCode",
-        get_code,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
+    define_properties_on(OBJECT_DECLS, gc_context, key, fn_proto);
     key.into()
 }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -4,11 +4,26 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::{NavigationMethod, RequestOptions};
 use gc_arena::MutationContext;
 use std::borrow::Cow;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "load" => method(load; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "send" => method(send; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "sendAndLoad" => method(send_and_load; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "decode" => method(decode; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getBytesLoaded" => method(get_bytes_loaded; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getBytesTotal" => method(get_bytes_total; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "toString" => method(to_string; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "contentType" => string("application/x-www-form-urlencoded"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "onLoad" => method(on_load; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "onData" => method(on_data; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "addRequestHeader" => method(add_request_header; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 /// Implements `LoadVars`
 pub fn constructor<'gc>(
@@ -25,95 +40,8 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function(
-        "load",
-        load,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "send",
-        send,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "sendAndLoad",
-        send_and_load,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "decode",
-        decode,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "getBytesLoaded",
-        get_bytes_loaded,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "getBytesTotal",
-        get_bytes_total,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "toString",
-        to_string,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.define_value(
-        gc_context,
-        "contentType",
-        "application/x-www-form-urlencoded".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    object.force_set_function(
-        "onLoad",
-        on_load,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "onData",
-        on_data,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "addRequestHeader",
-        add_request_header,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -4,10 +4,25 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{point_to_object, value_to_point};
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
 use swf::{Matrix, Twips};
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "toString" => method(to_string);
+    "identity" => method(identity);
+    "clone" => method(clone);
+    "scale" => method(scale);
+    "rotate" => method(rotate);
+    "translate" => method(translate);
+    "concat" => method(concat);
+    "invert" => method(invert);
+    "createBox" => method(create_box);
+    "createGradientBox" => method(create_gradient_box);
+    "transformPoint" => method(transform_point);
+    "deltaTransformPoint" => method(delta_transform_point);
+};
 
 pub fn value_to_matrix<'gc>(
     value: Value<'gc>,
@@ -421,103 +436,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function(
-        "toString",
-        to_string,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "identity",
-        identity,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "clone",
-        clone,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "scale",
-        scale,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "rotate",
-        rotate,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "translate",
-        translate,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "concat",
-        concat,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "invert",
-        invert,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "createBox",
-        create_box,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "createGradientBox",
-        create_gradient_box,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "transformPoint",
-        transform_point,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "deltaTransformPoint",
-        delta_transform_point,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -6,10 +6,17 @@ use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::script_object::ScriptObject;
 use crate::avm1::object::TObject;
 use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, Value};
 use crate::backend::navigator::RequestOptions;
 use crate::display_object::{DisplayObject, TDisplayObject};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "loadClip" => method(load_clip);
+    "unloadClip" => method(unload_clip);
+    "getProgress" => method(get_progress);
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -136,30 +143,7 @@ pub fn create_proto<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
     let mcl_proto = ScriptObject::object(gc_context, Some(proto));
-
     broadcaster_functions.initialize(gc_context, mcl_proto.into(), array_proto);
-
-    mcl_proto.as_script_object().unwrap().force_set_function(
-        "loadClip",
-        load_clip,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    mcl_proto.as_script_object().unwrap().force_set_function(
-        "unloadClip",
-        unload_clip,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    mcl_proto.as_script_object().unwrap().force_set_function(
-        "getProgress",
-        get_progress,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
+    define_properties_on(PROTO_DECLS, gc_context, mcl_proto, fn_proto);
     mcl_proto.into()
 }

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -4,9 +4,34 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "toString" => method(to_string);
+    "isEmpty" => method(is_empty);
+    "setEmpty" => method(set_empty);
+    "clone" => method(clone);
+    "contains" => method(contains);
+    "containsPoint" => method(contains_point);
+    "containsRectangle" => method(contains_rectangle);
+    "intersects" => method(intersects);
+    "union" => method(union);
+    "inflate" => method(inflate);
+    "inflatePoint" => method(inflate_point);
+    "offset" => method(offset);
+    "offsetPoint" => method(offset_point);
+    "intersection" => method(intersection);
+    "equals" => method(equals);
+    "left" => property(get_left, set_left; DONT_ENUM | DONT_DELETE);
+    "top" => property(get_top, set_top; DONT_ENUM | DONT_DELETE);
+    "right" => property(get_right, set_right; DONT_ENUM | DONT_DELETE);
+    "bottom" => property(get_bottom, set_bottom; DONT_ENUM | DONT_DELETE);
+    "size" => property(get_size, set_size; DONT_ENUM | DONT_DELETE);
+    "topLeft" => property(get_top_left, set_top_left; DONT_ENUM | DONT_DELETE);
+    "bottomRight" => property(get_bottom_right, set_bottom_right; DONT_ENUM | DONT_DELETE);
+};
 
 fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -683,253 +708,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
-    object.force_set_function(
-        "toString",
-        to_string,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "isEmpty",
-        is_empty,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "setEmpty",
-        set_empty,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "clone",
-        clone,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "contains",
-        contains,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "containsPoint",
-        contains_point,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "containsRectangle",
-        contains_rectangle,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "intersects",
-        intersects,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "union",
-        union,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "inflate",
-        inflate,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "inflatePoint",
-        inflate_point,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "offset",
-        offset,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "offsetPoint",
-        offset_point,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "intersection",
-        intersection,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "equals",
-        equals,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    object.add_property(
-        gc_context,
-        "left",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_left),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_left),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
-    object.add_property(
-        gc_context,
-        "top",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_top),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_top),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
-    object.add_property(
-        gc_context,
-        "right",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_right),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_right),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
-    object.add_property(
-        gc_context,
-        "bottom",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_bottom),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_bottom),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
-    object.add_property(
-        gc_context,
-        "size",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_size),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_size),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
-    object.add_property(
-        gc_context,
-        "topLeft",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_top_left),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_top_left),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
-    object.add_property(
-        gc_context,
-        "bottomRight",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_bottom_right),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_bottom_right),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_DELETE | Attribute::DONT_ENUM,
-    );
-
+    let object = ScriptObject::object(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -1,10 +1,19 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TDisplayObject, TObject, Value};
 use crate::display_object::{EditText, TextSelection};
 use gc_arena::MutationContext;
+
+const OBJECT_DECLS: &[Declaration] = declare_properties! {
+    "getBeginIndex" => method(get_begin_index; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getEndIndex" => method(get_end_index; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getCaretIndex" => method(get_caret_index; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setSelection" => method(set_selection; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setFocus" => method(set_focus; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getFocus" => method(get_focus; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 pub fn get_begin_index<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -139,58 +148,9 @@ pub fn create_selection_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut object = ScriptObject::object(gc_context, Some(proto));
-
+    let object = ScriptObject::object(gc_context, Some(proto));
     broadcaster_functions.initialize(gc_context, object.into(), array_proto);
-
-    object.force_set_function(
-        "getBeginIndex",
-        get_begin_index,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "getEndIndex",
-        get_end_index,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "getCaretIndex",
-        get_caret_index,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "setSelection",
-        set_selection,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "setFocus",
-        set_focus,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.force_set_function(
-        "getFocus",
-        get_focus,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
+    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -3,13 +3,32 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, SoundObject, TObject, Value};
 use crate::avm_warn;
 use crate::character::Character;
 use crate::display_object::{SoundTransform, TDisplayObject};
 use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "attachSound" => method(attach_sound; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "duration" => property(duration; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getDuration" => method(duration; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setDuration" => method(set_duration; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "id3" => method(id3; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getBytesLoaded" => method(get_bytes_loaded; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getBytesTotal" => method(get_bytes_total; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getPan" => method(get_pan; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getTransform" => method(get_transform; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getVolume" => method(get_volume; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "loadSound" => method(load_sound; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "position" => property(position; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setPan" => method(set_pan; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setTransform" => method(set_transform; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setVolume" => method(set_volume; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "start" => method(start; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "stop" => method(stop; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 /// Implements `Sound`
 pub fn constructor<'gc>(
@@ -38,160 +57,10 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = SoundObject::empty_sound(gc_context, Some(proto));
-
-    object.as_script_object().unwrap().force_set_function(
-        "attachSound",
-        attach_sound,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.add_property(
-        gc_context,
-        "duration",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(duration),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "getDuration",
-        duration,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "setDuration",
-        |_, _, _| Ok(Value::Undefined),
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.add_property(
-        gc_context,
-        "id3",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(id3),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "getBytesLoaded",
-        get_bytes_loaded,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "getBytesTotal",
-        get_bytes_total,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "getPan",
-        get_pan,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "getTransform",
-        get_transform,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "getVolume",
-        get_volume,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "loadSound",
-        load_sound,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.add_property(
-        gc_context,
-        "position",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(position),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "setPan",
-        set_pan,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "setTransform",
-        set_transform,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "setVolume",
-        set_volume,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "start",
-        start,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.as_script_object().unwrap().force_set_function(
-        "stop",
-        stop,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        Some(fn_proto),
-    );
-
-    object.into()
+    let sound = SoundObject::empty_sound(gc_context, Some(proto));
+    let object = sound.as_script_object().unwrap();
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    sound.into()
 }
 
 fn attach_sound<'gc>(
@@ -250,6 +119,14 @@ fn duration<'gc>(
         }
     }
 
+    Ok(Value::Undefined)
+}
+
+fn set_duration<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -3,11 +3,18 @@
 //! TODO: This is a very rough stub with not much implementation.
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
-use crate::avm1::property::Attribute;
-use crate::avm1::{AvmString, Object, ScriptObject, TObject, Value};
+use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::{AvmString, Object, ScriptObject, Value};
 use gc_arena::MutationContext;
+
+const OBJECT_DECLS: &[Declaration] = declare_properties! {
+    "align" => property(align, set_align; DONT_ENUM | DONT_DELETE);
+    "height" => property(height; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "scaleMode" => property(scale_mode, set_scale_mode; DONT_ENUM | DONT_DELETE);
+    "showMenu" => property(show_menu, set_show_menu; DONT_ENUM | DONT_DELETE);
+    "width" => property(width; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 pub fn create_stage_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
@@ -17,89 +24,8 @@ pub fn create_stage_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
     let stage = ScriptObject::object(gc_context, proto);
-
     broadcaster_functions.initialize(gc_context, stage.into(), array_proto.unwrap());
-
-    stage.add_property(
-        gc_context,
-        "align",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(align),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_align),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
-    );
-
-    stage.add_property(
-        gc_context,
-        "height",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(height),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    stage.add_property(
-        gc_context,
-        "scaleMode",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(scale_mode),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_scale_mode),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
-    );
-
-    stage.add_property(
-        gc_context,
-        "showMenu",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(show_menu),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        Some(FunctionObject::function(
-            gc_context,
-            Executable::Native(set_show_menu),
-            Some(fn_proto),
-            fn_proto,
-        )),
-        Attribute::DONT_ENUM | Attribute::DONT_DELETE,
-    );
-
-    stage.add_property(
-        gc_context,
-        "width",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(width),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
+    define_properties_on(OBJECT_DECLS, gc_context, stage, fn_proto);
     stage.into()
 }
 

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -2,10 +2,27 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::Object;
-use crate::avm1::property::Attribute;
-use crate::avm1::{ScriptObject, TObject, Value};
+use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::{ScriptObject, Value};
 use gc_arena::MutationContext;
 use std::convert::Into;
+
+const OBJECT_DECLS: &[Declaration] = declare_properties! {
+    "ALPHANUMERIC_FULL" => string("ALPHANUMERIC_FULL"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "ALPHANUMERIC_HALF" => string("ALPHANUMERIC_HALF"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "CHINESE" => string("CHINESE"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "JAPANESE_HIRAGANA" => string("JAPANESE_HIRAGANA"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "JAPENESE_KATAKANA_FULL" => string("JAPENESE_KATAKANA_FULL"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "KOREAN" => string("KOREAN"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "UNKNOWN" => string("UNKNOWN"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "onIMEComposition" => method(on_ime_composition; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "doConversion" => method(do_conversion; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getConversionMode" => method(get_conversion_mode; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "getEnabled" => method(get_enabled; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setCompositionString" => method(set_composition_string; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setConversionMode" => method(set_conversion_mode; DONT_ENUM | DONT_DELETE | READ_ONLY);
+    "setEnabled" => method(set_enabled; DONT_ENUM | DONT_DELETE | READ_ONLY);
+};
 
 fn on_ime_composition<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
@@ -66,118 +83,12 @@ fn set_enabled<'gc>(
 pub fn create<'gc>(
     gc_context: MutationContext<'gc, '_>,
     proto: Option<Object<'gc>>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut ime = ScriptObject::object(gc_context, proto);
-
+    let ime = ScriptObject::object(gc_context, proto);
     broadcaster_functions.initialize(gc_context, ime.into(), array_proto);
-
-    ime.define_value(
-        gc_context,
-        "ALPHANUMERIC_FULL",
-        "ALPHANUMERIC_FULL".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.define_value(
-        gc_context,
-        "ALPHANUMERIC_HALF",
-        "ALPHANUMERIC_HALF".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.define_value(
-        gc_context,
-        "CHINESE",
-        "CHINESE".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.define_value(
-        gc_context,
-        "JAPANESE_HIRAGANA",
-        "JAPANESE_HIRAGANA".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.define_value(
-        gc_context,
-        "JAPANESE_KATAKANA_FULL",
-        "JAPANESE_KATAKANA_FULL".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.define_value(
-        gc_context,
-        "KOREAN",
-        "KOREAN".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.define_value(
-        gc_context,
-        "UNKNOWN",
-        "UNKNOWN".into(),
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-    );
-
-    ime.force_set_function(
-        "onIMEComposition",
-        on_ime_composition,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    ime.force_set_function(
-        "doConversion",
-        do_conversion,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    ime.force_set_function(
-        "getConversionMode",
-        get_conversion_mode,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    ime.force_set_function(
-        "getEnabled",
-        get_enabled,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    ime.force_set_function(
-        "setCompositionString",
-        set_composition_string,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    ime.force_set_function(
-        "setConversionMode",
-        set_conversion_mode,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
-    ime.force_set_function(
-        "setEnabled",
-        set_enabled,
-        gc_context,
-        Attribute::DONT_DELETE | Attribute::READ_ONLY | Attribute::DONT_ENUM,
-        fn_proto,
-    );
-
+    define_properties_on(OBJECT_DECLS, gc_context, ime, fn_proto);
     ime.into()
 }

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -1,12 +1,21 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::Object;
-use crate::avm1::property::Attribute;
-use crate::avm1::{AvmString, ScriptObject, TObject, Value};
+use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::{AvmString, ScriptObject, Value};
 use crate::avm_warn;
 use gc_arena::MutationContext;
 use std::convert::Into;
+
+const OBJECT_DECLS: &[Declaration] = declare_properties! {
+    "PolicyFileResolver" => method(policy_file_resolver);
+    "allowDomain" => method(allow_domain);
+    "allowInsecureDomain" => method(allow_insecure_domain);
+    "loadPolicyFile" => method(load_policy_file);
+    "escapeDomain" => method(escape_domain);
+    "sandboxType" => property(get_sandbox_type);
+    "chooseLocalSwfPath" => property(get_choose_local_swf_path);
+};
 
 fn allow_domain<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -91,73 +100,7 @@ pub fn create<'gc>(
     proto: Option<Object<'gc>>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mut security = ScriptObject::object(gc_context, proto);
-
-    security.force_set_function(
-        "PolicyFileResolver",
-        policy_file_resolver,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    security.force_set_function(
-        "allowDomain",
-        allow_domain,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    security.force_set_function(
-        "allowInsecureDomain",
-        allow_insecure_domain,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    security.force_set_function(
-        "loadPolicyFile",
-        load_policy_file,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    security.force_set_function(
-        "escapeDomain",
-        escape_domain,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
-    security.add_property(
-        gc_context,
-        "sandboxType",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_sandbox_type),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::empty(),
-    );
-
-    security.add_property(
-        gc_context,
-        "chooseLocalSwfPath",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(get_choose_local_swf_path),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::empty(),
-    );
-
+    let security = ScriptObject::object(gc_context, proto);
+    define_properties_on(OBJECT_DECLS, gc_context, security, fn_proto);
     security.into()
 }

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -2,71 +2,47 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::{color_transform, matrix};
 use crate::avm1::object::transform_object::TransformObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject};
 use gc_arena::MutationContext;
 
-macro_rules! with_transform_props {
-    ($obj:ident, $gc:ident, $fn_proto:ident, $($name:literal => [$get:ident $(, $set:ident)*],)*) => {
-        $(
-            $obj.add_property(
-                $gc,
-                $name,
-                with_transform_props!(getter $gc, $fn_proto, $get),
-                with_transform_props!(setter $gc, $fn_proto, $($set),*),
-                Attribute::empty(),
-            );
-        )*
-    };
-
-    (getter $gc:ident, $fn_proto:ident, $get:ident) => {
-        FunctionObject::function(
-            $gc,
-            Executable::Native(
-                |activation: &mut Activation<'_, 'gc, '_>, this, _args| -> Result<Value<'gc>, Error<'gc>> {
-                    if let Some(transform) = this.as_transform_object() {
-                        if let Some(clip) = transform.clip() {
-                            return $get(activation, clip);
-                        }
-                    }
-                    Ok(Value::Undefined)
-                } as crate::avm1::function::NativeFunction<'gc>
-            ),
-            Some($fn_proto),
-            $fn_proto
-        )
-    };
-
-    (setter $gc:ident, $fn_proto:ident, $set:ident) => {
-        Some(FunctionObject::function(
-            $gc,
-            Executable::Native(
-                |activation: &mut Activation<'_, 'gc, '_>, this, args| -> Result<Value<'gc>, Error<'gc>> {
-                    if let Some(transform) = this.as_transform_object() {
-                        if let Some(clip) = transform.clip() {
-                            let value = args
-                                .get(0)
-                                .unwrap_or(&Value::Undefined)
-                                .clone();
-                            $set(activation, clip, value)?;
-                        }
-                    }
-                    Ok(Value::Undefined)
-                } as crate::avm1::function::NativeFunction<'gc>
-            ),
-            Some($fn_proto),
-            $fn_proto)
-        )
-    };
-
-    (setter $gc:ident, $fn_proto:ident,) => {
-        None
+macro_rules! tx_getter {
+    ( $get:ident ) => {
+        |activation, this, _args| {
+            if let Some(transform) = this.as_transform_object() {
+                if let Some(clip) = transform.clip() {
+                    return $get(activation, clip);
+                }
+            }
+            Ok(Value::Undefined)
+        }
     };
 }
+
+macro_rules! tx_setter {
+    ( $set:ident ) => {
+        |activation, this, args| {
+            if let Some(transform) = this.as_transform_object() {
+                if let Some(clip) = transform.clip() {
+                    let value = args.get(0).unwrap_or(&Value::Undefined).clone();
+                    $set(activation, clip, value)?;
+                }
+            }
+            Ok(Value::Undefined)
+        }
+    };
+}
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "concatenatedColorTransform" => property(tx_getter!(concatenated_color_transform));
+    "concatenatedMatrix" => property(tx_getter!(concatenated_matrix));
+    "colorTransform" => property(tx_getter!(color_transform), tx_setter!(set_color_transform));
+    "matrix" => property(tx_getter!(matrix), tx_setter!(set_matrix));
+    "pixelBounds" => property(tx_getter!(pixel_bounds));
+};
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
@@ -93,16 +69,8 @@ pub fn create_proto<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let transform_object = TransformObject::empty(gc_context, Some(proto));
-    let proto = transform_object.as_script_object().unwrap();
-
-    with_transform_props!(proto, gc_context, fn_proto,
-        "concatenatedColorTransform" => [concatenated_color_transform],
-        "concatenatedMatrix" => [concatenated_matrix],
-        "colorTransform" => [color_transform, set_color_transform],
-        "matrix" => [matrix, set_matrix],
-        "pixelBounds" => [pixel_bounds],
-    );
-
+    let object = transform_object.as_script_object().unwrap();
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     transform_object.into()
 }
 

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -2,10 +2,9 @@
 
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::script_object::ScriptObject;
 use crate::avm1::object::xml_object::XmlObject;
-use crate::avm1::property::Attribute;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{AvmString, Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::RequestOptions;
@@ -28,6 +27,45 @@ pub const XML_ATTRIBUTE_NOT_TERMINATED: f64 = -8.0;
 #[allow(dead_code)]
 pub const XML_MISMATCHED_START: f64 = -9.0;
 pub const XML_MISMATCHED_END: f64 = -10.0;
+
+const XMLNODE_PROTO_DECLS: &[Declaration] = declare_properties! {
+    "localName" => property(xmlnode_local_name; READ_ONLY);
+    "nodeName" => property(xmlnode_node_name; READ_ONLY);
+    "nodeType" => property(xmlnode_node_type; READ_ONLY);
+    "nodeValue" => property(xmlnode_node_value; READ_ONLY);
+    "prefix" => property(xmlnode_prefix; READ_ONLY);
+    "childNodes" => property(xmlnode_child_nodes; READ_ONLY);
+    "firstChild" => property(xmlnode_first_child; READ_ONLY);
+    "lastChild" => property(xmlnode_last_child; READ_ONLY);
+    "parentNode" => property(xmlnode_parent_node; READ_ONLY);
+    "previousSibling" => property(xmlnode_previous_sibling; READ_ONLY);
+    "nextSibling" => property(xmlnode_next_sibling; READ_ONLY);
+    "attributes" => property(xmlnode_attributes; READ_ONLY);
+    "namespaceURI" => property(xmlnode_namespace_uri; READ_ONLY);
+    "appendChild" => method(xmlnode_append_child);
+    "insertBefore" => method(xmlnode_insert_before);
+    "cloneNode" => method(xmlnode_clone_node);
+    "getNamespaceForPrefix" => method(xmlnode_get_namespace_for_prefix);
+    "getPrefixForNamespace" => method(xmlnode_get_prefix_for_namespace);
+    "hasChildNodes" => method(xmlnode_has_child_nodes);
+    "removeNode" => method(xmlnode_remove_node);
+    "toString" => method(xmlnode_to_string);
+};
+
+const XML_PROTO_DECLS: &[Declaration] = declare_properties! {
+    "docTypeDecl" => property(xml_doc_type_decl; READ_ONLY);
+    "ignoreWhite" => bool(false);
+    "contentType" => string("application/x-www-form-urlencoded"; READ_ONLY);
+    "xmlDecl" => property(xml_xml_decl; READ_ONLY);
+    "idMap" => property(xml_id_map; READ_ONLY);
+    "status" => property(xml_status; READ_ONLY);
+    "createElement" => method(xml_create_element);
+    "createTextNode" => method(xml_create_text_node);
+    "parseXML" => method(xml_parse_xml);
+    "load" => method(xml_load);
+    "sendAndLoad" => method(xml_send_and_load);
+    "onData" => method(xml_on_data);
+};
 
 /// Returns true if a particular node can or cannot be exposed to AVM1.
 ///
@@ -534,244 +572,8 @@ pub fn create_xmlnode_proto<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let xmlnode_proto = XmlObject::empty_node(gc_context, Some(proto));
-
-    xmlnode_proto.add_property(
-        gc_context,
-        "localName",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_local_name),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "nodeName",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_node_name),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "nodeType",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_node_type),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "nodeValue",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_node_value),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "prefix",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_prefix),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "childNodes",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_child_nodes),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "firstChild",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_first_child),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "lastChild",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_last_child),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "parentNode",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_parent_node),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "previousSibling",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_previous_sibling),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "nextSibling",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_next_sibling),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "attributes",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_attributes),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto.add_property(
-        gc_context,
-        "namespaceURI",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xmlnode_namespace_uri),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "appendChild",
-            xmlnode_append_child,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "insertBefore",
-            xmlnode_insert_before,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "cloneNode",
-            xmlnode_clone_node,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "getNamespaceForPrefix",
-            xmlnode_get_namespace_for_prefix,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "getPrefixForNamespace",
-            xmlnode_get_prefix_for_namespace,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "hasChildNodes",
-            xmlnode_has_child_nodes,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "removeNode",
-            xmlnode_remove_node,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-    xmlnode_proto
-        .as_script_object()
-        .unwrap()
-        .force_set_function(
-            "toString",
-            xmlnode_to_string,
-            gc_context,
-            Attribute::empty(),
-            Some(fn_proto),
-        );
-
+    let object = xmlnode_proto.as_script_object().unwrap();
+    define_properties_on(XMLNODE_PROTO_DECLS, gc_context, object, fn_proto);
     xmlnode_proto
 }
 
@@ -1126,104 +928,7 @@ pub fn create_xml_proto<'gc>(
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let xml_proto = XmlObject::empty_node(gc_context, Some(proto));
-
-    xml_proto.add_property(
-        gc_context,
-        "docTypeDecl",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xml_doc_type_decl),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xml_proto.define_value(gc_context, "ignoreWhite", false.into(), Attribute::empty());
-    xml_proto.define_value(
-        gc_context,
-        "contentType",
-        "application/x-www-form-urlencoded".into(),
-        Attribute::empty(),
-    );
-    xml_proto.add_property(
-        gc_context,
-        "xmlDecl",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xml_xml_decl),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xml_proto.add_property(
-        gc_context,
-        "idMap",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xml_id_map),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xml_proto.add_property(
-        gc_context,
-        "status",
-        FunctionObject::function(
-            gc_context,
-            Executable::Native(xml_status),
-            Some(fn_proto),
-            fn_proto,
-        ),
-        None,
-        Attribute::READ_ONLY,
-    );
-    xml_proto.as_script_object().unwrap().force_set_function(
-        "createElement",
-        xml_create_element,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    xml_proto.as_script_object().unwrap().force_set_function(
-        "createTextNode",
-        xml_create_text_node,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    xml_proto.as_script_object().unwrap().force_set_function(
-        "parseXML",
-        xml_parse_xml,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    xml_proto.as_script_object().unwrap().force_set_function(
-        "load",
-        xml_load,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    xml_proto.as_script_object().unwrap().force_set_function(
-        "sendAndLoad",
-        xml_send_and_load,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-    xml_proto.as_script_object().unwrap().force_set_function(
-        "onData",
-        xml_on_data,
-        gc_context,
-        Attribute::empty(),
-        Some(fn_proto),
-    );
-
+    let object = xml_proto.as_script_object().unwrap();
+    define_properties_on(XML_PROTO_DECLS, gc_context, object, fn_proto);
     xml_proto
 }

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -1,6 +1,6 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
-use crate::avm1::function::{Executable, ExecutionReason, FunctionObject, NativeFunction};
+use crate::avm1::function::ExecutionReason;
 use crate::avm1::property::{Attribute, Property};
 use crate::avm1::property_map::{Entry, PropertyMap};
 use crate::avm1::{AvmString, Object, ObjectPtr, TObject, Value};
@@ -166,35 +166,6 @@ impl<'gc> ScriptObject<'gc> {
                 watchers: PropertyMap::new(),
             },
         ))
-    }
-
-    /// Declare a native function on the current object.
-    ///
-    /// This is intended for use with defining host object prototypes. Notably,
-    /// this creates a function object without an explicit `prototype`, which
-    /// is only possible when defining host functions. User-defined functions
-    /// always get a fresh explicit prototype, so you should never force set a
-    /// user-defined function.
-    pub fn force_set_function(
-        &mut self,
-        name: &str,
-        function: NativeFunction<'gc>,
-        gc_context: MutationContext<'gc, '_>,
-        attributes: Attribute,
-        fn_proto: Option<Object<'gc>>,
-    ) {
-        self.define_value(
-            gc_context,
-            name,
-            FunctionObject::bare_function(
-                gc_context,
-                Some(function),
-                Option::<Executable>::None,
-                fn_proto,
-            )
-            .into(),
-            attributes,
-        )
     }
 
     pub fn set_type_of(&mut self, gc_context: MutationContext<'gc, '_>, type_of: &'static str) {
@@ -821,10 +792,10 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
 mod tests {
     use super::*;
 
-    use crate::avm1::activation::ActivationIdentifier;
     use crate::avm1::function::Executable;
     use crate::avm1::globals::system::SystemProperties;
     use crate::avm1::property::Attribute;
+    use crate::avm1::{activation::ActivationIdentifier, function::FunctionObject};
     use crate::avm1::{Avm1, Timers};
     use crate::avm2::Avm2;
     use crate::backend::audio::{AudioManager, NullAudioBackend};

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -1,7 +1,6 @@
 //! User-defined properties
 
-use crate::avm1::object::Object;
-use crate::avm1::Value;
+use crate::avm1::{Object, Value};
 use bitflags::bitflags;
 use core::fmt;
 use gc_arena::Collect;

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -1,0 +1,213 @@
+//! Declarative macro for defining AVM1 properties.
+
+use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
+use crate::avm1::property::Attribute;
+use crate::avm1::{Object, ScriptObject, TObject, Value};
+use gc_arena::MutationContext;
+
+/// Defines a list of properties on a [`ScriptObject`].
+#[inline(never)]
+pub fn define_properties_on<'gc>(
+    decls: &[Declaration],
+    mc: MutationContext<'gc, '_>,
+    this: ScriptObject<'gc>,
+    fn_proto: Object<'gc>,
+) {
+    for decl in decls {
+        decl.define_on(mc, this, fn_proto);
+    }
+}
+
+/// The declaration of a property, method, or simple field, that
+/// can be defined on a [`ScriptObject`].
+#[derive(Copy, Clone)]
+pub struct Declaration {
+    pub name: &'static str,
+    pub kind: DeclKind,
+    // This should be an `Attribute`, but because of `const` shenanigans
+    // we need to store the raw flags.
+    // See the comment in the `declare_properties!` macro.
+    pub attributes: u8,
+}
+
+/// All the possible types of a [`Declaration`].
+#[derive(Copy, Clone)]
+pub enum DeclKind {
+    /// Declares a property with a getter and an optional setter.
+    Property {
+        getter: NativeFunction,
+        setter: Option<NativeFunction>,
+    },
+    /// Declares a native host function.
+    ///
+    /// This is intended for use with defining host object prototypes. Notably,
+    /// this creates a function object without an explicit `prototype`, which
+    /// is only possible when defining host functions.
+    Method(NativeFunction),
+    /// Declares a native function with a `prototype`.
+    /// Prefer using [`Self::Method`] when defining host functions.
+    Function(NativeFunction),
+    /// Declares a static string value.
+    String(&'static str),
+    /// Declares a static bool value.
+    Bool(bool),
+    /// Declares a static int value.
+    Int(i32),
+    /// Declares a static float value.
+    Float(f64),
+}
+
+impl Declaration {
+    #[inline(never)]
+    /// Defines the field represented by this declaration on a [`ScriptObject`].
+    /// Returns the value defined on the object, or `undefined` if this declaration
+    /// defined a property.
+    pub fn define_on<'gc>(
+        &self,
+        mc: MutationContext<'gc, '_>,
+        this: ScriptObject<'gc>,
+        fn_proto: Object<'gc>,
+    ) -> Value<'gc> {
+        let attributes = Attribute::from_bits_truncate(self.attributes);
+        let value = match self.kind {
+            DeclKind::Property { getter, setter } => {
+                let getter = FunctionObject::function(
+                    mc,
+                    Executable::Native(getter),
+                    Some(fn_proto),
+                    fn_proto,
+                );
+                let setter = setter.map(|setter| {
+                    FunctionObject::function(
+                        mc,
+                        Executable::Native(setter),
+                        Some(fn_proto),
+                        fn_proto,
+                    )
+                });
+                this.add_property(mc, self.name, getter, setter, attributes);
+                return Value::Undefined;
+            }
+            DeclKind::Method(func) => FunctionObject::bare_function(
+                mc,
+                Some(Executable::Native(func)),
+                None,
+                Some(fn_proto),
+            )
+            .into(),
+            DeclKind::Function(func) => {
+                FunctionObject::function(mc, Executable::Native(func), Some(fn_proto), fn_proto)
+                    .into()
+            }
+            DeclKind::String(s) => s.into(),
+            DeclKind::Bool(b) => b.into(),
+            DeclKind::Int(i) => i.into(),
+            DeclKind::Float(f) => f.into(),
+        };
+
+        this.define_value(mc, self.name, value, attributes);
+        value
+    }
+}
+
+/// Declares a list of property [`Declaration`]s that can be later defined on [`ScriptObject`]s.
+///
+/// # Usage:
+///
+/// ```rust,ignored
+/// const DECLS: &'static [Declaration] = declare_properties! {
+///     "length" => property(get_length);
+///     "filters" => property(get_filters, set_filters);
+///     "to_string" => method(to_string);
+///     "to_string2" => function(to_string);
+///     "locale" => string("en-US");
+///     "enabled" => bool(true);
+///     "size" => int(123);
+///     "scale" => float(0.85);
+///     // all declarations can also specify attributes
+///     "hidden" => string("shh!"; DONT_ENUM | DONT_DELETE | READ_ONLY);
+/// }
+/// ```
+macro_rules! declare_properties {
+    ( $($name:literal => $kind:ident($($args:tt)*);)* ) => {
+        &[ $(
+            declare_properties!(@__prop $kind($name, $($args)*))
+        ),* ]
+    };
+    (@__prop $kind:ident($name:literal $(,$args:expr)*) ) => {
+        crate::avm1::property_decl::Declaration {
+            name: $name,
+            kind: declare_properties!(@__kind $kind ($($args),*)),
+            attributes: 0,
+        }
+    };
+    (@__prop $kind:ident($name:literal $(,$args:expr)*; $($attributes:ident)|*) ) => {
+        crate::avm1::property_decl::Declaration {
+            name: $name,
+            kind: declare_properties!(@__kind $kind ($($args),*)),
+            /*
+                WARNING: HORRIBLE HACK AHEAD!
+
+                To declare property attributes in a way that is valid in `const` context,
+                we store them as raw `u8`s and do the bitflag management ourselves.
+
+                Here are two better ways that unfortunately don't work.
+
+                A) `Attribute::FOO | Attribute::BAR`
+
+                This can't be used, because operator overloading doesn't work in `const` context.
+
+                B) `Attributes::from_bits_truncate(Attribute::FOO.bits() | Attribute::BAR.bits())`
+
+                Here, everything is a proper `const fn` and so this should work correctly,
+                but NO!, we hit an ICE in the compiler :(
+                See:
+                    https://github.com/rust-lang/rust/issues/81899
+                    https://github.com/rust-lang/rust/issues/84957
+
+                TODO: use the `B)` desugaring once the above ICE is fixed.
+            */
+            attributes: 0 $(| declare_properties!(@__attr $attributes))*,
+        }
+    };
+    // MAKE SURE THESE VALUES ARE IN SYNC WITH THE `Attribute` DEFINITION!
+    (@__attr DONT_ENUM) => {
+        (1 << 0)
+    };
+    (@__attr DONT_DELETE) => {
+        (1 << 1)
+    };
+    (@__attr READ_ONLY) => {
+        (1 << 2)
+    };
+    (@__kind property($getter:expr)) => {
+        crate::avm1::property_decl::DeclKind::Property {
+            getter: $getter,
+            setter: None,
+        }
+    };
+    (@__kind property($getter:expr, $setter:expr)) => {
+        crate::avm1::property_decl::DeclKind::Property {
+            getter: $getter,
+            setter: Some($setter),
+        }
+    };
+    (@__kind method($method:expr)) => {
+        crate::avm1::property_decl::DeclKind::Method($method)
+    };
+    (@__kind function($function:expr)) => {
+        crate::avm1::property_decl::DeclKind::Function($function)
+    };
+    (@__kind string($string:expr)) => {
+        crate::avm1::property_decl::DeclKind::String($string)
+    };
+    (@__kind bool($boolean:expr)) => {
+        crate::avm1::property_decl::DeclKind::Bool($boolean)
+    };
+    (@__kind int($int:expr)) => {
+        crate::avm1::property_decl::DeclKind::Int($int)
+    };
+    (@__kind float($float:expr)) => {
+        crate::avm1::property_decl::DeclKind::Float($float)
+    };
+}

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -126,7 +126,7 @@ macro_rules! test_method {
                 for version in &$versions {
                     with_avm(*version, |activation, _root| -> Result<(), Error> {
                         let object = $object(activation);
-                        let function = object.get($name, activation)?;
+                        let function = crate::avm1::object::TObject::get(&object, $name, activation)?;
 
                         $(
                             let args: Vec<Value> = vec![$($arg.into()),*];


### PR DESCRIPTION
`Declaration`s (`PDecl` for short) allow for reduced boilerplate when defining native methods, properties, and constants (but not values depending on other runtime values, like built-ins objects and prototypes).

Also remove `ScriptObject::force_set_function` (replaced by `PDecl::method`).

The diff is mainly mechanical changes to use `PDecl` in all `globals::*` modules; the meat of the PR is in [avm1::property_decl](https://github.com/moulins/ruffle/blob/b0830fb7/core/src/avm1/property_decl.rs).

------------

There are still things I would like to do before merging this:
  - `PDecl` methods aren't `const fn` due to limitations in const eval; I don't think this can be easily improved without some features in rustc, but maybe I missed something?
  - Prototypes declarations in `avm1::globals` still use the "manual" style, because `PDecl` can't handle runtime values like `Object`s. I have some ideas on how to fix  this, but it still needs work and probably some refactoring in the way built-in prototypes are created.