### PR TITLE
avm2: Initial MouseEvent stubs

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -544,6 +544,12 @@ pub fn load_player_globals<'gc>(
         domain,
         script,
     )?;
+    class(
+        activation,
+        flash::events::mouseevent::create_class(mc),
+        domain,
+        script,
+    )?;
     // package `flash.utils`
     avm2_system_class!(
         bytearray,

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -3,3 +3,4 @@
 pub mod event;
 pub mod eventdispatcher;
 pub mod ieventdispatcher;
+pub mod mouseevent;

--- a/core/src/avm2/globals/flash/events/mouseevent.rs
+++ b/core/src/avm2/globals/flash/events/mouseevent.rs
@@ -42,5 +42,10 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
+    const CONSTANTS: &[(&str, &str)] = &[
+        ("CLICK", "click"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
+
     class
 }

--- a/core/src/avm2/globals/flash/events/mouseevent.rs
+++ b/core/src/avm2/globals/flash/events/mouseevent.rs
@@ -42,9 +42,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&str, &str)] = &[
-        ("CLICK", "click"),
-    ];
+    const CONSTANTS: &[(&str, &str)] = &[("CLICK", "click")];
     write.define_public_constant_string_class_traits(CONSTANTS);
 
     class

--- a/core/src/avm2/globals/flash/events/mouseevent.rs
+++ b/core/src/avm2/globals/flash/events/mouseevent.rs
@@ -1,6 +1,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
-use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;

--- a/core/src/avm2/globals/flash/events/mouseevent.rs
+++ b/core/src/avm2/globals/flash/events/mouseevent.rs
@@ -1,0 +1,46 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.MouseEvent`'s instance constructor.
+pub fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        activation.super_init(this, args)?; // Event uses the first three parameters
+    }
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.MouseEvent`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `MouseEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.events"), "MouseEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init, "<MouseEvent instance initializer>", mc),
+        Method::from_builtin(class_init, "<MouseEvent class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED);
+
+    class
+}


### PR DESCRIPTION
I should note that there is very little here; the test file I was using crashed because of something likely unrelated to `MouseEvent`. Nevertheless, it was recommended that I submit this PR.

This PR adds `MouseEvent`'s class with a partial instance constructor as well as the constant property `MouseEvent.CLICK`. This PR has no tests currently as I am unable to build AS3 files.

I may be able to work on this more after the other bug gets fixed.