### PR TITLE
avm2: Always unbox primitives on the stack.

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -294,7 +294,13 @@ impl<'gc> Avm2<'gc> {
 
     /// Push a value onto the operand stack.
     fn push(&mut self, value: impl Into<Value<'gc>>) {
-        let value = value.into();
+        let mut value = value.into();
+        if let Value::Object(o) = value {
+            if let Some(prim) = o.as_primitive() {
+                value = prim.clone();
+            }
+        }
+
         avm_debug!(self, "Stack push {}: {:?}", self.stack.len(), value);
         self.stack.push(value);
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1233,7 +1233,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
             let name_value = self.context.avm2.pop();
             let object = self.context.avm2.pop().coerce_to_object(self)?;
-            if !name_value.is_boxed_primitive() {
+            if !name_value.is_primitive() {
                 if let Some(dictionary) = object.as_dictionary_object() {
                     let value =
                         dictionary.get_property_by_object(name_value.coerce_to_object(self)?);
@@ -1279,7 +1279,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
             let name_value = self.context.avm2.pop();
             let object = self.context.avm2.pop().coerce_to_object(self)?;
-            if !name_value.is_boxed_primitive() {
+            if !name_value.is_primitive() {
                 if let Some(dictionary) = object.as_dictionary_object() {
                     dictionary.set_property_by_object(
                         name_value.coerce_to_object(self)?,
@@ -1339,7 +1339,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
             let name_value = self.context.avm2.pop();
             let object = self.context.avm2.pop().coerce_to_object(self)?;
-            if !name_value.is_boxed_primitive() {
+            if !name_value.is_primitive() {
                 if let Some(dictionary) = object.as_dictionary_object() {
                     dictionary.delete_property_by_object(
                         name_value.coerce_to_object(self)?,
@@ -1423,7 +1423,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let name_value = self.context.avm2.pop();
 
         if let Some(dictionary) = obj.as_dictionary_object() {
-            if !name_value.is_boxed_primitive() {
+            if !name_value.is_primitive() {
                 let obj_key = name_value.coerce_to_object(self)?;
                 self.context
                     .avm2

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -259,14 +259,6 @@ impl<'gc> Value<'gc> {
         !matches!(self, Value::Object(_))
     }
 
-    /// Yields `true` if the given value is a primitive value, boxed or no.
-    pub fn is_boxed_primitive(&self) -> bool {
-        match self {
-            Value::Object(o) => o.as_primitive().is_some(),
-            _ => true,
-        }
-    }
-
     /// Coerce the value to a boolean.
     ///
     /// Boolean coercion happens according to the rules specified in the ES4


### PR DESCRIPTION
Because primitive types are still object values, it's necessary to coerce them into objects. This is accomplished via `PrimitiveObject`, which represents an immutable non-object value in contexts where object methods are needed. However, this means that the `Value` machinery can represent the same value by one of two ways, which necessitates kludges like `is_boxed_primitive`.

To avoid that, we're going to unbox primitives where feasible. The most obvious chokepoint is stack pushes, as this is the only way that user instructions can access values. So every call to `push` also checks for a primitive, and unboxes it at that point. This also means we don't need `is_boxed_primitive` anymore.

(For those wondering how user code would even *get* a `PrimitiveObject`, consider that those types have constructors. Currently, all methods have to accept an `Object` receiver; and all types have to return an `Object` when constructed. So `new String()` will return an object, not a string - but automatic unboxing ensures user code never sees this.)