### PR TITLE
tests: Don't build wgpu backend for non-img-tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 
 [dependencies]
 ruffle_core = { path = "../core" }
-ruffle_render_wgpu = { path = "../render/wgpu" }
+ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 image = "0.23.14"
 
 [features]
 # Enable running image comparison tests. This is off by default,
 # since the images we compare against are generated on CI, and may
 # not match your local machine's Vulkan version / image output.
-imgtests = []
+imgtests = ["ruffle_render_wgpu"]
 
 [dev-dependencies]
 approx = "0.5.0"

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -4,6 +4,7 @@
 
 use approx::assert_relative_eq;
 use ruffle_core::backend::render::RenderBackend;
+#[cfg(feature = "imgtests")]
 use ruffle_core::backend::video::SoftwareVideoBackend;
 use ruffle_core::backend::video::VideoBackend;
 use ruffle_core::backend::{
@@ -21,21 +22,19 @@ use ruffle_core::external::Value as ExternalValue;
 use ruffle_core::external::{ExternalInterfaceMethod, ExternalInterfaceProvider};
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::Player;
-use ruffle_render_wgpu::target::TextureTarget;
-use ruffle_render_wgpu::wgpu;
-use ruffle_render_wgpu::WgpuRenderBackend;
+#[cfg(feature = "imgtests")]
+use ruffle_render_wgpu::{target::TextureTarget, wgpu, WgpuRenderBackend};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[cfg(feature = "imgtests")]
 fn get_img_platform_suffix(info: &wgpu::AdapterInfo) -> String {
     format!("{}-{}", std::env::consts::OS, info.name)
 }
-
-const RUN_IMG_TESTS: bool = cfg!(feature = "imgtests");
 
 fn set_logger() {
     let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -923,6 +922,114 @@ fn test_swf_approx(
     Ok(())
 }
 
+#[cfg(feature = "imgtests")]
+fn get_render_backends(
+    movie: &SwfMovie,
+    platform_id: &mut Option<String>,
+) -> Result<(Box<dyn RenderBackend>, Box<dyn VideoBackend>), Error> {
+    let backend_bit = wgpu::BackendBit::PRIMARY;
+    let instance = wgpu::Instance::new(backend_bit);
+
+    let descriptors = WgpuRenderBackend::<TextureTarget>::build_descriptors(
+        backend_bit,
+        instance,
+        None,
+        Default::default(),
+        None,
+    )?;
+
+    *platform_id = Some(get_img_platform_suffix(&descriptors.info));
+
+    let target = TextureTarget::new(
+        &descriptors.device,
+        (
+            movie.width().to_pixels() as u32,
+            movie.height().to_pixels() as u32,
+        ),
+    );
+
+    let render_backend = Box::new(WgpuRenderBackend::new(descriptors, target)?);
+    let video_backend = Box::new(SoftwareVideoBackend::new());
+    Ok((render_backend, video_backend))
+}
+
+#[cfg(not(feature = "imgtests"))]
+fn get_render_backends(
+    _movie: &SwfMovie,
+    _platform_id: &mut Option<String>,
+) -> Result<(Box<dyn RenderBackend>, Box<dyn VideoBackend>), Error> {
+    Ok((Box::new(NullRenderer), Box::new(NullVideoBackend::new())))
+}
+
+#[cfg(feature = "imgtests")]
+fn check_image(
+    player: Arc<Mutex<Player>>,
+    swf_path: &str,
+    platform_id: Option<String>,
+) -> Result<(), Error> {
+    player.lock().unwrap().render();
+    let mut player_lock = player.lock().unwrap();
+    let renderer = player_lock
+        .renderer_mut()
+        .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
+        .unwrap();
+    let target = renderer.target();
+    let image = target
+        .capture(renderer.device())
+        .expect("Failed to capture image");
+
+    // The swf path ends in '<swf_name>/test.swf' - extract `swf_name`
+    let mut swf_path_buf = std::path::PathBuf::from(swf_path);
+    swf_path_buf.pop();
+
+    let swf_name = swf_path_buf.file_name().unwrap().to_string_lossy();
+    let img_name = format!("{}-{}.png", swf_name, platform_id.unwrap());
+
+    let mut img_path = swf_path_buf.clone();
+    img_path.push(&img_name);
+
+    let result = match image::open(&img_path) {
+        Ok(existing_img) => {
+            if existing_img
+                .as_rgba8()
+                .expect("Expected 8-bit RGBA image")
+                .as_raw()
+                == image.as_raw()
+            {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Test output does not match existing image `{:?}`",
+                    img_path
+                ))
+            }
+        }
+        Err(err) => Err(format!(
+            "Error occured when trying to read existing image `{:?}`: {}",
+            img_path, err
+        )),
+    };
+
+    if let Err(err) = result {
+        let new_img_path = img_path.with_file_name(img_name + ".updated");
+        image.save_with_format(&new_img_path, image::ImageFormat::Png)?;
+        panic!(
+            "Image test failed - saved new image to `{:?}`\n{}",
+            new_img_path, err
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "imgtests"))]
+fn check_image(
+    _player: Arc<Mutex<Player>>,
+    _swf_path: &str,
+    _platform_id: Option<String>,
+) -> Result<(), Error> {
+    Ok(())
+}
+
 /// Loads an SWF and runs it through the Ruffle core for a number of frames.
 /// Tests that the trace output matches the given expected output.
 fn run_swf(
@@ -930,10 +1037,8 @@ fn run_swf(
     num_frames: u32,
     before_start: impl FnOnce(Arc<Mutex<Player>>) -> Result<(), Error>,
     before_end: impl FnOnce(Arc<Mutex<Player>>) -> Result<(), Error>,
-    mut check_img: bool,
+    check_img: bool,
 ) -> Result<String, Error> {
-    check_img &= RUN_IMG_TESTS;
-
     let base_path = Path::new(swf_path).parent().unwrap();
     let (mut executor, channel) = NullExecutor::new();
     let movie = SwfMovie::from_path(swf_path, None)?;
@@ -941,33 +1046,10 @@ fn run_swf(
     let trace_output = Rc::new(RefCell::new(Vec::new()));
 
     let mut platform_id = None;
-    let backend_bit = wgpu::BackendBit::PRIMARY;
 
     let (render_backend, video_backend): (Box<dyn RenderBackend>, Box<dyn VideoBackend>) =
         if check_img {
-            let instance = wgpu::Instance::new(backend_bit);
-
-            let descriptors = WgpuRenderBackend::<TextureTarget>::build_descriptors(
-                backend_bit,
-                instance,
-                None,
-                Default::default(),
-                None,
-            )?;
-
-            platform_id = Some(get_img_platform_suffix(&descriptors.info));
-
-            let target = TextureTarget::new(
-                &descriptors.device,
-                (
-                    movie.width().to_pixels() as u32,
-                    movie.height().to_pixels() as u32,
-                ),
-            );
-
-            let render_backend = Box::new(WgpuRenderBackend::new(descriptors, target)?);
-            let video_backend = Box::new(SoftwareVideoBackend::new());
-            (render_backend, video_backend)
+            get_render_backends(&movie, &mut platform_id)?
         } else {
             (Box::new(NullRenderer), Box::new(NullVideoBackend::new()))
         };
@@ -999,57 +1081,7 @@ fn run_swf(
     // Render the image to disk
     // FIXME: Determine how we want to compare against on on-disk image
     if check_img {
-        player.lock().unwrap().render();
-        let mut player_lock = player.lock().unwrap();
-        let renderer = player_lock
-            .renderer_mut()
-            .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
-            .unwrap();
-        let target = renderer.target();
-        let image = target
-            .capture(renderer.device())
-            .expect("Failed to capture image");
-
-        // The swf path ends in '<swf_name>/test.swf' - extract `swf_name`
-        let mut swf_path_buf = PathBuf::from(swf_path);
-        swf_path_buf.pop();
-
-        let swf_name = swf_path_buf.file_name().unwrap().to_string_lossy();
-        let img_name = format!("{}-{}.png", swf_name, platform_id.unwrap());
-
-        let mut img_path = swf_path_buf.clone();
-        img_path.push(&img_name);
-
-        let result = match image::open(&img_path) {
-            Ok(existing_img) => {
-                if existing_img
-                    .as_rgba8()
-                    .expect("Expected 8-bit RGBA image")
-                    .as_raw()
-                    == image.as_raw()
-                {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "Test output does not match existing image `{:?}`",
-                        img_path
-                    ))
-                }
-            }
-            Err(err) => Err(format!(
-                "Error occured when trying to read existing image `{:?}`: {}",
-                img_path, err
-            )),
-        };
-
-        if let Err(err) = result {
-            let new_img_path = img_path.with_file_name(img_name + ".updated");
-            image.save_with_format(&new_img_path, image::ImageFormat::Png)?;
-            panic!(
-                "Image test failed - saved new image to `{:?}`\n{}",
-                new_img_path, err
-            );
-        }
+        check_image(player.clone(), swf_path, platform_id)?;
     }
 
     before_end(player)?;


### PR DESCRIPTION
This is a proposal.

The advantage is that when casually running `cd tests; cargo test` on my machine, wgpu alone increases build time and final binary size by a factor of ~2. This PR makes a fix-rebuild-test cycle considerably faster.
(will also speed up some CI builds... well only one after my other PR gets merged).
Disadvantage is slightly more spaghetti in `regression_tests.rs`.
The behavior should be unchanged.