### PR TITLE
chore: Bump h263-rs and h263-rs-yuv git refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "h263-rs"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=ce3d3c798190be1c78c47099e76d095756a195ac#ce3d3c798190be1c78c47099e76d095756a195ac"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=03dcd486e88381635647a7386105cb802921b69c#03dcd486e88381635647a7386105cb802921b69c"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1733,7 +1733,10 @@ dependencies = [
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=ce3d3c798190be1c78c47099e76d095756a195ac#ce3d3c798190be1c78c47099e76d095756a195ac"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=03dcd486e88381635647a7386105cb802921b69c#03dcd486e88381635647a7386105cb802921b69c"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "hashbrown"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,8 +35,8 @@ encoding_rs = "0.8.28"
 rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.130", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "ce3d3c798190be1c78c47099e76d095756a195ac", optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "ce3d3c798190be1c78c47099e76d095756a195ac", optional = true }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "03dcd486e88381635647a7386105cb802921b69c", optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "03dcd486e88381635647a7386105cb802921b69c", optional = true }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 json = "0.12.4"


### PR DESCRIPTION
To reap the benefits of PRs merged since the currently locked version:

 - https://github.com/ruffle-rs/h263-rs/pull/4
 - https://github.com/ruffle-rs/h263-rs/pull/7
 - https://github.com/ruffle-rs/h263-rs/pull/10
 - https://github.com/ruffle-rs/h263-rs/pull/12
 - https://github.com/ruffle-rs/h263-rs/pull/13