### PR TITLE
desktop: correct error when passing an invalid absolute windows filepath

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -127,11 +127,10 @@ fn load_movie_from_path(
         Url::from_file_path(absolute_path)
             .map_err(|_| "Path must be absolute and cannot be a URL")?
     } else {
-        let url = Url::parse(path.to_str().unwrap_or_default());
-        if url.is_err() || url.as_ref().unwrap().host().is_none() {
-            return Err("Input path is not a file and could not be parsed as a URL.".into());
-        }
-        url.unwrap()
+        Url::parse(path.to_str().unwrap_or_default())
+            .ok()
+            .filter(|url| url.host().is_some())
+            .ok_or("Input path is not a file and could not be parsed as a URL.")?
     };
 
     let mut movie = if movie_url.scheme() == "file" {


### PR DESCRIPTION
Previously, when running `.\target\debug\ruffle_desktop.exe 'C:\invalid_path'`, you got "unknown error" as Ruffle parsed it as a URL with scheme "c".

Now you get "not a file", as expected.