### PR TITLE
demo: Fix local file uploads on iOS

### DIFF
--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -112,6 +112,12 @@ main.addEventListener("drop", (event) => {
 });
 
 window.addEventListener("load", () => {
+    if (
+        navigator.userAgent.match(/iPad/i) ||
+        navigator.userAgent.match(/iPhone/i)
+    ) {
+        localFileInput.removeAttribute("accept");
+    }
     overlay.classList.remove("hidden");
 });
 


### PR DESCRIPTION
It seems Mobile Safari on iOS refuses to allow selection of any files when the "accept" attribute doesn't contain any file types it recognizes. To fix this, detect when the demo is running on an iOS device and remove the "accept" attribute from the file input in that case.

Fixes: 2d0c76c06f58 ("demo: Only accepts .swf and .spl files")

Please note that I don't do web development very often, so I'm not really up-to-date on best practices. If this code snippet works better in some other place, or if there's a better way to fix this issue, please let me know.