### PR TITLE
web: Enable the bulk-memory WebAssembly extension

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [target.wasm32-unknown-unknown]
-rustflags=["--cfg=web_sys_unstable_apis"]
+rustflags=["--cfg=web_sys_unstable_apis", "-C", "target-feature=+bulk-memory"]
+
+# on Windows, in release builds, link to CRT statically
+[target.'cfg(all(windows, not(debug_assertions)))']
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -91,12 +91,10 @@ jobs:
           - build_name: windows-x86_32
             os: windows-latest
             target: i686-pc-windows-msvc
-            RUSTFLAGS: -Ctarget-feature=+crt-static
 
           - build_name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            RUSTFLAGS: -Ctarget-feature=+crt-static
 
     env:
       PACKAGE_FILE: ${{ needs.create-nightly-release.outputs.package_prefix }}-${{ matrix.build_name }}.${{ startsWith(matrix.build_name, 'win') && 'zip' || 'tar.gz' }}
@@ -137,8 +135,6 @@ jobs:
         with:
           command: build
           args: --package ruffle_desktop --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
-        env:
-          RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
 
       - name: Package common
         run: |

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -30,6 +30,7 @@ const enum PanicError {
     Unknown,
     CSPConflict,
     FileProtocol,
+    NoWasmBulkMemory,
     InvalidWasm,
     JavascriptConfiguration,
     JavascriptConflict,
@@ -398,6 +399,13 @@ export class RufflePlayer extends HTMLElement {
                     e.ruffleIndexError = PanicError.WasmCors;
                 } else if (message.includes("disallowed by embedder")) {
                     e.ruffleIndexError = PanicError.CSPConflict;
+                } else if (
+                    message.includes("doesn't parse") &&
+                    message.includes("references are not enabled")
+                ) {
+                    // The "reference-types" extension is now based on the "bulk-memory" one,
+                    // hence the misleading error message from Safari.
+                    e.ruffleIndexError = PanicError.NoWasmBulkMemory;
                 } else if (e.name === "CompileError") {
                     e.ruffleIndexError = PanicError.InvalidWasm;
                 } else if (
@@ -1152,6 +1160,18 @@ export class RufflePlayer extends HTMLElement {
                 `;
                 errorFooter = `
                     <li><a target="_top" href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#web">View Ruffle Wiki</a></li>
+                    <li><a href="#" id="panic-view-details">View Error Details</a></li>
+                `;
+                break;
+            case PanicError.NoWasmBulkMemory:
+                // The browser does not support WebAssembly bulk memory, most likely Safari <15
+                errorBody = `
+                    <p>It seems like your browser has no support for the "Bulk Memory Operations" WebAssembly extension.</p>
+                    <p>This is required for Ruffle to work efficiently, so please update your browser.</p>
+                    <p>See the Ruffle wiki for the list of supported browsers and their minimum versions.</p>
+                `;
+                errorFooter = `
+                    <li><a target="_top" href="https://github.com/ruffle-rs/ruffle/wiki#web">View Ruffle Wiki</a></li>
                     <li><a href="#" id="panic-view-details">View Error Details</a></li>
                 `;
                 break;

--- a/web/packages/extension/README.md
+++ b/web/packages/extension/README.md
@@ -8,7 +8,7 @@ It automatically negotiates with websites that do have Ruffle installed, to ensu
 
 ## Using ruffle-extension
 
-The browser extension works in Chrome, Firefox, and Safari 14+.
+The browser extension works in Chrome, Firefox, and Safari 15+.
 
 Before you can install the extension, you must either download the [latest release](https://github.com/ruffle-rs/ruffle/releases) or [build it yourself](../../README.md).
 


### PR DESCRIPTION
This should improve all around performance on web, to a varying degree.
I'll gladly provide benchmark numbers upon request; but so far I've seen that at least while decoding videos, this should save anywhere between 10% and 20% of processing time, "for free".

There are still quite a few calls to the naive `memcpy` and `memset` functions (explicit loop and load/store in WASM), mostly from `core` and `std`.
To get rid of these as well, the `build-std` cargo feature would be needed (which does something similar to what Xargo was for), but that is a nightly-only flag as of now, because [there are still some issues with it](https://github.com/rust-lang/cargo/labels/Z-build-std).

This raises the minimum browser version requirements to:
 - ~Chrome 75 (released on 2019-06-05): https://v8.dev/blog/v8-release-75#bulk-memory-operations, https://www.chromestatus.com/feature/4590306448113664~
   Chrome 87 is already required
 - ~Firefox 79 (released on 2020-06-28): https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/79#webassembly~
   Firefox 84 is already required
 - Safari 15.0 (EDIT: released on 2021-09-20 - finally!): https://developer.apple.com/safari/technology-preview/release-notes/#r121

I know basically nothing about the habits of :apple: ecosystem users, but based on past data, Safari 15.0 is supposed to be the most used version by November, and is supposed to reach near its top market share by about January or February:

<p align="center">
<img src="https://user-images.githubusercontent.com/288816/132105296-cee58e94-dbae-4c2e-98a4-2c06080a622e.png" width="50%"/></p>

Source: https://gs.statcounter.com/browser-version-market-share

So, I don't think this should be merged for at least a couple weeks, but we can still talk about it here until then. :)