### PR TITLE
dev: run workflows only if certain file paths change

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -6,13 +6,15 @@ on:
     paths:
       - '.github/workflows/test_rust.yml'
       - '**.rs'
-      - '**/?Cargo.toml'
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
   pull_request:
     branches: [master]
     paths:
       - '.github/workflows/test_rust.yml'
       - '**.rs'
-      - '**/?Cargo.toml'
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
 
 jobs:
   build:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -3,8 +3,16 @@ name: Test Rust
 on:
   push:
     branches: [master]
+    paths:
+      - '.github/workflows/test_rust.yml'
+      - '**.rs'
+      - '**/?Cargo.toml'
   pull_request:
     branches: [master]
+    paths:
+      - '.github/workflows/test_rust.yml'
+      - '**.rs'
+      - '**/?Cargo.toml'
 
 jobs:
   build:

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -3,18 +3,13 @@ name: Test Rust
 on:
   push:
     branches: [master]
-    paths:
-      - '.github/workflows/test_rust.yml'
-      - '**.rs'
-      - 'Cargo.toml'
-      - '**/Cargo.toml'
   pull_request:
     branches: [master]
-    paths:
-      - '.github/workflows/test_rust.yml'
-      - '**.rs'
-      - 'Cargo.toml'
-      - '**/Cargo.toml'
+    paths-ignore:
+      - 'web/package.json'
+      - 'web/package-lock.json'
+      - 'web/packages/**'
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -3,8 +3,20 @@ name: Test Web
 on:
   push:
     branches: [ master ]
+    paths:
+      - '.github/workflows/test_web.yml'
+      - '**.rs'
+      - '**/?Cargo.toml'
+      - 'web/**'
+      - '!**.md'
   pull_request:
     branches: [ master ]
+    paths:
+      - '.github/workflows/test_web.yml'
+      - '**.rs'
+      - '**/?Cargo.toml'
+      - 'web/**'
+      - '!**.md'
 
 jobs:
   build:

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - '.github/workflows/test_web.yml'
       - '**.rs'
-      - '**/?Cargo.toml'
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
       - 'web/**'
       - '!**.md'
   pull_request:
@@ -14,7 +15,8 @@ on:
     paths:
       - '.github/workflows/test_web.yml'
       - '**.rs'
-      - '**/?Cargo.toml'
+      - 'Cargo.toml'
+      - '**/Cargo.toml'
       - 'web/**'
       - '!**.md'
 

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -3,22 +3,10 @@ name: Test Web
 on:
   push:
     branches: [ master ]
-    paths:
-      - '.github/workflows/test_web.yml'
-      - '**.rs'
-      - 'Cargo.toml'
-      - '**/Cargo.toml'
-      - 'web/**'
-      - '!**.md'
   pull_request:
     branches: [ master ]
-    paths:
-      - '.github/workflows/test_web.yml'
-      - '**.rs'
-      - 'Cargo.toml'
-      - '**/Cargo.toml'
-      - 'web/**'
-      - '!**.md'
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
Only run workflows if particular files change. In particular, avoid running the rust workflow for web-only changes (and avoid running any workflow for documentation changes)

Run the rust workflow on changes to:
* the rust workflow
* Any .rs file
* Any Cargo.toml

Run the web workflow on changes to:
* Any .rs file or Cargo.toml (to pick up changes to ruffle_core)
* Anything in web/ except for documentation