### PR TITLE
avm1: Rewrite TObject array methods

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1465,7 +1465,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
     fn action_init_array(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let num_elements = self.context.avm1.pop().coerce_to_f64(self)?;
-        let result = if num_elements < 0.0 || num_elements > std::i32::MAX as f64 {
+        let result = if num_elements < 0.0 || num_elements > i32::MAX as f64 {
             // InitArray pops no args and pushes undefined if num_elements is out of range.
             Value::Undefined
         } else {
@@ -1473,8 +1473,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 self.context.gc_context,
                 Some(self.context.avm1.prototypes.array),
             );
-            for i in 0..num_elements as usize {
-                array.set_array_element(i, self.context.avm1.pop(), self.context.gc_context);
+            for i in 0..num_elements as i32 {
+                let element = self.context.avm1.pop();
+                array.set_element(self, i, element).unwrap();
             }
             Value::Object(array.into())
         };
@@ -1485,7 +1486,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
     fn action_init_object(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let num_props = self.context.avm1.pop().coerce_to_f64(self)?;
-        let result = if num_props < 0.0 || num_props > std::i32::MAX as f64 {
+        let result = if num_props < 0.0 || num_props > i32::MAX as f64 {
             // InitArray pops no args and pushes undefined if num_props is out of range.
             Value::Undefined
         } else {

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -263,12 +263,10 @@ impl<'gc> Executable<'gc> {
                 );
 
                 if !af.flags.contains(FunctionFlags::SUPPRESS_ARGUMENTS) {
-                    for i in 0..args.len() {
-                        arguments.set_array_element(
-                            i,
-                            *args.get(i).unwrap(),
-                            activation.context.gc_context,
-                        );
+                    for (i, arg) in args.iter().enumerate() {
+                        arguments
+                            .set_element(activation, i as i32, arg.to_owned())
+                            .unwrap();
                     }
                 }
 
@@ -803,33 +801,37 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.base.as_ptr()
     }
 
-    fn length(&self) -> usize {
-        self.base.length()
+    fn length(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<i32, Error<'gc>> {
+        self.base.length(activation)
     }
 
-    fn set_length(&self, gc_context: MutationContext<'gc, '_>, new_length: usize) {
-        self.base.set_length(gc_context, new_length)
-    }
-
-    fn array(&self) -> Vec<Value<'gc>> {
-        self.base.array()
-    }
-
-    fn array_element(&self, index: usize) -> Value<'gc> {
-        self.base.array_element(index)
-    }
-
-    fn set_array_element(
+    fn set_length(
         &self,
-        index: usize,
-        value: Value<'gc>,
-        gc_context: MutationContext<'gc, '_>,
-    ) -> usize {
-        self.base.set_array_element(index, value, gc_context)
+        activation: &mut Activation<'_, 'gc, '_>,
+        length: i32,
+    ) -> Result<(), Error<'gc>> {
+        self.base.set_length(activation, length)
     }
 
-    fn delete_array_element(&self, index: usize, gc_context: MutationContext<'gc, '_>) {
-        self.base.delete_array_element(index, gc_context)
+    fn has_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.base.has_element(activation, index)
+    }
+
+    fn get_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> Value<'gc> {
+        self.base.get_element(activation, index)
+    }
+
+    fn set_element(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+        index: i32,
+        value: Value<'gc>,
+    ) -> Result<(), Error<'gc>> {
+        self.base.set_element(activation, index, value)
+    }
+
+    fn delete_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.base.delete_element(activation, index)
     }
 }
 

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -31,13 +31,11 @@ pub fn matrix<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.matrix();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.matrix().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -52,12 +50,13 @@ pub fn set_matrix<'gc>(
     let matrix = args.get(0).unwrap_or(&Value::Undefined);
 
     if let Value::Object(obj) = matrix {
-        let arr_len = obj.length().min(20);
+        let length = obj.length(activation)?.min(20);
         let mut arr = [0.0; 4 * 5];
 
-        for (index, item) in arr.iter_mut().enumerate().take(arr_len) {
-            let elem = obj.array_element(index).coerce_to_f64(activation)?;
-            *item = elem;
+        for (i, item) in arr.iter_mut().enumerate().take(length as usize) {
+            *item = obj
+                .get_element(activation, i as i32)
+                .coerce_to_f64(activation)?;
         }
 
         if let Some(filter) = this.as_color_matrix_filter_object() {

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -116,13 +116,11 @@ pub fn colors<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.colors();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.colors().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -138,16 +136,18 @@ pub fn set_colors<'gc>(
 
     if let Value::Object(obj) = colors {
         if let Some(filter) = this.as_gradient_bevel_filter_object() {
-            let arr_len = obj.length();
+            let arr_len = obj.length(activation)? as usize;
             let mut colors_arr = Vec::with_capacity(arr_len);
 
             let old_alphas = filter.alphas();
             let mut alphas_arr = Vec::with_capacity(arr_len);
 
-            for index in 0..arr_len {
-                let col = obj.array_element(index).coerce_to_u32(activation)?;
+            for i in 0..arr_len {
+                let col = obj
+                    .get_element(activation, i as i32)
+                    .coerce_to_u32(activation)?;
 
-                let alpha = if let Some(alpha) = old_alphas.get(index) {
+                let alpha = if let Some(alpha) = old_alphas.get(i) {
                     *alpha
                 } else if col >> 24 == 0 {
                     0.0
@@ -180,13 +180,11 @@ pub fn alphas<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.alphas();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.alphas().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -202,25 +200,25 @@ pub fn set_alphas<'gc>(
 
     if let Value::Object(obj) = alphas {
         if let Some(filter) = this.as_gradient_bevel_filter_object() {
-            let arr_len = obj.length().min(filter.colors().len());
-            let mut arr = Vec::with_capacity(arr_len);
+            let length = (obj.length(activation)? as usize).min(filter.colors().len());
 
-            for index in 0..arr_len {
-                arr.push(
-                    obj.array_element(index)
+            let alphas: Result<Vec<_>, Error<'gc>> = (0..length)
+                .map(|i| {
+                    Ok(obj
+                        .get_element(activation, i as i32)
                         .coerce_to_f64(activation)?
-                        .max(0.0)
-                        .min(1.0),
-                );
-            }
+                        .clamp(0.0, 1.0))
+                })
+                .collect();
+            let alphas = alphas?;
 
-            let colors = filter.colors().into_iter().take(arr_len).collect();
+            let colors = filter.colors().into_iter().take(length).collect();
             filter.set_colors(activation.context.gc_context, colors);
 
-            let ratios = filter.ratios().into_iter().take(arr_len).collect();
+            let ratios = filter.ratios().into_iter().take(length).collect();
             filter.set_ratios(activation.context.gc_context, ratios);
 
-            filter.set_alphas(activation.context.gc_context, arr);
+            filter.set_alphas(activation.context.gc_context, alphas);
         }
     }
 
@@ -237,13 +235,11 @@ pub fn ratios<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.ratios();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.ratios().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -259,25 +255,25 @@ pub fn set_ratios<'gc>(
 
     if let Value::Object(obj) = ratios {
         if let Some(filter) = this.as_gradient_bevel_filter_object() {
-            let arr_len = obj.length().min(filter.colors().len());
-            let mut arr = Vec::with_capacity(arr_len);
+            let length = (obj.length(activation)? as usize).min(filter.colors().len());
 
-            for index in 0..arr_len {
-                arr.push(
-                    obj.array_element(index)
+            let ratios: Result<Vec<_>, Error<'gc>> = (0..length)
+                .map(|i| {
+                    Ok(obj
+                        .get_element(activation, i as i32)
                         .coerce_to_i32(activation)?
-                        .max(0)
-                        .min(255) as u8,
-                );
-            }
+                        .clamp(0, 255) as u8)
+                })
+                .collect();
+            let ratios = ratios?;
 
-            let colors = filter.colors().into_iter().take(arr_len).collect();
+            let colors = filter.colors().into_iter().take(length).collect();
             filter.set_colors(activation.context.gc_context, colors);
 
-            let alphas = filter.alphas().into_iter().take(arr_len).collect();
+            let alphas = filter.alphas().into_iter().take(length).collect();
             filter.set_alphas(activation.context.gc_context, alphas);
 
-            filter.set_ratios(activation.context.gc_context, arr);
+            filter.set_ratios(activation.context.gc_context, ratios);
         }
     }
 

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -116,13 +116,11 @@ pub fn colors<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.colors();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.colors().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -138,16 +136,18 @@ pub fn set_colors<'gc>(
 
     if let Value::Object(obj) = colors {
         if let Some(filter) = this.as_gradient_glow_filter_object() {
-            let arr_len = obj.length();
+            let arr_len = obj.length(activation)? as usize;
             let mut colors_arr = Vec::with_capacity(arr_len);
 
             let old_alphas = filter.alphas();
             let mut alphas_arr = Vec::with_capacity(arr_len);
 
-            for index in 0..arr_len {
-                let col = obj.array_element(index).coerce_to_u32(activation)?;
+            for i in 0..arr_len {
+                let col = obj
+                    .get_element(activation, i as i32)
+                    .coerce_to_u32(activation)?;
 
-                let alpha = if let Some(alpha) = old_alphas.get(index) {
+                let alpha = if let Some(alpha) = old_alphas.get(i) {
                     *alpha
                 } else if col >> 24 == 0 {
                     0.0
@@ -180,13 +180,11 @@ pub fn alphas<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.alphas();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.alphas().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -202,25 +200,25 @@ pub fn set_alphas<'gc>(
 
     if let Value::Object(obj) = alphas {
         if let Some(filter) = this.as_gradient_glow_filter_object() {
-            let arr_len = obj.length().min(filter.colors().len());
-            let mut arr = Vec::with_capacity(arr_len);
+            let length = (obj.length(activation)? as usize).min(filter.colors().len());
 
-            for index in 0..arr_len {
-                arr.push(
-                    obj.array_element(index)
+            let alphas: Result<Vec<_>, Error<'gc>> = (0..length)
+                .map(|i| {
+                    Ok(obj
+                        .get_element(activation, i as i32)
                         .coerce_to_f64(activation)?
-                        .max(0.0)
-                        .min(1.0),
-                );
-            }
+                        .clamp(0.0, 1.0))
+                })
+                .collect();
+            let alphas = alphas?;
 
-            let colors = filter.colors().into_iter().take(arr_len).collect();
+            let colors = filter.colors().into_iter().take(length).collect();
             filter.set_colors(activation.context.gc_context, colors);
 
-            let ratios = filter.ratios().into_iter().take(arr_len).collect();
+            let ratios = filter.ratios().into_iter().take(length).collect();
             filter.set_ratios(activation.context.gc_context, ratios);
 
-            filter.set_alphas(activation.context.gc_context, arr);
+            filter.set_alphas(activation.context.gc_context, alphas);
         }
     }
 
@@ -237,13 +235,11 @@ pub fn ratios<'gc>(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.array),
         );
-
-        let arr = filter.ratios();
-
-        for (index, item) in arr.iter().copied().enumerate() {
-            array.set_array_element(index, item.into(), activation.context.gc_context);
+        for (i, item) in filter.ratios().iter().copied().enumerate() {
+            array
+                .set_element(activation, i as i32, item.into())
+                .unwrap();
         }
-
         return Ok(array.into());
     }
 
@@ -259,25 +255,25 @@ pub fn set_ratios<'gc>(
 
     if let Value::Object(obj) = ratios {
         if let Some(filter) = this.as_gradient_glow_filter_object() {
-            let arr_len = obj.length().min(filter.colors().len());
-            let mut arr = Vec::with_capacity(arr_len);
+            let length = (obj.length(activation)? as usize).min(filter.colors().len());
 
-            for index in 0..arr_len {
-                arr.push(
-                    obj.array_element(index)
+            let ratios: Result<Vec<_>, Error<'gc>> = (0..length)
+                .map(|i| {
+                    Ok(obj
+                        .get_element(activation, i as i32)
                         .coerce_to_i32(activation)?
-                        .max(0)
-                        .min(255) as u8,
-                );
-            }
+                        .clamp(0, 255) as u8)
+                })
+                .collect();
+            let ratios = ratios?;
 
-            let colors = filter.colors().into_iter().take(arr_len).collect();
+            let colors = filter.colors().into_iter().take(length).collect();
             filter.set_colors(activation.context.gc_context, colors);
 
-            let alphas = filter.alphas().into_iter().take(arr_len).collect();
+            let alphas = filter.alphas().into_iter().take(length).collect();
             filter.set_alphas(activation.context.gc_context, alphas);
 
-            filter.set_ratios(activation.context.gc_context, arr);
+            filter.set_ratios(activation.context.gc_context, ratios);
         }
     }
 

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -33,7 +33,7 @@ pub fn constructor<'gc>(
         Value::Object(listeners.into()),
         Attribute::DONT_ENUM,
     );
-    listeners.set_array_element(0, Value::Object(this), activation.context.gc_context);
+    listeners.set_element(activation, 0, this.into()).unwrap();
 
     Ok(this.into())
 }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -368,16 +368,18 @@ pub fn xmlnode_child_nodes<'gc>(
                 continue;
             }
 
-            array.set_array_element(
-                compatible_nodes as usize,
-                child
-                    .script_object(
-                        activation.context.gc_context,
-                        Some(activation.context.avm1.prototypes.xml_node),
-                    )
-                    .into(),
-                activation.context.gc_context,
-            );
+            array
+                .set_element(
+                    activation,
+                    compatible_nodes,
+                    child
+                        .script_object(
+                            activation.context.gc_context,
+                            Some(activation.context.avm1.prototypes.xml_node),
+                        )
+                        .into(),
+                )
+                .unwrap();
 
             compatible_nodes += 1;
         }

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -227,40 +227,28 @@ macro_rules! impl_custom_object {
             self.0.as_ptr() as *const crate::avm1::ObjectPtr
         }
 
-        fn length(&self) -> usize {
-            self.0.read().$field.length()
+        fn length(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>) -> Result<i32, crate::avm1::Error<'gc>> {
+            self.0.read().$field.length(activation)
         }
 
-        fn array(&self) -> Vec<crate::avm1::Value<'gc>> {
-            self.0.read().$field.array()
+        fn set_length(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>, length: i32) -> Result<(), crate::avm1::Error<'gc>> {
+            self.0.read().$field.set_length(activation, length)
         }
 
-        fn set_length(&self, gc_context: gc_arena::MutationContext<'gc, '_>, length: usize) {
-            self.0.read().$field.set_length(gc_context, length)
+        fn has_element(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>, index: i32) -> bool {
+            self.0.read().$field.has_element(activation, index)
         }
 
-        fn array_element(&self, index: usize) -> crate::avm1::Value<'gc> {
-            self.0.read().$field.array_element(index)
+        fn get_element(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>, index: i32) -> crate::avm1::Value<'gc> {
+            self.0.read().$field.get_element(activation, index)
         }
 
-        fn set_array_element(
-            &self,
-            index: usize,
-            value: crate::avm1::Value<'gc>,
-            gc_context: gc_arena::MutationContext<'gc, '_>,
-        ) -> usize {
-            self.0
-                .read()
-                .$field
-                .set_array_element(index, value, gc_context)
+        fn set_element(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>, index: i32, value: crate::avm1::Value<'gc>) -> Result<(), crate::avm1::Error<'gc>> {
+            self.0.read().$field.set_element(activation, index, value)
         }
 
-        fn delete_array_element(
-            &self,
-            index: usize,
-            gc_context: gc_arena::MutationContext<'gc, '_>,
-        ) {
-            self.0.read().$field.delete_array_element(index, gc_context)
+        fn delete_element(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>, index: i32) -> bool {
+            self.0.read().$field.delete_element(activation, index)
         }
 
         fn set_watcher(

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -414,36 +414,37 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         keys
     }
 
-    fn length(&self) -> usize {
-        self.0.read().base.length()
+    fn length(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<i32, Error<'gc>> {
+        self.0.read().base.length(activation)
     }
 
-    fn set_length(&self, gc_context: MutationContext<'gc, '_>, new_length: usize) {
-        self.0.read().base.set_length(gc_context, new_length)
-    }
-
-    fn array(&self) -> Vec<Value<'gc>> {
-        self.0.read().base.array()
-    }
-
-    fn array_element(&self, index: usize) -> Value<'gc> {
-        self.0.read().base.array_element(index)
-    }
-
-    fn set_array_element(
+    fn set_length(
         &self,
-        index: usize,
-        value: Value<'gc>,
-        gc_context: MutationContext<'gc, '_>,
-    ) -> usize {
-        self.0
-            .read()
-            .base
-            .set_array_element(index, value, gc_context)
+        activation: &mut Activation<'_, 'gc, '_>,
+        length: i32,
+    ) -> Result<(), Error<'gc>> {
+        self.0.read().base.set_length(activation, length)
     }
 
-    fn delete_array_element(&self, index: usize, gc_context: MutationContext<'gc, '_>) {
-        self.0.read().base.delete_array_element(index, gc_context)
+    fn has_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.0.read().base.has_element(activation, index)
+    }
+
+    fn get_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> Value<'gc> {
+        self.0.read().base.get_element(activation, index)
+    }
+
+    fn set_element(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+        index: i32,
+        value: Value<'gc>,
+    ) -> Result<(), Error<'gc>> {
+        self.0.read().base.set_element(activation, index, value)
+    }
+
+    fn delete_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.0.read().base.delete_element(activation, index)
     }
 
     fn interfaces(&self) -> Vec<Object<'gc>> {

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -252,30 +252,38 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         TYPE_OF_OBJECT
     }
 
-    fn length(&self) -> usize {
-        0
+    fn length(&self, _activation: &mut Activation<'_, 'gc, '_>) -> Result<i32, Error<'gc>> {
+        Ok(0)
     }
 
-    fn set_length(&self, _gc_context: MutationContext<'gc, '_>, _new_length: usize) {}
-
-    fn array(&self) -> Vec<Value<'gc>> {
-        vec![]
+    fn set_length(
+        &self,
+        _activation: &mut Activation<'_, 'gc, '_>,
+        _length: i32,
+    ) -> Result<(), Error<'gc>> {
+        Ok(())
     }
 
-    fn array_element(&self, _index: usize) -> Value<'gc> {
+    fn has_element(&self, _activation: &mut Activation<'_, 'gc, '_>, _index: i32) -> bool {
+        false
+    }
+
+    fn get_element(&self, _activation: &mut Activation<'_, 'gc, '_>, _index: i32) -> Value<'gc> {
         Value::Undefined
     }
 
-    fn set_array_element(
+    fn set_element(
         &self,
-        _index: usize,
+        _activation: &mut Activation<'_, 'gc, '_>,
+        _index: i32,
         _value: Value<'gc>,
-        _gc_context: MutationContext<'gc, '_>,
-    ) -> usize {
-        0
+    ) -> Result<(), Error<'gc>> {
+        Ok(())
     }
 
-    fn delete_array_element(&self, _index: usize, _gc_context: MutationContext<'gc, '_>) {}
+    fn delete_element(&self, _activation: &mut Activation<'_, 'gc, '_>, _index: i32) -> bool {
+        false
+    }
 
     fn interfaces(&self) -> Vec<Object<'gc>> {
         //`super` does not implement interfaces

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -235,32 +235,36 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
         self.base().as_ptr() as *const ObjectPtr
     }
 
-    fn length(&self) -> usize {
-        self.base().length()
+    fn length(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<i32, Error<'gc>> {
+        self.base().length(activation)
     }
 
-    fn array(&self) -> Vec<Value<'gc>> {
-        self.base().array()
-    }
-
-    fn set_length(&self, gc_context: MutationContext<'gc, '_>, length: usize) {
-        self.base().set_length(gc_context, length)
-    }
-
-    fn array_element(&self, index: usize) -> Value<'gc> {
-        self.base().array_element(index)
-    }
-
-    fn set_array_element(
+    fn set_length(
         &self,
-        index: usize,
-        value: Value<'gc>,
-        gc_context: MutationContext<'gc, '_>,
-    ) -> usize {
-        self.base().set_array_element(index, value, gc_context)
+        activation: &mut Activation<'_, 'gc, '_>,
+        length: i32,
+    ) -> Result<(), Error<'gc>> {
+        self.base().set_length(activation, length)
     }
 
-    fn delete_array_element(&self, index: usize, gc_context: MutationContext<'gc, '_>) {
-        self.base().delete_array_element(index, gc_context)
+    fn has_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.base().has_element(activation, index)
+    }
+
+    fn get_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> Value<'gc> {
+        self.base().get_element(activation, index)
+    }
+
+    fn set_element(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+        index: i32,
+        value: Value<'gc>,
+    ) -> Result<(), Error<'gc>> {
+        self.base().set_element(activation, index, value)
+    }
+
+    fn delete_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.base().delete_element(activation, index)
     }
 }

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -235,32 +235,36 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
         self.base().as_ptr() as *const ObjectPtr
     }
 
-    fn length(&self) -> usize {
-        self.base().length()
+    fn length(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<i32, Error<'gc>> {
+        self.base().length(activation)
     }
 
-    fn array(&self) -> Vec<Value<'gc>> {
-        self.base().array()
-    }
-
-    fn set_length(&self, gc_context: MutationContext<'gc, '_>, length: usize) {
-        self.base().set_length(gc_context, length)
-    }
-
-    fn array_element(&self, index: usize) -> Value<'gc> {
-        self.base().array_element(index)
-    }
-
-    fn set_array_element(
+    fn set_length(
         &self,
-        index: usize,
-        value: Value<'gc>,
-        gc_context: MutationContext<'gc, '_>,
-    ) -> usize {
-        self.base().set_array_element(index, value, gc_context)
+        activation: &mut Activation<'_, 'gc, '_>,
+        length: i32,
+    ) -> Result<(), Error<'gc>> {
+        self.base().set_length(activation, length)
     }
 
-    fn delete_array_element(&self, index: usize, gc_context: MutationContext<'gc, '_>) {
-        self.base().delete_array_element(index, gc_context)
+    fn has_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.base().has_element(activation, index)
+    }
+
+    fn get_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> Value<'gc> {
+        self.base().get_element(activation, index)
+    }
+
+    fn set_element(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+        index: i32,
+        value: Value<'gc>,
+    ) -> Result<(), Error<'gc>> {
+        self.base().set_element(activation, index, value)
+    }
+
+    fn delete_element(&self, activation: &mut Activation<'_, 'gc, '_>, index: i32) -> bool {
+        self.base().delete_element(activation, index)
     }
 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1227,15 +1227,13 @@ impl<'gc> EditText<'gc> {
             );
 
             if let Ok(Avm1Value::Object(listeners)) = object.get("_listeners", activation) {
-                if listeners.length() == 0 {
+                let length = listeners.length(activation);
+                if matches!(length, Ok(0)) {
                     // Add the TextField as its own listener to match Flash's behavior
                     // This makes it so that the TextField's handlers are called before other listeners'.
-                    listeners.set_array_element(0, object.into(), activation.context.gc_context);
+                    let _ = listeners.set_element(activation, 0, object.into());
                 } else {
-                    log::warn!(
-                        "_listeners should be empty, but its length is {}",
-                        listeners.length()
-                    );
+                    log::warn!("_listeners should be empty");
                 }
             }
         }


### PR DESCRIPTION
The current `TObject` array methods have some wrong assumptions about AVM1:
* An `Array` can have a negative length:
```as
var a = new Array(-1);
trace(a.length); // -1
```
* Although getting `length` doesn't invoke getters added using `addProperty`, it still might throw an exception because of `valueOf`:
```as
var o = { length: { valueOf() { trace("in valueOf"); throw "error"; } } };
Array.prototype.push.call(o); // traces "in valueOf"
trace("unreachable"); // not reached because of exception
```
* Similarly, setting `length` doesn't invoke setters added using `addProperty`, but it still invokes watchers which might throw an exception:
```as
var o = {};
o.watch("length", function() { trace("in watcher"); throw "error"; });
Array.prototype.push.call(o, 0); // traces "in watcher"
trace("unreachable"); // not reached because of exception
```

As a preparation for supporting these cases, rewrite the current `TObject` array methods to be able to handle negative lengths/indices and throw an exception:
* `TObject::length` - Now returns `Result<i32>` instead of `usize`.
* `TObject::set_length` - Accepts `i32` instead of `usize`. Also returns `Result<()>`.
* `TObject::array` - Removed completely.
* `TObject::has_element` - Added.
* `TObject::array_element` -> `TObject::get_element` - Accepts `i32` index.
* `TObject::set_array_element` -> `TObject::set_element` - Accepts `i32` index. Also returns `Result<()>`.
* `TObject::delete_array_element` -> `TObject::delete_element` - Accepts `i32` index.