### PR TITLE
dev: Make beta builds non-required

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.name }}
-    continue-on-error: ${{ matrix.rust_version == 'nightly' }}
+    continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In my understanding, this is needed for https://github.com/ruffle-rs/ruffle/pull/5106 to pass checks.