### PR TITLE
Revert "web: Simplify .wasm loading"

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -20,7 +20,13 @@ async function fetchRuffle(): Promise<typeof Ruffle> {
     // libraries, if needed.
     setPolyfillsOnLoad();
 
-    await init();
+    // wasm files are set to be resource assets,
+    // so this import will resolve to the URL of the wasm file.
+    const ruffleWasm = await import(
+        /* webpackMode: "eager" */
+        "../pkg/ruffle_web_bg.wasm"
+    );
+    await init(ruffleWasm.default);
 
     return Ruffle;
 }

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -22,6 +22,10 @@ module.exports = (_env, _argv) => {
                     test: /\.css$/i,
                     use: ["style-loader", "css-loader"],
                 },
+                {
+                    test: /\.wasm$/i,
+                    type: "asset/resource",
+                },
             ],
         },
         devtool: "source-map",

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -62,6 +62,10 @@ module.exports = (env, _argv) => {
                     test: /\.ts$/i,
                     use: "ts-loader",
                 },
+                {
+                    test: /\.wasm$/i,
+                    type: "asset/resource",
+                },
             ],
         },
         resolve: {

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -17,6 +17,14 @@ module.exports = (_env, _argv) => {
             chunkFilename: "core.ruffle.[contenthash].js",
             clean: true,
         },
+        module: {
+            rules: [
+                {
+                    test: /\.wasm$/i,
+                    type: "asset/resource",
+                },
+            ],
+        },
         devtool: "source-map",
         plugins: [
             new CopyPlugin({


### PR DESCRIPTION
This reverts commit 66bfff7687e4885eb6b0a9699b06ce806a3ba579.

Reason: It stops using `publicPath` for the .wasm location, and instead assumes the .wasm is always in the same directory as the .js. But from some reason ridesims.com fetches the .js manually and injects a <script> tag with the source code inline, so the .js doesn't know its origin URL.