### PR TITLE
web: Fix and cleanup npm build scripts

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -6,5 +6,8 @@
     "extends": [
         "eslint:recommended",
         "plugin:prettier/recommended"
-    ]
+    ],
+    "rules": {
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+    }
 }

--- a/web/README.md
+++ b/web/README.md
@@ -81,7 +81,7 @@ In this project, you may run the following commands to build all packages:
     -   This will build the wasm binary and every node package (notably selfhosted and extension).
     -   Output will be available in the `dist/` of each package (for example, `./packages/selfhosted/dist`),
         save for the extension which is directory `build/`.
-    -   You may also use `npm run build:avm_debug` to activate the (extremely verbose) actionscript debugging output
+    -   You may also use `npm run build:debug` to disable Webpack optimizations and activate the (extremely verbose) ActionScript debugging output.
 
 From here, you may follow the instructions to [use Ruffle on your website](packages/selfhosted/README.md),
 or run a demo locally with `npm run demo`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
                 "chai-html": "^2.0.1",
                 "chromedriver": "^91.0.1",
                 "copy-webpack-plugin": "^9.0.0",
+                "cross-env": "^7.0.3",
                 "eslint": "^7.29.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-prettier": "^3.4.0",
@@ -4837,6 +4838,24 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
             }
         },
         "node_modules/cross-spawn": {
@@ -18439,6 +18458,15 @@
             "requires": {
                 "crc-32": "^1.2.0",
                 "readable-stream": "^3.4.0"
+            }
+        },
+        "cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^7.0.1"
             }
         },
         "cross-spawn": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
         "chai-html": "^2.0.1",
         "chromedriver": "^91.0.1",
         "copy-webpack-plugin": "^9.0.0",
+        "cross-env": "^7.0.3",
         "eslint": "^7.29.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.4.0",
@@ -34,8 +35,7 @@
     "scripts": {
         "bootstrap": "npm install && lerna bootstrap --hoist",
         "build": "lerna run build --stream",
-        "buildProduction": "lerna run build --stream -- --mode=production",
-        "build:avm_debug": "lerna run build --stream -- -- --env features=avm_debug",
+        "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
         "demo": "lerna run --scope ruffle-demo serve --stream",
         "test": "lerna run test --stream",
         "docs": "lerna run docs --stream",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
-        "build:cargo": "cargo build --release --target wasm32-unknown-unknown",
+        "build:cargo": "cross-env-shell \"cargo build --release --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\"\"",
         "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name ruffle_web",
         "build:wasm-opt": "wasm-opt -o ./pkg/ruffle_web_bg.wasm -O -g ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$GITHUB_ACTIONS\" != true ] # > nul",
@@ -22,7 +22,6 @@
         "@types/mocha": "^8.2.2",
         "@typescript-eslint/eslint-plugin": "^4.28.1",
         "@typescript-eslint/parser": "^4.28.1",
-        "cross-env": "^7.0.3",
         "eslint": "^7.29.0",
         "eslint-plugin-jsdoc": "^35.4.1",
         "mocha": "^9.0.1",

--- a/web/packages/core/src/.eslintrc.json
+++ b/web/packages/core/src/.eslintrc.json
@@ -13,7 +13,7 @@
     ],
     "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_" }],
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
 
         "jsdoc/no-types": "error",
         "jsdoc/require-returns-type": "off",

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -3,12 +3,8 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 
-module.exports = (env, argv) => {
-    let mode = "production";
-    if (argv && argv.mode) {
-        mode = argv.mode;
-    }
-
+module.exports = (_env, _argv) => {
+    const mode = process.env.NODE_ENV || "production";
     console.log(`Building ${mode}...`);
 
     return {

--- a/web/packages/extension/src/.eslintrc.json
+++ b/web/packages/extension/src/.eslintrc.json
@@ -12,6 +12,6 @@
     ],
     "rules": {
         "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_" }]
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
     }
 }

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -37,12 +37,8 @@ function transformManifest(content, env) {
     return JSON.stringify(manifest);
 }
 
-module.exports = (env, argv) => {
-    let mode = "production";
-    if (argv && argv.mode) {
-        mode = argv.mode;
-    }
-
+module.exports = (env, _argv) => {
+    const mode = process.env.NODE_ENV || "production";
     console.log(`Building ${mode}...`);
 
     return {

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -3,12 +3,8 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 
-module.exports = (env, argv) => {
-    let mode = "production";
-    if (argv && argv.mode) {
-        mode = argv.mode;
-    }
-
+module.exports = (_env, _argv) => {
+    const mode = process.env.NODE_ENV || "production";
     console.log(`Building ${mode}...`);
 
     return {


### PR DESCRIPTION
* Remove `buildProduction` as it was equivalent to `build`.
* Fix `build:avm_debug` and change it to `build:debug`, which also disables Webpack optimizations.

Fixes #4480.
Supersedes #4726.