### PR TITLE
build: Use the 'union' SmallVec feature for minor memory savings

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ png = { version = "0.17.2" }
 ruffle_macros = { path = "macros" }
 swf = { path = "../swf" }
 bitflags = "1.3.2"
-smallvec = "1.7.0"
+smallvec = { version = "1.7.0", features = ["union"] }
 num-traits = "0.2"
 num-derive = "0.3"
 quick-xml = { git = "https://github.com/ruffle-rs/quick-xml", rev = "8496365ec1412eb5ba5de350937b6bce352fa0ba" }


### PR DESCRIPTION
(AFAIK the only reason it's not a default is compatibility with older rustc.)