### PR TITLE
dev: use env var over secret

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -267,7 +267,7 @@ jobs:
           npm run docs
 
       - name: Sign Firefox extension
-        if: secrets.FIREFOX_EXTENSION_ID != ""
+        if: env.FIREFOX_EXTENSION_ID != ""
         id: sign-firefox
         continue-on-error: true
         env:


### PR DESCRIPTION
By [https://github.com/actions/runner/issues/520#issuecomment-860043020](this comment), you can use `env` vars in `if`s, even if you can't use secrets.