### PR TITLE
Silence some warning notes on GitHub checks

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Run tests with image tests
         if: ${{ matrix.os.img_tests }}
         uses: actions-rs/cargo@v1
+        env:
+          XDG_RUNTIME_DIR: "" # dummy value, just to silence warnings about it missing
         with:
           command: test
           args: --features imgtests


### PR DESCRIPTION
By setting a dummy value for `$XDG_RUNTIME_DIR`.
It's not pretty, but the tests seem to also pass this way.
I was just annoyed by these little meaningless notes appearing on every PR check.