### PR TITLE
web: Simplify .wasm loading

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -20,13 +20,7 @@ async function fetchRuffle(): Promise<typeof Ruffle> {
     // libraries, if needed.
     setPolyfillsOnLoad();
 
-    // wasm files are set to be resource assets,
-    // so this import will resolve to the URL of the wasm file.
-    const ruffleWasm = await import(
-        /* webpackMode: "eager" */
-        "../pkg/ruffle_web_bg.wasm"
-    );
-    await init(ruffleWasm.default);
+    await init();
 
     return Ruffle;
 }

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -22,10 +22,6 @@ module.exports = (_env, _argv) => {
                     test: /\.css$/i,
                     use: ["style-loader", "css-loader"],
                 },
-                {
-                    test: /\.wasm$/i,
-                    type: "asset/resource",
-                },
             ],
         },
         devtool: "source-map",

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -62,10 +62,6 @@ module.exports = (env, _argv) => {
                     test: /\.ts$/i,
                     use: "ts-loader",
                 },
-                {
-                    test: /\.wasm$/i,
-                    type: "asset/resource",
-                },
             ],
         },
         resolve: {

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -17,14 +17,6 @@ module.exports = (_env, _argv) => {
             chunkFilename: "core.ruffle.[contenthash].js",
             clean: true,
         },
-        module: {
-            rules: [
-                {
-                    test: /\.wasm$/i,
-                    type: "asset/resource",
-                },
-            ],
-        },
         devtool: "source-map",
         plugins: [
             new CopyPlugin({


### PR DESCRIPTION
Use wasm-bindgen's built-in loader instead of relying on Webpack.
This allows to no longer declare .wasm files as resource assets in each `webpack.config.js`.
Also the bundled JS is a bit smaller (e.g. demo is now ~88KB vs. ~90KB before).