### PR TITLE
swf: Add swf::HeaderExt with additional info

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -769,7 +769,7 @@ fn get_bytes_loaded<'gc>(
     let bytes_loaded = if movie_clip.is_root() {
         movie_clip
             .movie()
-            .map(|mv| mv.header().uncompressed_len())
+            .map(|mv| mv.uncompressed_len())
             .unwrap_or_default()
     } else {
         movie_clip.tag_stream_len() as u32
@@ -787,7 +787,7 @@ fn get_bytes_total<'gc>(
     let bytes_total = if movie_clip.is_root() {
         movie_clip
             .movie()
-            .map(|mv| mv.header().uncompressed_len())
+            .map(|mv| mv.uncompressed_len())
             .unwrap_or_default()
     } else {
         movie_clip.tag_stream_len() as u32

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -769,7 +769,7 @@ fn get_bytes_loaded<'gc>(
     let bytes_loaded = if movie_clip.is_root() {
         movie_clip
             .movie()
-            .map(|mv| mv.header().uncompressed_length)
+            .map(|mv| mv.header().uncompressed_len())
             .unwrap_or_default()
     } else {
         movie_clip.tag_stream_len() as u32
@@ -787,7 +787,7 @@ fn get_bytes_total<'gc>(
     let bytes_total = if movie_clip.is_root() {
         movie_clip
             .movie()
-            .map(|mv| mv.header().uncompressed_length)
+            .map(|mv| mv.header().uncompressed_len())
             .unwrap_or_default()
     } else {
         movie_clip.tag_stream_len() as u32

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -114,7 +114,7 @@ pub fn get_progress<'gc>(
                 "bytesLoaded",
                 movieclip
                     .movie()
-                    .map(|mv| (mv.header().uncompressed_len()).into())
+                    .map(|mv| (mv.uncompressed_len()).into())
                     .unwrap_or(Value::Undefined),
                 Attribute::empty(),
             );
@@ -123,7 +123,7 @@ pub fn get_progress<'gc>(
                 "bytesTotal",
                 movieclip
                     .movie()
-                    .map(|mv| (mv.header().uncompressed_len()).into())
+                    .map(|mv| (mv.uncompressed_len()).into())
                     .unwrap_or(Value::Undefined),
                 Attribute::empty(),
             );

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -114,7 +114,7 @@ pub fn get_progress<'gc>(
                 "bytesLoaded",
                 movieclip
                     .movie()
-                    .map(|mv| (mv.header().uncompressed_length).into())
+                    .map(|mv| (mv.header().uncompressed_len()).into())
                     .unwrap_or(Value::Undefined),
                 Attribute::empty(),
             );
@@ -123,7 +123,7 @@ pub fn get_progress<'gc>(
                 "bytesTotal",
                 movieclip
                     .movie()
-                    .map(|mv| (mv.header().uncompressed_length).into())
+                    .map(|mv| (mv.header().uncompressed_len()).into())
                     .unwrap_or(Value::Undefined),
                 Attribute::empty(),
             );

--- a/core/src/avm1/timer.rs
+++ b/core/src/avm1/timer.rs
@@ -37,7 +37,7 @@ impl<'gc> Timers<'gc> {
             return None;
         }
 
-        let version = context.swf.header().version;
+        let version = context.swf.version();
         let globals = context.avm1.global_object_cell();
         let level0 = context.stage.root_clip();
 

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -107,11 +107,9 @@ pub fn bytes_total<'gc>(
     if let Some(this) = this {
         if let Some(loader_stream) = this.as_loader_stream() {
             match &*loader_stream {
-                LoaderStream::Stage => {
-                    return Ok(activation.context.swf.compressed_length().into())
-                }
+                LoaderStream::Stage => return Ok(activation.context.swf.compressed_len().into()),
                 LoaderStream::Swf(movie, _) => {
-                    return Ok(movie.compressed_length().into());
+                    return Ok(movie.compressed_len().into());
                 }
             }
         }

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -171,7 +171,7 @@ pub fn frame_rate<'gc>(
                     return Err("Error: The stage's loader info does not have a frame rate".into())
                 }
                 LoaderStream::Swf(root, _) => {
-                    return Ok(root.header().frame_rate().into());
+                    return Ok(root.frame_rate().into());
                 }
             }
         }

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -195,9 +195,7 @@ pub fn height<'gc>(
                     return Err("Error: The stage's loader info does not have a height".into())
                 }
                 LoaderStream::Swf(root, _) => {
-                    let y_min = root.header().stage_size().y_min;
-                    let y_max = root.header().stage_size().y_max;
-                    return Ok((y_max - y_min).to_pixels().into());
+                    return Ok(root.height().to_pixels().into());
                 }
             }
         }
@@ -273,9 +271,7 @@ pub fn width<'gc>(
                     return Err("Error: The stage's loader info does not have a width".into())
                 }
                 LoaderStream::Swf(root, _) => {
-                    let x_min = root.header().stage_size().x_min;
-                    let x_max = root.header().stage_size().x_max;
-                    return Ok((x_max - x_min).to_pixels().into());
+                    return Ok(root.width().to_pixels().into());
                 }
             }
         }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1197,11 +1197,9 @@ pub trait TDisplayObject<'gc>:
     /// Return the VM that this object belongs to.
     ///
     /// This function panics if the display object has no defining movie.
-    fn vm_type(&self, context: &mut UpdateContext<'_, 'gc, '_>) -> AvmType {
+    fn avm_type(&self) -> AvmType {
         let movie = self.movie().unwrap();
-        let library = context.library.library_for_movie_mut(movie);
-
-        library.avm_type()
+        movie.avm_type()
     }
 
     fn instantiate(&self, gc_context: MutationContext<'gc, '_>) -> DisplayObject<'gc>;
@@ -1333,10 +1331,7 @@ pub trait TDisplayObject<'gc>:
     /// The default root names change based on the AVM configuration of the
     /// clip; AVM2 clips get `rootN` while AVM1 clips get blank strings.
     fn set_default_root_name(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        let movie = self
-            .movie()
-            .expect("All roots should have an associated movie");
-        let vm_type = context.library.library_for_movie_mut(movie).avm_type();
+        let vm_type = self.avm_type();
 
         if matches!(vm_type, AvmType::Avm2) {
             self.set_name(context.gc_context, &format!("root{}", self.depth() + 1));

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1337,8 +1337,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
     /// Construct objects placed on this frame.
     fn construct_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        if self.vm_type(context) == AvmType::Avm2 && matches!(self.object2(), Avm2Value::Undefined)
-        {
+        if self.avm_type() == AvmType::Avm2 && matches!(self.object2(), Avm2Value::Undefined) {
             self.construct_as_avm2_object(context, (*self).into());
         }
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -964,7 +964,7 @@ impl<'gc> EditText<'gc> {
             activation.run_with_child_frame_for_display_object(
                 "[Text Field Binding]",
                 parent,
-                activation.context.swf.header().version,
+                activation.context.swf.version(),
                 |activation| {
                     if let Ok(Some((object, property))) =
                         activation.resolve_variable_path(parent, &variable)
@@ -1053,7 +1053,7 @@ impl<'gc> EditText<'gc> {
                     activation.run_with_child_frame_for_display_object(
                         "[Propagate Text Binding]",
                         self.avm1_parent().unwrap(),
-                        activation.context.swf.header().version,
+                        activation.context.swf.version(),
                         |activation| {
                             let _ = object.set(
                                 property,
@@ -1204,7 +1204,7 @@ impl<'gc> EditText<'gc> {
 
             if changed {
                 let globals = context.avm1.global_object_cell();
-                let swf_version = context.swf.header().version;
+                let swf_version = context.swf.version();
                 let mut activation = Avm1Activation::from_nothing(
                     context.reborrow(),
                     ActivationIdentifier::root("[Propagate Text Binding]"),

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -115,7 +115,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn construct_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        if self.vm_type(context) == AvmType::Avm2 {
+        if self.avm_type() == AvmType::Avm2 {
             let mut allocator = || {
                 let mut activation = Avm2Activation::from_nothing(context.reborrow());
                 let mut proto = activation.context.avm2.prototypes().shape;
@@ -196,7 +196,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         _instantiated_by: Instantiator,
         run_frame: bool,
     ) {
-        if self.vm_type(context) == AvmType::Avm2 {
+        if self.avm_type() == AvmType::Avm2 {
             self.set_default_instance_name(context);
         }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -185,7 +185,7 @@ impl<'gc> MovieClip<'gc> {
 
     /// Construct a movie clip that represents an entire movie.
     pub fn from_movie(gc_context: MutationContext<'gc, '_>, movie: Arc<SwfMovie>) -> Self {
-        let num_frames = movie.header().num_frames;
+        let num_frames = movie.header().num_frames();
         let mc = MovieClip(GcCell::allocate(
             gc_context,
             MovieClipData {
@@ -525,12 +525,7 @@ impl<'gc> MovieClip<'gc> {
                 )
             })?;
 
-        Avm1::run_stack_frame_for_init_action(
-            self.into(),
-            context.swf.header().version,
-            slice,
-            context,
-        );
+        Avm1::run_stack_frame_for_init_action(self.into(), context.swf.version(), slice, context);
 
         Ok(())
     }
@@ -2114,7 +2109,7 @@ impl<'gc> MovieClipData<'gc> {
     ) {
         let is_swf = movie.is_some();
         let movie = movie.unwrap_or_else(|| Arc::new(SwfMovie::empty(self.movie().version())));
-        let total_frames = movie.header().num_frames;
+        let total_frames = movie.header().num_frames();
 
         self.base.reset_for_movie_load();
         self.static_data = Gc::allocate(

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -185,7 +185,7 @@ impl<'gc> MovieClip<'gc> {
 
     /// Construct a movie clip that represents an entire movie.
     pub fn from_movie(gc_context: MutationContext<'gc, '_>, movie: Arc<SwfMovie>) -> Self {
-        let num_frames = movie.header().num_frames();
+        let num_frames = movie.num_frames();
         let mc = MovieClip(GcCell::allocate(
             gc_context,
             MovieClipData {
@@ -2086,7 +2086,7 @@ impl<'gc> MovieClipData<'gc> {
     ) {
         let is_swf = movie.is_some();
         let movie = movie.unwrap_or_else(|| Arc::new(SwfMovie::empty(self.movie().version())));
-        let total_frames = movie.header().num_frames();
+        let total_frames = movie.num_frames();
 
         self.base.reset_for_movie_load();
         self.static_data = Gc::allocate(

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -373,7 +373,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     }
 
     fn construct_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        let vm_type = self.vm_type(context);
+        let vm_type = self.avm_type();
         if vm_type == AvmType::Avm2 && matches!(self.object2(), Avm2Value::Undefined) {
             let object: Avm2Object<'_> = Avm2StageObject::for_display_object(
                 context.gc_context,

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -417,7 +417,7 @@ impl<'gc> Library<'gc> {
         if !self.movie_libraries.contains_key(&movie) {
             let slice = SwfSlice::from(movie.clone());
             let mut reader = slice.read_from(0);
-            let movie_version = movie.header().version;
+            let movie_version = movie.version();
             let vm_type = if movie_version > 8 {
                 match reader.read_tag_code_and_length() {
                     Ok((tag_code, _tag_len))

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -127,7 +127,7 @@ impl<'gc> LoadManager<'gc> {
         fetch: OwnedFuture<Vec<u8>, Error>,
         url: String,
         parameters: Vec<(String, String)>,
-        on_metadata: Box<dyn FnOnce(&swf::Header)>,
+        on_metadata: Box<dyn FnOnce(&swf::HeaderExt)>,
     ) -> OwnedFuture<(), Error> {
         let loader = Loader::RootMovie { self_handle: None };
         let handle = self.add_loader(loader);
@@ -366,7 +366,7 @@ impl<'gc> Loader<'gc> {
         fetch: OwnedFuture<Vec<u8>, Error>,
         mut url: String,
         parameters: Vec<(String, String)>,
-        on_metadata: Box<dyn FnOnce(&swf::Header)>,
+        on_metadata: Box<dyn FnOnce(&swf::HeaderExt)>,
     ) -> OwnedFuture<(), Error> {
         let _handle = match self {
             Loader::RootMovie { self_handle, .. } => {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1039,7 +1039,6 @@ impl Player {
     /// This should only be called once. Further movie loads should preload the
     /// specific `MovieClip` referenced.
     fn preload(&mut self) {
-        let mut is_action_script_3 = false;
         self.mutate_with_update_context(|context| {
             let mut morph_shapes = fnv::FnvHashMap::default();
             let root = context.stage.root_clip();
@@ -1051,14 +1050,13 @@ impl Player {
                 .library
                 .library_for_movie_mut(root.as_movie_clip().unwrap().movie().unwrap());
 
-            is_action_script_3 = lib.avm_type() == AvmType::Avm2;
             // Finalize morph shapes.
             for (id, static_data) in morph_shapes {
                 let morph_shape = MorphShape::new(context.gc_context, static_data);
                 lib.register_character(id, crate::character::Character::MorphShape(morph_shape));
             }
         });
-        if is_action_script_3 && self.warn_on_unsupported_content {
+        if self.swf.avm_type() == AvmType::Avm2 && self.warn_on_unsupported_content {
             self.ui.display_unsupported_message();
         }
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -346,7 +346,7 @@ impl Player {
         &mut self,
         movie_url: &str,
         parameters: Vec<(String, String)>,
-        on_metadata: Box<dyn FnOnce(&swf::Header)>,
+        on_metadata: Box<dyn FnOnce(&swf::HeaderExt)>,
     ) {
         self.mutate_with_update_context(|context| {
             let fetch = context.navigator.fetch(movie_url, RequestOptions::get());
@@ -370,12 +370,12 @@ impl Player {
     pub fn set_root_movie(&mut self, movie: Arc<SwfMovie>) {
         info!(
             "Loaded SWF version {}, with a resolution of {}x{}",
-            movie.header().version,
-            movie.header().stage_size.x_max,
-            movie.header().stage_size.y_max
+            movie.version(),
+            movie.header().stage_size().x_max,
+            movie.header().stage_size().y_max
         );
 
-        self.frame_rate = movie.header().frame_rate.into();
+        self.frame_rate = movie.header().frame_rate().into();
         self.swf = movie;
         self.instance_counter = 0;
 
@@ -626,7 +626,7 @@ impl Player {
         callback: Object<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) {
-        let version = context.swf.header().version;
+        let version = context.swf.version();
         let globals = context.avm1.global_object_cell();
         let root_clip = context.stage.root_clip();
 
@@ -1167,7 +1167,7 @@ impl Player {
                     Avm1::run_stack_frame_for_action(
                         actions.clip,
                         "[Frame]",
-                        context.swf.header().version,
+                        context.swf.version(),
                         bytecode,
                         context,
                     );
@@ -1194,7 +1194,7 @@ impl Player {
                                 let _ = activation.run_child_frame_for_action(
                                     "[Actions]",
                                     actions.clip,
-                                    activation.context.swf.header().version,
+                                    activation.context.swf.version(),
                                     event,
                                 );
                             }
@@ -1212,7 +1212,7 @@ impl Player {
                         Avm1::run_stack_frame_for_action(
                             actions.clip,
                             "[Construct]",
-                            context.swf.header().version,
+                            context.swf.version(),
                             event,
                             context,
                         );
@@ -1223,7 +1223,7 @@ impl Player {
                     Avm1::run_stack_frame_for_method(
                         actions.clip,
                         object,
-                        context.swf.header().version,
+                        context.swf.version(),
                         context,
                         name,
                         &args,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -375,7 +375,7 @@ impl Player {
             movie.height()
         );
 
-        self.frame_rate = movie.header().frame_rate().into();
+        self.frame_rate = movie.frame_rate().into();
         self.swf = movie;
         self.instance_counter = 0;
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -371,8 +371,8 @@ impl Player {
         info!(
             "Loaded SWF version {}, with a resolution of {}x{}",
             movie.version(),
-            movie.header().stage_size().x_max,
-            movie.header().stage_size().y_max
+            movie.width(),
+            movie.height()
         );
 
         self.frame_rate = movie.header().frame_rate().into();
@@ -382,8 +382,8 @@ impl Player {
         self.mutate_with_update_context(|context| {
             context.stage.set_movie_size(
                 context.gc_context,
-                context.swf.width(),
-                context.swf.height(),
+                context.swf.width().to_pixels() as u32,
+                context.swf.height().to_pixels() as u32,
             );
             let domain = Avm2Domain::movie_domain(context.gc_context, context.avm2.global_domain());
             let root: DisplayObject =

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -34,7 +34,7 @@ pub struct SwfMovie {
     encoding: &'static swf::Encoding,
 
     /// The compressed length of the entire datastream
-    compressed_length: usize,
+    compressed_len: usize,
 }
 
 impl SwfMovie {
@@ -47,7 +47,7 @@ impl SwfMovie {
             loader_url: None,
             parameters: Vec::new(),
             encoding: swf::UTF_8,
-            compressed_length: 0,
+            compressed_len: 0,
         }
     }
 
@@ -64,7 +64,7 @@ impl SwfMovie {
             loader_url: source.loader_url.clone(),
             parameters: source.parameters.clone(),
             encoding: source.encoding,
-            compressed_length: source.compressed_length,
+            compressed_len: source.compressed_len,
         }
     }
 
@@ -86,7 +86,7 @@ impl SwfMovie {
         url: Option<String>,
         loader_url: Option<String>,
     ) -> Result<Self, Error> {
-        let compressed_length = swf_data.len();
+        let compressed_len = swf_data.len();
         let swf_buf = swf::read::decompress_swf(swf_data)?;
         let encoding = swf::SwfStr::encoding_for_version(swf_buf.header.version());
         Ok(Self {
@@ -96,7 +96,7 @@ impl SwfMovie {
             loader_url,
             parameters: Vec::new(),
             encoding,
-            compressed_length,
+            compressed_len,
         })
     }
 
@@ -149,8 +149,12 @@ impl SwfMovie {
         self.parameters.extend(params);
     }
 
-    pub fn compressed_length(&self) -> usize {
-        self.compressed_length
+    pub fn compressed_len(&self) -> usize {
+        self.compressed_len
+    }
+
+    pub fn uncompressed_len(&self) -> u32 {
+        self.header.uncompressed_len()
     }
 
     pub fn avm_type(&self) -> AvmType {

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -1,4 +1,5 @@
 use crate::backend::navigator::url_from_relative_path;
+use crate::vminterface::AvmType;
 use gc_arena::Collect;
 use std::path::Path;
 use std::sync::Arc;
@@ -148,6 +149,14 @@ impl SwfMovie {
 
     pub fn compressed_length(&self) -> usize {
         self.compressed_length
+    }
+
+    pub fn avm_type(&self) -> AvmType {
+        if self.header.is_action_script_3() {
+            AvmType::Avm2
+        } else {
+            AvmType::Avm1
+        }
     }
 }
 

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -3,7 +3,7 @@ use crate::vminterface::AvmType;
 use gc_arena::Collect;
 use std::path::Path;
 use std::sync::Arc;
-use swf::{HeaderExt, TagCode};
+use swf::{HeaderExt, Rectangle, TagCode, Twips};
 
 pub type Error = Box<dyn std::error::Error>;
 pub type DecodeResult = Result<(), Error>;
@@ -121,12 +121,14 @@ impl SwfMovie {
         self.encoding
     }
 
-    pub fn width(&self) -> u32 {
-        (self.header.stage_size().x_max - self.header.stage_size().x_min).to_pixels() as u32
+    /// The width of the movie in twips.
+    pub fn width(&self) -> Twips {
+        self.header.stage_size().x_max - self.header.stage_size().x_min
     }
 
-    pub fn height(&self) -> u32 {
-        (self.header.stage_size().y_max - self.header.stage_size().y_min).to_pixels() as u32
+    /// The height of the movie in twips.
+    pub fn height(&self) -> Twips {
+        self.header.stage_size().y_max - self.header.stage_size().y_min
     }
 
     /// Get the URL this SWF was fetched from.
@@ -157,6 +159,10 @@ impl SwfMovie {
         } else {
             AvmType::Avm1
         }
+    }
+
+    pub fn stage_size(&self) -> &Rectangle {
+        self.header.stage_size()
     }
 }
 

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -168,6 +168,14 @@ impl SwfMovie {
     pub fn stage_size(&self) -> &Rectangle {
         self.header.stage_size()
     }
+
+    pub fn num_frames(&self) -> u16 {
+        self.header.num_frames()
+    }
+
+    pub fn frame_rate(&self) -> f32 {
+        self.header.frame_rate()
+    }
 }
 
 /// A shared-ownership reference to some portion of an SWF datastream.

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -526,7 +526,7 @@ fn run_timedemo(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         .as_ref()
         .ok_or("Input file necessary for timedemo")?;
     let (movie, _) = load_movie_from_path(&path, &opt)?;
-    let movie_frames = Some(movie.header().num_frames());
+    let movie_frames = Some(movie.num_frames());
 
     let viewport_width = 1920;
     let viewport_height = 1080;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -216,7 +216,7 @@ impl App {
 
             (
                 format!("Ruffle - {}", filename),
-                LogicalSize::new(movie.width(), movie.height()).cast::<f64>(),
+                LogicalSize::new(movie.width().to_pixels(), movie.height().to_pixels()),
             )
         } else {
             ("Ruffle".into(), Self::DEFAULT_WINDOW_SIZE)

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -526,7 +526,7 @@ fn run_timedemo(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {
         .as_ref()
         .ok_or("Input file necessary for timedemo")?;
     let (movie, _) = load_movie_from_path(&path, &opt)?;
-    let movie_frames = Some(movie.header().num_frames);
+    let movie_frames = Some(movie.header().num_frames());
 
     let viewport_width = 1920;
     let viewport_height = 1080;

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -23,7 +23,7 @@ use walkdir::{DirEntry, WalkDir};
 struct SizeOpt {
     /// The amount to scale the page size with
     #[clap(long = "scale", default_value = "1.0")]
-    scale: f32,
+    scale: f64,
 
     /// Optionally override the output width
     #[clap(long = "width")]
@@ -96,11 +96,17 @@ fn take_screenshot(
 ) -> Result<(Descriptors, Vec<RgbaImage>), Box<dyn std::error::Error>> {
     let movie = SwfMovie::from_path(&swf_path, None)?;
 
-    let width = size.width.unwrap_or_else(|| movie.width());
-    let width = (width as f32 * size.scale).round() as u32;
+    let width = size
+        .width
+        .map(f64::from)
+        .unwrap_or_else(|| movie.width().to_pixels());
+    let width = (width * size.scale).round() as u32;
 
-    let height = size.height.unwrap_or_else(|| movie.height());
-    let height = (height as f32 * size.scale).round() as u32;
+    let height = size
+        .height
+        .map(f64::from)
+        .unwrap_or_else(|| movie.height().to_pixels());
+    let height = (height * size.scale).round() as u32;
 
     let target = TextureTarget::new(&descriptors.device, (width, height));
     let player = Player::new(

--- a/swf/examples/reading.rs
+++ b/swf/examples/reading.rs
@@ -6,6 +6,6 @@ fn main() {
     let reader = BufReader::new(file);
     let swf_buf = swf::decompress_swf(reader).unwrap();
     let swf = swf::parse_swf(&swf_buf).unwrap();
-    println!("The SWF has {} frame(s).", swf.header.num_frames);
+    println!("The SWF has {} frame(s).", swf.header.num_frames());
     println!("The SWF has {} tag(s).", swf.tags.len());
 }

--- a/swf/examples/writing.rs
+++ b/swf/examples/writing.rs
@@ -1,31 +1,28 @@
 use swf::*;
 
 fn main() {
-    let swf = Swf {
-        header: Header {
-            compression: Compression::Zlib,
-            version: 6,
-            uncompressed_length: 29,
-            stage_size: Rectangle {
-                x_min: Twips::from_pixels(0.0),
-                x_max: Twips::from_pixels(400.0),
-                y_min: Twips::from_pixels(0.0),
-                y_max: Twips::from_pixels(400.0),
-            },
-            frame_rate: 60.0,
-            num_frames: 1,
+    let header = Header {
+        compression: Compression::Zlib,
+        version: 6,
+        stage_size: Rectangle {
+            x_min: Twips::from_pixels(0.0),
+            x_max: Twips::from_pixels(400.0),
+            y_min: Twips::from_pixels(0.0),
+            y_max: Twips::from_pixels(400.0),
         },
-        tags: vec![
-            Tag::SetBackgroundColor(Color {
-                r: 255,
-                g: 0,
-                b: 0,
-                a: 255,
-            }),
-            Tag::ShowFrame,
-        ],
+        frame_rate: 60.0,
+        num_frames: 1,
     };
+    let tags = [
+        Tag::SetBackgroundColor(Color {
+            r: 255,
+            g: 0,
+            b: 0,
+            a: 255,
+        }),
+        Tag::ShowFrame,
+    ];
     let file = std::fs::File::create("tests/swfs/SimpleRedBackground.swf").unwrap();
     let writer = std::io::BufWriter::new(file);
-    swf::write_swf(&swf, writer).unwrap();
+    swf::write_swf(&header, &tags, writer).unwrap();
 }

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -18,7 +18,7 @@ pub fn echo_swf(filename: &str) {
     let swf_buf = decompress_swf(&in_data[..]).unwrap();
     let swf = parse_swf(&swf_buf).unwrap();
     let out_file = File::create(filename).unwrap();
-    write_swf(&swf, out_file).unwrap();
+    write_swf(&swf.header.swf_header(), &swf.tags, out_file).unwrap();
 }
 
 pub type TestData<T> = (u8, T, Vec<u8>);

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -880,7 +880,7 @@ fn run_swf(
     let base_path = Path::new(swf_path).parent().unwrap();
     let (mut executor, channel) = NullExecutor::new();
     let movie = SwfMovie::from_path(swf_path, None)?;
-    let frame_time = 1000.0 / movie.header().frame_rate as f64;
+    let frame_time = 1000.0 / movie.header().frame_rate() as f64;
     let trace_output = Rc::new(RefCell::new(Vec::new()));
 
     let player = Player::new(

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -880,7 +880,7 @@ fn run_swf(
     let base_path = Path::new(swf_path).parent().unwrap();
     let (mut executor, channel) = NullExecutor::new();
     let movie = SwfMovie::from_path(swf_path, None)?;
-    let frame_time = 1000.0 / movie.header().frame_rate() as f64;
+    let frame_time = 1000.0 / movie.frame_rate() as f64;
     let trace_output = Rc::new(RefCell::new(Vec::new()));
 
     let player = Player::new(

--- a/web/packages/core/src/movie-metadata.ts
+++ b/web/packages/core/src/movie-metadata.ts
@@ -26,4 +26,15 @@ export interface MovieMetadata {
      * The SWF version of the movie.
      */
     readonly swfVersion: number;
+
+    /**
+     * The background color of the movie as a hex string, such as "#FFFFFF".
+     * May be `null` if the background color is unavailable.
+     */
+    readonly backgroundColor: string | null;
+
+    /**
+     * Whether this movie is an ActionScript 3.0 movie.
+     */
+    readonly isActionScript3: boolean;
 }

--- a/web/packages/selfhosted/test/js_api/metadata.js
+++ b/web/packages/selfhosted/test/js_api/metadata.js
@@ -16,6 +16,8 @@ describe("RufflePlayer.metadata", () => {
             frameRate: 24,
             numFrames: 1,
             swfVersion: 15,
+            isActionScript3: false,
+            backgroundColor: "#FF0000",
         });
     });
 });

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -207,7 +207,7 @@ impl Ruffle {
             let parameters_to_load = parse_movie_parameters(&parameters);
 
             let ruffle = *self;
-            let on_metadata = move |swf_header: &ruffle_core::swf::Header| {
+            let on_metadata = move |swf_header: &ruffle_core::swf::HeaderExt| {
                 ruffle.on_metadata(swf_header);
             };
 
@@ -976,16 +976,16 @@ impl Ruffle {
         });
     }
 
-    fn on_metadata(&self, swf_header: &ruffle_core::swf::Header) {
+    fn on_metadata(&self, swf_header: &ruffle_core::swf::HeaderExt) {
         let _ = self.with_instance(|instance| {
-            let width = swf_header.stage_size.x_max - swf_header.stage_size.x_min;
-            let height = swf_header.stage_size.y_max - swf_header.stage_size.y_min;
+            let width = swf_header.stage_size().x_max - swf_header.stage_size().x_min;
+            let height = swf_header.stage_size().y_max - swf_header.stage_size().y_min;
             let metadata = MovieMetadata {
                 width: width.to_pixels(),
                 height: height.to_pixels(),
-                frame_rate: swf_header.frame_rate,
-                num_frames: swf_header.num_frames,
-                swf_version: swf_header.version,
+                frame_rate: swf_header.frame_rate(),
+                num_frames: swf_header.num_frames(),
+                swf_version: swf_header.version(),
             };
 
             if let Ok(value) = JsValue::from_serde(&metadata) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -170,6 +170,10 @@ struct MovieMetadata {
     num_frames: u16,
     #[serde(rename = "swfVersion")]
     swf_version: u8,
+    #[serde(rename = "backgroundColor")]
+    background_color: Option<String>,
+    #[serde(rename = "isActionScript3")]
+    is_action_script_3: bool,
 }
 
 /// An opaque handle to a `RuffleInstance` inside the pool.
@@ -980,12 +984,18 @@ impl Ruffle {
         let _ = self.with_instance(|instance| {
             let width = swf_header.stage_size().x_max - swf_header.stage_size().x_min;
             let height = swf_header.stage_size().y_max - swf_header.stage_size().y_min;
+            // Convert the background color to an HTML hex color ("#FFFFFF").
+            let background_color = swf_header
+                .background_color()
+                .map(|color| format!("#{:06X}", color.to_rgb()));
             let metadata = MovieMetadata {
                 width: width.to_pixels(),
                 height: height.to_pixels(),
                 frame_rate: swf_header.frame_rate(),
                 num_frames: swf_header.num_frames(),
                 swf_version: swf_header.version(),
+                background_color,
+                is_action_script_3: swf_header.is_action_script_3(),
             };
 
             if let Ok(value) = JsValue::from_serde(&metadata) {


### PR DESCRIPTION
When reading an SWF, search the first few SWF tags for FileAttributes and SetBackgroundColor tags and return this with the other header metadata.
Motivation:
 * This metadata is generally useful when using `swf` as a crate, and there have been a few feature requests about it. See for example swfchan displaying background color information.
 * In particular, the AS3 flag in FileAttributes is useful to know as early as possible. This significantly cleans up a lot of Ruffle code that seemed unsure about the AVM type of the movie. Specifically I'd like to move toward `Player` having `Avm1` and `Avm2` inside an enum, so only one can exist at a time.

Changes:
 * HeaderExt contains all of the normal header info, in addition to the FileAttributes/SetBackgroundColor info.
 * Add various accessors to SwfMovie that access these header attributes.
 * Remove `Library::check_avm_type` and instead use `SwfMovie::avm_type` when checking for VM type.
 * Return the additional data in `onMetadata` handler on web.