### PR TITLE
avm1: Wire up _soundbuftime

### DIFF
--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -909,16 +909,21 @@ fn sound_buf_time<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "Unimplemented property _soundbuftime");
-    Ok(5.into())
+    Ok(activation.context.audio_manager.stream_buffer_time().into())
 }
 
 fn set_sound_buf_time<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: DisplayObject<'gc>,
-    _val: Value<'gc>,
+    val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    avm_warn!(activation, "Unimplemented property _soundbuftime");
+    avm_warn!(activation, "_soundbuftime is currently ignored by Ruffle");
+    if let Some(val) = property_coerce_to_i32(activation, val)? {
+        activation
+            .context
+            .audio_manager
+            .set_stream_buffer_time(val as i32);
+    }
     Ok(())
 }
 
@@ -973,4 +978,26 @@ fn property_coerce_to_number<'gc>(
 
     // Invalid value; do not set.
     Ok(None)
+}
+
+/// Coerces `value` to `i32` for use by a stage object property.
+///
+/// Values out of range of `i32` will be clamped to `i32::MIN`. Returns `None` if the value is
+/// invalid (NaN, null, or undefined).
+fn property_coerce_to_i32<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    value: Value<'gc>,
+) -> Result<Option<i32>, Error<'gc>> {
+    let n = value.coerce_to_f64(activation)?;
+    let ret = if n.is_nan() {
+        // NaN/undefined/null are invalid values; do not set.
+        None
+    } else if n >= i32::MIN as f64 && n <= i32::MAX as f64 {
+        Some(n as i32)
+    } else {
+        // Out of range of i32; snaps to `i32::MIN`.
+        Some(i32::MIN)
+    };
+
+    Ok(ret)
 }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -174,6 +174,13 @@ pub struct AudioManager<'gc> {
     /// The global sound transform applied to all sounds.
     global_sound_transform: DisplayObjectSoundTransform,
 
+    /// The number of seconds that a timeline audio stream should buffer before playing.
+    ///
+    /// This is returned by `_soundbuftime` in AVM1 and `SoundMixer.bufferTime` in AVM2.
+    /// Currently unused by Ruffle.
+    /// [ActionScript 3.0: SoundMixer.bufferTime](https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/media/SoundMixer.html#bufferTime)
+    stream_buffer_time: i32,
+
     /// Whether a sound transform has been changed.
     transforms_dirty: bool,
 }
@@ -182,10 +189,14 @@ impl<'gc> AudioManager<'gc> {
     /// The maximum number of sound instances that can play at once.
     pub const MAX_SOUNDS: usize = 32;
 
+    /// The default timeline stream buffer time in seconds.
+    pub const DEFAULT_STREAM_BUFFER_TIME: i32 = 5;
+
     pub fn new() -> Self {
         Self {
             sounds: Vec::with_capacity(Self::MAX_SOUNDS),
             global_sound_transform: Default::default(),
+            stream_buffer_time: Self::DEFAULT_STREAM_BUFFER_TIME,
             transforms_dirty: false,
         }
     }
@@ -333,6 +344,20 @@ impl<'gc> AudioManager<'gc> {
     pub fn set_global_sound_transform(&mut self, sound_transform: DisplayObjectSoundTransform) {
         self.global_sound_transform = sound_transform;
         self.transforms_dirty = true;
+    }
+
+    /// Returns the number of seconds that a timeline audio stream should buffer before playing.
+    ///
+    /// Currently unused by Ruffle.
+    pub fn stream_buffer_time(&self) -> i32 {
+        self.stream_buffer_time
+    }
+
+    /// Sets the number of seconds that a timeline audio stream should buffer before playing.
+    ///
+    /// Currently unused by Ruffle.
+    pub fn set_stream_buffer_time(&mut self, stream_buffer_time: i32) {
+        self.stream_buffer_time = stream_buffer_time;
     }
 
     pub fn set_sound_transforms_dirty(&mut self) {


### PR DESCRIPTION
Store the `_soundbuftime` value inside `AudioManager`. This setting still has no effect in Ruffle, but the value will be properly stored and returned.