### PR TITLE
docs: correct tested node versions

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -50,7 +50,7 @@ For the compiler to be able to output WebAssembly, an additional target has to b
 
 Follow the instructions [to install node.js](https://nodejs.org/en/) on your machine.
 
-We recommend using the currently active LTS 12, but we do also run tests with maintenance LTS 10.
+We recommend using the currently active LTS 14, but we do also run tests with maintenance LTS 12.
 
 #### wasm-bindgen
 


### PR DESCRIPTION
Very minor docs update: the node versions used by actions were updated in #2974, but the docs weren't.