### PR TITLE
avm1: Fix performance regression in `BitmapData::pixels_rgba`

### DIFF
--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -206,10 +206,21 @@ impl BitmapData {
     }
 
     pub fn pixels_rgba(&self) -> Vec<u8> {
-        self.pixels
-            .iter()
-            .flat_map(|p| [p.red(), p.green(), p.blue(), p.alpha()])
-            .collect()
+        // TODO: This could have been implemented as follows:
+        //
+        // self.pixels
+        //     .iter()
+        //     .flat_map(|p| [p.red(), p.green(), p.blue(), p.alpha()])
+        //     .collect()
+        //
+        // But currently Rust emits suboptimal code in that case. For now we use
+        // `Vec::with_capacity` manually to avoid unnecessary re-allocations.
+
+        let mut output = Vec::with_capacity(self.pixels.len() * 4);
+        for p in &self.pixels {
+            output.extend_from_slice(&[p.red(), p.green(), p.blue(), p.alpha()])
+        }
+        output
     }
 
     pub fn width(&self) -> u32 {


### PR DESCRIPTION
It was regressed in #4822 when changed to use `flat_map`. But currently Rust emits suboptimal code for such case. For now use `Vec::with_capacity` manually to avoid unnecessary re-allocations.