### PR TITLE
avm2: Stub flash.system.Security.

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -523,6 +523,12 @@ pub fn load_player_globals<'gc>(
     )?;
     class(
         activation,
+        flash::system::security::create_class(mc),
+        domain,
+        script,
+    )?;
+    class(
+        activation,
         flash::system::system::create_class(mc),
         domain,
         script,

--- a/core/src/avm2/globals/flash/system.rs
+++ b/core/src/avm2/globals/flash/system.rs
@@ -3,4 +3,5 @@
 
 pub mod application_domain;
 pub mod capabilities;
+pub mod security;
 pub mod system;

--- a/core/src/avm2/globals/flash/system/security.rs
+++ b/core/src/avm2/globals/flash/system/security.rs
@@ -1,0 +1,109 @@
+//! `flash.system.Security` class
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::AvmString;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Err("The Security class cannot be constructed.".into())
+}
+
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+fn sandbox_type<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    let sandbox_type = activation.context.system.sandbox_type.to_string();
+    return Ok(AvmString::new(activation.context.gc_context, sandbox_type).into());
+}
+
+fn allow_domain<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Security.allowDomain not implemented");
+    Ok(Value::Undefined)
+}
+
+fn allow_insecure_domain<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Security.allowInsecureDomain not implemented");
+    Ok(Value::Undefined)
+}
+
+fn load_policy_file<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Security.loadPolicyFile not implemented");
+    Ok(Value::Undefined)
+}
+
+fn show_settings<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Security.showSettings not implemented");
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.system"), "Security"),
+        Some(QName::new(Namespace::public(), "Object").into()),
+        Method::from_builtin(instance_init, "<Security instance initializer>", mc),
+        Method::from_builtin(class_init, "<Security class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED);
+
+    const PUBLIC_CLASS_TRAITS: &[(&str, Option<NativeMethodImpl>, Option<NativeMethodImpl>)] =
+        &[("sandboxType", Some(sandbox_type), None)];
+    write.define_public_builtin_class_properties(mc, PUBLIC_CLASS_TRAITS);
+
+    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[
+        ("allowDomain", allow_domain),
+        ("allowInsecureDomain", allow_insecure_domain),
+        ("loadPolicyFile", load_policy_file),
+        ("showSettings", show_settings),
+    ];
+    write.define_public_builtin_class_methods(mc, PUBLIC_CLASS_METHODS);
+
+    const CONSTANTS: &[(&str, &str)] = &[
+        ("APPLICATION", "application"),
+        ("LOCAL_TRUSTED", "localTrusted"),
+        ("LOCAL_WITH_FILE", "localWithFile"),
+        ("LOCAL_WITH_NETWORK", "localWithNetwork"),
+        ("REMOTE", "remote"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
+
+    class
+}


### PR DESCRIPTION
Fairly straightforward, similar to AVM1 impl.
No tests (it's all unimplemented stubs, `sandboxType` aside). I manually checked `allowDomain` gets called on real SWFs.
