### PR TITLE
avm1: Simplify `Value::abstract_lt`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1574,9 +1574,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         // ECMA-262 s. 11.8.1
         let a = self.context.avm1.pop();
         let b = self.context.avm1.pop();
-
-        let result = b.abstract_lt(a, self)?;
-
+        let result = b
+            .abstract_lt(a, self)?
+            .map_or(Value::Undefined, Value::from);
         self.context.avm1.push(result);
         Ok(FrameControl::Continue)
     }
@@ -1585,9 +1585,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         // ECMA-262 s. 11.8.2
         let a = self.context.avm1.pop();
         let b = self.context.avm1.pop();
-
-        let result = a.abstract_lt(b, self)?;
-
+        let result = a
+            .abstract_lt(b, self)?
+            .map_or(Value::Undefined, Value::from);
         self.context.avm1.push(result);
         Ok(FrameControl::Continue)
     }


### PR DESCRIPTION
* Change its return type to `Option<bool>`.
* Use Rust's `f64::partial_cmp` to compare two numbers, which should be more efficient.