### PR TITLE
dev: have required builds 'run'

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -20,10 +20,7 @@ jobs:
         with:
           filters: |
             src:
-              - '!web/package.json'
-              - '!web/package-lock.json'
-              - '!web/packages/**'
-              - '!**.md'
+              - '!(web/package.json|web/package-lock.json|web/packages/**|**.md)'
 
   build:
     needs: changes
@@ -94,3 +91,23 @@ jobs:
         with:
           name: swf_images
           path: tests/**/*.png.updated
+
+  check-required:
+    needs: changes
+    if: needs.changes.outputs.src == 'false'
+    name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_version: [stable]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - rust_version: nightly
+            os: ubuntu-latest
+          - rust_version: beta
+            os: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -108,4 +108,5 @@ jobs:
             os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: No-op
+        run: echo noop

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -97,9 +97,7 @@ jobs:
     if: needs.changes.outputs.src == 'false'
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
     strategy:
-      fail-fast: false
       matrix:
         rust_version: [stable]
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -82,3 +82,21 @@ jobs:
       - name: Run tests
         working-directory: web
         run: npm test
+
+  check-required:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'false' }}
+    name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.rust_version == 'nightly' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: ["12", "14"]
+        # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
+        rust_version: [stable]
+        # MIKE: Turning off macOS-latest for now (flaky tests on CI).
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -97,4 +97,5 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: No-op
+        run: echo noop

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -24,7 +24,7 @@ jobs:
 
   build:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: needs.changes.outputs.src == 'true'
     name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.rust_version == 'nightly' }}
@@ -85,12 +85,10 @@ jobs:
 
   check-required:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'false' }}
+    if: needs.changes.outputs.src == 'false'
     name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.rust_version == 'nightly' }}
     strategy:
-      fail-fast: false
       matrix:
         node_version: ["12", "14"]
         # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.


### PR DESCRIPTION
Bring in the OR filtering from #5212, but have the required builds "run" (with a blank step).