### PR TITLE
core: Implement Stage quality properties

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2176,7 +2176,22 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn toggle_quality(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
-        // TODO(Herschel): Noop for now? Could chang anti-aliasing on render backend.
+        use crate::display_object::StageQuality;
+        // Toggle between `Low` and `High`/`Best` quality.
+        // This op remembers whether the stage quality was `Best` or higher, so we have to maintain
+        // the bitmap downsampling flag to ensure we toggle back to the proper quality.
+        let use_bitmap_downsamping = self.context.stage.use_bitmap_downsampling();
+        let new_quality = match self.context.stage.quality() {
+            StageQuality::High | StageQuality::Best => StageQuality::Low,
+            _ if use_bitmap_downsamping => StageQuality::Best,
+            _ => StageQuality::High,
+        };
+        self.context
+            .stage
+            .set_quality(self.context.gc_context, new_quality);
+        self.context
+            .stage
+            .set_use_bitmap_downsampling(self.context.gc_context, use_bitmap_downsamping);
         Ok(FrameControl::Continue)
     }
 

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -906,16 +906,21 @@ fn quality<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "Unimplemented property _quality");
-    Ok("HIGH".into())
+    let quality = activation.context.stage.quality().into_avm_str();
+    Ok(AvmString::new(activation.context.gc_context, quality).into())
 }
 
 fn set_quality<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
-    _val: Value<'gc>,
+    val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    avm_warn!(activation, "Unimplemented property _quality");
+    if let Ok(quality) = val.coerce_to_string(activation)?.parse() {
+        activation
+            .context
+            .stage
+            .set_quality(activation.context.gc_context, quality);
+    }
     Ok(())
 }
 

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -855,16 +855,36 @@ fn high_quality<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "Unimplemented property _highquality");
-    Ok(1.into())
+    use crate::display_object::StageQuality;
+    let quality = match activation.context.stage.quality() {
+        StageQuality::Best => 2,
+        StageQuality::High => 1,
+        _ => 0,
+    };
+    Ok(quality.into())
 }
 
 fn set_high_quality<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
-    _val: Value<'gc>,
+    val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    avm_warn!(activation, "Unimplemented property _highquality");
+    use crate::display_object::StageQuality;
+    let val = val.coerce_to_f64(activation)?;
+    if !val.is_nan() {
+        // 0 -> Low, 1 -> High, 2 -> Best, but with some odd rules for non-integers.
+        let quality = if val > 1.5 {
+            StageQuality::Best
+        } else if val == 0.0 {
+            StageQuality::Low
+        } else {
+            StageQuality::High
+        };
+        activation
+            .context
+            .stage
+            .set_quality(activation.context.gc_context, quality);
+    }
     Ok(())
 }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -45,7 +45,7 @@ pub use edit_text::{AutoSizeMode, EditText, TextSelection};
 pub use graphic::Graphic;
 pub use morph_shape::{MorphShape, MorphShapeStatic};
 pub use movie_clip::{MovieClip, Scene};
-pub use stage::{Stage, StageAlign, StageScaleMode};
+pub use stage::{Stage, StageAlign, StageQuality, StageScaleMode};
 pub use text::Text;
 pub use video::Video;
 


### PR DESCRIPTION
The quality setting is still unused by Ruffle, but this implements the getters/setters so that the setting is stored and proper values are returned to user code. We could pass this along to the renderer and actually act on it. For example, enforcing no bitmap smoothing when quality is `Low`, which may be used by some pixel art movies.

 * Add `display_object::stage::StageQuality` enum.
 * `display_object::Stage::quality`/`set_quality` controls the value.
 * Wire up AVM1 `_quality` property, `_highquality` property, and `ToggleHighQuality` op.
 * Wire up AVM2 `Stage.quality`.
