### PR TITLE
fix: remove the version requirement for mesa drivers

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -38,7 +38,7 @@ jobs:
           sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt-get update
           sudo apt-get dist-upgrade
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev mesa-vulkan-drivers=21.1.5~kisak1~f
+          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Run tests with image tests
         if: ${{ matrix.os.img_tests }}


### PR DESCRIPTION
The [kisak-mesa PPA](https://launchpad.net/~kisak/+archive/ubuntu/kisak-mesa) removes older versions of the `mesa-drivers` package, so installing an exact version fails in the CI.

Remove the version requirement so this doesn't happen.

I also considered limiting to something more general: 21.1 or 21, say. I think given the state of the repository those will eventually fail as well, so it's better to leave it at the edge and keep going, updating the code if any breaking changes occur.