### PR TITLE
core: Introduce `InputManager`

### DIFF
--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -41,7 +41,7 @@ pub fn is_down<'gc>(
             .unwrap_or(&Value::Undefined)
             .coerce_to_i32(activation)? as u8,
     ) {
-        Ok(activation.context.ui.is_key_down(key).into())
+        Ok(activation.context.input.is_key_down(key).into())
     } else {
         Ok(false.into())
     }
@@ -52,7 +52,7 @@ pub fn get_ascii<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let ord = activation.context.ui.last_key_char().unwrap_or_default() as u32;
+    let ord = activation.context.input.last_key_char().unwrap_or_default() as u32;
     Ok(ord.into())
 }
 
@@ -61,7 +61,7 @@ pub fn get_code<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let code = activation.context.ui.last_key_code() as u8;
+    let code = activation.context.input.last_key_code() as u8;
     Ok(code.into())
 }
 

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -607,6 +607,7 @@ mod tests {
                 video: &mut NullVideoBackend::new(),
                 mouse_over_object: None,
                 mouse_down_object: None,
+                input: &Default::default(),
                 mouse_position: &(Twips::ZERO, Twips::ZERO),
                 drag_object: &mut None,
                 player: None,

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -60,6 +60,7 @@ where
             video: &mut NullVideoBackend::new(),
             mouse_over_object: None,
             mouse_down_object: None,
+            input: &Default::default(),
             mouse_position: &(Twips::ZERO, Twips::ZERO),
             drag_object: &mut None,
             player: None,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -12,7 +12,7 @@ use crate::backend::{
     navigator::NavigatorBackend,
     render::RenderBackend,
     storage::StorageBackend,
-    ui::UiBackend,
+    ui::{InputManager, UiBackend},
     video::VideoBackend,
 };
 use crate::context_menu::ContextMenuState;
@@ -100,6 +100,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// If the mouse is down, the display object that the mouse is currently pressing.
     pub mouse_down_object: Option<DisplayObject<'gc>>,
+
+    /// The input manager, tracking keys state.
+    pub input: &'a InputManager,
 
     /// The location of the mouse when it was last over the player.
     pub mouse_position: &'a (Twips, Twips),
@@ -297,6 +300,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             stage: self.stage,
             mouse_over_object: self.mouse_over_object,
             mouse_down_object: self.mouse_down_object,
+            input: self.input,
             mouse_position: self.mouse_position,
             drag_object: self.drag_object,
             player: self.player.clone(),

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1344,14 +1344,14 @@ impl<'gc> EditText<'gc> {
                 let length = text.len();
                 match key_code {
                     ButtonKeyCode::Left => {
-                        if (context.ui.is_key_down(KeyCode::Shift) || selection.is_caret())
+                        if (context.input.is_key_down(KeyCode::Shift) || selection.is_caret())
                             && selection.to > 0
                         {
                             selection.to = string_utils::prev_char_boundary(text, selection.to);
-                            if !context.ui.is_key_down(KeyCode::Shift) {
+                            if !context.input.is_key_down(KeyCode::Shift) {
                                 selection.from = selection.to;
                             }
-                        } else if !context.ui.is_key_down(KeyCode::Shift) {
+                        } else if !context.input.is_key_down(KeyCode::Shift) {
                             selection.to = selection.start();
                             selection.from = selection.to;
                         }
@@ -1360,14 +1360,14 @@ impl<'gc> EditText<'gc> {
                         return ClipEventResult::Handled;
                     }
                     ButtonKeyCode::Right => {
-                        if (context.ui.is_key_down(KeyCode::Shift) || selection.is_caret())
+                        if (context.input.is_key_down(KeyCode::Shift) || selection.is_caret())
                             && selection.to < length
                         {
                             selection.to = string_utils::next_char_boundary(text, selection.to);
-                            if !context.ui.is_key_down(KeyCode::Shift) {
+                            if !context.input.is_key_down(KeyCode::Shift) {
                                 selection.from = selection.to;
                             }
-                        } else if !context.ui.is_key_down(KeyCode::Shift) {
+                        } else if !context.input.is_key_down(KeyCode::Shift) {
                             selection.to = selection.end();
                             selection.from = selection.to;
                         }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -2,14 +2,33 @@ use swf::ClipEventFlag;
 
 #[derive(Debug)]
 pub enum PlayerEvent {
-    KeyDown { key_code: KeyCode },
-    KeyUp { key_code: KeyCode },
-    MouseMove { x: f64, y: f64 },
-    MouseUp { x: f64, y: f64 },
-    MouseDown { x: f64, y: f64 },
+    KeyDown {
+        key_code: KeyCode,
+        key_char: Option<char>,
+    },
+    KeyUp {
+        key_code: KeyCode,
+        key_char: Option<char>,
+    },
+    MouseMove {
+        x: f64,
+        y: f64,
+    },
+    MouseUp {
+        x: f64,
+        y: f64,
+    },
+    MouseDown {
+        x: f64,
+        y: f64,
+    },
     MouseLeft,
-    MouseWheel { delta: MouseWheelDelta },
-    TextInput { codepoint: char },
+    MouseWheel {
+        delta: MouseWheelDelta,
+    },
+    TextInput {
+        codepoint: char,
+    },
 }
 
 /// The distance scrolled by the mouse wheel.

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -28,22 +28,23 @@ use ruffle_core::{
         video,
     },
     config::Letterbox,
-    Player, StageDisplayState,
+    events::KeyCode,
+    tag_utils::SwfMovie,
+    Player, PlayerEvent, StageDisplayState,
 };
+use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use ruffle_render_wgpu::WgpuRenderBackend;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tinyfiledialogs::open_file_dialog;
 use url::Url;
-
-use ruffle_core::tag_utils::SwfMovie;
-use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
-use std::io::Read;
-use std::rc::Rc;
 use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Size};
 use winit::event::{
-    ElementState, KeyboardInput, MouseButton, MouseScrollDelta, VirtualKeyCode, WindowEvent,
+    ElementState, KeyboardInput, ModifiersState, MouseButton, MouseScrollDelta, VirtualKeyCode,
+    WindowEvent,
 };
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::{Icon, Window, WindowBuilder};
@@ -389,6 +390,8 @@ impl App {
                         return;
                     }
 
+                    // Allow KeyboardInput.modifiers (ModifiersChanged event not functional yet).
+                    #[allow(deprecated)]
                     match event {
                         // Core loop
                         winit::event::Event::MainEventsCleared => {
@@ -433,7 +436,7 @@ impl App {
                             WindowEvent::CursorMoved { position, .. } => {
                                 let mut player_lock = player.lock().unwrap();
                                 mouse_pos = position;
-                                let event = ruffle_core::PlayerEvent::MouseMove {
+                                let event = PlayerEvent::MouseMove {
                                     x: position.x,
                                     y: position.y,
                                 };
@@ -449,11 +452,11 @@ impl App {
                             } => {
                                 let mut player_lock = player.lock().unwrap();
                                 let event = match state {
-                                    ElementState::Pressed => ruffle_core::PlayerEvent::MouseDown {
+                                    ElementState::Pressed => PlayerEvent::MouseDown {
                                         x: mouse_pos.x,
                                         y: mouse_pos.y,
                                     },
-                                    ElementState::Released => ruffle_core::PlayerEvent::MouseUp {
+                                    ElementState::Released => PlayerEvent::MouseUp {
                                         x: mouse_pos.x,
                                         y: mouse_pos.y,
                                     },
@@ -474,7 +477,7 @@ impl App {
                                         MouseWheelDelta::Pixels(pos.y)
                                     }
                                 };
-                                let event = ruffle_core::PlayerEvent::MouseWheel { delta };
+                                let event = PlayerEvent::MouseWheel { delta };
                                 player_lock.handle_event(event);
                                 if player_lock.needs_render() {
                                     window.request_redraw();
@@ -482,19 +485,27 @@ impl App {
                             }
                             WindowEvent::CursorLeft { .. } => {
                                 let mut player_lock = player.lock().unwrap();
-                                player_lock.handle_event(ruffle_core::PlayerEvent::MouseLeft);
+                                player_lock.handle_event(PlayerEvent::MouseLeft);
                                 if player_lock.needs_render() {
                                     window.request_redraw();
                                 }
                             }
-                            WindowEvent::KeyboardInput { .. } => {
+                            WindowEvent::KeyboardInput { input, .. } => {
                                 let mut player_lock = player.lock().unwrap();
-                                if let Some(event) = player_lock
-                                    .ui_mut()
-                                    .downcast_mut::<ui::DesktopUiBackend>()
-                                    .unwrap()
-                                    .handle_event(event)
-                                {
+                                if let Some(key) = input.virtual_keycode {
+                                    let key_code = winit_to_ruffle_key_code(key);
+                                    let key_char = winit_key_to_char(
+                                        key,
+                                        input.modifiers.contains(ModifiersState::SHIFT),
+                                    );
+                                    let event = match input.state {
+                                        ElementState::Pressed => {
+                                            PlayerEvent::KeyDown { key_code, key_char }
+                                        }
+                                        ElementState::Released => {
+                                            PlayerEvent::KeyUp { key_code, key_char }
+                                        }
+                                    };
                                     player_lock.handle_event(event);
                                     if player_lock.needs_render() {
                                         window.request_redraw();
@@ -503,7 +514,7 @@ impl App {
                             }
                             WindowEvent::ReceivedCharacter(codepoint) => {
                                 let mut player_lock = player.lock().unwrap();
-                                let event = ruffle_core::PlayerEvent::TextInput { codepoint };
+                                let event = PlayerEvent::TextInput { codepoint };
                                 player_lock.handle_event(event);
                                 if player_lock.needs_render() {
                                     window.request_redraw();
@@ -525,6 +536,224 @@ impl App {
                 });
         }
     }
+}
+
+/// Convert a winit `VirtualKeyCode` into a Ruffle `KeyCode`.
+/// Return `KeyCode::Unknown` if there is no matching Flash key code.
+fn winit_to_ruffle_key_code(key_code: VirtualKeyCode) -> KeyCode {
+    match key_code {
+        VirtualKeyCode::Back => KeyCode::Backspace,
+        VirtualKeyCode::Tab => KeyCode::Tab,
+        VirtualKeyCode::Return => KeyCode::Return,
+        VirtualKeyCode::LShift | VirtualKeyCode::RShift => KeyCode::Shift,
+        VirtualKeyCode::LControl | VirtualKeyCode::RControl => KeyCode::Control,
+        VirtualKeyCode::LAlt | VirtualKeyCode::RAlt => KeyCode::Alt,
+        VirtualKeyCode::Capital => KeyCode::CapsLock,
+        VirtualKeyCode::Escape => KeyCode::Escape,
+        VirtualKeyCode::Space => KeyCode::Space,
+        VirtualKeyCode::Key0 => KeyCode::Key0,
+        VirtualKeyCode::Key1 => KeyCode::Key1,
+        VirtualKeyCode::Key2 => KeyCode::Key2,
+        VirtualKeyCode::Key3 => KeyCode::Key3,
+        VirtualKeyCode::Key4 => KeyCode::Key4,
+        VirtualKeyCode::Key5 => KeyCode::Key5,
+        VirtualKeyCode::Key6 => KeyCode::Key6,
+        VirtualKeyCode::Key7 => KeyCode::Key7,
+        VirtualKeyCode::Key8 => KeyCode::Key8,
+        VirtualKeyCode::Key9 => KeyCode::Key9,
+        VirtualKeyCode::A => KeyCode::A,
+        VirtualKeyCode::B => KeyCode::B,
+        VirtualKeyCode::C => KeyCode::C,
+        VirtualKeyCode::D => KeyCode::D,
+        VirtualKeyCode::E => KeyCode::E,
+        VirtualKeyCode::F => KeyCode::F,
+        VirtualKeyCode::G => KeyCode::G,
+        VirtualKeyCode::H => KeyCode::H,
+        VirtualKeyCode::I => KeyCode::I,
+        VirtualKeyCode::J => KeyCode::J,
+        VirtualKeyCode::K => KeyCode::K,
+        VirtualKeyCode::L => KeyCode::L,
+        VirtualKeyCode::M => KeyCode::M,
+        VirtualKeyCode::N => KeyCode::N,
+        VirtualKeyCode::O => KeyCode::O,
+        VirtualKeyCode::P => KeyCode::P,
+        VirtualKeyCode::Q => KeyCode::Q,
+        VirtualKeyCode::R => KeyCode::R,
+        VirtualKeyCode::S => KeyCode::S,
+        VirtualKeyCode::T => KeyCode::T,
+        VirtualKeyCode::U => KeyCode::U,
+        VirtualKeyCode::V => KeyCode::V,
+        VirtualKeyCode::W => KeyCode::W,
+        VirtualKeyCode::X => KeyCode::X,
+        VirtualKeyCode::Y => KeyCode::Y,
+        VirtualKeyCode::Z => KeyCode::Z,
+        VirtualKeyCode::Semicolon => KeyCode::Semicolon,
+        VirtualKeyCode::Equals => KeyCode::Equals,
+        VirtualKeyCode::Comma => KeyCode::Comma,
+        VirtualKeyCode::Minus => KeyCode::Minus,
+        VirtualKeyCode::Period => KeyCode::Period,
+        VirtualKeyCode::Slash => KeyCode::Slash,
+        VirtualKeyCode::Grave => KeyCode::Grave,
+        VirtualKeyCode::LBracket => KeyCode::LBracket,
+        VirtualKeyCode::Backslash => KeyCode::Backslash,
+        VirtualKeyCode::RBracket => KeyCode::RBracket,
+        VirtualKeyCode::Apostrophe => KeyCode::Apostrophe,
+        VirtualKeyCode::Numpad0 => KeyCode::Numpad0,
+        VirtualKeyCode::Numpad1 => KeyCode::Numpad1,
+        VirtualKeyCode::Numpad2 => KeyCode::Numpad2,
+        VirtualKeyCode::Numpad3 => KeyCode::Numpad3,
+        VirtualKeyCode::Numpad4 => KeyCode::Numpad4,
+        VirtualKeyCode::Numpad5 => KeyCode::Numpad5,
+        VirtualKeyCode::Numpad6 => KeyCode::Numpad6,
+        VirtualKeyCode::Numpad7 => KeyCode::Numpad7,
+        VirtualKeyCode::Numpad8 => KeyCode::Numpad8,
+        VirtualKeyCode::Numpad9 => KeyCode::Numpad9,
+        VirtualKeyCode::NumpadMultiply => KeyCode::Multiply,
+        VirtualKeyCode::NumpadAdd => KeyCode::Plus,
+        VirtualKeyCode::NumpadSubtract => KeyCode::NumpadMinus,
+        VirtualKeyCode::NumpadDecimal => KeyCode::NumpadPeriod,
+        VirtualKeyCode::NumpadDivide => KeyCode::NumpadSlash,
+        VirtualKeyCode::PageUp => KeyCode::PgUp,
+        VirtualKeyCode::PageDown => KeyCode::PgDown,
+        VirtualKeyCode::End => KeyCode::End,
+        VirtualKeyCode::Home => KeyCode::Home,
+        VirtualKeyCode::Left => KeyCode::Left,
+        VirtualKeyCode::Up => KeyCode::Up,
+        VirtualKeyCode::Right => KeyCode::Right,
+        VirtualKeyCode::Down => KeyCode::Down,
+        VirtualKeyCode::Insert => KeyCode::Insert,
+        VirtualKeyCode::Delete => KeyCode::Delete,
+        VirtualKeyCode::Pause => KeyCode::Pause,
+        VirtualKeyCode::Scroll => KeyCode::ScrollLock,
+        VirtualKeyCode::F1 => KeyCode::F1,
+        VirtualKeyCode::F2 => KeyCode::F2,
+        VirtualKeyCode::F3 => KeyCode::F3,
+        VirtualKeyCode::F4 => KeyCode::F4,
+        VirtualKeyCode::F5 => KeyCode::F5,
+        VirtualKeyCode::F6 => KeyCode::F6,
+        VirtualKeyCode::F7 => KeyCode::F7,
+        VirtualKeyCode::F8 => KeyCode::F8,
+        VirtualKeyCode::F9 => KeyCode::F9,
+        VirtualKeyCode::F10 => KeyCode::F10,
+        VirtualKeyCode::F11 => KeyCode::F11,
+        VirtualKeyCode::F12 => KeyCode::F12,
+        _ => KeyCode::Unknown,
+    }
+}
+
+/// Return a character for the given key code and shift state.
+fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<char> {
+    // We need to know the character that a keypress outputs for both key down and key up events,
+    // but the winit keyboard API does not provide a way to do this (winit/#753).
+    // CharacterReceived events are insufficent because they only fire on key down, not on key up.
+    // This is a half-measure to map from keyboard keys back to a character, but does will not work fully
+    // for international layouts.
+    Some(match (key_code, is_shift_down) {
+        (VirtualKeyCode::Space, _) => ' ',
+        (VirtualKeyCode::Key0, _) => '0',
+        (VirtualKeyCode::Key1, _) => '1',
+        (VirtualKeyCode::Key2, _) => '2',
+        (VirtualKeyCode::Key3, _) => '3',
+        (VirtualKeyCode::Key4, _) => '4',
+        (VirtualKeyCode::Key5, _) => '5',
+        (VirtualKeyCode::Key6, _) => '6',
+        (VirtualKeyCode::Key7, _) => '7',
+        (VirtualKeyCode::Key8, _) => '8',
+        (VirtualKeyCode::Key9, _) => '9',
+        (VirtualKeyCode::A, false) => 'a',
+        (VirtualKeyCode::A, true) => 'A',
+        (VirtualKeyCode::B, false) => 'b',
+        (VirtualKeyCode::B, true) => 'B',
+        (VirtualKeyCode::C, false) => 'c',
+        (VirtualKeyCode::C, true) => 'C',
+        (VirtualKeyCode::D, false) => 'd',
+        (VirtualKeyCode::D, true) => 'D',
+        (VirtualKeyCode::E, false) => 'e',
+        (VirtualKeyCode::E, true) => 'E',
+        (VirtualKeyCode::F, false) => 'f',
+        (VirtualKeyCode::F, true) => 'F',
+        (VirtualKeyCode::G, false) => 'g',
+        (VirtualKeyCode::G, true) => 'G',
+        (VirtualKeyCode::H, false) => 'h',
+        (VirtualKeyCode::H, true) => 'H',
+        (VirtualKeyCode::I, false) => 'i',
+        (VirtualKeyCode::I, true) => 'I',
+        (VirtualKeyCode::J, false) => 'j',
+        (VirtualKeyCode::J, true) => 'J',
+        (VirtualKeyCode::K, false) => 'k',
+        (VirtualKeyCode::K, true) => 'K',
+        (VirtualKeyCode::L, false) => 'l',
+        (VirtualKeyCode::L, true) => 'L',
+        (VirtualKeyCode::M, false) => 'm',
+        (VirtualKeyCode::M, true) => 'M',
+        (VirtualKeyCode::N, false) => 'n',
+        (VirtualKeyCode::N, true) => 'N',
+        (VirtualKeyCode::O, false) => 'o',
+        (VirtualKeyCode::O, true) => 'O',
+        (VirtualKeyCode::P, false) => 'p',
+        (VirtualKeyCode::P, true) => 'P',
+        (VirtualKeyCode::Q, false) => 'q',
+        (VirtualKeyCode::Q, true) => 'Q',
+        (VirtualKeyCode::R, false) => 'r',
+        (VirtualKeyCode::R, true) => 'R',
+        (VirtualKeyCode::S, false) => 's',
+        (VirtualKeyCode::S, true) => 'S',
+        (VirtualKeyCode::T, false) => 't',
+        (VirtualKeyCode::T, true) => 'T',
+        (VirtualKeyCode::U, false) => 'u',
+        (VirtualKeyCode::U, true) => 'U',
+        (VirtualKeyCode::V, false) => 'v',
+        (VirtualKeyCode::V, true) => 'V',
+        (VirtualKeyCode::W, false) => 'w',
+        (VirtualKeyCode::W, true) => 'W',
+        (VirtualKeyCode::X, false) => 'x',
+        (VirtualKeyCode::X, true) => 'X',
+        (VirtualKeyCode::Y, false) => 'y',
+        (VirtualKeyCode::Y, true) => 'Y',
+        (VirtualKeyCode::Z, false) => 'z',
+        (VirtualKeyCode::Z, true) => 'Z',
+
+        (VirtualKeyCode::Semicolon, false) => ';',
+        (VirtualKeyCode::Semicolon, true) => ':',
+        (VirtualKeyCode::Equals, false) => '=',
+        (VirtualKeyCode::Equals, true) => '+',
+        (VirtualKeyCode::Comma, false) => ',',
+        (VirtualKeyCode::Comma, true) => '<',
+        (VirtualKeyCode::Minus, false) => '-',
+        (VirtualKeyCode::Minus, true) => '_',
+        (VirtualKeyCode::Period, false) => '.',
+        (VirtualKeyCode::Period, true) => '>',
+        (VirtualKeyCode::Slash, false) => '/',
+        (VirtualKeyCode::Slash, true) => '?',
+        (VirtualKeyCode::Grave, false) => '`',
+        (VirtualKeyCode::Grave, true) => '~',
+        (VirtualKeyCode::LBracket, false) => '[',
+        (VirtualKeyCode::LBracket, true) => '{',
+        (VirtualKeyCode::Backslash, false) => '\\',
+        (VirtualKeyCode::Backslash, true) => '|',
+        (VirtualKeyCode::RBracket, false) => ']',
+        (VirtualKeyCode::RBracket, true) => '}',
+        (VirtualKeyCode::Apostrophe, false) => '\'',
+        (VirtualKeyCode::Apostrophe, true) => '"',
+        (VirtualKeyCode::NumpadMultiply, _) => '*',
+        (VirtualKeyCode::NumpadAdd, _) => '+',
+        (VirtualKeyCode::NumpadSubtract, _) => '-',
+        (VirtualKeyCode::NumpadDecimal, _) => '.',
+        (VirtualKeyCode::NumpadDivide, _) => '/',
+
+        (VirtualKeyCode::Numpad0, false) => '0',
+        (VirtualKeyCode::Numpad1, false) => '1',
+        (VirtualKeyCode::Numpad2, false) => '2',
+        (VirtualKeyCode::Numpad3, false) => '3',
+        (VirtualKeyCode::Numpad4, false) => '4',
+        (VirtualKeyCode::Numpad5, false) => '5',
+        (VirtualKeyCode::Numpad6, false) => '6',
+        (VirtualKeyCode::Numpad7, false) => '7',
+        (VirtualKeyCode::Numpad8, false) => '8',
+        (VirtualKeyCode::Numpad9, false) => '9',
+
+        _ => return None,
+    })
 }
 
 fn run_timedemo(opt: Opt) -> Result<(), Box<dyn std::error::Error>> {

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -1,18 +1,12 @@
 use clipboard::{ClipboardContext, ClipboardProvider};
 use ruffle_core::backend::ui::{Error, MouseCursor, UiBackend};
-use ruffle_core::events::{KeyCode, PlayerEvent};
-use std::collections::HashSet;
 use std::rc::Rc;
 use tinyfiledialogs::{message_box_ok, MessageBoxIcon};
-use winit::event::{ElementState, ModifiersState, VirtualKeyCode, WindowEvent};
 use winit::window::{Fullscreen, Window};
 
 pub struct DesktopUiBackend {
     window: Rc<Window>,
-    keys_down: HashSet<KeyCode>,
     cursor_visible: bool,
-    last_key: KeyCode,
-    last_char: Option<char>,
     clipboard: ClipboardContext,
 }
 
@@ -20,41 +14,9 @@ impl DesktopUiBackend {
     pub fn new(window: Rc<Window>) -> Self {
         Self {
             window,
-            keys_down: HashSet::new(),
             cursor_visible: true,
-            last_key: KeyCode::Unknown,
-            last_char: None,
             clipboard: ClipboardProvider::new().unwrap(),
         }
-    }
-
-    /// Process an input event, and return an event that should be forward to the player, if any.
-    pub fn handle_event(&mut self, event: WindowEvent) -> Option<PlayerEvent> {
-        // Allow KeyboardInput.modifiers (ModifiersChanged event not functional yet).
-        #[allow(deprecated)]
-        if let WindowEvent::KeyboardInput { input, .. } = event {
-            if let Some(key) = input.virtual_keycode {
-                let key_code = winit_to_ruffle_key_code(key);
-                self.last_key = key_code;
-                self.last_char =
-                    winit_key_to_char(key, input.modifiers.contains(ModifiersState::SHIFT));
-                match input.state {
-                    ElementState::Pressed => {
-                        self.keys_down.insert(key_code);
-                    }
-                    ElementState::Released => {
-                        self.keys_down.remove(&key_code);
-                    }
-                }
-                if key_code != KeyCode::Unknown {
-                    return Some(match input.state {
-                        ElementState::Pressed => PlayerEvent::KeyDown { key_code },
-                        ElementState::Released => PlayerEvent::KeyUp { key_code },
-                    });
-                }
-            }
-        }
-        None
     }
 }
 
@@ -68,18 +30,6 @@ https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users";
 const DOWNLOAD_FAILED_MESSAGE: &str = "Ruffle failed to open or download this file.";
 
 impl UiBackend for DesktopUiBackend {
-    fn is_key_down(&self, key: KeyCode) -> bool {
-        self.keys_down.contains(&key)
-    }
-
-    fn last_key_code(&self) -> KeyCode {
-        self.last_key
-    }
-
-    fn last_key_char(&self) -> Option<char> {
-        self.last_char
-    }
-
     fn mouse_visible(&self) -> bool {
         self.cursor_visible
     }
@@ -132,222 +82,4 @@ impl UiBackend for DesktopUiBackend {
     fn message(&self, message: &str) {
         message_box_ok("Ruffle", message, MessageBoxIcon::Info)
     }
-}
-
-/// Convert a winit `VirtualKeyCode` into a Ruffle `KeyCode`.
-/// Return `KeyCode::Unknown` if there is no matching Flash key code.
-fn winit_to_ruffle_key_code(key_code: VirtualKeyCode) -> KeyCode {
-    match key_code {
-        VirtualKeyCode::Back => KeyCode::Backspace,
-        VirtualKeyCode::Tab => KeyCode::Tab,
-        VirtualKeyCode::Return => KeyCode::Return,
-        VirtualKeyCode::LShift | VirtualKeyCode::RShift => KeyCode::Shift,
-        VirtualKeyCode::LControl | VirtualKeyCode::RControl => KeyCode::Control,
-        VirtualKeyCode::LAlt | VirtualKeyCode::RAlt => KeyCode::Alt,
-        VirtualKeyCode::Capital => KeyCode::CapsLock,
-        VirtualKeyCode::Escape => KeyCode::Escape,
-        VirtualKeyCode::Space => KeyCode::Space,
-        VirtualKeyCode::Key0 => KeyCode::Key0,
-        VirtualKeyCode::Key1 => KeyCode::Key1,
-        VirtualKeyCode::Key2 => KeyCode::Key2,
-        VirtualKeyCode::Key3 => KeyCode::Key3,
-        VirtualKeyCode::Key4 => KeyCode::Key4,
-        VirtualKeyCode::Key5 => KeyCode::Key5,
-        VirtualKeyCode::Key6 => KeyCode::Key6,
-        VirtualKeyCode::Key7 => KeyCode::Key7,
-        VirtualKeyCode::Key8 => KeyCode::Key8,
-        VirtualKeyCode::Key9 => KeyCode::Key9,
-        VirtualKeyCode::A => KeyCode::A,
-        VirtualKeyCode::B => KeyCode::B,
-        VirtualKeyCode::C => KeyCode::C,
-        VirtualKeyCode::D => KeyCode::D,
-        VirtualKeyCode::E => KeyCode::E,
-        VirtualKeyCode::F => KeyCode::F,
-        VirtualKeyCode::G => KeyCode::G,
-        VirtualKeyCode::H => KeyCode::H,
-        VirtualKeyCode::I => KeyCode::I,
-        VirtualKeyCode::J => KeyCode::J,
-        VirtualKeyCode::K => KeyCode::K,
-        VirtualKeyCode::L => KeyCode::L,
-        VirtualKeyCode::M => KeyCode::M,
-        VirtualKeyCode::N => KeyCode::N,
-        VirtualKeyCode::O => KeyCode::O,
-        VirtualKeyCode::P => KeyCode::P,
-        VirtualKeyCode::Q => KeyCode::Q,
-        VirtualKeyCode::R => KeyCode::R,
-        VirtualKeyCode::S => KeyCode::S,
-        VirtualKeyCode::T => KeyCode::T,
-        VirtualKeyCode::U => KeyCode::U,
-        VirtualKeyCode::V => KeyCode::V,
-        VirtualKeyCode::W => KeyCode::W,
-        VirtualKeyCode::X => KeyCode::X,
-        VirtualKeyCode::Y => KeyCode::Y,
-        VirtualKeyCode::Z => KeyCode::Z,
-        VirtualKeyCode::Semicolon => KeyCode::Semicolon,
-        VirtualKeyCode::Equals => KeyCode::Equals,
-        VirtualKeyCode::Comma => KeyCode::Comma,
-        VirtualKeyCode::Minus => KeyCode::Minus,
-        VirtualKeyCode::Period => KeyCode::Period,
-        VirtualKeyCode::Slash => KeyCode::Slash,
-        VirtualKeyCode::Grave => KeyCode::Grave,
-        VirtualKeyCode::LBracket => KeyCode::LBracket,
-        VirtualKeyCode::Backslash => KeyCode::Backslash,
-        VirtualKeyCode::RBracket => KeyCode::RBracket,
-        VirtualKeyCode::Apostrophe => KeyCode::Apostrophe,
-        VirtualKeyCode::Numpad0 => KeyCode::Numpad0,
-        VirtualKeyCode::Numpad1 => KeyCode::Numpad1,
-        VirtualKeyCode::Numpad2 => KeyCode::Numpad2,
-        VirtualKeyCode::Numpad3 => KeyCode::Numpad3,
-        VirtualKeyCode::Numpad4 => KeyCode::Numpad4,
-        VirtualKeyCode::Numpad5 => KeyCode::Numpad5,
-        VirtualKeyCode::Numpad6 => KeyCode::Numpad6,
-        VirtualKeyCode::Numpad7 => KeyCode::Numpad7,
-        VirtualKeyCode::Numpad8 => KeyCode::Numpad8,
-        VirtualKeyCode::Numpad9 => KeyCode::Numpad9,
-        VirtualKeyCode::NumpadMultiply => KeyCode::Multiply,
-        VirtualKeyCode::NumpadAdd => KeyCode::Plus,
-        VirtualKeyCode::NumpadSubtract => KeyCode::NumpadMinus,
-        VirtualKeyCode::NumpadDecimal => KeyCode::NumpadPeriod,
-        VirtualKeyCode::NumpadDivide => KeyCode::NumpadSlash,
-        VirtualKeyCode::PageUp => KeyCode::PgUp,
-        VirtualKeyCode::PageDown => KeyCode::PgDown,
-        VirtualKeyCode::End => KeyCode::End,
-        VirtualKeyCode::Home => KeyCode::Home,
-        VirtualKeyCode::Left => KeyCode::Left,
-        VirtualKeyCode::Up => KeyCode::Up,
-        VirtualKeyCode::Right => KeyCode::Right,
-        VirtualKeyCode::Down => KeyCode::Down,
-        VirtualKeyCode::Insert => KeyCode::Insert,
-        VirtualKeyCode::Delete => KeyCode::Delete,
-        VirtualKeyCode::Pause => KeyCode::Pause,
-        VirtualKeyCode::Scroll => KeyCode::ScrollLock,
-        VirtualKeyCode::F1 => KeyCode::F1,
-        VirtualKeyCode::F2 => KeyCode::F2,
-        VirtualKeyCode::F3 => KeyCode::F3,
-        VirtualKeyCode::F4 => KeyCode::F4,
-        VirtualKeyCode::F5 => KeyCode::F5,
-        VirtualKeyCode::F6 => KeyCode::F6,
-        VirtualKeyCode::F7 => KeyCode::F7,
-        VirtualKeyCode::F8 => KeyCode::F8,
-        VirtualKeyCode::F9 => KeyCode::F9,
-        VirtualKeyCode::F10 => KeyCode::F10,
-        VirtualKeyCode::F11 => KeyCode::F11,
-        VirtualKeyCode::F12 => KeyCode::F12,
-        _ => KeyCode::Unknown,
-    }
-}
-
-/// Return a character for the given key code and shift state.
-fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<char> {
-    // We need to know the character that a keypress outputs for both key down and key up events,
-    // but the winit keyboard API does not provide a way to do this (winit/#753).
-    // CharacterReceived events are insufficent because they only fire on key down, not on key up.
-    // This is a half-measure to map from keyboard keys back to a character, but does will not work fully
-    // for international layouts.
-    Some(match (key_code, is_shift_down) {
-        (VirtualKeyCode::Space, _) => ' ',
-        (VirtualKeyCode::Key0, _) => '0',
-        (VirtualKeyCode::Key1, _) => '1',
-        (VirtualKeyCode::Key2, _) => '2',
-        (VirtualKeyCode::Key3, _) => '3',
-        (VirtualKeyCode::Key4, _) => '4',
-        (VirtualKeyCode::Key5, _) => '5',
-        (VirtualKeyCode::Key6, _) => '6',
-        (VirtualKeyCode::Key7, _) => '7',
-        (VirtualKeyCode::Key8, _) => '8',
-        (VirtualKeyCode::Key9, _) => '9',
-        (VirtualKeyCode::A, false) => 'a',
-        (VirtualKeyCode::A, true) => 'A',
-        (VirtualKeyCode::B, false) => 'b',
-        (VirtualKeyCode::B, true) => 'B',
-        (VirtualKeyCode::C, false) => 'c',
-        (VirtualKeyCode::C, true) => 'C',
-        (VirtualKeyCode::D, false) => 'd',
-        (VirtualKeyCode::D, true) => 'D',
-        (VirtualKeyCode::E, false) => 'e',
-        (VirtualKeyCode::E, true) => 'E',
-        (VirtualKeyCode::F, false) => 'f',
-        (VirtualKeyCode::F, true) => 'F',
-        (VirtualKeyCode::G, false) => 'g',
-        (VirtualKeyCode::G, true) => 'G',
-        (VirtualKeyCode::H, false) => 'h',
-        (VirtualKeyCode::H, true) => 'H',
-        (VirtualKeyCode::I, false) => 'i',
-        (VirtualKeyCode::I, true) => 'I',
-        (VirtualKeyCode::J, false) => 'j',
-        (VirtualKeyCode::J, true) => 'J',
-        (VirtualKeyCode::K, false) => 'k',
-        (VirtualKeyCode::K, true) => 'K',
-        (VirtualKeyCode::L, false) => 'l',
-        (VirtualKeyCode::L, true) => 'L',
-        (VirtualKeyCode::M, false) => 'm',
-        (VirtualKeyCode::M, true) => 'M',
-        (VirtualKeyCode::N, false) => 'n',
-        (VirtualKeyCode::N, true) => 'N',
-        (VirtualKeyCode::O, false) => 'o',
-        (VirtualKeyCode::O, true) => 'O',
-        (VirtualKeyCode::P, false) => 'p',
-        (VirtualKeyCode::P, true) => 'P',
-        (VirtualKeyCode::Q, false) => 'q',
-        (VirtualKeyCode::Q, true) => 'Q',
-        (VirtualKeyCode::R, false) => 'r',
-        (VirtualKeyCode::R, true) => 'R',
-        (VirtualKeyCode::S, false) => 's',
-        (VirtualKeyCode::S, true) => 'S',
-        (VirtualKeyCode::T, false) => 't',
-        (VirtualKeyCode::T, true) => 'T',
-        (VirtualKeyCode::U, false) => 'u',
-        (VirtualKeyCode::U, true) => 'U',
-        (VirtualKeyCode::V, false) => 'v',
-        (VirtualKeyCode::V, true) => 'V',
-        (VirtualKeyCode::W, false) => 'w',
-        (VirtualKeyCode::W, true) => 'W',
-        (VirtualKeyCode::X, false) => 'x',
-        (VirtualKeyCode::X, true) => 'X',
-        (VirtualKeyCode::Y, false) => 'y',
-        (VirtualKeyCode::Y, true) => 'Y',
-        (VirtualKeyCode::Z, false) => 'z',
-        (VirtualKeyCode::Z, true) => 'Z',
-
-        (VirtualKeyCode::Semicolon, false) => ';',
-        (VirtualKeyCode::Semicolon, true) => ':',
-        (VirtualKeyCode::Equals, false) => '=',
-        (VirtualKeyCode::Equals, true) => '+',
-        (VirtualKeyCode::Comma, false) => ',',
-        (VirtualKeyCode::Comma, true) => '<',
-        (VirtualKeyCode::Minus, false) => '-',
-        (VirtualKeyCode::Minus, true) => '_',
-        (VirtualKeyCode::Period, false) => '.',
-        (VirtualKeyCode::Period, true) => '>',
-        (VirtualKeyCode::Slash, false) => '/',
-        (VirtualKeyCode::Slash, true) => '?',
-        (VirtualKeyCode::Grave, false) => '`',
-        (VirtualKeyCode::Grave, true) => '~',
-        (VirtualKeyCode::LBracket, false) => '[',
-        (VirtualKeyCode::LBracket, true) => '{',
-        (VirtualKeyCode::Backslash, false) => '\\',
-        (VirtualKeyCode::Backslash, true) => '|',
-        (VirtualKeyCode::RBracket, false) => ']',
-        (VirtualKeyCode::RBracket, true) => '}',
-        (VirtualKeyCode::Apostrophe, false) => '\'',
-        (VirtualKeyCode::Apostrophe, true) => '"',
-        (VirtualKeyCode::NumpadMultiply, _) => '*',
-        (VirtualKeyCode::NumpadAdd, _) => '+',
-        (VirtualKeyCode::NumpadSubtract, _) => '-',
-        (VirtualKeyCode::NumpadDecimal, _) => '.',
-        (VirtualKeyCode::NumpadDivide, _) => '/',
-
-        (VirtualKeyCode::Numpad0, false) => '0',
-        (VirtualKeyCode::Numpad1, false) => '1',
-        (VirtualKeyCode::Numpad2, false) => '2',
-        (VirtualKeyCode::Numpad3, false) => '3',
-        (VirtualKeyCode::Numpad4, false) => '4',
-        (VirtualKeyCode::Numpad5, false) => '5',
-        (VirtualKeyCode::Numpad6, false) => '6',
-        (VirtualKeyCode::Numpad7, false) => '7',
-        (VirtualKeyCode::Numpad8, false) => '8',
-        (VirtualKeyCode::Numpad9, false) => '9',
-
-        _ => return None,
-    })
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -18,7 +18,6 @@ use ruffle_core::backend::{
     audio::{AudioBackend, NullAudioBackend},
     render::RenderBackend,
     storage::{MemoryStorageBackend, StorageBackend},
-    ui::UiBackend,
     video::SoftwareVideoBackend,
 };
 use ruffle_core::config::Letterbox;
@@ -726,21 +725,9 @@ impl Ruffle {
                 let _ = ruffle.with_instance(|instance| {
                     if instance.has_focus {
                         let _ = instance.with_core_mut(|core| {
-                            let ui = if let Some(ui) =
-                                core.ui_mut().downcast_mut::<ui::WebUiBackend>()
-                            {
-                                ui
-                            } else {
-                                return;
-                            };
-                            ui.keydown(&js_event);
-
-                            let key_code = ui.last_key_code();
-                            let key_char = ui.last_key_char();
-
-                            if key_code != KeyCode::Unknown {
-                                core.handle_event(PlayerEvent::KeyDown { key_code });
-                            }
+                            let key_code = web_to_ruffle_key_code(&js_event.code());
+                            let key_char = web_key_to_codepoint(&js_event.key());
+                            core.handle_event(PlayerEvent::KeyDown { key_code, key_char });
 
                             if let Some(codepoint) = key_char {
                                 core.handle_event(PlayerEvent::TextInput { codepoint });
@@ -765,19 +752,9 @@ impl Ruffle {
                 let _ = ruffle.with_instance(|instance| {
                     if instance.has_focus {
                         let _ = instance.with_core_mut(|core| {
-                            let ui = if let Some(ui) =
-                                core.ui_mut().downcast_mut::<ui::WebUiBackend>()
-                            {
-                                ui
-                            } else {
-                                return;
-                            };
-                            ui.keyup(&js_event);
-
-                            let key_code = ui.last_key_code();
-                            if key_code != KeyCode::Unknown {
-                                core.handle_event(PlayerEvent::KeyUp { key_code });
-                            }
+                            let key_code = web_to_ruffle_key_code(&js_event.code());
+                            let key_char = web_key_to_codepoint(&js_event.key());
+                            core.handle_event(PlayerEvent::KeyUp { key_code, key_char });
                         });
                         js_event.prevent_default();
                     }
@@ -1359,4 +1336,129 @@ fn parse_html_color(color: impl AsRef<str>) -> Option<Color> {
         ret |= u32::from(digit);
     }
     Some(Color::from_rgb(ret, 255))
+}
+
+/// Convert a web `KeyboardEvent.code` value into a Ruffle `KeyCode`.
+/// Return `KeyCode::Unknown` if there is no matching Flash key code.
+fn web_to_ruffle_key_code(key_code: &str) -> KeyCode {
+    match key_code {
+        "Backspace" => KeyCode::Backspace,
+        "Tab" => KeyCode::Tab,
+        "Enter" => KeyCode::Return,
+        "ShiftLeft" | "ShiftRight" => KeyCode::Shift,
+        "ControlLeft" | "ControlRight" => KeyCode::Control,
+        "AltLeft" | "AltRight" => KeyCode::Alt,
+        "CapsLock" => KeyCode::CapsLock,
+        "Escape" => KeyCode::Escape,
+        "Space" => KeyCode::Space,
+        "Digit0" => KeyCode::Key0,
+        "Digit1" => KeyCode::Key1,
+        "Digit2" => KeyCode::Key2,
+        "Digit3" => KeyCode::Key3,
+        "Digit4" => KeyCode::Key4,
+        "Digit5" => KeyCode::Key5,
+        "Digit6" => KeyCode::Key6,
+        "Digit7" => KeyCode::Key7,
+        "Digit8" => KeyCode::Key8,
+        "Digit9" => KeyCode::Key9,
+        "KeyA" => KeyCode::A,
+        "KeyB" => KeyCode::B,
+        "KeyC" => KeyCode::C,
+        "KeyD" => KeyCode::D,
+        "KeyE" => KeyCode::E,
+        "KeyF" => KeyCode::F,
+        "KeyG" => KeyCode::G,
+        "KeyH" => KeyCode::H,
+        "KeyI" => KeyCode::I,
+        "KeyJ" => KeyCode::J,
+        "KeyK" => KeyCode::K,
+        "KeyL" => KeyCode::L,
+        "KeyM" => KeyCode::M,
+        "KeyN" => KeyCode::N,
+        "KeyO" => KeyCode::O,
+        "KeyP" => KeyCode::P,
+        "KeyQ" => KeyCode::Q,
+        "KeyR" => KeyCode::R,
+        "KeyS" => KeyCode::S,
+        "KeyT" => KeyCode::T,
+        "KeyU" => KeyCode::U,
+        "KeyV" => KeyCode::V,
+        "KeyW" => KeyCode::W,
+        "KeyX" => KeyCode::X,
+        "KeyY" => KeyCode::Y,
+        "KeyZ" => KeyCode::Z,
+        "Semicolon" => KeyCode::Semicolon,
+        "Equal" => KeyCode::Equals,
+        "Comma" => KeyCode::Comma,
+        "Minus" => KeyCode::Minus,
+        "Period" => KeyCode::Period,
+        "Slash" => KeyCode::Slash,
+        "Backquote" => KeyCode::Grave,
+        "BracketLeft" => KeyCode::LBracket,
+        "Backslash" => KeyCode::Backslash,
+        "BracketRight" => KeyCode::RBracket,
+        "Quote" => KeyCode::Apostrophe,
+        "Numpad0" => KeyCode::Numpad0,
+        "Numpad1" => KeyCode::Numpad1,
+        "Numpad2" => KeyCode::Numpad2,
+        "Numpad3" => KeyCode::Numpad3,
+        "Numpad4" => KeyCode::Numpad4,
+        "Numpad5" => KeyCode::Numpad5,
+        "Numpad6" => KeyCode::Numpad6,
+        "Numpad7" => KeyCode::Numpad7,
+        "Numpad8" => KeyCode::Numpad8,
+        "Numpad9" => KeyCode::Numpad9,
+        "NumpadMultiply" => KeyCode::Multiply,
+        "NumpadAdd" => KeyCode::Plus,
+        "NumpadSubtract" => KeyCode::NumpadMinus,
+        "NumpadDecimal" => KeyCode::NumpadPeriod,
+        "NumpadDivide" => KeyCode::NumpadSlash,
+        "PageUp" => KeyCode::PgUp,
+        "PageDown" => KeyCode::PgDown,
+        "End" => KeyCode::End,
+        "Home" => KeyCode::Home,
+        "ArrowLeft" => KeyCode::Left,
+        "ArrowUp" => KeyCode::Up,
+        "ArrowRight" => KeyCode::Right,
+        "ArrowDown" => KeyCode::Down,
+        "Insert" => KeyCode::Insert,
+        "Delete" => KeyCode::Delete,
+        "Pause" => KeyCode::Pause,
+        "ScrollLock" => KeyCode::ScrollLock,
+        "F1" => KeyCode::F1,
+        "F2" => KeyCode::F2,
+        "F3" => KeyCode::F3,
+        "F4" => KeyCode::F4,
+        "F5" => KeyCode::F5,
+        "F6" => KeyCode::F6,
+        "F7" => KeyCode::F7,
+        "F8" => KeyCode::F8,
+        "F9" => KeyCode::F9,
+        "F10" => KeyCode::F10,
+        "F11" => KeyCode::F11,
+        "F12" => KeyCode::F12,
+        _ => KeyCode::Unknown,
+    }
+}
+
+/// Convert a web `KeyboardEvent.key` value into a character codepoint.
+/// Return `None` if they input was not a printable character.
+fn web_key_to_codepoint(key: &str) -> Option<char> {
+    // TODO: This is a very cheesy way to tell if a `KeyboardEvent.key` is a printable character.
+    // Single character strings will be an actual printable char that we can use as text input.
+    // All the other special values are multiple characters (e.g. "ArrowLeft").
+    // It's probably better to explicitly match on all the variants.
+    let mut chars = key.chars();
+    let (c1, c2) = (chars.next(), chars.next());
+    if c2.is_none() {
+        // Single character.
+        c1
+    } else {
+        // Check for special characters.
+        match key {
+            "Backspace" => Some(8 as char),
+            "Delete" => Some(127 as char),
+            _ => None,
+        }
+    }
 }

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -1,9 +1,7 @@
 use super::JavascriptPlayer;
 use ruffle_core::backend::ui::{Error, MouseCursor, UiBackend};
-use ruffle_core::events::KeyCode;
 use ruffle_web_common::JsResult;
-use std::collections::HashSet;
-use web_sys::{HtmlCanvasElement, KeyboardEvent};
+use web_sys::HtmlCanvasElement;
 
 #[derive(Debug)]
 struct FullScreenError {
@@ -26,11 +24,8 @@ impl std::error::Error for FullScreenError {
 pub struct WebUiBackend {
     js_player: JavascriptPlayer,
     canvas: HtmlCanvasElement,
-    keys_down: HashSet<KeyCode>,
     cursor_visible: bool,
     cursor: MouseCursor,
-    last_key: KeyCode,
-    last_char: Option<char>,
 }
 
 impl WebUiBackend {
@@ -38,28 +33,9 @@ impl WebUiBackend {
         Self {
             js_player,
             canvas: canvas.clone(),
-            keys_down: HashSet::new(),
             cursor_visible: true,
             cursor: MouseCursor::Arrow,
-            last_key: KeyCode::Unknown,
-            last_char: None,
         }
-    }
-
-    /// Register a key press for a given code string.
-    pub fn keydown(&mut self, event: &KeyboardEvent) {
-        let key_code = web_to_ruffle_key_code(&event.code());
-        self.last_key = key_code;
-        self.keys_down.insert(key_code);
-        self.last_char = web_key_to_codepoint(&event.key());
-    }
-
-    /// Register a key release for a given code string.
-    pub fn keyup(&mut self, event: &KeyboardEvent) {
-        let key_code = web_to_ruffle_key_code(&event.code());
-        self.last_key = key_code;
-        self.keys_down.remove(&key_code);
-        self.last_char = web_key_to_codepoint(&event.key());
     }
 
     fn update_mouse_cursor(&self) {
@@ -81,18 +57,6 @@ impl WebUiBackend {
 }
 
 impl UiBackend for WebUiBackend {
-    fn is_key_down(&self, key: KeyCode) -> bool {
-        self.keys_down.contains(&key)
-    }
-
-    fn last_key_code(&self) -> KeyCode {
-        self.last_key
-    }
-
-    fn last_key_char(&self) -> Option<char> {
-        self.last_char
-    }
-
     fn mouse_visible(&self) -> bool {
         self.cursor_visible
     }
@@ -132,130 +96,5 @@ impl UiBackend for WebUiBackend {
 
     fn message(&self, message: &str) {
         self.js_player.display_message(message);
-    }
-}
-
-/// Convert a web `KeyboardEvent.code` value into a Ruffle `KeyCode`.
-/// Return `KeyCode::Unknown` if there is no matching Flash key code.
-fn web_to_ruffle_key_code(key_code: &str) -> KeyCode {
-    match key_code {
-        "Backspace" => KeyCode::Backspace,
-        "Tab" => KeyCode::Tab,
-        "Enter" => KeyCode::Return,
-        "ShiftLeft" | "ShiftRight" => KeyCode::Shift,
-        "ControlLeft" | "ControlRight" => KeyCode::Control,
-        "AltLeft" | "AltRight" => KeyCode::Alt,
-        "CapsLock" => KeyCode::CapsLock,
-        "Escape" => KeyCode::Escape,
-        "Space" => KeyCode::Space,
-        "Digit0" => KeyCode::Key0,
-        "Digit1" => KeyCode::Key1,
-        "Digit2" => KeyCode::Key2,
-        "Digit3" => KeyCode::Key3,
-        "Digit4" => KeyCode::Key4,
-        "Digit5" => KeyCode::Key5,
-        "Digit6" => KeyCode::Key6,
-        "Digit7" => KeyCode::Key7,
-        "Digit8" => KeyCode::Key8,
-        "Digit9" => KeyCode::Key9,
-        "KeyA" => KeyCode::A,
-        "KeyB" => KeyCode::B,
-        "KeyC" => KeyCode::C,
-        "KeyD" => KeyCode::D,
-        "KeyE" => KeyCode::E,
-        "KeyF" => KeyCode::F,
-        "KeyG" => KeyCode::G,
-        "KeyH" => KeyCode::H,
-        "KeyI" => KeyCode::I,
-        "KeyJ" => KeyCode::J,
-        "KeyK" => KeyCode::K,
-        "KeyL" => KeyCode::L,
-        "KeyM" => KeyCode::M,
-        "KeyN" => KeyCode::N,
-        "KeyO" => KeyCode::O,
-        "KeyP" => KeyCode::P,
-        "KeyQ" => KeyCode::Q,
-        "KeyR" => KeyCode::R,
-        "KeyS" => KeyCode::S,
-        "KeyT" => KeyCode::T,
-        "KeyU" => KeyCode::U,
-        "KeyV" => KeyCode::V,
-        "KeyW" => KeyCode::W,
-        "KeyX" => KeyCode::X,
-        "KeyY" => KeyCode::Y,
-        "KeyZ" => KeyCode::Z,
-        "Semicolon" => KeyCode::Semicolon,
-        "Equal" => KeyCode::Equals,
-        "Comma" => KeyCode::Comma,
-        "Minus" => KeyCode::Minus,
-        "Period" => KeyCode::Period,
-        "Slash" => KeyCode::Slash,
-        "Backquote" => KeyCode::Grave,
-        "BracketLeft" => KeyCode::LBracket,
-        "Backslash" => KeyCode::Backslash,
-        "BracketRight" => KeyCode::RBracket,
-        "Quote" => KeyCode::Apostrophe,
-        "Numpad0" => KeyCode::Numpad0,
-        "Numpad1" => KeyCode::Numpad1,
-        "Numpad2" => KeyCode::Numpad2,
-        "Numpad3" => KeyCode::Numpad3,
-        "Numpad4" => KeyCode::Numpad4,
-        "Numpad5" => KeyCode::Numpad5,
-        "Numpad6" => KeyCode::Numpad6,
-        "Numpad7" => KeyCode::Numpad7,
-        "Numpad8" => KeyCode::Numpad8,
-        "Numpad9" => KeyCode::Numpad9,
-        "NumpadMultiply" => KeyCode::Multiply,
-        "NumpadAdd" => KeyCode::Plus,
-        "NumpadSubtract" => KeyCode::NumpadMinus,
-        "NumpadDecimal" => KeyCode::NumpadPeriod,
-        "NumpadDivide" => KeyCode::NumpadSlash,
-        "PageUp" => KeyCode::PgUp,
-        "PageDown" => KeyCode::PgDown,
-        "End" => KeyCode::End,
-        "Home" => KeyCode::Home,
-        "ArrowLeft" => KeyCode::Left,
-        "ArrowUp" => KeyCode::Up,
-        "ArrowRight" => KeyCode::Right,
-        "ArrowDown" => KeyCode::Down,
-        "Insert" => KeyCode::Insert,
-        "Delete" => KeyCode::Delete,
-        "Pause" => KeyCode::Pause,
-        "ScrollLock" => KeyCode::ScrollLock,
-        "F1" => KeyCode::F1,
-        "F2" => KeyCode::F2,
-        "F3" => KeyCode::F3,
-        "F4" => KeyCode::F4,
-        "F5" => KeyCode::F5,
-        "F6" => KeyCode::F6,
-        "F7" => KeyCode::F7,
-        "F8" => KeyCode::F8,
-        "F9" => KeyCode::F9,
-        "F10" => KeyCode::F10,
-        "F11" => KeyCode::F11,
-        "F12" => KeyCode::F12,
-        _ => KeyCode::Unknown,
-    }
-}
-
-/// Convert a web `KeyboardEvent.key` value into a character codepoint.
-/// Return `None` if they input was not a printable character.
-fn web_key_to_codepoint(key: &str) -> Option<char> {
-    // TODO: This is a very cheesy way to tell if a `KeyboardEvent.key` is a printable character.
-    // Single character strings will be an actual printable char that we can use as text input.
-    // All the other special values are multiple characters (e.g. "ArrowLeft").
-    // It's probably better to explicitly match on all the variants.
-    let mut chars = key.chars();
-    let (c1, c2) = (chars.next(), chars.next());
-    if c2.is_none() {
-        // Single character.
-        c1
-    } else {
-        // Check for special characters.
-        match key {
-            "Backspace" => Some(8 as char),
-            "Delete" => Some(127 as char),
-            _ => None,
-        }
     }
 }


### PR DESCRIPTION
`InputManager` encapsulates the common logic that previously the `UiBackend`s used to implement.

Pulled out from #4644.