### PR TITLE
ci: Fix paths filter

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -20,10 +20,7 @@ jobs:
         with:
           filters: |
             src:
-              - '!web/package.json'
-              - '!web/package-lock.json'
-              - '!web/packages/**'
-              - '!**.md'
+              - '!(web/package.json|web/package-lock.json|web/packages/**|**.md)'
 
   build:
     needs: changes

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           filters: |
             src:
-              - '!**.md'
+              - '!(**.md)'
 
   build:
     needs: changes


### PR DESCRIPTION
Multiple patterns on one filter uses OR - it's enough that any file is matched by at least one pattern, and the filter becomes `true`.
This means the previous Rust filter became `true` even when only Web files were modified.

Use an extended glob feature to make the patterns work like an AND.