### PR TITLE
avm1: Refactor TObject

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -535,7 +535,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<Value<'gc>, Error<'gc>> {
+    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
         self.base.get_local(name, activation, this)
     }
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -539,13 +539,16 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.base.get_local(name, activation, this)
     }
 
-    fn set(
+    fn set_local(
         &self,
         name: &str,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
+        this: Object<'gc>,
+        base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
-        self.base.set(name, value, activation)
+        self.base
+            .set_local(name, value, activation, this, base_proto)
     }
 
     fn call(

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1069,8 +1069,12 @@ fn local_to_global<'gc>(
         // localToGlobal does no coercion; it fails if the properties are not numbers.
         // It does not search the prototype chain.
         if let (Value::Number(x), Value::Number(y)) = (
-            point.get_local("x", activation, *point)?,
-            point.get_local("y", activation, *point)?,
+            point
+                .get_local("x", activation, *point)
+                .unwrap_or(Ok(Value::Undefined))?,
+            point
+                .get_local("y", activation, *point)
+                .unwrap_or(Ok(Value::Undefined))?,
         ) {
             let x = Twips::from_pixels(x);
             let y = Twips::from_pixels(y);
@@ -1200,8 +1204,12 @@ fn global_to_local<'gc>(
         // globalToLocal does no coercion; it fails if the properties are not numbers.
         // It does not search the prototype chain.
         if let (Value::Number(x), Value::Number(y)) = (
-            point.get_local("x", activation, *point)?,
-            point.get_local("y", activation, *point)?,
+            point
+                .get_local("x", activation, *point)
+                .unwrap_or(Ok(Value::Undefined))?,
+            point
+                .get_local("y", activation, *point)
+                .unwrap_or(Ok(Value::Undefined))?,
         ) {
             let x = Twips::from_pixels(x);
             let y = Twips::from_pixels(y);

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -103,7 +103,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<Value<'gc>, Error<'gc>>;
+    ) -> Option<Result<Value<'gc>, Error<'gc>>>;
 
     /// Retrieve a named property from the object, or its prototype.
     fn get(
@@ -644,8 +644,8 @@ pub fn search_prototype<'gc>(
             return Err(Error::PrototypeRecursionLimit);
         }
 
-        if p.has_own_property(activation, name) {
-            return Ok((p.get_local(name, activation, this)?, Some(p)));
+        if let Some(value) = p.get_local(name, activation, this) {
+            return Ok((value?, Some(p)));
         }
 
         proto = p.proto();

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -111,6 +111,10 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error<'gc>> {
+        if name == "__proto__" {
+            return Ok(self.proto());
+        }
+
         let this = (*self).into();
         Ok(search_prototype(Value::Object(this), name, activation, this)?.0)
     }

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -58,7 +58,7 @@ macro_rules! impl_custom_object {
             name: &str,
             activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
             this: crate::avm1::Object<'gc>,
-        ) -> Result<crate::avm1::Value<'gc>, crate::avm1::Error<'gc>> {
+        ) -> Option<Result<crate::avm1::Value<'gc>, crate::avm1::Error<'gc>>> {
             self.0.read().$field.get_local(name, activation, this)
         }
 

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -5,31 +5,28 @@ macro_rules! impl_custom_object {
     };
 
     (@extra $field:ident set(proto: self)) => {
-        fn set(
+        fn set_local(
             &self,
             name: &str,
             value: crate::avm1::Value<'gc>,
             activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
+            this: crate::avm1::Object<'gc>,
+            base_proto: Option<crate::avm1::Object<'gc>>,
         ) -> Result<(), crate::avm1::Error<'gc>> {
-            self.0.read().$field.set(name, value, activation)
+            self.0.read().$field.set_local(name, value, activation, this, base_proto)
         }
     };
 
     (@extra $field:ident set(proto: $proto:ident)) => {
-        fn set(
+        fn set_local(
             &self,
             name: &str,
             value: crate::avm1::Value<'gc>,
             activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
+            this: crate::avm1::Object<'gc>,
+            _base_proto: Option<crate::avm1::Object<'gc>>,
         ) -> Result<(), crate::avm1::Error<'gc>> {
-            let base = self.0.read().$field;
-            base.internal_set(
-                name,
-                value,
-                activation,
-                (*self).into(),
-                Some(activation.context.avm1.prototypes.$proto),
-            )
+            self.0.read().$field.set_local(name, value, activation, this, Some(activation.context.avm1.prototypes.$proto))
         }
     };
 

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -83,8 +83,8 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         _name: &str,
         _activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
-    ) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Undefined)
+    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
+        Some(Ok(Value::Undefined))
     }
 
     fn set_local(

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -87,11 +87,13 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         Ok(Value::Undefined)
     }
 
-    fn set(
+    fn set_local(
         &self,
         _name: &str,
         _value: Value<'gc>,
         _activation: &mut Activation<'_, 'gc, '_>,
+        _this: Object<'gc>,
+        _base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
         //TODO: What happens if you set `super.__proto__`?
         Ok(())

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -69,18 +69,20 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
             .unwrap_or_else(|| Value::Undefined))
     }
 
-    fn set(
+    fn set_local(
         &self,
         name: &str,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
+        _this: Object<'gc>,
+        _base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
         self.node().set_attribute_value(
             activation.context.gc_context,
             &XmlName::from_str(name),
             &value.coerce_to_string(activation)?,
         );
-        self.base().set(name, value, activation)
+        Ok(())
     }
     fn call(
         &self,

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -61,12 +61,10 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
         _this: Object<'gc>,
-    ) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(self
-            .node()
+    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
+        self.node()
             .attribute_value(&XmlName::from_str(name))
-            .map(|s| AvmString::new(activation.context.gc_context, s).into())
-            .unwrap_or_else(|| Value::Undefined))
+            .map(|s| Ok(AvmString::new(activation.context.gc_context, s).into()))
     }
 
     fn set_local(

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -61,14 +61,14 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
-    ) -> Result<Value<'gc>, Error<'gc>> {
+    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
         if let Some(mut node) = self.document().get_node_by_id(name) {
-            Ok(node
+            Some(Ok(node
                 .script_object(
                     activation.context.gc_context,
                     Some(activation.context.avm1.prototypes().xml_node),
                 )
-                .into())
+                .into()))
         } else {
             self.base().get_local(name, activation, this)
         }

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -74,13 +74,16 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
         }
     }
 
-    fn set(
+    fn set_local(
         &self,
         name: &str,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
+        this: Object<'gc>,
+        base_proto: Option<Object<'gc>>,
     ) -> Result<(), Error<'gc>> {
-        self.base().set(name, value, activation)
+        self.base()
+            .set_local(name, value, activation, this, base_proto)
     }
     fn call(
         &self,


### PR DESCRIPTION
* Add `TObject::set_local` so `TObject::set` is never overridden. Also `ScriptObject::internal_set` is now split to `TObject::set` and `ScriptObject::set_local`.
* Make `TObject::get_local` return `None` when the property doesn't exist, instead of relying on `TObject::has_own_property` to tell that (because `StageObject::has_own_property` doesn't return `true` for all names handled by `StageObject::get_local`).