### PR TITLE
chore: Bump png from 0.16.8 to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f95bf05dffba6e6cce8dfbb30def788154949ccd9aed761b472119c21e01c70"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,7 +1776,7 @@ dependencies = [
  "num-iter",
  "num-rational",
  "num-traits",
- "png",
+ "png 0.16.8",
  "scoped_threadpool",
  "tiff",
 ]
@@ -2685,8 +2694,20 @@ checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
  "bitflags",
  "crc32fast",
- "deflate",
+ "deflate 0.8.6",
  "miniz_oxide 0.3.7",
+]
+
+[[package]]
+name = "png"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2ea6221e9aa7dccc581e610d92af4621d3589f7faa36ffd420bc52904e4aa9"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "deflate 0.9.1",
+ "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -3018,7 +3039,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "percent-encoding",
- "png",
+ "png 0.17.0",
  "pretty_assertions 0.7.2",
  "quick-xml",
  "rand",
@@ -3073,7 +3094,7 @@ dependencies = [
  "js-sys",
  "log",
  "percent-encoding",
- "png",
+ "png 0.17.0",
  "ruffle_core",
  "ruffle_web_common",
  "svg",
@@ -3100,7 +3121,7 @@ dependencies = [
  "js-sys",
  "log",
  "percent-encoding",
- "png",
+ "png 0.17.0",
  "ruffle_core",
  "ruffle_render_common_tess",
  "ruffle_web_common",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ gif = "0.11.2"
 indexmap = "1.6.2"
 log = "0.4"
 minimp3 = { version = "0.5.1", optional = true }
-png = { version = "0.16.8" }
+png = { version = "0.17.0" }
 ruffle_macros = { path = "macros" }
 swf = { path = "../swf" }
 bitflags = "1.3.2"

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -551,15 +551,15 @@ pub fn decode_png(data: &[u8]) -> Result<Bitmap, Error> {
     let mut decoder = png::Decoder::new(data);
     // EXPAND expands palettized types to RGB.
     decoder.set_transformations(Transformations::EXPAND);
-    let (info, mut reader) = decoder.read_info()?;
+    let mut reader = decoder.read_info()?;
 
-    let mut data = vec![0; info.buffer_size()];
-    reader.next_frame(&mut data)?;
+    let mut data = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut data)?;
 
     Ok(Bitmap {
         width: info.width,
         height: info.height,
-        data: if info.color_type == ColorType::RGBA {
+        data: if info.color_type == ColorType::Rgba {
             BitmapFormat::Rgba(data)
         } else {
             // EXPAND expands other types to RGB.

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 svg = "0.10.0"
 percent-encoding = "2.1.0"
-png = "0.16.8"
+png = "0.17.0"
 wasm-bindgen = "=0.2.75"
 
 [dependencies.jpeg-decoder]

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -234,11 +234,11 @@ impl WebCanvasRenderBackend {
             let data = match bitmap.data {
                 BitmapFormat::Rgba(mut data) => {
                     ruffle_core::backend::render::unmultiply_alpha_rgba(&mut data[..]);
-                    encoder.set_color(png::ColorType::RGBA);
+                    encoder.set_color(png::ColorType::Rgba);
                     data
                 }
                 BitmapFormat::Rgb(data) => {
-                    encoder.set_color(png::ColorType::RGB);
+                    encoder.set_color(png::ColorType::Rgb);
                     data
                 }
             };

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -10,7 +10,7 @@ fnv = "1.0.7"
 js-sys = "0.3.52"
 log = "0.4"
 percent-encoding = "2.1.0"
-png = "0.16.8"
+png = "0.17.0"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
 wasm-bindgen = "=0.2.75"


### PR DESCRIPTION
I'm not sure about the `data.resize(info.buffer_size(), 0);` line. It appears in the [docs](https://docs.rs/png/0.17.0/png/) like the right thing to do.