### PR TITLE
tests: Fix swf::Fixed tests in --release (fix #4313)

### DIFF
--- a/swf/src/types/fixed.rs
+++ b/swf/src/types/fixed.rs
@@ -424,7 +424,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn neg_overflow() {
         let _ = -Fixed8::from(-128);
     }
@@ -466,7 +466,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn add_overflow() {
         let _ = Fixed8::from(-128) + Fixed8::from(-1);
     }
@@ -508,7 +508,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn sub_overflow() {
         let _ = Fixed8::from(-128) - Fixed8::from(1);
     }
@@ -556,7 +556,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn mul_overflow() {
         let _ = Fixed8::from(64) * Fixed8::from(64);
     }
@@ -583,7 +583,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn mul_int_overflow() {
         let _ = Fixed8::from_f64(127.5).mul_int(30001);
     }
@@ -630,7 +630,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[cfg_attr(debug_assertions, should_panic)]
     fn div_overflow() {
         let _ = Fixed8::from(-128) / Fixed8::from(-1);
     }


### PR DESCRIPTION
Use `#[cfg_attr(debug_assertions, should_panic)]` to ensure that
the tests only expect to panic in debug builds.

Fixes #4313.