### PR TITLE
web: add isExtension info to panic info and context menu version string

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -697,8 +697,10 @@ export class RufflePlayer extends HTMLElement {
             }
         }
         items.push(null);
+
+        const extensionString = this.isExtension ? "extension" : "";
         items.push({
-            text: `About Ruffle (%VERSION_NAME%)`,
+            text: `About Ruffle ${extensionString} (%VERSION_NAME%)`,
             onClick() {
                 window.open(RUFFLE_ORIGIN, "_blank");
             },
@@ -975,6 +977,7 @@ export class RufflePlayer extends HTMLElement {
         errorArray.push(`Channel: %VERSION_CHANNEL%\n`);
         errorArray.push(`Built: %BUILD_DATE%\n`);
         errorArray.push(`Commit: %COMMIT_HASH%\n`);
+        errorArray.push(`Is extension: ${this.isExtension}\n`);
 
         const errorText = errorArray.join("");
 

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -40,6 +40,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
     player = ruffle.createPlayer();
     player.id = "player";
+    player.setIsExtension(true);
     document.getElementById("main")!.append(player);
 
     player.load({ url: swfUrl, ...config });


### PR DESCRIPTION
~~Draft, because it builds on top of the `isExtension` feature from https://github.com/ruffle-rs/ruffle/pull/4665 . After that gets accepted, this also will be merge-able.~~

Just a small piece of helpful info for triage :)

EDIT: also added this into to the context menu version string. 
![image](https://user-images.githubusercontent.com/4729533/127786417-58e8b5f8-8b3c-48df-9a7d-07d67d1e1262.png)
