### PR TITLE
web: Add error-report label to bug report link

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -990,7 +990,7 @@ export class RufflePlayer extends HTMLElement {
         const issueTitle = `Error on ${pageUrl}`;
         let issueLink = `https://github.com/ruffle-rs/ruffle/issues/new?title=${encodeURIComponent(
             issueTitle
-        )}&body=`;
+        )}&labels=error-report&body=`;
         let issueBody = encodeURIComponent(errorText);
         if (
             errorArray.stackIndex > -1 &&


### PR DESCRIPTION
Auto-add this label to the "Report Bug" link on web, so that issues are a little better organized.