### PR TITLE
avm1: Remove unnecessary gc_context parameters

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -750,35 +750,27 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     fn add_property_with_case(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
         attributes: Attribute,
     ) {
         self.base
-            .add_property_with_case(activation, gc_context, name, get, set, attributes)
+            .add_property_with_case(activation, name, get, set, attributes)
     }
 
     fn set_watcher(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
         user_data: Value<'gc>,
     ) {
-        self.base
-            .set_watcher(activation, gc_context, name, callback, user_data);
+        self.base.set_watcher(activation, name, callback, user_data);
     }
 
-    fn remove_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
-        name: Cow<str>,
-    ) -> bool {
-        self.base.remove_watcher(activation, gc_context, name)
+    fn remove_watcher(&self, activation: &mut Activation<'_, 'gc, '_>, name: Cow<str>) -> bool {
+        self.base.remove_watcher(activation, name)
     }
 
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -71,7 +71,6 @@ pub fn add_property<'gc>(
             if let Value::Object(set) = setter {
                 this.add_property_with_case(
                     activation,
-                    activation.context.gc_context,
                     &name,
                     get.to_owned(),
                     Some(set.to_owned()),
@@ -80,7 +79,6 @@ pub fn add_property<'gc>(
             } else if let Value::Null = setter {
                 this.add_property_with_case(
                     activation,
-                    activation.context.gc_context,
                     &name,
                     get.to_owned(),
                     None,
@@ -212,13 +210,7 @@ fn watch<'gc>(
     }
     let user_data = args.get(2).cloned().unwrap_or(Value::Undefined);
 
-    this.set_watcher(
-        activation,
-        activation.context.gc_context,
-        Cow::Borrowed(&name),
-        callback,
-        user_data,
-    );
+    this.set_watcher(activation, Cow::Borrowed(&name), callback, user_data);
 
     Ok(true.into())
 }
@@ -235,11 +227,7 @@ fn unwatch<'gc>(
         return Ok(false.into());
     };
 
-    let result = this.remove_watcher(
-        activation,
-        activation.context.gc_context,
-        Cow::Borrowed(&name),
-    );
+    let result = this.remove_watcher(activation, Cow::Borrowed(&name));
 
     Ok(result.into())
 }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -300,7 +300,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn add_property_with_case(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
@@ -313,7 +312,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn set_watcher(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
         user_data: Value<'gc>,
@@ -323,12 +321,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ///
     /// The return value will indicate if there was a watcher present before this method was
     /// called.
-    fn remove_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
-        name: Cow<str>,
-    ) -> bool;
+    fn remove_watcher(&self, activation: &mut Activation<'_, 'gc, '_>, name: Cow<str>) -> bool;
 
     /// Checks if the object has a given named property.
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool;

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -98,7 +98,6 @@ macro_rules! impl_custom_object_without_set {
         fn add_property_with_case(
             &self,
             activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
-            gc_context: gc_arena::MutationContext<'gc, '_>,
             name: &str,
             get: crate::avm1::object::Object<'gc>,
             set: Option<crate::avm1::object::Object<'gc>>,
@@ -107,7 +106,7 @@ macro_rules! impl_custom_object_without_set {
             self.0
                 .read()
                 .$field
-                .add_property_with_case(activation, gc_context, name, get, set, attributes)
+                .add_property_with_case(activation, name, get, set, attributes)
         }
 
         fn has_property(
@@ -215,7 +214,6 @@ macro_rules! impl_custom_object_without_set {
         fn set_watcher(
             &self,
             activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
-            gc_context: gc_arena::MutationContext<'gc, '_>,
             name: std::borrow::Cow<str>,
             callback: crate::avm1::object::Object<'gc>,
             user_data: crate::avm1::Value<'gc>,
@@ -223,19 +221,15 @@ macro_rules! impl_custom_object_without_set {
             self.0
                 .read()
                 .$field
-                .set_watcher(activation, gc_context, name, callback, user_data);
+                .set_watcher(activation, name, callback, user_data);
         }
 
         fn remove_watcher(
             &self,
             activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
-            gc_context: gc_arena::MutationContext<'gc, '_>,
             name: std::borrow::Cow<str>,
         ) -> bool {
-            self.0
-                .read()
-                .$field
-                .remove_watcher(activation, gc_context, name)
+            self.0.read().$field.remove_watcher(activation, name)
         }
     };
 }

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -496,13 +496,12 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn add_property_with_case(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
         attributes: Attribute,
     ) {
-        self.0.write(gc_context).values.insert(
+        self.0.write(activation.context.gc_context).values.insert(
             name,
             Property::Virtual {
                 get,
@@ -516,27 +515,21 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
     fn set_watcher(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
         user_data: Value<'gc>,
     ) {
-        self.0.write(gc_context).watchers.insert(
+        self.0.write(activation.context.gc_context).watchers.insert(
             &name,
             Watcher::new(callback, user_data),
             activation.is_case_sensitive(),
         );
     }
 
-    fn remove_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
-        name: Cow<str>,
-    ) -> bool {
+    fn remove_watcher(&self, activation: &mut Activation<'_, 'gc, '_>, name: Cow<str>) -> bool {
         let old = self
             .0
-            .write(gc_context)
+            .write(activation.context.gc_context)
             .watchers
             .remove(name.as_ref(), activation.is_case_sensitive());
         old.is_some()

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -345,7 +345,6 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
     fn add_property_with_case(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
@@ -354,13 +353,12 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0
             .read()
             .base
-            .add_property_with_case(activation, gc_context, name, get, set, attributes)
+            .add_property_with_case(activation, name, get, set, attributes)
     }
 
     fn set_watcher(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
         user_data: Value<'gc>,
@@ -368,19 +366,11 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0
             .read()
             .base
-            .set_watcher(activation, gc_context, name, callback, user_data);
+            .set_watcher(activation, name, callback, user_data);
     }
 
-    fn remove_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
-        name: Cow<str>,
-    ) -> bool {
-        self.0
-            .read()
-            .base
-            .remove_watcher(activation, gc_context, name)
+    fn remove_watcher(&self, activation: &mut Activation<'_, 'gc, '_>, name: Cow<str>) -> bool {
+        self.0.read().base.remove_watcher(activation, name)
     }
 
     fn has_property(&self, activation: &mut Activation<'_, 'gc, '_>, name: &str) -> bool {

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -203,7 +203,6 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     fn add_property_with_case(
         &self,
         _activation: &mut Activation<'_, 'gc, '_>,
-        _gc_context: MutationContext<'gc, '_>,
         _name: &str,
         _get: Object<'gc>,
         _set: Option<Object<'gc>>,
@@ -215,7 +214,6 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
     fn set_watcher(
         &self,
         _activation: &mut Activation<'_, 'gc, '_>,
-        _gc_context: MutationContext<'gc, '_>,
         _name: Cow<str>,
         _callback: Object<'gc>,
         _user_data: Value<'gc>,
@@ -223,12 +221,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         //`super` cannot have properties defined on it
     }
 
-    fn remove_watcher(
-        &self,
-        _activation: &mut Activation<'_, 'gc, '_>,
-        _gc_context: MutationContext<'gc, '_>,
-        _name: Cow<str>,
-    ) -> bool {
+    fn remove_watcher(&self, _activation: &mut Activation<'_, 'gc, '_>, _name: Cow<str>) -> bool {
         //`super` cannot have properties defined on it
         false
     }

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -133,35 +133,28 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
     fn add_property_with_case(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
         attributes: Attribute,
     ) {
         self.base()
-            .add_property_with_case(activation, gc_context, name, get, set, attributes)
+            .add_property_with_case(activation, name, get, set, attributes)
     }
 
     fn set_watcher(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
         user_data: Value<'gc>,
     ) {
         self.base()
-            .set_watcher(activation, gc_context, name, callback, user_data);
+            .set_watcher(activation, name, callback, user_data);
     }
 
-    fn remove_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
-        name: Cow<str>,
-    ) -> bool {
-        self.base().remove_watcher(activation, gc_context, name)
+    fn remove_watcher(&self, activation: &mut Activation<'_, 'gc, '_>, name: Cow<str>) -> bool {
+        self.base().remove_watcher(activation, name)
     }
 
     fn define_value(

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -131,35 +131,28 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
     fn add_property_with_case(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: &str,
         get: Object<'gc>,
         set: Option<Object<'gc>>,
         attributes: Attribute,
     ) {
         self.base()
-            .add_property_with_case(activation, gc_context, name, get, set, attributes)
+            .add_property_with_case(activation, name, get, set, attributes)
     }
 
     fn set_watcher(
         &self,
         activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
         name: Cow<str>,
         callback: Object<'gc>,
         user_data: Value<'gc>,
     ) {
         self.base()
-            .set_watcher(activation, gc_context, name, callback, user_data);
+            .set_watcher(activation, name, callback, user_data);
     }
 
-    fn remove_watcher(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        gc_context: MutationContext<'gc, '_>,
-        name: Cow<str>,
-    ) -> bool {
-        self.base().remove_watcher(activation, gc_context, name)
+    fn remove_watcher(&self, activation: &mut Activation<'_, 'gc, '_>, name: Cow<str>) -> bool {
+        self.base().remove_watcher(activation, name)
     }
 
     fn define_value(


### PR DESCRIPTION
`add_property_with_case`, `set_watcher` and `remove_watcher` already take an `activation`, from which the `gc_context` can be retrieved.