### PR TITLE
Allow XML parsing for invalid entities (to match Flash)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,9 +1814,9 @@ checksum = "90953f308a79fe6d62a4643e51f848fbfddcd05975a38e69fdf4ab86a7baf7ca"
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2931,9 +2937,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "regress"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a15e49468dd69419fec19290daec1c88859ff7098688b8ecdb7ecdaa88f2dc"
+checksum = "0a92ff21fe8026ce3f2627faaf43606f0b67b014dbc9ccf027181a804f75d92e"
 dependencies = [
  "memchr",
 ]
@@ -2989,6 +2995,7 @@ dependencies = [
  "gc-arena-derive",
  "generational-arena",
  "gif",
+ "htmlescape",
  "indexmap",
  "instant",
  "jpeg-decoder",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,6 +25,7 @@ smallvec = "1.6.1"
 num-traits = "0.2"
 num-derive = "0.3"
 quick-xml = "0.22.0"
+htmlescape = "0.3.1"
 downcast-rs = "1.2.0"
 url = "2.2.2"
 weak-table = "0.3.0"
@@ -36,7 +37,7 @@ encoding_rs = "0.8.28"
 rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.126", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
-regress = "0.3"
+regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "e39a8abc897289696672858e30bbc9e43b1c98ac" }
 json = "0.12.4"
 lzma-rs = {version = "0.2.0", optional = true }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -129,7 +129,6 @@ export class RufflePlayer extends HTMLElement {
     private swfUrl?: string;
     private instance: Ruffle | null;
     private options: BaseLoadOptions | null;
-    private _trace_observer: ((message: string) => void) | null;
     private lastActivePlayingState: boolean;
 
     private _metadata: MovieMetadata | null;
@@ -196,10 +195,7 @@ export class RufflePlayer extends HTMLElement {
         this.container = this.shadow.getElementById("container")!;
         this.playButton = this.shadow.getElementById("play_button")!;
         if (this.playButton) {
-            this.playButton.addEventListener(
-                "click",
-                this.playButtonClicked.bind(this)
-            );
+            this.playButton.addEventListener("click", () => this.play());
         }
 
         this.unmuteOverlay = this.shadow.getElementById("unmute_overlay")!;
@@ -212,7 +208,6 @@ export class RufflePlayer extends HTMLElement {
         this.instance = null;
         this.options = null;
         this.onFSCommand = null;
-        this._trace_observer = null;
 
         this._readyState = ReadyState.HaveNothing;
         this._metadata = null;
@@ -588,10 +583,6 @@ export class RufflePlayer extends HTMLElement {
             console.error(`Serious error occurred loading SWF file: ${err}`);
             throw err;
         }
-    }
-
-    private playButtonClicked(): void {
-        this.play();
     }
 
     /**

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -21,8 +21,11 @@ const sampleFileInputContainer = document.getElementById(
 );
 const localFileInput = document.getElementById("local-file");
 const sampleFileInput = document.getElementById("sample-swfs");
-const animOptGroup = document.getElementById("anim-optgroup");
-const gamesOptGroup = document.getElementById("games-optgroup");
+// prettier-ignore
+const optionGroups = {
+    "Animation": document.getElementById("anim-optgroup"),
+    "Game": document.getElementById("games-optgroup"),
+};
 
 // Default config used by the player.
 const config = {
@@ -66,7 +69,8 @@ async function loadFile(file) {
         return;
     }
     hideSample();
-    load({ data: await new Response(file).arrayBuffer(), ...config });
+    const data = await new Response(file).arrayBuffer();
+    load({ data, ...config });
 }
 
 function loadSample() {
@@ -123,14 +127,7 @@ window.addEventListener("load", () => {
         option.textContent = swfData.title;
         option.value = swfData.location;
         option.swfData = swfData;
-        switch (swfData.type) {
-            case "Animation":
-                animOptGroup.append(option);
-                break;
-            case "Game":
-                gamesOptGroup.append(option);
-                break;
-        }
+        optionGroups[swfData.type].append(option);
     }
     sampleFileInputContainer.classList.remove("hidden");
 

--- a/web/packages/selfhosted/test/utils.js
+++ b/web/packages/selfhosted/test/utils.js
@@ -55,17 +55,9 @@ function play_and_monitor(browser, player, expected_output) {
 
     // TODO: better way to test for this in the API
     browser.waitUntil(
-        () => {
-            return (
-                has_error(browser) ||
-                browser.execute((player) => {
-                    return (
-                        player.playButtonClicked !== undefined &&
-                        player.instance
-                    );
-                }, player)
-            );
-        },
+        () =>
+            has_error(browser) ||
+            browser.execute((player) => player.instance, player),
         {
             timeoutMsg: "Expected player to have initialized",
         }
@@ -76,9 +68,7 @@ function play_and_monitor(browser, player, expected_output) {
         player.traceObserver = (msg) => {
             player.__ruffle_log__ += msg + "\n";
         };
-
-        // TODO: make this an actual intended api...
-        player.playButtonClicked();
+        player.play();
     }, player);
 
     if (expected_output === undefined) {
@@ -86,13 +76,9 @@ function play_and_monitor(browser, player, expected_output) {
     }
 
     browser.waitUntil(
-        () => {
-            return (
-                browser.execute((player) => {
-                    return player.__ruffle_log__;
-                }, player) === expected_output
-            );
-        },
+        () =>
+            browser.execute((player) => player.__ruffle_log__, player) ===
+            expected_output,
         {
             timeoutMsg: "Expected Ruffle to trace a message",
         }
@@ -115,6 +101,7 @@ function open_test(browser, absolute_dir, file_name) {
 /** Test set-up for JS API testing. */
 function js_api_before(swf) {
     let player = null;
+
     before("Loads the test", () => {
         browser.url("http://localhost:4567/test_assets/js_api.html");
 
@@ -135,7 +122,6 @@ function js_api_before(swf) {
             play_and_monitor(browser, player);
         }
     });
-    return player;
 }
 
 module.exports = {


### PR DESCRIPTION
Closes #4699.

Not a permanent solution. A custom XML parser would be a far better solution. However, that is well beyond my knowledge.

See https://dnalc.cshl.edu/view/2022-G2C-3-D-Brain.html. I tested it with this branch and it works.