### PR TITLE
swf: Take advantage of `ClipEventFlag` bit pattern

### DIFF
--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -742,25 +742,30 @@ bitflags! {
     ///
     /// [SWF19 pp.48-50 ClipEvent](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=50)
     pub struct ClipEventFlag: u32 {
-        const CONSTRUCT       = 1 << 0;
-        const DATA            = 1 << 1;
-        const DRAG_OUT        = 1 << 2;
-        const DRAG_OVER       = 1 << 3;
-        const ENTER_FRAME     = 1 << 4;
-        const INITIALIZE      = 1 << 5;
-        const KEY_UP          = 1 << 6;
-        const KEY_DOWN        = 1 << 7;
-        const KEY_PRESS       = 1 << 8;
-        const LOAD            = 1 << 9;
-        const MOUSE_UP        = 1 << 10;
-        const MOUSE_DOWN      = 1 << 11;
-        const MOUSE_MOVE      = 1 << 12;
-        const PRESS           = 1 << 13;
+        const LOAD            = 1 << 0;
+        const ENTER_FRAME     = 1 << 1;
+        const UNLOAD          = 1 << 2;
+        const MOUSE_MOVE      = 1 << 3;
+        const MOUSE_DOWN      = 1 << 4;
+        const MOUSE_UP        = 1 << 5;
+        const KEY_DOWN        = 1 << 6;
+        const KEY_UP          = 1 << 7;
+
+        // Added in SWF6.
+        const DATA            = 1 << 8;
+        const INITIALIZE      = 1 << 9;
+        const PRESS           = 1 << 10;
+        const RELEASE         = 1 << 11;
+        const RELEASE_OUTSIDE = 1 << 12;
+        const ROLL_OVER       = 1 << 13;
         const ROLL_OUT        = 1 << 14;
-        const ROLL_OVER       = 1 << 15;
-        const RELEASE         = 1 << 16;
-        const RELEASE_OUTSIDE = 1 << 17;
-        const UNLOAD          = 1 << 18;
+        const DRAG_OVER       = 1 << 15;
+        const DRAG_OUT        = 1 << 16;
+        const KEY_PRESS       = 1 << 17;
+
+        // Construct was only added in SWF7, but it's not version-gated;
+        // Construct events will still fire in SWF6 in a v7+ player (#1424).
+        const CONSTRUCT       = 1 << 18;
     }
 }
 

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2009,30 +2009,11 @@ impl<W: Write> Writer<W> {
 
     fn write_clip_event_flags(&mut self, clip_events: ClipEventFlag) -> Result<()> {
         // TODO: Assert proper version.
-        let version = self.version;
-        let mut bits = self.bits();
-        bits.write_bit(clip_events.contains(ClipEventFlag::KEY_UP))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::KEY_DOWN))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::MOUSE_UP))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::MOUSE_DOWN))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::MOUSE_MOVE))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::UNLOAD))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::ENTER_FRAME))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::LOAD))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::DRAG_OVER))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::ROLL_OUT))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::ROLL_OVER))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::RELEASE_OUTSIDE))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::RELEASE))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::PRESS))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::INITIALIZE))?;
-        bits.write_bit(clip_events.contains(ClipEventFlag::DATA))?;
-        if version >= 6 {
-            bits.write_ubits(5, 0)?;
-            bits.write_bit(clip_events.contains(ClipEventFlag::CONSTRUCT))?;
-            bits.write_bit(clip_events.contains(ClipEventFlag::KEY_PRESS))?;
-            bits.write_bit(clip_events.contains(ClipEventFlag::DRAG_OUT))?;
-            bits.write_ubits(8, 0)?;
+        let bits = clip_events.bits();
+        if self.version >= 6 {
+            self.write_u32(bits)?;
+        } else {
+            self.write_u16((bits as u8).into())?;
         }
         Ok(())
     }


### PR DESCRIPTION
Re-number the `ClipEventFlag` enum members to match how they actually appear in a SWF. This allows much simpler read/write operations.

Also, gracefully handle malformed ClipActions that are only 1 or 0 bytes, as it seems that Flash accepts those too.