### PR TITLE
dev: Only test beta rust on ubuntu

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -34,10 +34,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, beta]
+        rust_version: [stable]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         include:
           - rust_version: nightly
+            os: ubuntu-latest
+          - rust_version: beta
             os: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Resurrecting the earlier version of #5106, now that beta builds are no longer required.