### PR TITLE
avm2: minor perf-oriented refactors/simplifications

### DIFF
--- a/core/src/avm2/names.rs
+++ b/core/src/avm2/names.rs
@@ -139,12 +139,21 @@ impl<'gc> Namespace<'gc> {
 /// `QName`. All other forms of names and multinames are either versions of
 /// `QName` with unspecified parameters, or multiple names to be checked in
 /// order.
-#[derive(Clone, Collect, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Collect, Debug, Hash)]
 #[collect(no_drop)]
 pub struct QName<'gc> {
     ns: Namespace<'gc>,
     name: AvmString<'gc>,
 }
+
+impl<'gc> PartialEq for QName<'gc> {
+    fn eq(&self, other: &Self) -> bool {
+        // Implemented by hand to enforce order of comparisons for perf
+        self.name == other.name && self.ns == other.ns
+    }
+}
+
+impl<'gc> Eq for QName<'gc> {}
 
 impl<'gc> QName<'gc> {
     pub fn new(ns: Namespace<'gc>, name: impl Into<AvmString<'gc>>) -> Self {

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -212,10 +212,9 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             }
         }
 
-        let has_no_getter =
-            self.has_own_virtual_setter(&name) && !self.has_own_virtual_getter(&name);
+        let is_set_only = self.base().has_own_virtual_set_only_property(&name);
 
-        if self.has_own_property(&name)? && !has_no_getter {
+        if self.has_own_property(&name)? && !is_set_only {
             return self.get_property_local(receiver, &name, activation);
         }
 
@@ -655,22 +654,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         let base = self.base();
 
         base.has_trait(name)
-    }
-
-    /// Check if a particular object contains a virtual getter by the given
-    /// name.
-    fn has_own_virtual_getter(self, name: &QName<'gc>) -> bool {
-        let base = self.base();
-
-        base.has_own_virtual_getter(name)
-    }
-
-    /// Check if a particular object contains a virtual setter by the given
-    /// name.
-    fn has_own_virtual_setter(self, name: &QName<'gc>) -> bool {
-        let base = self.base();
-
-        base.has_own_virtual_setter(name)
     }
 
     /// Indicates whether or not a property is overwritable.

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -363,17 +363,14 @@ impl<'gc> ScriptObjectData<'gc> {
         self.values.get(name).is_some()
     }
 
-    pub fn has_own_virtual_getter(&self, name: &QName<'gc>) -> bool {
+    pub fn has_own_virtual_set_only_property(&self, name: &QName<'gc>) -> bool {
         matches!(
             self.values.get(name),
-            Some(Property::Virtual { get: Some(_), .. })
-        )
-    }
-
-    pub fn has_own_virtual_setter(&self, name: &QName<'gc>) -> bool {
-        matches!(
-            self.values.get(name),
-            Some(Property::Virtual { set: Some(_), .. })
+            Some(Property::Virtual {
+                get: None,
+                set: Some(_),
+                ..
+            })
         )
     }
 


### PR DESCRIPTION
First commit simplifies `do_trait_lookup` to fit better the use cases it currently does. Validation was already handled by `validate_class()` too.
(Ideally, `do_trait_lookup` in its current form shouldn't exist, as non-initialization code should either pull instantiated traits (once _these_ are refactored :D ), or not need to do so at all (like `instance_method()` - by the time we call it, we should already have access to the unbound method trait in the caller))

Second simply merges two calls, to reduce number of hashmap lookups from in `get_property` "around 5-6" to "around 4-5" :) 

Third assumes that we should usually compare names before comparing namespaces.