### PR TITLE
desktop: Fix clap settings

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -98,13 +98,13 @@ struct Opt {
     proxy: Option<Url>,
 
     /// (Optional) Replace all embedded http URLs with https
-    #[clap(long, case_insensitive = true, takes_value = false)]
+    #[clap(long, takes_value = false)]
     upgrade_to_https: bool,
 
-    #[clap(long, case_insensitive = true, takes_value = false)]
+    #[clap(long, takes_value = false)]
     timedemo: bool,
 
-    #[clap(long, case_insensitive = true, takes_value = false)]
+    #[clap(long, takes_value = false)]
     dont_warn_on_unsupported_content: bool,
 }
 


### PR DESCRIPTION
Fixes a panic that happens in debug mode when running ruffle on the latest version. These settings don't need to be case insensitive because they don't take a value