### PR TITLE
dev: stop trying to sign Firefox extension again

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -267,7 +267,7 @@ jobs:
           npm run docs
 
       - name: Sign Firefox extension
-        if: secrets.SKIP_SIGN_FIREFOX_EXTENSION != ""
+        if: secrets.FIREFOX_EXTENSION_ID != ""
         id: sign-firefox
         continue-on-error: true
         env:


### PR DESCRIPTION
After #5489 enabled signing, it didn't fix the problem properly, so disable signing again.