### PR TITLE
CI FIXES / Clippy compliance with latest nightly compiler

### DIFF
--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -216,6 +216,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
     /// The `final_line_of_para` parameter should be flagged if this the final
     /// line in the paragraph or layout operation (e.g. it wasn't caused by an
     /// automatic newline and no more text is to be expected).
+    #[allow(clippy::or_fun_call)]
     fn fixup_line(
         &mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
@@ -248,7 +249,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             box_count += 1;
         }
 
-        let mut line_bounds = line_bounds.unwrap_or_else(Default::default);
+        let mut line_bounds = line_bounds.unwrap_or(Default::default());
 
         let left_adjustment =
             Self::left_alignment_offset(&self.current_line_span, self.is_first_line);
@@ -533,6 +534,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
     }
 
     /// Destroy the layout context, returning the newly constructed layout list.
+    #[allow(clippy::or_fun_call)]
     fn end_layout(
         mut self,
         context: &mut UpdateContext<'_, 'gc, '_>,
@@ -541,7 +543,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 
         (
             self.boxes,
-            self.exterior_bounds.unwrap_or_else(Default::default),
+            self.exterior_bounds.unwrap_or(Default::default()),
         )
     }
 

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -1574,6 +1574,7 @@ impl FormatSpans {
     /// a handful of presentational attributes in the HTML tree to generate
     /// styling. There's also a `lower_from_css` that respects both
     /// presentational markup and CSS stylesheets.
+    #[allow(clippy::or_fun_call)]
     pub fn lower_from_html(&mut self, tree: XmlDocument<'_>) {
         let mut format_stack = vec![self.default_format.clone()];
         let mut last_successful_format = None;
@@ -1615,10 +1616,7 @@ impl FormatSpans {
                             .eq_ignore_ascii_case("br") => {}
                 Step::In(node) => format_stack.push(TextFormat::from_presentational_markup(
                     node,
-                    format_stack
-                        .last()
-                        .cloned()
-                        .unwrap_or_else(Default::default),
+                    format_stack.last().cloned().unwrap_or(Default::default()),
                 )),
                 Step::Around(node) if node.is_text() => {
                     self.replace_text(


### PR DESCRIPTION
Another `rustc` release, another weird clippy lint in nightly that contradicts one in stable.