### PR TITLE
desktop: Add DX11 to default graphics backends

### DIFF
--- a/render/wgpu/src/clap.rs
+++ b/render/wgpu/src/clap.rs
@@ -12,7 +12,7 @@ pub enum GraphicsBackend {
 impl From<GraphicsBackend> for wgpu::BackendBit {
     fn from(backend: GraphicsBackend) -> Self {
         match backend {
-            GraphicsBackend::Default => wgpu::BackendBit::PRIMARY,
+            GraphicsBackend::Default => wgpu::BackendBit::PRIMARY | wgpu::BackendBit::DX11,
             GraphicsBackend::Vulkan => wgpu::BackendBit::VULKAN,
             GraphicsBackend::Metal => wgpu::BackendBit::METAL,
             GraphicsBackend::Dx12 => wgpu::BackendBit::DX12,


### PR DESCRIPTION
This way, if one's card only supports DX11, they don't need to explicitly pass `-g dx11`.