### PR TITLE
html: Small tweaks

### DIFF
--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -659,7 +659,7 @@ impl FormatSpans {
                         b"li" => {
                             format.bullet = Some(true);
                         }
-                        b"texformatormat" => {
+                        b"textformat" => {
                             //TODO: Spec says these are all in twips. That doesn't seem to
                             //match Flash 8.
                             if let Some(left_margin) = attribute(b"leftmargin") {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -585,15 +585,6 @@ impl FormatSpans {
                     };
                     let mut format = format_stack.last().unwrap().clone();
                     match &e.name().to_ascii_lowercase()[..] {
-                        b"br" | b"sbr" => {
-                            text.push('\n');
-                            if let Some(span) = spans.last_mut() {
-                                span.span_length += 1;
-                            }
-
-                            // Skip push to `format_stack`.
-                            continue;
-                        }
                         b"p" => match attribute(b"align").as_deref() {
                             Some(b"left") => format.align = Some(swf::TextAlign::Left),
                             Some(b"center") => format.align = Some(swf::TextAlign::Center),
@@ -707,10 +698,6 @@ impl FormatSpans {
                 }
                 Ok(Event::End(e)) => {
                     match &e.name().to_ascii_lowercase()[..] {
-                        b"br" | b"sbr" => {
-                            // Skip pop from `format_stack`.
-                            continue;
-                        }
                         b"p" | b"li" => {
                             text.push('\n');
                             if let Some(span) = spans.last_mut() {


### PR DESCRIPTION
* Fix a typo introduced in #5611 - `texformatormat` -> `texformat`.
* Remove handling of "br" and "sbr" tags - Seems like Flash just ignores them.