### PR TITLE
avm1: Display objects are indirectly referenced by string path (fix #1513)

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2225,7 +2225,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn action_type_of(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let type_of = self.context.avm1.pop().type_of();
+        let type_of = self.context.avm1.pop().type_of(self);
         self.context
             .avm1
             .push(AvmString::new(self.context.gc_context, type_of.to_string()).into());

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -292,7 +292,7 @@ impl<'gc> Executable<'gc> {
 
                     result.push('(');
                     for i in 0..args.len() {
-                        result.push_str(args.get(i).unwrap().type_of());
+                        result.push_str(args.get(i).unwrap().type_of(activation));
                         if i < args.len() - 1 {
                             result.push_str(", ");
                         }
@@ -788,7 +788,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.base.get_keys(activation)
     }
 
-    fn type_of(&self) -> &'static str {
+    fn type_of(&self, _activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
         TYPE_OF_FUNCTION
     }
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -279,7 +279,7 @@ impl<'gc> Executable<'gc> {
                 let effective_ver = if activation.swf_version() > 5 {
                     af.swf_version()
                 } else {
-                    this.as_display_object()
+                    this.as_display_object(activation)
                         .map(|dn| dn.swf_version())
                         .unwrap_or(activation.context.player_version)
                 };
@@ -308,7 +308,7 @@ impl<'gc> Executable<'gc> {
                 let base_clip = if effective_ver > 5 && !af.base_clip.removed() {
                     af.base_clip
                 } else {
-                    this.as_display_object()
+                    this.as_display_object(activation)
                         .unwrap_or_else(|| activation.base_clip())
                 };
                 let mut frame = Activation::from_action(

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -10,7 +10,7 @@ use gc_arena::MutationContext;
 macro_rules! button_getter {
     ($name:ident) => {
         |activation, this, _args| {
-            if let Some(display_object) = this.as_display_object() {
+            if let Some(display_object) = this.as_display_object(activation) {
                 if let Some(button) = display_object.as_avm1_button() {
                     return $name(button, activation);
                 }
@@ -23,7 +23,7 @@ macro_rules! button_getter {
 macro_rules! button_setter {
     ($name:ident) => {
         |activation, this, args| {
-            if let Some(display_object) = this.as_display_object() {
+            if let Some(display_object) = this.as_display_object(activation) {
                 if let Some(button) = display_object.as_avm1_button() {
                     let value = args.get(0).unwrap_or(&Value::Undefined).clone();
                     $name(button, activation, value)?;

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -62,7 +62,7 @@ pub fn get_parent<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(this
-        .as_display_object()
+        .as_display_object(activation)
         .and_then(|mc| mc.avm1_parent())
         .map(|dn| dn.object().coerce_to_object(activation))
         .map(Value::Object)
@@ -74,7 +74,7 @@ pub fn get_depth<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(display_object) = this.as_display_object() {
+    if let Some(display_object) = this.as_display_object(activation) {
         if activation.swf_version() >= 6 {
             let depth = display_object.depth().wrapping_sub(AVM_DEPTH_BIAS);
             return Ok(depth.into());
@@ -88,7 +88,7 @@ pub fn to_string<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(display_object) = this.as_display_object() {
+    if let Some(display_object) = this.as_display_object(activation) {
         Ok(AvmString::new(activation.context.gc_context, display_object.path()).into())
     } else {
         Ok(Value::Undefined)

--- a/core/src/avm1/globals/display_object.rs
+++ b/core/src/avm1/globals/display_object.rs
@@ -6,7 +6,6 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::display_object::{DisplayObject, Lists, TDisplayObject, TDisplayObjectContainer};
-use crate::string::AvmString;
 use gc_arena::MutationContext;
 
 /// Depths used/returned by ActionScript are offset by this amount from depths used inside the SWF/by the VM.
@@ -25,7 +24,6 @@ pub const AVM_MAX_REMOVE_DEPTH: i32 = 2_130_706_416;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "getDepth" => method(get_depth; DONT_ENUM | DONT_DELETE | READ_ONLY);
-    "toString" => method(to_string; DONT_ENUM | DONT_DELETE | READ_ONLY);
     "_global" => property(get_global, overwrite_global; DONT_ENUM | DONT_DELETE | READ_ONLY);
     "_root" => property(get_root, overwrite_root; DONT_ENUM | DONT_DELETE | READ_ONLY);
     "_parent" => property(get_parent, overwrite_parent; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -81,18 +79,6 @@ pub fn get_depth<'gc>(
         }
     }
     Ok(Value::Undefined)
-}
-
-pub fn to_string<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
-    this: Object<'gc>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(display_object) = this.as_display_object(activation) {
-        Ok(AvmString::new(activation.context.gc_context, display_object.path()).into())
-    } else {
-        Ok(Value::Undefined)
-    }
 }
 
 pub fn overwrite_root<'gc>(

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -48,7 +48,7 @@ pub fn load_clip<'gc>(
 
     if let Value::Object(target) = target {
         if let Some(mc) = target
-            .as_display_object()
+            .as_display_object(activation)
             .and_then(|dobj| dobj.as_movie_clip())
         {
             let fetch = activation
@@ -82,7 +82,7 @@ pub fn unload_clip<'gc>(
 
     if let Value::Object(target) = target {
         if let Some(mut mc) = target
-            .as_display_object()
+            .as_display_object(activation)
             .and_then(|dobj| dobj.as_movie_clip())
         {
             mc.unload(&mut activation.context);
@@ -104,7 +104,7 @@ pub fn get_progress<'gc>(
 
     if let Value::Object(target) = target {
         if let Some(mc) = target
-            .as_display_object()
+            .as_display_object(activation)
             .and_then(|dobj| dobj.as_movie_clip())
         {
             let ret_obj = ScriptObject::object(activation.context.gc_context, None);

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -126,7 +126,7 @@ pub fn set_focus<'gc>(
             Ok(true.into())
         }
         Some(Value::Object(obj)) => {
-            if let Some(display_object) = obj.as_display_object() {
+            if let Some(display_object) = obj.as_display_object(activation) {
                 if display_object.is_focusable() {
                     tracker.set(Some(display_object), &mut activation.context);
                 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -69,7 +69,7 @@ fn serialize_value<'gc>(
             // and which turn into undefined.
             if o.as_executable().is_some() {
                 None
-            } else if o.as_display_object().is_some() {
+            } else if o.as_display_object(activation).is_some() {
                 Some(AmfValue::Undefined)
             } else if o.as_array_object().is_some() {
                 let mut values = Vec::new();

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -41,7 +41,7 @@ pub fn constructor<'gc>(
     let owner = args
         .get(0)
         .map(|o| o.coerce_to_object(activation))
-        .and_then(|o| o.as_display_object());
+        .and_then(|o| o.as_display_object(activation));
 
     if let Some(sound) = this.as_sound_object() {
         sound.set_owner(activation.context.gc_context, owner);

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -13,7 +13,7 @@ use gc_arena::MutationContext;
 macro_rules! tf_method {
     ($fn:expr) => {
         |activation, this, args| {
-            if let Some(display_object) = this.as_display_object() {
+            if let Some(display_object) = this.as_display_object(activation) {
                 if let Some(text_field) = display_object.as_edit_text() {
                     return $fn(text_field, activation, args);
                 }
@@ -26,7 +26,7 @@ macro_rules! tf_method {
 macro_rules! tf_getter {
     ($get:expr) => {
         |activation, this, _args| {
-            if let Some(display_object) = this.as_display_object() {
+            if let Some(display_object) = this.as_display_object(activation) {
                 if let Some(edit_text) = display_object.as_edit_text() {
                     return $get(edit_text, activation);
                 }
@@ -39,7 +39,7 @@ macro_rules! tf_getter {
 macro_rules! tf_setter {
     ($set:expr) => {
         |activation, this, args| {
-            if let Some(display_object) = this.as_display_object() {
+            if let Some(display_object) = this.as_display_object(activation) {
                 if let Some(edit_text) = display_object.as_edit_text() {
                     let value = args.get(0).unwrap_or(&Value::Undefined).clone();
                     $set(edit_text, activation, value)?;

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -53,7 +53,7 @@ pub fn constructor<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .coerce_to_object(activation)
-        .as_display_object()
+        .as_display_object(activation)
         .and_then(|o| o.as_movie_clip());
 
     if let (Some(transform), Some(clip)) = (this.as_transform_object(), clip) {

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -427,7 +427,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn get_keys(&self, activation: &mut Activation<'_, 'gc, '_>) -> Vec<AvmString<'gc>>;
 
     /// Get the object's type string.
-    fn type_of(&self) -> &'static str;
+    fn type_of(&self, activation: &mut Activation<'_, 'gc, '_>) -> &'static str;
 
     /// Enumerate all interfaces implemented by this object.
     fn interfaces(&self) -> Vec<Object<'gc>>;

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -506,7 +506,11 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     }
 
     /// Get the underlying display node for this object, if it exists.
-    fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
+    #[allow(unused_variables)]
+    fn as_display_object(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+    ) -> Option<DisplayObject<'gc>> {
         None
     }
 

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -273,8 +273,8 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         self.0.read().get_keys(activation)
     }
 
-    fn type_of(&self) -> &'static str {
-        self.0.read().type_of()
+    fn type_of(&self, activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
+        self.0.read().type_of(activation)
     }
 
     fn interfaces(&self) -> Vec<Object<'gc>> {

--- a/core/src/avm1/object/custom_object.rs
+++ b/core/src/avm1/object/custom_object.rs
@@ -201,8 +201,8 @@ macro_rules! impl_custom_object {
             self.0.read().$field.get_keys(activation)
         }
 
-        fn type_of(&self) -> &'static str {
-            self.0.read().$field.type_of()
+        fn type_of(&self, activation: &mut crate::avm1::Activation<'_, 'gc, '_>) -> &'static str {
+            self.0.read().$field.type_of(activation)
         }
 
         fn interfaces(&self) -> Vec<crate::avm1::Object<'gc>> {

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -68,7 +68,6 @@ pub struct ScriptObject<'gc>(GcCell<'gc, ScriptObjectData<'gc>>);
 pub struct ScriptObjectData<'gc> {
     properties: PropertyMap<'gc, Property<'gc>>,
     interfaces: Vec<Object<'gc>>,
-    type_of: &'static str,
     watchers: PropertyMap<'gc, Watcher<'gc>>,
 }
 
@@ -86,7 +85,6 @@ impl<'gc> ScriptObject<'gc> {
         let object = Self(GcCell::allocate(
             gc_context,
             ScriptObjectData {
-                type_of: TYPE_OF_OBJECT,
                 properties: PropertyMap::new(),
                 interfaces: vec![],
                 watchers: PropertyMap::new(),
@@ -118,10 +116,6 @@ impl<'gc> ScriptObject<'gc> {
     /// friends.
     pub fn bare_object(gc_context: MutationContext<'gc, '_>) -> Self {
         Self::object(gc_context, None)
-    }
-
-    pub fn set_type_of(&mut self, gc_context: MutationContext<'gc, '_>, type_of: &'static str) {
-        self.0.write(gc_context).type_of = type_of;
     }
 
     /// Gets the value of a data property on this object.
@@ -491,8 +485,8 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         out_keys
     }
 
-    fn type_of(&self) -> &'static str {
-        self.0.read().type_of
+    fn type_of(&self, _activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
+        TYPE_OF_OBJECT
     }
 
     fn interfaces(&self) -> Vec<Object<'gc>> {

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -141,6 +141,14 @@ impl<'gc> StageObjectData<'gc> {
                 .as_container()
                 .and_then(|container| container.child_by_name(name, true))?;
         }
+        if activation.swf_version() <= 5 {
+            // In SWFv5 and earlier, only movie clips are accessible from the AVM.
+            // If we try to resolve a path to a different object type (such as a button),
+            // we instead resolve to the parent.
+            while display_object.as_movie_clip().is_none() {
+                display_object = display_object.avm1_parent()?;
+            }
+        }
         Some(display_object)
     }
 }

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -261,7 +261,7 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         vec![]
     }
 
-    fn type_of(&self) -> &'static str {
+    fn type_of(&self, _activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
         TYPE_OF_OBJECT
     }
 

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -315,9 +315,12 @@ impl<'gc> TObject<'gc> for SuperObject<'gc> {
         Some(*self)
     }
 
-    fn as_display_object(&self) -> Option<DisplayObject<'gc>> {
+    fn as_display_object(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+    ) -> Option<DisplayObject<'gc>> {
         //`super` actually can be used to invoke MovieClip methods
-        self.0.read().this.as_display_object()
+        self.0.read().this.as_display_object(activation)
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm1/object/transform_object.rs
+++ b/core/src/avm1/object/transform_object.rs
@@ -68,7 +68,7 @@ impl<'gc> TObject<'gc> for TransformObject<'gc> {
             .get(0)
             .unwrap_or(&Value::Undefined)
             .coerce_to_object(activation)
-            .as_display_object()
+            .as_display_object(activation)
             .and_then(|o| o.as_movie_clip());
 
         if clip.is_none() {

--- a/core/src/avm1/object/xml_attributes_object.rs
+++ b/core/src/avm1/object/xml_attributes_object.rs
@@ -240,8 +240,8 @@ impl<'gc> TObject<'gc> for XmlAttributesObject<'gc> {
         base
     }
 
-    fn type_of(&self) -> &'static str {
-        self.base().type_of()
+    fn type_of(&self, activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
+        self.base().type_of(activation)
     }
 
     fn interfaces(&self) -> Vec<Object<'gc>> {

--- a/core/src/avm1/object/xml_idmap_object.rs
+++ b/core/src/avm1/object/xml_idmap_object.rs
@@ -241,8 +241,8 @@ impl<'gc> TObject<'gc> for XmlIdMapObject<'gc> {
         keys
     }
 
-    fn type_of(&self) -> &'static str {
-        self.base().type_of()
+    fn type_of(&self, activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
+        self.base().type_of(activation)
     }
 
     fn interfaces(&self) -> Vec<Object<'gc>> {

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -472,14 +472,14 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    pub fn type_of(&self) -> &'static str {
+    pub fn type_of(&self, activation: &mut Activation<'_, 'gc, '_>) -> &'static str {
         match self {
             Value::Undefined => "undefined",
             Value::Null => "null",
             Value::Number(_) => "number",
             Value::Bool(_) => "boolean",
             Value::String(_) => "string",
-            Value::Object(object) => object.type_of(),
+            Value::Object(object) => object.type_of(activation),
         }
     }
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -251,16 +251,13 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
                 .add_to_exec_list(context.gc_context, (*self).into());
         }
 
-        let mut mc = self.0.write(context.gc_context);
-        if mc.object.is_none() {
+        if self.0.read().object.is_none() {
             let object = StageObject::for_display_object(
                 context.gc_context,
                 display_object,
                 Some(context.avm1.prototypes().button),
             );
-            mc.object = Some(object.into());
-
-            drop(mc);
+            self.0.write(context.gc_context).object = Some(object.into());
 
             if run_frame {
                 self.run_frame(context);

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1471,8 +1471,7 @@ impl<'gc> EditText<'gc> {
         display_object: DisplayObject<'gc>,
         run_frame: bool,
     ) {
-        let mut text = self.0.write(context.gc_context);
-        if text.object.is_none() {
+        if self.0.read().object.is_none() {
             let object: Avm1Object<'gc> = Avm1StageObject::for_display_object(
                 context.gc_context,
                 display_object,
@@ -1480,9 +1479,8 @@ impl<'gc> EditText<'gc> {
             )
             .into();
 
-            text.object = Some(object.into());
+            self.0.write(context.gc_context).object = Some(object.into());
         }
-        drop(text);
 
         Avm1::run_with_stack_frame_for_display_object(
             (*self).into(),


### PR DESCRIPTION
Proof-of-concept of changing `avm1::StageObject` to reference its display object via string path instead of `GcCell`. This is the last big gotcha to tackle in AVM1, so making a rough draft to gain an understanding of the behavior. Let's hold off on merging this until after #5339.

Display objects in AVM1 should not actually hold pointers to their linked display object, but instead refer to it indirectly via absolute string path (for example, `_level0.clip.foo`). See https://moock.org/asdg/technotes/movieclipDatatype for more info.

This means:
 * Every property access on an AVM1 display object requires dereferencing the path to grab the actual display object.
 * If that display object is removed from the stage, the AVM1 object still exists, but the the path no longer resolves to a display object, so the reference is "dangling". Any operations on the AVM1 object are noops.
 * If a display object with the same path is later added to the stage, the AVM1 object will once again resolve, and all operations will work using the new display object.

Every movieclip property access `clip.foo` now requires a full resolve of the path, so this could significantly hurt performance -- measurement is needed.

TODO:
 - [ ] Properly handle unload events (#1535).
   * Currently `onUnload` tests fail because the path no longer resolves. 
   * Clips with unload handlers should switch to "off-screen" depths (<0), which allows them to continue to exist for an extra frame. 
 - [ ] Remove `base` from `StageObject` and instead change the `DisplayObject::object` into a `ScriptObject`/`PropertyMap`?
   * We have to resolve the path to a display object for every operation, so it makes sense that doing so should grab the base `ScriptObject` from the display object itself.
   * Forward gets/sets/other methods to this `ScriptObject` after dereferencing the path.
   * Test how watches etc. work on movieclip objects after removing + replacing a clip with the same path.
   * Be careful that `prototype`, `interfaces` etc. work correctly.
 - [ ] Add tests
 - [ ] Investigate performance and potential optimizations.
   * Having benchmarks would be helpful.
   * Idea: `StageObject::path` could store the parsed path segments instead of full string. Something like `{ level: Depth, segments: SmallVec<AvmString> }`.
   * #5339 will help a lot; eventually will let us cache string hashes, etc.

Fixes #993, #1017, #1029, #1114, #1140, #1415, #1513, #3839, #3916, #4404, #4793, #5275, others...