### PR TITLE
Preallocate bitmaps for remaining cases in decode_define_bits_lossless

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -469,7 +469,8 @@ pub fn decode_define_bits_lossless(
                 });
                 i += 3;
             }
-            let mut out_data = vec![];
+            let mut out_data: Vec<u8> =
+                Vec::with_capacity(swf_tag.width as usize * swf_tag.height as usize * 4);
             for _ in 0..swf_tag.height {
                 for _ in 0..swf_tag.width {
                     let entry = decoded_data[i] as usize;
@@ -505,7 +506,8 @@ pub fn decode_define_bits_lossless(
                 });
                 i += 4;
             }
-            let mut out_data = vec![];
+            let mut out_data: Vec<u8> =
+                Vec::with_capacity(swf_tag.width as usize * swf_tag.height as usize * 4);
             for _ in 0..swf_tag.height {
                 for _ in 0..swf_tag.width {
                     let entry = decoded_data[i] as usize;


### PR DESCRIPTION
Looks like a simple omission.

I've seen cases (#4392) where `out_data.len()` is 35MB, but `out_data.capacity()` reaches 67MB, so that could help there a little bit - isn't anywhere close to solving it ofc.