### PR TITLE
swf: Optimize `read_f64_me` and `write_f64_me`

### DIFF
--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -45,12 +45,7 @@ impl<'a> Reader<'a> {
     fn read_f64_me(&mut self) -> Result<f64> {
         // Flash weirdly stores (some?) f64 as two LE 32-bit chunks.
         // First word is the hi-word, second word is the lo-word.
-        let mut bytes = self.read_u64()?.to_le_bytes();
-        bytes.swap(0, 4);
-        bytes.swap(1, 5);
-        bytes.swap(2, 6);
-        bytes.swap(3, 7);
-        Ok(f64::from_le_bytes(bytes))
+        Ok(f64::from_bits(self.read_u64()?.rotate_left(32)))
     }
 
     #[inline]

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -73,12 +73,7 @@ impl<W: Write> Writer<W> {
     fn write_f64_me(&mut self, n: f64) -> Result<()> {
         // Flash weirdly stores f64 as two LE 32-bit chunks.
         // First word is the hi-word, second word is the lo-word.
-        let mut bytes = n.to_le_bytes();
-        bytes.swap(0, 4);
-        bytes.swap(1, 5);
-        bytes.swap(2, 6);
-        bytes.swap(3, 7);
-        self.output.write_all(&bytes)
+        self.write_u64(n.to_bits().rotate_left(32))
     }
 
     pub fn write_action(&mut self, action: &Action) -> Result<()> {


### PR DESCRIPTION
Each function is reduced to just 3 opcodes on x86: https://godbolt.org/z/n6q6zxnh6
WebAssembly benefits as well: https://godbolt.org/z/fcETE9GYn
This should improve load-time performance because `read_f64_me` is used frequently (for each AVM1 double constant).