### PR TITLE
chore: Fix nightly clippy lint: clippy::if_then_panic

### DIFF
--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -41,17 +41,21 @@ pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
     let enum_input = parse_macro_input!(args as ItemEnum);
     let enum_name = enum_input.ident.clone();
 
-    if trait_generics.lifetimes().count() > 1 {
-        panic!("Only one lifetime parameter is currently supported");
-    }
+    assert!(
+        trait_generics.lifetimes().count() <= 1,
+        "Only one lifetime parameter is currently supported"
+    );
 
-    if trait_generics.type_params().count() > 1 {
-        panic!("Generic type parameters are currently unsupported");
-    }
+    assert!(
+        trait_generics.type_params().count() <= 1, // XXX shouldn't this be <= 0; or rather, == 0; or similar to .is_empty() or .has_next()?
+        "Generic type parameters are currently unsupported"
+    );
 
-    if trait_generics != enum_input.generics {
-        panic!("Trait and enum should have the same generic parameters");
-    }
+    assert_eq!(
+        trait_generics, enum_input.generics,
+        "Trait and enum should have the same generic parameters"
+    );
+
     // Implement each trait. This will match against each enum variant and delegate
     // to the underlying type.
     let trait_methods: Vec<_> = input_trait

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -41,13 +41,15 @@ pub fn enum_trait_object(args: TokenStream, item: TokenStream) -> TokenStream {
     let enum_input = parse_macro_input!(args as ItemEnum);
     let enum_name = enum_input.ident.clone();
 
+    // TODO: Revise whether the first two asserts are needed at all, and whether
+    // the second condition should be `== 0` instead, based on the error message.
     assert!(
         trait_generics.lifetimes().count() <= 1,
         "Only one lifetime parameter is currently supported"
     );
 
     assert!(
-        trait_generics.type_params().count() <= 1, // XXX shouldn't this be <= 0; or rather, == 0; or similar to .is_empty() or .has_next()?
+        trait_generics.type_params().count() <= 1,
         "Generic type parameters are currently unsupported"
     );
 

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -191,6 +191,7 @@ impl std::ops::MulAssign for Matrix {
 }
 
 #[cfg(test)]
+#[allow(clippy::if_then_panic)] // TODO: Remove when https://github.com/brendanzab/approx/pull/72 is merged.
 mod tests {
     use super::*;
     use approx::{assert_ulps_eq, AbsDiffEq, UlpsEq};

--- a/core/src/transform.rs
+++ b/core/src/transform.rs
@@ -46,9 +46,7 @@ impl TransformStack {
     }
 
     pub fn pop(&mut self) {
-        if self.0.len() <= 1 {
-            panic!("Transform stack underflow");
-        }
+        assert!(self.0.len() > 1, "Transform stack underflow");
         self.0.pop();
     }
 

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -370,13 +370,11 @@ pub mod tests {
         for (swf_version, expected_action, action_bytes) in test_data::avm1_tests() {
             let mut reader = Reader::new(&action_bytes[..], swf_version);
             let parsed_action = reader.read_action().unwrap().unwrap();
-            if parsed_action != expected_action {
-                // Failed, result doesn't match.
-                panic!(
-                    "Incorrectly parsed action.\nRead:\n{:?}\n\nExpected:\n{:?}",
-                    parsed_action, expected_action
-                );
-            }
+            assert_eq!(
+                parsed_action, expected_action,
+                "Incorrectly parsed action.\nRead:\n{:?}\n\nExpected:\n{:?}",
+                parsed_action, expected_action
+            );
         }
     }
 

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -439,12 +439,11 @@ mod tests {
             Writer::new(&mut written_bytes, swf_version)
                 .write_action(&action)
                 .unwrap();
-            if written_bytes != expected_bytes {
-                panic!(
-                    "Error writing action.\nTag:\n{:?}\n\nWrote:\n{:?}\n\nExpected:\n{:?}",
-                    action, written_bytes, expected_bytes
-                );
-            }
+            assert_eq!(
+                written_bytes, expected_bytes,
+                "Error writing action.\nTag:\n{:?}\n\nWrote:\n{:?}\n\nExpected:\n{:?}",
+                action, written_bytes, expected_bytes
+            );
         }
     }
 }

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -895,13 +895,11 @@ pub mod tests {
         for (_, abc_file, bytes) in test_data::avm2_tests() {
             let mut reader = Reader::new(&bytes[..]);
             let parsed = reader.read().unwrap();
-            if parsed != abc_file {
-                // Failed, result doesn't match.
-                panic!(
-                    "Incorrectly parsed ABC.\nRead:\n{:?}\n\nExpected:\n{:?}",
-                    parsed, abc_file
-                );
-            }
+            assert_eq!(
+                parsed, abc_file,
+                "Incorrectly parsed ABC.\nRead:\n{:?}\n\nExpected:\n{:?}",
+                parsed, abc_file
+            );
         }
     }
 

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -1069,7 +1069,7 @@ pub mod tests {
                 writer.write(abc_file).unwrap();
             }
             assert_eq!(
-                bytes, out,
+                out, bytes,
                 "Incorrectly written ABC.\nWritten:\n{:?}\n\nExpected:\n{:?}",
                 out, bytes
             );

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -1068,13 +1068,11 @@ pub mod tests {
                 let mut writer = Writer::new(&mut out);
                 writer.write(abc_file).unwrap();
             }
-            if bytes != out {
-                // Failed, result doesn't match.
-                panic!(
-                    "Incorrectly written ABC.\nWritten:\n{:?}\n\nExpected:\n{:?}",
-                    out, bytes
-                );
-            }
+            assert_eq!(
+                bytes, out,
+                "Incorrectly written ABC.\nWritten:\n{:?}\n\nExpected:\n{:?}",
+                out, bytes
+            );
         }
     }
 

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -3035,13 +3035,11 @@ pub mod tests {
                 Ok(tag) => tag,
                 Err(e) => panic!("Error parsing tag: {}", e),
             };
-            if parsed_tag != expected_tag {
-                // Failed, result doesn't match.
-                panic!(
-                    "Incorrectly parsed tag.\nRead:\n{:#?}\n\nExpected:\n{:#?}",
-                    parsed_tag, expected_tag
-                );
-            }
+            assert_eq!(
+                parsed_tag, expected_tag,
+                "Incorrectly parsed tag.\nRead:\n{:#?}\n\nExpected:\n{:#?}",
+                parsed_tag, expected_tag
+            );
         }
     }
 

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2793,12 +2793,11 @@ mod tests {
             Writer::new(&mut written_tag_bytes, swf_version)
                 .write_tag(&tag)
                 .unwrap();
-            if written_tag_bytes != expected_tag_bytes {
-                panic!(
-                    "Error reading tag.\nTag:\n{:?}\n\nWrote:\n{:?}\n\nExpected:\n{:?}",
-                    tag, written_tag_bytes, expected_tag_bytes
-                );
-            }
+            assert_eq!(
+                written_tag_bytes, expected_tag_bytes,
+                "Error reading tag.\nTag:\n{:?}\n\nWrote:\n{:?}\n\nExpected:\n{:?}",
+                tag, written_tag_bytes, expected_tag_bytes
+            );
         }
     }
 


### PR DESCRIPTION
Also note the `// XXX` comment about a potential typo / copy-paste error found by accident.