### PR TITLE
web: Give toggleable option to download swfs in extension/selfhosted config

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -161,6 +161,14 @@ export interface BaseLoadOptions {
     logLevel?: LogLevel;
 
     /**
+     * If set to true, the context menu has an option to download
+     * the SWF.
+     *
+     * @default false
+     */
+    showSwfDownload?: boolean;
+
+    /**
      * Whether or not to show a context menu when right-clicking
      * a Ruffle instance.
      *

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -136,6 +136,7 @@ export class RufflePlayer extends HTMLElement {
     private options: BaseLoadOptions | null;
     private lastActivePlayingState: boolean;
 
+    private showSwfDownload = false;
     private _metadata: MovieMetadata | null;
     private _readyState: ReadyState;
 
@@ -551,6 +552,7 @@ export class RufflePlayer extends HTMLElement {
             // `allowScriptAccess` can only be set in `options`.
             config.allowScriptAccess = options.allowScriptAccess;
 
+            this.showSwfDownload = config.showSwfDownload === true;
             this.options = options;
             this.hasContextMenu = config.contextMenu !== false;
 
@@ -667,6 +669,38 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
+    /**
+     * Fetches the loaded SWF and downloads it.
+     */
+    async downloadSwf(): Promise<void> {
+        try {
+            if (this.swfUrl) {
+                console.log("Downloading SWF: " + this.swfUrl);
+                const response = await fetch(this.swfUrl);
+                if (!response.ok) {
+                    console.error("SWF download failed");
+                    return;
+                }
+                const blob = await response.blob();
+                const blobUrl = URL.createObjectURL(blob);
+                const swfDownloadA = document.createElement("a");
+                swfDownloadA.style.display = "none";
+                swfDownloadA.href = blobUrl;
+                swfDownloadA.download = this.swfUrl.substring(
+                    this.swfUrl.lastIndexOf("/") + 1
+                );
+                document.body.appendChild(swfDownloadA);
+                swfDownloadA.click();
+                document.body.removeChild(swfDownloadA);
+                URL.revokeObjectURL(blobUrl);
+            } else {
+                console.error("SWF download failed");
+            }
+        } catch (err) {
+            console.error("SWF download failed");
+        }
+    }
+
     private contextMenuItems(): Array<ContextMenuItem | null> {
         const CHECKMARK = String.fromCharCode(0x2713);
         const items = [];
@@ -701,6 +735,15 @@ export class RufflePlayer extends HTMLElement {
                 });
             }
         }
+
+        if (this.instance && this.swfUrl && this.showSwfDownload) {
+            items.push(null);
+            items.push({
+                text: `Download .swf`,
+                onClick: this.downloadSwf.bind(this),
+            });
+        }
+
         items.push(null);
 
         const extensionString = this.isExtension ? "extension" : "";

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -8,6 +8,9 @@
     "settings_ignore_optout": {
         "message": "Ignore website compatibility warnings"
     },
+    "settings_show_swf_download": {
+        "message": "Show SWF download in context menu"
+    },
     "status_init": {
         "message": "Reading current tab…"
     },

--- a/web/packages/extension/assets/_locales/es/messages.json
+++ b/web/packages/extension/assets/_locales/es/messages.json
@@ -8,6 +8,9 @@
     "settings_ignore_optout": {
         "message": "Ignorar avisos de compatibilidad en páginas de internet"
     },
+    "settings_show_swf_download": {
+        "message": "Mostrar descarga de SWF en el menú contextual"
+    },
     "status_init": {
         "message": "Leyendo la pestaña actual…"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -39,6 +39,10 @@
                 </select>
                 <label for="log_level">Log level</label>
             </div>
+            <div class="option checkbox">
+                <input type="checkbox" id="show_swf_download" />
+                <label for="show_swf_download">Show SWF download in context menu</label>
+            </div>
         </div>
         <script src="dist/options.js"></script>
     </body>

--- a/web/packages/extension/assets/popup.html
+++ b/web/packages/extension/assets/popup.html
@@ -31,6 +31,10 @@
                 <input type="checkbox" id="ignore_optout" />
                 <label for="ignore_optout">Ignore website compatibility warnings</label>
             </div>
+            <div class="option checkbox">
+                <input type="checkbox" id="show_swf_download" />
+                <label for="show_swf_download">Show SWF download in context menu</label>
+            </div>
         </div>
         <button id="options-button">Settings</button>
         <button id="reload-button" disabled>Reload</button>

--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -6,6 +6,7 @@ export interface Options {
     ignoreOptout: boolean;
     warnOnUnsupportedContent: boolean;
     logLevel: LogLevel;
+    showSwfDownload: boolean;
 }
 
 interface OptionElement<T> {

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -172,6 +172,7 @@ function isXMLDocument(): boolean {
         config: {
             warnOnUnsupportedContent: options.warnOnUnsupportedContent,
             logLevel: options.logLevel,
+            showSwfDownload: options.showSwfDownload,
         },
     });
 })();

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -28,11 +28,10 @@ window.addEventListener("DOMContentLoaded", async () => {
     player.setIsExtension(true);
     document.getElementById("main")!.append(player);
 
-    const { warnOnUnsupportedContent, logLevel } = await utils.getOptions();
+    const options = await utils.getOptions();
     const config = {
         letterbox: Letterbox.On,
-        warnOnUnsupportedContent,
-        logLevel,
+        ...options,
     };
     player.load({ url: swfUrl, base: swfUrl, ...config });
 });

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -6,6 +6,7 @@ const DEFAULT_OPTIONS: Options = {
     ignoreOptout: false,
     warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
+    showSwfDownload: false,
 };
 
 export let i18n: {


### PR DESCRIPTION
Self-hosted:

    window.RufflePlayer.config = {
        showSwfDownload: true,
        ...
    }

Extension:

Added toggle "Show SWF download in context menu". Wording up to debate.

By default, there is no download button. However, a download button appears when showSwfDownload is set to true or extension toggle is on.

Since I added this to the popup extension toggles and not just the settings page (like log level and unsupported content warnings), i18n messages are perhaps more important, so I'd appreciate i18n help (https://github.com/ruffle-rs/ruffle/tree/master/web/packages/extension/assets/_locales; settings_show_swf_download) from international contributors.

Intended to supersede #1889.