### PR TITLE
audio: Don't trust sample rate from SWF tags

### DIFF
--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -58,11 +58,7 @@ pub fn make_decoder<R: 'static + Send + Read>(
             format.sample_rate,
         )?),
         #[cfg(any(feature = "minimp3", feature = "symphonia"))]
-        AudioCompression::Mp3 => Box::new(Mp3Decoder::new(
-            if format.is_stereo { 2 } else { 1 },
-            format.sample_rate.into(),
-            data,
-        )),
+        AudioCompression::Mp3 => Box::new(Mp3Decoder::new(data)?),
         AudioCompression::Nellymoser => {
             Box::new(NellymoserDecoder::new(data, format.sample_rate.into()))
         }

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -205,17 +205,9 @@ impl AudioMixer {
                 format.sample_rate,
             )?),
             #[cfg(feature = "minimp3")]
-            AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new(
-                if format.is_stereo { 2 } else { 1 },
-                format.sample_rate.into(),
-                data,
-            )),
+            AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new(data)?),
             #[cfg(all(feature = "symphonia", not(feature = "minimp3")))]
-            AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new_seekable(
-                if format.is_stereo { 2 } else { 1 },
-                format.sample_rate.into(),
-                data,
-            )),
+            AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new_seekable(data)?),
             AudioCompression::Nellymoser => {
                 Box::new(NellymoserDecoder::new(data, format.sample_rate.into()))
             }


### PR DESCRIPTION
For MP3 data, don't trust the sample rate indicated by the SWF tag, as this could be a lie. Instead, query the decoder for the actual sample rate of the data.

Fixes #335.