### PR TITLE
chore: Bump to wgpu 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,6 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "arrayvec"
@@ -113,10 +110,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269d0f5e68353a7cab87f81e7c736adc008d279a36ebc6a05dfe01193a89f0c9"
 
 [[package]]
-name = "ash"
-version = "0.32.1"
+name = "arrayvec"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06063a002a77d2734631db74e8f4ce7148b77fe522e6bca46f2ae7774fd48112"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ash"
+version = "0.33.2+1.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2b957a47afef62973ed5fa0a52afb3289c7a243bfbc3906090b8434971237"
 dependencies = [
  "libloading 0.7.0",
 ]
@@ -800,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091ed1b25fe47c7ff129fc440c23650b6114f36aa00bc7212cc8041879294428"
+checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
 dependencies = [
  "bitflags",
  "libloading 0.7.0",
@@ -1091,15 +1097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "drm-fourcc"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbf3a5ed4671aabffefce172ff43d69c1f27dd2c6aea28e5212a70f32ada0cf"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,16 +1215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "external-memory"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4dfe8d292b014422776a8c516862d2bff8a81b223a4461dfdc45f3862dc9d39"
-dependencies = [
- "bitflags",
- "drm-fourcc",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "flash-lso"
@@ -1472,168 +1459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gfx-auxil"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1694991b11d642680e82075a75c7c2bd75556b805efa7660b705689f05b1ab1c"
-dependencies = [
- "fxhash",
- "gfx-hal",
- "spirv_cross",
-]
-
-[[package]]
-name = "gfx-backend-dx11"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9e453baf3aaef2b0c354ce0b3d63d76402e406a59b64b7182d123cfa6635ae"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "gfx-auxil",
- "gfx-hal",
- "gfx-renderdoc",
- "libloading 0.7.0",
- "log",
- "parking_lot",
- "range-alloc",
- "raw-window-handle",
- "smallvec",
- "spirv_cross",
- "thunderdome",
- "winapi",
- "wio",
-]
-
-[[package]]
-name = "gfx-backend-dx12"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21506399f64a3c4d389182a89a30073856ae33eb712315456b4fd8f39ee7682a"
-dependencies = [
- "arrayvec 0.5.2",
- "bit-set",
- "bitflags",
- "d3d12",
- "gfx-auxil",
- "gfx-hal",
- "gfx-renderdoc",
- "log",
- "parking_lot",
- "range-alloc",
- "raw-window-handle",
- "smallvec",
- "spirv_cross",
- "thunderdome",
- "winapi",
-]
-
-[[package]]
-name = "gfx-backend-empty"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c8f813c47791918aa00dc9c9ddf961d23fa8c2a5d869e6cb8ea84f944820f4"
-dependencies = [
- "gfx-hal",
- "log",
- "raw-window-handle",
-]
-
-[[package]]
-name = "gfx-backend-gl"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bae057fc3a0ab23ecf97ae51d4017d27d5ddf0aab16ee6dcb58981af88c3152"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "fxhash",
- "gfx-hal",
- "glow",
- "js-sys",
- "khronos-egl",
- "libloading 0.7.0",
- "log",
- "naga",
- "parking_lot",
- "raw-window-handle",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gfx-backend-metal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de85808e2a98994c6af925253f8a9593bc57180ef1ea137deab6d35cc949517"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "block",
- "cocoa-foundation",
- "copyless",
- "core-graphics-types",
- "foreign-types",
- "fxhash",
- "gfx-hal",
- "log",
- "metal",
- "naga",
- "objc",
- "parking_lot",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "storage-map",
-]
-
-[[package]]
-name = "gfx-backend-vulkan"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9861ec855acbbc65c0e4f966d761224886e811dc2c6d413a4776e9293d0e5c0"
-dependencies = [
- "arrayvec 0.5.2",
- "ash",
- "byteorder",
- "core-graphics-types",
- "gfx-hal",
- "gfx-renderdoc",
- "inplace_it",
- "log",
- "naga",
- "objc",
- "parking_lot",
- "raw-window-handle",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "gfx-hal"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbb575ea793dd0507b3082f4f2cde62dc9f3cebd98f5cd49ba2a4da97a976fd"
-dependencies = [
- "bitflags",
- "external-memory",
- "naga",
- "raw-window-handle",
- "thiserror",
-]
-
-[[package]]
-name = "gfx-renderdoc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8027995e247e2426d3a00d13f5191dd56c314bff02dc4b54cbf727f1ba9c40a"
-dependencies = [
- "libloading 0.7.0",
- "log",
- "renderdoc-sys",
-]
-
-[[package]]
 name = "gif"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,9 +1476,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glow"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b80b98efaa8a34fce11d60dd2ce2760d5d83c373cbcc73bb87c2a3a84a54108"
+checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1663,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.4.7"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc1b6ca374e81862526786d9cb42357ce03706ed1b8761730caafd02ab91f3a"
+checksum = "ab8524eac5fc9d05625c891adf78fcf64dc0ee9f8d0882874b9f220f42b442bf"
 dependencies = [
  "bitflags",
  "gpu-alloc-types",
@@ -1682,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a70f1e87a3840ed6a3e99e02c2b861e4dbdf26f0d07e38f42ea5aff46cfce2"
+checksum = "d7a237f0419ab10d17006d55c62ac4f689a6bf52c75d3f38b8361d249e8d4b0b"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
@@ -2181,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d7d769f1c104b8388294d6594d491d2e21240636f5f94d37f8a0f3d7904450"
+checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
 dependencies = [
  "bitflags",
  "block",
@@ -2274,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef670817eef03d356d5a509ea275e7dd3a78ea9e24261ea3cb2dfed1abb08f64"
+checksum = "9b136bf483e309f330c74880370fa6f0553d9249399ac1dfa8e92c96a1612add"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2286,7 +2111,8 @@ dependencies = [
  "num-traits",
  "petgraph",
  "rose_tree",
- "spirv_headers",
+ "serde",
+ "spirv",
  "thiserror",
 ]
 
@@ -2661,9 +2487,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -3022,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "rose_tree"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284de9dae38774e2813aaabd7e947b4a6fe9b8c58c2309f754a487cdd50de1c2"
+checksum = "fcd16c61e9205949fa4f8a22096705b4c2f8b8025b2ff67ff6c86afd854039ae"
 dependencies = [
  "petgraph",
 ]
@@ -3367,9 +3193,12 @@ dependencies = [
 
 [[package]]
 name = "slotmap"
-version = "0.4.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61b40583e0c1bd3100652ba8940939decc8808e7b2a07f4f4606c6a8a40035a"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "sluice"
@@ -3418,21 +3247,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv_cross"
-version = "0.23.1"
+name = "spirv"
+version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60647fadbf83c4a72f0d7ea67a7ca3a81835cf442b8deae5c134c3e0055b2e14"
-dependencies = [
- "cc",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "spirv_headers"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5b132530b1ac069df335577e3581765995cba5a13995cdbbdbc8fb057c532c"
+checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
  "bitflags",
  "num-traits",
@@ -3449,15 +3267,6 @@ name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
-
-[[package]]
-name = "storage-map"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418bb14643aa55a7841d5303f72cf512cfb323b8cc221d51580500a1ca75206c"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "strength_reduce"
@@ -3639,12 +3448,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "thunderdome"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b4947742c93ece24a0032141d9caa3d853752e694a57e35029dd2bd08673e0"
 
 [[package]]
 name = "tiff"
@@ -4018,9 +3821,9 @@ checksum = "9a8f3bf74f2d43500dea6a8291b6ac943e3465ea9936b94bd017e61b7b21dd01"
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4054,11 +3857,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd247f8b26fd3d42ef2f320d378025cd6e84d782ef749fab45cc3b981fbe3275"
+checksum = "3d92a4fe73b1e7d7ef99938dacd49258cbf1ad87cdb5bf6efa20c27447442b45"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.7.1",
  "js-sys",
  "log",
  "naga",
@@ -4070,29 +3873,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "wgpu-core",
+ "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958a8a5e418492723ab4e7933bf6dbdf06f5dc87274ba2ae0e4f9c891aac579c"
+checksum = "425b975c319d311e051bf3afb54120a34b187f9d889edc68e347567e512774c8"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.7.1",
  "bitflags",
  "cfg_aliases",
  "copyless",
  "fxhash",
- "gfx-backend-dx11",
- "gfx-backend-dx12",
- "gfx-backend-empty",
- "gfx-backend-gl",
- "gfx-backend-metal",
- "gfx-backend-vulkan",
- "gfx-hal",
- "gpu-alloc",
- "gpu-descriptor",
  "log",
  "naga",
  "parking_lot",
@@ -4102,14 +3897,49 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
+ "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-types"
-version = "0.9.0"
+name = "wgpu-hal"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5c9678cd533558e28b416d66947b099742df1939307478db54f867137f1b60"
+checksum = "cd9bf514ccb78d4b409bb09db9d6c11ac54c9f69112faf5c0440bf54fdfb45ce"
+dependencies = [
+ "arrayvec 0.7.1",
+ "ash",
+ "bit-set",
+ "bitflags",
+ "block",
+ "core-graphics-types",
+ "d3d12",
+ "foreign-types",
+ "fxhash",
+ "glow",
+ "gpu-alloc",
+ "gpu-descriptor",
+ "inplace_it",
+ "khronos-egl",
+ "libloading 0.7.0",
+ "log",
+ "metal",
+ "naga",
+ "objc",
+ "parking_lot",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "thiserror",
+ "wgpu-types",
+ "winapi",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25feb2fbf24ab3219a9f10890ceb8e1ef02b13314ed89d64a9ae99dcad883e18"
 dependencies = [
  "bitflags",
  "serde",
@@ -4189,15 +4019,6 @@ name = "winreg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "wio"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
 ]

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-wgpu = "0.9.0"
+wgpu = { version = "0.10.1", features = ["spirv"] }
 image = "0.23.14"
 jpeg-decoder = "0.1.22"
 log = "0.4"

--- a/render/wgpu/src/bitmaps.rs
+++ b/render/wgpu/src/bitmaps.rs
@@ -46,7 +46,7 @@ impl BitmapSamplers {
             label: layout_label.as_deref(),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStage::FRAGMENT,
+                visibility: wgpu::ShaderStages::FRAGMENT,
                 ty: wgpu::BindingType::Sampler {
                     comparison: false,
                     filtering: true,

--- a/render/wgpu/src/clap.rs
+++ b/render/wgpu/src/clap.rs
@@ -7,14 +7,14 @@ pub enum GraphicsBackend {
     Dx11,
 }
 
-impl From<GraphicsBackend> for wgpu::BackendBit {
+impl From<GraphicsBackend> for wgpu::Backends {
     fn from(backend: GraphicsBackend) -> Self {
         match backend {
-            GraphicsBackend::Default => wgpu::BackendBit::PRIMARY | wgpu::BackendBit::DX11,
-            GraphicsBackend::Vulkan => wgpu::BackendBit::VULKAN,
-            GraphicsBackend::Metal => wgpu::BackendBit::METAL,
-            GraphicsBackend::Dx12 => wgpu::BackendBit::DX12,
-            GraphicsBackend::Dx11 => wgpu::BackendBit::DX11,
+            GraphicsBackend::Default => wgpu::Backends::PRIMARY | wgpu::Backends::DX11,
+            GraphicsBackend::Vulkan => wgpu::Backends::VULKAN,
+            GraphicsBackend::Metal => wgpu::Backends::METAL,
+            GraphicsBackend::Dx12 => wgpu::Backends::DX12,
+            GraphicsBackend::Dx11 => wgpu::Backends::DX11,
         }
     }
 }

--- a/render/wgpu/src/globals.rs
+++ b/render/wgpu/src/globals.rs
@@ -24,7 +24,7 @@ impl Globals {
             label: layout_label.as_deref(),
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStage::VERTEX,
+                visibility: wgpu::ShaderStages::VERTEX,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: false,
@@ -38,7 +38,7 @@ impl Globals {
         let buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: buffer_label.as_deref(),
             size: std::mem::size_of::<GlobalsUniform>() as u64,
-            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -90,7 +90,7 @@ impl Globals {
                     [-1.0, 1.0, 0.0, 1.0],
                 ],
             }]),
-            usage: wgpu::BufferUsage::COPY_SRC,
+            usage: wgpu::BufferUsages::COPY_SRC,
         });
 
         encoder.copy_buffer_to_buffer(

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -39,7 +39,6 @@ impl Pipelines {
                     wgpu::ShaderModuleDescriptor {
                         label: Some($($token)*),
                         source: wgpu::util::make_spirv(include_bytes!($($token)*)),
-                        flags: wgpu::ShaderFlags::empty(),
                     }
                 }
             };
@@ -55,7 +54,7 @@ impl Pipelines {
 
         let vertex_buffers_description = [wgpu::VertexBufferLayout {
             array_stride: std::mem::size_of::<Vertex>() as u64,
-            step_mode: wgpu::InputStepMode::Vertex,
+            step_mode: wgpu::VertexStepMode::Vertex,
             attributes: &vertex_attr_array![
                 0 => Float32x2,
                 1 => Float32x4,
@@ -77,7 +76,7 @@ impl Pipelines {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::VERTEX,
+                        visibility: wgpu::ShaderStages::VERTEX,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -87,7 +86,7 @@ impl Pipelines {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
                             multisampled: false,
                             sample_type: wgpu::TextureSampleType::Float { filterable: true },
@@ -116,7 +115,7 @@ impl Pipelines {
                 entries: &[
                     wgpu::BindGroupLayoutEntry {
                         binding: 0,
-                        visibility: wgpu::ShaderStage::VERTEX,
+                        visibility: wgpu::ShaderStages::VERTEX,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
@@ -126,7 +125,7 @@ impl Pipelines {
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 1,
-                        visibility: wgpu::ShaderStage::FRAGMENT,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Buffer {
                             ty: wgpu::BufferBindingType::Storage { read_only: true },
                             has_dynamic_offset: false,
@@ -217,11 +216,11 @@ fn create_color_pipelines(
         bind_group_layouts: &[globals_layout],
         push_constant_ranges: &[
             wgpu::PushConstantRange {
-                stages: wgpu::ShaderStage::VERTEX,
+                stages: wgpu::ShaderStages::VERTEX,
                 range: 0..transforms_size,
             },
             wgpu::PushConstantRange {
-                stages: wgpu::ShaderStage::FRAGMENT,
+                stages: wgpu::ShaderStages::FRAGMENT,
                 range: transforms_size..transforms_size + colors_size,
             },
         ],
@@ -390,11 +389,11 @@ fn create_bitmap_pipeline(
         bind_group_layouts: &[globals_layout, bitmap_bind_layout, sampler_layout],
         push_constant_ranges: &[
             wgpu::PushConstantRange {
-                stages: wgpu::ShaderStage::VERTEX,
+                stages: wgpu::ShaderStages::VERTEX,
                 range: 0..64,
             },
             wgpu::PushConstantRange {
-                stages: wgpu::ShaderStage::FRAGMENT,
+                stages: wgpu::ShaderStages::FRAGMENT,
                 range: 64..96,
             },
         ],
@@ -561,11 +560,11 @@ fn create_gradient_pipeline(
         bind_group_layouts: &[globals_layout, gradient_bind_layout],
         push_constant_ranges: &[
             wgpu::PushConstantRange {
-                stages: wgpu::ShaderStage::VERTEX,
+                stages: wgpu::ShaderStages::VERTEX,
                 range: 0..64,
             },
             wgpu::PushConstantRange {
-                stages: wgpu::ShaderStage::FRAGMENT,
+                stages: wgpu::ShaderStages::FRAGMENT,
                 range: 64..96,
             },
         ],
@@ -717,7 +716,7 @@ fn create_gradient_pipeline(
     ShapePipeline { mask_pipelines }
 }
 
-fn mask_render_state(state: MaskState) -> (wgpu::StencilState, wgpu::ColorWrite) {
+fn mask_render_state(state: MaskState) -> (wgpu::StencilState, wgpu::ColorWrites) {
     let (stencil_state, color_write) = match state {
         MaskState::NoMask => (
             wgpu::StencilFaceState {
@@ -726,7 +725,7 @@ fn mask_render_state(state: MaskState) -> (wgpu::StencilState, wgpu::ColorWrite)
                 depth_fail_op: wgpu::StencilOperation::Keep,
                 pass_op: wgpu::StencilOperation::Keep,
             },
-            wgpu::ColorWrite::ALL,
+            wgpu::ColorWrites::ALL,
         ),
         MaskState::DrawMaskStencil => (
             wgpu::StencilFaceState {
@@ -735,7 +734,7 @@ fn mask_render_state(state: MaskState) -> (wgpu::StencilState, wgpu::ColorWrite)
                 depth_fail_op: wgpu::StencilOperation::Keep,
                 pass_op: wgpu::StencilOperation::IncrementClamp,
             },
-            wgpu::ColorWrite::empty(),
+            wgpu::ColorWrites::empty(),
         ),
         MaskState::DrawMaskedContent => (
             wgpu::StencilFaceState {
@@ -744,7 +743,7 @@ fn mask_render_state(state: MaskState) -> (wgpu::StencilState, wgpu::ColorWrite)
                 depth_fail_op: wgpu::StencilOperation::Keep,
                 pass_op: wgpu::StencilOperation::Keep,
             },
-            wgpu::ColorWrite::ALL,
+            wgpu::ColorWrites::ALL,
         ),
         MaskState::ClearMaskStencil => (
             wgpu::StencilFaceState {
@@ -753,7 +752,7 @@ fn mask_render_state(state: MaskState) -> (wgpu::StencilState, wgpu::ColorWrite)
                 depth_fail_op: wgpu::StencilOperation::Keep,
                 pass_op: wgpu::StencilOperation::DecrementClamp,
             },
-            wgpu::ColorWrite::empty(),
+            wgpu::ColorWrites::empty(),
         ),
     };
 

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -19,7 +19,7 @@ pub trait RenderTarget: Debug + 'static {
 
     fn height(&self) -> u32;
 
-    fn get_next_texture(&mut self) -> Result<Self::Frame, wgpu::SwapChainError>;
+    fn get_next_texture(&mut self) -> Result<Self::Frame, wgpu::SurfaceError>;
 
     fn submit<I: IntoIterator<Item = wgpu::CommandBuffer>>(
         &self,
@@ -32,33 +32,34 @@ pub trait RenderTarget: Debug + 'static {
 #[derive(Debug)]
 pub struct SwapChainTarget {
     window_surface: wgpu::Surface,
-    swap_chain_desc: wgpu::SwapChainDescriptor,
-    swap_chain: wgpu::SwapChain,
+    surface_config: wgpu::SurfaceConfiguration,
 }
 
 #[derive(Debug)]
-pub struct SwapChainTargetFrame(wgpu::SwapChainFrame);
+pub struct SwapChainTargetFrame {
+    view: wgpu::TextureView,
+    frame: wgpu::SurfaceFrame,
+}
 
 impl RenderTargetFrame for SwapChainTargetFrame {
     fn view(&self) -> &wgpu::TextureView {
-        &self.0.output.view
+        &self.view
     }
 }
 
 impl SwapChainTarget {
     pub fn new(surface: wgpu::Surface, size: (u32, u32), device: &wgpu::Device) -> Self {
-        let swap_chain_desc = wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: wgpu::TextureFormat::Bgra8Unorm,
             width: size.0,
             height: size.1,
             present_mode: wgpu::PresentMode::Mailbox,
         };
-        let swap_chain = device.create_swap_chain(&surface, &swap_chain_desc);
+        surface.configure(device, &surface_config);
         Self {
+            surface_config,
             window_surface: surface,
-            swap_chain_desc,
-            swap_chain,
         }
     }
 }
@@ -67,27 +68,27 @@ impl RenderTarget for SwapChainTarget {
     type Frame = SwapChainTargetFrame;
 
     fn resize(&mut self, device: &wgpu::Device, width: u32, height: u32) {
-        self.swap_chain_desc.width = width;
-        self.swap_chain_desc.height = height;
-        self.swap_chain = device.create_swap_chain(&self.window_surface, &self.swap_chain_desc);
+        self.surface_config.width = width;
+        self.surface_config.height = height;
+        self.window_surface.configure(device, &self.surface_config);
     }
 
     fn format(&self) -> wgpu::TextureFormat {
-        self.swap_chain_desc.format
+        self.surface_config.format
     }
 
     fn width(&self) -> u32 {
-        self.swap_chain_desc.width
+        self.surface_config.width
     }
 
     fn height(&self) -> u32 {
-        self.swap_chain_desc.height
+        self.surface_config.height
     }
 
-    fn get_next_texture(&mut self) -> Result<Self::Frame, wgpu::SwapChainError> {
-        self.swap_chain
-            .get_current_frame()
-            .map(SwapChainTargetFrame)
+    fn get_next_texture(&mut self) -> Result<Self::Frame, wgpu::SurfaceError> {
+        let frame = self.window_surface.get_current_frame()?;
+        let view = frame.output.texture.create_view(&Default::default());
+        Ok(SwapChainTargetFrame { frame, view })
     }
 
     fn submit<I: IntoIterator<Item = wgpu::CommandBuffer>>(
@@ -137,14 +138,14 @@ impl TextureTarget {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         });
         let buffer_label = create_debug_label!("Render target buffer");
         let buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: buffer_label.as_deref(),
             size: (buffer_dimensions.padded_bytes_per_row.get() as u64
                 * buffer_dimensions.height as u64),
-            usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::MAP_READ,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
         Self {
@@ -201,14 +202,14 @@ impl RenderTarget for TextureTarget {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: self.format,
-            usage: wgpu::TextureUsage::RENDER_ATTACHMENT | wgpu::TextureUsage::COPY_SRC,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         });
 
         let buffer_label = create_debug_label!("Render target buffer");
         self.buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: buffer_label.as_deref(),
             size: width as u64 * height as u64 * 4,
-            usage: wgpu::BufferUsage::COPY_DST | wgpu::BufferUsage::MAP_READ,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
     }
@@ -225,7 +226,7 @@ impl RenderTarget for TextureTarget {
         self.size.height
     }
 
-    fn get_next_texture(&mut self) -> Result<Self::Frame, wgpu::SwapChainError> {
+    fn get_next_texture(&mut self) -> Result<Self::Frame, wgpu::SurfaceError> {
         Ok(TextureTargetFrame(
             self.texture.create_view(&Default::default()),
         ))
@@ -246,6 +247,7 @@ impl RenderTarget for TextureTarget {
                 texture: &self.texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
             },
             wgpu::ImageCopyBuffer {
                 buffer: &self.buffer,

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -27,25 +27,25 @@ pub fn format_list<'a>(values: &[&'a str], connector: &'a str) -> Cow<'a, str> {
     }
 }
 
-pub fn get_backend_names(backends: wgpu::BackendBit) -> Vec<&'static str> {
+pub fn get_backend_names(backends: wgpu::Backends) -> Vec<&'static str> {
     let mut names = Vec::new();
 
-    if backends.contains(wgpu::BackendBit::VULKAN) {
+    if backends.contains(wgpu::Backends::VULKAN) {
         names.push("Vulkan");
     }
-    if backends.contains(wgpu::BackendBit::DX12) {
+    if backends.contains(wgpu::Backends::DX12) {
         names.push("DirectX 12");
     }
-    if backends.contains(wgpu::BackendBit::DX11) {
+    if backends.contains(wgpu::Backends::DX11) {
         names.push("DirectX 11");
     }
-    if backends.contains(wgpu::BackendBit::METAL) {
+    if backends.contains(wgpu::Backends::METAL) {
         names.push("Metal");
     }
-    if backends.contains(wgpu::BackendBit::GL) {
+    if backends.contains(wgpu::Backends::GL) {
         names.push("Open GL");
     }
-    if backends.contains(wgpu::BackendBit::BROWSER_WEBGPU) {
+    if backends.contains(wgpu::Backends::BROWSER_WEBGPU) {
         names.push("Web GPU");
     }
 
@@ -55,7 +55,7 @@ pub fn get_backend_names(backends: wgpu::BackendBit) -> Vec<&'static str> {
 pub fn create_buffer_with_data(
     device: &wgpu::Device,
     data: &[u8],
-    usage: wgpu::BufferUsage,
+    usage: wgpu::BufferUsages,
     label: Option<String>,
 ) -> wgpu::Buffer {
     device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -985,7 +985,7 @@ fn run_swf(
     let trace_output = Rc::new(RefCell::new(Vec::new()));
 
     let mut platform_id = None;
-    let backend_bit = wgpu::BackendBit::PRIMARY;
+    let backend_bit = wgpu::Backends::PRIMARY;
 
     let (render_backend, video_backend): (Box<dyn RenderBackend>, Box<dyn VideoBackend>) =
         if check_img {


### PR DESCRIPTION
Bump to latest wgpu 0.10.1. The main breaking change was the merge of `wgpu::SwapChain` into `Surface`.