### PR TITLE
web: Support menu embed/object attribute (part of #4258)

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -765,6 +765,13 @@ impl Player {
         })
     }
 
+    pub fn set_show_menu(&mut self, show_menu: bool) {
+        self.mutate_with_update_context(|context| {
+            let stage = context.stage;
+            stage.set_show_menu(context, show_menu);
+        })
+    }
+
     pub fn handle_event(&mut self, event: PlayerEvent) {
         if cfg!(feature = "avm_debug") {
             if let PlayerEvent::KeyDown {

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -186,6 +186,15 @@ export interface BaseLoadOptions {
      * @default null
      */
     base?: string | null;
+
+    /**
+     * If set to true, the built-in context menu items are visible
+     *
+     * This is equivalent to Stage.showMenu.
+     *
+     * @default true
+     */
+    menu?: boolean;
 }
 
 /**

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -3,6 +3,7 @@ import {
     FUTURESPLASH_MIMETYPE,
     FLASH7_AND_8_MIMETYPE,
     FLASH_MOVIE_MIMETYPE,
+    isBuiltInContextMenuVisible,
     isScriptAccessAllowed,
     isSwfFilename,
     RufflePlayer,
@@ -39,6 +40,7 @@ export class RuffleEmbed extends RufflePlayer {
             const allowScriptAccess =
                 this.attributes.getNamedItem("allowScriptAccess")?.value ??
                 null;
+            const menu = this.attributes.getNamedItem("menu")?.value ?? null;
 
             // Kick off the SWF download.
             this.load({
@@ -50,6 +52,7 @@ export class RuffleEmbed extends RufflePlayer {
                 parameters: this.attributes.getNamedItem("flashvars")?.value,
                 backgroundColor: this.attributes.getNamedItem("bgcolor")?.value,
                 base: this.attributes.getNamedItem("base")?.value,
+                menu: isBuiltInContextMenuVisible(menu),
             });
         }
     }

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -4,6 +4,7 @@ import {
     FLASH7_AND_8_MIMETYPE,
     FLASH_MOVIE_MIMETYPE,
     FLASH_ACTIVEX_CLASSID,
+    isBuiltInContextMenuVisible,
     isScriptAccessAllowed,
     isSwfFilename,
     RufflePlayer,
@@ -118,6 +119,8 @@ export class RuffleObject extends RufflePlayer {
             this.getAttribute("base")
         );
 
+        const menu = findCaseInsensitive(this.params, "menu", null);
+
         if (url) {
             const options: URLLoadOptions = { url };
             options.allowScriptAccess = isScriptAccessAllowed(
@@ -133,6 +136,7 @@ export class RuffleObject extends RufflePlayer {
             if (base) {
                 options.base = base;
             }
+            options.menu = isBuiltInContextMenuVisible(menu);
 
             // Kick off the SWF download.
             this.load(options);

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1304,6 +1304,19 @@ export function isScriptAccessAllowed(
 }
 
 /**
+ * Returns whether a SWF file should show the built-in context menu items.
+ *
+ * @param menu The value of the `menu` attribute.
+ * @returns True if the built-in context items should be shown.
+ */
+export function isBuiltInContextMenuVisible(menu: string | null): boolean {
+    if (menu === "true" || menu === null) {
+        return true;
+    }
+    return false;
+}
+
+/**
  * Returns whether the given filename ends in a known flash extension.
  *
  * @param filename The filename to test.

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -141,6 +141,9 @@ pub struct Config {
     #[serde(rename = "base")]
     base_url: Option<String>,
 
+    #[serde(rename = "menu")]
+    show_menu: bool,
+
     #[serde(rename = "warnOnUnsupportedContent")]
     warn_on_unsupported_content: bool,
 
@@ -155,6 +158,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             allow_script_access: false,
+            show_menu: true,
             background_color: Default::default(),
             letterbox: Default::default(),
             upgrade_to_https: true,
@@ -488,6 +492,7 @@ impl Ruffle {
             core.set_letterbox(config.letterbox);
             core.set_warn_on_unsupported_content(config.warn_on_unsupported_content);
             core.set_max_execution_duration(config.max_execution_duration);
+            core.set_show_menu(config.show_menu);
 
             // Create the external interface.
             if allow_script_access {


### PR DESCRIPTION
The menu attribute functions the same as Stage.showMenu. This does not fix a recently discovered issue with Stage.showMenu (it is only supposed to hide built-in context menu items, but currently also hides custom context menu items). I did not touch show_menu's current functionality.

Tested with the menu on http://www.dnai.org/. The built-in context menu items are hidden on that page, but they are still visible on http://www.dnai.org/a/ which lacks a menu attribute. When testing, if using Chrome, make sure the extension is taking precedence by checking that the context menu says extension, which it seems to often not do in Chrome for reasons unknown to me.