### PR TITLE
audio: Store sound transform values in 30-bit integers

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -2,10 +2,7 @@ use crate::{
     avm1::SoundObject,
     avm2::Event as Avm2Event,
     avm2::Object as Avm2Object,
-    display_object::{
-        self, DisplayObject, MovieClip, SoundTransform as DisplayObjectSoundTransform,
-        TDisplayObject,
-    },
+    display_object::{self, DisplayObject, MovieClip, TDisplayObject},
 };
 use downcast_rs::Downcast;
 use gc_arena::Collect;
@@ -225,7 +222,7 @@ pub struct AudioManager<'gc> {
     sounds: Vec<SoundInstance<'gc>>,
 
     /// The global sound transform applied to all sounds.
-    global_sound_transform: DisplayObjectSoundTransform,
+    global_sound_transform: display_object::SoundTransform,
 
     /// The number of seconds that a timeline audio stream should buffer before playing.
     ///
@@ -319,7 +316,7 @@ impl<'gc> AudioManager<'gc> {
                 sound: Some(sound),
                 instance: handle,
                 display_object,
-                transform: DisplayObjectSoundTransform::default(),
+                transform: display_object::SoundTransform::default(),
                 avm1_object,
                 avm2_object: None,
             };
@@ -411,7 +408,7 @@ impl<'gc> AudioManager<'gc> {
                 sound: None,
                 instance: handle,
                 display_object: Some(movie_clip.into()),
-                transform: DisplayObjectSoundTransform::default(),
+                transform: display_object::SoundTransform::default(),
                 avm1_object: None,
                 avm2_object: None,
             };
@@ -423,11 +420,11 @@ impl<'gc> AudioManager<'gc> {
         }
     }
 
-    pub fn global_sound_transform(&self) -> &DisplayObjectSoundTransform {
+    pub fn global_sound_transform(&self) -> &display_object::SoundTransform {
         &self.global_sound_transform
     }
 
-    pub fn set_global_sound_transform(&mut self, sound_transform: DisplayObjectSoundTransform) {
+    pub fn set_global_sound_transform(&mut self, sound_transform: display_object::SoundTransform) {
         self.global_sound_transform = sound_transform;
         self.transforms_dirty = true;
     }
@@ -436,7 +433,7 @@ impl<'gc> AudioManager<'gc> {
     pub fn local_sound_transform(
         &self,
         instance: SoundInstanceHandle,
-    ) -> Option<&DisplayObjectSoundTransform> {
+    ) -> Option<&display_object::SoundTransform> {
         if let Some(i) = self
             .sounds
             .iter()
@@ -453,7 +450,7 @@ impl<'gc> AudioManager<'gc> {
     pub fn set_local_sound_transform(
         &mut self,
         instance: SoundInstanceHandle,
-        sound_transform: DisplayObjectSoundTransform,
+        sound_transform: display_object::SoundTransform,
     ) {
         if let Some(i) = self
             .sounds
@@ -539,17 +536,17 @@ pub struct SoundInstance<'gc> {
     /// Only AVM2 sounds have a local sound transform. In AVM1, sound instances
     /// instead get the sound transform of the display object they're
     /// associated with.
-    transform: DisplayObjectSoundTransform,
+    transform: display_object::SoundTransform,
 
     /// The AVM1 `Sound` object associated with this sound, if any.
-    pub avm1_object: Option<SoundObject<'gc>>,
+    avm1_object: Option<SoundObject<'gc>>,
 
     /// The AVM2 `Sound` object associated with this sound, if any.
-    pub avm2_object: Option<Avm2Object<'gc>>,
+    avm2_object: Option<Avm2Object<'gc>>,
 }
 
 /// A sound transform for a playing sound, for use by audio backends.
-/// This differs from `display_object::SoundTranform` by being
+/// This differs from `display_object::SoundTransform` by being
 /// already converted to `f32` and having `volume` baked in.
 #[derive(Debug, PartialEq, Clone, Collect)]
 #[collect(require_static)]
@@ -560,9 +557,9 @@ pub struct SoundTransform {
     pub right_to_right: f32,
 }
 
-impl From<DisplayObjectSoundTransform> for SoundTransform {
+impl From<display_object::SoundTransform> for SoundTransform {
     /// Converts from a `display_object::SoundTransform` to a `backend::audio::SoundTransform`.
-    fn from(other: DisplayObjectSoundTransform) -> Self {
+    fn from(other: display_object::SoundTransform) -> Self {
         const SCALE: f32 = display_object::SoundTransform::MAX_VOLUME.pow(2) as f32;
 
         // It seems like Flash stores sound transform values in 30-bit unsigned integers:

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -493,7 +493,7 @@ impl<'gc> AudioManager<'gc> {
             parent = display_object.parent();
         }
         transform.concat(&self.global_sound_transform);
-        SoundTransform::from_display_object_transform(&transform)
+        transform.into()
     }
 
     /// Update the sound transforms for all sounds.
@@ -560,16 +560,26 @@ pub struct SoundTransform {
     pub right_to_right: f32,
 }
 
-impl SoundTransform {
+impl From<DisplayObjectSoundTransform> for SoundTransform {
     /// Converts from a `display_object::SoundTransform` to a `backend::audio::SoundTransform`.
-    fn from_display_object_transform(other: &DisplayObjectSoundTransform) -> Self {
-        const SCALE: f32 = (display_object::SoundTransform::MAX_VOLUME
-            * display_object::SoundTransform::MAX_VOLUME) as f32;
+    fn from(other: DisplayObjectSoundTransform) -> Self {
+        const SCALE: f32 = display_object::SoundTransform::MAX_VOLUME.pow(2) as f32;
+
+        // It seems like Flash stores sound transform values in 30-bit unsigned integers:
+        // * Negative values are equivalent to their absolute value.
+        // * Specifically, 0x40000000, -0x40000000 and -0x80000000 are equivalent to zero.
+        // * The volume multiplication wraps around at `u32::MAX`.
+        let left_to_left = (other.left_to_left << 2) >> 2;
+        let left_to_right = (other.left_to_right << 2) >> 2;
+        let right_to_left = (other.right_to_left << 2) >> 2;
+        let right_to_right = (other.right_to_right << 2) >> 2;
+        let volume = (other.volume << 2) >> 2;
+
         Self {
-            left_to_left: other.left_to_left as f32 * other.volume as f32 / SCALE,
-            left_to_right: other.left_to_right as f32 * other.volume as f32 / SCALE,
-            right_to_left: other.right_to_left as f32 * other.volume as f32 / SCALE,
-            right_to_right: other.right_to_right as f32 * other.volume as f32 / SCALE,
+            left_to_left: left_to_left.wrapping_mul(volume) as f32 / SCALE,
+            left_to_right: left_to_right.wrapping_mul(volume) as f32 / SCALE,
+            right_to_left: right_to_left.wrapping_mul(volume) as f32 / SCALE,
+            right_to_right: right_to_right.wrapping_mul(volume) as f32 / SCALE,
         }
     }
 }


### PR DESCRIPTION
It seems like Flash stores sound transform values in 30-bit unsigned integers:
* In general, negative values are equivalent to their absolute value.
* Specifically, 0x40000000, -0x40000000 and -0x80000000 are equivalent to zero.

Plus a small cleanup.

Fixes the "marching" sound in #5126, which roughly does the following:
```as
var s = new Sound();
s.attachSound("marching");
s.setPan(NaN);
s.start();
```
Previously this played a terrible noise in Ruffle, while it plays normally in Flash as if no transform is applied.