### PR TITLE
core: Fix documentation spelling

### DIFF
--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{
     TraitItem, Visibility,
 };
 
-/// `enum_trat_object` will define an enum whose variants each implement a trait.
+/// `enum_trait_object` will define an enum whose variants each implement a trait.
 /// It can be used as faux-dynamic dispatch. This is used as an alternative to a
 /// trait object, which doesn't get along with GC'd types.
 ///

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -93,7 +93,7 @@ pub struct Avm1<'gc> {
     /// The global object.
     globals: Object<'gc>,
 
-    /// System builtins that we use internally to construct new objects.
+    /// System built-ins that we use internally to construct new objects.
     prototypes: globals::SystemPrototypes<'gc>,
 
     /// Cached functions for the AsBroadcaster
@@ -533,7 +533,7 @@ fn skip_actions(reader: &mut Reader<'_>, num_actions_to_skip: u8) {
     }
 }
 
-/// Starts draggining this display object, making it follow the cursor.
+/// Starts dragging this display object, making it follow the cursor.
 /// Runs via the `startDrag` method or `StartDrag` AVM1 action.
 pub fn start_drag<'gc>(
     display_object: DisplayObject<'gc>,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -32,7 +32,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 /// `UpdateContext` holds shared data that is used by the various subsystems of Ruffle.
-/// `Player` crates this when it begins a tick and passes it through the call stack to
+/// `Player` creates this when it begins a tick and passes it through the call stack to
 /// children and the VM.
 pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// The queue of actions that will be run after the display list updates.
@@ -53,7 +53,7 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// variables.
     pub player_version: u8,
 
-    /// Requests a that the player re-renders after this execution (e.g. due to `updateAfterEvent`).
+    /// Requests that the player re-renders after this execution (e.g. due to `updateAfterEvent`).
     pub needs_render: &'a mut bool,
 
     /// The root SWF file.
@@ -400,10 +400,10 @@ pub enum ActionType<'gc> {
     /// Normal frame or event actions.
     Normal { bytecode: SwfSlice },
 
-    /// AVM1 initialize clip event
+    /// AVM1 initialize clip event.
     Initialize { bytecode: SwfSlice },
 
-    /// Construct a movie with a custom class or on(construct) events
+    /// Construct a movie with a custom class or on(construct) events.
     Construct {
         constructor: Option<Avm1Object<'gc>>,
         events: Vec<SwfSlice>,
@@ -416,7 +416,7 @@ pub enum ActionType<'gc> {
         args: Vec<Avm1Value<'gc>>,
     },
 
-    /// A system listener method,
+    /// A system listener method.
     NotifyListeners {
         listener: &'static str,
         method: &'static str,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -90,7 +90,7 @@ pub struct DisplayObjectBase<'gc> {
     /// The display object we are currently masking.
     maskee: Option<DisplayObject<'gc>>,
 
-    /// Bit flags for various display object properites.
+    /// Bit flags for various display object properties.
     flags: DisplayObjectFlags,
 }
 
@@ -559,7 +559,7 @@ pub trait TDisplayObject<'gc>:
         let mut matrix = *self.matrix();
         while let Some(display_object) = node {
             // TODO: We don't want to include the stage transform because it includes the scale
-            // mode and alignemnt transform, but the AS APIs expect "global" to be relative to the
+            // mode and alignment transform, but the AS APIs expect "global" to be relative to the
             // Stage, not final view coordinates.
             // I suspect we want this to include the stage transform eventually.
             if display_object.as_stage().is_some() {
@@ -972,7 +972,7 @@ pub trait TDisplayObject<'gc>:
         self.run_frame(context);
     }
 
-    /// Emit an `frameConstructed` event on this DisplayObject and any children it
+    /// Emit a `frameConstructed` event on this DisplayObject and any children it
     /// may have.
     fn frame_constructed(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         let mut frame_constructed_evt = Avm2Event::new("frameConstructed");
@@ -1141,11 +1141,11 @@ pub trait TDisplayObject<'gc>:
     }
 
     fn object(&self) -> Avm1Value<'gc> {
-        Avm1Value::Undefined // todo: impl for every type and delete this fallback
+        Avm1Value::Undefined // TODO: Implement for every type and delete this fallback.
     }
 
     fn object2(&self) -> Avm2Value<'gc> {
-        Avm2Value::Undefined // todo: see above
+        Avm2Value::Undefined // TODO: See above.
     }
 
     fn set_object2(&mut self, _mc: MutationContext<'gc, '_>, _to: Avm2Object<'gc>) {}
@@ -1225,7 +1225,7 @@ pub trait TDisplayObject<'gc>:
         true
     }
 
-    /// The cursor to use when this object is the hovered element under a mouse
+    /// The cursor to use when this object is the hovered element under a mouse.
     fn mouse_cursor(&self) -> MouseCursor {
         MouseCursor::Hand
     }
@@ -1701,7 +1701,7 @@ bitflags! {
     }
 }
 
-/// Represents the sound transfomr of sounds played inside a Flash MovieClip.
+/// Represents the sound transform of sounds played inside a Flash MovieClip.
 /// Every value is a percentage (0-100), but out of range values are allowed.
 /// In AVM1, this is returned by `Sound.getTransform`.
 /// In AVM2, this is returned by `Sprite.soundTransform`.

--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -23,7 +23,7 @@ pub fn f64_to_string(n: f64) -> Cow<'static, str> {
         }
         Cow::Owned(s)
     } else if n == 0.0 {
-        // As of Rust nightly 4/13, Rust can returns an unwated "-0" for f64, which Flash doesn't want.
+        // As of Rust nightly 4/13, Rust can return "-0" for f64, which Flash doesn't want.
         Cow::Borrowed("0")
     } else {
         // Normal number.
@@ -31,7 +31,7 @@ pub fn f64_to_string(n: f64) -> Cow<'static, str> {
     }
 }
 
-/// Converts an `f64` to an `u16` with ECMAScript `ToUInt16` wrapping behavior.
+/// Converts an `f64` to a `u16` with ECMAScript `ToUInt16` wrapping behavior.
 /// The value will be wrapped modulo 2^16.
 pub fn f64_to_wrapping_u16(n: f64) -> u16 {
     if !n.is_finite() {
@@ -47,7 +47,7 @@ pub fn f64_to_wrapping_i16(n: f64) -> i16 {
     f64_to_wrapping_u16(n) as i16
 }
 
-/// Converts an `f64` to an `u32` with ECMAScript `ToUInt32` wrapping behavior.
+/// Converts an `f64` to a `u32` with ECMAScript `ToUInt32` wrapping behavior.
 /// The value will be wrapped modulo 2^32.
 #[allow(clippy::unreadable_literal)]
 pub fn f64_to_wrapping_u32(n: f64) -> u32 {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -88,7 +88,7 @@ impl ClipEvent {
             | ClipEventFlag::RELEASE_OUTSIDE.bits(),
     );
 
-    /// Returns the `swf::ClipEventFlag` cooresponding to this event type.
+    /// Returns the `swf::ClipEventFlag` corresponding to this event type.
     pub const fn flag(self) -> ClipEventFlag {
         match self {
             ClipEvent::Construct => ClipEventFlag::CONSTRUCT,

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -53,7 +53,7 @@ impl EvalParameters {
         }
     }
 
-    /// Get the height the font would be evaluated at.
+    /// Get the height that the font would be evaluated at.
     pub fn height(&self) -> Twips {
         self.height
     }

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -263,13 +263,13 @@ mod tests {
         }
     }
 
-    // Identity matrix inverted should be unchanged
+    // Identity matrix inverted should be unchanged.
     test_invert!(
         invert_identity_matrix,
         (Matrix::default(), Matrix::default())
     );
 
-    // Standard test cases; there's nothing special about these matrices
+    // Standard test cases; there's nothing special about these matrices.
     test_invert!(
         invert_matrices,
         (
@@ -346,7 +346,7 @@ mod tests {
         )
     );
 
-    // Anything multiplied by the identity matrix should be unchanged
+    // Anything multiplied by the identity matrix should be unchanged.
     test_multiply!(
         multiply_identity_matrix,
         (Matrix::default(), Matrix::default(), Matrix::default()),
@@ -390,7 +390,7 @@ mod tests {
         )
     );
 
-    // General test cases for matrix multiplication
+    // General test cases for matrix multiplication.
     test_multiply!(
         multiply_matrices,
         (
@@ -525,7 +525,7 @@ mod tests {
         )
     );
 
-    // Twips multiplied by the identity/default matrix should be unchanged
+    // Twips multiplied by the identity/default matrix should be unchanged.
     test_multiply_twips!(
         multiply_twips_identity_matrix,
         (
@@ -550,7 +550,7 @@ mod tests {
         )
     );
 
-    // multiply by translate matrices; values should be shifted
+    // Multiply by translate matrices; values should be shifted.
     test_multiply_twips!(
         multiply_twips_translate,
         (
@@ -579,7 +579,7 @@ mod tests {
         )
     );
 
-    // multiply by scalar matrices; values should be scaled up/down
+    // Multiply by scalar matrices; values should be scaled up/down.
     test_multiply_twips!(
         multiply_twips_scale,
         (
@@ -632,7 +632,7 @@ mod tests {
         )
     );
 
-    // multiply by rotation matrices; values should be rotated around origin
+    // Multiply by rotation matrices; values should be rotated around origin.
     test_multiply_twips!(
         multiply_twips_rotation,
         (
@@ -697,11 +697,11 @@ mod tests {
         )
     );
 
-    // Testing transformation matrices that have more than 1 translation applied
+    // Testing transformation matrices that have more than 1 translation applied.
     test_multiply_twips!(
         multiply_twips_complex,
         (
-            // result of scaling by 3 * rotation by 45 degrees
+            // Result of scaling by 3 * rotation by 45 degrees
             Matrix {
                 a: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
                 c: 3.0 * f32::sin(std::f32::consts::FRAC_PI_4),
@@ -714,7 +714,7 @@ mod tests {
             (Twips::new(424), Twips::ZERO)
         ),
         (
-            // result of translating by (-5, 5) * rotation by 45 degrees
+            // Result of translating by (-5, 5) * rotation by 45 degrees
             Matrix {
                 a: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
                 c: 3.0 * f32::sin(std::f32::consts::FRAC_PI_4),
@@ -727,7 +727,7 @@ mod tests {
             (Twips::new(419), Twips::new(5))
         ),
         (
-            // result of rotation by 45 degrees * translating by (-5, 5)
+            // Result of rotation by 45 degrees * translating by (-5, 5)
             Matrix {
                 a: f32::cos(std::f32::consts::FRAC_PI_4),
                 c: f32::sin(std::f32::consts::FRAC_PI_4),
@@ -740,7 +740,7 @@ mod tests {
             (Twips::new(136), Twips::new(5))
         ),
         (
-            // result of translating by (-5, 5) * rotation by 45 degrees
+            // Result of translating by (-5, 5) * rotation by 45 degrees
             Matrix {
                 a: f32::cos(std::f32::consts::FRAC_PI_4),
                 c: f32::sin(std::f32::consts::FRAC_PI_4),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -575,7 +575,7 @@ impl Player {
                 ActivationIdentifier::root("[ContextMenu]"),
             );
 
-            // TODO: this should use a pointed display object with `.menu`
+            // TODO: This should use a pointed display object with `.menu`
             let menu_object = {
                 let dobj = activation.context.stage.root_clip();
                 if let Value::Object(obj) = dobj.object() {
@@ -656,7 +656,7 @@ impl Player {
         // currently doesn't allow `this` to be a Value (#843).
         let undefined = Value::Undefined.coerce_to_object(&mut activation);
 
-        // TODO: remember to also change the first arg
+        // TODO: Remember to also change the first arg
         // when we support contextmenu on non-root-movie
         let params = vec![root_clip.object(), Value::Object(item)];
 

--- a/core/src/shape_utils.rs
+++ b/core/src/shape_utils.rs
@@ -377,7 +377,7 @@ impl<'a> ShapeConverter<'a> {
     }
 
     fn into_commands(mut self) -> Vec<DrawPath<'a>> {
-        // as u32 is okay because SWF has a max of 65536 fills (TODO: should be u16?)
+        // As u32 is okay because SWF has a max of 65536 fills (TODO: should be u16?)
         let mut num_fill_styles = self.fill_styles.len() as u32;
         let mut num_line_styles = self.line_styles.len() as u32;
         while let Some(record) = self.iter.next() {
@@ -855,7 +855,7 @@ pub fn shape_hit_test(
     winding & 0b1 != 0
 }
 
-/// Test whether the given point is contained with in the paths specified by the draw commands.
+/// Test whether the given point is contained within the paths specified by the draw commands.
 pub fn draw_command_fill_hit_test(
     commands: &[DrawCommand],
     (point_x, point_y): (Twips, Twips),
@@ -886,7 +886,7 @@ pub fn draw_command_fill_hit_test(
     winding & 0b1 != 0
 }
 
-/// Test whether the given point is contained with in the strokes specified by the draw commands.
+/// Test whether the given point is contained within the strokes specified by the draw commands.
 /// local_matrix is used to calculate the minimum stroke width.
 pub fn draw_command_stroke_hit_test(
     commands: &[DrawCommand],


### PR DESCRIPTION
Reviewed and fixed some minor spelling/grammar related issues within the documentation of 'core' files.

(Note: Just trying to get more experience with GitHub contributions with low-risk changes.)