### PR TITLE
web: Link all CompileErrors to wiki without a report bug button

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -397,20 +397,14 @@ export class RufflePlayer extends HTMLElement {
                     e.ruffleIndexError = PanicError.WasmCors;
                 } else if (message.includes("disallowed by embedder")) {
                     e.ruffleIndexError = PanicError.CSPConflict;
-                } else if (
-                    message.includes("webassembly.instantiate") &&
-                    e.name === "CompileError"
-                ) {
+                } else if (e.name === "CompileError") {
                     e.ruffleIndexError = PanicError.InvalidWasm;
                 } else if (
                     message.includes("could not download wasm module") &&
                     e.name === "TypeError"
                 ) {
                     e.ruffleIndexError = PanicError.WasmDownload;
-                } else if (
-                    !message.includes("magic") &&
-                    (e.name === "CompileError" || e.name === "TypeError")
-                ) {
+                } else if (e.name === "TypeError") {
                     e.ruffleIndexError = PanicError.JavascriptConflict;
                 }
             }


### PR DESCRIPTION
Compare the appearance of http://www.juegosjuegos.com/embed/witch-creator on Chrome to its appearance on Firefox. On Firefox, the error message is "Error message: wasm validation error: at offset 158589: bad type", and there is a Report Bug button. On Chrome, the error message is "Error message: WebAssembly.instantiate(): unknown section code #0x2f @+4405019" and there is no report bug button. There were two options to fix this:

1) Check if the message includes "webassembly.instantiate" or "wasm validation error", not just "webassembly.instantiate"
2) Assume every CompileError that does not include the message "disallowed by embedder" is caused by a botched deployment.

I went with option 2, as I believe that is actually accurate. If I am mistaken, I can switch to option 1. Mozilla's docs say a CompileError indicates an error during WebAssembly decoding or validation (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError). We have CI checks in place to ensure Ruffle, when properly deployed, can always be validated and decoded.