### PR TITLE
avm2: Add more Event class stubs and constants

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -574,6 +574,18 @@ pub fn load_player_globals<'gc>(
         domain,
         script,
     )?;
+    class(
+        activation,
+        flash::events::keyboardevent::create_class(mc),
+        domain,
+        script,
+    )?;
+    class(
+        activation,
+        flash::events::progressevent::create_class(mc),
+        domain,
+        script,
+    )?;
     // package `flash.utils`
     avm2_system_class!(
         bytearray,

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -3,4 +3,6 @@
 pub mod event;
 pub mod eventdispatcher;
 pub mod ieventdispatcher;
+pub mod keyboardevent;
 pub mod mouseevent;
+pub mod progressevent;

--- a/core/src/avm2/globals/flash/events/keyboardevent.rs
+++ b/core/src/avm2/globals/flash/events/keyboardevent.rs
@@ -7,7 +7,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
 
-/// Implements `flash.events.MouseEvent`'s instance constructor.
+/// Implements `flash.events.KeyboardEvent`'s instance constructor.
 pub fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
@@ -19,7 +19,7 @@ pub fn instance_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Implements `flash.events.MouseEvent`'s class constructor.
+/// Implements `flash.events.KeyboardEvent`'s class constructor.
 pub fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
@@ -28,13 +28,13 @@ pub fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Construct `MouseEvent`'s class.
+/// Construct `KeyboardEvent`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
-        QName::new(Namespace::package("flash.events"), "MouseEvent"),
+        QName::new(Namespace::package("flash.events"), "KeyboardEvent"),
         Some(QName::new(Namespace::package("flash.events"), "Event").into()),
-        Method::from_builtin(instance_init, "<MouseEvent instance initializer>", mc),
-        Method::from_builtin(class_init, "<MouseEvent class initializer>", mc),
+        Method::from_builtin(instance_init, "<KeyboardEvent instance initializer>", mc),
+        Method::from_builtin(class_init, "<KeyboardEvent class initializer>", mc),
         mc,
     );
 
@@ -42,26 +42,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&str, &str)] = &[
-        ("CLICK", "click"),
-        ("CONTEXT_MENU", "contextMenu"),
-        ("DOUBLE_CLICK", "doubleClick"),
-        ("MIDDLE_CLICK", "middleClick"),
-        ("MIDDLE_MOUSE_DOWN", "middleMouseDown"),
-        ("MIDDLE_MOUSE_UP", "middleMouseUp"),
-        ("MOUSE_DOWN", "mouseDown"),
-        ("MOUSE_MOVE", "mouseMove"),
-        ("MOUSE_OUT", "mouseOut"),
-        ("MOUSE_OVER", "mouseOver"),
-        ("MOUSE_UP", "mouseUp"),
-        ("MOUSE_WHEEL", "mouseWheel"),
-        ("RELEASE_OUTSIDE", "releaseOutside"),
-        ("RIGHT_CLICK", "rightClick"),
-        ("RIGHT_MOUSE_DOWN", "rightMouseDown"),
-        ("RIGHT_MOUSE_UP", "rightMouseUp"),
-        ("ROLL_OUT", "rollOut"),
-        ("ROLL_OVER", "rollOver"),
-    ];
+    const CONSTANTS: &[(&str, &str)] = &[("KEY_DOWN", "keyDown"), ("KEY_UP", "keyUp")];
 
     write.define_public_constant_string_class_traits(CONSTANTS);
 

--- a/core/src/avm2/globals/flash/events/progressevent.rs
+++ b/core/src/avm2/globals/flash/events/progressevent.rs
@@ -7,7 +7,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
 
-/// Implements `flash.events.MouseEvent`'s instance constructor.
+/// Implements `flash.events.ProgressEvent`'s instance constructor.
 pub fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
@@ -19,7 +19,7 @@ pub fn instance_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Implements `flash.events.MouseEvent`'s class constructor.
+/// Implements `flash.events.ProgressEvent`'s class constructor.
 pub fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
@@ -28,13 +28,13 @@ pub fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Construct `MouseEvent`'s class.
+/// Construct `ProgressEvent`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
-        QName::new(Namespace::package("flash.events"), "MouseEvent"),
+        QName::new(Namespace::package("flash.events"), "ProgressEvent"),
         Some(QName::new(Namespace::package("flash.events"), "Event").into()),
-        Method::from_builtin(instance_init, "<MouseEvent instance initializer>", mc),
-        Method::from_builtin(class_init, "<MouseEvent class initializer>", mc),
+        Method::from_builtin(instance_init, "<ProgressEvent instance initializer>", mc),
+        Method::from_builtin(class_init, "<ProgressEvent class initializer>", mc),
         mc,
     );
 
@@ -43,24 +43,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_attributes(ClassAttributes::SEALED);
 
     const CONSTANTS: &[(&str, &str)] = &[
-        ("CLICK", "click"),
-        ("CONTEXT_MENU", "contextMenu"),
-        ("DOUBLE_CLICK", "doubleClick"),
-        ("MIDDLE_CLICK", "middleClick"),
-        ("MIDDLE_MOUSE_DOWN", "middleMouseDown"),
-        ("MIDDLE_MOUSE_UP", "middleMouseUp"),
-        ("MOUSE_DOWN", "mouseDown"),
-        ("MOUSE_MOVE", "mouseMove"),
-        ("MOUSE_OUT", "mouseOut"),
-        ("MOUSE_OVER", "mouseOver"),
-        ("MOUSE_UP", "mouseUp"),
-        ("MOUSE_WHEEL", "mouseWheel"),
-        ("RELEASE_OUTSIDE", "releaseOutside"),
-        ("RIGHT_CLICK", "rightClick"),
-        ("RIGHT_MOUSE_DOWN", "rightMouseDown"),
-        ("RIGHT_MOUSE_UP", "rightMouseUp"),
-        ("ROLL_OUT", "rollOut"),
-        ("ROLL_OVER", "rollOver"),
+        ("PROGRESS", "progress"),
+        ("SOCKET_DATA", "socketData"),
+        ("STANDARD_ERROR_DATA", "standardErrorData"),
+        ("STANDARD_INPUT_PROGRESS", "standardInputProgress"),
+        ("STANDARD_OUTPUT_DATA", "standardOutputData"),
     ];
 
     write.define_public_constant_string_class_traits(CONSTANTS);


### PR DESCRIPTION
- remaining constants for MouseEvent
- KeyboardEvent constants
- ProgressEvent constants

This is mostly to let scripts progress a bit further and try to slightly reduce log spam in my test SWFs.
In practice it doesn't really help much, as a lot of `addEventListener` calls end with `TypeError: undefined is not an Object` anyway.