### PR TITLE
avm1: Simplify `ArrayObject::new`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1451,8 +1451,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             Value::Undefined
         } else {
             ArrayObject::new(
-                self.context.gc_context,
-                self.context.avm1.prototypes().array,
+                self,
                 (0..num_elements as i32).map(|_| self.context.avm1.pop()),
             )
             .into()

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -249,11 +249,7 @@ impl<'gc> Executable<'gc> {
                 let arguments = if af.flags.contains(FunctionFlags::SUPPRESS_ARGUMENTS) {
                     ArrayObject::empty(activation)
                 } else {
-                    ArrayObject::new(
-                        activation.context.gc_context,
-                        activation.context.avm1.prototypes().array,
-                        args.iter().cloned(),
-                    )
+                    ArrayObject::new(activation, args.iter().cloned())
                 };
                 arguments.define_value(
                     activation.context.gc_context,

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -91,12 +91,7 @@ pub fn constructor<'gc>(
         array.set_length(activation, length)?;
         Ok(array.into())
     } else {
-        Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            args.iter().cloned(),
-        )
-        .into())
+        Ok(ArrayObject::new(activation, args.iter().cloned()).into())
     }
 }
 
@@ -300,8 +295,7 @@ pub fn slice<'gc>(
     };
 
     Ok(ArrayObject::new(
-        activation.context.gc_context,
-        activation.context.avm1.prototypes().array,
+        activation,
         (start..end).map(|i| this.get_element(activation, i)),
     )
     .into())
@@ -359,12 +353,7 @@ pub fn splice<'gc>(
     }
     this.set_length(activation, length - delete_count + items.len() as i32)?;
 
-    Ok(ArrayObject::new(
-        activation.context.gc_context,
-        activation.context.avm1.prototypes().array,
-        result_elements,
-    )
-    .into())
+    Ok(ArrayObject::new(activation, result_elements).into())
 }
 
 pub fn concat<'gc>(
@@ -394,12 +383,7 @@ pub fn concat<'gc>(
             elements.push(value);
         }
     }
-    Ok(ArrayObject::new(
-        activation.context.gc_context,
-        activation.context.avm1.prototypes().array,
-        elements,
-    )
-    .into())
+    Ok(ArrayObject::new(activation, elements).into())
 }
 
 pub fn to_string<'gc>(
@@ -577,8 +561,7 @@ fn sort_with_function<'gc>(
         // Array.RETURNINDEXEDARRAY returns an array containing the sorted indices, and does not modify
         // the original array.
         Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
+            activation,
             values.into_iter().map(|(index, _)| index.into()),
         )
         .into())

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -27,12 +27,7 @@ pub fn matrix<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_color_matrix_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.matrix().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.matrix().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -183,12 +183,7 @@ pub fn matrix<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_convolution_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.matrix().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.matrix().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -110,12 +110,7 @@ pub fn colors<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_bevel_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.colors().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.colors().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)
@@ -170,12 +165,7 @@ pub fn alphas<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_bevel_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.alphas().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.alphas().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)
@@ -221,12 +211,7 @@ pub fn ratios<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_bevel_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.ratios().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.ratios().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -110,12 +110,7 @@ pub fn colors<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_glow_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.colors().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.colors().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)
@@ -170,12 +165,7 @@ pub fn alphas<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_glow_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.alphas().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.alphas().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)
@@ -221,12 +211,7 @@ pub fn ratios<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_glow_filter_object() {
-        return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            filter.ratios().iter().map(|&x| x.into()),
-        )
-        .into());
+        return Ok(ArrayObject::new(activation, filter.ratios().iter().map(|&x| x.into())).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -23,11 +23,7 @@ pub fn constructor<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let listeners = ArrayObject::new(
-        activation.context.gc_context,
-        activation.context.avm1.prototypes().array,
-        [this.into()],
-    );
+    let listeners = ArrayObject::new(activation, [this.into()]);
     this.define_value(
         activation.context.gc_context,
         "_listeners",

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -318,8 +318,7 @@ fn split<'gc>(
         // e.g., split("foo", "") returns ["", "f", "o", "o", ""] in Rust but ["f, "o", "o"] in Flash.
         // Special case this to match Flash's behavior.
         Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
+            activation,
             this.chars()
                 .take(limit)
                 .map(|c| AvmString::new(activation.context.gc_context, c.to_string()).into()),
@@ -327,8 +326,7 @@ fn split<'gc>(
         .into())
     } else {
         Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
+            activation,
             this.split(delimiter.as_ref())
                 .take(limit)
                 .map(|c| AvmString::new(activation.context.gc_context, c.to_string()).into()),

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -360,8 +360,7 @@ pub fn xmlnode_child_nodes<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
         return Ok(ArrayObject::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
+            activation,
             node.children().filter(is_as2_compatible).map(|mut child| {
                 child
                     .script_object(

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -16,11 +16,7 @@ impl fmt::Debug for ArrayObject<'_> {
 
 impl<'gc> ArrayObject<'gc> {
     pub fn empty(activation: &Activation<'_, 'gc, '_>) -> Self {
-        Self::new(
-            activation.context.gc_context,
-            activation.context.avm1.prototypes().array,
-            [],
-        )
+        Self::new(activation, [])
     }
 
     pub fn empty_with_proto(
@@ -31,11 +27,14 @@ impl<'gc> ArrayObject<'gc> {
     }
 
     pub fn new(
-        gc_context: MutationContext<'gc, '_>,
-        array_proto: Object<'gc>,
+        activation: &Activation<'_, 'gc, '_>,
         elements: impl IntoIterator<Item = Value<'gc>>,
     ) -> Self {
-        Self::new_internal(gc_context, Some(array_proto), elements)
+        Self::new_internal(
+            activation.context.gc_context,
+            Some(activation.context.avm1.prototypes().array),
+            elements,
+        )
     }
 
     fn new_internal(

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -168,8 +168,7 @@ impl Value {
                 object.into()
             }
             Value::List(values) => Avm1ArrayObject::new(
-                activation.context.gc_context,
-                activation.context.avm1.prototypes().array,
+                activation,
                 values
                     .iter()
                     .map(|value| value.to_owned().into_avm1(activation)),

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -684,12 +684,7 @@ impl TextFormat {
             .tab_stops
             .as_ref()
             .map_or(Avm1Value::Null, |tab_stops| {
-                Avm1ArrayObject::new(
-                    activation.context.gc_context,
-                    activation.context.avm1.prototypes().array,
-                    tab_stops.iter().map(|&x| x.into()),
-                )
-                .into()
+                Avm1ArrayObject::new(activation, tab_stops.iter().map(|&x| x.into())).into()
             });
         object.set("tabStops", tab_stops, activation)?;
         Ok(object.into())


### PR DESCRIPTION
It now takes an `activation` parameter, instead of `gc_context` + `proto`.