### PR TITLE
web: Mark TypeScript enums as const

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -1,4 +1,4 @@
-export enum AutoPlay {
+export const enum AutoPlay {
     /**
      * The player should automatically play the movie as soon as it is loaded.
      *
@@ -32,7 +32,7 @@ export enum AutoPlay {
  * When letterboxed, black bars will be rendered around the exterior
  * margins of the content.
  */
-export enum Letterbox {
+export const enum Letterbox {
     /**
      * The content will never be letterboxed.
      */
@@ -53,7 +53,7 @@ export enum Letterbox {
  * When the player is muted, this controls whether or not Ruffle will show a
  * "click to unmute" overlay on top of the movie.
  */
-export enum UnmuteOverlay {
+export const enum UnmuteOverlay {
     /**
      * Show an overlay explaining that the movie is muted.
      */
@@ -68,7 +68,7 @@ export enum UnmuteOverlay {
 /**
  * Console logging level.
  */
-export enum LogLevel {
+export const enum LogLevel {
     Error = "error",
     Warn = "warn",
     Info = "info",

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -24,7 +24,7 @@ export const FLASH_ACTIVEX_CLASSID =
 const RUFFLE_ORIGIN = "https://ruffle.rs";
 const DIMENSION_REGEX = /^\s*(\d+(\.\d+)?(%)?)/;
 
-enum PanicError {
+const enum PanicError {
     Unknown,
     CSPConflict,
     FileProtocol,
@@ -427,25 +427,17 @@ export class RufflePlayer extends HTMLElement {
             this.container.style.visibility = "";
         }
 
-        const autoplay = Object.values(Object(AutoPlay)).includes(
-            config.autoplay
-        )
-            ? config.autoplay
-            : AutoPlay.Auto;
-        const unmuteVisibility = Object.values(Object(UnmuteOverlay)).includes(
-            config.unmuteOverlay
-        )
-            ? config.unmuteOverlay
-            : UnmuteOverlay.Visible;
-
+        // Treat unspecified and invalid values as `AutoPlay.Auto`.
         if (
-            autoplay == AutoPlay.On ||
-            (autoplay == AutoPlay.Auto && this.audioState() === "running")
+            config.autoplay === AutoPlay.On ||
+            (config.autoplay !== AutoPlay.Off &&
+                this.audioState() === "running")
         ) {
             this.play();
 
             if (this.audioState() !== "running") {
-                if (unmuteVisibility === UnmuteOverlay.Visible) {
+                // Treat unspecified and invalid values as `UnmuteOverlay.Visible`.
+                if (config.unmuteOverlay !== UnmuteOverlay.Hidden) {
                     this.unmuteOverlay.style.display = "block";
                 }
 
@@ -1251,7 +1243,7 @@ export class RufflePlayer extends HTMLElement {
 /**
  * Describes the loading state of an SWF movie.
  */
-export enum ReadyState {
+export const enum ReadyState {
     /**
      * No movie is loaded, or no information is yet available about the movie.
      */


### PR DESCRIPTION
Unlike regular enums, const enums are completely removed during compilation, and as such are zero-cost in bundle size terms.

<s>However, it is not possible to query the possible values of a const enum, so revert the `autoplay` and `unmuteOverlay` validation logic, which I guess shouldn't make a big difference.
@Toad06, since you introduced that validation in #2299, maybe you can say why it's important?</s>