### PR TITLE
desktop: Revert cpal initialization on a separate thread

### DIFF
--- a/desktop/src/audio.rs
+++ b/desktop/src/audio.rs
@@ -15,17 +15,10 @@ use swf::AudioCompression;
 pub struct CpalAudioBackend {
     device: cpal::Device,
     output_config: cpal::StreamConfig,
-    stream: Stream,
+    stream: cpal::Stream,
     sounds: Arena<Sound>,
     sound_instances: Arc<Mutex<Arena<SoundInstance>>>,
 }
-
-// Because of https://github.com/RustAudio/cpal/pull/348, we have to initialize cpal on a
-// separate thread (see `new` below). Unfortunately `cpal::Stream` is marked `!Send`, but
-// we know this should be safe (since we aren't accessing the stream at all after creation;
-// we just want to keep it alive)
-struct Stream(cpal::Stream);
-unsafe impl Send for CpalAudioBackend {}
 
 type Signal = Box<dyn Send + dasp::signal::Signal<Frame = [i16; 2]>>;
 
@@ -71,21 +64,6 @@ struct SoundInstance {
 
 impl CpalAudioBackend {
     pub fn new() -> Result<Self, Error> {
-        // Initialize cpal on a separate thread to issues on Windows with cpal + winit:
-        // https://github.com/RustAudio/cpal/pull/348
-        // TODO: Revert back to doing this on the same thread when the above is fixed.
-        let init_thread = std::thread::spawn(move || -> Result<Self, String> {
-            Self::init().map_err(|e| e.to_string())
-        });
-
-        match init_thread.join() {
-            Ok(Ok(audio)) => Ok(audio),
-            Ok(Err(e)) => Err(e.into()),
-            Err(_) => Err("Panic when initializing audio".into()),
-        }
-    }
-
-    fn init() -> Result<Self, Error> {
         // Create CPAL audio device.
         let host = cpal::default_host();
         let device = host
@@ -139,7 +117,7 @@ impl CpalAudioBackend {
         Ok(Self {
             device,
             output_config: config,
-            stream: Stream(stream),
+            stream,
             sounds: Arena::new(),
             sound_instances,
         })
@@ -336,11 +314,11 @@ impl AudioBackend for CpalAudioBackend {
     }
 
     fn play(&mut self) {
-        self.stream.0.play().expect("Error trying to resume CPAL audio stream. This feature may not be supported by your audio device.");
+        self.stream.play().expect("Error trying to resume CPAL audio stream. This feature may not be supported by your audio device.");
     }
 
     fn pause(&mut self) {
-        self.stream.0.pause().expect("Error trying to pause CPAL audio stream. This feature may not be supported by your audio device.");
+        self.stream.pause().expect("Error trying to pause CPAL audio stream. This feature may not be supported by your audio device.");
     }
 
     fn start_stream(


### PR DESCRIPTION
It was initialized on a separate thread since 6178dd9, as a workaround for Windows.
But now thanks to RustAudio/cpal#597, this is no longer needed, and cpal can be initialized on the same thread as before.

Plus small cleanups.