### PR TITLE
html: Add basic support for h1-h6

### DIFF
--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -648,7 +648,8 @@ impl FormatSpans {
                             // Skip push to `format_stack`.
                             continue;
                         }
-                        b"p" if is_multiline => {
+                        // TODO: Remove heading tag 'polyfills' once stylesheets are supported
+                        b"p" | b"h1" | b"h2" | b"h3" | b"h4" | b"h5" | b"h6" if is_multiline => {
                             if let Some(align) = attribute(b"align") {
                                 if align == WStr::from_units(b"left") {
                                     format.align = Some(swf::TextAlign::Left)
@@ -768,7 +769,10 @@ impl FormatSpans {
                             // Skip pop from `format_stack`.
                             continue;
                         }
-                        b"p" | b"li" if is_multiline => {
+                        // TODO: Remove heading tag 'polyfills' once stylesheets are supported
+                        b"p" | b"li" | b"h1" | b"h2" | b"h3" | b"h4" | b"h5" | b"h6"
+                            if is_multiline =>
+                        {
                             text.push_byte(b'\n');
                             if let Some(span) = spans.last_mut() {
                                 span.span_length += 1;


### PR DESCRIPTION
Compare before and after by going to http://www.g2conline.org/ and clicking 3-D Brain under targeted content on the top-right.

~~I used the common browser defaults for font-size specification for heading tags (see https://stackoverflow.com/questions/6867254/browsers-default-css-for-html-elements).~~

~~These defaults match the HTML5 *suggested* specification: https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings~~