### PR TITLE
web: Add a `none` value to completely disable the unmute overlay

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -60,14 +60,9 @@ export enum UnmuteOverlay {
     Visible = "visible",
 
     /**
-     * Don't show an overlay but still make it clickable.
-     */
-    Hidden = "hidden",
-
-    /**
      * Don't show an overlay and pretend that everything is fine.
      */
-    None = "none",
+    Hidden = "hidden",
 }
 
 /**

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -60,9 +60,14 @@ export enum UnmuteOverlay {
     Visible = "visible",
 
     /**
-     * Don't show an overlay and pretend that everything is fine.
+     * Don't show an overlay but still make it clickable.
      */
     Hidden = "hidden",
+
+    /**
+     * Don't show an overlay and pretend that everything is fine.
+     */
+    None = "none",
 }
 
 /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -438,7 +438,10 @@ export class RufflePlayer extends HTMLElement {
         ) {
             this.play();
 
-            if (this.audioState() !== "running") {
+            if (
+                this.audioState() !== "running" &&
+                unmuteVisibility !== UnmuteOverlay.None
+            ) {
                 this.unmuteOverlay.style.display = "block";
 
                 // We need to mark each child as hidden or visible, as we want an overlay even if it's "hidden".

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -201,10 +201,6 @@ export class RufflePlayer extends HTMLElement {
         }
 
         this.unmuteOverlay = this.shadow.getElementById("unmute_overlay")!;
-        this.unmuteOverlay.addEventListener(
-            "click",
-            this.unmuteOverlayClicked.bind(this)
-        );
 
         this.contextMenuElement = this.shadow.getElementById("context-menu")!;
         this.addEventListener("contextmenu", this.showContextMenu.bind(this));
@@ -438,23 +434,18 @@ export class RufflePlayer extends HTMLElement {
         ) {
             this.play();
 
-            if (
-                this.audioState() !== "running" &&
-                unmuteVisibility !== UnmuteOverlay.None
-            ) {
-                this.unmuteOverlay.style.display = "block";
+            if (this.audioState() !== "running") {
+                if (unmuteVisibility === UnmuteOverlay.Visible) {
+                    this.unmuteOverlay.style.display = "block";
+                }
 
-                // We need to mark each child as hidden or visible, as we want an overlay even if it's "hidden".
-                // We need to undo this later if the config changed back to visible, but we already hid them.
-                this.unmuteOverlay.childNodes.forEach((node) => {
-                    if ("style" in node) {
-                        const style = (<ElementCSSInlineStyle>node).style;
-                        style.visibility =
-                            unmuteVisibility == UnmuteOverlay.Visible
-                                ? ""
-                                : "hidden";
+                this.container.addEventListener(
+                    "click",
+                    this.unmuteOverlayClicked.bind(this),
+                    {
+                        once: true,
                     }
-                });
+                );
 
                 const audioContext = this.instance?.audio_context();
                 if (audioContext) {


### PR DESCRIPTION
There's currently no way to completely disable the unmute overlay when `autoplay` is `on`: setting `unmuteOverlay` to `hidden` doesn't show the overlay but still requires an interaction if the browser prevents the AudioContext from starting (this is the intended behavior).

To bypass this, the PR adds a new `none` value to the `unmuteOverlay` option (which should only be used with files that don't play any audio since there's no way to resume it if the browser prevents the AudioContext from starting).