### PR TITLE
extension: Resolve paths relative to the SWF location

### DIFF
--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -15,8 +15,6 @@ window.RufflePlayer = api;
 __webpack_public_path__ = publicPath(api.config, "local");
 const ruffle = api.newest()!;
 
-let player;
-
 // Default config used by the player.
 const config = {
     letterbox: Letterbox.On,
@@ -24,7 +22,6 @@ const config = {
 };
 
 window.addEventListener("DOMContentLoaded", () => {
-    // TypeScript doesn't accept window.location alone.
     const url = new URL(window.location.href);
     const swfUrl = url.searchParams.get("url");
     if (!swfUrl) {
@@ -38,10 +35,10 @@ window.addEventListener("DOMContentLoaded", () => {
         // Ignore URL parsing errors.
     }
 
-    player = ruffle.createPlayer();
+    const player = ruffle.createPlayer();
     player.id = "player";
     player.setIsExtension(true);
     document.getElementById("main")!.append(player);
 
-    player.load({ url: swfUrl, ...config });
+    player.load({ url: swfUrl, base: swfUrl, ...config });
 });


### PR DESCRIPTION
In direct SWF mode, paths used to be resolved relative to the extension URL, which is invalid. Change it to be relative to the SWF location, using the `base` option.