### PR TITLE
avm2: Change core types from Object to ClassObject where possible

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -49,7 +49,9 @@ pub use crate::avm2::array::ArrayStorage;
 pub use crate::avm2::domain::Domain;
 pub use crate::avm2::events::Event;
 pub use crate::avm2::names::{Namespace, QName};
-pub use crate::avm2::object::{ArrayObject, Object, ScriptObject, StageObject, TObject};
+pub use crate::avm2::object::{
+    ArrayObject, ClassObject, Object, ScriptObject, StageObject, TObject,
+};
 pub use crate::avm2::value::Value;
 
 const BROADCAST_WHITELIST: [&str; 3] = ["enterFrame", "exitFrame", "frameConstructed"];
@@ -208,7 +210,7 @@ impl<'gc> Avm2<'gc> {
     pub fn broadcast_event(
         context: &mut UpdateContext<'_, 'gc, '_>,
         event: Event<'gc>,
-        on_type: Object<'gc>,
+        on_type: ClassObject<'gc>,
     ) -> Result<(), Error> {
         let event_name = event.event_type();
         if !BROADCAST_WHITELIST.iter().any(|x| *x == event_name) {

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::names::{Multiname, Namespace, QName};
-use crate::avm2::object::Object;
+use crate::avm2::object::{ClassObject, Object};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
@@ -50,7 +50,7 @@ bitflags! {
 ///  * `proto` - The prototype attached to the class object.
 ///  * `activation` - The current AVM2 activation.
 pub type AllocatorFn = for<'gc> fn(
-    Object<'gc>,
+    ClassObject<'gc>,
     Object<'gc>,
     &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error>;

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -297,6 +297,12 @@ impl<'gc> DispatchList<'gc> {
     }
 }
 
+impl<'gc> Default for DispatchList<'gc> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A single instance of an event handler.
 #[derive(Clone, Collect, Debug)]
 #[collect(no_drop)]

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::method::{BytecodeMethod, Method, NativeMethod};
-use crate::avm2::object::Object;
+use crate::avm2::object::{ClassObject, Object};
 use crate::avm2::scope::Scope;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -97,7 +97,7 @@ impl<'gc> Executable<'gc> {
         unbound_receiver: Option<Object<'gc>>,
         mut arguments: &[Value<'gc>],
         activation: &mut Activation<'_, 'gc, '_>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
         callee: Object<'gc>,
     ) -> Result<Value<'gc>, Error> {
         match self {

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -185,44 +185,44 @@ impl<'gc> SystemPrototypes<'gc> {
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct SystemClasses<'gc> {
-    pub object: Object<'gc>,
-    pub function: Object<'gc>,
-    pub class: Object<'gc>,
-    pub global: Object<'gc>,
-    pub string: Object<'gc>,
-    pub boolean: Object<'gc>,
-    pub number: Object<'gc>,
-    pub int: Object<'gc>,
-    pub uint: Object<'gc>,
-    pub namespace: Object<'gc>,
-    pub array: Object<'gc>,
-    pub movieclip: Object<'gc>,
-    pub framelabel: Object<'gc>,
-    pub scene: Object<'gc>,
-    pub application_domain: Object<'gc>,
-    pub event: Object<'gc>,
-    pub video: Object<'gc>,
-    pub xml: Object<'gc>,
-    pub xml_list: Object<'gc>,
-    pub display_object: Object<'gc>,
-    pub shape: Object<'gc>,
-    pub point: Object<'gc>,
-    pub rectangle: Object<'gc>,
-    pub textfield: Object<'gc>,
-    pub textformat: Object<'gc>,
-    pub graphics: Object<'gc>,
-    pub loaderinfo: Object<'gc>,
-    pub bytearray: Object<'gc>,
-    pub stage: Object<'gc>,
-    pub sprite: Object<'gc>,
-    pub simplebutton: Object<'gc>,
-    pub regexp: Object<'gc>,
-    pub vector: Object<'gc>,
-    pub soundtransform: Object<'gc>,
-    pub soundchannel: Object<'gc>,
-    pub bitmap: Object<'gc>,
-    pub bitmapdata: Object<'gc>,
-    pub date: Object<'gc>,
+    pub object: ClassObject<'gc>,
+    pub function: ClassObject<'gc>,
+    pub class: ClassObject<'gc>,
+    pub global: ClassObject<'gc>,
+    pub string: ClassObject<'gc>,
+    pub boolean: ClassObject<'gc>,
+    pub number: ClassObject<'gc>,
+    pub int: ClassObject<'gc>,
+    pub uint: ClassObject<'gc>,
+    pub namespace: ClassObject<'gc>,
+    pub array: ClassObject<'gc>,
+    pub movieclip: ClassObject<'gc>,
+    pub framelabel: ClassObject<'gc>,
+    pub scene: ClassObject<'gc>,
+    pub application_domain: ClassObject<'gc>,
+    pub event: ClassObject<'gc>,
+    pub video: ClassObject<'gc>,
+    pub xml: ClassObject<'gc>,
+    pub xml_list: ClassObject<'gc>,
+    pub display_object: ClassObject<'gc>,
+    pub shape: ClassObject<'gc>,
+    pub point: ClassObject<'gc>,
+    pub rectangle: ClassObject<'gc>,
+    pub textfield: ClassObject<'gc>,
+    pub textformat: ClassObject<'gc>,
+    pub graphics: ClassObject<'gc>,
+    pub loaderinfo: ClassObject<'gc>,
+    pub bytearray: ClassObject<'gc>,
+    pub stage: ClassObject<'gc>,
+    pub sprite: ClassObject<'gc>,
+    pub simplebutton: ClassObject<'gc>,
+    pub regexp: ClassObject<'gc>,
+    pub vector: ClassObject<'gc>,
+    pub soundtransform: ClassObject<'gc>,
+    pub soundchannel: ClassObject<'gc>,
+    pub bitmap: ClassObject<'gc>,
+    pub bitmapdata: ClassObject<'gc>,
+    pub date: ClassObject<'gc>,
 }
 
 impl<'gc> SystemClasses<'gc> {
@@ -233,51 +233,47 @@ impl<'gc> SystemClasses<'gc> {
     /// the empty object also handed to this function. It is the caller's
     /// responsibility to instantiate each class and replace the empty object
     /// with that.
-    fn new(
-        object: Object<'gc>,
-        function: Object<'gc>,
-        class: Object<'gc>,
-        empty: Object<'gc>,
-    ) -> Self {
+    fn new(object: ClassObject<'gc>, function: ClassObject<'gc>, class: ClassObject<'gc>) -> Self {
         SystemClasses {
             object,
             function,
             class,
-            global: empty,
-            string: empty,
-            boolean: empty,
-            number: empty,
-            int: empty,
-            uint: empty,
-            namespace: empty,
-            array: empty,
-            movieclip: empty,
-            framelabel: empty,
-            scene: empty,
-            application_domain: empty,
-            event: empty,
-            video: empty,
-            xml: empty,
-            xml_list: empty,
-            display_object: empty,
-            shape: empty,
-            point: empty,
-            rectangle: empty,
-            textfield: empty,
-            textformat: empty,
-            graphics: empty,
-            loaderinfo: empty,
-            bytearray: empty,
-            stage: empty,
-            sprite: empty,
-            simplebutton: empty,
-            regexp: empty,
-            vector: empty,
-            soundtransform: empty,
-            soundchannel: empty,
-            bitmap: empty,
-            bitmapdata: empty,
-            date: empty,
+            // temporary initialization
+            global: object,
+            string: object,
+            boolean: object,
+            number: object,
+            int: object,
+            uint: object,
+            namespace: object,
+            array: object,
+            movieclip: object,
+            framelabel: object,
+            scene: object,
+            application_domain: object,
+            event: object,
+            video: object,
+            xml: object,
+            xml_list: object,
+            display_object: object,
+            shape: object,
+            point: object,
+            rectangle: object,
+            textfield: object,
+            textformat: object,
+            graphics: object,
+            loaderinfo: object,
+            bytearray: object,
+            stage: object,
+            sprite: object,
+            simplebutton: object,
+            regexp: object,
+            vector: object,
+            soundtransform: object,
+            soundchannel: object,
+            bitmap: object,
+            bitmapdata: object,
+            date: object,
         }
     }
 }
@@ -311,13 +307,11 @@ fn function<'gc>(
 /// properties, if necessary.
 fn dynamic_class<'gc>(
     mc: MutationContext<'gc, '_>,
-    class_object: Object<'gc>,
+    class_object: ClassObject<'gc>,
     mut domain: Domain<'gc>,
     script: Script<'gc>,
 ) -> Result<(), Error> {
-    let class = class_object
-        .as_class_definition()
-        .ok_or("Attempted to create builtin dynamic class without class on it's constructor!")?;
+    let class = class_object.inner_class_definition();
     let name = class.read().name().clone();
 
     script
@@ -336,7 +330,7 @@ fn class<'gc>(
     class_def: GcCell<'gc, Class<'gc>>,
     mut domain: Domain<'gc>,
     script: Script<'gc>,
-) -> Result<(Object<'gc>, Object<'gc>), Error> {
+) -> Result<(ClassObject<'gc>, Object<'gc>), Error> {
     let mut global = script.init().1;
     let global_scope = Scope::push_scope(global.get_scope(), global, activation.context.gc_context);
 
@@ -353,8 +347,11 @@ fn class<'gc>(
                 )
                 .into()
             });
+        let super_class = super_class?
+            .as_class_object()
+            .ok_or_else(|| Error::from("Base class of a global class is not a class"))?;
 
-        Some(super_class?)
+        Some(super_class)
     } else {
         None
     };
@@ -375,7 +372,7 @@ fn class<'gc>(
 
     let proto = class_object
         .get_property(
-            class_object,
+            class_object.into(),
             &QName::new(Namespace::public(), "prototype").into(),
             activation,
         )?
@@ -448,12 +445,8 @@ pub fn load_player_globals<'gc>(
 
     let fn_scope = Some(Scope::push_scope(gs.get_scope(), gs, mc));
     let fn_classdef = function::create_class(mc);
-    let fn_class = ClassObject::from_class_partial(
-        activation,
-        fn_classdef,
-        Some(object_class.into()),
-        fn_scope,
-    )?;
+    let fn_class =
+        ClassObject::from_class_partial(activation, fn_classdef, Some(object_class), fn_scope)?;
     let fn_proto = ScriptObject::object(mc, object_proto);
 
     let class_scope = Some(Scope::push_scope(gs.get_scope(), gs, mc));
@@ -461,20 +454,20 @@ pub fn load_player_globals<'gc>(
     let class_class = ClassObject::from_class_partial(
         activation,
         class_classdef,
-        Some(object_class.into()),
+        Some(object_class),
         class_scope,
     )?;
     let class_proto = ScriptObject::object(mc, object_proto);
 
     // Now to weave the Gordian knot...
     object_class.link_prototype(activation, object_proto)?;
-    object_class.link_type(activation, class_proto, class_class.into());
+    object_class.link_type(activation, class_proto, class_class);
 
     fn_class.link_prototype(activation, fn_proto)?;
-    fn_class.link_type(activation, class_proto, class_class.into());
+    fn_class.link_type(activation, class_proto, class_class);
 
     class_class.link_prototype(activation, class_proto)?;
-    class_class.link_type(activation, class_proto, class_class.into());
+    class_class.link_type(activation, class_proto, class_class);
 
     // At this point, we need at least a partial set of system prototypes in
     // order to continue initializing the player. The rest of the prototypes
@@ -486,12 +479,8 @@ pub fn load_player_globals<'gc>(
         ScriptObject::bare_object(mc),
     ));
 
-    activation.context.avm2.system_classes = Some(SystemClasses::new(
-        object_class.into(),
-        fn_class.into(),
-        class_class.into(),
-        ScriptObject::bare_object(mc),
-    ));
+    activation.context.avm2.system_classes =
+        Some(SystemClasses::new(object_class, fn_class, class_class));
 
     // Our activation environment is now functional enough to finish
     // initializing the core class weave. The order of initialization shouldn't

--- a/core/src/avm2/globals/flash/media/sound.rs
+++ b/core/src/avm2/globals/flash/media/sound.rs
@@ -40,7 +40,7 @@ pub fn instance_init<'gc>(
                 {
                     this.set_sound(activation.context.gc_context, *sound);
                 } else {
-                    log::warn!("Attempted to construct subclass of Sound, {}, which is associated with non-Sound character {}", class_object.as_class_definition().expect("Class object is also a class").read().name().local_name(), symbol);
+                    log::warn!("Attempted to construct subclass of Sound, {}, which is associated with non-Sound character {}", class_object.inner_class_definition().read().name().local_name(), symbol);
                 }
             }
         }

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -33,7 +33,7 @@ pub fn get_qualified_class_name<'gc>(
     let class = match obj.as_class_object() {
         Some(class) => class,
         None => match obj.instance_of() {
-            Some(cls) => cls.as_class_object().unwrap(),
+            Some(cls) => cls,
             None => return Ok(Value::Null),
         },
     };
@@ -41,8 +41,7 @@ pub fn get_qualified_class_name<'gc>(
     Ok(AvmString::new(
         activation.context.gc_context,
         class
-            .as_class_definition()
-            .ok_or("This object does not have a class")?
+            .inner_class_definition()
             .read()
             .name()
             .to_qualified_name(),
@@ -64,7 +63,7 @@ pub fn get_qualified_super_class_name<'gc>(
     let class = match obj.as_class_object() {
         Some(class) => class,
         None => match obj.instance_of() {
-            Some(cls) => cls.as_class_object().unwrap(),
+            Some(cls) => cls,
             None => return Ok(Value::Null),
         },
     };
@@ -73,8 +72,7 @@ pub fn get_qualified_super_class_name<'gc>(
         Ok(AvmString::new(
             activation.context.gc_context,
             super_class
-                .as_class_definition()
-                .ok_or("This object does not have a class")?
+                .inner_class_definition()
                 .read()
                 .name()
                 .to_qualified_name(),

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -67,8 +67,7 @@ pub fn class_init<'gc>(
         let int_vector_class = this.apply(activation, &[int_class.into()])?;
         let int_vector_name = QName::new(Namespace::internal(NS_VECTOR), "Vector$int");
         int_vector_class
-            .as_class_definition()
-            .unwrap()
+            .inner_class_definition()
             .write(activation.context.gc_context)
             .set_name(int_vector_name.clone());
 
@@ -85,8 +84,7 @@ pub fn class_init<'gc>(
         let uint_vector_class = this.apply(activation, &[uint_class.into()])?;
         let uint_vector_name = QName::new(Namespace::internal(NS_VECTOR), "Vector$uint");
         uint_vector_class
-            .as_class_definition()
-            .unwrap()
+            .inner_class_definition()
             .write(activation.context.gc_context)
             .set_name(uint_vector_name.clone());
 
@@ -103,8 +101,7 @@ pub fn class_init<'gc>(
         let number_vector_class = this.apply(activation, &[number_class.into()])?;
         let number_vector_name = QName::new(Namespace::internal(NS_VECTOR), "Vector$double");
         number_vector_class
-            .as_class_definition()
-            .unwrap()
+            .inner_class_definition()
             .write(activation.context.gc_context)
             .set_name(number_vector_name.clone());
 
@@ -120,8 +117,7 @@ pub fn class_init<'gc>(
         let object_vector_class = this.apply(activation, &[Value::Null])?;
         let object_vector_name = QName::new(Namespace::internal(NS_VECTOR), "Vector$object");
         object_vector_class
-            .as_class_definition()
-            .unwrap()
+            .inner_class_definition()
             .write(activation.context.gc_context)
             .set_name(object_vector_name.clone());
 
@@ -288,11 +284,7 @@ pub fn concat<'gc>(
                 return Err(format!(
                     "TypeError: Cannot coerce argument of type {:?} to argument of type {:?}",
                     arg_class.read().name(),
-                    my_class
-                        .as_class_definition()
-                        .ok_or("TypeError: Tried to concat into a bare object")?
-                        .read()
-                        .name()
+                    my_class.inner_class_definition().read().name()
                 )
                 .into());
             }
@@ -313,11 +305,7 @@ pub fn concat<'gc>(
                         return Err(format!(
                             "TypeError: Cannot coerce Vector value of type {:?} to type {:?}",
                             other_val_class.read().name(),
-                            val_class
-                                .as_class_definition()
-                                .ok_or("TypeError: Tried to concat into a bare object")?
-                                .read()
-                                .name()
+                            val_class.inner_class_definition().read().name()
                         )
                         .into());
                     }
@@ -521,8 +509,6 @@ pub fn filter<'gc>(
         let value_type = this
             .instance_of()
             .unwrap()
-            .as_class_object()
-            .unwrap()
             .as_class_params()
             .ok_or("Cannot filter unparameterized vector")?
             .unwrap_or(activation.avm2().classes().object);
@@ -690,8 +676,6 @@ pub fn map<'gc>(
 
         let value_type = this
             .instance_of()
-            .unwrap()
-            .as_class_object()
             .unwrap()
             .as_class_params()
             .ok_or("Cannot filter unparameterized vector")?

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -4,7 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::array::ArrayStorage;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
@@ -13,7 +13,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates array objects.
 pub fn array_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::bitmap::bitmap_data::BitmapData;
@@ -12,7 +12,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates BitmapData objects.
 pub fn bitmapdata_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -45,11 +45,11 @@ impl<'gc> BitmapDataObject<'gc> {
     pub fn from_bitmap_data(
         activation: &mut Activation<'_, 'gc, '_>,
         bitmap_data: GcCell<'gc, BitmapData<'gc>>,
-        class: Object<'gc>,
+        class: ClassObject<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let proto = class
             .get_property(
-                class,
+                class.into(),
                 &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -2,7 +2,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
@@ -11,7 +11,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates ByteArray objects.
 pub fn bytearray_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -207,10 +207,8 @@ impl<'gc> ClassObject<'gc> {
         mut self,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Object<'gc>, Error> {
-        let class = self
-            .as_class_definition()
-            .ok_or("Cannot finish initialization of core class without a class definition!")?;
-        let class_class = self.0.read().base.instance_of().ok_or(
+        let class = self.inner_class_definition();
+        let class_class = self.instance_of().ok_or(
             "Cannot finish initialization of core class without it being linked to a type!",
         )?;
 
@@ -524,9 +522,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         nullable_params: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error> {
-        let self_class = self
-            .as_class_definition()
-            .ok_or("Attempted to apply type arguments to non-class!")?;
+        let self_class = self.inner_class_definition();
 
         if !self_class.read().is_generic() {
             return Err(format!("Class {:?} is not generic", self_class.read().name()).into());

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -1,6 +1,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::{Hint, Value};
 use crate::avm2::Error;
 use chrono::{DateTime, Utc};
@@ -9,7 +9,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Date objects.
 pub fn date_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 /// A class instance allocator that allocates Dictionary objects.
 pub fn dictionary_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -4,7 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::domain::Domain;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -12,7 +12,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates AppDomain objects.
 pub fn appdomain_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -141,6 +141,8 @@ impl<'gc> TObject<'gc> for DomainObject<'gc> {
                 activation,
             )?
             .coerce_to_object(activation)?;
+
+        let constr = constr.as_class_object().unwrap(); // XXXXX TODO
 
         appdomain_allocator(constr, this, activation)
     }

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -4,7 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::events::Event;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
@@ -13,7 +13,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Event objects.
 pub fn event_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -50,12 +50,12 @@ impl<'gc> EventObject<'gc> {
     /// we will pull the `prototype` off the `class` given to us.
     pub fn from_event(
         activation: &mut Activation<'_, 'gc, '_>,
-        class: Object<'gc>,
+        class: ClassObject<'gc>,
         event: Event<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let proto = class
             .get_property(
-                class,
+                class.into(),
                 &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -5,7 +5,7 @@ use crate::avm2::function::Executable;
 use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::{ScriptObject, ScriptObjectData};
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::scope::Scope;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -117,7 +117,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         receiver: Option<Object<'gc>>,
         arguments: &[Value<'gc>],
         activation: &mut Activation<'_, 'gc, '_>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
     ) -> Result<Value<'gc>, Error> {
         if let Some(exec) = &self.0.read().exec {
             exec.exec(

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::DisplayObject;
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 /// A class instance allocator that allocates LoaderInfo objects.
 pub fn loaderinfo_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::names::Namespace;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -11,7 +11,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates namespace objects.
 pub fn namespace_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -4,7 +4,7 @@ use std::cell::{Ref, RefMut};
 
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
@@ -12,7 +12,7 @@ use gc_arena::{Collect, GcCell, MutationContext};
 
 /// A class instance allocator that allocates primitive objects.
 pub fn primitive_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::regexp::RegExp;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -12,7 +12,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates RegExp objects.
 pub fn regexp_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::backend::audio::SoundHandle;
@@ -12,7 +12,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Sound objects.
 pub fn sound_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -48,12 +48,12 @@ impl<'gc> SoundObject<'gc> {
     /// an instance of the correct class.
     pub fn from_sound(
         activation: &mut Activation<'_, 'gc, '_>,
-        class: Object<'gc>,
+        class: ClassObject<'gc>,
         sound: SoundHandle,
     ) -> Result<Object<'gc>, Error> {
         let proto = class
             .get_property(
-                class,
+                class.into(),
                 &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::backend::audio::SoundInstanceHandle;
@@ -12,7 +12,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates SoundChannel objects.
 pub fn soundchannel_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -49,7 +49,7 @@ impl<'gc> SoundChannelObject<'gc> {
         let class = activation.avm2().classes().soundchannel;
         let proto = class
             .get_property(
-                class,
+                class.into(),
                 &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::DisplayObject;
@@ -12,7 +12,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Stage objects.
 pub fn stage_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -56,11 +56,11 @@ impl<'gc> StageObject<'gc> {
     pub fn for_display_object(
         activation: &mut Activation<'_, 'gc, '_>,
         display_object: DisplayObject<'gc>,
-        class: Object<'gc>,
+        class: ClassObject<'gc>,
     ) -> Result<Self, Error> {
         let proto = class
             .get_property(
-                class,
+                class.into(),
                 &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?
@@ -86,7 +86,7 @@ impl<'gc> StageObject<'gc> {
     pub fn for_display_object_childless(
         activation: &mut Activation<'_, 'gc, '_>,
         display_object: DisplayObject<'gc>,
-        class: Object<'gc>,
+        class: ClassObject<'gc>,
     ) -> Result<Self, Error> {
         let this = Self::for_display_object(activation, display_object, class)?;
 

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -3,7 +3,7 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::vector::VectorStorage;
 use crate::avm2::Error;
@@ -13,7 +13,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Vector objects.
 pub fn vector_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
@@ -23,8 +23,6 @@ pub fn vector_allocator<'gc>(
     //the unspecialized Vector class, we have to fall back to Object when
     //getting the parameter type for our storage.
     let param_type = class
-        .as_class_object()
-        .unwrap()
         .as_class_params()
         .flatten()
         .unwrap_or_else(|| activation.avm2().classes().object);
@@ -66,7 +64,7 @@ impl<'gc> VectorObject<'gc> {
         let applied_class = vector_class.apply(activation, &[value_type.into()])?;
         let applied_proto = applied_class
             .get_property(
-                applied_class,
+                applied_class.into(),
                 &QName::new(Namespace::public(), "prototype").into(),
                 activation,
             )?

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -2,7 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
-use crate::avm2::object::{Object, ObjectPtr, TObject};
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -10,7 +10,7 @@ use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates XML objects.
 pub fn xml_allocator<'gc>(
-    class: Object<'gc>,
+    class: ClassObject<'gc>,
     proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -1,6 +1,6 @@
 //! Property data structures
 
-use crate::avm2::object::{Object, TObject};
+use crate::avm2::object::{ClassObject, Object, TObject};
 use crate::avm2::return_value::ReturnValue;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -167,7 +167,7 @@ impl<'gc> Property<'gc> {
     pub fn get(
         &self,
         this: Object<'gc>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
     ) -> Result<ReturnValue<'gc>, Error> {
         match self {
             Property::Virtual { get: Some(get), .. } => Ok(ReturnValue::defer_execution(
@@ -195,7 +195,7 @@ impl<'gc> Property<'gc> {
     pub fn set(
         &mut self,
         this: Object<'gc>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
         new_value: impl Into<Value<'gc>>,
     ) -> Result<ReturnValue<'gc>, Error> {
         match self {
@@ -239,7 +239,7 @@ impl<'gc> Property<'gc> {
     pub fn init(
         &mut self,
         this: Object<'gc>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
         new_value: impl Into<Value<'gc>>,
     ) -> Result<ReturnValue<'gc>, Error> {
         match self {

--- a/core/src/avm2/return_value.rs
+++ b/core/src/avm2/return_value.rs
@@ -1,7 +1,7 @@
 //! Return value enum
 
 use crate::avm2::activation::Activation;
-use crate::avm2::object::{Object, TObject};
+use crate::avm2::object::{ClassObject, Object, TObject};
 use crate::avm2::{Error, Value};
 use std::fmt;
 
@@ -40,7 +40,7 @@ pub enum ReturnValue<'gc> {
         callee: Object<'gc>,
         unbound_reciever: Option<Object<'gc>>,
         arguments: Vec<Value<'gc>>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
     },
 }
 
@@ -70,7 +70,7 @@ impl<'gc> ReturnValue<'gc> {
         callee: Object<'gc>,
         unbound_reciever: Option<Object<'gc>>,
         arguments: Vec<Value<'gc>>,
-        subclass_object: Option<Object<'gc>>,
+        subclass_object: Option<ClassObject<'gc>>,
     ) -> Self {
         Self::ResultOf {
             callee,

--- a/core/src/avm2/vector.rs
+++ b/core/src/avm2/vector.rs
@@ -1,7 +1,7 @@
 //! Storage for AS3 Vectors
 
 use crate::avm2::activation::Activation;
-use crate::avm2::object::Object;
+use crate::avm2::object::{ClassObject, Object};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::Collect;
@@ -35,14 +35,14 @@ pub struct VectorStorage<'gc> {
     /// incorrectly typed values to the given type if possible. Values that do
     /// not coerce are replaced with the default value for the given value
     /// type.
-    value_type: Object<'gc>,
+    value_type: ClassObject<'gc>,
 }
 
 impl<'gc> VectorStorage<'gc> {
     pub fn new(
         length: usize,
         is_fixed: bool,
-        value_type: Object<'gc>,
+        value_type: ClassObject<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Self {
         let storage = Vec::new();
@@ -64,7 +64,11 @@ impl<'gc> VectorStorage<'gc> {
     ///
     /// The values are assumed to already have been coerced to the value type
     /// given.
-    pub fn from_values(storage: Vec<Value<'gc>>, is_fixed: bool, value_type: Object<'gc>) -> Self {
+    pub fn from_values(
+        storage: Vec<Value<'gc>>,
+        is_fixed: bool,
+        value_type: ClassObject<'gc>,
+    ) -> Self {
         VectorStorage {
             storage,
             is_fixed,
@@ -112,7 +116,7 @@ impl<'gc> VectorStorage<'gc> {
     }
 
     /// Get the value type this vector coerces things to.
-    pub fn value_type(&self) -> Object<'gc> {
+    pub fn value_type(&self) -> ClassObject<'gc> {
         self.value_type
     }
 

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -1,7 +1,7 @@
 use crate::avm1::Object as Avm1Object;
 use crate::avm2::{
-    Activation as Avm2Activation, Error as Avm2Error, Object as Avm2Object,
-    StageObject as Avm2StageObject, TObject as Avm2TObject, Value as Avm2Value,
+    Activation as Avm2Activation, ClassObject as Avm2ClassObject, Error as Avm2Error,
+    Object as Avm2Object, StageObject as Avm2StageObject, Value as Avm2Value,
 };
 use crate::backend::ui::MouseCursor;
 use crate::context::{RenderContext, UpdateContext};
@@ -48,7 +48,7 @@ pub struct Avm2ButtonData<'gc> {
     ///
     /// If not specified in `SymbolClass`, this will be
     /// `flash.display.SimpleButton`.
-    class: Avm2Object<'gc>,
+    class: Avm2ClassObject<'gc>,
 
     /// The AVM2 representation of this button.
     object: Option<Avm2Object<'gc>>,
@@ -379,7 +379,7 @@ impl<'gc> Avm2Button<'gc> {
         self.0.write(context.gc_context).tracking = tracking;
     }
 
-    pub fn set_avm2_class(self, mc: MutationContext<'gc, '_>, class: Avm2Object<'gc>) {
+    pub fn set_avm2_class(self, mc: MutationContext<'gc, '_>, class: Avm2ClassObject<'gc>) {
         self.0.write(mc).class = class;
     }
 }

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -2,8 +2,8 @@
 
 use crate::avm1;
 use crate::avm2::{
-    Activation as Avm2Activation, Object as Avm2Object, StageObject as Avm2StageObject,
-    Value as Avm2Value,
+    Activation as Avm2Activation, ClassObject as Avm2ClassObject, Object as Avm2Object,
+    StageObject as Avm2StageObject, Value as Avm2Value,
 };
 use crate::backend::render::BitmapHandle;
 use crate::context::{RenderContext, UpdateContext};
@@ -58,7 +58,7 @@ pub struct BitmapData<'gc> {
     ///
     /// This association is unusual relative to other things that use AS3
     /// linkage, where the symbol class usually directly represents the symbol.
-    avm2_bitmapdata_class: Option<Avm2Object<'gc>>,
+    avm2_bitmapdata_class: Option<Avm2ClassObject<'gc>>,
 }
 
 impl<'gc> Bitmap<'gc> {
@@ -164,11 +164,15 @@ impl<'gc> Bitmap<'gc> {
         }
     }
 
-    pub fn avm2_bitmapdata_class(self) -> Option<Avm2Object<'gc>> {
+    pub fn avm2_bitmapdata_class(self) -> Option<Avm2ClassObject<'gc>> {
         self.0.read().avm2_bitmapdata_class
     }
 
-    pub fn set_avm2_bitmapdata_class(self, mc: MutationContext<'gc, '_>, class: Avm2Object<'gc>) {
+    pub fn set_avm2_bitmapdata_class(
+        self,
+        mc: MutationContext<'gc, '_>,
+        class: Avm2ClassObject<'gc>,
+    ) {
         self.0.write(mc).avm2_bitmapdata_class = Some(class);
     }
 

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -1,6 +1,6 @@
 use crate::avm1::function::FunctionObject;
 use crate::avm1::property_map::PropertyMap as Avm1PropertyMap;
-use crate::avm2::{Domain as Avm2Domain, Object as Avm2Object};
+use crate::avm2::{ClassObject as Avm2ClassObject, Domain as Avm2Domain};
 use crate::backend::{audio::SoundHandle, render};
 use crate::character::Character;
 use crate::display_object::{Bitmap, Graphic, MorphShape, TDisplayObject, Text};
@@ -80,7 +80,7 @@ impl WeakElement for WeakMovieSymbol {
 pub struct Avm2ClassRegistry<'gc> {
     /// A list of AVM2 class objects and the character IDs they are expected to
     /// instantiate.
-    class_map: WeakValueHashMap<Avm2Object<'gc>, WeakMovieSymbol>,
+    class_map: WeakValueHashMap<Avm2ClassObject<'gc>, WeakMovieSymbol>,
 }
 
 unsafe impl Collect for Avm2ClassRegistry<'_> {
@@ -110,7 +110,7 @@ impl<'gc> Avm2ClassRegistry<'gc> {
     /// a library symbol.
     pub fn class_symbol(
         &self,
-        class_object: Avm2Object<'gc>,
+        class_object: Avm2ClassObject<'gc>,
     ) -> Option<(Arc<SwfMovie>, CharacterId)> {
         match self.class_map.get(&class_object) {
             Some(MovieSymbol(movie, symbol)) => Some((movie, symbol)),
@@ -121,7 +121,7 @@ impl<'gc> Avm2ClassRegistry<'gc> {
     /// Associate an AVM2 class object with a given library symbol.
     pub fn set_class_symbol(
         &mut self,
-        class_object: Avm2Object<'gc>,
+        class_object: Avm2ClassObject<'gc>,
         movie: Arc<SwfMovie>,
         symbol: CharacterId,
     ) {


### PR DESCRIPTION
Unfortunately there wasn't a good way to split up this commit without having it take much, much more time; if I changed the components commit by commit, each commit would have tons of churn just to convert types between layers that in the end would passing the objects without any changes.

This commit adds a bunch of assumptions about AVM2 into our type system; specifically, that the following are always AS3 classes (ClassObjects):
- any object's `instance_of`
- classes' `superclass_object`, interfaces
- vector type params and generic applications cache keys/values
- types attached via SymbolClass
- every SystemClass
- activations' `activation_class` and `subclass_object` (the latter also implies it for our function call and property infrastructure)
- arguments to `as` and `is` related opcodes

This assumption _does_ break in several places related to prototype-based classes. I marked these places as `XXXXX TODO` and they are the only reasons why this PR is a draft; I'd love some advice on handling these. Despite not handling these well, all tests pass :)

The main benefit is that this allows interpreter internals to confidently use classes without constantly doing `.as_class_object.ok_or("some error message here")` on every use, leaving validation to the "edges". You can see the improvements in functions like `has_class_in_chain`, `install_instance_traits` etc. This could also  improve perf, as this is basically hand-written devirtualization of Object methods.

Downside is that while this makes the type system stricter, it also makes is "stiffer", making other possible refactors possibly require more churn all around the codebase (especially if we ever mess with our enum-class object implementation). In particular, if any of these assumptions above turn out false, the reversal will be costly.

(I also did some minor related refactors, like moving more methods to `ClassObject`, and removing iteration over 1-element vector type param vec.)