### PR TITLE
core: Remove collect::CollectWrapper

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -6,7 +6,6 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::string::AvmString;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::{Avm2, Error};
-use crate::collect::CollectWrapper;
 use bitflags::bitflags;
 use gc_arena::{Collect, GcCell, MutationContext};
 use swf::avm2::types::{
@@ -40,7 +39,8 @@ pub struct Class<'gc> {
     super_class: Option<Multiname<'gc>>,
 
     /// Attributes of the given class.
-    attributes: CollectWrapper<ClassAttributes>,
+    #[collect(require_static)]
+    attributes: ClassAttributes,
 
     /// The namespace that protected traits of this class are stored into.
     protected_namespace: Option<Namespace<'gc>>,
@@ -153,7 +153,7 @@ impl<'gc> Class<'gc> {
             Self {
                 name,
                 super_class,
-                attributes: CollectWrapper(ClassAttributes::empty()),
+                attributes: ClassAttributes::empty(),
                 protected_namespace: None,
                 interfaces: Vec::new(),
                 instance_init,
@@ -167,7 +167,7 @@ impl<'gc> Class<'gc> {
 
     /// Set the attributes of the class (sealed/final/interface status).
     pub fn set_attributes(&mut self, attributes: ClassAttributes) {
-        self.attributes = CollectWrapper(attributes);
+        self.attributes = attributes;
     }
 
     /// Add a protected namespace to this class.
@@ -237,7 +237,7 @@ impl<'gc> Class<'gc> {
             Self {
                 name,
                 super_class,
-                attributes: CollectWrapper(attributes),
+                attributes,
                 protected_namespace,
                 interfaces,
                 instance_init,
@@ -318,7 +318,7 @@ impl<'gc> Class<'gc> {
             Self {
                 name: QName::dynamic_name(name),
                 super_class: None,
-                attributes: CollectWrapper(ClassAttributes::empty()),
+                attributes: ClassAttributes::empty(),
                 protected_namespace: None,
                 interfaces: Vec::new(),
                 instance_init: Method::from_builtin(|_, _, _| {
@@ -579,6 +579,6 @@ impl<'gc> Class<'gc> {
 
     /// Determine if this class is sealed (no dynamic properties)
     pub fn is_sealed(&self) -> bool {
-        self.attributes.0.contains(ClassAttributes::SEALED)
+        self.attributes.contains(ClassAttributes::SEALED)
     }
 }

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::Object;
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::collect::CollectWrapper;
 use gc_arena::{Collect, CollectionContext, Gc, MutationContext};
 use std::fmt;
 use std::rc::Rc;
@@ -40,7 +39,8 @@ pub struct BytecodeMethod<'gc> {
     pub txunit: TranslationUnit<'gc>,
 
     /// The underlying ABC file of the above translation unit.
-    pub abc: CollectWrapper<Rc<AbcFile>>,
+    #[collect(require_static)]
+    pub abc: Rc<AbcFile>,
 
     /// The ABC method this function uses.
     pub abc_method: u32,
@@ -68,7 +68,7 @@ impl<'gc> BytecodeMethod<'gc> {
                         mc,
                         Self {
                             txunit,
-                            abc: CollectWrapper(txunit.abc()),
+                            abc: txunit.abc(),
                             abc_method: abc_method.0,
                             abc_method_body: Some(index as u32),
                         },
@@ -81,7 +81,7 @@ impl<'gc> BytecodeMethod<'gc> {
             mc,
             Self {
                 txunit,
-                abc: CollectWrapper(txunit.abc()),
+                abc: txunit.abc(),
                 abc_method: abc_method.0,
                 abc_method_body: None,
             },
@@ -100,7 +100,7 @@ impl<'gc> BytecodeMethod<'gc> {
 
     /// Get a reference to the ABC method entry this refers to.
     pub fn method(&self) -> &AbcMethod {
-        &self.abc.0.methods.get(self.abc_method as usize).unwrap()
+        &self.abc.methods.get(self.abc_method as usize).unwrap()
     }
 
     /// Get a reference to the ABC method body entry this refers to.
@@ -108,7 +108,7 @@ impl<'gc> BytecodeMethod<'gc> {
     /// Some methods do not have bodies; this returns `None` in that case.
     pub fn body(&self) -> Option<&AbcMethodBody> {
         if let Some(abc_method_body) = self.abc_method_body {
-            self.abc.0.method_bodies.get(abc_method_body as usize)
+            self.abc.method_bodies.get(abc_method_body as usize)
         } else {
             None
         }

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -1,7 +1,6 @@
 //! RegExp Structure
 
 use crate::avm2::string::AvmString;
-use crate::collect::CollectWrapper;
 use bitflags::bitflags;
 use gc_arena::Collect;
 use regress::Regex;
@@ -10,11 +9,13 @@ use regress::Regex;
 #[collect(no_drop)]
 pub struct RegExp<'gc> {
     source: AvmString<'gc>,
-    flags: CollectWrapper<RegExpFlags>,
+    flags: RegExpFlags,
     last_index: usize,
 }
 
 bitflags! {
+    #[derive(Collect)]
+    #[collect(require_static)]
     struct RegExpFlags: u8 {
         const GLOBAL       = 1 << 0;
         const IGNORE_CASE  = 1 << 1;
@@ -31,7 +32,7 @@ impl<'gc> RegExp<'gc> {
     {
         Self {
             source: source.into(),
-            flags: CollectWrapper(RegExpFlags::empty()),
+            flags: RegExpFlags::empty(),
             last_index: 0,
         }
     }
@@ -56,43 +57,43 @@ impl<'gc> RegExp<'gc> {
     }
 
     pub fn dotall(&self) -> bool {
-        self.flags.0.contains(RegExpFlags::DOTALL)
+        self.flags.contains(RegExpFlags::DOTALL)
     }
 
     pub fn set_dotall(&mut self, value: bool) {
-        self.flags.0.set(RegExpFlags::DOTALL, value);
+        self.flags.set(RegExpFlags::DOTALL, value);
     }
 
     pub fn extended(&self) -> bool {
-        self.flags.0.contains(RegExpFlags::EXTENDED)
+        self.flags.contains(RegExpFlags::EXTENDED)
     }
 
     pub fn set_extended(&mut self, value: bool) {
-        self.flags.0.set(RegExpFlags::EXTENDED, value);
+        self.flags.set(RegExpFlags::EXTENDED, value);
     }
 
     pub fn global(&self) -> bool {
-        self.flags.0.contains(RegExpFlags::GLOBAL)
+        self.flags.contains(RegExpFlags::GLOBAL)
     }
 
     pub fn set_global(&mut self, value: bool) {
-        self.flags.0.set(RegExpFlags::GLOBAL, value);
+        self.flags.set(RegExpFlags::GLOBAL, value);
     }
 
     pub fn ignore_case(&self) -> bool {
-        self.flags.0.contains(RegExpFlags::IGNORE_CASE)
+        self.flags.contains(RegExpFlags::IGNORE_CASE)
     }
 
     pub fn set_ignore_case(&mut self, value: bool) {
-        self.flags.0.set(RegExpFlags::IGNORE_CASE, value);
+        self.flags.set(RegExpFlags::IGNORE_CASE, value);
     }
 
     pub fn multiline(&self) -> bool {
-        self.flags.0.contains(RegExpFlags::MULTILINE)
+        self.flags.contains(RegExpFlags::MULTILINE)
     }
 
     pub fn set_multiline(&mut self, value: bool) {
-        self.flags.0.set(RegExpFlags::MULTILINE, value);
+        self.flags.set(RegExpFlags::MULTILINE, value);
     }
 
     pub fn test(&mut self, text: &str) -> bool {

--- a/core/src/collect.rs
+++ b/core/src/collect.rs
@@ -1,7 +1,0 @@
-//! Collect Wrapper Utility
-
-use gc_arena::Collect;
-
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
-pub struct CollectWrapper<T>(pub T);

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -1,6 +1,5 @@
 //! Layout box structure
 
-use crate::collect::CollectWrapper;
 use crate::context::UpdateContext;
 use crate::drawing::Drawing;
 use crate::font::{EvalParameters, Font};
@@ -582,7 +581,8 @@ pub enum LayoutContent<'gc> {
         params: EvalParameters,
 
         /// The color to render the font with.
-        color: CollectWrapper<swf::Color>,
+        #[collect(require_static)]
+        color: swf::Color,
     },
 
     /// A layout box containing a bullet.
@@ -601,7 +601,8 @@ pub enum LayoutContent<'gc> {
         params: EvalParameters,
 
         /// The color to render the font with.
-        color: CollectWrapper<swf::Color>,
+        #[collect(require_static)]
+        color: swf::Color,
     },
 
     /// A layout box containing a drawing.
@@ -625,7 +626,7 @@ impl<'gc> LayoutBox<'gc> {
                 text_format: span.get_text_format(),
                 font,
                 params,
-                color: CollectWrapper(span.color.clone()),
+                color: span.color.clone(),
             },
         }
     }
@@ -640,7 +641,7 @@ impl<'gc> LayoutBox<'gc> {
                 text_format: span.get_text_format(),
                 font,
                 params,
-                color: CollectWrapper(span.color.clone()),
+                color: span.color.clone(),
             },
         }
     }
@@ -790,14 +791,14 @@ impl<'gc> LayoutBox<'gc> {
                 &text_format,
                 *font,
                 *params,
-                color.0.clone(),
+                color.clone(),
             )),
             LayoutContent::Bullet {
                 text_format,
                 font,
                 params,
                 color,
-            } => Some(("\u{2022}", &text_format, *font, *params, color.0.clone())),
+            } => Some(("\u{2022}", &text_format, *font, *params, color.clone())),
             LayoutContent::Drawing(..) => None,
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,6 @@ mod avm2;
 pub mod bitmap;
 mod bounding_box;
 mod character;
-mod collect;
 pub mod color_transform;
 pub mod context;
 pub mod context_menu;


### PR DESCRIPTION
No longer necessary, it is possible to mark individual fields
as `#[collect(require_static)]`.