### PR TITLE
ci: Use `dorny/paths-filter` to run only if certain file paths change

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -7,7 +7,25 @@ on:
     branches: [master]
 
 jobs:
+  changes:
+    name: Paths filter
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!web/package.json'
+              - '!web/package-lock.json'
+              - '!web/packages/**'
+              - '!**.md'
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.name }}
     continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -7,7 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
+  changes:
+    name: Paths filter
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!**.md'
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.rust_version == 'nightly' }}


### PR DESCRIPTION
The previous approach of `paths-ignore` was flawed because currently it doesn't interact well with GitHub's "Require status checks to pass before merging" setting. As a result, PRs that didn't trigger all workflows couldn't be merged, because GitHub waited for the skipped workflows to finish.

[`dorny/paths-filter`](https://github.com/dorny/paths-filter) is a somewhat elegant workaround proposed in https://stackoverflow.com/questions/66751567.

Plus some formattings.