### PR TITLE
chore: Replace `min` + `max` with `clamp`

### DIFF
--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -155,7 +155,7 @@ pub fn set_highlight_alpha<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(1.0))?;
+        .map(|x| x.clamp(0.0, 1.0))?;
 
     if let Some(filter) = this.as_bevel_filter_object() {
         filter.set_highlight_alpha(activation.context.gc_context, highlight_alpha);
@@ -214,7 +214,7 @@ pub fn set_shadow_alpha<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(1.0))?;
+        .map(|x| x.clamp(0.0, 1.0))?;
 
     if let Some(filter) = this.as_bevel_filter_object() {
         filter.set_shadow_alpha(activation.context.gc_context, shadow_alpha);
@@ -244,7 +244,7 @@ pub fn set_quality<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))?;
+        .map(|x| x.clamp(0, 15))?;
 
     if let Some(filter) = this.as_bevel_filter_object() {
         filter.set_quality(activation.context.gc_context, quality);
@@ -274,7 +274,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_bevel_filter_object() {
         filter.set_strength(activation.context.gc_context, strength);
@@ -333,7 +333,7 @@ pub fn set_blur_x<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_bevel_filter_object() {
         filter.set_blur_x(activation.context.gc_context, blur_x);
@@ -363,7 +363,7 @@ pub fn set_blur_y<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_bevel_filter_object() {
         filter.set_blur_y(activation.context.gc_context, blur_y);

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -46,7 +46,7 @@ pub fn set_blur_x<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_blur_filter_object() {
         filter.set_blur_x(activation.context.gc_context, blur_x);
@@ -76,7 +76,7 @@ pub fn set_blur_y<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_blur_filter_object() {
         filter.set_blur_y(activation.context.gc_context, blur_y);
@@ -106,7 +106,7 @@ pub fn set_quality<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))?;
+        .map(|x| x.clamp(0, 15))?;
 
     if let Some(filter) = this.as_blur_filter_object() {
         filter.set_quality(activation.context.gc_context, quality);

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -58,7 +58,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&0.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(1.0))?;
+        .map(|x| x.clamp(0.0, 1.0))?;
 
     if let Some(filter) = this.as_convolution_filter_object() {
         filter.set_alpha(activation.context.gc_context, alpha);
@@ -246,7 +246,7 @@ pub fn set_matrix_x<'gc>(
         .get(0)
         .unwrap_or(&0.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))? as u8;
+        .map(|x| x.clamp(0, 15))? as u8;
 
     if let Some(filter) = this.as_convolution_filter_object() {
         filter.set_matrix_x(activation.context.gc_context, matrix_x);
@@ -276,7 +276,7 @@ pub fn set_matrix_y<'gc>(
         .get(0)
         .unwrap_or(&0.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))? as u8;
+        .map(|x| x.clamp(0, 15))? as u8;
 
     if let Some(filter) = this.as_convolution_filter_object() {
         filter.set_matrix_y(activation.context.gc_context, matrix_y);

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -59,7 +59,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&0.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(1.0))?;
+        .map(|x| x.clamp(0.0, 1.0))?;
 
     if let Some(filter) = this.as_displacement_map_filter_object() {
         filter.set_alpha(activation.context.gc_context, alpha);

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -62,7 +62,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(1.0))?;
+        .map(|x| x.clamp(0.0, 1.0))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_alpha(activation.context.gc_context, alpha);
@@ -153,7 +153,7 @@ pub fn set_blur_x<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_blur_x(activation.context.gc_context, blur_x);
@@ -183,7 +183,7 @@ pub fn set_blur_y<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_blur_y(activation.context.gc_context, blur_y);
@@ -329,7 +329,7 @@ pub fn set_quality<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))?;
+        .map(|x| x.clamp(0, 15))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_quality(activation.context.gc_context, quality);
@@ -359,7 +359,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_strength(activation.context.gc_context, strength);

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -54,7 +54,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(1.0))?;
+        .map(|x| x.clamp(0.0, 1.0))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_alpha(activation.context.gc_context, alpha);
@@ -84,7 +84,7 @@ pub fn set_blur_x<'gc>(
         .get(0)
         .unwrap_or(&6.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_blur_x(activation.context.gc_context, blur_x);
@@ -114,7 +114,7 @@ pub fn set_blur_y<'gc>(
         .get(0)
         .unwrap_or(&6.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_blur_y(activation.context.gc_context, blur_y);
@@ -144,7 +144,7 @@ pub fn set_color<'gc>(
         .get(0)
         .unwrap_or(&0xFF0000.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(1).min(0xFFFFFF))?;
+        .map(|x| x.clamp(1, 0xFFFFFF))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_color(activation.context.gc_context, color);
@@ -232,7 +232,7 @@ pub fn set_quality<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))?;
+        .map(|x| x.clamp(0, 15))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_quality(activation.context.gc_context, quality);
@@ -262,7 +262,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&2.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_strength(activation.context.gc_context, strength);

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -287,7 +287,7 @@ pub fn set_blur_x<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_bevel_filter_object() {
         object.set_blur_x(activation.context.gc_context, blur_x);
@@ -317,7 +317,7 @@ pub fn set_blur_y<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_bevel_filter_object() {
         object.set_blur_y(activation.context.gc_context, blur_y);
@@ -347,7 +347,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_bevel_filter_object() {
         object.set_strength(activation.context.gc_context, strength);
@@ -377,7 +377,7 @@ pub fn set_quality<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))?;
+        .map(|x| x.clamp(0, 15))?;
 
     if let Some(object) = this.as_gradient_bevel_filter_object() {
         object.set_quality(activation.context.gc_context, quality);

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -287,7 +287,7 @@ pub fn set_blur_x<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_glow_filter_object() {
         object.set_blur_x(activation.context.gc_context, blur_x);
@@ -317,7 +317,7 @@ pub fn set_blur_y<'gc>(
         .get(0)
         .unwrap_or(&4.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_glow_filter_object() {
         object.set_blur_y(activation.context.gc_context, blur_y);
@@ -347,7 +347,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.max(0.0).min(255.0))?;
+        .map(|x| x.clamp(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_glow_filter_object() {
         object.set_strength(activation.context.gc_context, strength);
@@ -377,7 +377,7 @@ pub fn set_quality<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_i32(activation)
-        .map(|x| x.max(0).min(15))?;
+        .map(|x| x.clamp(0, 15))?;
 
     if let Some(object) = this.as_gradient_glow_filter_object() {
         object.set_quality(activation.context.gc_context, quality);

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -242,11 +242,11 @@ fn line_style<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(width) = args.get(0) {
-        let width = Twips::from_pixels(width.coerce_to_f64(activation)?.min(255.0).max(0.0));
+        let width = Twips::from_pixels(width.coerce_to_f64(activation)?.clamp(0.0, 255.0));
         let color = if let Some(rgb) = args.get(1) {
             let rgb = rgb.coerce_to_u32(activation)?;
             let alpha = if let Some(alpha) = args.get(2) {
-                alpha.coerce_to_f64(activation)?.min(100.0).max(0.0)
+                alpha.coerce_to_f64(activation)?.clamp(0.0, 100.0)
             } else {
                 100.0
             } as f32
@@ -285,7 +285,7 @@ fn line_style<'gc>(
         {
             Some("miter") => {
                 if let Some(limit) = args.get(7) {
-                    let limit = limit.coerce_to_f64(activation)?.max(0.0).min(255.0);
+                    let limit = limit.coerce_to_f64(activation)?.clamp(0.0, 255.0);
                     LineJoinStyle::Miter(Fixed8::from_f64(limit))
                 } else {
                     LineJoinStyle::Miter(Fixed8::from_f32(3.0))
@@ -326,7 +326,7 @@ fn begin_fill<'gc>(
     if let Some(rgb) = args.get(0) {
         let rgb = rgb.coerce_to_u32(activation)?;
         let alpha = if let Some(alpha) = args.get(1) {
-            alpha.coerce_to_f64(activation)?.min(100.0).max(0.0)
+            alpha.coerce_to_f64(activation)?.clamp(0.0, 100.0)
         } else {
             100.0
         } as f32

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -236,7 +236,7 @@ fn line_style<'gc>(
                 .unwrap_or_else(|| 3.0.into())
                 .coerce_to_number(activation)?;
 
-            let width = Twips::from_pixels(thickness.min(255.0).max(0.0));
+            let width = Twips::from_pixels(thickness.clamp(0.0, 255.0));
             let color = color_from_args(color, alpha);
             let join_style = joints_to_join_style(activation, joints, miter_limit)?;
             let (allow_scale_x, allow_scale_y) = scale_mode_to_allow_scale_bits(&scale_mode)?;

--- a/core/src/bounding_box.rs
+++ b/core/src/bounding_box.rs
@@ -14,15 +14,14 @@ pub struct BoundingBox {
 
 impl BoundingBox {
     /// Clamps the given point inside this bounding box.
-    pub fn clamp(&self, point: (Twips, Twips)) -> (Twips, Twips) {
+    pub fn clamp(&self, (x, y): (Twips, Twips)) -> (Twips, Twips) {
         if self.valid {
-            use std::cmp::{max, min};
             (
-                min(max(point.0, self.x_min), self.x_max),
-                min(max(point.1, self.y_min), self.y_max),
+                x.clamp(self.x_min, self.x_max),
+                y.clamp(self.y_min, self.y_max),
             )
         } else {
-            point
+            (x, y)
         }
     }
 

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -1455,7 +1455,7 @@ pub fn srgb_to_linear(mut color: swf::Color) -> swf::Color {
         } else {
             f32::powf((n + 0.055) / 1.055, 2.4)
         };
-        (n.max(0.0).min(1.0) * 255.0).round() as u8
+        (n.clamp(0.0, 1.0) * 255.0).round() as u8
     }
     color.r = to_linear_channel(color.r);
     color.g = to_linear_channel(color.g);

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -724,8 +724,8 @@ impl RenderBackend for WebGlRenderBackend {
         self.build_matrices();
 
         // Setup GL viewport and renderbuffers clamped to reasonable sizes.
-        self.renderbuffer_width = self.view_width.max(1).min(self.gl.drawing_buffer_width());
-        self.renderbuffer_height = self.view_height.max(1).min(self.gl.drawing_buffer_height());
+        self.renderbuffer_width = self.view_width.clamp(1, self.gl.drawing_buffer_width());
+        self.renderbuffer_height = self.view_height.clamp(1, self.gl.drawing_buffer_height());
 
         // Recreate framebuffers with the new size.
         let _ = self.build_msaa_buffers(self.renderbuffer_width, self.renderbuffer_height);


### PR DESCRIPTION
`clamp` is a bit more efficient, in both runtime and size terms.