### PR TITLE
web/desktop: Mouse clicks count as a key (Fix #4603)

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -163,9 +163,11 @@ impl ClipEvent {
 }
 
 /// Flash virtual keycode.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, Hash)]
 pub enum KeyCode {
-    Unknown = 0,
+    MouseLeft = 0,
+    MouseRight = 1,
+    Unknown = 2,
     Backspace = 8,
     Tab = 9,
     Return = 13,

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -165,9 +165,9 @@ impl ClipEvent {
 /// Flash virtual keycode.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, Hash)]
 pub enum KeyCode {
-    MouseLeft = 0,
-    MouseRight = 1,
-    Unknown = 2,
+    Unknown = 0,
+    MouseLeft = 1,
+    MouseRight = 2,
     Backspace = 8,
     Tab = 9,
     Return = 13,

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -37,6 +37,7 @@ use std::time::Instant;
 use tinyfiledialogs::open_file_dialog;
 use url::Url;
 
+use ruffle_core::events::KeyCode;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use std::io::Read;
@@ -447,20 +448,43 @@ impl App {
                                 ..
                             } => {
                                 let mut player_lock = player.lock().unwrap();
+                                let ui = player_lock
+                                    .ui_mut()
+                                    .downcast_mut::<ui::DesktopUiBackend>()
+                                    .unwrap();
                                 let event = if pressed == ElementState::Pressed {
+                                    ui.insert_keydown(KeyCode::MouseLeft);
                                     ruffle_core::PlayerEvent::MouseDown {
                                         x: mouse_pos.x,
                                         y: mouse_pos.y,
                                     }
                                 } else {
+                                    ui.remove_keydown(KeyCode::MouseLeft);
                                     ruffle_core::PlayerEvent::MouseUp {
                                         x: mouse_pos.x,
                                         y: mouse_pos.y,
                                     }
                                 };
+
                                 player_lock.handle_event(event);
                                 if player_lock.needs_render() {
                                     window.request_redraw();
+                                }
+                            }
+                            WindowEvent::MouseInput {
+                                button: MouseButton::Right,
+                                state: pressed,
+                                ..
+                            } => {
+                                let mut player_lock = player.lock().unwrap();
+                                let ui = player_lock
+                                    .ui_mut()
+                                    .downcast_mut::<ui::DesktopUiBackend>()
+                                    .unwrap();
+                                if pressed == ElementState::Pressed {
+                                    ui.insert_keydown(KeyCode::MouseRight);
+                                } else {
+                                    ui.remove_keydown(KeyCode::MouseRight);
                                 }
                             }
                             WindowEvent::MouseWheel { delta, .. } => {

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -9,7 +9,7 @@ use winit::window::Window;
 
 pub struct DesktopUiBackend {
     window: Rc<Window>,
-    keys_down: HashSet<VirtualKeyCode>,
+    keys_down: HashSet<KeyCode>,
     cursor_visible: bool,
     last_key: KeyCode,
     last_char: Option<char>,
@@ -36,11 +36,11 @@ impl DesktopUiBackend {
             WindowEvent::KeyboardInput { input, .. } => match input.state {
                 ElementState::Pressed => {
                     if let Some(key) = input.virtual_keycode {
-                        self.keys_down.insert(key);
                         self.last_char =
                             winit_key_to_char(key, input.modifiers.contains(ModifiersState::SHIFT));
                         if let Some(key_code) = winit_to_ruffle_key_code(key) {
                             self.last_key = key_code;
+                            self.keys_down.insert(key_code);
                             return Some(PlayerEvent::KeyDown { key_code });
                         } else {
                             self.last_key = KeyCode::Unknown;
@@ -49,11 +49,11 @@ impl DesktopUiBackend {
                 }
                 ElementState::Released => {
                     if let Some(key) = input.virtual_keycode {
-                        self.keys_down.remove(&key);
                         self.last_char =
                             winit_key_to_char(key, input.modifiers.contains(ModifiersState::SHIFT));
                         if let Some(key_code) = winit_to_ruffle_key_code(key) {
                             self.last_key = key_code;
+                            self.keys_down.remove(&key_code);
                             return Some(PlayerEvent::KeyUp { key_code });
                         } else {
                             self.last_key = KeyCode::Unknown;
@@ -68,6 +68,16 @@ impl DesktopUiBackend {
         }
         None
     }
+
+    /// Inserts a key directly into the keys_down HashSet
+    pub fn insert_keydown(&mut self, code: KeyCode) {
+        self.keys_down.insert(code);
+    }
+
+    /// Removes a key directly from the keys_down HashSet
+    pub fn remove_keydown(&mut self, code: KeyCode) {
+        self.keys_down.remove(&code);
+    }
 }
 
 // TODO: Move link to https://ruffle.rs/faq or similar
@@ -79,113 +89,7 @@ https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users";
 
 impl UiBackend for DesktopUiBackend {
     fn is_key_down(&self, key: KeyCode) -> bool {
-        match key {
-            KeyCode::Unknown => false,
-            KeyCode::Backspace => self.keys_down.contains(&VirtualKeyCode::Back),
-            KeyCode::Tab => self.keys_down.contains(&VirtualKeyCode::Tab),
-            KeyCode::Return => self.keys_down.contains(&VirtualKeyCode::Return),
-            KeyCode::Shift => {
-                self.keys_down.contains(&VirtualKeyCode::LShift)
-                    || self.keys_down.contains(&VirtualKeyCode::RShift)
-            }
-            KeyCode::Control => {
-                self.keys_down.contains(&VirtualKeyCode::LControl)
-                    || self.keys_down.contains(&VirtualKeyCode::RControl)
-            }
-            KeyCode::Alt => {
-                self.keys_down.contains(&VirtualKeyCode::LAlt)
-                    || self.keys_down.contains(&VirtualKeyCode::RAlt)
-            }
-            KeyCode::CapsLock => self.keys_down.contains(&VirtualKeyCode::Capital),
-            KeyCode::Escape => self.keys_down.contains(&VirtualKeyCode::Escape),
-            KeyCode::Space => self.keys_down.contains(&VirtualKeyCode::Space),
-            KeyCode::Key0 => self.keys_down.contains(&VirtualKeyCode::Key0),
-            KeyCode::Key1 => self.keys_down.contains(&VirtualKeyCode::Key1),
-            KeyCode::Key2 => self.keys_down.contains(&VirtualKeyCode::Key2),
-            KeyCode::Key3 => self.keys_down.contains(&VirtualKeyCode::Key3),
-            KeyCode::Key4 => self.keys_down.contains(&VirtualKeyCode::Key4),
-            KeyCode::Key5 => self.keys_down.contains(&VirtualKeyCode::Key5),
-            KeyCode::Key6 => self.keys_down.contains(&VirtualKeyCode::Key6),
-            KeyCode::Key7 => self.keys_down.contains(&VirtualKeyCode::Key7),
-            KeyCode::Key8 => self.keys_down.contains(&VirtualKeyCode::Key8),
-            KeyCode::Key9 => self.keys_down.contains(&VirtualKeyCode::Key9),
-            KeyCode::A => self.keys_down.contains(&VirtualKeyCode::A),
-            KeyCode::B => self.keys_down.contains(&VirtualKeyCode::B),
-            KeyCode::C => self.keys_down.contains(&VirtualKeyCode::C),
-            KeyCode::D => self.keys_down.contains(&VirtualKeyCode::D),
-            KeyCode::E => self.keys_down.contains(&VirtualKeyCode::E),
-            KeyCode::F => self.keys_down.contains(&VirtualKeyCode::F),
-            KeyCode::G => self.keys_down.contains(&VirtualKeyCode::G),
-            KeyCode::H => self.keys_down.contains(&VirtualKeyCode::H),
-            KeyCode::I => self.keys_down.contains(&VirtualKeyCode::I),
-            KeyCode::J => self.keys_down.contains(&VirtualKeyCode::J),
-            KeyCode::K => self.keys_down.contains(&VirtualKeyCode::K),
-            KeyCode::L => self.keys_down.contains(&VirtualKeyCode::L),
-            KeyCode::M => self.keys_down.contains(&VirtualKeyCode::M),
-            KeyCode::N => self.keys_down.contains(&VirtualKeyCode::N),
-            KeyCode::O => self.keys_down.contains(&VirtualKeyCode::O),
-            KeyCode::P => self.keys_down.contains(&VirtualKeyCode::P),
-            KeyCode::Q => self.keys_down.contains(&VirtualKeyCode::Q),
-            KeyCode::R => self.keys_down.contains(&VirtualKeyCode::R),
-            KeyCode::S => self.keys_down.contains(&VirtualKeyCode::S),
-            KeyCode::T => self.keys_down.contains(&VirtualKeyCode::T),
-            KeyCode::U => self.keys_down.contains(&VirtualKeyCode::U),
-            KeyCode::V => self.keys_down.contains(&VirtualKeyCode::V),
-            KeyCode::W => self.keys_down.contains(&VirtualKeyCode::W),
-            KeyCode::X => self.keys_down.contains(&VirtualKeyCode::X),
-            KeyCode::Y => self.keys_down.contains(&VirtualKeyCode::Y),
-            KeyCode::Z => self.keys_down.contains(&VirtualKeyCode::Z),
-            KeyCode::Semicolon => self.keys_down.contains(&VirtualKeyCode::Semicolon),
-            KeyCode::Equals => self.keys_down.contains(&VirtualKeyCode::Equals),
-            KeyCode::Comma => self.keys_down.contains(&VirtualKeyCode::Comma),
-            KeyCode::Minus => self.keys_down.contains(&VirtualKeyCode::Minus),
-            KeyCode::Period => self.keys_down.contains(&VirtualKeyCode::Period),
-            KeyCode::Slash => self.keys_down.contains(&VirtualKeyCode::Slash),
-            KeyCode::Grave => self.keys_down.contains(&VirtualKeyCode::Grave),
-            KeyCode::LBracket => self.keys_down.contains(&VirtualKeyCode::LBracket),
-            KeyCode::Backslash => self.keys_down.contains(&VirtualKeyCode::Backslash),
-            KeyCode::RBracket => self.keys_down.contains(&VirtualKeyCode::RBracket),
-            KeyCode::Apostrophe => self.keys_down.contains(&VirtualKeyCode::Apostrophe),
-            KeyCode::Numpad0 => self.keys_down.contains(&VirtualKeyCode::Numpad0),
-            KeyCode::Numpad1 => self.keys_down.contains(&VirtualKeyCode::Numpad1),
-            KeyCode::Numpad2 => self.keys_down.contains(&VirtualKeyCode::Numpad2),
-            KeyCode::Numpad3 => self.keys_down.contains(&VirtualKeyCode::Numpad3),
-            KeyCode::Numpad4 => self.keys_down.contains(&VirtualKeyCode::Numpad4),
-            KeyCode::Numpad5 => self.keys_down.contains(&VirtualKeyCode::Numpad5),
-            KeyCode::Numpad6 => self.keys_down.contains(&VirtualKeyCode::Numpad6),
-            KeyCode::Numpad7 => self.keys_down.contains(&VirtualKeyCode::Numpad7),
-            KeyCode::Numpad8 => self.keys_down.contains(&VirtualKeyCode::Numpad8),
-            KeyCode::Numpad9 => self.keys_down.contains(&VirtualKeyCode::Numpad9),
-            KeyCode::Multiply => self.keys_down.contains(&VirtualKeyCode::NumpadMultiply),
-            KeyCode::Plus => self.keys_down.contains(&VirtualKeyCode::NumpadAdd),
-            KeyCode::NumpadMinus => self.keys_down.contains(&VirtualKeyCode::NumpadSubtract),
-            KeyCode::NumpadPeriod => self.keys_down.contains(&VirtualKeyCode::NumpadDecimal),
-            KeyCode::NumpadSlash => self.keys_down.contains(&VirtualKeyCode::NumpadDivide),
-            KeyCode::PgUp => self.keys_down.contains(&VirtualKeyCode::PageUp),
-            KeyCode::PgDown => self.keys_down.contains(&VirtualKeyCode::PageDown),
-            KeyCode::End => self.keys_down.contains(&VirtualKeyCode::End),
-            KeyCode::Home => self.keys_down.contains(&VirtualKeyCode::Home),
-            KeyCode::Left => self.keys_down.contains(&VirtualKeyCode::Left),
-            KeyCode::Up => self.keys_down.contains(&VirtualKeyCode::Up),
-            KeyCode::Right => self.keys_down.contains(&VirtualKeyCode::Right),
-            KeyCode::Down => self.keys_down.contains(&VirtualKeyCode::Down),
-            KeyCode::Insert => self.keys_down.contains(&VirtualKeyCode::Insert),
-            KeyCode::Delete => self.keys_down.contains(&VirtualKeyCode::Delete),
-            KeyCode::Pause => self.keys_down.contains(&VirtualKeyCode::Pause),
-            KeyCode::ScrollLock => self.keys_down.contains(&VirtualKeyCode::Scroll),
-            KeyCode::F1 => self.keys_down.contains(&VirtualKeyCode::F1),
-            KeyCode::F2 => self.keys_down.contains(&VirtualKeyCode::F2),
-            KeyCode::F3 => self.keys_down.contains(&VirtualKeyCode::F3),
-            KeyCode::F4 => self.keys_down.contains(&VirtualKeyCode::F4),
-            KeyCode::F5 => self.keys_down.contains(&VirtualKeyCode::F5),
-            KeyCode::F6 => self.keys_down.contains(&VirtualKeyCode::F6),
-            KeyCode::F7 => self.keys_down.contains(&VirtualKeyCode::F7),
-            KeyCode::F8 => self.keys_down.contains(&VirtualKeyCode::F8),
-            KeyCode::F9 => self.keys_down.contains(&VirtualKeyCode::F9),
-            KeyCode::F10 => self.keys_down.contains(&VirtualKeyCode::F10),
-            KeyCode::F11 => self.keys_down.contains(&VirtualKeyCode::F11),
-            KeyCode::F12 => self.keys_down.contains(&VirtualKeyCode::F12),
-        }
+        self.keys_down.contains(&key)
     }
 
     fn last_key_code(&self) -> KeyCode {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -569,7 +569,26 @@ impl Ruffle {
                             y: f64::from(js_event.offset_y()) * device_pixel_ratio,
                         };
                         let _ = instance.with_core_mut(|core| {
+                            let ui = if let Some(ui) =
+                                core.ui_mut().downcast_mut::<ui::WebUiBackend>()
+                            {
+                                ui
+                            } else {
+                                return;
+                            };
+                            ui.insert_keydown(KeyCode::MouseLeft);
                             core.handle_event(event);
+                        });
+                    } else if js_event.button() == 2 {
+                        let _ = instance.with_core_mut(|core| {
+                            let ui = if let Some(ui) =
+                                core.ui_mut().downcast_mut::<ui::WebUiBackend>()
+                            {
+                                ui
+                            } else {
+                                return;
+                            };
+                            ui.insert_keydown(KeyCode::MouseRight);
                         });
                     }
 
@@ -640,7 +659,26 @@ impl Ruffle {
                             y: f64::from(js_event.offset_y()) * instance.device_pixel_ratio,
                         };
                         let _ = instance.with_core_mut(|core| {
+                            let ui = if let Some(ui) =
+                                core.ui_mut().downcast_mut::<ui::WebUiBackend>()
+                            {
+                                ui
+                            } else {
+                                return;
+                            };
+                            ui.remove_keydown(KeyCode::MouseLeft);
                             core.handle_event(event);
+                        });
+                    } else if js_event.button() == 2 {
+                        let _ = instance.with_core_mut(|core| {
+                            let ui = if let Some(ui) =
+                                core.ui_mut().downcast_mut::<ui::WebUiBackend>()
+                            {
+                                ui
+                            } else {
+                                return;
+                            };
+                            ui.remove_keydown(KeyCode::MouseRight);
                         });
                     }
 

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -10,7 +10,7 @@ use web_sys::{HtmlCanvasElement, KeyboardEvent};
 pub struct WebUiBackend {
     js_player: JavascriptPlayer,
     canvas: HtmlCanvasElement,
-    keys_down: HashSet<String>,
+    keys_down: HashSet<KeyCode>,
     cursor_visible: bool,
     cursor: MouseCursor,
     last_key: KeyCode,
@@ -34,7 +34,7 @@ impl WebUiBackend {
     pub fn keydown(&mut self, event: &KeyboardEvent) {
         let code = event.code();
         self.last_key = web_to_ruffle_key_code(&code).unwrap_or(KeyCode::Unknown);
-        self.keys_down.insert(code);
+        self.keys_down.insert(self.last_key);
         self.last_char = web_key_to_codepoint(&event.key());
     }
 
@@ -42,8 +42,18 @@ impl WebUiBackend {
     pub fn keyup(&mut self, event: &KeyboardEvent) {
         let code = event.code();
         self.last_key = web_to_ruffle_key_code(&code).unwrap_or(KeyCode::Unknown);
-        self.keys_down.remove(&code);
+        self.keys_down.remove(&self.last_key);
         self.last_char = web_key_to_codepoint(&event.key());
+    }
+
+    /// Inserts a key directly into the keys_down HashSet
+    pub fn insert_keydown(&mut self, code: KeyCode) {
+        self.keys_down.insert(code);
+    }
+
+    /// Removes a key directly from the keys_down HashSet
+    pub fn remove_keydown(&mut self, code: KeyCode) {
+        self.keys_down.remove(&code);
     }
 
     fn update_mouse_cursor(&self) {
@@ -66,110 +76,7 @@ impl WebUiBackend {
 
 impl UiBackend for WebUiBackend {
     fn is_key_down(&self, key: KeyCode) -> bool {
-        match key {
-            KeyCode::Unknown => false,
-            KeyCode::Backspace => self.keys_down.contains("Backspace"),
-            KeyCode::Tab => self.keys_down.contains("Tab"),
-            KeyCode::Return => self.keys_down.contains("Enter"),
-            KeyCode::Shift => {
-                self.keys_down.contains("ShiftLeft") || self.keys_down.contains("ShiftRight")
-            }
-            KeyCode::Control => {
-                self.keys_down.contains("ControlLeft") || self.keys_down.contains("ControlRight")
-            }
-            KeyCode::Alt => {
-                self.keys_down.contains("AltLeft") || self.keys_down.contains("AltRight")
-            }
-            KeyCode::CapsLock => self.keys_down.contains("CapsLock"),
-            KeyCode::Escape => self.keys_down.contains("Escape"),
-            KeyCode::Space => self.keys_down.contains("Space"),
-            KeyCode::Key0 => self.keys_down.contains("Digit0"),
-            KeyCode::Key1 => self.keys_down.contains("Digit1"),
-            KeyCode::Key2 => self.keys_down.contains("Digit2"),
-            KeyCode::Key3 => self.keys_down.contains("Digit3"),
-            KeyCode::Key4 => self.keys_down.contains("Digit4"),
-            KeyCode::Key5 => self.keys_down.contains("Digit5"),
-            KeyCode::Key6 => self.keys_down.contains("Digit6"),
-            KeyCode::Key7 => self.keys_down.contains("Digit7"),
-            KeyCode::Key8 => self.keys_down.contains("Digit8"),
-            KeyCode::Key9 => self.keys_down.contains("Digit9"),
-            KeyCode::A => self.keys_down.contains("KeyA"),
-            KeyCode::B => self.keys_down.contains("KeyB"),
-            KeyCode::C => self.keys_down.contains("KeyC"),
-            KeyCode::D => self.keys_down.contains("KeyD"),
-            KeyCode::E => self.keys_down.contains("KeyE"),
-            KeyCode::F => self.keys_down.contains("KeyF"),
-            KeyCode::G => self.keys_down.contains("KeyG"),
-            KeyCode::H => self.keys_down.contains("KeyH"),
-            KeyCode::I => self.keys_down.contains("KeyI"),
-            KeyCode::J => self.keys_down.contains("KeyJ"),
-            KeyCode::K => self.keys_down.contains("KeyK"),
-            KeyCode::L => self.keys_down.contains("KeyL"),
-            KeyCode::M => self.keys_down.contains("KeyM"),
-            KeyCode::N => self.keys_down.contains("KeyN"),
-            KeyCode::O => self.keys_down.contains("KeyO"),
-            KeyCode::P => self.keys_down.contains("KeyP"),
-            KeyCode::Q => self.keys_down.contains("KeyQ"),
-            KeyCode::R => self.keys_down.contains("KeyR"),
-            KeyCode::S => self.keys_down.contains("KeyS"),
-            KeyCode::T => self.keys_down.contains("KeyT"),
-            KeyCode::U => self.keys_down.contains("KeyU"),
-            KeyCode::V => self.keys_down.contains("KeyV"),
-            KeyCode::W => self.keys_down.contains("KeyW"),
-            KeyCode::X => self.keys_down.contains("KeyX"),
-            KeyCode::Y => self.keys_down.contains("KeyY"),
-            KeyCode::Z => self.keys_down.contains("KeyZ"),
-            KeyCode::Semicolon => self.keys_down.contains("Semicolon"),
-            KeyCode::Equals => self.keys_down.contains("Equal"),
-            KeyCode::Comma => self.keys_down.contains("Comma"),
-            KeyCode::Minus => self.keys_down.contains("Minus"),
-            KeyCode::Period => self.keys_down.contains("Period"),
-            KeyCode::Slash => self.keys_down.contains("Slash"),
-            KeyCode::Grave => self.keys_down.contains("Backquote"),
-            KeyCode::LBracket => self.keys_down.contains("BracketLeft"),
-            KeyCode::Backslash => self.keys_down.contains("Backslash"),
-            KeyCode::RBracket => self.keys_down.contains("BracketRight"),
-            KeyCode::Apostrophe => self.keys_down.contains("Quote"),
-            KeyCode::Numpad0 => self.keys_down.contains("Numpad0"),
-            KeyCode::Numpad1 => self.keys_down.contains("Numpad1"),
-            KeyCode::Numpad2 => self.keys_down.contains("Numpad2"),
-            KeyCode::Numpad3 => self.keys_down.contains("Numpad3"),
-            KeyCode::Numpad4 => self.keys_down.contains("Numpad4"),
-            KeyCode::Numpad5 => self.keys_down.contains("Numpad5"),
-            KeyCode::Numpad6 => self.keys_down.contains("Numpad6"),
-            KeyCode::Numpad7 => self.keys_down.contains("Numpad7"),
-            KeyCode::Numpad8 => self.keys_down.contains("Numpad8"),
-            KeyCode::Numpad9 => self.keys_down.contains("Numpad9"),
-            KeyCode::Multiply => self.keys_down.contains("NumpadMultiply"),
-            KeyCode::Plus => self.keys_down.contains("NumpadAdd"),
-            KeyCode::NumpadMinus => self.keys_down.contains("NumpadSubtract"),
-            KeyCode::NumpadPeriod => self.keys_down.contains("NumpadDecimal"),
-            KeyCode::NumpadSlash => self.keys_down.contains("NumpadDivide"),
-            KeyCode::PgUp => self.keys_down.contains("PageUp"),
-            KeyCode::PgDown => self.keys_down.contains("PageDown"),
-            KeyCode::End => self.keys_down.contains("End"),
-            KeyCode::Home => self.keys_down.contains("Home"),
-            KeyCode::Left => self.keys_down.contains("ArrowLeft"),
-            KeyCode::Up => self.keys_down.contains("ArrowUp"),
-            KeyCode::Right => self.keys_down.contains("ArrowRight"),
-            KeyCode::Down => self.keys_down.contains("ArrowDown"),
-            KeyCode::Insert => self.keys_down.contains("Insert"),
-            KeyCode::Delete => self.keys_down.contains("Delete"),
-            KeyCode::Pause => self.keys_down.contains("Pause"),
-            KeyCode::ScrollLock => self.keys_down.contains("ScrollLock"),
-            KeyCode::F1 => self.keys_down.contains("F1"),
-            KeyCode::F2 => self.keys_down.contains("F2"),
-            KeyCode::F3 => self.keys_down.contains("F3"),
-            KeyCode::F4 => self.keys_down.contains("F4"),
-            KeyCode::F5 => self.keys_down.contains("F5"),
-            KeyCode::F6 => self.keys_down.contains("F6"),
-            KeyCode::F7 => self.keys_down.contains("F7"),
-            KeyCode::F8 => self.keys_down.contains("F8"),
-            KeyCode::F9 => self.keys_down.contains("F9"),
-            KeyCode::F10 => self.keys_down.contains("F10"),
-            KeyCode::F11 => self.keys_down.contains("F11"),
-            KeyCode::F12 => self.keys_down.contains("F12"),
-        }
+        self.keys_down.contains(&key)
     }
 
     fn last_key_code(&self) -> KeyCode {
@@ -215,6 +122,8 @@ impl UiBackend for WebUiBackend {
 /// Return `None` if there is no matching Flash key code.
 pub fn web_to_ruffle_key_code(key_code: &str) -> Option<KeyCode> {
     Some(match key_code {
+        "MouseLeft" => KeyCode::MouseLeft,
+        "MouseRight" => KeyCode::MouseRight,
         "Backspace" => KeyCode::Backspace,
         "Tab" => KeyCode::Tab,
         "Enter" => KeyCode::Return,

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -122,8 +122,6 @@ impl UiBackend for WebUiBackend {
 /// Return `None` if there is no matching Flash key code.
 pub fn web_to_ruffle_key_code(key_code: &str) -> Option<KeyCode> {
     Some(match key_code {
-        "MouseLeft" => KeyCode::MouseLeft,
-        "MouseRight" => KeyCode::MouseRight,
         "Backspace" => KeyCode::Backspace,
         "Tab" => KeyCode::Tab,
         "Enter" => KeyCode::Return,


### PR DESCRIPTION
So I actually didn't just fix #4603, I also refactored the UI backend a bit. I'm not exactly sure if the changes I made regresses something, basically I changed the `keys_down` HashSet to be `HashSet<KeyCode>` instead of `HashSet<String>` in ruffle web, and from `HashSet<VirtualKeyCode>` to `HashSet<KeyCode>` in ruffle desktop. 

The reason I say I might have regressed something is because this seems really obvious to do, and i'm not sure why it wasn't done before, so I feel like i'm missing something important.

The main reason I wanted to change the HashSet type is because it makes it a lot easier to add more variants (like the mouse click variants), and it also reduces a lot of code. If this isn't the correct thing to do, i'll close this PR.

Also, some interesting behavior I saw while testing:
Key.isDown detects mouse clicks, however Key.getAscii & Key.getCode do not detect mouse clicks. The current implementation I wrote recreates this behavior 