### PR TITLE
web: Bump wasm-bindgen to 0.2.75

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -243,7 +243,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: wasm-bindgen-cli --version 0.2.74
+          args: wasm-bindgen-cli --version 0.2.75
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -38,7 +38,7 @@ jobs:
     # wasm-bindgen-cli version must match wasm-bindgen crate version.
     # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
     - name: Install wasm-bindgen
-      run: cargo install wasm-bindgen-cli --version 0.2.74
+      run: cargo install wasm-bindgen-cli --version 0.2.75
 
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3769,9 +3769,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3781,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3796,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3808,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3818,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wayland-client"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 base64 = "0.13.0"
 fnv = "1.0.7"
-js-sys = "0.3.51"
+js-sys = "0.3.52"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 svg = "0.10.0"
 percent-encoding = "2.1.0"
 png = "0.16.8"
-wasm-bindgen = "=0.2.74"
+wasm-bindgen = "=0.2.75"
 
 [dependencies.jpeg-decoder]
 version = "0.1.22"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -7,13 +7,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 fnv = "1.0.7"
-js-sys = "0.3.51"
+js-sys = "0.3.52"
 log = "0.4"
 percent-encoding = "2.1.0"
 png = "0.16.8"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.74"
+wasm-bindgen = "=0.2.75"
 bytemuck = { version = "1.7.0", features = ["derive"] }
 
 [dependencies.jpeg-decoder]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -26,14 +26,14 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"
 generational-arena = "0.2.8"
-js-sys = "0.3.51"
+js-sys = "0.3.52"
 log = { version = "0.4", features = ["serde"] }
 ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 url = "2.2.2"
-wasm-bindgen = { version = "=0.2.74", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.24"
+wasm-bindgen = { version = "=0.2.75", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.25"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.127", features = ["derive"] }

--- a/web/README.md
+++ b/web/README.md
@@ -55,7 +55,7 @@ We recommend using the currently active LTS 14, but we do also run tests with ma
 #### wasm-bindgen
 
 <!-- Be sure to also update the wasm-bindgen-cli version in .github/workflows/*.yaml and web/Cargo.toml -->
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.74`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.75`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.51"
+js-sys = "0.3.52"
 log = "0.4"
-wasm-bindgen = "=0.2.74"
+wasm-bindgen = "=0.2.75"
 
 [dependencies.web-sys]
 version = "0.3.50"


### PR DESCRIPTION
Also bump its helper crates (js-sys, wasm-bindgen-futures) to the latest versions, except for web-sys which seems to be locked by wgpu to 0.3.50.