### PR TITLE
docs: Fix CONTRIBUTING.md table of contents link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ This document serves as a general guide for contributing to Ruffle. Follow your 
  * [Reporting Bugs](#reporting-bugs)
  * [Debugging ActionScript Content](#debugging-actionscript-content)
  * [Code Guidelines](#code-guidelines)
- * [Commit Message Guidelines](#commit-guidelines)
+ * [Commit Message Guidelines](#commit-message-guidelines)
  * [Pull Requests](#pull-requests)
 
 ## Getting Started


### PR DESCRIPTION
This corrects the link to the *Commit Message Guidelines* section in the `CONTRIBUTING.md` file

Sorry in advance if I've done anything wrong, this is my first time opening a PR for this project, found this minor mistake while reading through the doc.