### PR TITLE
core: Use swf::ClipEventFlag in stored clip event handlers

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -735,7 +735,7 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
             activation.context.gc_context,
             &*movie_clip.color_transform(),
         );
-        new_clip.as_movie_clip().unwrap().set_clip_actions(
+        new_clip.as_movie_clip().unwrap().set_clip_event_handlers(
             activation.context.gc_context,
             movie_clip.clip_actions().to_vec(),
         );

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1086,18 +1086,20 @@ pub trait TDisplayObject<'gc>:
             if let (Some(clip_actions), Some(clip)) =
                 (&place_object.clip_actions, self.as_movie_clip())
             {
-                // Convert from `swf::ClipAction` to Ruffle's `ClipAction`.
-                use crate::display_object::movie_clip::ClipAction;
+                // Convert from `swf::ClipAction` to Ruffle's `ClipEventHandler`.
+                use crate::display_object::movie_clip::ClipEventHandler;
                 if let Some(placing_movie) = placing_movie {
-                    clip.set_clip_actions(
+                    clip.set_clip_event_handlers(
                         context.gc_context,
                         clip_actions
                             .iter()
                             .cloned()
                             .map(|a| {
-                                ClipAction::from_action_and_movie(a, Arc::clone(&placing_movie))
+                                ClipEventHandler::from_action_and_movie(
+                                    a,
+                                    Arc::clone(&placing_movie),
+                                )
                             })
-                            .flatten()
                             .collect(),
                     );
                 } else {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,3 +1,5 @@
+use swf::ClipEventFlag;
+
 #[derive(Debug)]
 pub enum PlayerEvent {
     KeyDown { key_code: KeyCode },
@@ -75,8 +77,44 @@ impl ClipEvent {
         "onRollOver",
     ];
 
+    pub const BUTTON_EVENT_FLAGS: ClipEventFlag = ClipEventFlag::from_bits_truncate(
+        ClipEventFlag::DRAG_OUT.bits()
+            | ClipEventFlag::DRAG_OVER.bits()
+            | ClipEventFlag::KEY_PRESS.bits()
+            | ClipEventFlag::PRESS.bits()
+            | ClipEventFlag::ROLL_OUT.bits()
+            | ClipEventFlag::ROLL_OVER.bits()
+            | ClipEventFlag::RELEASE.bits()
+            | ClipEventFlag::RELEASE_OUTSIDE.bits(),
+    );
+
+    /// Returns the `swf::ClipEventFlag` cooresponding to this event type.
+    pub const fn flag(self) -> ClipEventFlag {
+        match self {
+            ClipEvent::Construct => ClipEventFlag::CONSTRUCT,
+            ClipEvent::Data => ClipEventFlag::DATA,
+            ClipEvent::DragOut => ClipEventFlag::DRAG_OUT,
+            ClipEvent::DragOver => ClipEventFlag::DRAG_OVER,
+            ClipEvent::EnterFrame => ClipEventFlag::ENTER_FRAME,
+            ClipEvent::Initialize => ClipEventFlag::INITIALIZE,
+            ClipEvent::KeyDown => ClipEventFlag::KEY_DOWN,
+            ClipEvent::KeyPress { .. } => ClipEventFlag::KEY_PRESS,
+            ClipEvent::KeyUp => ClipEventFlag::KEY_UP,
+            ClipEvent::Load => ClipEventFlag::LOAD,
+            ClipEvent::MouseDown => ClipEventFlag::MOUSE_DOWN,
+            ClipEvent::MouseMove => ClipEventFlag::MOUSE_MOVE,
+            ClipEvent::MouseUp => ClipEventFlag::MOUSE_UP,
+            ClipEvent::Press => ClipEventFlag::PRESS,
+            ClipEvent::RollOut => ClipEventFlag::ROLL_OUT,
+            ClipEvent::RollOver => ClipEventFlag::ROLL_OVER,
+            ClipEvent::Release => ClipEventFlag::RELEASE,
+            ClipEvent::ReleaseOutside => ClipEventFlag::RELEASE_OUTSIDE,
+            ClipEvent::Unload => ClipEventFlag::UNLOAD,
+        }
+    }
+
     /// Indicates that the event should be propagated down to children.
-    pub fn propagates(self) -> bool {
+    pub const fn propagates(self) -> bool {
         matches!(
             self,
             Self::MouseUp
@@ -89,27 +127,17 @@ impl ClipEvent {
     }
 
     /// Indicates whether this is an event type used by Buttons (i.e., on that can be used in an `on` handler in Flash).
-    pub fn is_button_event(self) -> bool {
-        matches!(
-            self,
-            Self::DragOut
-                | Self::DragOver
-                | Self::KeyPress { .. }
-                | Self::Press
-                | Self::RollOut
-                | Self::RollOver
-                | Self::Release
-                | Self::ReleaseOutside
-        )
+    pub const fn is_button_event(self) -> bool {
+        self.flag().contains(Self::BUTTON_EVENT_FLAGS)
     }
 
     /// Indicates whether this is a keyboard event type (keyUp, keyDown, keyPress).
-    pub fn is_key_event(self) -> bool {
+    pub const fn is_key_event(self) -> bool {
         matches!(self, Self::KeyDown | Self::KeyUp | Self::KeyPress { .. })
     }
 
     /// Returns the method name of the event handler for this event.
-    pub fn method_name(self) -> Option<&'static str> {
+    pub const fn method_name(self) -> Option<&'static str> {
         match self {
             ClipEvent::Construct => None,
             ClipEvent::Data => Some("onData"),


### PR DESCRIPTION
 * Rename movie_clip::ClipAction to movie_clip::ClipEventHandler.
 * Store the swf::ClipEventFlag event flags that trigger the event
   directly in the event handler. Previously we split up any event
   that had multiple event flags into separate events. Now these
   can be kept as a single event.
 * Remove `MovieClip::has_button_event`, and instead store the
   union of all event flags in `MovieClip::clip_event_flags`. This
   will be useful for other cases in the future.