### PR TITLE
web: remove firefox extension version restriction

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -23,7 +23,6 @@ function transformManifest(content, env) {
         manifest.browser_specific_settings = {
             gecko: {
                 id: process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs",
-                strict_min_version: "91.1.0",
             },
         };
     } else {


### PR DESCRIPTION
Fixes #5699.

It was hoped that adding this restriction would let the extension be reviewed sooner, but this didn't happen. Remove it so that people who want to use older versions can still use the extension.