### PR TITLE
swf: SwfStr: reimplement `Debug` with `std::ascii::escape_default`

### DIFF
--- a/swf/src/string.rs
+++ b/swf/src/string.rs
@@ -257,9 +257,18 @@ impl<'a, T: ?Sized + AsRef<str>> PartialEq<T> for SwfStr {
 impl fmt::Debug for SwfStr {
     /// Formats the `SwfStr` using the given formatter.
     ///
-    /// Note: this method assumes UTF-8 encoding;
-    /// other encodings like Shift-JIS will output gibberish.
+    /// Non-ASCII characters will be formatted in hexadecimal
+    /// form (`\xNN`).
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_str_lossy(UTF_8))
+        fmt::Write::write_char(f, '"')?;
+        for chr in self
+            .string
+            .iter()
+            .map(|&c| std::ascii::escape_default(c))
+            .flatten()
+        {
+            fmt::Write::write_char(f, char::from(chr))?;
+        }
+        fmt::Write::write_char(f, '"')
     }
 }


### PR DESCRIPTION
The string will now be surrounded with quotes (`"`), non-ASCII characters (UTF-8 or not) will be escaped in hexadecimal form (`\xNN`) and ASCII control characters will be escaped (`\x01`, `\n`, `\t`).

This brings the result closer to the output of `str`'s `Debug`.