### PR TITLE
dev: Set Firefox min version to try to help with signing

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -41,9 +41,4 @@
         "webRequestBlocking",
     ],
     "web_accessible_resources": ["*"],
-    "browser_specific_settings": {
-        "gecko": {
-            "strict_min_version": "91.1.0",
-        }
-    }
 }

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -23,6 +23,7 @@ function transformManifest(content, env) {
         manifest.browser_specific_settings = {
             gecko: {
                 id: process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs",
+                strict_min_version: "91.1.0",
             },
         };
     } else {


### PR DESCRIPTION
There is [a post](https://discourse.mozilla.org/t/can-anyone-release-extensions-right-now-to-me-it-looks-like-addons-mozilla-org-is-critically-broken/84830/25) on the Firefox extension signing difficulty thread saying that there's a problem reviewing extensions targeting versions below 91.1.0.

91 is the current ESR version, and two versions behind the current. I think it's acceptable to target: most users will be running evergreen or ESR.

Trying this will put us back to the end of the queue, but we've been in a while with no apparent progress, so I think it's worth a shot.

Signing has been re-enabled for nightly, and if it doesn't work we can disable it again :).