### PR TITLE
Fix minor bug/typo in `action_get_url_2`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1345,7 +1345,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 }
             }
             return Ok(FrameControl::Continue);
-        } else if window_target.starts_with("_level") && url.len() > 6 {
+        } else if window_target.starts_with("_level") && window_target.len() > 6 {
             // target of `_level#` indicates a `loadMovieNum` call.
             match window_target[6..].parse::<i32>() {
                 Ok(level_id) => {


### PR DESCRIPTION
The current version just doesn't make any sense.
The fixed version is akin to the `target.starts_with("_level") && target.len() > 6` line a bit earlier in this file.