### PR TITLE
chore: Avoid unused_variables annotations

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2259,7 +2259,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         Ok(FrameControl::Continue)
     }
 
-    #[allow(unused_variables)]
     fn action_throw(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.context.avm1.pop();
         avm_debug!(

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2789,7 +2789,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         Ok(FrameControl::Continue)
     }
 
-    #[allow(unused_variables)]
     #[cfg(avm_debug)]
     fn op_debug(
         &mut self,
@@ -2810,19 +2809,17 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         Ok(FrameControl::Continue)
     }
 
-    #[allow(unused_variables)]
     #[cfg(not(avm_debug))]
     fn op_debug(
         &mut self,
-        method: Gc<'gc, BytecodeMethod<'gc>>,
-        is_local_register: bool,
-        register_name: Index<String>,
-        register: u8,
+        _method: Gc<'gc, BytecodeMethod<'gc>>,
+        _is_local_register: bool,
+        _register_name: Index<String>,
+        _register: u8,
     ) -> Result<FrameControl<'gc>, Error> {
         Ok(FrameControl::Continue)
     }
 
-    #[allow(unused_variables)]
     #[cfg(avm_debug)]
     fn op_debug_file(
         &mut self,
@@ -2836,17 +2833,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         Ok(FrameControl::Continue)
     }
 
-    #[allow(unused_variables)]
     #[cfg(not(avm_debug))]
     fn op_debug_file(
         &mut self,
-        method: Gc<'gc, BytecodeMethod<'gc>>,
-        file_name: Index<String>,
+        _method: Gc<'gc, BytecodeMethod<'gc>>,
+        _file_name: Index<String>,
     ) -> Result<FrameControl<'gc>, Error> {
         Ok(FrameControl::Continue)
     }
 
-    #[allow(unused_variables)]
     fn op_debug_line(&mut self, line_num: u32) -> Result<FrameControl<'gc>, Error> {
         avm_debug!(self.avm2(), "Line: {}", line_num);
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1115,8 +1115,7 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Called when this object should be replaced by a PlaceObject tag.
-    #[allow(unused_variables)]
-    fn replace_with(&self, context: &mut UpdateContext<'_, 'gc, '_>, id: CharacterId) {
+    fn replace_with(&self, _context: &mut UpdateContext<'_, 'gc, '_>, _id: CharacterId) {
         // Noop for most symbols; only shapes can replace their innards with another graphic.
     }
 


### PR DESCRIPTION
Instead prefix the unused variables with an underscore.