### PR TITLE
web: Support salign, quality, & scale embed/object attributes (part of #4258)

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -18,7 +18,9 @@ use crate::backend::{
 use crate::config::Letterbox;
 use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
 use crate::context_menu::{ContextMenuCallback, ContextMenuItem, ContextMenuState};
-use crate::display_object::{EditText, MorphShape, MovieClip, Stage};
+use crate::display_object::{
+    EditText, MorphShape, MovieClip, Stage, StageAlign, StageQuality, StageScaleMode,
+};
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, PlayerEvent};
 use crate::external::Value as ExternalValue;
 use crate::external::{ExternalInterface, ExternalInterfaceProvider};
@@ -35,6 +37,7 @@ use log::info;
 use rand::{rngs::SmallRng, SeedableRng};
 use std::collections::{HashMap, VecDeque};
 use std::ops::DerefMut;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
@@ -769,6 +772,33 @@ impl Player {
         self.mutate_with_update_context(|context| {
             let stage = context.stage;
             stage.set_show_menu(context, show_menu);
+        })
+    }
+
+    pub fn set_stage_align(&mut self, stage_align: &str) {
+        self.mutate_with_update_context(|context| {
+            let stage = context.stage;
+            if let Ok(stage_align) = StageAlign::from_str(stage_align) {
+                stage.set_align(context, stage_align);
+            }
+        })
+    }
+
+    pub fn set_quality(&mut self, quality: &str) {
+        self.mutate_with_update_context(|context| {
+            let stage = context.stage;
+            if let Ok(quality) = StageQuality::from_str(quality) {
+                stage.set_quality(context.gc_context, quality);
+            }
+        })
+    }
+
+    pub fn set_scale_mode(&mut self, scale_mode: &str) {
+        self.mutate_with_update_context(|context| {
+            let stage = context.stage;
+            if let Ok(scale_mode) = StageScaleMode::from_str(scale_mode) {
+                stage.set_scale_mode(context, scale_mode);
+            }
         })
     }
 

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -195,6 +195,30 @@ export interface BaseLoadOptions {
      * @default true
      */
     menu?: boolean;
+
+    /**
+     *
+     * This is equivalent to Stage.align.
+     *
+     * @default ""
+     */
+    salign?: string;
+
+    /**
+     *
+     * This is equivalent to Stage.quality.
+     *
+     * @default "high"
+     */
+    quality?: string;
+
+    /**
+     *
+     * This is equivalent to Stage.scaleMode.
+     *
+     * @default "showAll"
+     */
+    scale?: string;
 }
 
 /**

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -53,6 +53,11 @@ export class RuffleEmbed extends RufflePlayer {
                 backgroundColor: this.attributes.getNamedItem("bgcolor")?.value,
                 base: this.attributes.getNamedItem("base")?.value,
                 menu: isBuiltInContextMenuVisible(menu),
+                salign: this.attributes.getNamedItem("salign")?.value ?? "",
+                quality:
+                    this.attributes.getNamedItem("quality")?.value ?? "high",
+                scale:
+                    this.attributes.getNamedItem("scale")?.value ?? "showAll",
             });
         }
     }

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -120,6 +120,9 @@ export class RuffleObject extends RufflePlayer {
         );
 
         const menu = findCaseInsensitive(this.params, "menu", null);
+        const salign = findCaseInsensitive(this.params, "salign", "");
+        const quality = findCaseInsensitive(this.params, "quality", "high");
+        const scale = findCaseInsensitive(this.params, "scale", "showAll");
 
         if (url) {
             const options: URLLoadOptions = { url };
@@ -137,6 +140,15 @@ export class RuffleObject extends RufflePlayer {
                 options.base = base;
             }
             options.menu = isBuiltInContextMenuVisible(menu);
+            if (salign) {
+                options.salign = salign;
+            }
+            if (quality) {
+                options.quality = quality;
+            }
+            if (scale) {
+                options.scale = scale;
+            }
 
             // Kick off the SWF download.
             this.load(options);

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -144,6 +144,12 @@ pub struct Config {
     #[serde(rename = "menu")]
     show_menu: bool,
 
+    salign: Option<String>,
+
+    quality: Option<String>,
+
+    scale: Option<String>,
+
     #[serde(rename = "warnOnUnsupportedContent")]
     warn_on_unsupported_content: bool,
 
@@ -159,6 +165,9 @@ impl Default for Config {
         Self {
             allow_script_access: false,
             show_menu: true,
+            salign: Some("".to_owned()),
+            quality: Some("high".to_owned()),
+            scale: Some("showAll".to_owned()),
             background_color: Default::default(),
             letterbox: Default::default(),
             upgrade_to_https: true,
@@ -493,6 +502,9 @@ impl Ruffle {
             core.set_warn_on_unsupported_content(config.warn_on_unsupported_content);
             core.set_max_execution_duration(config.max_execution_duration);
             core.set_show_menu(config.show_menu);
+            core.set_stage_align(config.salign.as_deref().unwrap_or(""));
+            core.set_quality(config.quality.as_deref().unwrap_or("high"));
+            core.set_scale_mode(config.scale.as_deref().unwrap_or("showAll"));
 
             // Create the external interface.
             if allow_script_access {


### PR DESCRIPTION
Good test for salign (recently mentioned in Discord):

https://deconcept.com/

If anyone knows a good test for scale, let me know. I tested it locally and it seems to work. According to #4601, quality does nothing currently in Ruffle, but I still added support for it since implementing all three of these attributes followed the exact same process so it made sense to do so.

To be added to [the Wiki](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#list-of-options):

> `salign` A string with a default value of "". This controls the position of the movie after scaling to fill the viewport and crops it as needed. The default alignment is centered. T, L, B, and R mean top, left, bottom, and right respectively. Can technically be any number of T's, L's, B's, and R's in any order, but the logical choices are "", "T", "L", "B", "R", "TL"/"LT", "TR"/"RT", "BL"/"LB", or "BR"/"RB". If you use some strange combination with both T's and B's or both L's and R's, keep in mind the precedence is L > R > "" and T > B > "".
> 
> `scale` A string with a default value of "showAll". The options are:
> * "showAll": Makes the entire SWF file visible in the specified area without distortion, while maintaining the original aspect ratio of the movie. Borders can appear on two sides of the movie.
> * "noborder": Scales the SWF file to fill the specified area, while maintaining the original aspect ratio of the file. The content may be cropped, but no distortion occurs.
> * "exactfit": Makes the entire SWF file visible in the specified area without trying to preserve the original aspect ratio. Distortion can occur.
> * "noscale": Prevents the SWF file from scaling to fit the area of the player. Cropping can occur.
> 
> `quality` A string with a default value of "high". Does nothing in Ruffle currently but can still be set and may do something in the future. The main options are "low", "medium", "high", and "best".