### PR TITLE
Fix endless loop when layouting text

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -705,7 +705,14 @@ impl<'gc> LayoutBox<'gc> {
                             offset,
                             layout_context.is_start_of_line(),
                         ) {
-                            if breakpoint == 0 {
+                            // If text doesn't fit at the start of a line, it
+                            // won't fit on the next either, abort and put the
+                            // whole text on the line (will be cut-off). This
+                            // can happen for small text fields with single
+                            // characters.
+                            if breakpoint == 0 && layout_context.is_start_of_line() {
+                                break;
+                            } else if breakpoint == 0 {
                                 layout_context.newline(context);
 
                                 let next_dim = layout_context.wrap_dimensions(&span);


### PR DESCRIPTION
If a textfield has word wrapping enabled, is very small in size and
tries to layout a single character onto it, the layout code can run into
an endless loop where it's creating new lines and trying to fit the text
again.

If text doesn't fit at the start of a line, it won't fit on the next
either, so abort and display the whole text span on the line. Text will
be cut-off.

This can be reproduced with a AS2 file like this:

    class Test {
      static var app : Test;

      function Test() {
        _root.createTextField("tf",0,0,0,6,20);
        _root.tf.text = "0";
        _root.tf.wordWrap = true;
      }

      static function main(mc) {
        app = new Test();
      }
    }

Build it with `mtasc -main -header 10010030 test.as -swf test.swf`

---

Noticed this issue here: https://www.newgrounds.com/portal/view/463278 (https://uploads.ungrounded.net/463000/463278_MWC_Completed.swf)

This happens when after completing the tutorial, one clicks on the weapons button. This is also reported a couple times in the comments section of that page.