### PR TITLE
core: Simplifiy goto logic and use ratio field

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -195,7 +195,6 @@ pub trait TDisplayObjectContainer<'gc>:
             .replace_at_depth(child, depth);
 
         child.set_parent(context, Some(self.into()));
-        child.set_place_frame(context.gc_context, 0);
         child.set_depth(context.gc_context, depth);
 
         if let Some(removed_child) = removed_child {
@@ -260,7 +259,6 @@ pub trait TDisplayObjectContainer<'gc>:
 
         let child_was_on_stage = child.is_on_stage(context);
 
-        child.set_place_frame(context.gc_context, 0);
         child.set_parent(context, Some(this));
         if !context.is_action_script_3() {
             child.set_avm1_removed(context.gc_context, false);
@@ -370,6 +368,21 @@ pub trait TDisplayObjectContainer<'gc>:
 
         self.raw_container_mut(context.gc_context)
             .remove_child_from_depth_list(child);
+    }
+
+    /// Removes (without unloading) a child display object from this container's depth list.
+    fn remove_child_from_render_list(
+        &mut self,
+        context: &mut UpdateContext<'_, 'gc>,
+        child: DisplayObject<'gc>,
+    ) {
+        debug_assert!(DisplayObject::ptr_eq(
+            child.parent().unwrap(),
+            (*self).into()
+        ));
+
+        self.raw_container_mut(context.gc_context)
+            .remove_child_from_render_list(child);
     }
 
     /// Remove a set of children identified by their render list indicies from

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -28,7 +28,6 @@ impl fmt::Debug for MorphShape<'_> {
 pub struct MorphShapeData<'gc> {
     base: DisplayObjectBase<'gc>,
     static_data: Gc<'gc, MorphShapeStatic>,
-    ratio: u16,
 }
 
 impl<'gc> MorphShape<'gc> {
@@ -43,17 +42,8 @@ impl<'gc> MorphShape<'gc> {
             MorphShapeData {
                 base: Default::default(),
                 static_data: Gc::allocate(gc_context, static_data),
-                ratio: 0,
             },
         ))
-    }
-
-    pub fn ratio(self) -> u16 {
-        self.0.read().ratio
-    }
-
-    pub fn set_ratio(&mut self, gc_context: MutationContext<'gc, '_>, ratio: u16) {
-        self.0.write(gc_context).ratio = ratio;
     }
 }
 
@@ -100,7 +90,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
 
     fn render_self(&self, context: &mut RenderContext) {
         let this = self.0.read();
-        let ratio = this.ratio;
+        let ratio = this.base.ratio;
         let static_data = this.static_data;
         let shape_handle = static_data.get_shape(context, context.library, ratio);
         context
@@ -110,7 +100,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
 
     fn self_bounds(&self) -> Rectangle<Twips> {
         let this = self.0.read();
-        let ratio = this.ratio;
+        let ratio = this.base.ratio;
         let static_data = this.static_data;
         let frame = static_data.get_frame(ratio);
         frame.bounds.clone()


### PR DESCRIPTION
 * When seeking, step through frames as normal instead of folding goto commands into a final delta.
 * Remove all `GotoPlaceObject` and `goto_*` machinery in `MovieClip`.
 * Remove `place_frame`, and instead use `ratio` field to determine if a display object survives a rewinding goto (fix #1291).

### Simplified goto

Previously when seeking, Ruffle would aggregate the frame-by-frame changes into a final delta, and then execute the final delta. This avoided creating objects on the intermediate frames only to destroy them immediately if they didn't exist on the final frame.

Unfortunately, this is too clever, because Flash seems to actually instantiate these transient display objects while seeking. This can be observed in a few ways:

 * AVM1/AVM2: The default instance name will increase due to the intermediate display objects. For example, `instance1` will increase to `instance4` even if only one new object appears on the final frame. [(example)](https://github.com/ruffle-rs/ruffle/files/7289748/avm1-goto-default-name.zip)
 * AVM1: Unload clip events will run for transient display objects. [(example)](https://github.com/ruffle-rs/ruffle/files/7289760/avm1-goto-unload.zip)
* AVM1/AVM2: Event sounds on frame 1 of intermediate display objects will play when seeking, both on rewind and fast-forward. [(example)](https://github.com/ruffle-rs/ruffle/files/7314183/soundas2.zip)
* AVM2 w/ SWFv9: Constructors for intermediate display objects are run on fast-forward (not rewind). This was fixed w/ improved timeline behavior in SWFv10+. [(example)](https://github.com/ruffle-rs/ruffle/files/7314349/avm2-swf9-goto-ctor.zip)

Nested clips within the transient objects also affect the above, so I don't think there's a clever way to cheat this. We need to do the "dumb" way and step through the frames normally, instantiating and destroying objects as we go. The upside is that this removes all of the complicated logic to fold the PlaceObject tags into a final delta (`GotoPlaceObject`, etc.). The downside is that this will certainly be slower, requiring more allocations and GC churn.

### Use the `ratio` field during rewinding gotos

Because Flash timelines are stored as deltas from frame to frame, rewinding to a previous frame requires clearing everything, restarting from frame 1, and stepping forward. However, any object that was created before the target frame should "survive" the goto and be reused, not re-created.

Previously, every display object stored a `place_frame` indicating the frame that the object was created on. When rewinding, an object would survive if `place_frame` was <= the frame we are seeking to.

However, #1291 shows that Flash uses the `ratio` field of the `PlaceObject` tag to handle this. If a depth is occupied both before and after a rewind, the ratio field is used to decide whether the two objects are the "same". If the ratios are equal, the original object should survive the goto and be reused instead of the new object.

The Flash IDE always exports SWFs with the object's creation frame stored in the `ratio` field, which matches our current `place_frame` behavior, so this hasn't been much of an issue. But the ratio can be any arbitrary value, and this behavior can be observed in AVM2 by storing a reference to the object before the seek, and comparing it afterwards
[(example)](https://github.com/ruffle-rs/ruffle/files/7289777/avm2-goto-reference.zip). 3rd party tools also export SWFs with weirdo ratio fields (#1060). 

This PR removes `DisplayObject::place_frame` in favor of `DisplayObject::ratio`.  The downside is that we can't know if a display object will survive the rewind until after the rewind is finished, because we have to compare it to a potential new object at the same depth. The survival check compares multiple properties in addition to the ratio depending on the display object type. From experimentation, Flash seems to have three categories:
* "Shapes" including Shape, MorphShape, and Text are recreated if they differ in ratio, character id, clip depth, or transform. These could not be accessed directly in AVM1, so they don't really have any important state. It's safe to trash and recreate them.
* "Objects" such as Buttons and EditText are recreated if the ratio, character id, or clip depth differ. These can have properties assigned to them, so a user expects these properties to survive after a rewind. 
* MovieClips are recreated only if the ratio differs. Not 100% sure why  the character id is not considered here -- I guess because an SWF can be loaded into a movieclip, erasing its character ID, but it's still otherwise be the same clip.

This check is handled by `DisplayObject::survives_rewind`.

Which properties must match in order to survive a rewind, in table form:
|  | ratio | id | clip_depth | matrix | color_transform |
| --- | --- | --- | --- | --- | --- |
| Shape, MorphShape, Text |✔|✔️|✔️|✔️|✔️|
| Button, EditText, Bitmap, Video |✔️|✔️|✔️| | |
| MovieClip |✔️| | | | |

[(example)](https://github.com/ruffle-rs/ruffle/files/7289777/avm2-goto-reference.zip)

Fixes #1060, #1291.
Supersedes #1305.

TODO:
 * Handling the event order in AVM2 feels clumsy. I settled on adding a `SEEKING` flag to disable AVM2 events firing while a clip is  seeking, and then manually firing the events in the proper order when the seek is complete.
 * I believe the official player runs the constructors for intermediate display objects during a goto in SWFv9 (sort-of buggy behavior). This was fixed in SWF10+.
 * Some properties of a `PlaceObject` tag (such as `name`) should only apply to a newly instantiated object (`PlaceObjectAction::Place`, not `PlaceObjectAction::Modify`). This will be for a future PR.