### PR TITLE
core: Fix autosize when wordwrap is true (Fix part of #1095)

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -839,6 +839,9 @@ impl<'gc> EditText<'gc> {
             AutoSizeMode::Left => {
                 if !is_word_wrap {
                     edit_text.bounds.set_width(intrinsic_bounds.width());
+                } else {
+                    let orig_bounds = edit_text.static_data.text.bounds.clone();
+                    edit_text.bounds.set_width(orig_bounds.x_max);
                 }
 
                 edit_text.bounds.set_height(intrinsic_bounds.height());
@@ -853,6 +856,9 @@ impl<'gc> EditText<'gc> {
                         .bounds
                         .set_x(center - intrinsic_bounds.width() / 2);
                     edit_text.bounds.set_width(intrinsic_bounds.width());
+                } else {
+                    let orig_bounds = edit_text.static_data.text.bounds.clone();
+                    edit_text.bounds.set_width(orig_bounds.x_max);
                 }
 
                 edit_text.bounds.set_height(intrinsic_bounds.height());
@@ -865,6 +871,9 @@ impl<'gc> EditText<'gc> {
                     let new_x = edit_text.bounds.x_max - intrinsic_bounds.width();
                     edit_text.bounds.set_x(new_x);
                     edit_text.bounds.set_width(intrinsic_bounds.width());
+                } else {
+                    let orig_bounds = edit_text.static_data.text.bounds.clone();
+                    edit_text.bounds.set_width(orig_bounds.x_max);
                 }
 
                 edit_text.bounds.set_height(intrinsic_bounds.height());


### PR DESCRIPTION
This should fix the sonny hover text issue. Since relayout sets the bounds width if wordwrap is false, it needs to reset it to the default width if it's true.

There are still some font and layout issues (text is not bold or bounding borders are not the same, so this is not a complete fix.