### PR TITLE
avm2: Add a basic ContextMenu stub

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -133,6 +133,8 @@ pub struct SystemPrototypes<'gc> {
     pub date: Object<'gc>,
     pub qname: Object<'gc>,
     pub sharedobject: Object<'gc>,
+    pub nativemenu: Object<'gc>,
+    pub contextmenu: Object<'gc>,
 }
 
 impl<'gc> SystemPrototypes<'gc> {
@@ -192,6 +194,8 @@ impl<'gc> SystemPrototypes<'gc> {
             date: empty,
             qname: empty,
             sharedobject: empty,
+            nativemenu: empty,
+            contextmenu: empty,
         }
     }
 }
@@ -241,6 +245,8 @@ pub struct SystemClasses<'gc> {
     pub date: ClassObject<'gc>,
     pub qname: ClassObject<'gc>,
     pub sharedobject: ClassObject<'gc>,
+    pub nativemenu: ClassObject<'gc>,
+    pub contextmenu: ClassObject<'gc>,
 }
 
 impl<'gc> SystemClasses<'gc> {
@@ -300,6 +306,8 @@ impl<'gc> SystemClasses<'gc> {
             date: object,
             qname: object,
             sharedobject: object,
+            nativemenu: object,
+            contextmenu: object,
         }
     }
 }
@@ -829,6 +837,12 @@ pub fn load_player_globals<'gc>(
         flash::display::pixelsnapping::create_class(mc),
         script,
     )?;
+    avm2_system_class!(
+        nativemenu,
+        activation,
+        flash::display::nativemenu::create_class(mc),
+        script
+    );
 
     // package `flash.geom`
     avm2_system_class!(
@@ -867,6 +881,14 @@ pub fn load_player_globals<'gc>(
         soundchannel,
         activation,
         flash::media::soundchannel::create_class(mc),
+        script
+    );
+
+    // package `flash.ui`
+    avm2_system_class!(
+        contextmenu,
+        activation,
+        flash::ui::contextmenu::create_class(mc),
         script
     );
 

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -8,4 +8,5 @@ pub mod media;
 pub mod net;
 pub mod system;
 pub mod text;
+pub mod ui;
 pub mod utils;

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -14,6 +14,7 @@ pub mod jointstyle;
 pub mod linescalemode;
 pub mod loaderinfo;
 pub mod movieclip;
+pub mod nativemenu;
 pub mod pixelsnapping;
 pub mod scene;
 pub mod shape;

--- a/core/src/avm2/globals/flash/display/interactiveobject.rs
+++ b/core/src/avm2/globals/flash/display/interactiveobject.rs
@@ -115,6 +115,44 @@ pub fn set_double_click_enabled<'gc>(
     Ok(Value::Undefined)
 }
 
+/// Implements `InteractiveObject.contextMenu`'s getter.
+fn context_menu<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(int) = this
+        .and_then(|t| t.as_display_object())
+        .and_then(|dobj| dobj.as_interactive())
+    {
+        return Ok(int.context_menu());
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Implements `InteractiveObject.contextMenu`'s setter.
+fn set_context_menu<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(int) = this
+        .and_then(|t| t.as_display_object())
+        .and_then(|dobj| dobj.as_interactive())
+    {
+        let cls = activation.avm2().classes().nativemenu;
+        let value = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_type(activation, cls)?;
+        int.set_context_menu(activation.context.gc_context, value);
+    }
+
+    Ok(Value::Undefined)
+}
+
 /// Construct `InteractiveObject`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
@@ -148,6 +186,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(double_click_enabled),
             Some(set_double_click_enabled),
         ),
+        ("contextMenu", Some(context_menu), Some(set_context_menu)),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/nativemenu.rs
+++ b/core/src/avm2/globals/flash/display/nativemenu.rs
@@ -1,0 +1,46 @@
+//! `flash.display.NativeMenu` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        activation.super_init(this, &[])?;
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `NativeMenu`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.display"), "NativeMenu"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init, "<NativeMenu instance initializer>", mc),
+        Method::from_builtin(class_init, "<NativeMenu class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+    write.set_attributes(ClassAttributes::SEALED);
+
+    class
+}

--- a/core/src/avm2/globals/flash/ui.rs
+++ b/core/src/avm2/globals/flash/ui.rs
@@ -1,0 +1,3 @@
+//! `flash.ui` namespace
+
+pub mod contextmenu;

--- a/core/src/avm2/globals/flash/ui/contextmenu.rs
+++ b/core/src/avm2/globals/flash/ui/contextmenu.rs
@@ -1,0 +1,80 @@
+//! `flash.ui.ContextMenu` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        log::warn!("flash.ui.ContextMenu is a stub");
+        activation.super_init(this, &[])?;
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+fn hide_built_in_items<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    // TODO: replace this by a proper implementation.
+    log::warn!("flash.ui.ContextMenu is a stub");
+    activation
+        .context
+        .stage
+        .set_show_menu(&mut activation.context, false);
+
+    Ok(Value::Undefined)
+}
+
+fn is_supported<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    // TODO: return true when replaced by proper implementation
+    Ok(false.into())
+}
+
+/// Construct `ContextMenu`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.ui"), "ContextMenu"),
+        Some(QName::new(Namespace::package("flash.display"), "NativeMenu").into()),
+        Method::from_builtin(instance_init, "<ContextMenu instance initializer>", mc),
+        Method::from_builtin(class_init, "<ContextMenu class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
+
+    const PUBLIC_CLASS_PROPERTIES: &[(&str, Option<NativeMethodImpl>, Option<NativeMethodImpl>)] =
+        &[("isSupported", Some(is_supported), None)];
+    write.define_public_builtin_class_properties(mc, PUBLIC_CLASS_PROPERTIES);
+
+    const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] =
+        &[("hideBuiltInItems", hide_built_in_items)];
+    write.define_public_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
+
+    class
+}

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -1,5 +1,6 @@
 //! Interactive object enumtrait
 
+use crate::avm2::Value;
 use crate::context::UpdateContext;
 use crate::display_object::avm1_button::Avm1Button;
 use crate::display_object::avm2_button::Avm2Button;
@@ -35,6 +36,7 @@ bitflags! {
 pub struct InteractiveObjectBase<'gc> {
     pub base: DisplayObjectBase<'gc>,
     flags: InteractiveObjectFlags,
+    context_menu: Value<'gc>,
 }
 
 impl<'gc> Default for InteractiveObjectBase<'gc> {
@@ -42,6 +44,7 @@ impl<'gc> Default for InteractiveObjectBase<'gc> {
         Self {
             base: Default::default(),
             flags: InteractiveObjectFlags::MOUSE_ENABLED,
+            context_menu: Value::Null,
         }
     }
 }
@@ -92,6 +95,14 @@ pub trait TInteractiveObject<'gc>:
         self.ibase_mut(mc)
             .flags
             .set(InteractiveObjectFlags::DOUBLE_CLICK_ENABLED, value)
+    }
+
+    fn context_menu(self) -> Value<'gc> {
+        self.ibase().context_menu
+    }
+
+    fn set_context_menu(self, mc: MutationContext<'gc, '_>, value: Value<'gc>) {
+        self.ibase_mut(mc).context_menu = value;
     }
 
     /// Filter the incoming clip event.


### PR DESCRIPTION
Just enough for this to work (which is what a lot of content ends up doing):
```
mc.contextMenu = new ContextMenu();
mc.contextMenu.hideBuiltInItems();
```