### PR TITLE
chore: Avoid spelling "movieclip"

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -217,7 +217,7 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     local_registers: Option<GcCell<'gc, RegisterSet<'gc>>>,
 
     /// The base clip of this stack frame.
-    /// This will be the movieclip that contains the bytecode.
+    /// This will be the MovieClip that contains the bytecode.
     base_clip: DisplayObject<'gc>,
 
     /// The current target display object of this stack frame.
@@ -769,7 +769,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 call_frame = Some((target, f64_to_wrapping_u32(frame)));
             }
         } else {
-            // An optional path to a movieclip and a frame #/label, such as "/clip:framelabel".
+            // An optional path to a MovieClip and a frame #/label, such as "/clip:framelabel".
             let frame_path = arg.coerce_to_string(self)?;
             if let Some((clip, frame)) = self.resolve_variable_path(target, &frame_path)? {
                 if let Some(clip) = clip.as_display_object().and_then(|o| o.as_movie_clip()) {
@@ -1974,16 +1974,16 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 return self.action_set_target(&target);
             }
             Value::Undefined => {
-                // Reset
+                // Reset.
                 let base_clip = self.base_clip();
                 self.set_target_clip(Some(base_clip));
             }
             Value::Object(o) => {
                 if let Some(clip) = o.as_display_object() {
-                    // Movieclips can be targeted directly
+                    // MovieClips can be targeted directly.
                     self.set_target_clip(Some(clip));
                 } else {
-                    // Other objects get coerced to string
+                    // Other objects get coerced to string.
                     let target = target.coerce_to_string(self)?;
                     return self.action_set_target(&target);
                 }

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -47,7 +47,7 @@ pub fn load_clip<'gc>(
     let target = args.get(1).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(target) = target {
-        if let Some(movieclip) = target
+        if let Some(mc) = target
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
@@ -57,7 +57,7 @@ pub fn load_clip<'gc>(
                 .fetch(&url, RequestOptions::get());
             let process = activation.context.load_manager.load_movie_into_clip(
                 activation.context.player.clone().unwrap(),
-                DisplayObject::MovieClip(movieclip),
+                DisplayObject::MovieClip(mc),
                 fetch,
                 url.to_string(),
                 None,
@@ -81,12 +81,12 @@ pub fn unload_clip<'gc>(
     let target = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(target) = target {
-        if let Some(mut movieclip) = target
+        if let Some(mut mc) = target
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
-            movieclip.unload(&mut activation.context);
-            movieclip.replace_with_movie(activation.context.gc_context, None);
+            mc.unload(&mut activation.context);
+            mc.replace_with_movie(activation.context.gc_context, None);
 
             return Ok(true.into());
         }
@@ -103,7 +103,7 @@ pub fn get_progress<'gc>(
     let target = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     if let Value::Object(target) = target {
-        if let Some(movieclip) = target
+        if let Some(mc) = target
             .as_display_object()
             .and_then(|dobj| dobj.as_movie_clip())
         {
@@ -111,8 +111,7 @@ pub fn get_progress<'gc>(
             ret_obj.define_value(
                 activation.context.gc_context,
                 "bytesLoaded",
-                movieclip
-                    .movie()
+                mc.movie()
                     .map(|mv| (mv.uncompressed_len()).into())
                     .unwrap_or(Value::Undefined),
                 Attribute::empty(),
@@ -120,8 +119,7 @@ pub fn get_progress<'gc>(
             ret_obj.define_value(
                 activation.context.gc_context,
                 "bytesTotal",
-                movieclip
-                    .movie()
+                mc.movie()
                     .map(|mv| (mv.uncompressed_len()).into())
                     .unwrap_or(Value::Undefined),
                 Attribute::empty(),

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -47,7 +47,7 @@ impl<'gc> StageObject<'gc> {
     ) -> Self {
         let mut base = ScriptObject::object(gc_context, proto);
 
-        // Movieclips have a special typeof "movieclip", while others are the default "object".
+        // MovieClips have a special typeof "movieclip", while others are the default "object".
         if display_object.as_movie_clip().is_some() {
             base.set_type_of(gc_context, TYPE_OF_MOVIE_CLIP);
         }

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -285,8 +285,8 @@ impl<'gc> Scope<'gc> {
             // Traverse the scope chain in search of the value.
             scope.set(name, value, activation, this)
         } else {
-            // This probably shouldn't happen -- all AVM1 code runs in reference to some movieclip,
-            // so we should always have a movieclip scope.
+            // This probably shouldn't happen -- all AVM1 code runs in reference to some MovieClip,
+            // so we should always have a MovieClip scope.
             // Define on the top-level scope.
             debug_assert!(false, "Scope::set: No top-level movie clip scope");
             self.locals().set(name, value, activation)

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1137,7 +1137,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Called when this object should be replaced by a PlaceObject tag.
     fn replace_with(&self, _context: &mut UpdateContext<'_, 'gc, '_>, _id: CharacterId) {
-        // Noop for most symbols; only shapes can replace their innards with another graphic.
+        // Noop for most symbols; only shapes can replace their innards with another Graphic.
     }
 
     fn object(&self) -> Avm1Value<'gc> {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -441,8 +441,8 @@ macro_rules! impl_display_object_container {
             depth: Depth,
         ) {
             // Verify this is actually our child.
-            // TODO: This seems unnecessary (especially since AS3 movieclips
-            // are allowed to be used in ways that would trip this assert)
+            // TODO: This seems unnecessary (especially since AS3 MovieClips
+            // are allowed to be used in ways that would trip this assert).
             debug_assert!(DisplayObject::ptr_eq(
                 child.parent().unwrap(),
                 (*self).into()

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -147,7 +147,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn replace_with(&self, context: &mut UpdateContext<'_, 'gc, '_>, id: CharacterId) {
-        // Static assets like graphics can replace themselves via a PlaceObject tag with PlaceObjectAction::Replace.
+        // Static assets like Graphics can replace themselves via a PlaceObject tag with PlaceObjectAction::Replace.
         // This does not create a new instance, but instead swaps out the underlying static data to point to the new art.
         if let Some(new_graphic) = context
             .library
@@ -156,7 +156,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
         {
             self.0.write(context.gc_context).static_data = new_graphic.0.read().static_data;
         } else {
-            log::warn!("PlaceObject: expected graphic at character ID {}", id);
+            log::warn!("PlaceObject: expected Graphic at character ID {}", id);
         }
     }
 
@@ -249,7 +249,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 }
 
-/// Static data shared between all instances of a graphic.
+/// Static data shared between all instances of a Graphic.
 #[allow(dead_code)]
 #[derive(Collect)]
 #[collect(require_static)]

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -975,14 +975,14 @@ impl<'gc> MovieClip<'gc> {
         }
     }
 
-    /// Gets the clip events for this movieclip.
+    /// Gets the clip events for this MovieClip.
     pub fn clip_actions(&self) -> Ref<[ClipEventHandler]> {
         Ref::map(self.0.read(), |mc| mc.clip_event_handlers())
     }
 
-    /// Sets the clip actions (a.k.a. clip events) for this movieclip.
+    /// Sets the clip actions (a.k.a. clip events) for this MovieClip.
     /// Clip actions are created in the Flash IDE by using the `onEnterFrame`
-    /// tag on a movieclip instance.
+    /// tag on a MovieClip instance.
     pub fn set_clip_event_handlers(
         self,
         gc_context: MutationContext<'gc, '_>,
@@ -1921,7 +1921,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
             }
 
             if self.world_bounds().contains(point) {
-                // This movieclip operates in "button mode" if it has a mouse handler,
+                // This MovieClip operates in "button mode" if it has a mouse handler,
                 // either via on(..) or via property mc.onRelease, etc.
                 let is_button_mode = self.is_button_mode(context);
 
@@ -2274,7 +2274,7 @@ impl<'gc> MovieClipData<'gc> {
                 // (e.g., clip.onEnterFrame = foo).
                 if context.swf.version() >= 6 {
                     if let Some(name) = event.method_name() {
-                        // Keyboard events don't fire their methods unless the movieclip has focus (#2120).
+                        // Keyboard events don't fire their methods unless the MovieClip has focus (#2120).
                         if !event.is_key_event() || self.has_focus {
                             context.action_queue.queue_actions(
                                 self_display_object,

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -287,7 +287,7 @@ impl<'gc> MovieLibrary<'gc> {
         self.fonts.get(&descriptor).copied()
     }
 
-    /// Returns the graphic with the given character ID.
+    /// Returns the `Graphic` with the given character ID.
     /// Returns `None` if the ID does not exist or is not a `Graphic`.
     pub fn get_graphic(&self, id: CharacterId) -> Option<Graphic<'gc>> {
         if let Some(&Character::Graphic(graphic)) = self.characters.get(&id) {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -281,7 +281,7 @@ pub enum Loader<'gc> {
         self_handle: Option<Handle>,
     },
 
-    /// Loader that is loading a new movie into a movieclip.
+    /// Loader that is loading a new movie into a MovieClip.
     Movie {
         /// The handle to refer to this loader instance.
         #[collect(require_static)]

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1275,7 +1275,7 @@ impl Player {
             }
 
             match actions.action_type {
-                // DoAction/clip event code
+                // DoAction/clip event code.
                 ActionType::Normal { bytecode } | ActionType::Initialize { bytecode } => {
                     Avm1::run_stack_frame_for_action(
                         actions.clip,
@@ -1285,7 +1285,7 @@ impl Player {
                         context,
                     );
                 }
-                // Change the prototype of a movieclip & run constructor events
+                // Change the prototype of a MovieClip and run constructor events.
                 ActionType::Construct {
                     constructor: Some(constructor),
                     events,
@@ -1316,7 +1316,7 @@ impl Player {
                         }
                     }
                 }
-                // Run constructor events without changing the prototype
+                // Run constructor events without changing the prototype.
                 ActionType::Construct {
                     constructor: None,
                     events,
@@ -1331,7 +1331,7 @@ impl Player {
                         );
                     }
                 }
-                // Event handler method call (e.g. onEnterFrame)
+                // Event handler method call (e.g. onEnterFrame).
                 ActionType::Method { object, name, args } => {
                     Avm1::run_stack_frame_for_method(
                         actions.clip,
@@ -1343,7 +1343,7 @@ impl Player {
                     );
                 }
 
-                // Event handler method call (e.g. onEnterFrame)
+                // Event handler method call (e.g. onEnterFrame).
                 ActionType::NotifyListeners {
                     listener,
                     method,

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -715,7 +715,7 @@ impl BlendMode {
     }
 }
 
-/// An clip action (a.k.a. clip event) placed on a movieclip instance.
+/// An clip action (a.k.a. clip event) placed on a MovieClip instance.
 /// Created in the Flash IDE using `onClipEvent` or `on` blocks.
 ///
 /// [SWF19 pp.37-38 ClipActionRecord](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=39)
@@ -727,8 +727,7 @@ pub struct ClipAction<'a> {
 }
 
 bitflags! {
-    /// An event that can be attached to a movieclip instance using
-    /// an `onClipEvent` or `on` block.
+    /// An event that can be attached to a MovieClip instance using an `onClipEvent` or `on` block.
     ///
     /// [SWF19 pp.48-50 ClipEvent](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=50)
     pub struct ClipEventFlag: u32 {
@@ -760,7 +759,7 @@ pub type KeyCode = u8;
 /// Represents a tag in an SWF file.
 ///
 /// The SWF format is made up of a stream of tags. Each tag either
-/// defines a character (graphic, sound, movieclip), or places/modifies
+/// defines a character (Graphic, Sound, MovieClip), or places/modifies
 /// an instance of these characters on the display list.
 ///
 // [SWF19 p.29](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=29)


### PR DESCRIPTION
* Prefer "MovieClip" in comments.
* Prefer "mc" for variable names.