### PR TITLE
web: Menu embed/object attribute true value is case-insensitive

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1307,7 +1307,7 @@ export function isScriptAccessAllowed(
  * @returns True if the built-in context items should be shown.
  */
 export function isBuiltInContextMenuVisible(menu: string | null): boolean {
-    if (menu === "true" || menu === null) {
+    if (menu === null || menu.toLowerCase() === "true") {
         return true;
     }
     return false;


### PR DESCRIPTION
I realized from looking at other code that this was probably the case, tested it in Basilisk, and confirmed it to be true.