### PR TITLE
audio: Sync animation with embedded audio streams

### DIFF
--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -106,11 +106,11 @@ struct StandardStreamDecoder {
 impl StandardStreamDecoder {
     /// Constructs a new `StandardStreamDecoder.
     /// `swf_data` should be the tag data of the MovieClip that contains the stream.
-    fn new(format: &SoundFormat, swf_data: SwfSlice) -> Result<Self, Error> {
+    fn new(stream_info: &swf::SoundStreamHead, swf_data: SwfSlice) -> Result<Self, Error> {
         // Create a tag reader to get the audio data from SoundStreamBlock tags.
-        let tag_reader = StreamTagReader::new(format.compression, swf_data);
+        let tag_reader = StreamTagReader::new(stream_info, swf_data);
         // Wrap the tag reader in the decoder.
-        let decoder = make_decoder(format, tag_reader)?;
+        let decoder = make_decoder(&stream_info.stream_format, tag_reader)?;
         Ok(Self { decoder })
     }
 }
@@ -144,17 +144,17 @@ pub struct AdpcmStreamDecoder {
 }
 
 impl AdpcmStreamDecoder {
-    fn new(format: &SoundFormat, swf_data: SwfSlice) -> Result<Self, Error> {
+    fn new(stream_info: &swf::SoundStreamHead, swf_data: SwfSlice) -> Result<Self, Error> {
         let movie = swf_data.movie.clone();
-        let mut tag_reader = StreamTagReader::new(format.compression, swf_data);
+        let mut tag_reader = StreamTagReader::new(stream_info, swf_data);
         let audio_data = tag_reader.next().unwrap_or_else(|| SwfSlice::empty(movie));
         let decoder = AdpcmDecoder::new(
             Cursor::new(audio_data),
-            format.is_stereo,
-            format.sample_rate,
+            stream_info.stream_format.is_stereo,
+            stream_info.stream_format.sample_rate,
         )?;
         Ok(Self {
-            format: format.clone(),
+            format: stream_info.stream_format.clone(),
             tag_reader,
             decoder,
         })
@@ -200,14 +200,15 @@ impl Iterator for AdpcmStreamDecoder {
 /// Makes a `StreamDecoder` for the given stream. `swf_data` should be the MovieClip's tag data.
 /// Generally this will return a `StandardStreamDecoder`, except for ADPCM streams.
 pub fn make_stream_decoder(
-    format: &swf::SoundFormat,
+    stream_info: &swf::SoundStreamHead,
     swf_data: SwfSlice,
 ) -> Result<Box<dyn Decoder + Send>, Error> {
-    let decoder: Box<dyn Decoder + Send> = if format.compression == AudioCompression::Adpcm {
-        Box::new(AdpcmStreamDecoder::new(format, swf_data)?)
-    } else {
-        Box::new(StandardStreamDecoder::new(format, swf_data)?)
-    };
+    let decoder: Box<dyn Decoder + Send> =
+        if stream_info.stream_format.compression == AudioCompression::Adpcm {
+            Box::new(AdpcmStreamDecoder::new(stream_info, swf_data)?)
+        } else {
+            Box::new(StandardStreamDecoder::new(stream_info, swf_data)?)
+        };
     Ok(decoder)
 }
 
@@ -235,24 +236,41 @@ pub trait SeekableDecoder: Decoder {
 /// audio data from the `SoundStreamBlock` tags. It can be used as an `Iterator` that
 /// will return consecutive slices of the underlying audio data.
 struct StreamTagReader {
+    /// The tag data of the `MovieClip` that contains the streaming audio track.
     swf_data: SwfSlice,
+
+    /// The audio playback position inside `swf_data`.
     pos: usize,
-    current_frame: u16,
+
+    /// The compressed audio data in the most recent `SoundStreamBlock` we've seen, returned by `Iterator::next`.
     current_audio_data: SwfSlice,
+
+    /// The compression used by the audio data.
     compression: AudioCompression,
+
+    /// The number of audio samples for use in future animation frames.
+    ///
+    /// Only used in MP3 encoding to properly handle gaps in the audio track.
+    mp3_samples_buffered: i32,
+
+    /// The ideal number of audio samples in each animation frame, i.e. the sample rate divided by frame rate.
+    ///
+    /// Only used in MP3 encoding to properly handle gaps in the audio track.
+    mp3_samples_per_block: u16,
 }
 
 impl StreamTagReader {
     /// Builds a new `StreamTagReader` from the given SWF data.
     /// `swf_data` should be the tag data of a MovieClip.
-    fn new(compression: AudioCompression, swf_data: SwfSlice) -> Self {
+    fn new(stream_info: &swf::SoundStreamHead, swf_data: SwfSlice) -> Self {
         let current_audio_data = SwfSlice::empty(swf_data.movie.clone());
         Self {
             swf_data,
             pos: 0,
-            compression,
-            current_frame: 1,
+            compression: stream_info.stream_format.compression,
             current_audio_data,
+            mp3_samples_buffered: 0,
+            mp3_samples_per_block: stream_info.num_samples_per_block,
         }
     }
 }
@@ -261,48 +279,58 @@ impl Iterator for StreamTagReader {
     type Item = SwfSlice;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let current_frame = &mut self.current_frame;
         let audio_data = &mut self.current_audio_data;
         let compression = self.compression;
         let mut found = false;
-        // MP3 stream blocks store seek samples and sample count in the first 4 bytes.
-        // SWF19 p.184, p.188
-        let skip_len = if compression == AudioCompression::Mp3 {
-            4
-        } else {
-            0
-        };
 
         let swf_data = &self.swf_data;
-        let tag_callback = |reader: &mut swf::read::Reader<'_>, tag_code, tag_len| match tag_code {
-            TagCode::ShowFrame => {
-                *current_frame += 1;
-                Ok(())
-            }
-            TagCode::SoundStreamBlock => {
-                // TODO: Implement index ops on `SwfSlice`.
-                //let pos = reader.get_ref().as_ptr() as usize - swf_data.as_ref().as_ptr() as usize;
-                found = true;
-                if tag_len >= skip_len {
-                    *audio_data = swf_data
-                        .to_subslice(&reader.get_ref()[skip_len..tag_len])
-                        .unwrap()
-                } else {
-                    *audio_data = swf_data.to_subslice(&reader.get_ref()[..tag_len]).unwrap()
+        loop {
+            let tag_callback =
+                |reader: &mut swf::read::Reader<'_>, tag_code, tag_len| match tag_code {
+                    TagCode::SoundStreamBlock if !found => {
+                        found = true;
+                        let mut audio_block = &reader.get_ref()[..tag_len];
+                        // MP3 audio blocks start with a header indicating sample count + seek offset (SWF19 p.184).
+                        if compression == AudioCompression::Mp3 && audio_block.len() >= 4 {
+                            // MP3s deliver audio in frames of 576 samples, which means we may have SoundStreamBlocks with
+                            // lots of extra samples, followed by a block with 0 samples. Worse, there may be frames without
+                            // blocks at all despite SWF19 saying this shouldn't happen. This may or may not indicate a gap
+                            // in the audio depending on the number of empty frames.
+                            // Keep a tally of the # of samples we've seen compared to the number of samples that will be
+                            // played in each timeline frame. Only stop an MP3 sound if we've exhausted all of the samples.
+                            // RESEARCHME: How does Flash Player actually determine when there is an audio gap or not?
+                            // If an MP3 audio track has gaps, Flash Player will often play it out of sync (too early).
+                            // Seems closely related to `stream_info.num_samples_per_block`.
+                            let num_samples =
+                                u16::from_le_bytes(audio_block[..2].try_into().unwrap());
+                            self.mp3_samples_buffered += i32::from(num_samples);
+                            audio_block = &audio_block[4..];
+                        }
+                        *audio_data = swf_data.to_subslice(audio_block).unwrap();
+                        Ok(())
+                    }
+                    TagCode::ShowFrame if compression == AudioCompression::Mp3 => {
+                        self.mp3_samples_buffered -= i32::from(self.mp3_samples_per_block);
+                        Ok(())
+                    }
+                    _ => Ok(()),
                 };
-                Ok(())
+
+            let mut reader = self.swf_data.read_from(self.pos as u64);
+            let _ = crate::tag_utils::decode_tags(&mut reader, tag_callback, TagCode::ShowFrame);
+            self.pos = reader.get_ref().as_ptr() as usize - swf_data.as_ref().as_ptr() as usize;
+
+            // If we hit a SoundStreamBlock within this frame, return it. Otherwise, the stream should end.
+            // The exception is MP3 streaming sounds, which will continue to play even when a few frames
+            // are missing SoundStreamBlock tags (see above).
+            if found {
+                break Some(self.current_audio_data.clone());
+            } else if compression != AudioCompression::Mp3
+                || self.mp3_samples_buffered <= 0
+                || reader.get_ref().is_empty()
+            {
+                break None;
             }
-            _ => Ok(()),
-        };
-
-        let mut reader = self.swf_data.read_from(self.pos as u64);
-        let _ = crate::tag_utils::decode_tags(&mut reader, tag_callback, TagCode::ShowFrame);
-        self.pos = reader.get_ref().as_ptr() as usize - swf_data.as_ref().as_ptr() as usize;
-
-        if found {
-            Some(self.current_audio_data.clone())
-        } else {
-            None
         }
     }
 }

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -296,7 +296,7 @@ impl Iterator for StreamTagReader {
         };
 
         let mut reader = self.swf_data.read_from(self.pos as u64);
-        let _ = crate::tag_utils::decode_tags(&mut reader, tag_callback, TagCode::SoundStreamBlock);
+        let _ = crate::tag_utils::decode_tags(&mut reader, tag_callback, TagCode::ShowFrame);
         self.pos = reader.get_ref().as_ptr() as usize - swf_data.as_ref().as_ptr() as usize;
 
         if found {

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -290,11 +290,11 @@ impl AudioMixer {
     /// Creates a `Stream` that decodes and resamples a timeline "stream" sound.
     fn make_stream_from_swf_slice<'a>(
         &self,
-        format: &swf::SoundFormat,
+        stream_info: &swf::SoundStreamHead,
         data_stream: SwfSlice,
     ) -> Result<Box<dyn 'a + Stream>, Error> {
         // Instantiate a decoder for the compression that the sound data uses.
-        let clip_stream_decoder = decoders::make_stream_decoder(format, data_stream)?;
+        let clip_stream_decoder = decoders::make_stream_decoder(stream_info, data_stream)?;
 
         // Convert the `Decoder` to a `Stream`, and resample it to the output sample rate.
         let stream = DecoderStream::new(clip_stream_decoder);
@@ -377,12 +377,10 @@ impl AudioMixer {
         clip_data: SwfSlice,
         stream_info: &swf::SoundStreamHead,
     ) -> Result<SoundInstanceHandle, Error> {
-        let format = &stream_info.stream_format;
-
         // The audio data for stream sounds is distributed among the frames of a
         // movie clip. The stream tag reader will parse through the SWF and
         // feed the decoder audio data on the fly.
-        let stream = self.make_stream_from_swf_slice(format, clip_data)?;
+        let stream = self.make_stream_from_swf_slice(stream_info, clip_data)?;
 
         let mut sound_instances = self.sound_instances.lock().unwrap();
         let handle = sound_instances.insert(SoundInstance {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -243,6 +243,10 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
         self.audio_manager.stop_all_sounds(self.audio)
     }
 
+    pub fn is_sound_playing(&mut self, sound: SoundInstanceHandle) -> bool {
+        self.audio_manager.is_sound_playing(sound)
+    }
+
     pub fn is_sound_playing_with_handle(&mut self, sound: SoundHandle) -> bool {
         self.audio_manager.is_sound_playing_with_handle(sound)
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1095,7 +1095,6 @@ impl<'gc> MovieClip<'gc> {
         let tag_stream_start = mc.static_data.swf.as_ref().as_ptr() as u64;
         let data = mc.static_data.swf.clone();
         let mut reader = data.read_from(mc.tag_stream_pos);
-        let mut has_stream_block = false;
         drop(mc);
 
         let vm_type = context.avm_type();
@@ -1119,24 +1118,23 @@ impl<'gc> MovieClip<'gc> {
             TagCode::RemoveObject2 if run_display_actions => self.remove_object(context, reader, 2),
             TagCode::SetBackgroundColor => self.set_background_color(context, reader),
             TagCode::StartSound => self.start_sound_1(context, reader),
-            TagCode::SoundStreamBlock => {
-                has_stream_block = true;
-                self.sound_stream_block(context, reader)
-            }
+            TagCode::SoundStreamBlock => self.sound_stream_block(context, reader),
             _ => Ok(()),
         };
         let _ = tag_utils::decode_tags(&mut reader, tag_callback, TagCode::ShowFrame);
 
-        self.0.write(context.gc_context).tag_stream_pos =
-            reader.get_ref().as_ptr() as u64 - tag_stream_start;
+        let mut write = self.0.write(context.gc_context);
+        write.tag_stream_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
-        // If we are playing a streaming sound, there should(?) be a `SoundStreamBlock` on each frame.
-        if !has_stream_block {
-            self.0.write(context.gc_context).stop_audio_stream(context);
+        // Check if our audio track has finished playing.
+        if let Some(audio_stream) = write.audio_stream {
+            if !context.is_sound_playing(audio_stream) {
+                write.audio_stream = None;
+            }
         }
 
-        let frame_id = self.0.read().current_frame;
-        self.0.write(context.gc_context).queued_script_frame = Some(frame_id);
+        let frame_id = write.current_frame;
+        write.queued_script_frame = Some(frame_id);
     }
 
     /// Instantiate a given child object on the timeline at a given depth.
@@ -3277,7 +3275,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                 let audio_stream = context.start_stream(
                     mc.static_data.audio_stream_handle,
                     self,
-                    mc.current_frame() + 1,
+                    mc.current_frame(),
                     slice,
                     stream_info,
                 );

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -512,7 +512,8 @@ impl Player {
 
         if self.is_playing() {
             self.frame_accumulator += dt;
-            let frame_time = 1000.0 / self.frame_rate;
+            let frame_rate = self.frame_rate;
+            let frame_time = 1000.0 / frame_rate;
 
             let max_frames_per_tick = self.max_frames_per_tick();
             let mut frame = 0;
@@ -549,6 +550,15 @@ impl Player {
             if self.frame_accumulator >= frame_time {
                 self.frame_accumulator = 0.0;
             }
+
+            // Adjust playback speed for next frame to stay in sync with timeline audio tracks ("stream" sounds).
+            let cur_frame_offset = self.frame_accumulator;
+            self.frame_accumulator += self.mutate_with_update_context(|context| {
+                context
+                    .audio_manager
+                    .audio_skew_time(context.audio, cur_frame_offset)
+                    * 1000.0
+            });
 
             self.update_timers(dt);
             self.audio.tick();


### PR DESCRIPTION
This is a proof-of-concept first pass at syncing animation and audio playback when an embedded audio stream is playing. These streams are formed by `SoundStreamBlock` SWF tags and cause the Flash Player to skip frames in an attempt to keep the audio and video in sync.

 * Get the current time of the primary audio stream from the `AudioBackend`.
    * We consider the first "stream" sound to be the primary stream; typically only one stream is playing anyway.
 * Get the animation time of the clip that owns the audio stream.
   * Animation time is `(clip.current_frame() - stream.start_frame) / clip.movie().frame_rate`.
 * Compare audio time to animation time. If they differ by some threshold, adjust the playback speed to compensate.
   * Speed up or slow down the player by adding an offset to `Player::frame_accumulator`.
   * If they differ by a large threshold, we're way out of sync, so stop the stream completely. The movie clip will restart the sound at the correct position on the next frame.
 * Improve the handling of audio tracks with gaps (frames without `SoundStreamBlock` tags) on both desktop and web, particularly for MP3 tracks.
   * Specifically this will fix cases such as #3817 where a 1 or 2 frame gap should still play seamless audio. 
   * For MP3s, instead of stopping the stream when a SoundStreamBlock is missing, keep a running tally of the number of samples read from the stream vs. the number of timeline frames elapsed, and only create a gap if all of the samples have been consumed.
   * More research is needed as this isn't 100% accurate -- specifically the behavior of an MP3 stream track with larger gaps.
   * The Flash IDE seems to export and play larger Mp3 gaps out of sync in a strange way, for example: [stream_gaps_mp3.zip](https://github.com/ruffle-rs/ruffle/files/7807093/stream_gaps_mp3.zip).
   * But this Flash behavior is buggy-ish and was generally avoided in actual Flash content. (The trick was to fill gaps with a silent sound).

Here's a metronome SWF for testing:
[metronome.zip](https://github.com/ruffle-rs/ruffle/files/7358922/metronome.zip)

On Windows, you can test by clicking and holding on the window's maximize or close button, which will freeze the player until you drag off and release the mouse button. You can then see if the player recovers sync.
 
Fixes #3020, #3663, #3817, #3958.