### PR TITLE
audio: Calculate sound transform values using 30-bit integers

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -580,21 +580,12 @@ impl From<display_object::SoundTransform> for SoundTransform {
     fn from(other: display_object::SoundTransform) -> Self {
         const SCALE: f32 = display_object::SoundTransform::MAX_VOLUME.pow(2) as f32;
 
-        // It seems like Flash stores sound transform values in 30-bit unsigned integers:
-        // * Negative values are equivalent to their absolute value.
-        // * Specifically, 0x40000000, -0x40000000 and -0x80000000 are equivalent to zero.
-        // * The volume multiplication wraps around at `u32::MAX`.
-        let left_to_left = (other.left_to_left << 2) >> 2;
-        let left_to_right = (other.left_to_right << 2) >> 2;
-        let right_to_left = (other.right_to_left << 2) >> 2;
-        let right_to_right = (other.right_to_right << 2) >> 2;
-        let volume = (other.volume << 2) >> 2;
-
+        // The volume multiplication wraps around at `u32::MAX`.
         Self {
-            left_to_left: left_to_left.wrapping_mul(volume) as f32 / SCALE,
-            left_to_right: left_to_right.wrapping_mul(volume) as f32 / SCALE,
-            right_to_left: right_to_left.wrapping_mul(volume) as f32 / SCALE,
-            right_to_right: right_to_right.wrapping_mul(volume) as f32 / SCALE,
+            left_to_left: other.left_to_left.wrapping_mul(other.volume) as f32 / SCALE,
+            left_to_right: other.left_to_right.wrapping_mul(other.volume) as f32 / SCALE,
+            right_to_left: other.right_to_left.wrapping_mul(other.volume) as f32 / SCALE,
+            right_to_right: other.right_to_right.wrapping_mul(other.volume) as f32 / SCALE,
         }
     }
 }


### PR DESCRIPTION
The fix in #5218 wasn't sufficient; 30-bit arithmetic should be used
along all the way when calculating an effective sound transform.

For example, a sound transform composited by volumes `-0x80000000` and
`25` should end up as effectively 0, whereas previously it would have
been calculated as `-0x80000000 * 25 / 100 = -0x20000000`, which is a
30-bit integer that hasn't been truncated.

Fixes #5655.