### PR TITLE
web: fix base parameter

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -197,7 +197,7 @@ pub trait NavigatorBackend {
     /// defined base. For a web browser, the most obvious base would be the
     /// current document's base URL, while the most obvious base for a desktop
     /// client would be the file-URL form of the current path.
-    fn resolve_relative_url<'a>(&mut self, url: &'a str) -> Cow<'a, str>;
+    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str>;
 
     /// Handle any context specific pre-processing
     ///
@@ -376,7 +376,7 @@ impl NavigatorBackend for NullNavigatorBackend {
         }
     }
 
-    fn resolve_relative_url<'a>(&mut self, url: &'a str) -> Cow<'a, str> {
+    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str> {
         let relative = url_from_relative_path(&self.relative_base_path, url);
         if let Ok(relative) = relative {
             String::from(relative).into()

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -179,7 +179,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
         }
     }
 
-    fn resolve_relative_url<'a>(&mut self, url: &'a str) -> Cow<'a, str> {
+    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str> {
         let relative = self.movie_url.join(url);
         if let Ok(relative) = relative {
             String::from(relative).into()

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -577,7 +577,7 @@ export class RufflePlayer extends HTMLElement {
                     ...sanitizeParameters(options.parameters),
                 };
 
-                this.instance!.stream_from(options.url, parameters);
+                this.instance!.stream_from(this.swfUrl, parameters);
             } else if ("data" in options) {
                 console.log("Loading SWF data");
                 this.instance!.load_data(


### PR DESCRIPTION
This fixes the issue @albertstill brought up when asking in #5026 about the base parameter. I've had several issues in the original pull request - mostly because I assumed a few things I shouldn't have and didn't check throughly enough.

1. The web impl fetch function now uses resolve_relative_url for relative urls so base url would be taken into account - this should be fine, right?
2. base can now accept directories as well as full URLs.
3. this.swfUrl is passed into stream_from instead of options.url - this is because options.url can be relative and we don't want ruffle to apply the base url to the swf url (this.swfUrl is the calculated full url of options.url).
4. resolve_relative_url changed to non mut self because why not?
