### PR TITLE
core: Reset mouse visible when loading movie to root (Fixes #4358)

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -400,6 +400,7 @@ impl Player {
                 .library
                 .library_for_movie_mut(context.swf.clone())
                 .set_avm2_domain(domain);
+            context.ui.set_mouse_visible(true);
 
             let root: DisplayObject =
                 MovieClip::from_movie(context.gc_context, context.swf.clone()).into();


### PR DESCRIPTION
Seems like a main swf is doing loadMovie on another swf. The second swf calls mouse.hide(), runs, and runs loadMovie on the original to _root without calling mouse.show().
I assume that when a movie is reloaded to root it should reset whether the mouse is visible.
I'd like an opinion of whether my assumption and the placement of the assignment are correct.