### PR TITLE
canvas: Fix alpha calculation in canvas renderer

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -331,7 +331,7 @@ impl WebCanvasRenderBackend {
             && color_transform.a_add == 0
         {
             self.context
-                .set_global_alpha(f64::from(color_transform.a_mult) / 255.0);
+                .set_global_alpha(f64::from(color_transform.a_mult));
         } else {
             let mult = color_transform.mult_rgba_normalized();
             let add = color_transform.add_rgba_normalized();


### PR DESCRIPTION
Fix alpha calculation regression on canvas backend. The change to using fixed point internally means alpha is already normalized.