### PR TITLE
avm1: Don't warn in case a method doesn't exist

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -329,7 +329,9 @@ impl<'gc> Avm1<'gc> {
             active_clip,
         );
 
-        let _ = obj.call_method(name, args, &mut activation);
+        if obj.has_property(&mut activation, name) {
+            let _ = obj.call_method(name, args, &mut activation);
+        }
     }
 
     pub fn notify_system_listeners(


### PR DESCRIPTION
Fixes #5333, #5273.