### PR TITLE
extension: Fix warning on Firefox

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -2,7 +2,6 @@
     "manifest_version": 2,
     "name": "Ruffle",
     "version": null, // Filled by Webpack.
-    "version_name": null, // Filled by Webpack.
     "default_locale": "en",
     "description": "__MSG_description__",
     "homepage_url": "https://ruffle.rs/",

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -15,23 +15,21 @@ function transformManifest(content, env) {
 
     // The extension marketplaces require the version to monotonically increase,
     // so append the build date onto the end of the manifest version.
-    const version = process.env.BUILD_ID
+    manifest.version = process.env.BUILD_ID
         ? `${packageVersion}.${process.env.BUILD_ID}`
         : packageVersion;
 
-    const version_name =
-        versionChannel === "nightly"
-            ? `${packageVersion} nightly ${buildDate}`
-            : packageVersion;
-
-    Object.assign(manifest, { version, version_name });
     if (env.firefox) {
-        const id = process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs";
-        Object.assign(manifest, {
-            browser_specific_settings: {
-                gecko: { id },
+        manifest.browser_specific_settings = {
+            gecko: {
+                id: process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs",
             },
-        });
+        };
+    } else {
+        manifest.version_name =
+            versionChannel === "nightly"
+                ? `${packageVersion} nightly ${buildDate}`
+                : packageVersion;
     }
 
     return JSON.stringify(manifest);


### PR DESCRIPTION
Firefox doesn't know the manifest [`version_name`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name) key, so it shows a warning when loading the extension (#5053).

So define `version_name` only for the "generic" variant, along with a nearby cleanup of using regular property assignments instead of `Object.assign`.