### PR TITLE
AVM2: callproperty/getproperty split

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -252,12 +252,7 @@ impl<'gc> Avm2<'gc> {
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) -> Result<(), Error> {
         let mut evt_activation = Activation::from_nothing(context.reborrow());
-        callable.call(
-            reciever,
-            args,
-            &mut evt_activation,
-            reciever.and_then(|r| r.instance_of()),
-        )?;
+        callable.call(reciever, args, &mut evt_activation)?;
 
         Ok(())
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1126,11 +1126,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ) -> Result<FrameControl<'gc>, Error> {
         let args = self.context.avm2.pop_args(arg_count);
         let receiver = self.context.avm2.pop().coerce_to_object(self)?;
-        let function: Result<Object<'gc>, Error> = receiver
-            .get_method(index.0)
-            .ok_or_else(|| format!("Object method {} does not exist", index.0).into());
-        let superclass_object = receiver.instance_of();
-        let value = function?.call(Some(receiver), &args, self, superclass_object)?;
+
+        let value = receiver.call_method(index.0, &args, self)?;
 
         self.context.avm2.push(value);
 

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -833,10 +833,11 @@ impl<'gc> Class<'gc> {
         false
     }
 
-    /// Determines if this class provides a given trait on its instances.
-    pub fn has_instance_trait_by_id(&self, id: u32) -> bool {
+    /// Determines if this class provides a given trait with a particular
+    /// dispatch ID on its instances.
+    pub fn has_instance_trait_by_disp_id(&self, id: u32) -> bool {
         for trait_entry in self.instance_traits.iter() {
-            if id == trait_entry.slot_id() {
+            if Some(id) == trait_entry.disp_id() {
                 return true;
             }
         }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -144,6 +144,12 @@ pub struct Class<'gc> {
 
     /// Whether or not this `Class` has loaded its traits or not.
     traits_loaded: bool,
+
+    /// Whether or not this is a system-defined class.
+    ///
+    /// System defined classes are allowed to have illegal trait configurations
+    /// without throwing a VerifyError.
+    is_system: bool,
 }
 
 /// Find traits in a list of traits matching a name.
@@ -244,6 +250,7 @@ impl<'gc> Class<'gc> {
                     mc,
                 ),
                 traits_loaded: true,
+                is_system: true,
             },
         )
     }
@@ -365,6 +372,7 @@ impl<'gc> Class<'gc> {
                     activation.context.gc_context,
                 ),
                 traits_loaded: false,
+                is_system: false,
             },
         ))
     }
@@ -419,6 +427,11 @@ impl<'gc> Class<'gc> {
     /// has been resolved. It will return Ok for a valid class, and a
     /// VerifyError for any invalid class.
     pub fn validate_class(&self, superclass: Option<ClassObject<'gc>>) -> Result<(), Error> {
+        // System classes do not throw verify errors.
+        if self.is_system {
+            return Ok(());
+        }
+
         if let Some(superclass) = superclass {
             for instance_trait in self.instance_traits.iter() {
                 let mut current_superclass = Some(superclass);
@@ -519,6 +532,7 @@ impl<'gc> Class<'gc> {
                 class_initializer_called: false,
                 class_traits: Vec::new(),
                 traits_loaded: true,
+                is_system: false,
             },
         ))
     }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -765,6 +765,17 @@ impl<'gc> Class<'gc> {
         false
     }
 
+    /// Determines if this class provides a given trait on its instances.
+    pub fn has_instance_trait_by_id(&self, id: u32) -> bool {
+        for trait_entry in self.instance_traits.iter() {
+            if id == trait_entry.slot_id() {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Return instance traits provided by this class.
     pub fn instance_traits(&self) -> &[Trait<'gc>] {
         &self.instance_traits[..]

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -416,9 +416,8 @@ pub fn dispatch_event_to_target<'gc>(
         }
 
         let object = activation.global_scope();
-        let superclass_object = object.and_then(|o| o.instance_of());
 
-        handler.call(object, &[event.into()], activation, superclass_object)?;
+        handler.call(object, &[event.into()], activation)?;
     }
 
     Ok(())

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -6,7 +6,7 @@ use crate::avm2::object::{ClassObject, Object};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use gc_arena::{Collect, Gc, MutationContext};
+use gc_arena::{Collect, Gc};
 use std::fmt;
 
 /// Represents code written in AVM2 bytecode that can be executed by some
@@ -59,10 +59,10 @@ pub struct NativeExecutable<'gc> {
 #[collect(no_drop)]
 pub enum Executable<'gc> {
     /// Code defined in Ruffle's binary.
-    Native(Gc<'gc, NativeExecutable<'gc>>),
+    Native(NativeExecutable<'gc>),
 
     /// Code defined in a loaded ABC file.
-    Action(Gc<'gc, BytecodeExecutable<'gc>>),
+    Action(BytecodeExecutable<'gc>),
 }
 
 impl<'gc> Executable<'gc> {
@@ -72,27 +72,20 @@ impl<'gc> Executable<'gc> {
         scope: ScopeChain<'gc>,
         receiver: Option<Object<'gc>>,
         superclass: Option<ClassObject<'gc>>,
-        mc: MutationContext<'gc, '_>,
     ) -> Self {
         match method {
-            Method::Native(method) => Self::Native(Gc::allocate(
-                mc,
-                NativeExecutable {
-                    method,
-                    scope,
-                    bound_receiver: receiver,
-                    bound_superclass: superclass,
-                },
-            )),
-            Method::Bytecode(method) => Self::Action(Gc::allocate(
-                mc,
-                BytecodeExecutable {
-                    method,
-                    scope,
-                    receiver,
-                    bound_superclass: superclass,
-                },
-            )),
+            Method::Native(method) => Self::Native(NativeExecutable {
+                method,
+                scope,
+                bound_receiver: receiver,
+                bound_superclass: superclass,
+            }),
+            Method::Bytecode(method) => Self::Action(BytecodeExecutable {
+                method,
+                scope,
+                receiver,
+                bound_superclass: superclass,
+            }),
         }
     }
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -298,7 +298,7 @@ fn function<'gc>(
     let scope = activation.create_scopechain();
     let qname = QName::new(Namespace::package(package), name);
     let method = Method::from_builtin(nf, name, mc);
-    let as3fn = FunctionObject::from_method(activation, method, scope, None).into();
+    let as3fn = FunctionObject::from_method(activation, method, scope, None, None).into();
     domain.export_definition(qname.clone(), script, mc)?;
     script
         .init()

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -322,7 +322,7 @@ fn dynamic_class<'gc>(
     let class = class_object.inner_class_definition();
     let name = class.read().name().clone();
 
-    global.install_const(mc, name.clone(), 0, class_object.into(), false);
+    global.install_const(mc, name.clone(), 0, class_object.into());
     domain.export_definition(name, script, mc)
 }
 
@@ -368,7 +368,6 @@ fn class<'gc>(
         class_name.clone(),
         0,
         class_object.into(),
-        false,
     );
     domain.export_definition(class_name, script, activation.context.gc_context)?;
 
@@ -394,7 +393,7 @@ fn constant<'gc>(
     let (_, mut global, mut domain) = script.init();
     let name = QName::new(Namespace::package(package), name);
     domain.export_definition(name.clone(), script, mc)?;
-    global.install_const(mc, name, 0, value, false);
+    global.install_const(mc, name, 0, value);
 
     Ok(())
 }

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -374,12 +374,7 @@ pub fn for_each<'gc>(
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
 
-            callback.call(
-                receiver,
-                &[item, i.into(), this.into()],
-                activation,
-                receiver.and_then(|r| r.instance_of()),
-            )?;
+            callback.call(receiver, &[item, i.into(), this.into()], activation)?;
         }
     }
 
@@ -409,12 +404,7 @@ pub fn map<'gc>(
 
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
-            let new_item = callback.call(
-                receiver,
-                &[item, i.into(), this.into()],
-                activation,
-                receiver.and_then(|r| r.instance_of()),
-            )?;
+            let new_item = callback.call(receiver, &[item, i.into(), this.into()], activation)?;
 
             new_array.push(new_item);
         }
@@ -449,12 +439,7 @@ pub fn filter<'gc>(
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
             let is_allowed = callback
-                .call(
-                    receiver,
-                    &[item.clone(), i.into(), this.into()],
-                    activation,
-                    receiver.and_then(|r| r.instance_of()),
-                )?
+                .call(receiver, &[item.clone(), i.into(), this.into()], activation)?
                 .coerce_to_boolean();
 
             if is_allowed {
@@ -492,12 +477,7 @@ pub fn every<'gc>(
             let (i, item) = r?;
 
             let result = callback
-                .call(
-                    receiver,
-                    &[item, i.into(), this.into()],
-                    activation,
-                    receiver.and_then(|r| r.instance_of()),
-                )?
+                .call(receiver, &[item, i.into(), this.into()], activation)?
                 .coerce_to_boolean();
 
             if !result {
@@ -535,12 +515,7 @@ pub fn some<'gc>(
             let (i, item) = r?;
 
             let result = callback
-                .call(
-                    receiver,
-                    &[item, i.into(), this.into()],
-                    activation,
-                    receiver.and_then(|r| r.instance_of()),
-                )?
+                .call(receiver, &[item, i.into(), this.into()], activation)?
                 .coerce_to_boolean();
 
             if result {
@@ -1078,7 +1053,7 @@ pub fn sort<'gc>(
                 options,
                 constrain(|activation, a, b| {
                     let order = v
-                        .call(None, &[a, b], activation, None)?
+                        .call(None, &[a, b], activation)?
                         .coerce_to_number(activation)?;
 
                     if order > 0.0 {

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -31,6 +31,7 @@ pub fn class_init<'gc>(
             .coerce_to_object(activation)?;
         let scope = activation.create_scopechain();
         let gc_context = activation.context.gc_context;
+        let this_class = this.as_class_object().unwrap();
 
         object_proto.install_dynamic_property(
             gc_context,
@@ -40,6 +41,7 @@ pub fn class_init<'gc>(
                 Method::from_builtin(has_own_property, "hasOwnProperty", gc_context),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;
@@ -51,6 +53,7 @@ pub fn class_init<'gc>(
                 Method::from_builtin(property_is_enumerable, "propertyIsEnumerable", gc_context),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;
@@ -66,6 +69,7 @@ pub fn class_init<'gc>(
                 ),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;
@@ -77,6 +81,7 @@ pub fn class_init<'gc>(
                 Method::from_builtin(is_prototype_of, "isPrototypeOf", gc_context),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;
@@ -88,6 +93,7 @@ pub fn class_init<'gc>(
                 Method::from_builtin(to_string, "toString", gc_context),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;
@@ -99,6 +105,7 @@ pub fn class_init<'gc>(
                 Method::from_builtin(to_locale_string, "toLocaleString", gc_context),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;
@@ -110,6 +117,7 @@ pub fn class_init<'gc>(
                 Method::from_builtin(value_of, "valueOf", gc_context),
                 scope,
                 None,
+                Some(this_class),
             )
             .into(),
         )?;

--- a/core/src/avm2/globals/qname.rs
+++ b/core/src/avm2/globals/qname.rs
@@ -74,6 +74,7 @@ pub fn class_init<'gc>(
     let mut qname_proto = this
         .get_property(this, &QName::dynamic_name("prototype").into(), activation)?
         .coerce_to_object(activation)?;
+    let this_class = this.as_class_object().unwrap();
 
     qname_proto.set_property(
         qname_proto,
@@ -83,6 +84,7 @@ pub fn class_init<'gc>(
             Method::from_builtin(to_string, "toString", activation.context.gc_context),
             scope,
             None,
+            Some(this_class),
         )
         .into(),
         activation,
@@ -96,6 +98,7 @@ pub fn class_init<'gc>(
             Method::from_builtin(value_of, "valueOf", activation.context.gc_context),
             scope,
             None,
+            Some(this_class),
         )
         .into(),
         activation,

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -76,7 +76,6 @@ pub fn class_init<'gc>(
             int_vector_name.clone(),
             0,
             int_vector_class.into(),
-            false,
         );
         domain.export_definition(int_vector_name, script, activation.context.gc_context)?;
 
@@ -93,7 +92,6 @@ pub fn class_init<'gc>(
             uint_vector_name.clone(),
             0,
             uint_vector_class.into(),
-            false,
         );
         domain.export_definition(uint_vector_name, script, activation.context.gc_context)?;
 
@@ -110,7 +108,6 @@ pub fn class_init<'gc>(
             number_vector_name.clone(),
             0,
             number_vector_class.into(),
-            false,
         );
         domain.export_definition(number_vector_name, script, activation.context.gc_context)?;
 
@@ -126,7 +123,6 @@ pub fn class_init<'gc>(
             object_vector_name.clone(),
             0,
             object_vector_class.into(),
-            false,
         );
         domain.export_definition(object_vector_name, script, activation.context.gc_context)?;
     }

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -873,8 +873,8 @@ pub fn sort<'gc>(
             let (compare_fnc, options) = if fn_or_options
                 .coerce_to_object(activation)
                 .ok()
-                .and_then(|o| o.as_executable())
-                .is_some()
+                .map(|o| o.as_executable().is_some())
+                .unwrap_or(false)
             {
                 (
                     Some(fn_or_options.coerce_to_object(activation)?),

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -425,12 +425,7 @@ pub fn every<'gc>(
             let (i, item) = r?;
 
             let result = callback
-                .call(
-                    receiver,
-                    &[item, i.into(), this.into()],
-                    activation,
-                    receiver.and_then(|r| r.instance_of()),
-                )?
+                .call(receiver, &[item, i.into(), this.into()], activation)?
                 .coerce_to_boolean();
 
             if !result {
@@ -468,12 +463,7 @@ pub fn some<'gc>(
             let (i, item) = r?;
 
             let result = callback
-                .call(
-                    receiver,
-                    &[item, i.into(), this.into()],
-                    activation,
-                    receiver.and_then(|r| r.instance_of()),
-                )?
+                .call(receiver, &[item, i.into(), this.into()], activation)?
                 .coerce_to_boolean();
 
             if result {
@@ -519,12 +509,7 @@ pub fn filter<'gc>(
             let (i, item) = r?;
 
             let result = callback
-                .call(
-                    receiver,
-                    &[item.clone(), i.into(), this.into()],
-                    activation,
-                    receiver.and_then(|r| r.instance_of()),
-                )?
+                .call(receiver, &[item.clone(), i.into(), this.into()], activation)?
                 .coerce_to_boolean();
 
             if result {
@@ -561,12 +546,7 @@ pub fn for_each<'gc>(
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
 
-            callback.call(
-                receiver,
-                &[item, i.into(), this.into()],
-                activation,
-                receiver.and_then(|r| r.instance_of()),
-            )?;
+            callback.call(receiver, &[item, i.into(), this.into()], activation)?;
         }
     }
 
@@ -686,12 +666,8 @@ pub fn map<'gc>(
         while let Some(r) = iter.next(activation) {
             let (i, item) = r?;
 
-            let new_item = callback.call(
-                receiver,
-                &[item.clone(), i.into(), this.into()],
-                activation,
-                receiver.and_then(|r| r.instance_of()),
-            )?;
+            let new_item =
+                callback.call(receiver, &[item.clone(), i.into(), this.into()], activation)?;
             let coerced_item = new_item.coerce_to_type(activation, value_type)?;
 
             new_storage.push(coerced_item)?;
@@ -914,7 +890,7 @@ pub fn sort<'gc>(
             let compare = move |activation: &mut Activation<'_, 'gc, '_>, a, b| {
                 if let Some(compare_fnc) = compare_fnc {
                     let order = compare_fnc
-                        .call(Some(this), &[a, b], activation, None)?
+                        .call(Some(this), &[a, b], activation)?
                         .coerce_to_number(activation)?;
 
                     if order > 0.0 {

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -367,4 +367,12 @@ impl<'gc> Method<'gc> {
             Method::Bytecode(bm) => Ok(bm),
         }
     }
+
+    /// Check if this method needs `arguments`.
+    pub fn needs_arguments_object(&self) -> bool {
+        match self {
+            Method::Native { .. } => false,
+            Method::Bytecode(bm) => bm.method().needs_arguments_object,
+        }
+    }
 }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -401,14 +401,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 if !method.needs_arguments_object() {
                     let scope = class.instance_scope();
 
-                    return Executable::from_method(
-                        method,
-                        scope,
-                        None,
-                        Some(superclass),
-                        activation.context.gc_context,
-                    )
-                    .exec(
+                    return Executable::from_method(method, scope, None, Some(superclass)).exec(
                         Some(self.into()),
                         arguments,
                         activation,
@@ -424,14 +417,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 if !method.needs_arguments_object() {
                     let scope = class.class_scope();
 
-                    return Executable::from_method(
-                        method,
-                        scope,
-                        None,
-                        Some(class),
-                        activation.context.gc_context,
-                    )
-                    .exec(
+                    return Executable::from_method(method, scope, None, Some(class)).exec(
                         Some(self.into()),
                         arguments,
                         activation,
@@ -1257,7 +1243,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     }
 
     /// Get this object's `Executable`, if it has one.
-    fn as_executable(&self) -> Option<Executable<'gc>> {
+    fn as_executable(&self) -> Option<Ref<Executable<'gc>>> {
         None
     }
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -337,6 +337,22 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             }
         }
 
+        if let Some(class) = self.as_class_object() {
+            if let Some(method_trait) = class.class_method(&name)? {
+                let method = method_trait.as_method().unwrap();
+                let scope = class.class_scope();
+
+                return Executable::from_method(method, scope, None, activation.context.gc_context)
+                    .exec(
+                        Some(self.into()),
+                        arguments,
+                        activation,
+                        Some(class),
+                        class.into(),
+                    );
+            }
+        }
+
         let function = self
             .get_property(self.into(), multiname, activation)?
             .coerce_to_object(activation);

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -909,21 +909,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
                 Ok(default_value.clone())
             }
-            TraitKind::Method {
-                disp_id, method, ..
-            } => {
-                let function =
-                    FunctionObject::from_method(activation, method.clone(), scope, Some(receiver));
-                self.install_method(
-                    activation.context.gc_context,
-                    trait_name,
-                    *disp_id,
-                    function,
-                    is_final,
-                );
-
-                Ok(function.into())
-            }
+            TraitKind::Method { .. } => Ok(Value::Undefined),
             TraitKind::Getter {
                 disp_id, method, ..
             } => {

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -411,32 +411,46 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 TraitKind::Method { method, .. } => Some(method.clone()),
                 _ => None,
             }) {
-                let scope = superclass_object.instance_scope();
+                if !method.needs_arguments_object() {
+                    let scope = superclass_object.instance_scope();
 
-                return Executable::from_method(method, scope, None, activation.context.gc_context)
+                    return Executable::from_method(
+                        method,
+                        scope,
+                        None,
+                        activation.context.gc_context,
+                    )
                     .exec(
                         Some(self.into()),
                         arguments,
                         activation,
                         Some(superclass_object),
-                        superclass_object.into(),
+                        superclass_object.into(), //Deliberately invalid.
                     );
+                }
             }
         }
 
         if let Some(class) = self.as_class_object() {
             if let Some(method_trait) = class.class_method(&name)? {
                 let method = method_trait.as_method().unwrap();
-                let scope = class.class_scope();
+                if !method.needs_arguments_object() {
+                    let scope = class.class_scope();
 
-                return Executable::from_method(method, scope, None, activation.context.gc_context)
+                    return Executable::from_method(
+                        method,
+                        scope,
+                        None,
+                        activation.context.gc_context,
+                    )
                     .exec(
                         Some(self.into()),
                         arguments,
                         activation,
                         Some(class),
-                        class.into(),
+                        class.into(), //Deliberately invalid.
                     );
+                }
             }
         }
 

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -68,7 +68,7 @@ impl<'gc> ArrayObject<'gc> {
         .into();
         instance.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(instance), &[], activation, Some(class))?;
+        class.call_native_init(Some(instance), &[], activation)?;
 
         Ok(instance)
     }

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -67,7 +67,7 @@ impl<'gc> BitmapDataObject<'gc> {
             .write(activation.context.gc_context)
             .init_object2(instance.into());
         instance.install_instance_traits(activation, class)?;
-        class.call_native_init(Some(instance.into()), &[], activation, Some(class))?;
+        class.call_native_init(Some(instance.into()), &[], activation)?;
 
         Ok(instance.into())
     }

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -59,7 +59,7 @@ impl<'gc> ByteArrayObject<'gc> {
         .into();
         instance.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(instance), &[], activation, Some(class))?;
+        class.call_native_init(Some(instance), &[], activation)?;
 
         Ok(instance)
     }

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -452,13 +452,8 @@ impl<'gc> ClassObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         let scope = self.0.read().instance_scope;
-        let constructor = Executable::from_method(
-            self.0.read().constructor.clone(),
-            scope,
-            None,
-            Some(self),
-            activation.context.gc_context,
-        );
+        let constructor =
+            Executable::from_method(self.0.read().constructor.clone(), scope, None, Some(self));
 
         constructor.exec(receiver, arguments, activation, self.into())
     }
@@ -480,7 +475,6 @@ impl<'gc> ClassObject<'gc> {
             scope,
             None,
             Some(self),
-            activation.context.gc_context,
         );
 
         constructor.exec(receiver, arguments, activation, self.into())

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -221,6 +221,9 @@ impl<'gc> ClassObject<'gc> {
     ///
     /// Make sure to call them before calling this function, or it may yield an
     /// error.
+    ///
+    /// This function is also when class trait validation happens. Verify
+    /// errors will be raised at this time.
     pub fn into_finished_class(
         mut self,
         activation: &mut Activation<'_, 'gc, '_>,
@@ -239,6 +242,9 @@ impl<'gc> ClassObject<'gc> {
         )?;
         self.install_instance_traits(activation, class_class)?;
         self.run_class_initializer(activation)?;
+        self.inner_class_definition()
+            .read()
+            .validate_class(self.superclass_object())?;
 
         Ok(self)
     }

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -260,14 +260,12 @@ impl<'gc> ClassObject<'gc> {
             QName::new(Namespace::public(), "prototype"),
             0,
             class_proto.into(),
-            false,
         );
         class_proto.install_slot(
             activation.context.gc_context,
             QName::new(Namespace::public(), "constructor"),
             0,
             self.into(),
-            false,
         );
 
         Ok(())
@@ -736,8 +734,8 @@ impl<'gc> ClassObject<'gc> {
     /// Retrieve a bound instance method suitable for use as a value.
     ///
     /// This returns the bound method object itself, as well as it's dispatch
-    /// ID and if it's a final method. You will need the additional properties
-    /// in order to install the method into your object.
+    /// ID. You will need the additional properties in order to install the
+    /// method into your object.
     ///
     /// You should only call this method once per reciever/name pair, and cache
     /// the result. Otherwise, code that relies on bound methods having stable
@@ -748,11 +746,10 @@ impl<'gc> ClassObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         receiver: Object<'gc>,
         name: &QName<'gc>,
-    ) -> Result<Option<(Object<'gc>, u32, bool)>, Error> {
+    ) -> Result<Option<(Object<'gc>, u32)>, Error> {
         if let Some((superclass, method_trait)) = self.instance_method(name)? {
             let method = method_trait.as_method().unwrap();
             let disp_id = method_trait.slot_id();
-            let is_final = method_trait.is_final();
             let scope = self.instance_scope();
 
             Ok(Some((
@@ -764,7 +761,6 @@ impl<'gc> ClassObject<'gc> {
                     Some(superclass),
                 ),
                 disp_id,
-                is_final,
             )))
         } else {
             Ok(None)
@@ -773,9 +769,9 @@ impl<'gc> ClassObject<'gc> {
 
     /// Retrieve a bound instance method by slot ID.
     ///
-    /// This returns the bound method object itself, as well as it's name,
-    /// and if it's a final method. You will need the additional properties in
-    /// order to install the method into your object.
+    /// This returns the bound method object itself, as well as it's name. You
+    /// will need the additional properties in order to install the method into
+    /// your object.
     ///
     /// You should only call this method once per reciever/name pair, and cache
     /// the result. Otherwise, code that relies on bound methods having stable
@@ -786,7 +782,7 @@ impl<'gc> ClassObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         receiver: Object<'gc>,
         id: u32,
-    ) -> Result<Option<(Object<'gc>, QName<'gc>, bool)>, Error> {
+    ) -> Result<Option<(Object<'gc>, QName<'gc>)>, Error> {
         if let Some(superclass) = self.find_class_for_trait_by_id(id)? {
             let superclassdef = superclass.inner_class_definition();
             let traits = superclassdef.read().lookup_instance_traits_by_slot(id)?;
@@ -797,7 +793,6 @@ impl<'gc> ClassObject<'gc> {
             }) {
                 let name = method_trait.name().clone();
                 let method = method_trait.as_method().unwrap();
-                let is_final = method_trait.is_final();
                 let scope = self.instance_scope();
 
                 Ok(Some((
@@ -809,7 +804,6 @@ impl<'gc> ClassObject<'gc> {
                         Some(superclass),
                     ),
                     name,
-                    is_final,
                 )))
             } else {
                 Ok(None)
@@ -839,8 +833,8 @@ impl<'gc> ClassObject<'gc> {
     /// Retrieve a bound class method suitable for use as a value.
     ///
     /// This returns the bound method object itself, as well as it's dispatch
-    /// ID and if it's a final method. You will need the additional properties
-    /// in order to install the method into your object.
+    /// ID. You will need the additional properties in order to install the
+    /// method into your object.
     ///
     /// You should only call this method once per reciever/name pair, and cache
     /// the result. Otherwise, code that relies on bound methods having stable
@@ -850,11 +844,10 @@ impl<'gc> ClassObject<'gc> {
         self,
         activation: &mut Activation<'_, 'gc, '_>,
         name: &QName<'gc>,
-    ) -> Result<Option<(Object<'gc>, u32, bool)>, Error> {
+    ) -> Result<Option<(Object<'gc>, u32)>, Error> {
         if let Some(method_trait) = self.class_method(name)? {
             let method = method_trait.as_method().unwrap();
             let disp_id = method_trait.slot_id();
-            let is_final = method_trait.is_final();
             let scope = self.class_scope();
 
             Ok(Some((
@@ -866,7 +859,6 @@ impl<'gc> ClassObject<'gc> {
                     Some(self),
                 ),
                 disp_id,
-                is_final,
             )))
         } else {
             Ok(None)
@@ -875,9 +867,9 @@ impl<'gc> ClassObject<'gc> {
 
     /// Retrieve a bound class method by id.
     ///
-    /// This returns the bound method object itself, as well as it's name,
-    /// and if it's a final method. You will need the additional properties in
-    /// order to install the method into your object.
+    /// This returns the bound method object itself, as well as it's name. You
+    /// will need the additional properties in order to install the method into
+    /// your object.
     ///
     /// You should only call this method once per reciever/name pair, and cache
     /// the result. Otherwise, code that relies on bound methods having stable
@@ -887,7 +879,7 @@ impl<'gc> ClassObject<'gc> {
         self,
         activation: &mut Activation<'_, 'gc, '_>,
         id: u32,
-    ) -> Result<Option<(Object<'gc>, QName<'gc>, bool)>, Error> {
+    ) -> Result<Option<(Object<'gc>, QName<'gc>)>, Error> {
         let classdef = self.inner_class_definition();
         let traits = classdef.read().lookup_class_traits_by_slot(id)?;
 
@@ -897,7 +889,6 @@ impl<'gc> ClassObject<'gc> {
         }) {
             let method = method_trait.as_method().unwrap();
             let name = method_trait.name().clone();
-            let is_final = method_trait.is_final();
             let scope = self.class_scope();
 
             Ok(Some((
@@ -909,7 +900,6 @@ impl<'gc> ClassObject<'gc> {
                     Some(self),
                 ),
                 name,
-                is_final,
             )))
         } else {
             Ok(None)

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -59,7 +59,7 @@ impl<'gc> DomainObject<'gc> {
         .into();
         this.install_instance_traits(activation, class)?;
 
-        class.call_init(Some(this), &[], activation, Some(class))?;
+        class.call_init(Some(this), &[], activation)?;
 
         Ok(this)
     }

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -48,7 +48,6 @@ impl<'gc> FunctionObject<'gc> {
             QName::new(Namespace::public(), "prototype"),
             0,
             es3_proto.into(),
-            false,
         );
 
         Ok(this)

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -85,7 +85,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         .into();
         this.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(this), &[], activation, Some(class))?;
+        class.call_native_init(Some(this), &[], activation)?;
 
         Ok(this)
     }
@@ -106,7 +106,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         .into();
         this.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(this), &[], activation, Some(class))?;
+        class.call_native_init(Some(this), &[], activation)?;
 
         Ok(this)
     }

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -59,7 +59,7 @@ impl<'gc> NamespaceObject<'gc> {
         .into();
         this.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(this), &[], activation, Some(class))?;
+        class.call_native_init(Some(this), &[], activation)?;
 
         Ok(this)
     }

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -59,7 +59,7 @@ impl<'gc> QNameObject<'gc> {
         .into();
         this.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(this), &[], activation, Some(class))?;
+        class.call_native_init(Some(this), &[], activation)?;
 
         Ok(this)
     }

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -57,7 +57,7 @@ impl<'gc> RegExpObject<'gc> {
         .into();
         this.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(this), &[], activation, Some(class))?;
+        class.call_native_init(Some(this), &[], activation)?;
 
         Ok(this)
     }

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -372,7 +372,11 @@ impl<'gc> ScriptObjectData<'gc> {
     }
 
     pub fn has_own_property(&self, name: &QName<'gc>) -> Result<bool, Error> {
-        Ok(self.values.get(name).is_some() || self.has_trait(name)?)
+        Ok(self.has_own_instantiated_property(name) || self.has_trait(name)?)
+    }
+
+    pub fn has_own_instantiated_property(&self, name: &QName<'gc>) -> bool {
+        self.values.get(name).is_some()
     }
 
     pub fn has_own_virtual_getter(&self, name: &QName<'gc>) -> bool {

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -70,7 +70,7 @@ impl<'gc> SoundObject<'gc> {
         .into();
         sound_object.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(sound_object), &[], activation, Some(class))?;
+        class.call_native_init(Some(sound_object), &[], activation)?;
 
         Ok(sound_object)
     }

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -73,7 +73,7 @@ impl<'gc> SoundChannelObject<'gc> {
         ));
         sound_object.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(sound_object.into()), &[], activation, Some(class))?;
+        class.call_native_init(Some(sound_object.into()), &[], activation)?;
 
         Ok(sound_object)
     }

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -90,7 +90,7 @@ impl<'gc> StageObject<'gc> {
     ) -> Result<Self, Error> {
         let this = Self::for_display_object(activation, display_object, class)?;
 
-        class.call_native_init(Some(this.into()), &[], activation, Some(class))?;
+        class.call_native_init(Some(this.into()), &[], activation)?;
 
         Ok(this)
     }
@@ -111,7 +111,7 @@ impl<'gc> StageObject<'gc> {
         ));
         this.install_instance_traits(activation, class)?;
 
-        class.call_native_init(Some(this.into()), &[], activation, Some(class))?;
+        class.call_native_init(Some(this.into()), &[], activation)?;
 
         Ok(this)
     }

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -1,6 +1,6 @@
 //! Property data structures
 
-use crate::avm2::object::{ClassObject, Object, TObject};
+use crate::avm2::object::{Object, TObject};
 use crate::avm2::return_value::ReturnValue;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -164,18 +164,11 @@ impl<'gc> Property<'gc> {
     ///
     /// This function yields `ReturnValue` because some properties may be
     /// user-defined.
-    pub fn get(
-        &self,
-        this: Object<'gc>,
-        subclass_object: Option<ClassObject<'gc>>,
-    ) -> Result<ReturnValue<'gc>, Error> {
+    pub fn get(&self, this: Object<'gc>) -> Result<ReturnValue<'gc>, Error> {
         match self {
-            Property::Virtual { get: Some(get), .. } => Ok(ReturnValue::defer_execution(
-                *get,
-                Some(this),
-                vec![],
-                subclass_object,
-            )),
+            Property::Virtual { get: Some(get), .. } => {
+                Ok(ReturnValue::defer_execution(*get, Some(this), vec![]))
+            }
             Property::Virtual { get: None, .. } => Ok(Value::Undefined.into()),
             Property::Stored { value, .. } => Ok(value.to_owned().into()),
 
@@ -195,7 +188,6 @@ impl<'gc> Property<'gc> {
     pub fn set(
         &mut self,
         this: Object<'gc>,
-        subclass_object: Option<ClassObject<'gc>>,
         new_value: impl Into<Value<'gc>>,
     ) -> Result<ReturnValue<'gc>, Error> {
         match self {
@@ -205,7 +197,6 @@ impl<'gc> Property<'gc> {
                         *function,
                         Some(this),
                         vec![new_value.into()],
-                        subclass_object,
                     ));
                 }
 
@@ -239,7 +230,6 @@ impl<'gc> Property<'gc> {
     pub fn init(
         &mut self,
         this: Object<'gc>,
-        subclass_object: Option<ClassObject<'gc>>,
         new_value: impl Into<Value<'gc>>,
     ) -> Result<ReturnValue<'gc>, Error> {
         match self {
@@ -249,7 +239,6 @@ impl<'gc> Property<'gc> {
                         *function,
                         Some(this),
                         vec![new_value.into()],
-                        subclass_object,
                     ));
                 }
 

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -19,9 +19,6 @@ bitflags! {
 
         /// Property cannot be set.
         const READ_ONLY   = 1 << 1;
-
-        /// Property cannot be overridden in subclasses.
-        const FINAL       = 1 << 2;
     }
 }
 
@@ -46,12 +43,8 @@ pub enum Property<'gc> {
 
 impl<'gc> Property<'gc> {
     /// Create a new stored property.
-    pub fn new_stored(value: impl Into<Value<'gc>>, is_final: bool) -> Self {
-        let mut attributes = Attribute::DONT_DELETE;
-
-        if is_final {
-            attributes |= Attribute::FINAL;
-        }
+    pub fn new_stored(value: impl Into<Value<'gc>>) -> Self {
+        let attributes = Attribute::DONT_DELETE;
 
         Property::Stored {
             value: value.into(),
@@ -60,12 +53,8 @@ impl<'gc> Property<'gc> {
     }
 
     /// Create a new stored property.
-    pub fn new_const(value: impl Into<Value<'gc>>, is_final: bool) -> Self {
-        let mut attributes = Attribute::DONT_DELETE | Attribute::READ_ONLY;
-
-        if is_final {
-            attributes |= Attribute::FINAL;
-        }
+    pub fn new_const(value: impl Into<Value<'gc>>) -> Self {
+        let attributes = Attribute::DONT_DELETE | Attribute::READ_ONLY;
 
         Property::Stored {
             value: value.into(),
@@ -84,12 +73,8 @@ impl<'gc> Property<'gc> {
     /// Convert a function into a method.
     ///
     /// This applies READ_ONLY/DONT_DELETE to the property.
-    pub fn new_method(fn_obj: Object<'gc>, is_final: bool) -> Self {
-        let mut attributes = Attribute::DONT_DELETE | Attribute::READ_ONLY;
-
-        if is_final {
-            attributes |= Attribute::FINAL;
-        }
+    pub fn new_method(fn_obj: Object<'gc>) -> Self {
+        let attributes = Attribute::DONT_DELETE | Attribute::READ_ONLY;
 
         Property::Stored {
             value: fn_obj.into(),
@@ -98,12 +83,8 @@ impl<'gc> Property<'gc> {
     }
 
     /// Create a new, unconfigured virtual property item.
-    pub fn new_virtual(is_final: bool) -> Self {
-        let mut attributes = Attribute::DONT_DELETE | Attribute::READ_ONLY;
-
-        if is_final {
-            attributes |= Attribute::FINAL;
-        }
+    pub fn new_virtual() -> Self {
+        let attributes = Attribute::DONT_DELETE | Attribute::READ_ONLY;
 
         Property::Virtual {
             get: None,
@@ -113,13 +94,7 @@ impl<'gc> Property<'gc> {
     }
 
     /// Create a new slot property.
-    pub fn new_slot(slot_id: u32, is_final: bool) -> Self {
-        let mut attributes = Attribute::DONT_DELETE;
-
-        if is_final {
-            attributes |= Attribute::FINAL;
-        }
-
+    pub fn new_slot(slot_id: u32) -> Self {
         Property::Slot {
             slot_id,
             attributes: Attribute::DONT_DELETE,
@@ -286,14 +261,5 @@ impl<'gc> Property<'gc> {
             Property::Slot { attributes, .. } => attributes,
         };
         !attributes.contains(Attribute::READ_ONLY)
-    }
-
-    pub fn is_final(&self) -> bool {
-        let attributes = match self {
-            Property::Virtual { attributes, .. } => attributes,
-            Property::Stored { attributes, .. } => attributes,
-            Property::Slot { attributes, .. } => attributes,
-        };
-        attributes.contains(Attribute::FINAL)
     }
 }

--- a/core/src/avm2/return_value.rs
+++ b/core/src/avm2/return_value.rs
@@ -1,7 +1,7 @@
 //! Return value enum
 
 use crate::avm2::activation::Activation;
-use crate::avm2::object::{ClassObject, Object, TObject};
+use crate::avm2::object::{Object, TObject};
 use crate::avm2::{Error, Value};
 use std::fmt;
 
@@ -40,7 +40,6 @@ pub enum ReturnValue<'gc> {
         callee: Object<'gc>,
         unbound_reciever: Option<Object<'gc>>,
         arguments: Vec<Value<'gc>>,
-        subclass_object: Option<ClassObject<'gc>>,
     },
 }
 
@@ -52,13 +51,11 @@ impl fmt::Debug for ReturnValue<'_> {
                 callee,
                 unbound_reciever,
                 arguments,
-                subclass_object,
             } => f
                 .debug_struct("ReturnValue")
                 .field("callee", callee)
                 .field("unbound_reciever", unbound_reciever)
                 .field("arguments", arguments)
-                .field("subclass_object", subclass_object)
                 .finish(),
         }
     }
@@ -70,13 +67,11 @@ impl<'gc> ReturnValue<'gc> {
         callee: Object<'gc>,
         unbound_reciever: Option<Object<'gc>>,
         arguments: Vec<Value<'gc>>,
-        subclass_object: Option<ClassObject<'gc>>,
     ) -> Self {
         Self::ResultOf {
             callee,
             unbound_reciever,
             arguments,
-            subclass_object,
         }
     }
 
@@ -91,12 +86,10 @@ impl<'gc> ReturnValue<'gc> {
                 callee,
                 unbound_reciever,
                 arguments,
-                subclass_object,
             } => callee.as_executable().unwrap().exec(
                 unbound_reciever,
                 &arguments,
                 activation,
-                subclass_object,
                 callee,
             ),
         }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -383,6 +383,7 @@ impl<'gc> Script<'gc> {
                 &mut null_activation,
                 &self.traits()?,
                 ScopeChain::new(domain),
+                None,
             )?;
 
             Avm2::run_script_initializer(*self, context)?;

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -300,29 +300,55 @@ impl<'gc> Trait<'gc> {
         self
     }
 
-    /// Get the slot or dispatch ID of this trait.
-    pub fn slot_id(&self) -> u32 {
+    /// Get the slot ID of this trait.
+    pub fn slot_id(&self) -> Option<u32> {
         match self.kind {
-            TraitKind::Slot { slot_id, .. } => slot_id,
-            TraitKind::Method { disp_id, .. } => disp_id,
-            TraitKind::Getter { disp_id, .. } => disp_id,
-            TraitKind::Setter { disp_id, .. } => disp_id,
-            TraitKind::Class { slot_id, .. } => slot_id,
-            TraitKind::Function { slot_id, .. } => slot_id,
-            TraitKind::Const { slot_id, .. } => slot_id,
+            TraitKind::Slot { slot_id, .. } => Some(slot_id),
+            TraitKind::Method { .. } => None,
+            TraitKind::Getter { .. } => None,
+            TraitKind::Setter { .. } => None,
+            TraitKind::Class { slot_id, .. } => Some(slot_id),
+            TraitKind::Function { slot_id, .. } => Some(slot_id),
+            TraitKind::Const { slot_id, .. } => Some(slot_id),
         }
     }
 
-    /// Set the slot or dispatch ID of this trait.
+    /// Set the slot ID of this trait.
     pub fn set_slot_id(&mut self, id: u32) {
         match &mut self.kind {
             TraitKind::Slot { slot_id, .. } => *slot_id = id,
-            TraitKind::Method { disp_id, .. } => *disp_id = id,
-            TraitKind::Getter { disp_id, .. } => *disp_id = id,
-            TraitKind::Setter { disp_id, .. } => *disp_id = id,
+            TraitKind::Method { .. } => {}
+            TraitKind::Getter { .. } => {}
+            TraitKind::Setter { .. } => {}
             TraitKind::Class { slot_id, .. } => *slot_id = id,
             TraitKind::Function { slot_id, .. } => *slot_id = id,
             TraitKind::Const { slot_id, .. } => *slot_id = id,
+        }
+    }
+
+    /// Get the dispatch ID of this trait.
+    pub fn disp_id(&self) -> Option<u32> {
+        match self.kind {
+            TraitKind::Slot { .. } => None,
+            TraitKind::Method { disp_id, .. } => Some(disp_id),
+            TraitKind::Getter { disp_id, .. } => Some(disp_id),
+            TraitKind::Setter { disp_id, .. } => Some(disp_id),
+            TraitKind::Class { .. } => None,
+            TraitKind::Function { .. } => None,
+            TraitKind::Const { .. } => None,
+        }
+    }
+
+    /// Set the dispatch ID of this trait.
+    pub fn set_disp_id(&mut self, id: u32) {
+        match &mut self.kind {
+            TraitKind::Slot { .. } => {}
+            TraitKind::Method { disp_id, .. } => *disp_id = id,
+            TraitKind::Getter { disp_id, .. } => *disp_id = id,
+            TraitKind::Setter { disp_id, .. } => *disp_id = id,
+            TraitKind::Class { .. } => {}
+            TraitKind::Function { .. } => {}
+            TraitKind::Const { .. } => {}
         }
     }
 

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -300,6 +300,19 @@ impl<'gc> Trait<'gc> {
         self
     }
 
+    /// Get the slot or dispatch ID of this trait.
+    pub fn slot_id(&self) -> u32 {
+        match self.kind {
+            TraitKind::Slot { slot_id, .. } => slot_id,
+            TraitKind::Method { disp_id, .. } => disp_id,
+            TraitKind::Getter { disp_id, .. } => disp_id,
+            TraitKind::Setter { disp_id, .. } => disp_id,
+            TraitKind::Class { slot_id, .. } => slot_id,
+            TraitKind::Function { slot_id, .. } => slot_id,
+            TraitKind::Const { slot_id, .. } => slot_id,
+        }
+    }
+
     /// Set the slot or dispatch ID of this trait.
     pub fn set_slot_id(&mut self, id: u32) {
         match &mut self.kind {
@@ -310,6 +323,17 @@ impl<'gc> Trait<'gc> {
             TraitKind::Class { slot_id, .. } => *slot_id = id,
             TraitKind::Function { slot_id, .. } => *slot_id = id,
             TraitKind::Const { slot_id, .. } => *slot_id = id,
+        }
+    }
+
+    /// Get the method contained within this trait, if it has one.
+    pub fn as_method(&self) -> Option<Method<'gc>> {
+        match &self.kind {
+            TraitKind::Method { method, .. } => Some(method.clone()),
+            TraitKind::Getter { method, .. } => Some(method.clone()),
+            TraitKind::Setter { method, .. } => Some(method.clone()),
+            TraitKind::Function { function, .. } => Some(function.clone()),
+            _ => None,
         }
     }
 }

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -539,7 +539,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             if let Some(avm2_object) = avm2_object {
                 let mut constr_thing = || {
                     let mut activation = Avm2Activation::from_nothing(context.reborrow());
-                    class.call_native_init(Some(avm2_object), &[], &mut activation, Some(class))?;
+                    class.call_native_init(Some(avm2_object), &[], &mut activation)?;
 
                     Ok(())
                 };

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1590,12 +1590,7 @@ impl<'gc> MovieClip<'gc> {
         if let Avm2Value::Object(object) = self.object2() {
             let mut constr_thing = || {
                 let mut activation = Avm2Activation::from_nothing(context.reborrow());
-                class_object.call_native_init(
-                    Some(object),
-                    &[],
-                    &mut activation,
-                    Some(class_object),
-                )?;
+                class_object.call_native_init(Some(object), &[], &mut activation)?;
 
                 Ok(())
             };


### PR DESCRIPTION
This PR primarily intends to reduce the amount of time spent constructing bound method properties, by implementing a performance trick implemented by a number of high-level languages that have bound methods (including both avmplus and CPython).

The way we've currently implemented `callproperty` is equivalent to issuing `getproperty` followed by `call`. This means that every object has to have bound methods preallocated for it at allocation time, which significantly increases the cost of object construction. Instead, we can...

1. Lazily instantiate bound methods, so we don't pay the cost of allocating methods that don't get called.
2. Call methods by name without binding them, so we don't pay the cost of allocating methods that are not used as event handlers.

The first item might be somewhat controversial. Lazy traits is something we got rid of in `avm2-ragnarok`, after all. I've written the commits in this PR in such a way that I could rebase this feature out should it prove to not be a good idea. (For example, doing this lazily breaks `final` enforcement as we currently have it implemented...) Alternatively, it may make more sense to implement this as a separate `Property::Method` variant rather than explicit checks in all the standard `TObject` methods.

The second item is simple enough to implement, but it won't actually provide a benefit without the first item. (Also, we can't do this for methods with `needs_arguments` flagged, because `arguments.callee` must be a bound method.)

I also removed `superclass_object` (the class that defined the currently-called method) from `TObject.call` and related properties. Instead, this property is bound alongside `receiver` in methods. The only cases in which we will be calling methods *without* this bound information are cases where we already know what class defined a method anyway. This work could potentially be separated from this PR if needs be.

# TODOs

- [x] Allow calling methods directly in `callproperty` without intervening `getproperty`
  - [x] Except for things that need `arguments`
  - [x] Make `Executable` zero-alloc (e.g. no `Gc`) and `Copy` for extra performance. We gain no benefit from it having shareable data.
- [x] Lazily instantiate bound methods in `getproperty`
  - [x] Make `ClassObject` report class traits as properties in `has_own_property`, `has_trait`, and `resolve_any`
  - [x] Detect uninstantiated bound methods in `setproperty`, `initproperty`, and `deleteproperty`, and refuse to allow setting or deleting those properties
- [x] Lazily instantiate bound methods in `callmethod` (which, AFAIK, I don't think is even used?)
- [x] Figure out how to do `final` enforcement earlier than instance construction time
  - [x] Remove `is_property_final` as it no longer works for this purpose
- [x] Bind `superclass_object` to methods
  - [x] Remove `superclass_object` from `TObject.call` and all related methods (this touches a *surprising* amount of code)