### PR TITLE
web: Fix build without wasm-opt on Windows

### DIFF
--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -13,7 +13,7 @@
         "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
         "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name ruffle_web",
         "build:wasm-opt": "wasm-opt -o ./pkg/ruffle_web_bg.wasm -O -g ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",
-        "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && [[ $GITHUB_ACTIONS != true ]]",
+        "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$GITHUB_ACTIONS\" != true ] # > nul",
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha"


### PR DESCRIPTION
Since #3111, `wasm-opt` became mandatory on GitHub Actions. But the check whether we run on GitHub Actions is Bash-specific, and fails on Windows. That means builds on Windows without `wasm-opt` always fail.

As a workaround, use the trick from https://gist.github.com/prail/24acc95908e581722c0e9df5795180f6 to run the check only on Unix, and skip it on Windows:

```
echo ; [ \"$GITHUB_ACTIONS\" != true ] # > nul
```

On Unix, `echo` does nothing, the check runs, and the rest is considered a comment.
On Windows, `echo` prints everything until the `> nul`, which suppresses the print by redirection, making the whole statement effectively a no-op.

Fixes #3162.