### PR TITLE
web: Add a loadeddata event, which triggers when loadedmetadata does for now

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -146,6 +146,13 @@ export class RufflePlayer extends HTMLElement {
     static LOADED_METADATA = "loadedmetadata";
 
     /**
+     * Triggered when a movie is fully loaded.
+     *
+     * @event RufflePlayer#loadeddata
+     */
+    static LOADED_DATA = "loadeddata";
+
+    /**
      * A movie can communicate with the hosting page using fscommand
      * as long as script access is allowed.
      *
@@ -1200,6 +1207,8 @@ export class RufflePlayer extends HTMLElement {
         // TODO: Switch this to ReadyState.Loading when we have streaming support.
         this._readyState = ReadyState.Loaded;
         this.dispatchEvent(new Event(RufflePlayer.LOADED_METADATA));
+        // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
+        this.dispatchEvent(new Event(RufflePlayer.LOADED_DATA));
     }
 }
 


### PR DESCRIPTION
This can be used by someone who expects it to indicate when the swf is fully loaded, without fear that that functionality will change in the future (which means it will need to be changed when streaming support is added). Based on https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadeddata_event.

**Edit:** This builds on top of #4084, so there are some important things to note. First, that PR said RufflePlayer.readyState was supposed to mimic the media APIs. However, https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState has 5 possible values, not just 3. I'm not saying Ruffle should duplicate that, but loadeddata triggers when the ready state is HAVE_CURRENT_DATA for media elements, so it may not be the best name for the event for the RufflePlayer, since people familiar with the media APIs will be confused by it.

I''m not sure what the best event name would be.

For media elements, loadeddata triggers when the ReadyState is 2 (HAVE_CURRENT_DATA). canplay triggers, I believe, when the ReadyState is 3 (HAVE_FUTURE_DATA), and canplaythrough triggers, I believe, when the ReadyState is 4 (HAVE_ENOUGH_DATA).

For RufflePlayer, the ReadyState can hold the values 0 (HAVE_NOTHING), 1 (LOADING), or 2 (LOADED).