### PR TITLE
Apply _width and _height scaling after init.

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -640,7 +640,7 @@ pub trait TDisplayObject<'gc>:
     /// The width is based on the AABB of the object.
     /// Set by the ActionScript `_width`/`width` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
-    fn set_width(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_scale_from_width(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let object_bounds = self.bounds();
         let object_width = (object_bounds.x_max - object_bounds.x_min).to_pixels();
         let object_height = (object_bounds.y_max - object_bounds.y_min).to_pixels();
@@ -677,6 +677,9 @@ pub trait TDisplayObject<'gc>:
         self.set_scale_x(gc_context, Percent::from_unit(new_scale_x));
         self.set_scale_y(gc_context, Percent::from_unit(new_scale_y));
     }
+    fn set_width(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
+        self.set_scale_from_width(gc_context, value);
+    }
 
     /// Gets the pixel height of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_height`/`height` properties.
@@ -688,7 +691,7 @@ pub trait TDisplayObject<'gc>:
     /// Sets the pixel height of this display object in local space.
     /// Set by the ActionScript `_height`/`height` properties.
     /// This does odd things on rotated clips to match the behavior of Flash.
-    fn set_height(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_scale_from_height(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
         let object_bounds = self.bounds();
         let object_width = (object_bounds.x_max - object_bounds.x_min).to_pixels();
         let object_height = (object_bounds.y_max - object_bounds.y_min).to_pixels();
@@ -724,6 +727,9 @@ pub trait TDisplayObject<'gc>:
 
         self.set_scale_x(gc_context, Percent::from_unit(new_scale_x));
         self.set_scale_y(gc_context, Percent::from_unit(new_scale_y));
+    }
+    fn set_height(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
+        self.set_scale_from_height(gc_context, value);
     }
 
     /// The opacity of this display object.


### PR DESCRIPTION
This fixes #3414 by saving the `_width` and `_height` passed in to `attachMovie()`. The underlying bounding box is initially empty, so the scale was getting set to 0. Instead I save those values until the clip has had a chance to start.

I have a [test case](https://github.com/hcs64/attachMovie_width_height/). this should render one column (`blast_meter`, class `BlastMeter`) of four images (`blast_icon`), scaled by sending `_width` and `_height` to `attachMovie()`. Current Ruffle only shows one image.

Here's what it looks like in Flash Player 32.0.0.465:

![flash_output](https://user-images.githubusercontent.com/857753/120280426-82b3a580-c26c-11eb-8403-9ef56f14a4c1.png)

[This patch](https://gashlin.net/tests/attachMovie_width_height/build/index.html) matches that output.

There is also a second column of images added, but this should not appear. This uses `_width` on the `attachMovie()` that adds the parent object (`BlastMeter`), which doesn't get any children until its `onLoad`, so it still gets properly stuck with 0 scale as now.

#2006 still seems ok, I checked that the dropdown works in www.fonologia.org/flash/exercicios/exercicio1.swf

A simpler solution is to just skip setting the scale if it would be non-finite, rather than setting it to 0 as #3917 did. This doesn't handle the scaling effect, but it might be better than completely failing to render. I noticed this with [a game](https://gashlin.net/games/ld18/r68/) that I'd dashed off in a weekend, in that case I was just redundantly setting the actual image dimensions.

Outstanding questions and concerns:

* I have very little idea of exactly when this scaling should happen. The second column doesn't show up, so it doesn't delay indefinitely.
* Two `Option<f64>`s on every `MovieClip` just to support this edge case seems waseful.
* Should this happen with other `DisplayObject`s?
* Should this delay apply to any other properties?
* Is this consistent across versions of Flash?