### PR TITLE
avm1: Implement MovieClip.beginBitmapFill

### DIFF
--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -102,6 +102,49 @@ pub fn object_to_matrix<'gc>(
     Ok(Matrix { a, b, c, d, tx, ty })
 }
 
+/// Returns a `Matrix` with the properties from `object`.
+///
+/// Returns the identity matrix if any of the `a`, `b`, `c`, `d`, or `tx` properties do not exist.
+pub fn object_to_matrix_or_default<'gc>(
+    object: Object<'gc>,
+    activation: &mut Activation<'_, 'gc, '_>,
+) -> Result<Matrix, Error<'gc>> {
+    // This works with raw properties (`get_local`).
+    // TODO: This should ignore virtual properties.
+    let a = if let Some(val) = object.get_local("a", activation, object) {
+        val?.coerce_to_f64(activation)? as f32
+    } else {
+        return Ok(Default::default());
+    };
+    let b = if let Some(val) = object.get_local("b", activation, object) {
+        val?.coerce_to_f64(activation)? as f32
+    } else {
+        return Ok(Default::default());
+    };
+    let c = if let Some(val) = object.get_local("c", activation, object) {
+        val?.coerce_to_f64(activation)? as f32
+    } else {
+        return Ok(Default::default());
+    };
+    let d = if let Some(val) = object.get_local("d", activation, object) {
+        val?.coerce_to_f64(activation)? as f32
+    } else {
+        return Ok(Default::default());
+    };
+    let tx = if let Some(val) = object.get_local("tx", activation, object) {
+        Twips::from_pixels(val?.coerce_to_f64(activation)?)
+    } else {
+        return Ok(Default::default());
+    };
+    let ty = if let Some(val) = object.get_local("ty", activation, object) {
+        Twips::from_pixels(val?.coerce_to_f64(activation)?)
+    } else {
+        return Ok(Default::default());
+    };
+
+    Ok(Matrix { a, b, c, d, tx, ty })
+}
+
 pub fn matrix_to_object<'gc>(
     matrix: Matrix,
     activation: &mut Activation<'_, 'gc, '_>,

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -11,12 +11,12 @@ pub trait RenderBackend: Downcast {
     fn register_shape(
         &mut self,
         shape: DistilledShape,
-        library: Option<&MovieLibrary<'_>>,
+        bitmap_source: &dyn BitmapSource,
     ) -> ShapeHandle;
     fn replace_shape(
         &mut self,
         shape: DistilledShape,
-        library: Option<&MovieLibrary<'_>>,
+        bitmap_source: &dyn BitmapSource,
         handle: ShapeHandle,
     );
     fn register_glyph_shape(&mut self, shape: &swf::Glyph) -> ShapeHandle;
@@ -80,6 +80,21 @@ pub struct BitmapInfo {
     pub height: u16,
 }
 
+/// An object that returns a bitmap given an ID.
+///
+/// This is used by render backends to get the bitmap used in a bitmap fill.
+/// For movie libraries, this will return the bitmap with the given character ID.
+pub trait BitmapSource {
+    fn bitmap(&self, id: u16) -> Option<BitmapInfo>;
+}
+
+pub struct NullBitmapSource;
+impl BitmapSource for NullBitmapSource {
+    fn bitmap(&self, _id: u16) -> Option<BitmapInfo> {
+        None
+    }
+}
+
 pub struct NullRenderer;
 
 impl NullRenderer {
@@ -99,14 +114,14 @@ impl RenderBackend for NullRenderer {
     fn register_shape(
         &mut self,
         _shape: DistilledShape,
-        _library: Option<&MovieLibrary<'_>>,
+        _bitmap_source: &dyn BitmapSource,
     ) -> ShapeHandle {
         ShapeHandle(0)
     }
     fn replace_shape(
         &mut self,
         _shape: DistilledShape,
-        _library: Option<&MovieLibrary<'_>>,
+        _bitmap_source: &dyn BitmapSource,
         _handle: ShapeHandle,
     ) {
     }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -930,8 +930,7 @@ impl<'gc> EditText<'gc> {
         }
 
         if let Some(drawing) = lbox.as_renderable_drawing() {
-            let movie = self.movie();
-            drawing.render(context, movie);
+            drawing.render(context);
         }
 
         context.transform_stack.pop();
@@ -1476,8 +1475,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             return;
         }
 
-        let movie = self.movie();
-
         let edit_text = self.0.read();
         context.transform_stack.push(&Transform {
             matrix: Matrix {
@@ -1488,7 +1485,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
             ..Default::default()
         });
 
-        edit_text.drawing.render(context, movie);
+        edit_text.drawing.render(context);
 
         context.renderer.push_mask();
         let mask = Matrix::create_box(

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -36,7 +36,7 @@ impl<'gc> Graphic<'gc> {
         swf_shape: swf::Shape,
         movie: Arc<SwfMovie>,
     ) -> Self {
-        let library = context.library.library_for_movie(movie.clone());
+        let library = context.library.library_for_movie(movie.clone()).unwrap();
         let static_data = GraphicStatic {
             id: swf_shape.id,
             bounds: swf_shape.shape_bounds.clone().into(),

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -171,7 +171,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         }
 
         if let Some(drawing) = &self.0.read().drawing {
-            drawing.render(context, self.0.read().static_data.movie.clone());
+            drawing.render(context);
         } else if let Some(render_handle) = self.0.read().static_data.render_handle {
             context
                 .renderer

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -154,7 +154,10 @@ impl MorphShapeStatic {
             return;
         }
 
-        let library = context.library.library_for_movie(Arc::clone(&self.movie));
+        let library = context
+            .library
+            .library_for_movie(Arc::clone(&self.movie))
+            .unwrap();
 
         // Interpolate MorphShapes into a Shape.
         use swf::{FillStyle, LineStyle, ShapeRecord, ShapeStyles};
@@ -281,8 +284,9 @@ impl MorphShapeStatic {
             shape,
         };
 
+        let shape_handle = context.renderer.register_shape((&shape).into(), library);
         let frame = Frame {
-            shape_handle: context.renderer.register_shape((&shape).into(), library),
+            shape_handle,
             shape,
             bounds: bounds.into(),
         };

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1821,9 +1821,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
-        let movie = self.movie();
-
-        self.0.read().drawing.render(context, movie);
+        self.0.read().drawing.render(context);
         self.render_children(context);
     }
 

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -2,10 +2,8 @@ use crate::backend::render::{BitmapInfo, BitmapSource, ShapeHandle};
 use crate::bounding_box::BoundingBox;
 use crate::context::RenderContext;
 use crate::shape_utils::{DistilledShape, DrawCommand, DrawPath};
-use crate::tag_utils::SwfMovie;
 use gc_arena::Collect;
 use std::cell::Cell;
-use std::sync::Arc;
 use swf::{FillStyle, LineStyle, Twips};
 
 #[derive(Clone, Debug, Collect)]
@@ -198,7 +196,7 @@ impl Drawing {
         id
     }
 
-    pub fn render(&self, context: &mut RenderContext, movie: Option<Arc<SwfMovie>>) {
+    pub fn render(&self, context: &mut RenderContext) {
         if self.dirty.get() {
             self.dirty.set(false);
             let mut paths = Vec::new();

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -1,7 +1,7 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_map::PropertyMap as Avm1PropertyMap;
 use crate::avm2::{Domain as Avm2Domain, Object as Avm2Object};
-use crate::backend::audio::SoundHandle;
+use crate::backend::{audio::SoundHandle, render};
 use crate::character::Character;
 use crate::display_object::{Bitmap, Graphic, MorphShape, TDisplayObject, Text};
 use crate::font::{Font, FontDescriptor};
@@ -337,7 +337,7 @@ impl<'gc> MovieLibrary<'gc> {
         self.jpeg_tables = if data.is_empty() {
             None
         } else {
-            Some(crate::backend::render::remove_invalid_jpeg_data(&data[..]).to_vec())
+            Some(render::remove_invalid_jpeg_data(&data[..]).to_vec())
         }
     }
 
@@ -371,6 +371,16 @@ impl<'gc> MovieLibrary<'gc> {
     /// an AVM1 movie, and thus this domain is unused.
     pub fn avm2_domain(&self) -> Avm2Domain<'gc> {
         self.avm2_domain.unwrap()
+    }
+}
+
+impl<'gc> render::BitmapSource for MovieLibrary<'gc> {
+    fn bitmap(&self, id: u16) -> Option<render::BitmapInfo> {
+        self.get_bitmap(id).map(|bitmap| render::BitmapInfo {
+            handle: bitmap.bitmap_handle(),
+            width: bitmap.width(),
+            height: bitmap.height(),
+        })
     }
 }
 


### PR DESCRIPTION
Implements `MovieClip.beginBitmapFill`. Also removes the dependency of the render backends on `MovieLibrary`. This will allow for more decoupling later to improve compile times.