### PR TITLE
web: Cleanup tests

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,7 +26,7 @@
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-prettier": "^3.4.0",
                 "lerna": "^4.0.0",
-                "mocha": "^8.4.0",
+                "mocha": "^9.0.1",
                 "prettier": "^2.3.1",
                 "source-map-loader": "^3.0.0",
                 "stylelint": "^13.13.1",
@@ -2519,6 +2519,131 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/js-yaml": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+            "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/log-symbols": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/mocha": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+            "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+            "dev": true,
+            "dependencies": {
+                "@ungap/promise-all-settled": "1.1.2",
+                "ansi-colors": "4.1.1",
+                "browser-stdout": "1.3.1",
+                "chokidar": "3.5.1",
+                "debug": "4.3.1",
+                "diff": "5.0.0",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.1.6",
+                "growl": "1.10.5",
+                "he": "1.2.0",
+                "js-yaml": "4.0.0",
+                "log-symbols": "4.0.0",
+                "minimatch": "3.0.4",
+                "ms": "2.1.3",
+                "nanoid": "3.1.20",
+                "serialize-javascript": "5.0.1",
+                "strip-json-comments": "3.1.1",
+                "supports-color": "8.1.1",
+                "which": "2.0.2",
+                "wide-align": "1.1.3",
+                "workerpool": "6.1.0",
+                "yargs": "16.2.0",
+                "yargs-parser": "20.2.4",
+                "yargs-unparser": "2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha"
+            },
+            "engines": {
+                "node": ">= 10.12.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mochajs"
+            }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/nanoid": {
+            "version": "3.1.20",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+            "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@wdio/mocha-framework/node_modules/workerpool": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+            "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+            "dev": true
         },
         "node_modules/@wdio/protocols": {
             "version": "7.5.3",
@@ -9482,9 +9607,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-            "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.1.tgz",
+            "integrity": "sha512-9zwsavlRO+5csZu6iRtl3GHImAbhERoDsZwdRkdJ/bE+eVplmoxNKE901ZJ9LdSchYBjSCPbjKc5XvcAri2ylw==",
             "dev": true,
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -9495,20 +9620,20 @@
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.6",
+                "glob": "7.1.7",
                 "growl": "1.10.5",
                 "he": "1.2.0",
-                "js-yaml": "4.0.0",
-                "log-symbols": "4.0.0",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
                 "minimatch": "3.0.4",
                 "ms": "2.1.3",
-                "nanoid": "3.1.20",
+                "nanoid": "3.1.23",
                 "serialize-javascript": "5.0.1",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
                 "wide-align": "1.1.3",
-                "workerpool": "6.1.0",
+                "workerpool": "6.1.4",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -9518,7 +9643,7 @@
                 "mocha": "bin/mocha"
             },
             "engines": {
-                "node": ">= 10.12.0"
+                "node": ">= 12.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -9543,28 +9668,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "7.1.7",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/mocha/node_modules/js-yaml": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-            "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/mocha/node_modules/log-symbols": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/mocha/node_modules/ms": {
@@ -9678,9 +9811,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-            "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -14129,9 +14262,9 @@
             "dev": true
         },
         "node_modules/workerpool": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-            "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.4.tgz",
+            "integrity": "sha512-jGWPzsUqzkow8HoAvqaPWTUPCrlPJaJ5tY8Iz7n1uCz3tTp6s3CDG0FF1NsX42WNlkRSW6Mr+CDZGnNoSsKa7g==",
             "dev": true
         },
         "node_modules/wrap-ansi": {
@@ -16671,6 +16804,98 @@
                 "@wdio/utils": "7.7.3",
                 "expect-webdriverio": "^3.0.0",
                 "mocha": "^8.0.1"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+                    "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
+                },
+                "log-symbols": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+                    "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "mocha": {
+                    "version": "8.4.0",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+                    "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+                    "dev": true,
+                    "requires": {
+                        "@ungap/promise-all-settled": "1.1.2",
+                        "ansi-colors": "4.1.1",
+                        "browser-stdout": "1.3.1",
+                        "chokidar": "3.5.1",
+                        "debug": "4.3.1",
+                        "diff": "5.0.0",
+                        "escape-string-regexp": "4.0.0",
+                        "find-up": "5.0.0",
+                        "glob": "7.1.6",
+                        "growl": "1.10.5",
+                        "he": "1.2.0",
+                        "js-yaml": "4.0.0",
+                        "log-symbols": "4.0.0",
+                        "minimatch": "3.0.4",
+                        "ms": "2.1.3",
+                        "nanoid": "3.1.20",
+                        "serialize-javascript": "5.0.1",
+                        "strip-json-comments": "3.1.1",
+                        "supports-color": "8.1.1",
+                        "which": "2.0.2",
+                        "wide-align": "1.1.3",
+                        "workerpool": "6.1.0",
+                        "yargs": "16.2.0",
+                        "yargs-parser": "20.2.4",
+                        "yargs-unparser": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+                    "dev": true
+                },
+                "nanoid": {
+                    "version": "3.1.20",
+                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+                    "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "workerpool": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+                    "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+                    "dev": true
+                }
             }
         },
         "@wdio/protocols": {
@@ -22087,9 +22312,9 @@
             }
         },
         "mocha": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-            "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.1.tgz",
+            "integrity": "sha512-9zwsavlRO+5csZu6iRtl3GHImAbhERoDsZwdRkdJ/bE+eVplmoxNKE901ZJ9LdSchYBjSCPbjKc5XvcAri2ylw==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -22100,20 +22325,20 @@
                 "diff": "5.0.0",
                 "escape-string-regexp": "4.0.0",
                 "find-up": "5.0.0",
-                "glob": "7.1.6",
+                "glob": "7.1.7",
                 "growl": "1.10.5",
                 "he": "1.2.0",
-                "js-yaml": "4.0.0",
-                "log-symbols": "4.0.0",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
                 "minimatch": "3.0.4",
                 "ms": "2.1.3",
-                "nanoid": "3.1.20",
+                "nanoid": "3.1.23",
                 "serialize-javascript": "5.0.1",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
                 "which": "2.0.2",
                 "wide-align": "1.1.3",
-                "workerpool": "6.1.0",
+                "workerpool": "6.1.4",
                 "yargs": "16.2.0",
                 "yargs-parser": "20.2.4",
                 "yargs-unparser": "2.0.0"
@@ -22131,22 +22356,27 @@
                     "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
                     "dev": true
                 },
+                "glob": {
+                    "version": "7.1.7",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
                 "js-yaml": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-                    "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
                     "dev": true,
                     "requires": {
                         "argparse": "^2.0.1"
-                    }
-                },
-                "log-symbols": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-                    "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^4.0.0"
                     }
                 },
                 "ms": {
@@ -22242,9 +22472,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.20",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-            "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
             "dev": true
         },
         "natural-compare": {
@@ -25674,9 +25904,9 @@
             "dev": true
         },
         "workerpool": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-            "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.4.tgz",
+            "integrity": "sha512-jGWPzsUqzkow8HoAvqaPWTUPCrlPJaJ5tY8Iz7n1uCz3tTp6s3CDG0FF1NsX42WNlkRSW6Mr+CDZGnNoSsKa7g==",
             "dev": true
         },
         "wrap-ansi": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.4.0",
         "lerna": "^4.0.0",
-        "mocha": "^8.4.0",
+        "mocha": "^9.0.1",
         "prettier": "^2.3.1",
         "source-map-loader": "^3.0.0",
         "stylelint": "^13.13.1",

--- a/web/packages/core/.mocharc.json
+++ b/web/packages/core/.mocharc.json
@@ -1,0 +1,5 @@
+{
+    "extension": ["ts"],
+    "spec": "test/**.ts",
+    "require": ["ts-node/esm"]
+}

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -25,7 +25,7 @@
         "eslint": "^7.29.0",
         "eslint-plugin-jsdoc": "^35.4.1",
         "esm": "^3.2.25",
-        "mocha": "^8.4.0",
+        "mocha": "^9.0.1",
         "replace-in-file": "^6.2.0",
         "ts-node": "^10.0.0",
         "typedoc": "^0.21.2",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -19,11 +19,9 @@
         "test": "mocha -r esm -r ts-node/register test/**.ts"
     },
     "devDependencies": {
-        "@types/chai": "^4.2.19",
         "@types/mocha": "^8.2.2",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
         "@typescript-eslint/parser": "^4.28.1",
-        "chai": "^4.3.4",
         "eslint": "^7.29.0",
         "eslint-plugin-jsdoc": "^35.4.1",
         "esm": "^3.2.25",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -16,7 +16,7 @@
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && [[ $GITHUB_ACTIONS != true ]]",
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
-        "test": "mocha -r esm -r ts-node/register test/**.ts"
+        "test": "mocha"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -16,12 +16,13 @@
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && [[ $GITHUB_ACTIONS != true ]]",
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
-        "test": "mocha"
+        "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha"
     },
     "devDependencies": {
         "@types/mocha": "^8.2.2",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
         "@typescript-eslint/parser": "^4.28.1",
+        "cross-env": "^7.0.3",
         "eslint": "^7.29.0",
         "eslint-plugin-jsdoc": "^35.4.1",
         "esm": "^3.2.25",

--- a/web/packages/core/test/tsconfig.json
+++ b/web/packages/core/test/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "extends": "../tsconfig",
-    "compilerOptions": {
-        "module": "commonjs"
-    }
-}

--- a/web/packages/core/test/version-range.ts
+++ b/web/packages/core/test/version-range.ts
@@ -1,4 +1,4 @@
-import { assert } from "chai";
+import { strict as assert } from "assert";
 import { VersionRange } from "../src/version-range";
 import { Version } from "../src/version";
 

--- a/web/packages/core/test/version.ts
+++ b/web/packages/core/test/version.ts
@@ -1,4 +1,4 @@
-import { assert } from "chai";
+import { strict as assert } from "assert";
 import { Version } from "../src/version";
 
 // Each row should be a list of compatible versions.
@@ -71,7 +71,7 @@ describe("Version", function () {
             for (const test of testMatrix) {
                 for (const a of test) {
                     for (const b of test) {
-                        assert.isOk(
+                        assert(
                             Version.fromSemver(a).isCompatibleWith(
                                 Version.fromSemver(b)
                             ),
@@ -87,8 +87,8 @@ describe("Version", function () {
                     for (const otherTest of testMatrix) {
                         if (test === otherTest) continue;
                         for (const b of otherTest) {
-                            assert.isNotOk(
-                                Version.fromSemver(a).isCompatibleWith(
+                            assert(
+                                !Version.fromSemver(a).isCompatibleWith(
                                     Version.fromSemver(b)
                                 ),
                                 `${a} is not compatible with ${b}`
@@ -112,7 +112,7 @@ describe("Version", function () {
                         // Skip "builds" for purposes of this test.
                         continue;
                     }
-                    assert.isOk(
+                    assert(
                         Version.fromSemver(tests[a]).hasPrecedenceOver(
                             Version.fromSemver(tests[b])
                         ),
@@ -132,8 +132,8 @@ describe("Version", function () {
                         // Skip "builds" for purposes of this test.
                         continue;
                     }
-                    assert.isNotOk(
-                        Version.fromSemver(tests[a]).hasPrecedenceOver(
+                    assert(
+                        !Version.fromSemver(tests[a]).hasPrecedenceOver(
                             Version.fromSemver(tests[b])
                         ),
                         `${tests[a]} doesn't have precedence over ${tests[b]}`
@@ -147,7 +147,7 @@ describe("Version", function () {
         it("returns true when it should", function () {
             const tests = flatten(testMatrix);
             for (const version of tests) {
-                assert.isOk(
+                assert(
                     Version.fromSemver(version).isEqual(
                         Version.fromSemver(version)
                     ),
@@ -168,8 +168,8 @@ describe("Version", function () {
                         // Skip "builds" and "identifiers" for purposes of this test.
                         continue;
                     }
-                    assert.isNotOk(
-                        Version.fromSemver(tests[a]).isEqual(
+                    assert(
+                        !Version.fromSemver(tests[a]).isEqual(
                             Version.fromSemver(tests[b])
                         ),
                         `${tests[a]} does not equal ${tests[b]}`
@@ -183,7 +183,7 @@ describe("Version", function () {
         it("returns true for own versions", function () {
             const tests = flatten(testMatrix);
             for (const version of tests) {
-                assert.isOk(
+                assert(
                     Version.fromSemver(version).isStableOrCompatiblePrerelease(
                         Version.fromSemver(version)
                     ),
@@ -195,7 +195,7 @@ describe("Version", function () {
             const tests = ["1.2.3", "1.2.3-alpha", "1.2.3-beta1.build2"];
             for (const a of tests) {
                 for (const b of tests) {
-                    assert.isOk(
+                    assert(
                         Version.fromSemver(a).isStableOrCompatiblePrerelease(
                             Version.fromSemver(b)
                         ),
@@ -209,8 +209,8 @@ describe("Version", function () {
             for (const a of tests) {
                 for (const b of tests) {
                     if (a === b) continue;
-                    assert.isNotOk(
-                        Version.fromSemver(a).isStableOrCompatiblePrerelease(
+                    assert(
+                        !Version.fromSemver(a).isStableOrCompatiblePrerelease(
                             Version.fromSemver(b)
                         ),
                         `${a} is not compatible with ${b}`


### PR DESCRIPTION
Along with some cleanups, fix the integration of mocha with ES modules using the workaround from [here](https://github.com/mochajs/mocha-examples/tree/master/packages/typescript#es-modules.).
The [`cross-env`](https://www.npmjs.com/package/cross-env) package is for both Unix and Windows systems support.

Closes #4630.