### PR TITLE
dev: remove wdio/sync

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,6 @@
                 "@wdio/mocha-framework": "^7.9.0",
                 "@wdio/spec-reporter": "^7.9.0",
                 "@wdio/static-server-service": "^7.7.3",
-                "@wdio/sync": "^7.7.4",
                 "chai": "^4.3.4",
                 "chai-html": "^2.0.1",
                 "chromedriver": "^91.0.1",
@@ -1931,12 +1930,6 @@
                 "@types/range-parser": "*"
             }
         },
-        "node_modules/@types/fibers": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@types/fibers/-/fibers-3.1.0.tgz",
-            "integrity": "sha512-1o3I9xtk2PZFxwaLCC6gTaBfBZ5rvw/DSZZPK89fwuwO6LNrzSbC6rEs1xI0bQ3fCRWmO+uNJQQeD2J56oTMDg==",
-            "dev": true
-        },
         "node_modules/@types/fs-extra": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
@@ -2099,15 +2092,6 @@
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
             "dev": true
-        },
-        "node_modules/@types/puppeteer": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz",
-            "integrity": "sha512-3nE8YgR9DIsgttLW+eJf6mnXxq8Ge+27m5SU3knWmrlfl6+KOG0Bf9f7Ua7K+C4BnaTMAh3/UpySqdAYvrsvjg==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/qs": {
             "version": "6.9.6",
@@ -2800,21 +2784,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@wdio/config": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.7.3.tgz",
-            "integrity": "sha512-I8gkb5BjXLe6/9NK7OCA9Mc+A6xeGUqbYTRd4PNKdObE6HomKOxw4plVZCYF0DlD2FCo4OGrvYGmalojFsCMdA==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.7.3",
-                "deepmerge": "^4.0.0",
-                "glob": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/local-runner": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-7.9.0.tgz",
@@ -2952,18 +2921,6 @@
             "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.7.4.tgz",
             "integrity": "sha512-gfGPOjvqUws3/dTnrXbCYP2keYE6O5BK5qHWnOEu6c7ubE4hebxV8W5c822L7ntabc1e38+diEbM+qFuIT890Q==",
             "dev": true,
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/repl": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.7.3.tgz",
-            "integrity": "sha512-7nhvUa3Zd5Ny9topJGRZwkomlveuO3RIv+jBUHgQ2jiDIGvG9MroHxKEniIbscVSsD32XFOOZY59kSpX1b50VQ==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/utils": "7.7.3"
-            },
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -3398,23 +3355,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@wdio/sync": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@wdio/sync/-/sync-7.7.4.tgz",
-            "integrity": "sha512-x0ZU78Je0yl05TfwiNtkKkJZ+90y6MndR4z5n/m6ADRzSGdFOazGJSFO0h2bN8MkPRusfqYsJwB6MKftCP0URA==",
-            "dev": true,
-            "dependencies": {
-                "@types/fibers": "^3.1.0",
-                "@types/puppeteer": "^5.4.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.7.3",
-                "fibers": "^5.0.0",
-                "webdriverio": "7.7.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/types": {
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.7.3.tgz",
@@ -3423,19 +3363,6 @@
             "dependencies": {
                 "@types/node": "^14.14.31",
                 "got": "^11.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/utils": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.7.3.tgz",
-            "integrity": "sha512-bvOoE2gve8Z8HFguVw0RMp5BbSmJR4zSr8DwbwnA8RSL3NshKlRk33HWYLmKsxjkH+ZWI2ihFbpvLD4W4imXag==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.7.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -5800,56 +5727,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "dev": true,
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/devtools": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.7.4.tgz",
-            "integrity": "sha512-rkO9k6yOA2XzFTph9y+gO/387653jou0La7QSLd57XTQiM3D/UODqLBt+fMVu8w3fdQzZHVAlIIvP4B8rkXY1Q==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^14.14.31",
-                "@wdio/config": "7.7.3",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.7.3",
-                "@wdio/utils": "7.7.3",
-                "chrome-launcher": "^0.14.0",
-                "edge-paths": "^2.1.0",
-                "puppeteer-core": "^9.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "ua-parser-js": "^0.7.21",
-                "uuid": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/devtools-protocol": {
-            "version": "0.0.892017",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.892017.tgz",
-            "integrity": "sha512-23yn1+zeMBlWiZTtrCViNQt+W+FRDw5rEetI19bMuyKIYeK11xo/dS+Hmuu8ifGJnJvXUU3Y79IoxSPWZWcVOA==",
-            "dev": true
-        },
-        "node_modules/devtools/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/dezalgo": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -6783,19 +6660,6 @@
             "dev": true,
             "dependencies": {
                 "pend": "~1.2.0"
-            }
-        },
-        "node_modules/fibers": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-            "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "detect-libc": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=10.0.0"
             }
         },
         "node_modules/figures": {
@@ -10092,12 +9956,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
-        },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -11837,35 +11695,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/puppeteer-core": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-9.1.1.tgz",
-            "integrity": "sha512-zbedbitVIGhmgz0nt7eIdLsnaoVZSlNJfBivqm2w67T8LR2bU1dvnruDZ8nQO0zn++Iet7zHbAOdnuS5+H2E7A==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.1.0",
-                "devtools-protocol": "0.0.869402",
-                "extract-zip": "^2.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
-                "pkg-dir": "^4.2.0",
-                "progress": "^2.0.1",
-                "proxy-from-env": "^1.1.0",
-                "rimraf": "^3.0.2",
-                "tar-fs": "^2.0.0",
-                "unbzip2-stream": "^1.3.3",
-                "ws": "^7.2.3"
-            },
-            "engines": {
-                "node": ">=10.18.1"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-            "version": "0.0.869402",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
-            "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
-            "dev": true
         },
         "node_modules/q": {
             "version": "1.5.1",
@@ -13677,24 +13506,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dev": true,
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-fs/node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
         "node_modules/tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -14133,16 +13944,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
-        },
         "node_modules/unified": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
@@ -14416,79 +14217,6 @@
             "peerDependencies": {
                 "@wdio/cli": "^7.0.0",
                 "chromedriver": "*"
-            }
-        },
-        "node_modules/webdriver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.7.4.tgz",
-            "integrity": "sha512-bE6/A+OYb040GZ1MiuZebc8bOOYm797dmqEfmj6aoEQ4BMy1juiFlzCzeBzAlPrq33qPa8/CSYfH7rnkB3RRwg==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^14.14.31",
-                "@wdio/config": "7.7.3",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.7.3",
-                "@wdio/utils": "7.7.3",
-                "got": "^11.0.2",
-                "lodash.merge": "^4.6.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/webdriverio": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.7.4.tgz",
-            "integrity": "sha512-VSWRj2mmvA8WbideFAYb5BMWPkBCJ7gJHhYrUSibTrMHKreRtX++cw/oGxxowy9/pTHsAW6OxlnaDxFL5Gt08A==",
-            "dev": true,
-            "dependencies": {
-                "@types/aria-query": "^4.2.1",
-                "@types/node": "^14.14.31",
-                "@wdio/config": "7.7.3",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.7.3",
-                "@wdio/types": "7.7.3",
-                "@wdio/utils": "7.7.3",
-                "archiver": "^5.0.0",
-                "aria-query": "^4.2.2",
-                "atob": "^2.1.2",
-                "css-shorthand-properties": "^1.1.1",
-                "css-value": "^0.0.1",
-                "devtools": "7.7.4",
-                "devtools-protocol": "^0.0.892017",
-                "fs-extra": "^10.0.0",
-                "get-port": "^5.1.1",
-                "grapheme-splitter": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isobject": "^3.0.2",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.zip": "^4.2.0",
-                "minimatch": "^3.0.4",
-                "puppeteer-core": "^9.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "resq": "^1.9.1",
-                "rgb2hex": "0.2.5",
-                "serialize-error": "^8.0.0",
-                "webdriver": "7.7.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/webdriverio/node_modules/fs-extra": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-            "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/webidl-conversions": {
@@ -14947,27 +14675,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/ws": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-            "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/xtend": {
@@ -16839,12 +16546,6 @@
                 "@types/range-parser": "*"
             }
         },
-        "@types/fibers": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@types/fibers/-/fibers-3.1.0.tgz",
-            "integrity": "sha512-1o3I9xtk2PZFxwaLCC6gTaBfBZ5rvw/DSZZPK89fwuwO6LNrzSbC6rEs1xI0bQ3fCRWmO+uNJQQeD2J56oTMDg==",
-            "dev": true
-        },
         "@types/fs-extra": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
@@ -17007,15 +16708,6 @@
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
             "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
             "dev": true
-        },
-        "@types/puppeteer": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz",
-            "integrity": "sha512-3nE8YgR9DIsgttLW+eJf6mnXxq8Ge+27m5SU3knWmrlfl6+KOG0Bf9f7Ua7K+C4BnaTMAh3/UpySqdAYvrsvjg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
         },
         "@types/qs": {
             "version": "6.9.6",
@@ -17543,18 +17235,6 @@
                 }
             }
         },
-        "@wdio/config": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.7.3.tgz",
-            "integrity": "sha512-I8gkb5BjXLe6/9NK7OCA9Mc+A6xeGUqbYTRd4PNKdObE6HomKOxw4plVZCYF0DlD2FCo4OGrvYGmalojFsCMdA==",
-            "dev": true,
-            "requires": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.7.3",
-                "deepmerge": "^4.0.0",
-                "glob": "^7.1.2"
-            }
-        },
         "@wdio/local-runner": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-7.9.0.tgz",
@@ -17669,15 +17349,6 @@
             "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.7.4.tgz",
             "integrity": "sha512-gfGPOjvqUws3/dTnrXbCYP2keYE6O5BK5qHWnOEu6c7ubE4hebxV8W5c822L7ntabc1e38+diEbM+qFuIT890Q==",
             "dev": true
-        },
-        "@wdio/repl": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.7.3.tgz",
-            "integrity": "sha512-7nhvUa3Zd5Ny9topJGRZwkomlveuO3RIv+jBUHgQ2jiDIGvG9MroHxKEniIbscVSsD32XFOOZY59kSpX1b50VQ==",
-            "dev": true,
-            "requires": {
-                "@wdio/utils": "7.7.3"
-            }
         },
         "@wdio/reporter": {
             "version": "7.9.0",
@@ -18036,20 +17707,6 @@
                 }
             }
         },
-        "@wdio/sync": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@wdio/sync/-/sync-7.7.4.tgz",
-            "integrity": "sha512-x0ZU78Je0yl05TfwiNtkKkJZ+90y6MndR4z5n/m6ADRzSGdFOazGJSFO0h2bN8MkPRusfqYsJwB6MKftCP0URA==",
-            "dev": true,
-            "requires": {
-                "@types/fibers": "^3.1.0",
-                "@types/puppeteer": "^5.4.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.7.3",
-                "fibers": "^5.0.0",
-                "webdriverio": "7.7.4"
-            }
-        },
         "@wdio/types": {
             "version": "7.7.3",
             "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.7.3.tgz",
@@ -18058,16 +17715,6 @@
             "requires": {
                 "@types/node": "^14.14.31",
                 "got": "^11.8.1"
-            }
-        },
-        "@wdio/utils": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.7.3.tgz",
-            "integrity": "sha512-bvOoE2gve8Z8HFguVw0RMp5BbSmJR4zSr8DwbwnA8RSL3NshKlRk33HWYLmKsxjkH+ZWI2ihFbpvLD4W4imXag==",
-            "dev": true,
-            "requires": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.7.3"
             }
         },
         "@webassemblyjs/ast": {
@@ -19920,46 +19567,6 @@
             "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
             "dev": true
         },
-        "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "dev": true
-        },
-        "devtools": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.7.4.tgz",
-            "integrity": "sha512-rkO9k6yOA2XzFTph9y+gO/387653jou0La7QSLd57XTQiM3D/UODqLBt+fMVu8w3fdQzZHVAlIIvP4B8rkXY1Q==",
-            "dev": true,
-            "requires": {
-                "@types/node": "^14.14.31",
-                "@wdio/config": "7.7.3",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.7.3",
-                "@wdio/utils": "7.7.3",
-                "chrome-launcher": "^0.14.0",
-                "edge-paths": "^2.1.0",
-                "puppeteer-core": "^9.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "ua-parser-js": "^0.7.21",
-                "uuid": "^8.0.0"
-            },
-            "dependencies": {
-                "uuid": {
-                    "version": "8.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-                    "dev": true
-                }
-            }
-        },
-        "devtools-protocol": {
-            "version": "0.0.892017",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.892017.tgz",
-            "integrity": "sha512-23yn1+zeMBlWiZTtrCViNQt+W+FRDw5rEetI19bMuyKIYeK11xo/dS+Hmuu8ifGJnJvXUU3Y79IoxSPWZWcVOA==",
-            "dev": true
-        },
         "dezalgo": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
@@ -20700,15 +20307,6 @@
             "dev": true,
             "requires": {
                 "pend": "~1.2.0"
-            }
-        },
-        "fibers": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-            "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
-            "dev": true,
-            "requires": {
-                "detect-libc": "^1.0.3"
             }
         },
         "figures": {
@@ -23217,12 +22815,6 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true
         },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
-        },
         "mkdirp-infer-owner": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -24573,34 +24165,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
-        },
-        "puppeteer-core": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-9.1.1.tgz",
-            "integrity": "sha512-zbedbitVIGhmgz0nt7eIdLsnaoVZSlNJfBivqm2w67T8LR2bU1dvnruDZ8nQO0zn++Iet7zHbAOdnuS5+H2E7A==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.0",
-                "devtools-protocol": "0.0.869402",
-                "extract-zip": "^2.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.1",
-                "pkg-dir": "^4.2.0",
-                "progress": "^2.0.1",
-                "proxy-from-env": "^1.1.0",
-                "rimraf": "^3.0.2",
-                "tar-fs": "^2.0.0",
-                "unbzip2-stream": "^1.3.3",
-                "ws": "^7.2.3"
-            },
-            "dependencies": {
-                "devtools-protocol": {
-                    "version": "0.0.869402",
-                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
-                    "integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
-                    "dev": true
-                }
-            }
         },
         "q": {
             "version": "1.5.1",
@@ -26003,26 +25567,6 @@
                 "yallist": "^4.0.0"
             }
         },
-        "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dev": true,
-            "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            },
-            "dependencies": {
-                "chownr": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-                    "dev": true
-                }
-            }
-        },
         "tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -26340,16 +25884,6 @@
                 "which-boxed-primitive": "^1.0.2"
             }
         },
-        "unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "dev": true,
-            "requires": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
-        },
         "unified": {
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
@@ -26566,72 +26100,6 @@
                 "@wdio/logger": "^7.5.3",
                 "fs-extra": "^9.1.0",
                 "split2": "^3.2.2"
-            }
-        },
-        "webdriver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.7.4.tgz",
-            "integrity": "sha512-bE6/A+OYb040GZ1MiuZebc8bOOYm797dmqEfmj6aoEQ4BMy1juiFlzCzeBzAlPrq33qPa8/CSYfH7rnkB3RRwg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "^14.14.31",
-                "@wdio/config": "7.7.3",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.7.3",
-                "@wdio/utils": "7.7.3",
-                "got": "^11.0.2",
-                "lodash.merge": "^4.6.1"
-            }
-        },
-        "webdriverio": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.7.4.tgz",
-            "integrity": "sha512-VSWRj2mmvA8WbideFAYb5BMWPkBCJ7gJHhYrUSibTrMHKreRtX++cw/oGxxowy9/pTHsAW6OxlnaDxFL5Gt08A==",
-            "dev": true,
-            "requires": {
-                "@types/aria-query": "^4.2.1",
-                "@types/node": "^14.14.31",
-                "@wdio/config": "7.7.3",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.7.3",
-                "@wdio/types": "7.7.3",
-                "@wdio/utils": "7.7.3",
-                "archiver": "^5.0.0",
-                "aria-query": "^4.2.2",
-                "atob": "^2.1.2",
-                "css-shorthand-properties": "^1.1.1",
-                "css-value": "^0.0.1",
-                "devtools": "7.7.4",
-                "devtools-protocol": "^0.0.892017",
-                "fs-extra": "^10.0.0",
-                "get-port": "^5.1.1",
-                "grapheme-splitter": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isobject": "^3.0.2",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.zip": "^4.2.0",
-                "minimatch": "^3.0.4",
-                "puppeteer-core": "^9.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "resq": "^1.9.1",
-                "rgb2hex": "0.2.5",
-                "serialize-error": "^8.0.0",
-                "webdriver": "7.7.4"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "10.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-                    "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^6.0.1",
-                        "universalify": "^2.0.0"
-                    }
-                }
             }
         },
         "webidl-conversions": {
@@ -26975,13 +26443,6 @@
                     }
                 }
             }
-        },
-        "ws": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-            "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-            "dev": true,
-            "requires": {}
         },
         "xtend": {
             "version": "4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
         "@wdio/mocha-framework": "^7.9.0",
         "@wdio/spec-reporter": "^7.9.0",
         "@wdio/static-server-service": "^7.7.3",
-        "@wdio/sync": "^7.7.4",
         "chai": "^4.3.4",
         "chai-html": "^2.0.1",
         "chromedriver": "^91.0.1",

--- a/web/packages/selfhosted/test/js_api/load.js
+++ b/web/packages/selfhosted/test/js_api/load.js
@@ -7,11 +7,11 @@ use(chaiHtml);
 describe("RufflePlayer.load", () => {
     js_api_before();
 
-    it("loads and plays a URL", () => {
-        const player = browser.$("<ruffle-player>");
-        browser.execute((player) => {
+    it("loads and plays a URL", async () => {
+        const player = await browser.$("<ruffle-player>");
+        await browser.execute((player) => {
             player.load("/test_assets/example.swf");
         }, player);
-        play_and_monitor(browser, player);
+        await play_and_monitor(browser, player);
     });
 });

--- a/web/packages/selfhosted/test/js_api/metadata.js
+++ b/web/packages/selfhosted/test/js_api/metadata.js
@@ -7,9 +7,9 @@ use(chaiHtml);
 describe("RufflePlayer.metadata", () => {
     js_api_before("/test_assets/example.swf");
 
-    it("has metadata after load", () => {
-        const player = browser.$("<ruffle-player>");
-        const metadata = browser.execute((player) => player.metadata, player);
+    it("has metadata after load", async () => {
+        const player = await browser.$("<ruffle-player>");
+        const metadata = await browser.execute((player) => player.metadata, player);
         expect(metadata).to.eql({
             width: 550,
             height: 400,

--- a/web/packages/selfhosted/test/js_api/metadata.js
+++ b/web/packages/selfhosted/test/js_api/metadata.js
@@ -9,7 +9,10 @@ describe("RufflePlayer.metadata", () => {
 
     it("has metadata after load", async () => {
         const player = await browser.$("<ruffle-player>");
-        const metadata = await browser.execute((player) => player.metadata, player);
+        const metadata = await browser.execute(
+            (player) => player.metadata,
+            player
+        );
         expect(metadata).to.eql({
             width: 550,
             height: 400,

--- a/web/packages/selfhosted/test/polyfill/classic_frames_injected/test.js
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_injected/test.js
@@ -6,37 +6,37 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Flash inside frame with injected ruffle", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills inside a frame", () => {
-        inject_ruffle_and_wait(browser);
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+    it("polyfills inside a frame", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("polyfills even after a reload", () => {
+    it("polyfills even after a reload", async () => {
         // Contaminate the old contents, to ensure we get a "fresh" state
-        browser.execute(() => {
+        await browser.execute(() => {
             document.getElementById("test-container").remove();
         });
 
         // Then reload
-        browser.switchToParentFrame();
-        browser.switchToFrame(browser.$("#nav-frame"));
-        browser.$("#reload-link").click();
+        await browser.switchToParentFrame();
+        await browser.switchToFrame(await browser.$("#nav-frame"));
+        await browser.$("#reload-link").click();
 
         // And finally, check
-        browser.switchToParentFrame();
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+        await browser.switchToParentFrame();
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/classic_frames_provided/test.js
+++ b/web/packages/selfhosted/test/polyfill/classic_frames_provided/test.js
@@ -6,36 +6,36 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Flash inside frame with provided ruffle", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills inside a frame", () => {
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+    it("polyfills inside a frame", async () => {
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("polyfills even after a reload", () => {
+    it("polyfills even after a reload", async () => {
         // Contaminate the old contents, to ensure we get a "fresh" state
-        browser.execute(() => {
+        await browser.execute(() => {
             document.getElementById("test-container").remove();
         });
 
         // Then reload
-        browser.switchToParentFrame();
-        browser.switchToFrame(browser.$("#nav-frame"));
-        browser.$("#reload-link").click();
+        await browser.switchToParentFrame();
+        await browser.switchToFrame(await browser.$("#nav-frame"));
+        await browser.$("#reload-link").click();
 
         // And finally, check
-        browser.switchToParentFrame();
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+        await browser.switchToParentFrame();
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/test.js
+++ b/web/packages/selfhosted/test/polyfill/crossorigin_broken_cors/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Doesn't error with cross-origin frames", () => {
-    it("Loads the test", () => {
-        open_test(browser, __dirname);
+    it("Loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("Polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_default/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_default/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Embed tag", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_insensitive/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Embed with case-insensitive MIME type", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-embed />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-embed />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_src/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_src/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Embed without src attribute", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("doesn't polyfill with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("doesn't polyfill with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/embed_missing_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_missing_type/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Embed without type attribute", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/embed_unexpected_string/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_unexpected_string/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Embed with unexpected string", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/embed_wrong_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_wrong_type/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Embed with wrong type attribute value", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/iframes_injected/test.js
+++ b/web/packages/selfhosted/test/polyfill/iframes_injected/test.js
@@ -6,36 +6,36 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Flash inside iframe with injected ruffle", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills inside an iframe", () => {
-        inject_ruffle_and_wait(browser);
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+    it("polyfills inside an iframe", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("polyfills even after a reload", () => {
+    it("polyfills even after a reload", async () => {
         // Contaminate the old contents, to ensure we get a "fresh" state
-        browser.execute(() => {
+        await browser.execute(() => {
             document.getElementById("test-container").remove();
         });
 
         // Then reload
-        browser.switchToParentFrame();
-        browser.$("#reload-link").click();
+        await browser.switchToParentFrame();
+        await browser.$("#reload-link").click();
 
         // And finally, check
-        browser.switchToParentFrame();
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+        await browser.switchToParentFrame();
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/iframes_onload/test.js
+++ b/web/packages/selfhosted/test/polyfill/iframes_onload/test.js
@@ -6,15 +6,15 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("iframe onload", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("runs the iframe onload event", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<div />").waitForExist();
+    it("runs the iframe onload event", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<div />").waitForExist();
 
-        const actual = browser.$("#container").getHTML(false);
+        const actual = await browser.$("#container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/iframes_provided/test.js
+++ b/web/packages/selfhosted/test/polyfill/iframes_provided/test.js
@@ -6,35 +6,35 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Flash inside iframe with provided ruffle", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills inside an iframe", () => {
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+    it("polyfills inside an iframe", async () => {
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("polyfills even after a reload", () => {
+    it("polyfills even after a reload", async () => {
         // Contaminate the old contents, to ensure we get a "fresh" state
-        browser.execute(() => {
+        await browser.execute(() => {
             document.getElementById("test-container").remove();
         });
 
         // Then reload
-        browser.switchToParentFrame();
-        browser.$("#reload-link").click();
+        await browser.switchToParentFrame();
+        await browser.$("#reload-link").click();
 
         // And finally, check
-        browser.switchToParentFrame();
-        browser.switchToFrame(browser.$("#test-frame"));
-        browser.$("<ruffle-object />").waitForExist();
+        await browser.switchToParentFrame();
+        await browser.switchToFrame(await browser.$("#test-frame"));
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_MIME_insensitive/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with case-insensitive MIME type", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-object />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_insensitive/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with case-insensitive clsid", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-object />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_clsid_with_embed/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with clsid and embed", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_data/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_data/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with only data attribute", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-object />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_default/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_default/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object tag", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_double_object/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_double_object/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with another object tag", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills only the first tag with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills only the first tag with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_flashvars/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object tag", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie with flashvars", () => {
-        play_and_monitor(
+    it("Plays a movie with flashvars", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("<ruffle-embed />"),
             `// _level0.a
 1
 

--- a/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_flashvars_in_url/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object tag", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie with flashvars", () => {
-        play_and_monitor(
+    it("Plays a movie with flashvars", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />"),
+            await browser.$("#test-container").$("<ruffle-embed />"),
             `// _level0.a
 1
 

--- a/web/packages/selfhosted/test/polyfill/object_ie_only/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_ie_only/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object for old IE must work everywhere", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_data/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_data/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object without data attribute", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("doesn't polyfill with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("doesn't polyfill with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object without type attribute", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_missing_type_and_classid/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object without type and classid attributes", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_unexpected_string/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with unexpected string", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_with_ruffle_embed/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with ruffle-embed tag", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("already polyfilled with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("already polyfilled with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/object_wrong_type/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_wrong_type/test.js
@@ -10,21 +10,21 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Object with wrong type attribute value", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-embed />")
+            await browser.$("#test-container").$("<ruffle-embed />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/pdf/test.js
+++ b/web/packages/selfhosted/test/polyfill/pdf/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("PDF object", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("doesn't polyfill with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("doesn't polyfill with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/pdf_with_get/test.js
+++ b/web/packages/selfhosted/test/polyfill/pdf_with_get/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("PDF with .swf GET", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("doesn't polyfill with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("doesn't polyfill with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/remove_object/test.js
+++ b/web/packages/selfhosted/test/polyfill/remove_object/test.js
@@ -6,23 +6,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("Remove object", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("deletes ruffle player by id", () => {
-        browser.execute(() => {
+    it("deletes ruffle player by id", async () => {
+        await browser.execute(() => {
             const obj = document.getElementById("foo");
             obj.remove();
         });
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = "";
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/spl/test.js
+++ b/web/packages/selfhosted/test/polyfill/spl/test.js
@@ -6,13 +6,13 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("SPL", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("polyfills with ruffle", () => {
-        inject_ruffle_and_wait(browser);
-        const actual = browser.$("#test-container").getHTML(false);
+    it("polyfills with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_insensitive/test.js
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_insensitive/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("SWF extension insensitive", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-object />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_with_fragment/test.js
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_with_fragment/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("SWF extension, file with fragment", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-object />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/polyfill/swf_extension_with_get/test.js
+++ b/web/packages/selfhosted/test/polyfill/swf_extension_with_get/test.js
@@ -10,23 +10,23 @@ const fs = require("fs");
 use(chaiHtml);
 
 describe("SWF extension, file with GET parameter", () => {
-    it("loads the test", () => {
-        open_test(browser, __dirname);
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
     });
 
-    it("Polyfills", () => {
-        inject_ruffle_and_wait(browser);
-        browser.$("<ruffle-object />").waitForExist();
+    it("Polyfills", async () => {
+        await inject_ruffle_and_wait(browser);
+        await browser.$("<ruffle-object />").waitForExist();
 
-        const actual = browser.$("#test-container").getHTML(false);
+        const actual = await browser.$("#test-container").getHTML(false);
         const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
         expect(actual).html.to.equal(expected);
     });
 
-    it("Plays a movie", () => {
-        play_and_monitor(
+    it("Plays a movie", async () => {
+        await play_and_monitor(
             browser,
-            browser.$("#test-container").$("<ruffle-object />")
+            await browser.$("#test-container").$("<ruffle-object />")
         );
     });
 });

--- a/web/packages/selfhosted/test/utils.js
+++ b/web/packages/selfhosted/test/utils.js
@@ -1,7 +1,7 @@
 const path = require("path");
 
-function is_ruffle_loaded(browser) {
-    return browser.execute(
+async function is_ruffle_loaded(browser) {
+    return await browser.execute(
         () =>
             window !== undefined &&
             window.RufflePlayer !== undefined &&
@@ -9,15 +9,15 @@ function is_ruffle_loaded(browser) {
     );
 }
 
-function wait_for_ruffle(browser) {
-    browser.waitUntil(() => is_ruffle_loaded(browser), {
+async function wait_for_ruffle(browser) {
+    await browser.waitUntil(async () => await is_ruffle_loaded(browser), {
         timeoutMsg: "Expected Ruffle to load",
     });
-    throw_if_error(browser);
+    await throw_if_error(browser);
 }
 
-function setup_error_handler(browser) {
-    browser.execute(() => {
+async function setup_error_handler(browser) {
+    await browser.execute(() => {
         window.ruffleErrors = [];
         window.addEventListener("error", (error) => {
             window.ruffleErrors.push(error);
@@ -25,45 +25,45 @@ function setup_error_handler(browser) {
     });
 }
 
-function has_error(browser) {
-    return browser.execute(
+async function has_error(browser) {
+    return await browser.execute(
         () => window.ruffleErrors && window.ruffleErrors.length > 0
     );
 }
 
-function throw_if_error(browser) {
-    return browser.execute(() => {
+async function throw_if_error(browser) {
+    return await browser.execute(() => {
         if (window.ruffleErrors && window.ruffleErrors.length > 0) {
             throw window.ruffleErrors[0];
         }
     });
 }
 
-function inject_ruffle(browser) {
-    setup_error_handler(browser);
-    browser.execute(() => {
+async function inject_ruffle(browser) {
+    await setup_error_handler(browser);
+    await browser.execute(() => {
         const script = document.createElement("script");
         script.type = "text/javascript";
         script.src = "/dist/ruffle.js";
         document.head.appendChild(script);
     });
-    throw_if_error(browser);
+    await throw_if_error(browser);
 }
 
-function play_and_monitor(browser, player, expected_output) {
-    throw_if_error(browser);
+async function play_and_monitor(browser, player, expected_output) {
+    await throw_if_error(browser);
 
     // TODO: better way to test for this in the API
-    browser.waitUntil(
-        () =>
-            has_error(browser) ||
-            browser.execute((player) => player.instance, player),
+    await browser.waitUntil(
+        async () =>
+            await has_error(browser) ||
+            await browser.execute((player) => player.instance, player),
         {
             timeoutMsg: "Expected player to have initialized",
         }
     );
 
-    browser.execute((player) => {
+    await browser.execute((player) => {
         player.__ruffle_log__ = "";
         player.traceObserver = (msg) => {
             player.__ruffle_log__ += msg + "\n";
@@ -75,9 +75,9 @@ function play_and_monitor(browser, player, expected_output) {
         expected_output = "Hello from Flash!\n";
     }
 
-    browser.waitUntil(
-        () =>
-            browser.execute((player) => player.__ruffle_log__, player) ===
+    await browser.waitUntil(
+        async () =>
+            await browser.execute((player) => player.__ruffle_log__, player) ===
             expected_output,
         {
             timeoutMsg: "Expected Ruffle to trace a message",
@@ -85,29 +85,29 @@ function play_and_monitor(browser, player, expected_output) {
     );
 }
 
-function inject_ruffle_and_wait(browser) {
-    inject_ruffle(browser);
-    wait_for_ruffle(browser);
+async function inject_ruffle_and_wait(browser) {
+    await inject_ruffle(browser);
+    await wait_for_ruffle(browser);
 }
 
-function open_test(browser, absolute_dir, file_name) {
+async function open_test(browser, absolute_dir, file_name) {
     const dir_name = path.basename(absolute_dir);
     if (file_name === undefined) {
         file_name = "index.html";
     }
-    browser.url(`http://localhost:4567/test/polyfill/${dir_name}/${file_name}`);
+    await browser.url(`http://localhost:4567/test/polyfill/${dir_name}/${file_name}`);
 }
 
 /** Test set-up for JS API testing. */
 function js_api_before(swf) {
     let player = null;
 
-    before("Loads the test", () => {
-        browser.url("http://localhost:4567/test_assets/js_api.html");
+    before("Loads the test", async () => {
+        await browser.url("http://localhost:4567/test_assets/js_api.html");
 
-        inject_ruffle_and_wait(browser);
+        await inject_ruffle_and_wait(browser);
 
-        player = browser.execute(() => {
+        player = await browser.execute(() => {
             const ruffle = window.RufflePlayer.newest();
             const player = ruffle.createPlayer();
             const container = document.getElementById("test-container");
@@ -116,10 +116,10 @@ function js_api_before(swf) {
         });
 
         if (swf) {
-            browser.execute((player) => {
+            await browser.execute((player) => {
                 player.load("/test_assets/example.swf");
             }, player);
-            play_and_monitor(browser, player);
+            await play_and_monitor(browser, player);
         }
     });
 }

--- a/web/packages/selfhosted/test/utils.js
+++ b/web/packages/selfhosted/test/utils.js
@@ -56,8 +56,8 @@ async function play_and_monitor(browser, player, expected_output) {
     // TODO: better way to test for this in the API
     await browser.waitUntil(
         async () =>
-            await has_error(browser) ||
-            await browser.execute((player) => player.instance, player),
+            (await has_error(browser)) ||
+            (await browser.execute((player) => player.instance, player)),
         {
             timeoutMsg: "Expected player to have initialized",
         }
@@ -77,8 +77,10 @@ async function play_and_monitor(browser, player, expected_output) {
 
     await browser.waitUntil(
         async () =>
-            await browser.execute((player) => player.__ruffle_log__, player) ===
-            expected_output,
+            (await browser.execute(
+                (player) => player.__ruffle_log__,
+                player
+            )) === expected_output,
         {
             timeoutMsg: "Expected Ruffle to trace a message",
         }
@@ -95,7 +97,9 @@ async function open_test(browser, absolute_dir, file_name) {
     if (file_name === undefined) {
         file_name = "index.html";
     }
-    await browser.url(`http://localhost:4567/test/polyfill/${dir_name}/${file_name}`);
+    await browser.url(
+        `http://localhost:4567/test/polyfill/${dir_name}/${file_name}`
+    );
 }
 
 /** Test set-up for JS API testing. */


### PR DESCRIPTION
The wdio team are [deprecating](https://webdriver.io/blog/2021/07/28/sync-api-deprecation/) `wdio/sync` because it'll no longer work on Node 16 (which we'll want to move to at some point).

Fixing this seems to be just a matter of slapping "await" on everything.

This removes a fair few packages, and doesn't seem to change the speed of the tests.