### PR TITLE
web: Bump wasm-bindgen to 0.2.78

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -243,7 +243,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: wasm-bindgen-cli --version 0.2.77
+          args: wasm-bindgen-cli --version 0.2.78
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -55,7 +55,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.77
+        run: cargo install wasm-bindgen-cli --version 0.2.78
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 base64 = "0.13.0"
 fnv = "1.0.7"
-js-sys = "0.3.53"
+js-sys = "0.3.55"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 svg = "0.10.0"
 percent-encoding = "2.1.0"
 png = "0.17.1"
-wasm-bindgen = "=0.2.77"
+wasm-bindgen = "=0.2.78"
 
 [dependencies.jpeg-decoder]
 version = "0.1.22"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.53"
+js-sys = "0.3.55"
 log = "0.4"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.77"
+wasm-bindgen = "=0.2.78"
 bytemuck = { version = "1.7.0", features = ["derive"] }
 
 [dependencies.ruffle_core]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -31,14 +31,14 @@ console_error_panic_hook = { version = "0.1.1", optional = true }
 console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"
 generational-arena = "0.2.8"
-js-sys = "0.3.53"
+js-sys = "0.3.55"
 log = { version = "0.4", features = ["serde"] }
 ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 url = "2.2.2"
-wasm-bindgen = { version = "=0.2.77", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.26"
+wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.28"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/web/README.md
+++ b/web/README.md
@@ -54,9 +54,9 @@ We recommend using the currently active LTS 14, but we do also run tests with ma
 
 #### wasm-bindgen
 
-<!-- Be sure to also update the wasm-bindgen-cli version in .github/workflows/*.yaml and web/Cargo.toml -->
+<!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.77`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.78`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.53"
+js-sys = "0.3.55"
 log = "0.4"
-wasm-bindgen = "=0.2.77"
+wasm-bindgen = "=0.2.78"
 
 [dependencies.web-sys]
 version = "0.3.50"


### PR DESCRIPTION
As usual, also bump its helper crates (`js-sys`, `wasm-bindgen-futures`) to the latest versions, except for `web-sys` which is locked by wgpu to 0.3.50.