### PR TITLE
wgpu: Fix some invalid WGSL

### DIFF
--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -10,10 +10,10 @@ var<uniform> textureTransforms: TextureTransforms;
 [[group(2), binding(1)]]
 var texture: texture_2d<f32>;
 [[group(3), binding(0)]]
-var sampler: sampler;
+var texture_sampler: sampler;
 
 [[stage(vertex)]]
-fn main(in: VertexInput) -> VertexOutput {
+fn main_vertex(in: VertexInput) -> VertexOutput {
     let matrix = textureTransforms.matrix;
     let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
     let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
@@ -21,8 +21,8 @@ fn main(in: VertexInput) -> VertexOutput {
 }
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    var color: vec4<f32> = textureSample(texture, sampler, in.uv);
+fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+    var color: vec4<f32> = textureSample(texture, texture_sampler, in.uv);
     // Texture is premultiplied by alpha.
     // Unmultiply alpha, apply color transform, remultiply alpha.
     if( color.a > 0.0 ) {

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -6,13 +6,13 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main(in: VertexInput) -> VertexOutput {
+fn main_vertex(in: VertexInput) -> VertexOutput {
     let pos: vec4<f32> = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     return VertexOutput(pos, in.color);
 }
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let out = in.color * transforms.mult_color + transforms.add_color;
     return output(out);
 }

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -22,7 +22,7 @@ var<uniform> textureTransforms: TextureTransforms;
 var<storage> gradient: Gradient;
 
 [[stage(vertex)]]
-fn main(in: VertexInput) -> VertexOutput {
+fn main_vertex(in: VertexInput) -> VertexOutput {
     let matrix = textureTransforms.matrix;
     let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
     let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
@@ -30,7 +30,7 @@ fn main(in: VertexInput) -> VertexOutput {
 }
 
 [[stage(fragment)]]
-fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let last = gradient.num_colors - 1u;
 
     // Calculate normalized `t` position in gradient, [0.0, 1.0] being the bounds of the ratios.
@@ -90,11 +90,11 @@ fn main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     t = clamp(t, gradient.ratios[0], gradient.ratios[last]);
 
     // Find the two gradient colors bordering our position.
-    var j: u32 = 1u;
-    for( var j: u32 = 1u; t > gradient.ratios[j]; j = j + 1u) {
+    var j: u32;
+    for( j = 1u; t > gradient.ratios[j]; j = j + 1u) {
         // Noop
     }
-    var i: u32 = j - 1u;
+    let i = j - 1u;
 
     // Lerp between the two colors.
     let a = (t - gradient.ratios[i]) / (gradient.ratios[j] - gradient.ratios[i]);

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -212,12 +212,12 @@ fn create_pipeline_descriptor<'a>(
         layout: Some(pipeline_layout),
         vertex: wgpu::VertexState {
             module: vertex_shader,
-            entry_point: "main",
+            entry_point: "main_vertex",
             buffers: vertex_buffer_layout,
         },
         fragment: Some(wgpu::FragmentState {
             module: fragment_shader,
-            entry_point: "main",
+            entry_point: "main_fragment",
             targets: color_target_state,
         }),
         primitive: wgpu::PrimitiveState {


### PR DESCRIPTION
naga is currently lenient about some things which are invalid by the WGSL spec. The Tint WGSL compiler disagrees, so these shaders failed to compile in Chrome.