### PR TITLE
chore: Bump TypeScript config to es2017

### DIFF
--- a/web/packages/core/tsconfig.json
+++ b/web/packages/core/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
-        "module": "esnext",
+    	"target": "es2017",
+        "module": "es2015",
         "moduleResolution": "node",
-        "target": "es6",
         "strict": true,
         "outDir": "pkg",
     },

--- a/web/packages/extension/tsconfig.json
+++ b/web/packages/extension/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
-        "module": "esnext",
+    	"target": "es2017",
+        "module": "es2015",
         "moduleResolution": "node",
-        "target": "es6",
         "strict": true,
     },
     "include": ["src/**/*"],


### PR DESCRIPTION
We're already using way beyond this in Web API, so bump this to avoid some ugly async/await polyfills.