### PR TITLE
demo: Add favicon to demo page

### DIFF
--- a/web/packages/demo/www/index.html
+++ b/web/packages/demo/www/index.html
@@ -6,6 +6,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Ruffle Web Demo</title>
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato" />
+        <link rel="icon" href="https://ruffle.rs/assets/favicon-32.png" sizes="32x32">
+        <link rel="icon" href="https://ruffle.rs/assets/favicon-64.png" sizes="64x64">
+        <link rel="icon" href="https://ruffle.rs/assets/favicon-180.png" sizes="180x180">
     </head>
     <body>
         <div id="nav">


### PR DESCRIPTION
Fix #2910

I'm fairly sure the code in [ruffle-rs/ruffle-rs.github.io/_includes/head.html](https://github.com/ruffle-rs/ruffle-rs.github.io/blob/master/_includes/head.html) never applied on the demo page. Even back when the demo page was not part of its own repo, I did not see an include statement on it, even in the initial commit: [ruffle-rs/ruffle-rs.github.io/demo/index.html@`479675a`](https://github.com/ruffle-rs/ruffle-rs.github.io/blob/479675ad142cc97847a63f1acb038ab055fefb42/demo/index.html).

I also created https://github.com/ruffle-rs/ruffle-rs.github.io/pull/52 to remove the unneeded code from `head.html`.