### PR TITLE
avm2: Refactor object methods to do multiname lookups

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -254,7 +254,7 @@ impl<'gc> Avm2<'gc> {
             reciever,
             args,
             &mut evt_activation,
-            reciever.and_then(|r| r.proto()),
+            reciever.and_then(|r| r.instance_of()),
         )?;
 
         Ok(())

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1531,11 +1531,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let multiname = self.pool_multiname(method, index)?;
         let source = self.context.avm2.pop().coerce_to_object(self)?;
 
-        let ctor = source
-            .get_property(source, &multiname, self)?
-            .coerce_to_object(self)?;
-
-        let object = ctor.construct(self, &args)?;
+        let object = source.construct_prop(&multiname, &args, self)?;
 
         self.context.avm2.push(object);
 

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1068,8 +1068,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let args = self.context.avm2.pop_args(arg_count);
         let receiver = self.context.avm2.pop().coerce_to_object(self).ok();
         let function = self.context.avm2.pop().coerce_to_object(self)?;
-        let base_proto = receiver.and_then(|r| r.proto());
-        let value = function.call(receiver, &args, self, base_proto)?;
+        let superclass_object = receiver.and_then(|r| r.instance_of());
+        let value = function.call(receiver, &args, self, superclass_object)?;
 
         self.context.avm2.push(value);
 
@@ -1086,8 +1086,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let function: Result<Object<'gc>, Error> = receiver
             .get_method(index.0)
             .ok_or_else(|| format!("Object method {} does not exist", index.0).into());
-        let base_proto = receiver.proto();
-        let value = function?.call(Some(receiver), &args, self, base_proto)?;
+        let superclass_object = receiver.instance_of();
+        let value = function?.call(Some(receiver), &args, self, superclass_object)?;
 
         self.context.avm2.push(value);
 

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -629,6 +629,19 @@ impl<'gc> Class<'gc> {
             ));
         }
     }
+    #[inline(never)]
+    pub fn define_private_slot_instance_traits(
+        &mut self,
+        items: &[(&'static str, &'static str, &'static str, &'static str)],
+    ) {
+        for &(ns, name, type_ns, type_name) in items {
+            self.define_instance_trait(Trait::from_slot(
+                QName::new(Namespace::Private(ns.into()), name),
+                QName::new(Namespace::Package(type_ns.into()), type_name).into(),
+                None,
+            ));
+        }
+    }
 
     /// Define a trait on the class.
     ///

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -145,7 +145,7 @@ impl<'gc> Domain<'gc> {
             .ok_or_else(|| format!("MovieClip Symbol {} does not exist", name.local_name()))?;
         let globals = script.globals(&mut activation.context)?;
 
-        globals.get_property(globals, &name, activation)
+        globals.get_property(globals, &name.clone().into(), activation)
     }
 
     /// Export a definition from a script into the current application domain.

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -374,7 +374,7 @@ pub fn dispatch_event_to_target<'gc>(
     let dispatch_list = target
         .get_property(
             target,
-            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
             activation,
         )?
         .coerce_to_object(activation);
@@ -428,7 +428,7 @@ pub fn dispatch_event<'gc>(
     let target = this
         .get_property(
             this,
-            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target"),
+            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target").into(),
             activation,
         )?
         .coerce_to_object(activation)

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -409,12 +409,10 @@ pub fn dispatch_event_to_target<'gc>(
             break;
         }
 
-        handler.call(
-            activation.global_scope().coerce_to_object(activation).ok(),
-            &[event.into()],
-            activation,
-            None,
-        )?;
+        let object = activation.global_scope().coerce_to_object(activation).ok();
+        let superclass_object = object.and_then(|o| o.instance_of());
+
+        handler.call(object, &[event.into()], activation, superclass_object)?;
     }
 
     Ok(())

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -350,7 +350,14 @@ fn class<'gc>(
             .get_property(global, &super_name, activation)?
             .coerce_to_object(activation)
             .map_err(|_e| {
-                format!("Could not resolve superclass {:?}", super_name.local_name()).into()
+                format!(
+                    "Could not resolve superclass {:?} when defining global class {:?}",
+                    sc_name
+                        .local_name(activation)
+                        .unwrap_or_else(|_| Some("<uncoercible name>".into())),
+                    class_read.name().local_name()
+                )
+                .into()
             });
 
         Some(super_class?)

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -342,19 +342,13 @@ fn class<'gc>(
 
     let class_read = class_def.read();
     let super_class = if let Some(sc_name) = class_read.super_class_name() {
-        let super_name = global
-            .resolve_multiname(sc_name)?
-            .unwrap_or_else(|| QName::dynamic_name("Object"));
-
         let super_class: Result<Object<'gc>, Error> = global
-            .get_property(global, &super_name, activation)?
+            .get_property(global, sc_name, activation)?
             .coerce_to_object(activation)
             .map_err(|_e| {
                 format!(
                     "Could not resolve superclass {:?} when defining global class {:?}",
-                    sc_name
-                        .local_name(activation)
-                        .unwrap_or_else(|_| Some("<uncoercible name>".into())),
+                    sc_name.local_name(),
                     class_read.name().local_name()
                 )
                 .into()
@@ -382,7 +376,7 @@ fn class<'gc>(
     let proto = class_object
         .get_property(
             class_object,
-            &QName::new(Namespace::public(), "prototype"),
+            &QName::new(Namespace::public(), "prototype").into(),
             activation,
         )?
         .coerce_to_object(activation)?;

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -136,7 +136,8 @@ pub fn resolve_array_hole<'gc>(
                     &QName::new(
                         Namespace::public(),
                         AvmString::new(activation.context.gc_context, i.to_string()),
-                    ),
+                    )
+                    .into(),
                     activation,
                 )
             })
@@ -217,7 +218,7 @@ pub fn to_locale_string<'gc>(
 
         let tls = o.get_property(
             o,
-            &QName::new(Namespace::public(), "toLocaleString"),
+            &QName::new(Namespace::public(), "toLocaleString").into(),
             activation,
         )?;
 
@@ -278,7 +279,7 @@ impl<'gc> ArrayIter<'gc> {
         let length = array_object
             .get_property(
                 array_object,
-                &QName::new(Namespace::public(), "length"),
+                &QName::new(Namespace::public(), "length").into(),
                 activation,
             )?
             .coerce_to_u32(activation)?;
@@ -310,7 +311,8 @@ impl<'gc> ArrayIter<'gc> {
                         &QName::new(
                             Namespace::public(),
                             AvmString::new(activation.context.gc_context, i.to_string()),
-                        ),
+                        )
+                        .into(),
                         activation,
                     )
                     .map(|val| (i, val)),
@@ -340,7 +342,8 @@ impl<'gc> ArrayIter<'gc> {
                         &QName::new(
                             Namespace::public(),
                             AvmString::new(activation.context.gc_context, i.to_string()),
-                        ),
+                        )
+                        .into(),
                         activation,
                     )
                     .map(|val| (i, val)),
@@ -1208,14 +1211,14 @@ pub fn sort_on<'gc>(
                         let a_object = a.coerce_to_object(activation)?;
                         let a_field = a_object.get_property(
                             a_object,
-                            &QName::new(Namespace::public(), *field_name),
+                            &QName::new(Namespace::public(), *field_name).into(),
                             activation,
                         )?;
 
                         let b_object = b.coerce_to_object(activation)?;
                         let b_field = b_object.get_property(
                             b_object,
-                            &QName::new(Namespace::public(), *field_name),
+                            &QName::new(Namespace::public(), *field_name).into(),
                             activation,
                         )?;
 

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -378,7 +378,7 @@ pub fn for_each<'gc>(
                 receiver,
                 &[item, i.into(), this.into()],
                 activation,
-                receiver.and_then(|r| r.proto()),
+                receiver.and_then(|r| r.instance_of()),
             )?;
         }
     }
@@ -413,7 +413,7 @@ pub fn map<'gc>(
                 receiver,
                 &[item, i.into(), this.into()],
                 activation,
-                receiver.and_then(|r| r.proto()),
+                receiver.and_then(|r| r.instance_of()),
             )?;
 
             new_array.push(new_item);
@@ -453,7 +453,7 @@ pub fn filter<'gc>(
                     receiver,
                     &[item.clone(), i.into(), this.into()],
                     activation,
-                    receiver.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.instance_of()),
                 )?
                 .coerce_to_boolean();
 
@@ -496,7 +496,7 @@ pub fn every<'gc>(
                     receiver,
                     &[item, i.into(), this.into()],
                     activation,
-                    receiver.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.instance_of()),
                 )?
                 .coerce_to_boolean();
 
@@ -539,7 +539,7 @@ pub fn some<'gc>(
                     receiver,
                     &[item, i.into(), this.into()],
                     activation,
-                    receiver.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.instance_of()),
                 )?
                 .coerce_to_boolean();
 

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -216,14 +216,11 @@ pub fn to_locale_string<'gc>(
     join_inner(act, this, &[",".into()], |v, activation| {
         let o = v.coerce_to_object(activation)?;
 
-        let tls = o.get_property(
-            o,
+        o.call_property(
             &QName::new(Namespace::public(), "toLocaleString").into(),
+            &[],
             activation,
-        )?;
-
-        tls.coerce_to_object(activation)?
-            .call(Some(o), &[], activation, o.proto())
+        )
     })
 }
 

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -49,7 +49,7 @@ pub fn instance_init<'gc>(
 
                     this.set_property(
                         this,
-                        &QName::new(Namespace::public(), "bitmapData"),
+                        &QName::new(Namespace::public(), "bitmapData").into(),
                         bd_object.into(),
                         activation,
                     )?;

--- a/core/src/avm2/globals/flash/display/framelabel.rs
+++ b/core/src/avm2/globals/flash/display/framelabel.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
+use crate::avm2::globals::NS_RUFFLE_INTERNAL;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
@@ -31,13 +32,13 @@ pub fn instance_init<'gc>(
 
         this.set_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "name"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "name").into(),
             name.into(),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "frame"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "frame").into(),
             frame.into(),
             activation,
         )?;
@@ -64,7 +65,7 @@ pub fn name<'gc>(
     if let Some(this) = this {
         return this.get_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "name"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "name").into(),
             activation,
         );
     }
@@ -81,7 +82,7 @@ pub fn frame<'gc>(
     if let Some(this) = this {
         return this.get_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "frame"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "frame").into(),
             activation,
         );
     }
@@ -107,6 +108,12 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         Option<NativeMethodImpl>,
     )] = &[("name", Some(name), None), ("frame", Some(frame), None)];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+
+    const PRIVATE_INSTANCE_SLOTS: &[(&str, &str, &str, &str)] = &[
+        (NS_RUFFLE_INTERNAL, "name", "", "String"),
+        (NS_RUFFLE_INTERNAL, "frame", "", "int"),
+    ];
+    write.define_private_slot_instance_traits(PRIVATE_INSTANCE_SLOTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -388,7 +388,7 @@ pub fn parameters<'gc>(
                         let avm_v = AvmString::new(activation.context.gc_context, v);
                         params_obj.set_property(
                             params_obj,
-                            &QName::new(Namespace::public(), avm_k),
+                            &QName::new(Namespace::public(), avm_k).into(),
                             avm_v.into(),
                             activation,
                         )?;

--- a/core/src/avm2/globals/flash/display/scene.rs
+++ b/core/src/avm2/globals/flash/display/scene.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
+use crate::avm2::globals::NS_RUFFLE_INTERNAL;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
@@ -32,19 +33,19 @@ pub fn instance_init<'gc>(
 
         this.set_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "name"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "name").into(),
             name.into(),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "labels"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "labels").into(),
             labels,
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "numFrames"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "numFrames").into(),
             num_frames.into(),
             activation,
         )?;
@@ -71,7 +72,7 @@ pub fn labels<'gc>(
     if let Some(this) = this {
         this.get_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "labels"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "labels").into(),
             activation,
         )
     } else {
@@ -88,7 +89,7 @@ pub fn name<'gc>(
     if let Some(this) = this {
         this.get_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "name"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "name").into(),
             activation,
         )
     } else {
@@ -105,7 +106,7 @@ pub fn num_frames<'gc>(
     if let Some(this) = this {
         this.get_property(
             this,
-            &QName::new(Namespace::Private("ruffle".into()), "numFrames"),
+            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "numFrames").into(),
             activation,
         )
     } else {
@@ -135,6 +136,13 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("numFrames", Some(num_frames), None),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+
+    const PRIVATE_INSTANCE_SLOTS: &[(&str, &str, &str, &str)] = &[
+        (NS_RUFFLE_INTERNAL, "name", "", "String"),
+        (NS_RUFFLE_INTERNAL, "labels", "", "Array"),
+        (NS_RUFFLE_INTERNAL, "numFrames", "", "int"),
+    ];
+    write.define_private_slot_instance_traits(PRIVATE_INSTANCE_SLOTS);
 
     class
 }

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -58,14 +58,14 @@ pub fn graphics<'gc>(
             // Lazily initialize the `Graphics` object in a hidden property.
             let graphics = match this.get_property(
                 this,
-                &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
+                &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics").into(),
                 activation,
             )? {
                 Value::Undefined | Value::Null => {
                     let graphics = Value::from(StageObject::graphics(activation, dobj)?);
                     this.set_property(
                         this,
-                        &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
+                        &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics").into(),
                         graphics.clone(),
                         activation,
                     )?;

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -45,14 +45,14 @@ pub fn graphics<'gc>(
             // Lazily initialize the `Graphics` object in a hidden property.
             let graphics = match this.get_property(
                 this,
-                &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
+                &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics").into(),
                 activation,
             )? {
                 Value::Undefined | Value::Null => {
                     let graphics = Value::from(StageObject::graphics(activation, dobj)?);
                     this.set_property(
                         this,
-                        &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
+                        &QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics").into(),
                         graphics.clone(),
                         activation,
                     )?;

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -171,7 +171,8 @@ pub fn format_to_string<'gc>(
                 let param_name = QName::dynamic_name(match param_name {
                     Value::Undefined | Value::Null => "null".into(),
                     _ => param_name.coerce_to_string(activation)?,
-                });
+                })
+                .into();
 
                 let param_value = this
                     .get_property(this, &param_name, activation)?
@@ -179,7 +180,7 @@ pub fn format_to_string<'gc>(
                 write!(
                     stringified_params,
                     " {}={}",
-                    param_name.local_name(),
+                    param_name.local_name().unwrap(),
                     param_value
                 )
                 .unwrap();

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -28,13 +28,13 @@ pub fn instance_init<'gc>(
 
         this.init_property(
             this,
-            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target"),
+            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target").into(),
             target,
             activation,
         )?;
         this.init_property(
             this,
-            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+            &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
             dispatch_list.into(),
             activation,
         )?;
@@ -53,7 +53,7 @@ pub fn add_event_listener<'gc>(
         let dispatch_list = this
             .get_property(
                 this,
-                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -100,7 +100,7 @@ pub fn remove_event_listener<'gc>(
         let dispatch_list = this
             .get_property(
                 this,
-                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -139,7 +139,7 @@ pub fn has_event_listener<'gc>(
         let dispatch_list = this
             .get_property(
                 this,
-                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -169,7 +169,7 @@ pub fn will_trigger<'gc>(
         let dispatch_list = this
             .get_property(
                 this,
-                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -190,7 +190,7 @@ pub fn will_trigger<'gc>(
         let target = this
             .get_property(
                 this,
-                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target"),
+                &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target").into(),
                 activation,
             )?
             .coerce_to_object(activation)

--- a/core/src/avm2/globals/flash/geom/point.rs
+++ b/core/src/avm2/globals/flash/geom/point.rs
@@ -33,10 +33,18 @@ fn coords<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<(f64, f64), Error> {
     let x = this
-        .get_property(*this, &QName::new(Namespace::public(), "x"), activation)?
+        .get_property(
+            *this,
+            &QName::new(Namespace::public(), "x").into(),
+            activation,
+        )?
         .coerce_to_number(activation)?;
     let y = this
-        .get_property(*this, &QName::new(Namespace::public(), "y"), activation)?
+        .get_property(
+            *this,
+            &QName::new(Namespace::public(), "y").into(),
+            activation,
+        )?
         .coerce_to_number(activation)?;
     Ok((x, y))
 }
@@ -48,13 +56,13 @@ fn set_coords<'gc>(
 ) -> Result<(), Error> {
     this.set_property(
         *this,
-        &QName::new(Namespace::public(), "x"),
+        &QName::new(Namespace::public(), "x").into(),
         value.0.into(),
         activation,
     )?;
     this.set_property(
         *this,
-        &QName::new(Namespace::public(), "y"),
+        &QName::new(Namespace::public(), "y").into(),
         value.1.into(),
         activation,
     )?;
@@ -320,10 +328,18 @@ pub fn to_string<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         let x = this
-            .get_property(this, &QName::new(Namespace::public(), "x"), activation)?
+            .get_property(
+                this,
+                &QName::new(Namespace::public(), "x").into(),
+                activation,
+            )?
             .coerce_to_string(activation)?;
         let y = this
-            .get_property(this, &QName::new(Namespace::public(), "y"), activation)?
+            .get_property(
+                this,
+                &QName::new(Namespace::public(), "y").into(),
+                activation,
+            )?
             .coerce_to_string(activation)?;
         return Ok(
             AvmString::new(activation.context.gc_context, format!("(x={}, y={})", x, y)).into(),

--- a/core/src/avm2/globals/flash/geom/point.rs
+++ b/core/src/avm2/globals/flash/geom/point.rs
@@ -353,6 +353,9 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     )] = &[("length", Some(length), None)];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 
+    const PUBLIC_INSTANCE_NUMBER_SLOTS: &[(&str, Option<f64>)] = &[("x", None), ("y", None)];
+    write.define_public_slot_number_instance_traits(PUBLIC_INSTANCE_NUMBER_SLOTS);
+
     const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("distance", distance),
         ("interpolate", interpolate),

--- a/core/src/avm2/globals/flash/geom/rectangle.rs
+++ b/core/src/avm2/globals/flash/geom/rectangle.rs
@@ -27,7 +27,11 @@ pub fn create_rectangle<'gc>(
 macro_rules! get_prop {
     ($this:expr, $activation:expr, $name: expr) => {
         $this
-            .get_property($this, &QName::new(Namespace::public(), $name), $activation)?
+            .get_property(
+                $this,
+                &QName::new(Namespace::public(), $name).into(),
+                $activation,
+            )?
             .coerce_to_number($activation)
     };
 }
@@ -36,7 +40,7 @@ macro_rules! set_prop {
     ($this:expr, $activation:expr, $name: expr, $value: expr) => {
         $this.set_property(
             $this,
-            &QName::new(Namespace::public(), $name),
+            &QName::new(Namespace::public(), $name).into(),
             $value.into(),
             $activation,
         )
@@ -452,12 +456,26 @@ pub fn copy_from<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(rect) = args.get(0) {
         let rect = rect.coerce_to_object(activation)?;
-        let x = rect.get_property(rect, &QName::new(Namespace::public(), "x"), activation)?;
-        let y = rect.get_property(rect, &QName::new(Namespace::public(), "y"), activation)?;
-        let width =
-            rect.get_property(rect, &QName::new(Namespace::public(), "width"), activation)?;
-        let height =
-            rect.get_property(rect, &QName::new(Namespace::public(), "height"), activation)?;
+        let x = rect.get_property(
+            rect,
+            &QName::new(Namespace::public(), "x").into(),
+            activation,
+        )?;
+        let y = rect.get_property(
+            rect,
+            &QName::new(Namespace::public(), "y").into(),
+            activation,
+        )?;
+        let width = rect.get_property(
+            rect,
+            &QName::new(Namespace::public(), "width").into(),
+            activation,
+        )?;
+        let height = rect.get_property(
+            rect,
+            &QName::new(Namespace::public(), "height").into(),
+            activation,
+        )?;
 
         set_to(activation, this, &[x, y, width, height])?;
     }
@@ -740,16 +758,32 @@ pub fn to_string<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         let x = this
-            .get_property(this, &QName::new(Namespace::public(), "x"), activation)?
+            .get_property(
+                this,
+                &QName::new(Namespace::public(), "x").into(),
+                activation,
+            )?
             .coerce_to_string(activation)?;
         let y = this
-            .get_property(this, &QName::new(Namespace::public(), "y"), activation)?
+            .get_property(
+                this,
+                &QName::new(Namespace::public(), "y").into(),
+                activation,
+            )?
             .coerce_to_string(activation)?;
         let width = this
-            .get_property(this, &QName::new(Namespace::public(), "width"), activation)?
+            .get_property(
+                this,
+                &QName::new(Namespace::public(), "width").into(),
+                activation,
+            )?
             .coerce_to_string(activation)?;
         let height = this
-            .get_property(this, &QName::new(Namespace::public(), "height"), activation)?
+            .get_property(
+                this,
+                &QName::new(Namespace::public(), "height").into(),
+                activation,
+            )?
             .coerce_to_string(activation)?;
 
         return Ok(AvmString::new(

--- a/core/src/avm2/globals/flash/geom/rectangle.rs
+++ b/core/src/avm2/globals/flash/geom/rectangle.rs
@@ -863,6 +863,10 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 
+    const PUBLIC_INSTANCE_NUMBER_SLOTS: &[(&str, Option<f64>)] =
+        &[("x", None), ("y", None), ("width", None), ("height", None)];
+    write.define_public_slot_number_instance_traits(PUBLIC_INSTANCE_NUMBER_SLOTS);
+
     const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("contains", contains),
         ("containsPoint", contains_point),

--- a/core/src/avm2/globals/flash/media/soundtransform.rs
+++ b/core/src/avm2/globals/flash/media/soundtransform.rs
@@ -31,13 +31,13 @@ pub fn instance_init<'gc>(
 
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "volume"),
+            &QName::new(Namespace::public(), "volume").into(),
             volume.into(),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "pan"),
+            &QName::new(Namespace::public(), "pan").into(),
             pan.into(),
             activation,
         )?;
@@ -65,14 +65,14 @@ pub fn pan<'gc>(
         let left_to_right = this
             .get_property(
                 this,
-                &QName::new(Namespace::public(), "leftToRight"),
+                &QName::new(Namespace::public(), "leftToRight").into(),
                 activation,
             )?
             .coerce_to_number(activation)?;
         let right_to_left = this
             .get_property(
                 this,
-                &QName::new(Namespace::public(), "rightToLeft"),
+                &QName::new(Namespace::public(), "rightToLeft").into(),
                 activation,
             )?
             .coerce_to_number(activation)?;
@@ -84,7 +84,7 @@ pub fn pan<'gc>(
         let left_to_left = this
             .get_property(
                 this,
-                &QName::new(Namespace::public(), "leftToLeft"),
+                &QName::new(Namespace::public(), "leftToLeft").into(),
                 activation,
             )?
             .coerce_to_number(activation)?;
@@ -110,25 +110,25 @@ pub fn set_pan<'gc>(
 
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "leftToLeft"),
+            &QName::new(Namespace::public(), "leftToLeft").into(),
             (1.0 - pan).sqrt().into(),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "rightToRight"),
+            &QName::new(Namespace::public(), "rightToRight").into(),
             (1.0 + pan).sqrt().into(),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "leftToRight"),
+            &QName::new(Namespace::public(), "leftToRight").into(),
             (0.0).into(),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "rightToLeft"),
+            &QName::new(Namespace::public(), "rightToLeft").into(),
             (0.0).into(),
             activation,
         )?;

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -35,7 +35,7 @@ pub fn class_init<'gc>(
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
         QName::new(Namespace::package("flash.media"), "Video"),
-        Some(QName::new(Namespace::package("flash.media"), "DisplayObject").into()),
+        Some(QName::new(Namespace::package("flash.display"), "DisplayObject").into()),
         Method::from_builtin(instance_init, "<Video instance initializer>", mc),
         Method::from_builtin(class_init, "<Video class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -80,7 +80,7 @@ pub fn get_definition<'gc>(
             .get_defining_script(&qname.into())?
             .ok_or_else(|| format!("No definition called {} exists", local_name))?;
         let globals = defined_script.globals(&mut activation.context)?;
-        let definition = globals.get_property(globals, &qname, activation)?;
+        let definition = globals.get_property(globals, &qname.into(), activation)?;
 
         return Ok(definition);
     }

--- a/core/src/avm2/globals/flash/text/textformat.rs
+++ b/core/src/avm2/globals/flash/text/textformat.rs
@@ -21,79 +21,79 @@ pub fn instance_init<'gc>(
 
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "font"),
+            &QName::new(Namespace::public(), "font").into(),
             args.get(0).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "size"),
+            &QName::new(Namespace::public(), "size").into(),
             args.get(1).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "color"),
+            &QName::new(Namespace::public(), "color").into(),
             args.get(2).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "bold"),
+            &QName::new(Namespace::public(), "bold").into(),
             args.get(3).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "italic"),
+            &QName::new(Namespace::public(), "italic").into(),
             args.get(4).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "underline"),
+            &QName::new(Namespace::public(), "underline").into(),
             args.get(5).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "url"),
+            &QName::new(Namespace::public(), "url").into(),
             args.get(6).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "target"),
+            &QName::new(Namespace::public(), "target").into(),
             args.get(7).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "align"),
+            &QName::new(Namespace::public(), "align").into(),
             args.get(8).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "leftMargin"),
+            &QName::new(Namespace::public(), "leftMargin").into(),
             args.get(9).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "rightMargin"),
+            &QName::new(Namespace::public(), "rightMargin").into(),
             args.get(10).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "indent"),
+            &QName::new(Namespace::public(), "indent").into(),
             args.get(11).cloned().unwrap_or(Value::Null),
             activation,
         )?;
         this.set_property(
             this,
-            &QName::new(Namespace::public(), "leading"),
+            &QName::new(Namespace::public(), "leading").into(),
             args.get(12).cloned().unwrap_or(Value::Null),
             activation,
         )?;

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -31,7 +31,7 @@ pub fn class_init<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         let mut function_proto = this
-            .get_property(this, &QName::dynamic_name("prototype"), activation)?
+            .get_property(this, &QName::dynamic_name("prototype").into(), activation)?
             .coerce_to_object(activation)?;
 
         function_proto.install_dynamic_property(

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -69,7 +69,7 @@ fn call<'gc>(
     let this = args
         .get(0)
         .and_then(|v| v.coerce_to_object(activation).ok());
-    let base_proto = this.and_then(|that| that.proto());
+    let base_proto = this.and_then(|that| that.instance_of());
 
     if let Some(func) = func {
         if args.len() > 1 {
@@ -91,7 +91,7 @@ fn apply<'gc>(
     let this = args
         .get(0)
         .and_then(|v| v.coerce_to_object(activation).ok());
-    let base_proto = this.and_then(|that| that.proto());
+    let base_proto = this.and_then(|that| that.instance_of());
 
     if let Some(func) = func {
         let arg_array = args

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -27,7 +27,7 @@ pub fn class_init<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         let mut object_proto = this
-            .get_property(this, &QName::dynamic_name("prototype"), activation)?
+            .get_property(this, &QName::dynamic_name("prototype").into(), activation)?
             .coerce_to_object(activation)?;
         let gc_context = activation.context.gc_context;
 

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -441,7 +441,7 @@ pub fn every<'gc>(
                     receiver,
                     &[item, i.into(), this.into()],
                     activation,
-                    receiver.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.instance_of()),
                 )?
                 .coerce_to_boolean();
 
@@ -484,7 +484,7 @@ pub fn some<'gc>(
                     receiver,
                     &[item, i.into(), this.into()],
                     activation,
-                    receiver.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.instance_of()),
                 )?
                 .coerce_to_boolean();
 
@@ -537,7 +537,7 @@ pub fn filter<'gc>(
                     receiver,
                     &[item.clone(), i.into(), this.into()],
                     activation,
-                    receiver.and_then(|r| r.proto()),
+                    receiver.and_then(|r| r.instance_of()),
                 )?
                 .coerce_to_boolean();
 
@@ -579,7 +579,7 @@ pub fn for_each<'gc>(
                 receiver,
                 &[item, i.into(), this.into()],
                 activation,
-                receiver.and_then(|r| r.proto()),
+                receiver.and_then(|r| r.instance_of()),
             )?;
         }
     }
@@ -706,7 +706,7 @@ pub fn map<'gc>(
                 receiver,
                 &[item.clone(), i.into(), this.into()],
                 activation,
-                receiver.and_then(|r| r.proto()),
+                receiver.and_then(|r| r.instance_of()),
             )?;
             let coerced_item = new_item.coerce_to_type(activation, value_type)?;
 

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -402,13 +402,11 @@ pub fn to_locale_string<'gc>(
 ) -> Result<Value<'gc>, Error> {
     join_inner(activation, this, &[",".into()], |v, act| {
         if let Ok(o) = v.coerce_to_object(act) {
-            let ls = o.get_property(
-                o,
+            o.call_property(
                 &QName::new(Namespace::public(), "toLocaleString").into(),
+                &[],
                 act,
-            )?;
-
-            ls.coerce_to_object(act)?.call(Some(o), &[], act, None)
+            )
         } else {
             Ok(v)
         }

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -146,7 +146,7 @@ pub fn specialized_class_init<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         let mut proto = this
-            .get_property(this, &QName::dynamic_name("prototype"), activation)?
+            .get_property(this, &QName::dynamic_name("prototype").into(), activation)?
             .coerce_to_object(activation)?;
         let scope = this.get_scope();
 
@@ -174,7 +174,7 @@ pub fn specialized_class_init<'gc>(
         for (pubname, func) in PUBLIC_PROTOTYPE_METHODS {
             proto.set_property(
                 this,
-                &QName::dynamic_name(*pubname),
+                &QName::dynamic_name(*pubname).into(),
                 FunctionObject::from_function(
                     activation,
                     Method::from_builtin(*func, pubname, activation.context.gc_context),
@@ -402,7 +402,11 @@ pub fn to_locale_string<'gc>(
 ) -> Result<Value<'gc>, Error> {
     join_inner(activation, this, &[",".into()], |v, act| {
         if let Ok(o) = v.coerce_to_object(act) {
-            let ls = o.get_property(o, &QName::new(Namespace::public(), "toLocaleString"), act)?;
+            let ls = o.get_property(
+                o,
+                &QName::new(Namespace::public(), "toLocaleString").into(),
+                act,
+            )?;
 
             ls.coerce_to_object(act)?.call(Some(o), &[], act, None)
         } else {
@@ -601,7 +605,11 @@ pub fn index_of<'gc>(
 
         let from_index = if from_index < 0 {
             let length = this
-                .get_property(this, &QName::new(Namespace::public(), "length"), activation)?
+                .get_property(
+                    this,
+                    &QName::new(Namespace::public(), "length").into(),
+                    activation,
+                )?
                 .coerce_to_i32(activation)?;
             max(length + from_index, 0) as u32
         } else {
@@ -638,7 +646,11 @@ pub fn last_index_of<'gc>(
 
         let from_index = if from_index < 0 {
             let length = this
-                .get_property(this, &QName::new(Namespace::public(), "length"), activation)?
+                .get_property(
+                    this,
+                    &QName::new(Namespace::public(), "length").into(),
+                    activation,
+                )?
                 .coerce_to_i32(activation)?;
             max(length + from_index, 0) as u32
         } else {

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -1030,6 +1030,22 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         Err("Object is not constructable".into())
     }
 
+    /// Construct a property of this object by Multiname lookup.
+    ///
+    /// This corresponds directly to the AVM2 operation `constructprop`.
+    fn construct_prop(
+        self,
+        multiname: &Multiname<'gc>,
+        args: &[Value<'gc>],
+        activation: &mut Activation<'_, 'gc, '_>,
+    ) -> Result<Object<'gc>, Error> {
+        let ctor = self
+            .get_property(self.into(), multiname, activation)?
+            .coerce_to_object(activation)?;
+
+        ctor.construct(activation, args)
+    }
+
     /// Construct a host object prototype of some kind and return it.
     ///
     /// This is called specifically to allocate old-style ES3 instances. The

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -846,18 +846,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 Some(superclass_object),
             )
         } else {
-            if let Ok(callee) = reciever
-                .get_property(reciever, multiname, activation)
-                .and_then(|v| v.coerce_to_object(activation))
-            {
-                return callee.call(Some(reciever), arguments, activation, None);
-            }
-
-            Err(format!(
-                "Attempted to supercall method {:?}, which does not exist",
-                name
-            )
-            .into())
+            reciever.call_property(multiname, arguments, activation)
         }
     }
 

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -54,7 +54,7 @@ impl<'gc> BitmapDataObject<'gc> {
         let proto = class
             .get_property(
                 class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -96,7 +96,7 @@ impl<'gc> ClassObject<'gc> {
             let base_proto = superclass_object
                 .get_property(
                     superclass_object,
-                    &QName::new(Namespace::public(), "prototype"),
+                    &QName::new(Namespace::public(), "prototype").into(),
                     activation,
                 )?
                 .coerce_to_object(activation)?;
@@ -437,7 +437,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         let prototype = self
             .get_property(
                 class_object,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -585,7 +585,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
             let base_proto = superclass_object
                 .get_property(
                     superclass_object,
-                    &QName::new(Namespace::public(), "prototype"),
+                    &QName::new(Namespace::public(), "prototype").into(),
                     activation,
                 )?
                 .coerce_to_object(activation)?;

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -87,8 +87,6 @@ impl<'gc> ClassObject<'gc> {
     ) -> Result<Object<'gc>, Error> {
         let class_object = Self::from_class_partial(activation, class, superclass_object, scope)?;
 
-        let instance_allocator = class_object.0.read().instance_allocator.0;
-
         //TODO: Class prototypes are *not* instances of their class and should
         //not be allocated by the class allocator, but instead should be
         //regular objects
@@ -100,7 +98,7 @@ impl<'gc> ClassObject<'gc> {
                     activation,
                 )?
                 .coerce_to_object(activation)?;
-            instance_allocator(superclass_object, base_proto, activation)?
+            ScriptObject::object(activation.context.gc_context, base_proto)
         } else {
             ScriptObject::bare_object(activation.context.gc_context)
         };

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -133,7 +133,7 @@ impl<'gc> TObject<'gc> for DomainObject<'gc> {
         let constr = this
             .get_property(
                 this,
-                &QName::new(Namespace::public(), "constructor"),
+                &QName::new(Namespace::public(), "constructor").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -60,7 +60,7 @@ impl<'gc> EventObject<'gc> {
         let proto = class
             .get_property(
                 class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -136,7 +136,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         let prototype = self
             .get_property(
                 class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -58,7 +58,7 @@ impl<'gc> SoundObject<'gc> {
         let proto = class
             .get_property(
                 class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -54,7 +54,7 @@ impl<'gc> SoundChannelObject<'gc> {
         let proto = class
             .get_property(
                 class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -63,7 +63,7 @@ impl<'gc> StageObject<'gc> {
         let proto = class
             .get_property(
                 class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -69,7 +69,7 @@ impl<'gc> VectorObject<'gc> {
         let applied_proto = applied_class
             .get_property(
                 applied_class,
-                &QName::new(Namespace::public(), "prototype"),
+                &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
             .coerce_to_object(activation)?;

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -146,7 +146,7 @@ impl<'gc> Scope<'gc> {
             if self.locals().has_property(&qname)? {
                 return Ok(Some(self.values.get_property(
                     self.values,
-                    &qname,
+                    &qname.into(),
                     activation,
                 )?));
             }
@@ -164,7 +164,7 @@ impl<'gc> Scope<'gc> {
 
                 return Ok(Some(script_scope.get_property(
                     script_scope,
-                    &qname,
+                    &qname.into(),
                     activation,
                 )?));
             }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -303,7 +303,7 @@ impl<'gc> Value<'gc> {
                 let object = *o;
 
                 if let Value::Object(f) =
-                    object.get_property(*o, &QName::dynamic_name("toString"), activation)?
+                    object.get_property(*o, &QName::dynamic_name("toString").into(), activation)?
                 {
                     prim = f.call(Some(*o), &[], activation, None)?;
                 }
@@ -313,7 +313,7 @@ impl<'gc> Value<'gc> {
                 }
 
                 if let Value::Object(f) =
-                    object.get_property(*o, &QName::dynamic_name("valueOf"), activation)?
+                    object.get_property(*o, &QName::dynamic_name("valueOf").into(), activation)?
                 {
                     prim = f.call(Some(*o), &[], activation, None)?;
                 }
@@ -329,7 +329,7 @@ impl<'gc> Value<'gc> {
                 let object = *o;
 
                 if let Value::Object(f) =
-                    object.get_property(*o, &QName::dynamic_name("valueOf"), activation)?
+                    object.get_property(*o, &QName::dynamic_name("valueOf").into(), activation)?
                 {
                     prim = f.call(Some(*o), &[], activation, None)?;
                 }
@@ -339,7 +339,7 @@ impl<'gc> Value<'gc> {
                 }
 
                 if let Value::Object(f) =
-                    object.get_property(*o, &QName::dynamic_name("toString"), activation)?
+                    object.get_property(*o, &QName::dynamic_name("toString").into(), activation)?
                 {
                     prim = f.call(Some(*o), &[], activation, None)?;
                 }

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -302,20 +302,28 @@ impl<'gc> Value<'gc> {
                 let mut prim = self.clone();
                 let object = *o;
 
-                if let Value::Object(f) =
+                if let Value::Object(_) =
                     object.get_property(*o, &QName::dynamic_name("toString").into(), activation)?
                 {
-                    prim = f.call(Some(*o), &[], activation, None)?;
+                    prim = object.call_property(
+                        &QName::dynamic_name("toString").into(),
+                        &[],
+                        activation,
+                    )?;
                 }
 
                 if prim.is_primitive() {
                     return Ok(prim);
                 }
 
-                if let Value::Object(f) =
+                if let Value::Object(_) =
                     object.get_property(*o, &QName::dynamic_name("valueOf").into(), activation)?
                 {
-                    prim = f.call(Some(*o), &[], activation, None)?;
+                    prim = object.call_property(
+                        &QName::dynamic_name("valueOf").into(),
+                        &[],
+                        activation,
+                    )?;
                 }
 
                 if prim.is_primitive() {
@@ -328,20 +336,28 @@ impl<'gc> Value<'gc> {
                 let mut prim = self.clone();
                 let object = *o;
 
-                if let Value::Object(f) =
+                if let Value::Object(_) =
                     object.get_property(*o, &QName::dynamic_name("valueOf").into(), activation)?
                 {
-                    prim = f.call(Some(*o), &[], activation, None)?;
+                    prim = object.call_property(
+                        &QName::dynamic_name("valueOf").into(),
+                        &[],
+                        activation,
+                    )?;
                 }
 
                 if prim.is_primitive() {
                     return Ok(prim);
                 }
 
-                if let Value::Object(f) =
+                if let Value::Object(_) =
                     object.get_property(*o, &QName::dynamic_name("toString").into(), activation)?
                 {
-                    prim = f.call(Some(*o), &[], activation, None)?;
+                    prim = object.call_property(
+                        &QName::dynamic_name("toString").into(),
+                        &[],
+                        activation,
+                    )?;
                 }
 
                 if prim.is_primitive() {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1780,7 +1780,7 @@ impl SoundTransform {
             left_to_left: (as3_st
                 .get_property(
                     as3_st,
-                    &Avm2QName::new(Avm2Namespace::public(), "leftToLeft"),
+                    &Avm2QName::new(Avm2Namespace::public(), "leftToLeft").into(),
                     activation,
                 )?
                 .coerce_to_number(activation)?
@@ -1788,7 +1788,7 @@ impl SoundTransform {
             left_to_right: (as3_st
                 .get_property(
                     as3_st,
-                    &Avm2QName::new(Avm2Namespace::public(), "leftToRight"),
+                    &Avm2QName::new(Avm2Namespace::public(), "leftToRight").into(),
                     activation,
                 )?
                 .coerce_to_number(activation)?
@@ -1796,7 +1796,7 @@ impl SoundTransform {
             right_to_left: (as3_st
                 .get_property(
                     as3_st,
-                    &Avm2QName::new(Avm2Namespace::public(), "rightToLeft"),
+                    &Avm2QName::new(Avm2Namespace::public(), "rightToLeft").into(),
                     activation,
                 )?
                 .coerce_to_number(activation)?
@@ -1804,7 +1804,7 @@ impl SoundTransform {
             right_to_right: (as3_st
                 .get_property(
                     as3_st,
-                    &Avm2QName::new(Avm2Namespace::public(), "rightToRight"),
+                    &Avm2QName::new(Avm2Namespace::public(), "rightToRight").into(),
                     activation,
                 )?
                 .coerce_to_number(activation)?
@@ -1812,7 +1812,7 @@ impl SoundTransform {
             volume: (as3_st
                 .get_property(
                     as3_st,
-                    &Avm2QName::new(Avm2Namespace::public(), "volume"),
+                    &Avm2QName::new(Avm2Namespace::public(), "volume").into(),
                     activation,
                 )?
                 .coerce_to_number(activation)?
@@ -1832,31 +1832,31 @@ impl SoundTransform {
 
         as3_st.set_property(
             as3_st,
-            &Avm2QName::new(Avm2Namespace::public(), "leftToLeft"),
+            &Avm2QName::new(Avm2Namespace::public(), "leftToLeft").into(),
             (self.left_to_left as f64 / 100.0).into(),
             activation,
         )?;
         as3_st.set_property(
             as3_st,
-            &Avm2QName::new(Avm2Namespace::public(), "leftToRight"),
+            &Avm2QName::new(Avm2Namespace::public(), "leftToRight").into(),
             (self.left_to_right as f64 / 100.0).into(),
             activation,
         )?;
         as3_st.set_property(
             as3_st,
-            &Avm2QName::new(Avm2Namespace::public(), "rightToLeft"),
+            &Avm2QName::new(Avm2Namespace::public(), "rightToLeft").into(),
             (self.right_to_left as f64 / 100.0).into(),
             activation,
         )?;
         as3_st.set_property(
             as3_st,
-            &Avm2QName::new(Avm2Namespace::public(), "rightToRight"),
+            &Avm2QName::new(Avm2Namespace::public(), "rightToRight").into(),
             (self.right_to_right as f64 / 100.0).into(),
             activation,
         )?;
         as3_st.set_property(
             as3_st,
-            &Avm2QName::new(Avm2Namespace::public(), "volume"),
+            &Avm2QName::new(Avm2Namespace::public(), "volume").into(),
             (self.volume as f64 / 100.0).into(),
             activation,
         )?;

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1173,7 +1173,8 @@ impl<'gc> MovieClip<'gc> {
                             AvmString::new(context.gc_context, child.name().to_owned()),
                         );
                         let mut activation = Avm2Activation::from_nothing(context.reborrow());
-                        if let Err(e) = p.init_property(p, &name, c.into(), &mut activation) {
+                        if let Err(e) = p.init_property(p, &name.into(), c.into(), &mut activation)
+                        {
                             log::error!(
                                 "Got error when setting AVM2 child named \"{}\": {}",
                                 &child.name(),

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -198,7 +198,7 @@ fn getstr_from_avm2_object<'gc>(
     Ok(
         match object.get_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), pubname),
+            &Avm2QName::new(Avm2Namespace::public(), pubname).into(),
             activation,
         )? {
             Avm2Value::Undefined => None,
@@ -216,7 +216,7 @@ fn getfloat_from_avm2_object<'gc>(
     Ok(
         match object.get_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), pubname),
+            &Avm2QName::new(Avm2Namespace::public(), pubname).into(),
             activation,
         )? {
             Avm2Value::Undefined => None,
@@ -234,7 +234,7 @@ fn getbool_from_avm2_object<'gc>(
     Ok(
         match object.get_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), pubname),
+            &Avm2QName::new(Avm2Namespace::public(), pubname).into(),
             activation,
         )? {
             Avm2Value::Undefined => None,
@@ -252,7 +252,7 @@ fn getfloatarray_from_avm2_object<'gc>(
     Ok(
         match object.get_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), pubname),
+            &Avm2QName::new(Avm2Namespace::public(), pubname).into(),
             activation,
         )? {
             Avm2Value::Undefined => None,
@@ -271,7 +271,8 @@ fn getfloatarray_from_avm2_object<'gc>(
                                 &Avm2QName::new(
                                     Avm2Namespace::public(),
                                     AvmString::new(activation.context.gc_context, format!("{}", i)),
-                                ),
+                                )
+                                .into(),
                                 activation,
                             )?
                             .coerce_to_number(activation)?,
@@ -704,7 +705,7 @@ impl TextFormat {
 
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "font"),
+            &Avm2QName::new(Avm2Namespace::public(), "font").into(),
             self.font
                 .clone()
                 .map(|v| AvmString::new(activation.context.gc_context, v).into())
@@ -713,13 +714,13 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "size"),
+            &Avm2QName::new(Avm2Namespace::public(), "size").into(),
             self.size.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "color"),
+            &Avm2QName::new(Avm2Namespace::public(), "color").into(),
             self.color
                 .clone()
                 .map(|v| v.to_rgb().into())
@@ -728,7 +729,7 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "align"),
+            &Avm2QName::new(Avm2Namespace::public(), "align").into(),
             self.align
                 .map(|v| {
                     AvmString::new(
@@ -748,25 +749,25 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "bold"),
+            &Avm2QName::new(Avm2Namespace::public(), "bold").into(),
             self.bold.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "italic"),
+            &Avm2QName::new(Avm2Namespace::public(), "italic").into(),
             self.italic.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "underline"),
+            &Avm2QName::new(Avm2Namespace::public(), "underline").into(),
             self.underline.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "leftMargin"),
+            &Avm2QName::new(Avm2Namespace::public(), "leftMargin").into(),
             self.left_margin
                 .map(|v| v.into())
                 .unwrap_or(Avm2Value::Null),
@@ -774,7 +775,7 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "rightMargin"),
+            &Avm2QName::new(Avm2Namespace::public(), "rightMargin").into(),
             self.right_margin
                 .map(|v| v.into())
                 .unwrap_or(Avm2Value::Null),
@@ -782,13 +783,13 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "indent"),
+            &Avm2QName::new(Avm2Namespace::public(), "indent").into(),
             self.indent.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "blockIndent"),
+            &Avm2QName::new(Avm2Namespace::public(), "blockIndent").into(),
             self.block_indent
                 .map(|v| v.into())
                 .unwrap_or(Avm2Value::Null),
@@ -796,19 +797,19 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "kerning"),
+            &Avm2QName::new(Avm2Namespace::public(), "kerning").into(),
             self.kerning.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "leading"),
+            &Avm2QName::new(Avm2Namespace::public(), "leading").into(),
             self.leading.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "letterSpacing"),
+            &Avm2QName::new(Avm2Namespace::public(), "letterSpacing").into(),
             self.letter_spacing
                 .map(|v| v.into())
                 .unwrap_or(Avm2Value::Null),
@@ -816,13 +817,13 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "bullet"),
+            &Avm2QName::new(Avm2Namespace::public(), "bullet").into(),
             self.bullet.map(|v| v.into()).unwrap_or(Avm2Value::Null),
             activation,
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "url"),
+            &Avm2QName::new(Avm2Namespace::public(), "url").into(),
             self.url
                 .clone()
                 .map(|v| AvmString::new(activation.context.gc_context, v).into())
@@ -831,7 +832,7 @@ impl TextFormat {
         )?;
         object.set_property(
             object,
-            &Avm2QName::new(Avm2Namespace::public(), "target"),
+            &Avm2QName::new(Avm2Namespace::public(), "target").into(),
             self.target
                 .clone()
                 .map(|v| AvmString::new(activation.context.gc_context, v).into())
@@ -846,14 +847,14 @@ impl TextFormat {
 
             object.set_property(
                 object,
-                &Avm2QName::new(Avm2Namespace::public(), "tabStops"),
+                &Avm2QName::new(Avm2Namespace::public(), "tabStops").into(),
                 tab_stops.into(),
                 activation,
             )?;
         } else {
             object.set_property(
                 object,
-                &Avm2QName::new(Avm2Namespace::public(), "tabStops"),
+                &Avm2QName::new(Avm2Namespace::public(), "tabStops").into(),
                 Avm2Value::Null,
                 activation,
             )?;


### PR DESCRIPTION
This PR includes a number of refactors necessary for future AVM2 work. Since these are cross-cutting concerns and imply a lot of code churn, I'm packaging them separately from the work that will benefit from it.

 * ~~Multinames can now hold an `Object` directly.~~ Nope.
 * `TObject` methods such as `get_property`, `set_property`, and `init_property` now take a `Multiname` and do the name resolution internally.
 * `call_property` and `construct_prop` are now `TObject` methods, and existing code has been changed to use them.
 * Setting dynamic properties outside of the public namespace is no longer permitted, and dynamic properties on sealed classes is now forbidden entirely. Instance slots have been added for impacted native class implementations.
 * Prototypes of classes are no longer instances of that class (required by the prior rule change)
   * This is required by the fact that we currently do not allow calls to unbound methods through the prototype chain, which AVM2 actually does allow. I cannot implement that until both this PR and #5325 land; and in practice this only matters for ES3 legacy support.

This will enable ~~implementation of `Dictionary`, as well as~~ optimizations to method lookup, such as not instantiating bound-receiver copies of methods for each call.