### PR TITLE
Make rendering raw bitmaps faster with the canvas backend

### DIFF
--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -31,6 +31,6 @@ default-features = false
 version = "0.3.50"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
-    "Document", "Element", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "Navigator", "Node", "Path2d",
-    "SvgMatrix", "SvgsvgElement", "UiEvent", "Window",
+    "Document", "Element", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "ImageData", "Navigator",
+    "Node", "Path2d", "SvgMatrix", "SvgsvgElement", "UiEvent", "Window",
 ]

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -1443,12 +1443,14 @@ fn swf_shape_to_canvas_commands(
 
                             let matrix = matrix_factory.create_svg_matrix();
 
-                            matrix.set_a(a.a.to_f32());
-                            matrix.set_b(a.b.to_f32());
-                            matrix.set_c(a.c.to_f32());
-                            matrix.set_d(a.d.to_f32());
-                            matrix.set_e(a.tx.get() as f32);
-                            matrix.set_f(a.ty.get() as f32);
+                            // The `1.0 / 20.0` in `bounds_viewbox_matrix` does not
+                            // affect this, so we have to do it manually here.
+                            matrix.set_a(a.a.to_f32() / 20.0);
+                            matrix.set_b(a.b.to_f32() / 20.0);
+                            matrix.set_c(a.c.to_f32() / 20.0);
+                            matrix.set_d(a.d.to_f32() / 20.0);
+                            matrix.set_e(a.tx.get() as f32 / 20.0);
+                            matrix.set_f(a.ty.get() as f32 / 20.0);
 
                             bitmap_pattern.set_transform(&matrix);
 

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -857,7 +857,8 @@ impl RenderBackend for WebCanvasRenderBackend {
         height: u32,
         rgba: Vec<u8>,
     ) -> Result<BitmapHandle, Error> {
-
+        // TODO: Could be optimized to a single put_image_data call
+        // in case it is already stored as a canvas+context.
         self.bitmaps[handle.0] = BitmapData {
             image: BitmapDataStorage::from_image_data(
                 ImageData::new_with_u8_clamped_array(Clamped(&rgba), width).unwrap(),
@@ -1421,10 +1422,13 @@ fn swf_shape_to_canvas_commands(
                             .and_then(|bitmap| bitmaps.get(bitmap.handle.0))
                         {
                             if !*is_smoothed {
+                                // TODO
                                 //image = image.set("image-rendering", pixelated_property_value);
                             }
 
                             let repeat = if !*is_repeating {
+                                // NOTE: The WebGL backend does clamping in this case, just like
+                                // Flash Player, but CanvasPattern has no such option...
                                 "no-repeat"
                             } else {
                                 "repeat"

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -666,6 +666,8 @@ impl RenderBackend for WebCanvasRenderBackend {
             return;
         }
 
+        self.context.set_image_smoothing_enabled(smoothing);
+
         self.set_transform(&transform.matrix);
         self.set_color_filter(transform);
         if let Some(bitmap) = self.bitmaps.get(bitmap.0) {

--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -22,7 +22,7 @@
             "run_at": "document_start",
         }
     ],
-    "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'; connect-src *;",
+    "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'; connect-src *; img-src data:;",
     "icons": {
         "16": "images/icon16.png",
         "32": "images/icon32.png",


### PR DESCRIPTION
This is supposed to fix #5379, and make video playback in general much faster with the canvas backend.
By avoiding PNG and base64 compression and encoding (then decoding and decompression by the browser) every time a texture is updated.

I'm uncertain about the lazy caching of the `data_uri`, as the whole bitmap array needs to be `mut` for this;
perhaps simply computing it every time it is needed (which is, I have no idea how often) would be better.