### PR TITLE
swf: Ignore length mismatch in `read_action`

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -511,17 +511,23 @@ impl<'gc> Avm1<'gc> {
 }
 
 pub fn root_error_handler<'gc>(activation: &mut Activation<'_, 'gc, '_>, error: Error<'gc>) {
-    if let Error::ThrownValue(error) = &error {
-        let message = error
-            .coerce_to_string(activation)
-            .unwrap_or_else(|_| "undefined".into());
-        activation.context.log.avm_trace(&message);
-    } else {
-        log::error!("{}", error);
+    match &error {
+        Error::ThrownValue(value) => {
+            let message = value
+                .coerce_to_string(activation)
+                .unwrap_or_else(|_| "undefined".into());
+            activation.context.log.avm_trace(&message);
+            // Continue execution without halting.
+            return;
+        }
+        Error::InvalidSwf(swf_error) => {
+            log::error!("{}: {}", error, swf_error);
+        }
+        _ => {
+            log::error!("{}", error);
+        }
     }
-    if error.is_halting() {
-        activation.context.avm1.halt();
-    }
+    activation.context.avm1.halt();
 }
 
 /// Utility function used by `Avm1::action_wait_for_frame` and

--- a/core/src/avm1/error.rs
+++ b/core/src/avm1/error.rs
@@ -15,26 +15,12 @@ pub enum Error<'gc> {
     #[error("66 levels of special recursion were exceeded in one action list. This is probably an infinite loop.")]
     SpecialRecursionLimit,
 
-    #[error("Couldn't parse SWF. This may or may not be a bug in Ruffle, please help us by reporting it to https://github.com/ruffle-rs/ruffle/issues and include the swf that triggered it.")]
+    #[error("Couldn't parse SWF")]
     InvalidSwf(#[from] swf::error::Error),
 
-    #[error("Attempted to interact with a rootless display object in AVM1. Such objects can only be created in AS3, this is a runtime bug in Ruffle. Please help us by reporting it to https://github.com/ruffle-rs/ruffle/issues and include the swf that triggered it.")]
+    #[error("Attempted to interact with a rootless display object in AVM1. Such objects can only be created in AS3, this is a runtime bug in Ruffle.")]
     InvalidDisplayObjectHierarchy,
 
     #[error("A script has thrown a custom error.")]
     ThrownValue(Value<'gc>),
-}
-
-impl Error<'_> {
-    pub fn is_halting(&self) -> bool {
-        match self {
-            Error::PrototypeRecursionLimit => true,
-            Error::ExecutionTimeout => true,
-            Error::FunctionRecursionLimit(_) => true,
-            Error::SpecialRecursionLimit => true,
-            Error::InvalidSwf(_) => true,
-            Error::InvalidDisplayObjectHierarchy => true,
-            Error::ThrownValue(_) => false,
-        }
-    }
 }

--- a/swf/src/avm1/opcode.rs
+++ b/swf/src/avm1/opcode.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code, clippy::useless_attribute)]
 #[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
 pub enum OpCode {
     End = 0x00,
@@ -115,4 +114,18 @@ pub enum OpCode {
     If = 0x9D,
     Call = 0x9E,
     GotoFrame2 = 0x9F,
+}
+
+impl OpCode {
+    pub fn from_u8(n: u8) -> Option<Self> {
+        num_traits::FromPrimitive::from_u8(n)
+    }
+
+    pub fn format(opcode: u8) -> String {
+        if let Some(op) = Self::from_u8(opcode) {
+            format!("{:?}", op)
+        } else {
+            format!("Unknown({})", opcode)
+        }
+    }
 }

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -48,18 +48,19 @@ impl<'a> Reader<'a> {
 
         let action = self.read_op(opcode, &mut length);
 
-        let end_pos = (start.as_ptr() as usize + length) as *const u8;
         if let Err(e) = action {
             return Err(Error::avm1_parse_error_with_source(opcode, e));
         }
 
         // Verify that we parsed the correct amount of data.
+        let end_pos = (start.as_ptr() as usize + length) as *const u8;
         if self.input.as_ptr() != end_pos {
-            self.input = &start[length.min(start.len())..];
             // We incorrectly parsed this action.
             // Re-sync to the expected end of the action and throw an error.
-            return Err(Error::avm1_parse_error(opcode));
+            self.input = &start[length.min(start.len())..];
+            log::warn!("Length mismatch in AVM1 action: {}", OpCode::format(opcode));
         }
+
         action
     }
 
@@ -423,5 +424,27 @@ pub mod tests {
         let mut reader = Reader::new(&action_bytes[..], 5);
         let action = reader.read_action().unwrap().unwrap();
         assert_eq!(action, Action::Push(vec![Value::Null, Value::Undefined]));
+    }
+
+    #[test]
+    fn read_length_mismatch() {
+        let action_bytes = [
+            OpCode::ConstantPool as u8,
+            5,
+            0,
+            1,
+            0,
+            b'a',
+            0,
+            OpCode::Add as u8,
+            OpCode::Subtract as u8,
+        ];
+        let mut reader = Reader::new(&action_bytes[..], 5);
+
+        let action = reader.read_action().unwrap().unwrap();
+        assert_eq!(action, Action::ConstantPool(vec!["a".into()]));
+
+        let action = reader.read_action().unwrap().unwrap();
+        assert_eq!(action, Action::Subtract);
     }
 }

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -81,7 +81,6 @@ impl<'a> Reader<'a> {
     #[inline]
     #[allow(clippy::inconsistent_digit_grouping)]
     fn read_op(&mut self, opcode: u8, length: &mut usize) -> Result<Option<Action<'a>>> {
-        use num_traits::FromPrimitive;
         let action = if let Some(op) = OpCode::from_u8(opcode) {
             match op {
                 OpCode::End => return Ok(None),

--- a/swf/src/error.rs
+++ b/swf/src/error.rs
@@ -1,3 +1,4 @@
+use crate::avm1::opcode::OpCode;
 use crate::tag_code::TagCode;
 use std::{borrow, error, fmt, io};
 
@@ -73,30 +74,21 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use crate::num_traits::FromPrimitive;
         match self {
             Self::Avm1ParseError { opcode, source } => {
-                let op = crate::avm1::opcode::OpCode::from_u8(*opcode);
-                "Error parsing AVM1 action ".fmt(f)?;
-                if let Some(op) = op {
-                    write!(f, "{:?}", op)?;
-                } else {
-                    write!(f, "Unknown({})", opcode)?;
-                };
+                write!(f, "Error parsing AVM1 action {}", OpCode::format(*opcode))?;
                 if let Some(source) = source {
                     write!(f, ": {}", source)?;
                 }
                 Ok(())
             }
             Self::SwfParseError { tag_code, source } => {
-                "Error parsing SWF tag ".fmt(f)?;
-                if let Some(tag_code) = TagCode::from_u16(*tag_code) {
-                    write!(f, "{:?}", tag_code)?;
-                } else {
-                    write!(f, "Unknown({})", tag_code)?;
-                };
-                write!(f, ": {}", source)?;
-                Ok(())
+                write!(
+                    f,
+                    "Error parsing SWF tag {}: {}",
+                    TagCode::format(*tag_code),
+                    source
+                )
             }
             Self::IoError(e) => e.fmt(f),
             Self::InvalidData(message) => write!(f, "Invalid data: {}", message),

--- a/swf/src/tag_code.rs
+++ b/swf/src/tag_code.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::useless_attribute)]
-
-#[allow(dead_code)]
 #[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
 pub enum TagCode {
     End = 0,
@@ -94,5 +91,13 @@ pub enum TagCode {
 impl TagCode {
     pub fn from_u16(n: u16) -> Option<Self> {
         num_traits::FromPrimitive::from_u16(n)
+    }
+
+    pub fn format(tag_code: u16) -> String {
+        if let Some(tag_code) = TagCode::from_u16(tag_code) {
+            format!("{:?}", tag_code)
+        } else {
+            format!("Unknown({})", tag_code)
+        }
     }
 }


### PR DESCRIPTION
Flash continues in such case, so just warn instead of failing.

Fixes #3060.