### PR TITLE
html: Fixes

### DIFF
--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -585,7 +585,7 @@ impl FormatSpans {
                     };
                     let mut format = format_stack.last().unwrap().clone();
                     match &e.name().to_ascii_lowercase()[..] {
-                        b"sbr" => {
+                        b"br" | b"sbr" => {
                             text.push('\n');
                             if let Some(span) = spans.last_mut() {
                                 span.span_length += 1;
@@ -707,7 +707,7 @@ impl FormatSpans {
                 }
                 Ok(Event::End(e)) => {
                     match &e.name().to_ascii_lowercase()[..] {
-                        b"sbr" => {
+                        b"br" | b"sbr" => {
                             // Skip pop from `format_stack`.
                             continue;
                         }

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -573,6 +573,15 @@ impl FormatSpans {
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
+                Ok(Event::Empty(ref e)) => match &e.name().to_ascii_lowercase()[..] {
+                    b"br" | b"sbr" => {
+                        text.push('\n');
+                        if let Some(span) = spans.last_mut() {
+                            span.span_length += 1;
+                        }
+                    }
+                    _ => {}
+                },
                 Ok(Event::Start(ref e)) => {
                     let attribute = move |name| {
                         e.attributes().with_checks(false).find_map(|attribute| {


### PR DESCRIPTION
* Restore handling of "br" tags - This fully reverts commit 2119ce9. Seems like Flash does handle "br" tags, but ignores them under some unknown circumstances (e.g. setting `htmlText` in AVM1). For now handle "br" tags unconditionally.
* Handle self-closing tags - "br" and "sbr" tags can appear in a self-closing form (i.e. `<br />`). Commit 3cab464026c02bd22ce5b7464604a786bd1c1ab5 forgot to handle this.

Fixes #5658.