### PR TITLE
Allow the if_then_panic clippy lint in one more place

### DIFF
--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -81,6 +81,7 @@ macro_rules! swf_tests_approx {
     ($($(#[$attr:meta])* ($name:ident, $path:expr, $num_frames:literal $(, $opt:ident = $val:expr)*),)*) => {
         $(
         #[test]
+        #[allow(clippy::if_then_panic)] // TODO: Remove when https://github.com/brendanzab/approx/pull/72 is merged.
         $(#[$attr])*
         fn $name() -> Result<(), Error> {
             set_logger();


### PR DESCRIPTION
This is a follow-up/continuation of https://github.com/ruffle-rs/ruffle/pull/5400.

I still can't get these warnings on my nightly clippy installation, so these instances were missed.