### PR TITLE
web:  Reland "Simplify .wasm loading"

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -9,15 +9,7 @@ import { BaseLoadOptions } from "./load-options";
  */
 export interface Config extends BaseLoadOptions {
     /**
-     * A map of public paths from source name to URL.
-     */
-    publicPaths?: Record<string, string>;
-
-    /**
-     * The URL at which Ruffle can load its extra files (ie `.wasm`).
-     *
-     * [publicPaths] is consulted first for a source-specific URL,
-     * with this field being a fallback.
+     * The URL at which Ruffle can load its extra files (i.e. `.wasm`).
      */
     publicPath?: string;
 

--- a/web/packages/core/src/globals.d.ts
+++ b/web/packages/core/src/globals.d.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare let __webpack_public_path__: string;
-
 interface Error {
     ruffleIndexError?: number;
 }

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -6,7 +6,7 @@ import { Config } from "./config";
 
 let isExtension: boolean;
 const globalConfig: Config = window.RufflePlayer?.config ?? {};
-const jsScriptUrl = publicPath(globalConfig, "ruffle.js") + "ruffle.js";
+const jsScriptUrl = publicPath(globalConfig) + "ruffle.js";
 
 /**
  * Polyfill native Flash elements with Ruffle equivalents.

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -1,5 +1,21 @@
 import { Config } from "./config";
 
+// This must be in global scope because `document.currentScript`
+// works only while the script is initially being processed.
+let currentScriptURL = "";
+try {
+    if (
+        document.currentScript !== undefined &&
+        document.currentScript !== null &&
+        "src" in document.currentScript &&
+        document.currentScript.src !== ""
+    ) {
+        currentScriptURL = new URL(".", document.currentScript.src).href;
+    }
+} catch (e) {
+    console.warn("Unable to get currentScript URL");
+}
+
 /**
  * Attempt to discover the public path of the current Ruffle source. This can
  * be used to configure Webpack.
@@ -18,21 +34,10 @@ import { Config } from "./config";
  * @returns The public path for the given source.
  */
 export function publicPath(config: Config): string {
-    let path = "";
+    // Default to the directory where this script resides.
+    let path = currentScriptURL;
     if (config !== undefined && config.publicPath !== undefined) {
         path = config.publicPath;
-    } else if (
-        document.currentScript !== undefined &&
-        document.currentScript !== null &&
-        "src" in document.currentScript &&
-        document.currentScript.src !== ""
-    ) {
-        // Default to the directory where this script resides.
-        try {
-            path = new URL(".", document.currentScript.src).href;
-        } catch (e) {
-            console.warn("Unable to get currentScript URL");
-        }
     }
 
     // Webpack expects the paths to end with a slash.

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -4,31 +4,22 @@ import { Config } from "./config";
  * Attempt to discover the public path of the current Ruffle source. This can
  * be used to configure Webpack.
  *
- * We have several points of configuration for how the Ruffle public path can
- * be determined:
+ * A global public path can be specified for all sources using the RufflePlayer
+ * config:
  *
- * 1. The public path can be specified on a per-source basis using the
- * RufflePlayer config, for example:
- * `window.RufflePlayer.config.publicPaths.local = "/dist/";`
- * 2. A global public path can be specified for all sources, also in config.
- * `window.RufflePlayer.config.publicPath = "/dist/";`
- * 3. If there is absolutely no configuration that yields a public path then we
- * return the parent path of where this script is hosted, which should be
- * the correct default in most cases.
+ * ```js
+ * window.RufflePlayer.config.publicPath = "/dist/";
+ * ```
+ *
+ * If no such config is specified, then the parent path of where this script is
+ * hosted is assumed, which should be the correct default in most cases.
  *
  * @param config The `window.RufflePlayer.config` object.
- * @param source_name The name of the source.
  * @returns The public path for the given source.
  */
-export function publicPath(config: Config, source_name: string): string {
+export function publicPath(config: Config): string {
     let path = "";
-    if (
-        config !== undefined &&
-        config.publicPaths !== undefined &&
-        config.publicPaths[source_name] !== undefined
-    ) {
-        path = config.publicPaths[source_name];
-    } else if (config !== undefined && config.publicPath !== undefined) {
+    if (config !== undefined && config.publicPath !== undefined) {
         path = config.publicPath;
     } else if (
         document.currentScript !== undefined &&
@@ -44,7 +35,7 @@ export function publicPath(config: Config, source_name: string): string {
         }
     }
 
-    // Webpack expects the paths to end with a /.
+    // Webpack expects the paths to end with a slash.
     if (path !== "" && !path.endsWith("/")) {
         path += "/";
     }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -135,7 +135,6 @@ export class RufflePlayer extends HTMLElement {
     private _metadata: MovieMetadata | null;
     private _readyState: ReadyState;
 
-    private ruffleConstructor: Promise<typeof Ruffle>;
     private panicked = false;
 
     private isExtension = false;
@@ -221,8 +220,6 @@ export class RufflePlayer extends HTMLElement {
 
         this._readyState = ReadyState.HaveNothing;
         this._metadata = null;
-
-        this.ruffleConstructor = loadRuffle();
 
         this.lastActivePlayingState = false;
         this.setupPauseOnTabHidden();
@@ -379,7 +376,7 @@ export class RufflePlayer extends HTMLElement {
     private async ensureFreshInstance(config: BaseLoadOptions): Promise<void> {
         this.destroy();
 
-        const ruffleConstructor = await this.ruffleConstructor.catch((e) => {
+        const ruffleConstructor = await loadRuffle(config).catch((e) => {
             console.error(`Serious error loading Ruffle: ${e}`);
 
             // Serious duck typing. In error conditions, let's not make assumptions.

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -22,10 +22,6 @@ module.exports = (_env, _argv) => {
                     test: /\.css$/i,
                     use: ["style-loader", "css-loader"],
                 },
-                {
-                    test: /\.wasm$/i,
-                    type: "asset/resource",
-                },
             ],
         },
         devtool: "source-map",

--- a/web/packages/extension/src/globals.d.ts
+++ b/web/packages/extension/src/globals.d.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare let __webpack_public_path__: string;

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -1,10 +1,4 @@
-import {
-    PublicAPI,
-    SourceAPI,
-    publicPath,
-    Letterbox,
-    LogLevel,
-} from "ruffle-core";
+import { PublicAPI, SourceAPI, Letterbox, LogLevel } from "ruffle-core";
 
 const api = PublicAPI.negotiate(
     window.RufflePlayer!,
@@ -12,7 +6,6 @@ const api = PublicAPI.negotiate(
     new SourceAPI("local")
 );
 window.RufflePlayer = api;
-__webpack_public_path__ = publicPath(api.config);
 const ruffle = api.newest()!;
 
 let player;

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -12,7 +12,7 @@ const api = PublicAPI.negotiate(
     new SourceAPI("local")
 );
 window.RufflePlayer = api;
-__webpack_public_path__ = publicPath(api.config, "local");
+__webpack_public_path__ = publicPath(api.config);
 const ruffle = api.newest()!;
 
 let player;

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -1,12 +1,10 @@
-import { PublicAPI, SourceAPI, publicPath } from "ruffle-core";
+import { PublicAPI, SourceAPI } from "ruffle-core";
 
-const api = PublicAPI.negotiate(
+window.RufflePlayer = PublicAPI.negotiate(
     window.RufflePlayer!,
     "extension",
     new SourceAPI("extension")
 );
-window.RufflePlayer = api;
-__webpack_public_path__ = publicPath(api.config);
 
 let uniqueMessageSuffix: string | null = null;
 if (

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -6,7 +6,7 @@ const api = PublicAPI.negotiate(
     new SourceAPI("extension")
 );
 window.RufflePlayer = api;
-__webpack_public_path__ = publicPath(api.config, "extension");
+__webpack_public_path__ = publicPath(api.config);
 
 let uniqueMessageSuffix: string | null = null;
 if (

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -62,10 +62,6 @@ module.exports = (env, _argv) => {
                     test: /\.ts$/i,
                     use: "ts-loader",
                 },
-                {
-                    test: /\.wasm$/i,
-                    type: "asset/resource",
-                },
             ],
         },
         resolve: {

--- a/web/packages/selfhosted/js/.eslintrc.json
+++ b/web/packages/selfhosted/js/.eslintrc.json
@@ -4,8 +4,5 @@
     },
     "parserOptions": {
         "sourceType": "module"
-    },
-    "globals": {
-        "__webpack_public_path__": "writable"
     }
 }

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -1,8 +1,7 @@
-import { PublicAPI, SourceAPI, publicPath } from "ruffle-core";
+import { PublicAPI, SourceAPI } from "ruffle-core";
 
 window.RufflePlayer = PublicAPI.negotiate(
     window.RufflePlayer,
     "local",
     new SourceAPI("local")
 );
-__webpack_public_path__ = publicPath(window.RufflePlayer.config);

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -5,4 +5,4 @@ window.RufflePlayer = PublicAPI.negotiate(
     "local",
     new SourceAPI("local")
 );
-__webpack_public_path__ = publicPath(window.RufflePlayer.config, "local");
+__webpack_public_path__ = publicPath(window.RufflePlayer.config);

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -17,14 +17,6 @@ module.exports = (_env, _argv) => {
             chunkFilename: "core.ruffle.[contenthash].js",
             clean: true,
         },
-        module: {
-            rules: [
-                {
-                    test: /\.wasm$/i,
-                    type: "asset/resource",
-                },
-            ],
-        },
         devtool: "source-map",
         plugins: [
             new CopyPlugin({


### PR DESCRIPTION
In #4922 I tried to simplify the .wasm loading by using wasm-bindgen's built-in loader instead of relying on Webpack.
This allows to no longer declare .wasm files as resource assets in each `webpack.config.js`.

However it turned out to be problematic because it stopped respecting the `publicPath` config for the .wasm location, and instead assumed it is always in the same directory as the .js, which is not always the case. So the change was reverted in #4936.

This is a redo of the change, with fixes - the `publicPath` config is taken into account in `load-ruffle.ts`, which now sets `__webpack_public_path__` instead of each package (selfhosted, extension, demo).
However this removes the `publicPaths` config, but it should be fine as long as nobody uses it.