### PR TITLE
[avm1] extend impl_custom_object! to reduce boilerplate

### DIFF
--- a/core/src/avm1/object/bevel_filter.rs
+++ b/core/src/avm1/object/bevel_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 #[derive(Copy, Clone, Debug, Collect)]
@@ -119,33 +117,8 @@ impl<'gc> BevelFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for BevelFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.bevel_filter),
-        )
-    }
-
-    fn as_bevel_filter_object(&self) -> Option<BevelFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(BevelFilterObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: bevel_filter);
+        bare_object(as_bevel_filter_object -> BevelFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use crate::avm1::object::color_transform_object::ColorTransformObject;
 use crate::backend::render::{BitmapHandle, RenderBackend};
 use crate::bitmap::turbulence::Turbulence;
@@ -903,33 +901,8 @@ impl<'gc> BitmapDataObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.bitmap_data),
-        )
-    }
-
-    fn as_bitmap_data_object(&self) -> Option<BitmapDataObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(BitmapDataObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: bitmap_data);
+        bare_object(as_bitmap_data_object -> BitmapDataObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/blur_filter.rs
+++ b/core/src/avm1/object/blur_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 /// A BlurFilter
@@ -55,33 +53,8 @@ impl<'gc> BlurFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for BlurFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.blur_filter),
-        )
-    }
-
-    fn as_blur_filter_object(&self) -> Option<BlurFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(BlurFilterObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: blur_filter);
+        bare_object(as_blur_filter_object -> BlurFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/color_matrix_filter.rs
+++ b/core/src/avm1/object/color_matrix_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 /// A ColorMatrixFilter
@@ -48,33 +46,8 @@ impl<'gc> ColorMatrixFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ColorMatrixFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.color_matrix_filter),
-        )
-    }
-
-    fn as_color_matrix_filter_object(&self) -> Option<ColorMatrixFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ColorMatrixFilterObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: color_matrix_filter);
+        bare_object(as_color_matrix_filter_object -> ColorMatrixFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/color_transform_object.rs
+++ b/core/src/avm1/object/color_transform_object.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 /// A ColorTransform
@@ -93,37 +91,8 @@ impl<'gc> ColorTransformObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ColorTransformObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.color_transform),
-        )
-    }
-
-    fn as_color_transform_object(&self) -> Option<ColorTransformObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ColorTransformObject::empty_color_transform_object(
-            activation.context.gc_context,
-            Some(this),
-        )
-        .into())
-    }
+    impl_custom_object!(base {
+        set(proto: color_transform);
+        bare_object(as_color_transform_object -> ColorTransformObject::empty_color_transform_object);
+    });
 }

--- a/core/src/avm1/object/convolution_filter.rs
+++ b/core/src/avm1/object/convolution_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 /// A ConvolutionFilter
@@ -101,33 +99,8 @@ impl<'gc> ConvolutionFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ConvolutionFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.convolution_filter),
-        )
-    }
-
-    fn as_convolution_filter_object(&self) -> Option<ConvolutionFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ConvolutionFilterObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: convolution_filter);
+        bare_object(as_convolution_filter_object -> ConvolutionFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/date_object.rs
+++ b/core/src/avm1/object/date_object.rs
@@ -1,5 +1,3 @@
-use crate::avm1::activation::Activation;
-use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TObject};
 use crate::impl_custom_object;
 use chrono::{DateTime, Utc};
@@ -31,6 +29,13 @@ impl fmt::Debug for DateObject<'_> {
 }
 
 impl<'gc> DateObject<'gc> {
+    pub fn empty(
+        gc_context: MutationContext<'gc, '_>,
+        proto: Option<Object<'gc>>,
+    ) -> DateObject<'gc> {
+        Self::with_date_time(gc_context, proto, None)
+    }
+
     pub fn with_date_time(
         gc_context: MutationContext<'gc, '_>,
         proto: Option<Object<'gc>>,
@@ -59,17 +64,8 @@ impl<'gc> DateObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DateObject<'gc> {
-    impl_custom_object!(base);
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(DateObject::with_date_time(activation.context.gc_context, Some(this), None).into())
-    }
-
-    fn as_date_object(&self) -> Option<DateObject<'gc>> {
-        Some(*self)
-    }
+    impl_custom_object!(base {
+        set(proto: self);
+        bare_object(as_date_object -> DateObject::empty);
+    });
 }

--- a/core/src/avm1/object/displacement_map_filter.rs
+++ b/core/src/avm1/object/displacement_map_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, Collect)]
@@ -117,36 +115,8 @@ impl<'gc> DisplacementMapFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DisplacementMapFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.displacement_map_filter),
-        )
-    }
-
-    fn as_displacement_map_filter_object(&self) -> Option<DisplacementMapFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(
-            DisplacementMapFilterObject::empty_object(activation.context.gc_context, Some(this))
-                .into(),
-        )
-    }
+    impl_custom_object!(base {
+        set(proto: displacement_map_filter);
+        bare_object(as_displacement_map_filter_object -> DisplacementMapFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/drop_shadow_filter.rs
+++ b/core/src/avm1/object/drop_shadow_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 /// A DropShadowFilter
@@ -87,33 +85,8 @@ impl<'gc> DropShadowFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for DropShadowFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.drop_shadow_filter),
-        )
-    }
-
-    fn as_drop_shadow_filter_object(&self) -> Option<DropShadowFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(DropShadowFilterObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: drop_shadow_filter);
+        bare_object(as_drop_shadow_filter_object -> DropShadowFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/glow_filter.rs
+++ b/core/src/avm1/object/glow_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use std::fmt;
 
 /// A GlowFilter
@@ -75,33 +73,8 @@ impl<'gc> GlowFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for GlowFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.glow_filter),
-        )
-    }
-
-    fn as_glow_filter_object(&self) -> Option<GlowFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(GlowFilterObject::empty_object(activation.context.gc_context, Some(this)).into())
-    }
+    impl_custom_object!(base {
+        set(proto: glow_filter);
+        bare_object(as_glow_filter_object -> GlowFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/gradient_bevel_filter.rs
+++ b/core/src/avm1/object/gradient_bevel_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use crate::avm1::object::bevel_filter::BevelFilterType;
 use std::fmt;
 
@@ -100,36 +98,8 @@ impl<'gc> GradientBevelFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for GradientBevelFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.gradient_bevel_filter),
-        )
-    }
-
-    fn as_gradient_bevel_filter_object(&self) -> Option<GradientBevelFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(
-            GradientBevelFilterObject::empty_object(activation.context.gc_context, Some(this))
-                .into(),
-        )
-    }
+    impl_custom_object!(base {
+        set(proto: gradient_bevel_filter);
+        bare_object(as_gradient_bevel_filter_object -> GradientBevelFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/gradient_glow_filter.rs
+++ b/core/src/avm1/object/gradient_glow_filter.rs
@@ -1,10 +1,8 @@
 use crate::add_field_accessors;
-use crate::avm1::error::Error;
-use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::impl_custom_object_without_set;
+use crate::avm1::{Object, ScriptObject, TObject};
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
 use crate::avm1::object::bevel_filter::BevelFilterType;
 use std::fmt;
 
@@ -100,36 +98,8 @@ impl<'gc> GradientGlowFilterObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for GradientGlowFilterObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.gradient_glow_filter),
-        )
-    }
-
-    fn as_gradient_glow_filter_object(&self) -> Option<GradientGlowFilterObject<'gc>> {
-        Some(*self)
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(
-            GradientGlowFilterObject::empty_object(activation.context.gc_context, Some(this))
-                .into(),
-        )
-    }
+    impl_custom_object!(base {
+        set(proto: gradient_glow_filter);
+        bare_object(as_gradient_glow_filter_object -> GradientGlowFilterObject::empty_object);
+    });
 }

--- a/core/src/avm1/object/shared_object.rs
+++ b/core/src/avm1/object/shared_object.rs
@@ -1,8 +1,6 @@
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-use crate::avm1::activation::Activation;
-use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TObject};
 use std::fmt;
 
@@ -60,17 +58,8 @@ impl<'gc> SharedObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for SharedObject<'gc> {
-    impl_custom_object!(base);
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(SharedObject::empty_shared_obj(activation.context.gc_context, Some(this)).into())
-    }
-
-    fn as_shared_object(&self) -> Option<SharedObject<'gc>> {
-        Some(*self)
-    }
+    impl_custom_object!(base {
+        set(proto: self);
+        bare_object(as_shared_object -> SharedObject::empty_shared_obj);
+    });
 }

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -1,7 +1,5 @@
 //! AVM1 object type to represent Sound objects.
 
-use crate::avm1::activation::Activation;
-use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TObject};
 use crate::backend::audio::{SoundHandle, SoundInstanceHandle};
 use crate::display_object::DisplayObject;
@@ -120,17 +118,8 @@ impl<'gc> SoundObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for SoundObject<'gc> {
-    impl_custom_object!(base);
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(SoundObject::empty_sound(activation.context.gc_context, Some(this)).into())
-    }
-
-    fn as_sound_object(&self) -> Option<SoundObject<'gc>> {
-        Some(*self)
-    }
+    impl_custom_object!(base {
+        set(proto: self);
+        bare_object(as_sound_object -> SoundObject::empty_sound);
+    });
 }

--- a/core/src/avm1/object/transform_object.rs
+++ b/core/src/avm1/object/transform_object.rs
@@ -1,7 +1,7 @@
 use crate::avm1::error::Error;
 use crate::avm1::{Object, ScriptObject, TDisplayObject, TObject, Value};
 use crate::display_object::MovieClip;
-use crate::impl_custom_object_without_set;
+use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
 use crate::avm1::activation::Activation;
@@ -50,11 +50,10 @@ impl<'gc> TransformObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for TransformObject<'gc> {
-    impl_custom_object_without_set!(base);
-
-    fn as_transform_object(&self) -> Option<TransformObject<'gc>> {
-        Some(*self)
-    }
+    impl_custom_object!(base {
+        set(proto: color_transform);
+        bare_object(as_transform_object -> TransformObject::empty);
+    });
 
     fn construct(
         &self,
@@ -79,29 +78,5 @@ impl<'gc> TObject<'gc> for TransformObject<'gc> {
         let this = prototype.create_bare_object(activation, prototype)?;
         self.construct_on_existing(activation, this, args)?;
         Ok(this.into())
-    }
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(TransformObject::empty(activation.context.gc_context, Some(this)).into())
-    }
-
-    fn set(
-        &self,
-        name: &str,
-        value: Value<'gc>,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Result<(), Error<'gc>> {
-        let base = self.0.read().base;
-        base.internal_set(
-            name,
-            value,
-            activation,
-            (*self).into(),
-            Some(activation.context.avm1.prototypes.color_transform),
-        )
     }
 }

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -1,7 +1,6 @@
 //! Object impl for boxed values
 
 use crate::avm1::activation::Activation;
-use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::impl_custom_object;
@@ -116,20 +115,8 @@ impl fmt::Debug for ValueObject<'_> {
 }
 
 impl<'gc> TObject<'gc> for ValueObject<'gc> {
-    impl_custom_object!(base);
-
-    fn create_bare_object(
-        &self,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ValueObject::empty_box(
-            activation.context.gc_context,
-            Some(this),
-        ))
-    }
-
-    fn as_value_object(&self) -> Option<ValueObject<'gc>> {
-        Some(*self)
-    }
+    impl_custom_object!(base {
+        set(proto: self);
+        bare_object(as_value_object -> ValueObject::empty_box);
+    });
 }


### PR DESCRIPTION
This add two knobs to the `impl_custom_object!` macro:
  - `set(...)`, for using a specific prototype in the `set` method;
  - `bare_object(...)`, for objects that are convertible to a raw object type.