### PR TITLE
canvas: Fill using the even-odd rule

### DIFF
--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -30,6 +30,7 @@ default-features = false
 [dependencies.web-sys]
 version = "0.3.50"
 features = [
-    "CanvasRenderingContext2d", "CssStyleDeclaration", "Document", "Element", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement",
-    "Navigator", "Node", "UiEvent", "Window", "Path2d", "CanvasGradient", "CanvasPattern", "SvgMatrix", "SvgsvgElement"
+    "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
+    "Document", "Element", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "Navigator", "Node", "Path2d",
+    "SvgMatrix", "SvgsvgElement", "UiEvent", "Window",
 ]


### PR DESCRIPTION
Flash always uses the even-odd fill rule, whereas canvas defaults to
nonzero.
Specify the fill rule explicitly in both `swf_shape_to_canvas_commands`
and `swf_shape_to_svg`.

Fixes the text issue in #5616.