### PR TITLE
avm1: Fix panic while self assigning transform (#4377)

### DIFF
--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -53,6 +53,7 @@ pub fn constructor<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .coerce_to_object(activation)
+        .clone()
         .as_display_object()
         .and_then(|o| o.as_movie_clip());
 


### PR DESCRIPTION
Supersedes #4741

The clip passed to the transform constructor should be cloned to prevent a panic in the case of:
```as
var t1 = test.transform;
test.transform = t1;
```
assume `test` is a movieclip that is currently visible on the stage