### PR TITLE
core: Refactor PCM decoder a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,6 +2977,7 @@ dependencies = [
  "approx",
  "bitflags",
  "bitstream-io",
+ "byteorder",
  "chrono",
  "downcast-rs",
  "encoding_rs",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+byteorder = "1.4"
 bitstream-io = "1.1.0"
 flate2 = "1.0.20"
 fnv = "1.0.7"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -21,7 +21,7 @@ canvas = ["ruffle_render_canvas"]
 webgl = ["ruffle_render_webgl"]
 
 [dependencies]
-byteorder = "1.4.3"
+byteorder = "1.4"
 console_error_panic_hook = { version = "0.1.1", optional = true }
 console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"


### PR DESCRIPTION
Extract a `read_sample` method to avoid code duplication, and use the [`byteorder`](https://docs.rs/byteorder/1.4.3/byteorder/) crate as already done in other places.