### PR TITLE
avm1: Remove `TObject::get_local` in favor of `TObject::get_local_stored`

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -515,15 +515,6 @@ impl<'gc> FunctionObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for FunctionObject<'gc> {
-    fn get_local(
-        &self,
-        name: &str,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
-        self.base.get_local(name, activation, this)
-    }
-
     fn get_local_stored(
         &self,
         name: &str,
@@ -644,6 +635,10 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
             let _ = self.call("[ctor]", activation, this, None, args)?;
             Ok(this.into())
         }
+    }
+
+    fn getter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {
+        self.base.getter(name, activation)
     }
 
     fn setter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -109,39 +109,35 @@ pub fn object_to_matrix_or_default<'gc>(
     object: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Matrix, Error<'gc>> {
-    // This works with raw properties (`get_local`).
-    // TODO: This should ignore virtual properties.
-    let a = if let Some(val) = object.get_local("a", activation, object) {
-        val?.coerce_to_f64(activation)? as f32
-    } else {
-        return Ok(Default::default());
-    };
-    let b = if let Some(val) = object.get_local("b", activation, object) {
-        val?.coerce_to_f64(activation)? as f32
-    } else {
-        return Ok(Default::default());
-    };
-    let c = if let Some(val) = object.get_local("c", activation, object) {
-        val?.coerce_to_f64(activation)? as f32
-    } else {
-        return Ok(Default::default());
-    };
-    let d = if let Some(val) = object.get_local("d", activation, object) {
-        val?.coerce_to_f64(activation)? as f32
-    } else {
-        return Ok(Default::default());
-    };
-    let tx = if let Some(val) = object.get_local("tx", activation, object) {
-        Twips::from_pixels(val?.coerce_to_f64(activation)?)
-    } else {
-        return Ok(Default::default());
-    };
-    let ty = if let Some(val) = object.get_local("ty", activation, object) {
-        Twips::from_pixels(val?.coerce_to_f64(activation)?)
-    } else {
-        return Ok(Default::default());
-    };
-
+    // These lookups do not search the prototype chain and ignore virtual properties.
+    let a = object
+        .get_local_stored("a", activation)
+        .unwrap_or(Value::Undefined)
+        .coerce_to_f64(activation)? as f32;
+    let b = object
+        .get_local_stored("b", activation)
+        .unwrap_or(Value::Undefined)
+        .coerce_to_f64(activation)? as f32;
+    let c = object
+        .get_local_stored("c", activation)
+        .unwrap_or(Value::Undefined)
+        .coerce_to_f64(activation)? as f32;
+    let d = object
+        .get_local_stored("d", activation)
+        .unwrap_or(Value::Undefined)
+        .coerce_to_f64(activation)? as f32;
+    let tx = Twips::from_pixels(
+        object
+            .get_local_stored("tx", activation)
+            .unwrap_or(Value::Undefined)
+            .coerce_to_f64(activation)?,
+    );
+    let ty = Twips::from_pixels(
+        object
+            .get_local_stored("ty", activation)
+            .unwrap_or(Value::Undefined)
+            .coerce_to_f64(activation)?,
+    );
     Ok(Matrix { a, b, c, d, tx, ty })
 }
 

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1160,14 +1160,14 @@ fn local_to_global<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Value::Object(point) = args.get(0).unwrap_or(&Value::Undefined) {
         // localToGlobal does no coercion; it fails if the properties are not numbers.
-        // It does not search the prototype chain.
+        // It does not search the prototype chain and ignores virtual properties.
         if let (Value::Number(x), Value::Number(y)) = (
             point
-                .get_local("x", activation, *point)
-                .unwrap_or(Ok(Value::Undefined))?,
+                .get_local_stored("x", activation)
+                .unwrap_or(Value::Undefined),
             point
-                .get_local("y", activation, *point)
-                .unwrap_or(Ok(Value::Undefined))?,
+                .get_local_stored("y", activation)
+                .unwrap_or(Value::Undefined),
         ) {
             let x = Twips::from_pixels(x);
             let y = Twips::from_pixels(y);
@@ -1295,14 +1295,14 @@ fn global_to_local<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Value::Object(point) = args.get(0).unwrap_or(&Value::Undefined) {
         // globalToLocal does no coercion; it fails if the properties are not numbers.
-        // It does not search the prototype chain.
+        // It does not search the prototype chain and ignores virtual properties.
         if let (Value::Number(x), Value::Number(y)) = (
             point
-                .get_local("x", activation, *point)
-                .unwrap_or(Ok(Value::Undefined))?,
+                .get_local_stored("x", activation)
+                .unwrap_or(Value::Undefined),
             point
-                .get_local("y", activation, *point)
-                .unwrap_or(Ok(Value::Undefined))?,
+                .get_local_stored("y", activation)
+                .unwrap_or(Value::Undefined),
         ) {
             let x = Twips::from_pixels(x);
             let y = Twips::from_pixels(y);

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -93,15 +93,6 @@ impl<'gc> ArrayObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for ArrayObject<'gc> {
-    fn get_local(
-        &self,
-        name: &str,
-        activation: &mut Activation<'_, 'gc, '_>,
-        this: Object<'gc>,
-    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
-        self.0.read().get_local(name, activation, this)
-    }
-
     fn get_local_stored(
         &self,
         name: &str,
@@ -142,6 +133,10 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
         self.0.read().call(name, activation, this, base_proto, args)
+    }
+
+    fn getter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {
+        self.0.read().getter(name, activation)
     }
 
     fn setter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -53,15 +53,6 @@ macro_rules! impl_custom_object {
             crate::impl_custom_object!(@extra $field $extra_name($($extra)*));
         )*
 
-        fn get_local(
-            &self,
-            name: &str,
-            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
-            this: crate::avm1::Object<'gc>,
-        ) -> Option<Result<crate::avm1::Value<'gc>, crate::avm1::Error<'gc>>> {
-            self.0.read().$field.get_local(name, activation, this)
-        }
-
         fn get_local_stored(
             &self,
             name: &str,
@@ -82,6 +73,14 @@ macro_rules! impl_custom_object {
                 .read()
                 .$field
                 .call(name, activation, this, base_proto, args)
+        }
+
+        fn getter(
+            &self,
+            name: &str,
+            activation: &mut crate::avm1::Activation<'_, 'gc, '_>,
+        ) -> Option<crate::avm1::object::Object<'gc>> {
+            self.0.read().$field.getter(name, activation)
         }
 
         fn setter(

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -47,15 +47,6 @@ impl<'gc> SuperObject<'gc> {
 }
 
 impl<'gc> TObject<'gc> for SuperObject<'gc> {
-    fn get_local(
-        &self,
-        _name: &str,
-        _activation: &mut Activation<'_, 'gc, '_>,
-        _this: Object<'gc>,
-    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
-        Some(Ok(Value::Undefined))
-    }
-
     fn get_local_stored(
         &self,
         _name: &str,
@@ -110,6 +101,10 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         }
 
         method.call(name, activation, this, base_proto, args)
+    }
+
+    fn getter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {
+        self.0.read().this.getter(name, activation)
     }
 
     fn setter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -41,16 +41,6 @@ impl<'gc> XmlAttributesObject<'gc> {
             XmlAttributesObject(_, node) => *node,
         }
     }
-
-    fn get_local_sub(
-        &self,
-        name: &str,
-        activation: &mut Activation<'_, 'gc, '_>,
-    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
-        self.node()
-            .attribute_value(&XmlName::from_str(name))
-            .map(|s| Ok(AvmString::new(activation.context.gc_context, s).into()))
-    }
 }
 
 impl fmt::Debug for XmlAttributesObject<'_> {
@@ -66,21 +56,14 @@ impl fmt::Debug for XmlAttributesObject<'_> {
 }
 
 impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
-    fn get_local(
-        &self,
-        name: &str,
-        activation: &mut Activation<'_, 'gc, '_>,
-        _this: Object<'gc>,
-    ) -> Option<Result<Value<'gc>, Error<'gc>>> {
-        self.get_local_sub(name, activation)
-    }
-
     fn get_local_stored(
         &self,
         name: &str,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Option<Value<'gc>> {
-        self.get_local_sub(name, activation).map(|res| res.unwrap())
+        self.node()
+            .attribute_value(&XmlName::from_str(name))
+            .map(|s| AvmString::new(activation.context.gc_context, s).into())
     }
 
     fn set_local(
@@ -98,6 +81,7 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
         );
         Ok(())
     }
+
     fn call(
         &self,
         name: &str,
@@ -107,6 +91,10 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
         args: &[Value<'gc>],
     ) -> Result<Value<'gc>, Error<'gc>> {
         self.base().call(name, activation, this, base_proto, args)
+    }
+
+    fn getter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {
+        self.base().getter(name, activation)
     }
 
     fn setter(&self, name: &str, activation: &mut Activation<'_, 'gc, '_>) -> Option<Object<'gc>> {


### PR DESCRIPTION
`get_local` is basically equivalent to `get_local_stored` that also handles virtual getters. So instead handle virtual getters in `search_prototype`. This allows to inline the `get_local_sub` helper methods into the implementations of `get_local_stored`.
The remaining usages of `get_local` were not exactly correct as they all should ignore virtual getters. This change solves this as well by using `get_local_stored` that ignores virtual getters.