### PR TITLE
web: allow entering fullscreen after using escape to exit

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -223,7 +223,7 @@ export class RufflePlayer extends HTMLElement {
         );
         this.addEventListener(
             "webkitfullscreenchange",
-            this.webKitFullScreenChange.bind(this)
+            this.fullScreenChange.bind(this)
         );
         window.addEventListener("click", this.hideContextMenu.bind(this));
 
@@ -686,23 +686,10 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
-     * Called when entering / leaving fullscreen on non-Safari
+     * Called when entering / leaving fullscreen
      */
     private fullScreenChange(): void {
-        // check if we have just stopped being full screen
-        if (document.fullscreenElement === null) {
-            this.instance?.set_fullscreen(false);
-        }
-    }
-
-    /**
-     * Called when entering / leaving fullscreen on Safari
-     */
-    private webKitFullScreenChange(): void {
-        // check if we have just stopped being full screen
-        if (document.webkitFullscreenElement === null) {
-            this.instance?.set_fullscreen(false);
-        }
+        this.instance?.set_fullscreen(Boolean(document.fullscreenElement || document.webkitFullscreenElement));
     }
 
     private pointerDown(event: PointerEvent): void {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -221,6 +221,10 @@ export class RufflePlayer extends HTMLElement {
             "fullscreenchange",
             this.fullScreenChange.bind(this)
         );
+        this.addEventListener(
+            "webkitfullscreenchange",
+            this.webKitFullScreenChange.bind(this)
+        );
         window.addEventListener("click", this.hideContextMenu.bind(this));
 
         this.instance = null;
@@ -682,12 +686,21 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
-     * Tell Ruffle that the player is no longer fullscreen.
+     * Called when entering / leaving fullscreen on non-Safari
      */
     private fullScreenChange(): void {
-        // if we have just stopped being full screen, e.g. because escape was
-        // pressed (which isn't normally caught)
+        // check if we have just stopped being full screen
         if (document.fullscreenElement === null) {
+            this.instance?.set_fullscreen(false);
+        }
+    }
+
+    /**
+     * Called when entering / leaving fullscreen on Safari
+     */
+    private webKitFullScreenChange(): void {
+        // check if we have just stopped being full screen
+        if (document.webkitFullscreenElement === null) {
             this.instance?.set_fullscreen(false);
         }
     }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -217,6 +217,7 @@ export class RufflePlayer extends HTMLElement {
         this.contextMenuElement = this.shadow.getElementById("context-menu")!;
         this.addEventListener("contextmenu", this.showContextMenu.bind(this));
         this.addEventListener("pointerdown", this.pointerDown.bind(this));
+        this.addEventListener("fullscreenchange", this.fullScreenChange.bind(this));
         window.addEventListener("click", this.hideContextMenu.bind(this));
 
         this.instance = null;
@@ -675,6 +676,17 @@ export class RufflePlayer extends HTMLElement {
         } else if (document.webkitCancelFullScreen) {
             document.webkitCancelFullScreen();
         }
+    }
+
+    /**
+     * Tell Ruffle that the player is no longer fullscreen.
+     */
+    private fullScreenChange(): void {
+      // if we have just stopped being full screen, e.g. because escape was
+      // pressed (which isn't normally caught)
+      if (document.fullscreenElement === null) {
+        this.instance?.set_fullscreen(false)
+      }
     }
 
     private pointerDown(event: PointerEvent): void {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -689,7 +689,11 @@ export class RufflePlayer extends HTMLElement {
      * Called when entering / leaving fullscreen
      */
     private fullScreenChange(): void {
-        this.instance?.set_fullscreen(Boolean(document.fullscreenElement || document.webkitFullscreenElement));
+        this.instance?.set_fullscreen(
+            Boolean(
+                document.fullscreenElement || document.webkitFullscreenElement
+            )
+        );
     }
 
     private pointerDown(event: PointerEvent): void {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -217,7 +217,10 @@ export class RufflePlayer extends HTMLElement {
         this.contextMenuElement = this.shadow.getElementById("context-menu")!;
         this.addEventListener("contextmenu", this.showContextMenu.bind(this));
         this.addEventListener("pointerdown", this.pointerDown.bind(this));
-        this.addEventListener("fullscreenchange", this.fullScreenChange.bind(this));
+        this.addEventListener(
+            "fullscreenchange",
+            this.fullScreenChange.bind(this)
+        );
         window.addEventListener("click", this.hideContextMenu.bind(this));
 
         this.instance = null;
@@ -682,11 +685,11 @@ export class RufflePlayer extends HTMLElement {
      * Tell Ruffle that the player is no longer fullscreen.
      */
     private fullScreenChange(): void {
-      // if we have just stopped being full screen, e.g. because escape was
-      // pressed (which isn't normally caught)
-      if (document.fullscreenElement === null) {
-        this.instance?.set_fullscreen(false)
-      }
+        // if we have just stopped being full screen, e.g. because escape was
+        // pressed (which isn't normally caught)
+        if (document.fullscreenElement === null) {
+            this.instance?.set_fullscreen(false);
+        }
     }
 
     private pointerDown(event: PointerEvent): void {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -689,11 +689,7 @@ export class RufflePlayer extends HTMLElement {
      * Called when entering / leaving fullscreen
      */
     private fullScreenChange(): void {
-        this.instance?.set_fullscreen(
-            Boolean(
-                document.fullscreenElement || document.webkitFullscreenElement
-            )
-        );
+        this.instance?.set_fullscreen(this.isFullscreen);
     }
 
     private pointerDown(event: PointerEvent): void {


### PR DESCRIPTION
Fixes #5698.

Ruffle does a React-style property check using the State to determine whether it's full screen or not, and using escape (or a manual `document.exitFullscreen()`) can cause that to go out of sync with reality, and the fix here is to listen to the `fullscreenchange` event and set Ruffle's fullscreen setting accordingly if it's exiting full screen.