### PR TITLE
web: Re-enable context menu on mobile, with option to disable

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -126,6 +126,8 @@ export class RufflePlayer extends HTMLElement {
     // Whether this device is a touch device.
     // Set to true when a touch event is encountered.
     private isTouch = false;
+    // Whether the user chose to hide the context menu.
+    private hiddenContextMenu = false;
 
     private swfUrl?: string;
     private instance: Ruffle | null;
@@ -661,8 +663,15 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
+    /**
+     * Makes the context menu hidden so long clicks can be used for other purposes.
+     */
+    setContextMenuHidden(): void {
+        this.hiddenContextMenu = true;
+    }
+
     private pointerDown(event: PointerEvent): void {
-        // Disable context menu when touch support is being used
+        // Give option to disable context menu when touch support is being used
         // to avoid a long press triggering the context menu. (#1972)
         if (event.pointerType === "touch" || event.pointerType === "pen") {
             this.isTouch = true;
@@ -712,13 +721,20 @@ export class RufflePlayer extends HTMLElement {
                 window.open(RUFFLE_ORIGIN, "_blank");
             },
         });
+        if (this.isTouch) {
+            items.push(null);
+            items.push({
+                text: "Hide this menu",
+                onClick: this.setContextMenuHidden.bind(this),
+            });
+        }
         return items;
     }
 
     private showContextMenu(e: MouseEvent): void {
         e.preventDefault();
 
-        if (!this.hasContextMenu || this.isTouch) {
+        if (!this.hasContextMenu || this.hiddenContextMenu) {
             return;
         }
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -122,12 +122,12 @@ export class RufflePlayer extends HTMLElement {
     // so avoid shadowing it.
     private contextMenuElement: HTMLElement;
     private hasContextMenu = false;
+    // Allows the user to permanently disable the context menu.
+    private contextMenuForceDisabled = false;
 
     // Whether this device is a touch device.
     // Set to true when a touch event is encountered.
     private isTouch = false;
-    // Whether the user chose to hide the context menu.
-    private hiddenContextMenu = false;
 
     private swfUrl?: string;
     private instance: Ruffle | null;
@@ -663,13 +663,6 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
-    /**
-     * Makes the context menu hidden so long clicks can be used for other purposes.
-     */
-    setContextMenuHidden(): void {
-        this.hiddenContextMenu = true;
-    }
-
     private pointerDown(event: PointerEvent): void {
         // Give option to disable context menu when touch support is being used
         // to avoid a long press triggering the context menu. (#1972)
@@ -725,7 +718,7 @@ export class RufflePlayer extends HTMLElement {
             items.push(null);
             items.push({
                 text: "Hide this menu",
-                onClick: this.setContextMenuHidden.bind(this),
+                onClick: () => (this.contextMenuForceDisabled = true),
             });
         }
         return items;
@@ -734,7 +727,7 @@ export class RufflePlayer extends HTMLElement {
     private showContextMenu(e: MouseEvent): void {
         e.preventDefault();
 
-        if (!this.hasContextMenu || this.hiddenContextMenu) {
+        if (!this.hasContextMenu || this.contextMenuForceDisabled) {
             return;
         }
 


### PR DESCRIPTION
Fix #4980, while still keeping in mind the intention of #3967. Tested with the helicopter game (#1972). After a quick appearance of the menu, it is simple enough to click "Hide this menu", and then the game functions fine from then on.

Note: There is no way, currently, to re-enable the context menu after disabling it. The one way I could think of was appending a small div with an "Enable context menu" button above a corner of the ruffle player after disabling the context menu, but that would have potentially obscured controls or text or graphics. However, I still think this is better than hiding the context menu altogether on mobile devices, as it is useful (especially the full screen option) more often than not.