### PR TITLE
avm1: Fix read of exceeding With opcodes

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -431,10 +431,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     pub fn run_actions(&mut self, code: SwfSlice) -> Result<ReturnType<'gc>, Error<'gc>> {
-        let mut read = Reader::new(&code.movie.data()[code.start..], self.swf_version());
+        let mut reader = Reader::new(code.as_ref(), self.swf_version());
 
         loop {
-            let result = self.do_action(&code, &mut read);
+            let result = self.do_action(&code, &mut reader);
             match result {
                 Ok(FrameControl::Return(return_type)) => break Ok(return_type),
                 Ok(FrameControl::Continue) => {}

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -237,11 +237,12 @@ impl<'a> Reader<'a> {
                     num_actions_to_skip: self.read_u8()?,
                 },
                 OpCode::With => {
-                    let code_length: usize = (self.read_u16()?).into();
+                    let code_length: usize = self.read_u16()?.into();
+                    // Read in bounds of the DoAction tag.
+                    let code_length = code_length.min(self.input.len());
                     *length += code_length;
-                    Action::With {
-                        actions: self.read_slice(code_length)?,
-                    }
+                    let actions = self.read_slice(code_length).unwrap();
+                    Action::With { actions }
                 }
                 OpCode::WaitForFrame2 => Action::WaitForFrame2 {
                     num_actions_to_skip: self.read_u8()?,

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -353,7 +353,8 @@ impl<W: Write> Writer<W> {
                 self.write_u8(num_actions_to_skip)?;
             }
             Action::With { actions } => {
-                self.write_action_header(OpCode::With, actions.len())?;
+                self.write_action_header(OpCode::With, 2)?;
+                self.write_u16(actions.len() as u16)?;
                 self.output.write_all(actions)?;
             }
             Action::Unknown { opcode, data } => {


### PR DESCRIPTION
In such a case, it seems that Flash executes only the part that is in bounds of the DoAction tag.
Example SWF: [out.zip](https://github.com/ruffle-rs/ruffle/files/7229527/out.zip)
 