### PR TITLE
Extension: Sidestep CORS issues by offering to load the SWF in a tab

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -23,6 +23,12 @@ pub trait UiBackend: Downcast {
     /// Displays a warning about unsupported content in Ruffle.
     /// The user can still click an "OK" or "run anyway" message to dismiss the warning.
     fn display_unsupported_message(&self);
+
+    /// Displays a message about an error during root movie download.
+    /// In particular, on web this can be a CORS error, which we can sidestep
+    /// by providing a direct .swf link instead.
+    fn display_root_movie_download_failed_message(&self);
+
     // Unused, but kept in case we need it later
     fn message(&self, message: &str);
 }
@@ -86,6 +92,8 @@ impl UiBackend for NullUiBackend {
     }
 
     fn display_unsupported_message(&self) {}
+
+    fn display_root_movie_download_failed_message(&self) {}
 
     fn message(&self, _message: &str) {}
 }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -402,6 +402,11 @@ impl<'gc> Loader<'gc> {
                 player.lock().unwrap().set_root_movie(Arc::new(movie));
                 Ok(())
             } else {
+                player
+                    .lock()
+                    .unwrap()
+                    .ui()
+                    .display_root_movie_download_failed_message();
                 Err(Error::FetchError(url))
             }
         })

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -77,6 +77,8 @@ This content is not yet supported by Ruffle and will likely not run as intended.
 See the following link for more info:
 https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users";
 
+const DOWNLOAD_FAILED_MESSAGE: &str = "Ruffle failed to open or download this file.";
+
 impl UiBackend for DesktopUiBackend {
     fn is_key_down(&self, key: KeyCode) -> bool {
         match key {
@@ -228,6 +230,14 @@ impl UiBackend for DesktopUiBackend {
         message_box_ok(
             "Ruffle - Unsupported content",
             UNSUPPORTED_CONTENT_MESSAGE,
+            MessageBoxIcon::Warning,
+        );
+    }
+
+    fn display_root_movie_download_failed_message(&self) {
+        message_box_ok(
+            "Ruffle - Load failed",
+            DOWNLOAD_FAILED_MESSAGE,
             MessageBoxIcon::Warning,
         );
     }

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -31,12 +31,14 @@ function polyfillFlashInstances(): void {
         for (const elem of Array.from(objects)) {
             if (RuffleObject.isInterdictable(elem)) {
                 const ruffleObject = RuffleObject.fromNativeObjectElement(elem);
+                ruffleObject.setIsExtension(isExtension);
                 elem.replaceWith(ruffleObject);
             }
         }
         for (const elem of Array.from(embeds)) {
             if (RuffleEmbed.isInterdictable(elem)) {
                 const ruffleEmbed = RuffleEmbed.fromNativeEmbedElement(elem);
+                ruffleEmbed.setIsExtension(isExtension);
                 elem.replaceWith(ruffleEmbed);
             }
         }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -107,6 +107,9 @@ extern "C" {
     #[wasm_bindgen(method, js_name = "displayUnsupportedMessage")]
     fn display_unsupported_message(this: &JavascriptPlayer);
 
+    #[wasm_bindgen(method, js_name = "displayRootMovieDownloadFailedMessage")]
+    fn display_root_movie_download_failed_message(this: &JavascriptPlayer);
+
     #[wasm_bindgen(method, js_name = "displayMessage")]
     fn display_message(this: &JavascriptPlayer, message: &str);
 

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -206,6 +206,10 @@ impl UiBackend for WebUiBackend {
         self.js_player.display_unsupported_message()
     }
 
+    fn display_root_movie_download_failed_message(&self) {
+        self.js_player.display_root_movie_download_failed_message()
+    }
+
     fn message(&self, message: &str) {
         self.js_player.display_message(message);
     }


### PR DESCRIPTION
Things left to do:

- ~~write a nice user-facing message~~
- test a bit more? I only tested it on http://www.nitrome.com/games/faultline/ and tested other cases by flipping the conditions in code
- the `isExtension` check seems to work, but not sure if `setIsExtension()` is the best way to do it design-wise
- ~~decide on Rust-layer design, not sure which is better:~~
  - ~~current: `Loader` panics, then the JS panic handler optionally calls `displayCorsWalkaroundMessage()` if walkaround conditions are met~~
  - alternative: `Loader` calls `player.ui.display_cors_walkaround_message()` without panicking, then the JS function falls back to `panic()` if walkaround conditions aren't met
 
Also: it appears that all `Loader::Error` cases are eaten by `spawn_future` and turned into just `log::error`? Probably all root movie load errors should be turned into some user-facing panic message, but that's out of scope I think.

Also: I only handle fetch errors on loading root movies, but not any subsequent movie loads. This feels like a rare case and can also be considered out of scope for now, I think.