### PR TITLE
string: Correctly return None in `WStr::offset_in` for overlapping WStrs

### DIFF
--- a/core/src/string/ops.rs
+++ b/core/src/string/ops.rs
@@ -162,7 +162,7 @@ pub fn str_hash<H: Hasher>(s: &WStr, state: &mut H) {
 }
 
 pub fn str_offset_in(s: &WStr, other: &WStr) -> Option<usize> {
-    match (s.units(), other.units()) {
+    let offset = match (s.units(), other.units()) {
         (Units::Bytes(a), Units::Bytes(b)) => {
             (a.as_ptr() as usize).checked_sub(b.as_ptr() as usize)
         }
@@ -170,7 +170,9 @@ pub fn str_offset_in(s: &WStr, other: &WStr) -> Option<usize> {
             .checked_sub(b.as_ptr() as usize)
             .map(|n| n / std::mem::size_of::<u16>()),
         _ => None,
-    }
+    };
+
+    offset.filter(|o| o + s.len() <= other.len())
 }
 
 fn map_latin1_chars(s: &WStr, mut map: impl FnMut(u8) -> u8) -> WString {

--- a/core/src/string/tests.rs
+++ b/core/src/string/tests.rs
@@ -120,6 +120,25 @@ fn buf_concat_wide() {
     assert!(matches!(s.units(), Units::Wide(_)));
 }
 
+#[test]
+fn offset_in() {
+    let bstr = bstr!(b"abcdefghijk");
+    assert_eq!(bstr.offset_in(bstr), Some(0));
+    assert_eq!(bstr[3..6].offset_in(bstr), Some(3));
+    assert_eq!(bstr.offset_in(&bstr[3..6]), None);
+    assert_eq!(bstr[..3].offset_in(&bstr[6..]), None);
+    assert_eq!(bstr[6..].offset_in(&bstr[..3]), None);
+
+    let wstr = wstr!('a''b''c''d''e''f''g''h''i''j''k');
+    assert_eq!(wstr.offset_in(wstr), Some(0));
+    assert_eq!(wstr[3..6].offset_in(wstr), Some(3));
+    assert_eq!(wstr.offset_in(&wstr[3..6]), None);
+    assert_eq!(wstr[..3].offset_in(&wstr[6..]), None);
+    assert_eq!(wstr[6..].offset_in(&wstr[..3]), None);
+
+    assert_eq!(bstr.offset_in(wstr), None);
+}
+
 fn test_pattern<'a, P: Pattern<'a> + Clone + Debug>(
     haystack: &'a WStr,
     pattern: P,


### PR DESCRIPTION
This fixes a bug in `WStr::offset_in`:

```rs
let source = WStr::from_units(b"abcdef");
let a = source[2..];
let b = source[..3];

// Fail: Some(2) != None
assert_eq!(a.offset_in(b), None);
```