### PR TITLE
core: Use bitflags for HitTestOptions

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -136,10 +136,7 @@ pub fn hit_test<'gc>(
                 movie_clip.hit_test_shape(
                     &mut activation.context,
                     point,
-                    HitTestOptions {
-                        skip_mask: true,
-                        skip_invisible: false,
-                    },
+                    HitTestOptions::AVM_HIT_TEST,
                 )
             } else {
                 movie_clip.hit_test_bounds(point)

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -512,10 +512,7 @@ pub fn hit_test_point<'gc>(
                 .hit_test_shape(
                     &mut activation.context,
                     (x, y),
-                    HitTestOptions {
-                        skip_mask: true,
-                        skip_invisible: false,
-                    },
+                    HitTestOptions::AVM_HIT_TEST,
                 )
                 .into());
         } else {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1589,15 +1589,22 @@ bitflags! {
     }
 }
 
-/// Defines how hit testing should be performed.
-/// Used for mouse picking and ActionScript's hitTestClip functions.
-#[derive(Debug, Copy, Clone)]
-pub struct HitTestOptions {
-    /// Ignore objects used as masks (setMask / clipDepth).
-    pub skip_mask: bool,
+bitflags! {
+    /// Defines how hit testing should be performed.
+    /// Used for mouse picking and ActionScript's hitTestClip functions.
+    pub struct HitTestOptions: u8 {
+        /// Ignore objects used as masks (setMask / clipDepth).
+        const SKIP_MASK = 1 << 0;
 
-    /// Ignore objects with the ActionScript's visibility flag turned off.
-    pub skip_invisible: bool,
+        /// Ignore objects with the ActionScript's visibility flag turned off.
+        const SKIP_INVISIBLE = 1 << 1;
+
+        /// The options used for `hitTest` calls in ActionScript.
+        const AVM_HIT_TEST = Self::SKIP_MASK.bits;
+
+        /// The options used for mouse picking, such as clicking on buttons.
+        const MOUSE_PICK = Self::SKIP_MASK.bits | Self::SKIP_INVISIBLE.bits;
+    }
 }
 
 /// Represents the sound transfomr of sounds played inside a Flash MovieClip.

--- a/core/src/display_object/button.rs
+++ b/core/src/display_object/button.rs
@@ -364,14 +364,7 @@ impl<'gc> TDisplayObject<'gc> for Button<'gc> {
             }
 
             for child in self.0.read().hit_area.values() {
-                if child.hit_test_shape(
-                    context,
-                    point,
-                    HitTestOptions {
-                        skip_mask: true,
-                        skip_invisible: true,
-                    },
-                ) {
+                if child.hit_test_shape(context, point, HitTestOptions::MOUSE_PICK) {
                     return Some(self_node);
                 }
             }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1606,14 +1606,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         // The button is hovered if the mouse is over any child nodes.
         if self.visible()
             && self.is_selectable()
-            && self.hit_test_shape(
-                context,
-                point,
-                HitTestOptions {
-                    skip_mask: true,
-                    skip_invisible: true,
-                },
-            )
+            && self.hit_test_shape(context, point, HitTestOptions::MOUSE_PICK)
         {
             Some(self_node)
         } else {


### PR DESCRIPTION
Use bitflags for `HitTestOptions`, and store a few common presets as constants.