### PR TITLE
web: Add buildDbg target

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "scripts": {
         "bootstrap": "npm install && lerna bootstrap --hoist",
         "build": "lerna run build --stream",
+        "buildDbg": "lerna run buildDbg --stream",
         "buildProduction": "lerna run build --stream -- --mode=production",
         "build:avm_debug": "lerna run build --stream -- -- --env features=avm_debug",
         "demo": "lerna run --scope ruffle-demo serve --stream",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -10,6 +10,7 @@
     ],
     "scripts": {
         "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
+        "buildDbg": "npm run build",
         "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
         "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name ruffle_web",
         "build:wasm-opt": "wasm-opt -o ./pkg/ruffle_web_bg.wasm -O -g ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -6,6 +6,7 @@
     "private": true,
     "scripts": {
         "build": "webpack",
+        "buildDbg": "webpack --mode=development",
         "serve": "webpack serve"
     },
     "dependencies": {

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -6,8 +6,11 @@
     "private": true,
     "scripts": {
         "build": "npm run build:generic && npm run build:firefox",
+        "buildDbg": "npm run build:genericDbg && npm run build:firefoxDbg",
         "build:generic": "webpack --env generic && node tools/zip.js dist/ruffle_extension.zip",
-        "build:firefox": "webpack --env firefox && node tools/zip.js dist/firefox_unsigned.xpi && node tools/sign_xpi.js dist/firefox_unsigned.xpi dist/firefox.xpi"
+        "build:genericDbg": "webpack --env generic --mode=development && node tools/zip.js dist/ruffle_extension.zip",
+        "build:firefox": "webpack --env firefox && node tools/zip.js dist/firefox_unsigned.xpi && node tools/sign_xpi.js dist/firefox_unsigned.xpi dist/firefox.xpi",
+        "build:firefoxDbg": "webpack --env firefox --mode=development && node tools/zip.js dist/firefox_unsigned.xpi && node tools/sign_xpi.js dist/firefox_unsigned.xpi dist/firefox.xpi"
     },
     "dependencies": {
         "ruffle-core": "^0.1.0"

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -12,6 +12,7 @@
     "repository": "github:ruffle-rs/ruffle",
     "scripts": {
         "build": "webpack",
+        "buildDbg": "webpack --mode=development",
         "serve": "webpack-dev-server",
         "test": "wdio"
     },


### PR DESCRIPTION
The buildDbg target will build webpack in
development mode.
This will make debugging web-specific issues easier.