### PR TITLE
Async / Chunked Preloading

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -860,15 +860,7 @@ fn get_bytes_loaded<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let bytes_loaded = if movie_clip.is_root() {
-        movie_clip
-            .movie()
-            .map(|mv| mv.uncompressed_len())
-            .unwrap_or_default()
-    } else {
-        movie_clip.tag_stream_len() as u32
-    };
-    Ok(bytes_loaded.into())
+    Ok(movie_clip.loaded_bytes().into())
 }
 
 fn get_bytes_total<'gc>(
@@ -876,17 +868,7 @@ fn get_bytes_total<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    // For a loaded SWF, returns the uncompressed size of the SWF.
-    // Otherwise, returns the size of the tag list in the clip's DefineSprite tag.
-    let bytes_total = if movie_clip.is_root() {
-        movie_clip
-            .movie()
-            .map(|mv| mv.uncompressed_len())
-            .unwrap_or_default()
-    } else {
-        movie_clip.tag_stream_len() as u32
-    };
-    Ok(bytes_total.into())
+    Ok(movie_clip.total_bytes().into())
 }
 
 fn get_instance_at_depth<'gc>(

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -35,6 +35,8 @@ pub fn instance_init<'gc>(
                 activation.context.gc_context,
             );
 
+            new_do.preload(&mut activation.context, &mut Default::default(), None);
+
             this.init_display_object(activation.context.gc_context, new_do.into());
         }
     }

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -35,8 +35,6 @@ pub fn instance_init<'gc>(
                 activation.context.gc_context,
             );
 
-            new_do.preload(&mut activation.context, &mut Default::default(), None);
-
             this.init_display_object(activation.context.gc_context, new_do.into());
         }
     }

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -286,7 +286,12 @@ impl Iterator for StreamTagReader {
 
         let version = swf_data.version();
         let mut reader = swf::read::Reader::new(&self.swf_data.as_ref()[self.pos..], version);
-        let _ = crate::tag_utils::decode_tags(&mut reader, tag_callback, TagCode::SoundStreamBlock);
+        let _ = crate::tag_utils::decode_tags(
+            &mut reader,
+            tag_callback,
+            TagCode::SoundStreamBlock,
+            None,
+        );
         self.pos = reader.get_ref().as_ptr() as usize - swf_data.as_ref().as_ptr() as usize;
 
         if found {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -190,7 +190,7 @@ pub trait NavigatorBackend {
     /// This seems highly limiting.
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>);
 
-    /// Suspend an asynchronous function until a later time.
+    /// Schedule async code to be executed in the background.
     ///
     /// This is intended to allow async code to yield execution to the event
     /// loop. When the future in question is awaited, other events are allowed
@@ -199,7 +199,7 @@ pub trait NavigatorBackend {
     /// In contexts where Ruffle is not running in an event loop, this future
     /// is permitted to yield it's result immediately instead of suspending the
     /// current task.
-    fn suspend(&self) -> OwnedFuture<(), Infallible>;
+    fn background(&self) -> OwnedFuture<(), Infallible>;
 
     /// Resolve a relative URL.
     ///
@@ -388,7 +388,7 @@ impl NavigatorBackend for NullNavigatorBackend {
         }
     }
 
-    fn suspend(&self) -> OwnedFuture<(), Infallible> {
+    fn background(&self) -> OwnedFuture<(), Infallible> {
         Box::pin(async { Ok(()) })
     }
 

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -273,7 +273,7 @@ impl NullExecutor {
     /// If any task in the executor yields an error, then this function will
     /// stop polling futures and return that error. Otherwise, it will yield
     /// `Ok`, indicating that no errors occurred. More work may still be
-    /// available,
+    /// available, you can check so with `has_work`.
     pub fn poll_all(&mut self) -> Result<(), Error> {
         self.flush_channel();
 

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -4,6 +4,7 @@ use crate::loader::Error;
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::collections::VecDeque;
+use std::convert::Infallible;
 use std::fs;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -188,6 +189,17 @@ pub trait NavigatorBackend {
     /// TODO: For some reason, `wasm_bindgen_futures` wants unpinnable futures.
     /// This seems highly limiting.
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>);
+
+    /// Suspend an asynchronous function until a later time.
+    ///
+    /// This is intended to allow async code to yield execution to the event
+    /// loop. When the future in question is awaited, other events are allowed
+    /// to be processed.
+    ///
+    /// In contexts where Ruffle is not running in an event loop, this future
+    /// is permitted to yield it's result immediately instead of suspending the
+    /// current task.
+    fn suspend(&self) -> OwnedFuture<(), Infallible>;
 
     /// Resolve a relative URL.
     ///
@@ -374,6 +386,10 @@ impl NavigatorBackend for NullNavigatorBackend {
         if let Some(channel) = self.channel.as_ref() {
             channel.send(future).unwrap();
         }
+    }
+
+    fn suspend(&self) -> OwnedFuture<(), Infallible> {
+        Box::pin(async { Ok(()) })
     }
 
     fn resolve_relative_url<'a>(&mut self, url: &'a str) -> Cow<'a, str> {

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -5,7 +5,7 @@ use crate::display_object::{
 use crate::font::Font;
 use gc_arena::Collect;
 
-#[derive(Clone, Collect)]
+#[derive(Clone, Collect, Debug)]
 #[collect(no_drop)]
 pub enum Character<'gc> {
     EditText(EditText<'gc>),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -25,6 +25,7 @@ use crate::display_object::{
 use crate::drawing::Drawing;
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult};
 use crate::font::Font;
+use crate::limits::ExecutionLimit;
 use crate::prelude::*;
 use crate::tag_utils::{self, ControlFlow, DecodeResult, Error, SwfMovie, SwfSlice, SwfStream};
 use crate::types::{Degrees, Percent};
@@ -253,7 +254,7 @@ impl<'gc> MovieClip<'gc> {
         self,
         context: &mut UpdateContext<'_, 'gc, '_>,
         morph_shapes: &mut fnv::FnvHashMap<CharacterId, MorphShapeStatic>,
-        chunk_limit: &mut Option<usize>,
+        chunk_limit: &mut ExecutionLimit,
     ) -> bool {
         use swf::TagCode;
         // TODO: Re-creating static data because preload step occurs after construction.
@@ -272,27 +273,39 @@ impl<'gc> MovieClip<'gc> {
                     .character_by_id(cur_preload_symbol)
                 {
                     Some(Character::MovieClip(mc)) => {
-                        let sub_preload_done = mc.preload(context, morph_shapes, chunk_limit);
-                        if sub_preload_done {
+                        if mc.preload(context, morph_shapes, chunk_limit) {
                             static_data.cur_preload_symbol = None;
                         }
                     }
-                    Some(unk) => log::warn!(
-                        "Symbol {} changed to unexpected type {:?}",
-                        cur_preload_symbol,
-                        unk
-                    ),
-                    None => log::warn!(
-                        "Symbol {} disappeared during preloading",
-                        cur_preload_symbol
-                    ),
+                    Some(unk) => {
+                        log::error!(
+                            "Symbol {} changed to unexpected type {:?}",
+                            cur_preload_symbol,
+                            unk
+                        );
+
+                        static_data.cur_preload_symbol = None;
+                    }
+                    None => {
+                        log::error!(
+                            "Symbol {} disappeared during preloading",
+                            cur_preload_symbol
+                        );
+
+                        static_data.cur_preload_symbol = None;
+                    }
                 }
+            } else {
+                log::error!(
+                    "Attempted to preload symbol {} in movie clip not associated with movie!",
+                    cur_preload_symbol
+                );
             }
         }
 
-        let mut is_finished = false;
+        let mut end_tag_found = false;
 
-        let chunk_exhausted = chunk_limit.map(|v| v == 0).unwrap_or(false);
+        let sub_preload_done = static_data.cur_preload_symbol.is_none();
         let tag_callback = |reader: &mut SwfStream<'_>, tag_code, tag_len| {
             match tag_code {
                 TagCode::CsmTextSettings => self
@@ -519,29 +532,26 @@ impl<'gc> MovieClip<'gc> {
                     )
                 }
                 TagCode::End => {
-                    is_finished = true;
+                    end_tag_found = true;
                     return Ok(ControlFlow::Exit);
                 }
                 _ => Ok(()),
             }?;
 
-            if let Some(chunk_limit) = chunk_limit {
-                *chunk_limit -= 1;
-
-                if *chunk_limit == 0 {
-                    return Ok(ControlFlow::Exit);
-                }
+            // Each preloaded byte is treated as an action.
+            if chunk_limit.did_actions_breach_limit(context, tag_len) {
+                return Ok(ControlFlow::Exit);
             }
 
             Ok(ControlFlow::Continue)
         };
 
-        let result = if !chunk_exhausted {
+        let result = if sub_preload_done {
             tag_utils::decode_tags(&mut reader, tag_callback)
         } else {
             Ok(true)
         };
-        let is_finished = is_finished || result.is_err() || !result.unwrap();
+        let is_finished = end_tag_found || result.is_err() || !result.unwrap();
 
         // These variables will be persisted to be picked back up in the next
         // chunk.
@@ -3103,7 +3113,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         reader: &mut SwfStream<'a>,
         tag_len: usize,
         morph_shapes: &mut fnv::FnvHashMap<CharacterId, MorphShapeStatic>,
-        chunk_limit: &mut Option<usize>,
+        chunk_limit: &mut ExecutionLimit,
         static_data: &mut MovieClipStatic,
     ) -> DecodeResult {
         let id = reader.read_character_id()?;
@@ -3128,27 +3138,20 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .library_for_movie_mut(self.movie())
             .register_character(id, Character::MovieClip(movie_clip));
 
-        if let Some(chunk_limit) = chunk_limit {
-            *chunk_limit -= 1;
-            static_data.cur_preload_symbol = Some(id);
+        static_data.cur_preload_symbol = Some(id);
 
-            if *chunk_limit == 0 {
-                return Ok(ControlFlow::Exit);
-            }
+        let should_exit = chunk_limit.did_actions_breach_limit(context, 4);
+        if should_exit {
+            return Ok(ControlFlow::Exit);
         }
 
-        let preload_done = movie_clip.preload(context, morph_shapes, chunk_limit);
-        if preload_done {
+        if movie_clip.preload(context, morph_shapes, chunk_limit) {
             static_data.cur_preload_symbol = None;
-        }
 
-        if let Some(chunk_limit) = chunk_limit {
-            if *chunk_limit == 0 {
-                return Ok(ControlFlow::Exit);
-            }
+            Ok(ControlFlow::Continue)
+        } else {
+            Ok(ControlFlow::Exit)
         }
-
-        Ok(ControlFlow::Continue)
     }
 
     #[inline]

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -995,6 +995,25 @@ impl<'gc> MovieClip<'gc> {
             .saturating_sub(1)
     }
 
+    pub fn total_bytes(self) -> u32 {
+        // For a loaded SWF, returns the uncompressed size of the SWF.
+        // Otherwise, returns the size of the tag list in the clip's DefineSprite tag.
+        if self.is_root() {
+            self.movie()
+                .map(|mv| mv.uncompressed_len())
+                .unwrap_or_default()
+        } else {
+            self.tag_stream_len() as u32
+        }
+    }
+
+    pub fn loaded_bytes(self) -> u32 {
+        let read = self.0.read();
+        let swf_header_size = self.total_bytes() - self.tag_stream_len() as u32;
+
+        swf_header_size + read.static_data.next_preload_chunk as u32
+    }
+
     pub fn set_avm2_class(
         self,
         gc_context: MutationContext<'gc, '_>,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2979,7 +2979,10 @@ impl<'gc, 'a> MovieClipData<'gc> {
             num_frames,
         );
 
-        movie_clip.preload(context, morph_shapes);
+        let mut is_finished = false;
+        while !is_finished {
+            is_finished = movie_clip.preload(context, morph_shapes);
+        }
 
         context
             .library

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -952,7 +952,11 @@ impl<'gc> MovieClip<'gc> {
     }
 
     pub fn frames_loaded(self) -> FrameNumber {
-        self.0.read().static_data.cur_preload_frame
+        self.0
+            .read()
+            .static_data
+            .cur_preload_frame
+            .saturating_sub(1)
     }
 
     pub fn set_avm2_class(

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -504,7 +504,8 @@ impl<'gc> MovieClip<'gc> {
 
             Ok(ControlFlow::Continue)
         };
-        let _ = tag_utils::decode_tags(&mut reader, tag_callback);
+        let result = tag_utils::decode_tags(&mut reader, tag_callback);
+        let is_finished = is_finished || result.is_err() || !result.unwrap();
 
         // These variables will be persisted to be picked back up in the next
         // chunk.
@@ -520,6 +521,9 @@ impl<'gc> MovieClip<'gc> {
                     static_data.audio_stream_handle = Some(sound);
                 }
             }
+
+            //Flag the movie as fully preloaded.
+            static_data.cur_preload_frame = static_data.total_frames + 1;
         }
 
         self.0.write(context.gc_context).static_data =

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3453,8 +3453,21 @@ struct MovieClipStatic {
 }
 
 impl MovieClipStatic {
+    /// Construct static data for an empty movie clip.
+    ///
+    /// The associated `swf` may either be an empty movie or a 0-length slice
+    /// of a valid movie. In either case, you will get back static data
+    /// corresponding to a movieclip with a character ID of zero, one valid
+    /// frame, and one loaded frame.
+    ///
+    /// You should not preload any movie clips associated with the static data
+    /// returned by this function.
     fn empty(swf: SwfSlice) -> Self {
-        Self::with_data(0, swf, 1)
+        let mut s = Self::with_data(0, swf, 1);
+
+        s.cur_preload_frame = s.total_frames + 1;
+
+        s
     }
 
     fn with_data(id: CharacterId, swf: SwfSlice, total_frames: FrameNumber) -> Self {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod focus_tracker;
 mod font;
 mod html;
 mod library;
+mod limits;
 pub mod loader;
 pub mod matrix;
 mod player;

--- a/core/src/limits.rs
+++ b/core/src/limits.rs
@@ -65,10 +65,10 @@ impl ExecutionLimit {
         context: &mut UpdateContext<'_, '_, '_>,
         actions: usize,
     ) -> bool {
-        if let Some(mut action_limit) = self.current_action_limit {
-            action_limit = action_limit.saturating_sub(actions);
+        if let Some(ref mut action_limit) = self.current_action_limit {
+            *action_limit = action_limit.saturating_sub(actions);
 
-            if action_limit == 0 {
+            if *action_limit == 0 {
                 if context.update_start.elapsed() >= self.time_limit {
                     return true;
                 }

--- a/core/src/limits.rs
+++ b/core/src/limits.rs
@@ -1,0 +1,94 @@
+use crate::context::UpdateContext;
+use std::time::Duration;
+
+/// Indication of how long execution is allowed to take.
+///
+/// Execution is limited by two mechanisms:
+///
+/// 1. An *action limit*, which is a certain number of *actions* that can be
+///    taken before checking...
+/// 2. A *time limit*, which is checked every time the action limit runs out.
+///    If it has not yet expired, then the action limit is refreshed.
+///
+/// This two-tiered system is intended to reduce the overhead of enforcing
+/// execution limits.
+///
+/// What constitutes an "action" is up to the user of this structure. It may
+/// cover individual interpreter opcodes, bytes decoded in a data stream, or so
+/// on.
+pub struct ExecutionLimit {
+    /// How many actions remain before the next timelimit check.
+    ///
+    /// If `None`, then the execution limit is not enforced.
+    current_action_limit: Option<usize>,
+
+    /// The number of actions allowed between timelimit checks.
+    ///
+    /// If `None`, then the execution limit is not enforced.
+    max_actions_per_check: Option<usize>,
+
+    /// The amount of time allowed to be taken regardless of the action count.
+    time_limit: Duration,
+}
+
+impl ExecutionLimit {
+    /// Construct an execution limit that allows unlimited execution.
+    pub fn none() -> ExecutionLimit {
+        Self {
+            current_action_limit: None,
+            max_actions_per_check: None,
+            time_limit: Duration::MAX,
+        }
+    }
+
+    /// Construct an execution limit that checks the current wall-clock time
+    /// after a certain number of actions are taken.
+    pub fn with_max_actions_and_time(actions: usize, time_limit: Duration) -> ExecutionLimit {
+        Self {
+            current_action_limit: Some(actions),
+            max_actions_per_check: Some(actions),
+            time_limit,
+        }
+    }
+
+    /// Check if the execution of a certain number of actions has exceeded the
+    /// execution limit.
+    ///
+    /// This is intended to be called after the given actions have been
+    /// executed. The actions will be deducted from the action limit and, if
+    /// that limit is zero, the time limit will be checked. If both limits have
+    /// been breached, this returns `true`. Otherwise, this returns `false`,
+    /// and if the action limit was exhausted, it will be returned to the
+    /// starting maximum.
+    pub fn did_actions_breach_limit(
+        &mut self,
+        context: &mut UpdateContext<'_, '_, '_>,
+        actions: usize,
+    ) -> bool {
+        if let Some(mut action_limit) = self.current_action_limit {
+            action_limit = action_limit.saturating_sub(actions);
+
+            if action_limit == 0 {
+                if context.update_start.elapsed() >= self.time_limit {
+                    return true;
+                }
+
+                self.current_action_limit = self.max_actions_per_check;
+            }
+        }
+
+        false
+    }
+
+    /// Determine if the execution limit was exhausted without deducting any
+    /// actions.
+    pub fn is_exhausted(&mut self, context: &mut UpdateContext<'_, '_, '_>) -> bool {
+        if let Some(action_limit) = self.current_action_limit {
+            if action_limit == 0 && context.update_start.elapsed() >= self.time_limit {
+                return true;
+            }
+        }
+
+        false
+    }
+}

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -426,13 +426,14 @@ impl<'gc> Loader<'gc> {
                             .as_movie_clip()
                             .expect("Attempted to load movie into not movie clip");
 
+                        //Time limit is 75% of the frame time of the current movie.
+                        let frame_time =
+                            Duration::from_nanos((750_000_000.0 / *uc.frame_rate) as u64);
+
                         preload_done = mc.preload(
                             uc,
                             &mut morph_shapes,
-                            &mut ExecutionLimit::with_max_actions_and_time(
-                                10000,
-                                Duration::from_millis(5),
-                            ),
+                            &mut ExecutionLimit::with_max_actions_and_time(10000, frame_time),
                         );
                         background = Some(uc.navigator.background());
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -429,7 +429,10 @@ impl<'gc> Loader<'gc> {
                         preload_done = mc.preload(
                             uc,
                             &mut morph_shapes,
-                            &mut ExecutionLimit::with_max_actions_and_time(1, Duration::ZERO),
+                            &mut ExecutionLimit::with_max_actions_and_time(
+                                10000,
+                                Duration::from_millis(5),
+                            ),
                         );
                         suspender = Some(uc.navigator.suspend());
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -6,6 +6,7 @@ use crate::avm2::{Activation as Avm2Activation, Domain as Avm2Domain};
 use crate::backend::navigator::OwnedFuture;
 use crate::context::{ActionQueue, ActionType};
 use crate::display_object::{DisplayObject, MorphShape, TDisplayObject};
+use crate::limits::ExecutionLimit;
 use crate::player::{Player, NEWEST_PLAYER_VERSION};
 use crate::tag_utils::SwfMovie;
 use crate::vminterface::Instantiator;
@@ -15,6 +16,7 @@ use gc_arena::{Collect, CollectionContext};
 use generational_arena::{Arena, Index};
 use std::string::FromUtf8Error;
 use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
 use thiserror::Error;
 use url::form_urlencoded;
 
@@ -424,7 +426,11 @@ impl<'gc> Loader<'gc> {
                             .as_movie_clip()
                             .expect("Attempted to load movie into not movie clip");
 
-                        preload_done = mc.preload(uc, &mut morph_shapes, &mut Some(1));
+                        preload_done = mc.preload(
+                            uc,
+                            &mut morph_shapes,
+                            &mut ExecutionLimit::with_max_actions_and_time(1, Duration::ZERO),
+                        );
                         suspender = Some(uc.navigator.suspend());
 
                         Ok(())

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -538,6 +538,7 @@ impl<'gc> Loader<'gc> {
 
                 let mut preload_done = false;
                 let mut morph_shapes = fnv::FnvHashMap::default();
+                let mut suspender = None;
 
                 while !preload_done {
                     player
@@ -555,9 +556,14 @@ impl<'gc> Loader<'gc> {
                                 .expect("Attempted to load movie into not movie clip");
 
                             preload_done = mc.preload(uc, &mut morph_shapes, Some(1));
+                            suspender = Some(uc.navigator.suspend());
 
                             Ok(())
                         })?;
+
+                    if let Some(suspender) = suspender.take() {
+                        suspender.await.unwrap();
+                    }
                 }
 
                 player

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -408,7 +408,7 @@ impl<'gc> Loader<'gc> {
         Box::pin(async move {
             let mut preload_done = false;
             let mut morph_shapes = fnv::FnvHashMap::default();
-            let mut suspender = None;
+            let mut background = None;
 
             while !preload_done {
                 player
@@ -434,13 +434,13 @@ impl<'gc> Loader<'gc> {
                                 Duration::from_millis(5),
                             ),
                         );
-                        suspender = Some(uc.navigator.suspend());
+                        background = Some(uc.navigator.background());
 
                         Ok(())
                     })?;
 
-                if let Some(suspender) = suspender.take() {
-                    suspender.await.unwrap();
+                if let Some(background) = background.take() {
+                    background.await.unwrap();
                 }
             }
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -424,7 +424,7 @@ impl<'gc> Loader<'gc> {
                             .as_movie_clip()
                             .expect("Attempted to load movie into not movie clip");
 
-                        preload_done = mc.preload(uc, &mut morph_shapes, Some(1));
+                        preload_done = mc.preload(uc, &mut morph_shapes, &mut Some(1));
                         suspender = Some(uc.navigator.suspend());
 
                         Ok(())

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1150,9 +1150,14 @@ impl Player {
         self.mutate_with_update_context(|context| {
             let mut morph_shapes = fnv::FnvHashMap::default();
             let root = context.stage.root_clip();
-            root.as_movie_clip()
-                .unwrap()
-                .preload(context, &mut morph_shapes);
+            let mut preload_done = false;
+
+            while !preload_done {
+                preload_done = root
+                    .as_movie_clip()
+                    .unwrap()
+                    .preload(context, &mut morph_shapes);
+            }
 
             let lib = context
                 .library

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1150,13 +1150,13 @@ impl Player {
         self.mutate_with_update_context(|context| {
             let mut morph_shapes = fnv::FnvHashMap::default();
             let root = context.stage.root_clip();
-            let mut preload_done = false;
-
-            while !preload_done {
-                preload_done = root
-                    .as_movie_clip()
+            let preload_done =
+                root.as_movie_clip()
                     .unwrap()
-                    .preload(context, &mut morph_shapes);
+                    .preload(context, &mut morph_shapes, None);
+
+            if !preload_done {
+                log::warn!("Preloading of root clip did not complete in a single call.");
             }
 
             let lib = context

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -5,8 +5,17 @@ use std::path::Path;
 use std::sync::Arc;
 use swf::{Fixed8, HeaderExt, Rectangle, TagCode, Twips};
 
+/// Whether or not to end tag decoding.
+pub enum ControlFlow {
+    /// Stop decoding after this tag.
+    Exit,
+
+    /// Continue decoding the next tag.
+    Continue,
+}
+
 pub type Error = Box<dyn std::error::Error>;
-pub type DecodeResult = Result<(), Error>;
+pub type DecodeResult = Result<ControlFlow, Error>;
 pub type SwfStream<'a> = swf::read::Reader<'a>;
 
 /// An open, fully parsed SWF movie ready to play back, either in a Player or a
@@ -319,34 +328,19 @@ impl SwfSlice {
 ///
 /// Decoding will terminate when the following conditions occur:
 ///
-///  * After the given `stop_tag` is encountered and passed to the callback
+///  * The `tag_callback` calls for the decoding to finish.
 ///  * The decoder encounters a tag longer than the underlying SWF slice
-///  * The decoder decodes more than `chunk_limit` tags (if provided), in which
-///    case this function also returns `false`
 ///  * The SWF stream is otherwise corrupt or unreadable (indicated as an error
 ///    result)
 ///
 /// Decoding will also log tags longer than the SWF slice, error messages
 /// yielded from the tag callback, and unknown tags. It will *only* return an
-/// error message if the SWF tag itself could not be parsed. Otherwise, it
-/// returns `true` if decoding progressed to the stop tag or EOF, or `false` if
-/// the chunk limit was reached.
-pub fn decode_tags<'a, F>(
-    reader: &mut SwfStream<'a>,
-    mut tag_callback: F,
-    stop_tag: TagCode,
-    mut chunk_limit: Option<usize>,
-) -> Result<bool, Error>
+/// error message if the SWF tag itself could not be parsed.
+pub fn decode_tags<'a, F>(reader: &mut SwfStream<'a>, mut tag_callback: F) -> Result<(), Error>
 where
-    F: for<'b> FnMut(&'b mut SwfStream<'a>, TagCode, usize) -> DecodeResult,
+    F: for<'b> FnMut(&'b mut SwfStream<'a>, TagCode, usize) -> Result<ControlFlow, Error>,
 {
     loop {
-        if let Some(chunk_limit) = chunk_limit {
-            if chunk_limit < 1 {
-                return Ok(false);
-            }
-        }
-
         let (tag_code, tag_len) = reader.read_tag_code_and_length()?;
         if tag_len > reader.get_ref().len() {
             log::error!("Unexpected EOF when reading tag");
@@ -360,24 +354,22 @@ where
             *reader.get_mut() = tag_slice;
             let result = tag_callback(reader, tag, tag_len);
 
-            if let Err(e) = result {
-                log::error!("Error running definition tag: {:?}, got {}", tag, e);
-            }
-
-            if stop_tag == tag {
-                *reader.get_mut() = end_slice;
-                break;
+            match result {
+                Err(e) => {
+                    log::error!("Error running definition tag: {:?}, got {}", tag, e)
+                }
+                Ok(ControlFlow::Exit) => {
+                    *reader.get_mut() = end_slice;
+                    break;
+                }
+                Ok(ControlFlow::Continue) => {}
             }
         } else {
             log::warn!("Unknown tag code: {:?}", tag_code);
         }
 
         *reader.get_mut() = end_slice;
-
-        if let Some(ref mut chunk_limit) = chunk_limit {
-            *chunk_limit -= 1;
-        }
     }
 
-    Ok(true)
+    Ok(())
 }

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -330,13 +330,15 @@ impl SwfSlice {
 ///
 ///  * The `tag_callback` calls for the decoding to finish.
 ///  * The decoder encounters a tag longer than the underlying SWF slice
+///    (indicated by returning false)
 ///  * The SWF stream is otherwise corrupt or unreadable (indicated as an error
 ///    result)
 ///
 /// Decoding will also log tags longer than the SWF slice, error messages
 /// yielded from the tag callback, and unknown tags. It will *only* return an
-/// error message if the SWF tag itself could not be parsed.
-pub fn decode_tags<'a, F>(reader: &mut SwfStream<'a>, mut tag_callback: F) -> Result<(), Error>
+/// error message if the SWF tag itself could not be parsed. Other forms of
+/// irregular decoding will be signalled by returning false.
+pub fn decode_tags<'a, F>(reader: &mut SwfStream<'a>, mut tag_callback: F) -> Result<bool, Error>
 where
     F: for<'b> FnMut(&'b mut SwfStream<'a>, TagCode, usize) -> Result<ControlFlow, Error>,
 {
@@ -345,7 +347,7 @@ where
         if tag_len > reader.get_ref().len() {
             log::error!("Unexpected EOF when reading tag");
             *reader.get_mut() = &reader.get_ref()[reader.get_ref().len()..];
-            break;
+            return Ok(false);
         }
 
         let tag_slice = &reader.get_ref()[..tag_len];
@@ -371,5 +373,5 @@ where
         *reader.get_mut() = end_slice;
     }
 
-    Ok(())
+    Ok(true)
 }

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -310,15 +310,43 @@ impl SwfSlice {
     }
 }
 
+/// Decode tags from a SWF stream reader.
+///
+/// The given `tag_callback` will be called for each decoded tag. It will be
+/// provided with the stream to read from, the tag code read, and the tag's
+/// size. The callback is responsible for (optionally) parsing the contents of
+/// the tag; otherwise, it will be skipped.
+///
+/// Decoding will terminate when the following conditions occur:
+///
+///  * After the given `stop_tag` is encountered and passed to the callback
+///  * The decoder encounters a tag longer than the underlying SWF slice
+///  * The decoder decodes more than `chunk_limit` tags (if provided), in which
+///    case this function also returns `false`
+///  * The SWF stream is otherwise corrupt or unreadable (indicated as an error
+///    result)
+///
+/// Decoding will also log tags longer than the SWF slice, error messages
+/// yielded from the tag callback, and unknown tags. It will *only* return an
+/// error message if the SWF tag itself could not be parsed. Otherwise, it
+/// returns `true` if decoding progressed to the stop tag or EOF, or `false` if
+/// the chunk limit was reached.
 pub fn decode_tags<'a, F>(
     reader: &mut SwfStream<'a>,
     mut tag_callback: F,
     stop_tag: TagCode,
-) -> Result<(), Error>
+    mut chunk_limit: Option<usize>,
+) -> Result<bool, Error>
 where
     F: for<'b> FnMut(&'b mut SwfStream<'a>, TagCode, usize) -> DecodeResult,
 {
     loop {
+        if let Some(chunk_limit) = chunk_limit {
+            if chunk_limit < 1 {
+                return Ok(false);
+            }
+        }
+
         let (tag_code, tag_len) = reader.read_tag_code_and_length()?;
         if tag_len > reader.get_ref().len() {
             log::error!("Unexpected EOF when reading tag");
@@ -345,7 +373,11 @@ where
         }
 
         *reader.get_mut() = end_slice;
+
+        if let Some(ref mut chunk_limit) = chunk_limit {
+            *chunk_limit -= 1;
+        }
     }
 
-    Ok(())
+    Ok(true)
 }

--- a/desktop/src/executor.rs
+++ b/desktop/src/executor.rs
@@ -1,7 +1,7 @@
 //! Async executor
 
 use crate::custom_event::RuffleEvent;
-use crate::navigator::SuspendFutureState;
+use crate::navigator::BackgroundTaskHandle;
 use crate::task::Task;
 use generational_arena::{Arena, Index};
 use ruffle_core::backend::navigator::OwnedFuture;
@@ -222,7 +222,7 @@ impl GlutinAsyncExecutor {
 /// Event source for the event loop ending.
 pub struct GlutinSuspendSource {
     /// Source of tasks sent to us by the `NavigatorBackend`.
-    channel: Receiver<(Waker, Arc<Mutex<SuspendFutureState>>)>,
+    channel: Receiver<BackgroundTaskHandle>,
 }
 
 impl GlutinSuspendSource {
@@ -230,10 +230,7 @@ impl GlutinSuspendSource {
     ///
     /// This function returns the executor itself, plus the `Sender` that you
     /// queue wakers on in order for them to be unsuspended.
-    pub fn new() -> (
-        Arc<Mutex<Self>>,
-        Sender<(Waker, Arc<Mutex<SuspendFutureState>>)>,
-    ) {
+    pub fn new() -> (Arc<Mutex<Self>>, Sender<BackgroundTaskHandle>) {
         let (send, recv) = channel();
         let new_self = Arc::new(Mutex::new(Self { channel: recv }));
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -393,11 +393,6 @@ impl App {
                         _ => (),
                     }
 
-                    suspender
-                        .lock()
-                        .expect("Unlocked suspender")
-                        .unsuspend_tasks();
-
                     if movie.is_none() {
                         return;
                     }
@@ -424,6 +419,14 @@ impl App {
                             if !minimized {
                                 player.lock().unwrap().render();
                             }
+                        }
+
+                        // Schedule background tasks
+                        winit::event::Event::RedrawEventsCleared => {
+                            suspender
+                                .lock()
+                                .expect("Unlocked suspender")
+                                .unsuspend_tasks();
                         }
 
                         winit::event::Event::WindowEvent { event, .. } => match event {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -989,6 +989,8 @@ fn run_swf(
 
     before_start(player.clone())?;
 
+    executor.block_all().unwrap();
+
     for _ in 0..num_frames {
         player.lock().unwrap().run_frame();
         player.lock().unwrap().update_timers(frame_time);

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -18,25 +18,25 @@ use wasm_bindgen::{closure::Closure, JsCast};
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 use web_sys::{window, Blob, BlobPropertyBag, Performance, Request, RequestInit, Response};
 
-/// The internal shared state of a single SuspendFuture.
-struct SuspendFutureState {
+/// The internal shared state of a single BackgroundFuture.
+struct BackgroundFutureState {
     /// Whether or not the macrotask was already resolved.
     macrotask_resolved: bool,
 }
 
 /// A future that suspends it's awaited task on the JavaScript macrotask queue.
-pub struct SuspendFuture(Arc<Mutex<SuspendFutureState>>);
+pub struct BackgroundFuture(Arc<Mutex<BackgroundFutureState>>);
 
-impl SuspendFuture {
+impl BackgroundFuture {
     #[allow(clippy::new_ret_no_self)]
     fn new() -> OwnedFuture<(), Infallible> {
-        Box::pin(Self(Arc::new(Mutex::new(SuspendFutureState {
+        Box::pin(Self(Arc::new(Mutex::new(BackgroundFutureState {
             macrotask_resolved: false,
         }))))
     }
 }
 
-impl Future for SuspendFuture {
+impl Future for BackgroundFuture {
     type Output = Result<(), Infallible>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -257,8 +257,8 @@ impl NavigatorBackend for WebNavigatorBackend {
         })
     }
 
-    fn suspend(&self) -> OwnedFuture<(), Infallible> {
-        SuspendFuture::new()
+    fn background(&self) -> OwnedFuture<(), Infallible> {
+        BackgroundFuture::new()
     }
 
     fn resolve_relative_url<'a>(&mut self, url: &'a str) -> Cow<'a, str> {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108736/126855254-b6267a91-45c3-4902-b6a5-299fee539ea0.png)

This PR implements an asynchronous version of the preload step of Ruffle's movie clip lifecycle. This allows very complicated SWFs to load, remain interactive, and _not_ bottleneck the player as they are loading.

- [x] Background task suspension - this allows us to run the preload step in an async task and yield time back to the interactive event loop
- [x] Partial preloading (based on a tag count) on the root movie clip
- [x] Transition all movie loading paths (script-initiated, initial fetched, and initial provided) to async preload
- [x] Block movie playback on the preload step (frame granularity)
- [x] Partial preloading on movie clips defined in `DefineSprite` tags
- [x] Use execution time rather than tag count to determine when to suspend and resume preloading
- [x] Propagate `preload` step status to movie preloaders
- [x] Figure out how [S] Cascade's preloader works