### PR TITLE
avm2: Multiname resolution performance improvements

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -7,8 +7,8 @@ use crate::avm2::script::{Script, TranslationUnit};
 use crate::context::UpdateContext;
 use crate::string::AvmString;
 use crate::tag_utils::SwfSlice;
+use fnv::FnvHashMap;
 use gc_arena::{Collect, MutationContext};
-use std::collections::HashMap;
 use std::rc::Rc;
 use swf::avm2::read::Reader;
 
@@ -86,7 +86,7 @@ pub struct Avm2<'gc> {
     ///
     /// TODO: These should be weak object pointers, but our current garbage
     /// collector does not support weak references.
-    broadcast_list: HashMap<AvmString<'gc>, Vec<Object<'gc>>>,
+    broadcast_list: FnvHashMap<AvmString<'gc>, Vec<Object<'gc>>>,
 
     #[cfg(feature = "avm_debug")]
     pub debug_output: bool,
@@ -102,7 +102,7 @@ impl<'gc> Avm2<'gc> {
             globals,
             system_prototypes: None,
             system_classes: None,
-            broadcast_list: HashMap::new(),
+            broadcast_list: Default::default(),
 
             #[cfg(feature = "avm_debug")]
             debug_output: false,

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1468,7 +1468,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
         let name = name_value.coerce_to_string(self)?;
         let qname = QName::new(Namespace::public(), name);
-        let has_prop = obj.has_property_via_in(self, &qname)?;
+        let has_prop = obj.has_property_via_in(self, qname)?;
 
         self.context.avm2.push(has_prop);
 

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -773,15 +773,6 @@ impl<'gc> Class<'gc> {
         self.instance_traits.push(my_trait);
     }
 
-    /// Given a name, return the instance class trait matching the name and filter.
-    pub fn lookup_instance_traits(
-        &self,
-        name: &QName<'gc>,
-        filter: fn(&Trait<'gc>) -> bool,
-    ) -> Option<Trait<'gc>> {
-        do_trait_lookup(name, &self.instance_traits, filter)
-    }
-
     /// Given a slot ID, return the first instance trait matching the slot.
     pub fn lookup_instance_traits_by_slot(&self, id: u32) -> Option<Trait<'gc>> {
         do_trait_lookup_by_slot(id, &self.instance_traits)
@@ -813,20 +804,6 @@ impl<'gc> Class<'gc> {
     /// Return instance traits provided by this class.
     pub fn instance_traits(&self) -> &[Trait<'gc>] {
         &self.instance_traits[..]
-    }
-
-    /// Look for all instance traits with a given local name, and return their
-    /// namespaces.
-    pub fn resolve_instance_trait_ns(&self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
-        let mut ns_set = vec![];
-
-        for trait_entry in self.instance_traits.iter() {
-            if local_name == trait_entry.name().local_name() {
-                ns_set.push(trait_entry.name().namespace().clone());
-            }
-        }
-
-        ns_set
     }
 
     /// Get this class's instance allocator.

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -497,8 +497,8 @@ impl<'gc> Class<'gc> {
         ))
     }
 
-    pub fn name(&self) -> &QName<'gc> {
-        &self.name
+    pub fn name(&self) -> QName<'gc> {
+        self.name
     }
 
     pub fn set_name(&mut self, name: QName<'gc>) {
@@ -727,7 +727,7 @@ impl<'gc> Class<'gc> {
     }
 
     /// Determines if this class provides a given trait on its instances.
-    pub fn has_instance_trait(&self, name: &QName<'gc>) -> bool {
+    pub fn has_instance_trait(&self, name: QName<'gc>) -> bool {
         for trait_entry in self.instance_traits.iter() {
             if name == trait_entry.name() {
                 return true;

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -750,19 +750,18 @@ impl<'gc> Class<'gc> {
         &self.class_traits[..]
     }
 
-    /// Look for a class trait with a given local name, and return its
-    /// namespace.
-    ///
-    /// TODO: Matching multiple namespaces with the same local name is at least
-    /// claimed by the AVM2 specification to be a `VerifyError`.
-    pub fn resolve_any_class_trait(&self, local_name: AvmString<'gc>) -> Option<Namespace<'gc>> {
+    /// Look for all class traits with a given local name, and return their
+    /// namespaces.
+    pub fn resolve_class_trait_ns(&self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
+        let mut ns_set = vec![];
+
         for trait_entry in self.class_traits.iter() {
             if local_name == trait_entry.name().local_name() {
-                return Some(trait_entry.name().namespace().clone());
+                ns_set.push(trait_entry.name().namespace().clone());
             }
         }
 
-        None
+        ns_set
     }
 
     /// Define a trait on instances of the class.
@@ -816,19 +815,18 @@ impl<'gc> Class<'gc> {
         &self.instance_traits[..]
     }
 
-    /// Look for an instance trait with a given local name, and return its
-    /// namespace.
-    ///
-    /// TODO: Matching multiple namespaces with the same local name is at least
-    /// claimed by the AVM2 specification to be a `VerifyError`.
-    pub fn resolve_any_instance_trait(&self, local_name: AvmString<'gc>) -> Option<Namespace<'gc>> {
+    /// Look for all instance traits with a given local name, and return their
+    /// namespaces.
+    pub fn resolve_instance_trait_ns(&self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
+        let mut ns_set = vec![];
+
         for trait_entry in self.instance_traits.iter() {
             if local_name == trait_entry.name().local_name() {
-                return Some(trait_entry.name().namespace().clone());
+                ns_set.push(trait_entry.name().namespace().clone());
             }
         }
 
-        None
+        ns_set
     }
 
     /// Get this class's instance allocator.

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -110,14 +110,14 @@ impl<'gc> Domain<'gc> {
                 if let Some(local_name) = multiname.local_name() {
                     for (qname, script) in read.defs.iter() {
                         if qname.local_name() == local_name {
-                            return Ok(Some((qname.clone(), *script)));
+                            return Ok(Some((*qname, *script)));
                         }
                     }
                 } else {
                     return Ok(None);
                 }
             } else if let Some(name) = multiname.local_name() {
-                let qname = QName::new(ns.clone(), name);
+                let qname = QName::new(*ns, name);
                 if read.defs.contains_key(&qname) {
                     let script = read.defs.get(&qname).cloned().unwrap();
                     return Ok(Some((qname, script)));
@@ -141,11 +141,11 @@ impl<'gc> Domain<'gc> {
         name: QName<'gc>,
     ) -> Result<Value<'gc>, Error> {
         let (name, mut script) = self
-            .get_defining_script(&name.clone().into())?
+            .get_defining_script(&name.into())?
             .ok_or_else(|| format!("MovieClip Symbol {} does not exist", name.local_name()))?;
         let globals = script.globals(&mut activation.context)?;
 
-        globals.get_property(globals, &name.clone().into(), activation)
+        globals.get_property(globals, &name.into(), activation)
     }
 
     /// Export a definition from a script into the current application domain.
@@ -158,7 +158,7 @@ impl<'gc> Domain<'gc> {
         script: Script<'gc>,
         mc: MutationContext<'gc, '_>,
     ) -> Result<(), Error> {
-        if self.has_definition(name.clone()) {
+        if self.has_definition(name) {
             return Err(format!(
                 "VerifyError: Attempted to redefine existing name {}",
                 name.local_name()

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -108,7 +108,7 @@ impl<'gc> Domain<'gc> {
         let matching_set = if let Some(local_name) = multiname.local_name() {
             read.defs.namespaces_of(local_name)
         } else {
-            vec![]
+            smallvec![]
         };
 
         if let Some(name) = multiname.local_name() {

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -6,8 +6,8 @@ use crate::avm2::object::{ByteArrayObject, TObject};
 use crate::avm2::script::Script;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use fnv::FnvHashMap;
 use gc_arena::{Collect, GcCell, MutationContext};
-use std::collections::HashMap;
 
 /// Represents a set of scripts and movies that share traits across different
 /// script-global scopes.
@@ -19,7 +19,7 @@ pub struct Domain<'gc>(GcCell<'gc, DomainData<'gc>>);
 #[collect(no_drop)]
 struct DomainData<'gc> {
     /// A list of all exported definitions and the script that exported them.
-    defs: HashMap<QName<'gc>, Script<'gc>>,
+    defs: FnvHashMap<QName<'gc>, Script<'gc>>,
 
     /// The parent domain.
     parent: Option<Domain<'gc>>,
@@ -46,7 +46,7 @@ impl<'gc> Domain<'gc> {
         Self(GcCell::allocate(
             mc,
             DomainData {
-                defs: HashMap::new(),
+                defs: Default::default(),
                 parent: None,
                 domain_memory: None,
             },
@@ -64,7 +64,7 @@ impl<'gc> Domain<'gc> {
         let this = Self(GcCell::allocate(
             activation.context.gc_context,
             DomainData {
-                defs: HashMap::new(),
+                defs: Default::default(),
                 parent: Some(parent),
                 domain_memory: None,
             },

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -7,8 +7,9 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
+use fnv::FnvHashMap;
 use gc_arena::Collect;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
 /// Which phase of event dispatch is currently occurring.
@@ -174,12 +175,12 @@ impl<'gc> Event<'gc> {
 /// A set of handlers organized by event type, priority, and order added.
 #[derive(Clone, Collect, Debug)]
 #[collect(no_drop)]
-pub struct DispatchList<'gc>(HashMap<AvmString<'gc>, BTreeMap<i32, Vec<EventHandler<'gc>>>>);
+pub struct DispatchList<'gc>(FnvHashMap<AvmString<'gc>, BTreeMap<i32, Vec<EventHandler<'gc>>>>);
 
 impl<'gc> DispatchList<'gc> {
     /// Construct a new dispatch list.
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(Default::default())
     }
 
     /// Get all of the event handlers for a given event type, if such a type

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -312,7 +312,7 @@ fn function<'gc>(
     let qname = QName::new(Namespace::package(package), name);
     let method = Method::from_builtin(nf, name, mc);
     let as3fn = FunctionObject::from_method(activation, method, scope, None, None).into();
-    domain.export_definition(qname.clone(), script, mc)?;
+    domain.export_definition(qname, script, mc)?;
     script
         .init()
         .1
@@ -333,9 +333,9 @@ fn dynamic_class<'gc>(
 ) -> Result<(), Error> {
     let (_, mut global, mut domain) = script.init();
     let class = class_object.inner_class_definition();
-    let name = class.read().name().clone();
+    let name = class.read().name();
 
-    global.install_const(mc, name.clone(), 0, class_object.into());
+    global.install_const(mc, name, 0, class_object.into());
     domain.export_definition(name, script, mc)
 }
 
@@ -372,13 +372,13 @@ fn class<'gc>(
         None
     };
 
-    let class_name = class_read.name().clone();
+    let class_name = class_read.name();
     drop(class_read);
 
     let class_object = ClassObject::from_class(activation, class_def, super_class)?;
     global.install_const(
         activation.context.gc_context,
-        class_name.clone(),
+        class_name,
         0,
         class_object.into(),
     );
@@ -405,7 +405,7 @@ fn constant<'gc>(
 ) -> Result<(), Error> {
     let (_, mut global, mut domain) = script.init();
     let name = QName::new(Namespace::package(package), name);
-    domain.export_definition(name.clone(), script, mc)?;
+    domain.export_definition(name, script, mc)?;
     global.install_const(mc, name, 0, value);
 
     Ok(())

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -21,9 +21,7 @@ pub fn instance_init<'gc>(
     if let Some(this) = this {
         activation.super_init(this, &[])?;
 
-        let name = this
-            .instance_of_class_definition()
-            .map(|c| c.read().name().clone());
+        let name = this.instance_of_class_definition().map(|c| c.read().name());
         let character = this
             .instance_of()
             .and_then(|t| {

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -168,7 +168,7 @@ pub fn has_own_property<'gc>(
     let name = name?.coerce_to_string(activation)?;
 
     let qname = QName::dynamic_name(name);
-    Ok(this.has_own_property(&qname)?.into())
+    Ok(this.has_own_property(qname)?.into())
 }
 
 /// `Object.prototype.isPrototypeOf`
@@ -205,7 +205,7 @@ pub fn property_is_enumerable<'gc>(
     let name = name?.coerce_to_string(activation)?;
 
     let qname = QName::dynamic_name(name);
-    Ok(this.property_is_enumerable(&qname).into())
+    Ok(this.property_is_enumerable(qname).into())
 }
 
 /// `Object.prototype.setPropertyIsEnumerable`
@@ -221,7 +221,7 @@ pub fn set_property_is_enumerable<'gc>(
 
     if let Some(Value::Bool(is_enum)) = args.get(1) {
         let qname = QName::dynamic_name(name);
-        this.set_local_property_is_enumerable(activation.context.gc_context, &qname, *is_enum)?;
+        this.set_local_property_is_enumerable(activation.context.gc_context, qname, *is_enum)?;
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/qname.rs
+++ b/core/src/avm2/globals/qname.rs
@@ -22,9 +22,7 @@ pub fn instance_init<'gc>(
                 let local_arg = args.get(1).cloned().unwrap_or(Value::Undefined);
 
                 let namespace = match ns_arg {
-                    Value::Object(o) if o.as_namespace().is_some() => {
-                        o.as_namespace().unwrap().clone()
-                    }
+                    Value::Object(o) if o.as_namespace().is_some() => *o.as_namespace().unwrap(),
                     Value::Undefined | Value::Null => Namespace::Any,
                     v => Namespace::Namespace(v.coerce_to_string(activation)?),
                 };
@@ -33,13 +31,9 @@ pub fn instance_init<'gc>(
             } else {
                 let qname_arg = args.get(0).cloned().unwrap_or(Value::Undefined);
                 let namespace = match qname_arg {
-                    Value::Object(o) if o.as_qname_object().is_some() => o
-                        .as_qname_object()
-                        .unwrap()
-                        .qname()
-                        .unwrap()
-                        .namespace()
-                        .clone(),
+                    Value::Object(o) if o.as_qname_object().is_some() => {
+                        o.as_qname_object().unwrap().qname().unwrap().namespace()
+                    }
                     _ => Namespace::Namespace("".into()),
                 };
 

--- a/core/src/avm2/globals/regexp.rs
+++ b/core/src/avm2/globals/regexp.rs
@@ -217,14 +217,14 @@ pub fn exec<'gc>(
 
             object.set_property_local(
                 object,
-                &QName::new(Namespace::public(), "index"),
+                QName::new(Namespace::public(), "index"),
                 Value::Number(index as f64),
                 activation,
             )?;
 
             object.set_property_local(
                 object,
-                &QName::new(Namespace::public(), "input"),
+                QName::new(Namespace::public(), "input"),
                 text.into(),
                 activation,
             )?;

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -69,11 +69,11 @@ pub fn class_init<'gc>(
         int_vector_class
             .inner_class_definition()
             .write(activation.context.gc_context)
-            .set_name(int_vector_name.clone());
+            .set_name(int_vector_name);
 
         globals.install_const(
             activation.context.gc_context,
-            int_vector_name.clone(),
+            int_vector_name,
             0,
             int_vector_class.into(),
         );
@@ -85,11 +85,11 @@ pub fn class_init<'gc>(
         uint_vector_class
             .inner_class_definition()
             .write(activation.context.gc_context)
-            .set_name(uint_vector_name.clone());
+            .set_name(uint_vector_name);
 
         globals.install_const(
             activation.context.gc_context,
-            uint_vector_name.clone(),
+            uint_vector_name,
             0,
             uint_vector_class.into(),
         );
@@ -101,11 +101,11 @@ pub fn class_init<'gc>(
         number_vector_class
             .inner_class_definition()
             .write(activation.context.gc_context)
-            .set_name(number_vector_name.clone());
+            .set_name(number_vector_name);
 
         globals.install_const(
             activation.context.gc_context,
-            number_vector_name.clone(),
+            number_vector_name,
             0,
             number_vector_class.into(),
         );
@@ -116,11 +116,11 @@ pub fn class_init<'gc>(
         object_vector_class
             .inner_class_definition()
             .write(activation.context.gc_context)
-            .set_name(object_vector_name.clone());
+            .set_name(object_vector_name);
 
         globals.install_const(
             activation.context.gc_context,
-            object_vector_name.clone(),
+            object_vector_name,
             0,
             object_vector_class.into(),
         );

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -21,6 +21,7 @@ use crate::html::TextFormat;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_macros::enum_trait_object;
+use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
@@ -548,7 +549,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         let matching_set = if let Some(local_name) = multiname.local_name() {
             self.resolve_ns(local_name)?
         } else {
-            vec![]
+            smallvec![]
         };
 
         if let Some(name) = multiname.local_name() {
@@ -581,7 +582,10 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Trait names will be resolved on class objects and object instances, but
     /// not prototypes. If you want to search a prototype's provided traits you
     /// must walk the prototype chain using `resolve_any_trait`.
-    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+    fn resolve_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
         let base = self.base();
 
         base.resolve_ns(local_name)

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -604,20 +604,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         base.resolve_any(local_name)
     }
 
-    /// Given a local name of a trait, find the namespace it resides in, if any.
-    ///
-    /// This function only works for names which are trait properties, not
-    /// dynamic or prototype properties. Furthermore, instance prototypes *will*
-    /// resolve trait names here, contrary to their behavior in `resolve_any.`
-    fn resolve_any_trait(
-        self,
-        local_name: AvmString<'gc>,
-    ) -> Result<Option<Namespace<'gc>>, Error> {
-        let base = self.base();
-
-        base.resolve_any_trait(local_name)
-    }
-
     /// Implements the `in` opcode and AS3 operator.
     ///
     /// By default, this just calls `has_property`, but may be overridden by

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -573,16 +573,15 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             vec![]
         };
 
-        let multiname_set: Vec<_> = multiname.namespace_set().cloned().collect();
         if let Some(name) = multiname.local_name() {
             for ns in matching_set.iter() {
-                if multiname_set.contains(ns) {
+                if multiname.namespace_set().any(|n| n == ns) {
                     return Ok(Some(QName::new(ns.clone(), name)));
                 }
             }
         }
 
-        if multiname_set.contains(&Namespace::Any) {
+        if multiname.namespace_set().any(|n| *n == Namespace::Any) {
             return Ok(matching_set
                 .first()
                 .map(|ns| QName::new(ns.clone(), multiname.local_name().unwrap())));

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -585,7 +585,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn resolve_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
+    ) -> Result<SmallVec<[Namespace<'gc>; 1]>, Error> {
         let base = self.base();
 
         base.resolve_ns(local_name)

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -575,7 +575,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 }
             } else if let Some(name) = multiname.local_name() {
                 let qname = QName::new(ns.clone(), name);
-                if self.has_property(&qname)? {
+                if self.has_own_property(&qname)? {
                     return Ok(Some(qname));
                 }
             } else {

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -9,6 +9,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
+use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates array objects.
@@ -189,7 +190,10 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         self.0.read().base.has_own_property(name)
     }
 
-    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+    fn resolve_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
         let base = self.base();
 
         let mut ns_set = base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -90,7 +90,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
     fn get_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         let read = self.0.read();
@@ -111,7 +111,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
     fn set_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
@@ -139,7 +139,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
     fn init_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
@@ -167,7 +167,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
     fn delete_property_local(
         &self,
         gc_context: MutationContext<'gc, '_>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
     ) -> Result<bool, Error> {
         if name.namespace().is_public() {
             if let Ok(index) = name.local_name().parse::<usize>() {
@@ -179,7 +179,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         Ok(self.0.write(gc_context).base.delete_property(name))
     }
 
-    fn has_own_property(self, name: &QName<'gc>) -> Result<bool, Error> {
+    fn has_own_property(self, name: QName<'gc>) -> Result<bool, Error> {
         if name.namespace().is_public() {
             if let Ok(index) = name.local_name().parse::<usize>() {
                 return Ok(self.0.read().array.get(index).is_some());
@@ -239,7 +239,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         }
     }
 
-    fn property_is_enumerable(&self, name: &QName<'gc>) -> bool {
+    fn property_is_enumerable(&self, name: QName<'gc>) -> bool {
         name.local_name()
             .parse::<u32>()
             .map(|index| self.0.read().array.length() as u32 >= index)

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -193,7 +193,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
     fn resolve_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
+    ) -> Result<SmallVec<[Namespace<'gc>; 1]>, Error> {
         let base = self.base();
 
         let mut ns_set = base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -192,7 +192,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
     fn resolve_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
+    ) -> Result<SmallVec<[Namespace<'gc>; 1]>, Error> {
         let base = self.base();
 
         let mut ns_set = base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -81,7 +81,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
     fn get_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         let read = self.0.read();
@@ -106,7 +106,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
     fn set_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
@@ -136,7 +136,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
     fn init_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
@@ -166,7 +166,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
     fn delete_property_local(
         &self,
         gc_context: MutationContext<'gc, '_>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
     ) -> Result<bool, Error> {
         if name.namespace().is_public() {
             if let Ok(index) = name.local_name().parse::<usize>() {
@@ -178,7 +178,7 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
         Ok(self.0.write(gc_context).base.delete_property(name))
     }
 
-    fn has_own_property(self, name: &QName<'gc>) -> Result<bool, Error> {
+    fn has_own_property(self, name: QName<'gc>) -> Result<bool, Error> {
         if name.namespace().is_public() {
             if let Ok(index) = name.local_name().parse::<usize>() {
                 return Ok(self.0.read().storage.get(index).is_some());

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -7,6 +7,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
+use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates ByteArray objects.
@@ -188,7 +189,10 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
         self.0.read().base.has_own_property(name)
     }
 
-    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+    fn resolve_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
         let base = self.base();
 
         let mut ns_set = base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -188,14 +188,19 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
         self.0.read().base.has_own_property(name)
     }
 
-    fn resolve_any(self, local_name: AvmString<'gc>) -> Result<Option<Namespace<'gc>>, Error> {
-        if let Ok(index) = local_name.parse::<usize>() {
-            if self.0.read().storage.get(index).is_some() {
-                return Ok(Some(Namespace::public()));
+    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+        let base = self.base();
+
+        let mut ns_set = base.resolve_ns(local_name)?;
+        if !ns_set.contains(&Namespace::public()) {
+            if let Ok(index) = local_name.parse::<usize>() {
+                if self.0.read().storage.get(index).is_some() {
+                    ns_set.push(Namespace::public())
+                }
             }
         }
 
-        self.0.read().base.resolve_any(local_name)
+        Ok(ns_set)
     }
 
     fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -554,7 +554,7 @@ impl<'gc> ClassObject<'gc> {
     pub fn resolve_instance_trait_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> SmallVec<[Namespace<'gc>; 2]> {
+    ) -> SmallVec<[Namespace<'gc>; 1]> {
         self.0
             .read()
             .resolved_instance_traits
@@ -976,7 +976,7 @@ impl<'gc> ClassObject<'gc> {
     pub fn resolve_class_trait_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> SmallVec<[Namespace<'gc>; 2]> {
+    ) -> SmallVec<[Namespace<'gc>; 1]> {
         self.0
             .read()
             .resolved_class_traits
@@ -1188,7 +1188,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
     fn resolve_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
+    ) -> Result<SmallVec<[Namespace<'gc>; 1]>, Error> {
         let read = self.0.read();
 
         let mut ns_set = read.base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -16,6 +16,7 @@ use crate::avm2::Error;
 use crate::string::AvmString;
 use fnv::FnvHashMap;
 use gc_arena::{Collect, GcCell, MutationContext};
+use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 use std::hash::{Hash, Hasher};
 
@@ -550,7 +551,10 @@ impl<'gc> ClassObject<'gc> {
 
     /// List all namespaces that contain one or more instance traits of a given
     /// local name.
-    pub fn resolve_instance_trait_ns(self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
+    pub fn resolve_instance_trait_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> SmallVec<[Namespace<'gc>; 2]> {
         self.0
             .read()
             .resolved_instance_traits
@@ -969,7 +973,10 @@ impl<'gc> ClassObject<'gc> {
 
     /// List all namespaces that contain one or more class traits of a given
     /// local name.
-    pub fn resolve_class_trait_ns(self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
+    pub fn resolve_class_trait_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> SmallVec<[Namespace<'gc>; 2]> {
         self.0
             .read()
             .resolved_class_traits
@@ -1178,7 +1185,10 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
             || read.base.has_trait(name)?)
     }
 
-    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+    fn resolve_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
         let read = self.0.read();
 
         let mut ns_set = read.base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -14,9 +14,9 @@ use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
+use fnv::FnvHashMap;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
-use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 /// An Object which can be called to execute its function code.
@@ -70,7 +70,7 @@ pub struct ClassObjectData<'gc> {
     /// as `None` here. AVM2 considers both applications to be separate
     /// classes, though we consider the parameter to be the class `Object` when
     /// we get a param of `null`.
-    applications: HashMap<Option<ClassObject<'gc>>, ClassObject<'gc>>,
+    applications: FnvHashMap<Option<ClassObject<'gc>>, ClassObject<'gc>>,
 
     /// Interfaces implemented by this class.
     interfaces: Vec<ClassObject<'gc>>,
@@ -199,7 +199,7 @@ impl<'gc> ClassObject<'gc> {
                 constructor: class.read().instance_init(),
                 native_constructor: class.read().native_instance_init(),
                 params: None,
-                applications: HashMap::new(),
+                applications: Default::default(),
                 interfaces: Vec::new(),
                 resolved_instance_traits: PropertyMap::new(),
                 resolved_class_traits: PropertyMap::new(),
@@ -1294,7 +1294,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
                 constructor,
                 native_constructor,
                 params: Some(object_param),
-                applications: HashMap::new(),
+                applications: Default::default(),
                 interfaces: Vec::new(),
                 resolved_instance_traits: PropertyMap::new(),
                 resolved_class_traits: PropertyMap::new(),

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -1035,20 +1035,6 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         read.base.resolve_any(local_name)
     }
 
-    fn resolve_any_trait(
-        self,
-        local_name: AvmString<'gc>,
-    ) -> Result<Option<Namespace<'gc>>, Error> {
-        let read = self.0.read();
-        let class = read.class.read();
-
-        if let Some(ns) = class.resolve_any_class_trait(local_name) {
-            return Ok(Some(ns));
-        }
-
-        read.base.resolve_any_trait(local_name)
-    }
-
     fn as_class_object(&self) -> Option<ClassObject<'gc>> {
         Some(*self)
     }

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -5,9 +5,9 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use fnv::FnvHashMap;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
-use std::collections::HashMap;
 
 /// A class instance allocator that allocates Dictionary objects.
 pub fn dictionary_allocator<'gc>(
@@ -21,7 +21,7 @@ pub fn dictionary_allocator<'gc>(
         activation.context.gc_context,
         DictionaryObjectData {
             base,
-            object_space: HashMap::new(),
+            object_space: Default::default(),
         },
     ))
     .into())
@@ -43,7 +43,7 @@ pub struct DictionaryObjectData<'gc> {
     base: ScriptObjectData<'gc>,
 
     /// Object key storage
-    object_space: HashMap<Object<'gc>, Value<'gc>>,
+    object_space: FnvHashMap<Object<'gc>, Value<'gc>>,
 }
 
 impl<'gc> DictionaryObject<'gc> {
@@ -101,7 +101,7 @@ impl<'gc> TObject<'gc> for DictionaryObject<'gc> {
             activation.context.gc_context,
             DictionaryObjectData {
                 base,
-                object_space: HashMap::new(),
+                object_space: Default::default(),
             },
         ))
         .into())

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -76,10 +76,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         if let Some(local_name) = multiname.local_name() {
             for namespace in multiname.namespace_set() {
                 if namespace.is_any() || namespace.is_public() || namespace.is_namespace() {
-                    let qname = QNameObject::from_qname(
-                        activation,
-                        QName::new(namespace.clone(), local_name),
-                    )?;
+                    let qname =
+                        QNameObject::from_qname(activation, QName::new(*namespace, local_name))?;
 
                     return receiver.call_property(
                         &QName::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "getProperty")
@@ -116,10 +114,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         if let Some(local_name) = multiname.local_name() {
             for namespace in multiname.namespace_set() {
                 if namespace.is_any() || namespace.is_public() || namespace.is_namespace() {
-                    let qname = QNameObject::from_qname(
-                        activation,
-                        QName::new(namespace.clone(), local_name),
-                    )?;
+                    let qname =
+                        QNameObject::from_qname(activation, QName::new(*namespace, local_name))?;
 
                     receiver.call_property(
                         &QName::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "setProperty")
@@ -160,10 +156,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         if let Some(local_name) = multiname.local_name() {
             for namespace in multiname.namespace_set() {
                 if namespace.is_any() || namespace.is_public() || namespace.is_namespace() {
-                    let qname = QNameObject::from_qname(
-                        activation,
-                        QName::new(namespace.clone(), local_name),
-                    )?;
+                    let qname =
+                        QNameObject::from_qname(activation, QName::new(*namespace, local_name))?;
 
                     let mut args = vec![qname.into()];
                     args.extend_from_slice(arguments);
@@ -197,10 +191,8 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         if let Some(local_name) = multiname.local_name() {
             for namespace in multiname.namespace_set() {
                 if namespace.is_any() || namespace.is_public() || namespace.is_namespace() {
-                    let qname = QNameObject::from_qname(
-                        activation,
-                        QName::new(namespace.clone(), local_name),
-                    )?;
+                    let qname =
+                        QNameObject::from_qname(activation, QName::new(*namespace, local_name))?;
 
                     return Ok(self
                         .call_property(
@@ -227,7 +219,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
     fn has_property_via_in(
         self,
         activation: &mut Activation<'_, 'gc, '_>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
     ) -> Result<bool, Error> {
         Ok(self
             .call_property(

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -309,30 +309,6 @@ impl<'gc> ScriptObjectData<'gc> {
             }
         }
 
-        let trait_ns = self.resolve_any_trait(local_name)?;
-
-        if trait_ns.is_none() {
-            if let Some(proto) = self.proto() {
-                proto.resolve_any(local_name)
-            } else {
-                Ok(None)
-            }
-        } else {
-            Ok(trait_ns)
-        }
-    }
-
-    pub fn resolve_any_trait(
-        &self,
-        local_name: AvmString<'gc>,
-    ) -> Result<Option<Namespace<'gc>>, Error> {
-        if let Some(proto) = self.proto {
-            let proto_trait_name = proto.resolve_any_trait(local_name)?;
-            if let Some(ns) = proto_trait_name {
-                return Ok(Some(ns));
-            }
-        }
-
         match &self.instance_of {
             Some(class) => {
                 let mut cur_class = Some(*class);

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -282,7 +282,7 @@ impl<'gc> ScriptObjectData<'gc> {
     pub fn resolve_ns(
         &self,
         local_name: AvmString<'gc>,
-    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
+    ) -> Result<SmallVec<[Namespace<'gc>; 1]>, Error> {
         let mut ns_set = self.values.namespaces_of(local_name);
 
         if let Some(class) = &self.instance_of {

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -12,7 +12,6 @@ use crate::avm2::Error;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
-use std::collections::HashMap;
 use std::fmt::Debug;
 
 /// A class instance allocator that allocates `ScriptObject`s.
@@ -126,7 +125,7 @@ impl<'gc> ScriptObject<'gc> {
 impl<'gc> ScriptObjectData<'gc> {
     pub fn base_new(proto: Option<Object<'gc>>, instance_of: Option<ClassObject<'gc>>) -> Self {
         ScriptObjectData {
-            values: HashMap::new(),
+            values: PropertyMap::new(),
             slots: Vec::new(),
             methods: Vec::new(),
             proto,
@@ -303,9 +302,9 @@ impl<'gc> ScriptObjectData<'gc> {
     }
 
     pub fn resolve_any(&self, local_name: AvmString<'gc>) -> Result<Option<Namespace<'gc>>, Error> {
-        for (key, _value) in self.values.iter() {
-            if key.local_name() == local_name {
-                return Ok(Some(key.namespace().clone()));
+        for (ns, local, _value) in self.values.iter() {
+            if *local == local_name {
+                return Ok(Some(ns.clone()));
             }
         }
 

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -11,6 +11,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
+use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 
@@ -278,7 +279,10 @@ impl<'gc> ScriptObjectData<'gc> {
         }
     }
 
-    pub fn resolve_ns(&self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+    pub fn resolve_ns(
+        &self,
+        local_name: AvmString<'gc>,
+    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
         let mut ns_set = self.values.namespaces_of(local_name);
 
         if let Some(class) = &self.instance_of {

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -101,7 +101,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
     fn get_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         let read = self.0.read();
@@ -122,7 +122,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
     fn set_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
@@ -160,7 +160,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
     fn init_property_local(
         self,
         receiver: Object<'gc>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
@@ -198,7 +198,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
     fn delete_property_local(
         &self,
         gc_context: MutationContext<'gc, '_>,
-        name: &QName<'gc>,
+        name: QName<'gc>,
     ) -> Result<bool, Error> {
         if name.namespace().is_package("") && name.local_name().parse::<usize>().is_ok() {
             return Ok(true);
@@ -207,7 +207,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         Ok(self.0.write(gc_context).base.delete_property(name))
     }
 
-    fn has_own_property(self, name: &QName<'gc>) -> Result<bool, Error> {
+    fn has_own_property(self, name: QName<'gc>) -> Result<bool, Error> {
         if name.namespace().is_package("") {
             if let Ok(index) = name.local_name().parse::<usize>() {
                 return Ok(self.0.read().vector.is_in_range(index));
@@ -259,7 +259,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         }
     }
 
-    fn property_is_enumerable(&self, name: &QName<'gc>) -> bool {
+    fn property_is_enumerable(&self, name: QName<'gc>) -> bool {
         name.local_name()
             .parse::<u32>()
             .map(|index| self.0.read().vector.length() as u32 >= index)

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -9,6 +9,7 @@ use crate::avm2::vector::VectorStorage;
 use crate::avm2::Error;
 use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
+use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 
 /// A class instance allocator that allocates Vector objects.
@@ -217,7 +218,10 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         self.0.read().base.has_own_property(name)
     }
 
-    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+    fn resolve_ns(
+        self,
+        local_name: AvmString<'gc>,
+    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
         let base = self.base();
 
         let mut ns_set = base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -221,7 +221,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
     fn resolve_ns(
         self,
         local_name: AvmString<'gc>,
-    ) -> Result<SmallVec<[Namespace<'gc>; 2]>, Error> {
+    ) -> Result<SmallVec<[Namespace<'gc>; 1]>, Error> {
         let base = self.base();
 
         let mut ns_set = base.resolve_ns(local_name)?;

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -217,14 +217,19 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         self.0.read().base.has_own_property(name)
     }
 
-    fn resolve_any(self, local_name: AvmString<'gc>) -> Result<Option<Namespace<'gc>>, Error> {
-        if let Ok(index) = local_name.parse::<usize>() {
-            if self.0.read().vector.is_in_range(index) {
-                return Ok(Some(Namespace::package("")));
+    fn resolve_ns(self, local_name: AvmString<'gc>) -> Result<Vec<Namespace<'gc>>, Error> {
+        let base = self.base();
+
+        let mut ns_set = base.resolve_ns(local_name)?;
+        if !ns_set.contains(&Namespace::public()) {
+            if let Ok(index) = local_name.parse::<usize>() {
+                if self.0.read().vector.is_in_range(index) {
+                    ns_set.push(Namespace::public())
+                }
             }
         }
 
-        self.0.read().base.resolve_any(local_name)
+        Ok(ns_set)
     }
 
     fn get_next_enumerant(

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -114,7 +114,7 @@ impl<'gc, V> PropertyMap<'gc, V> {
         None
     }
 
-    pub fn namespaces_of(&self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
+    pub fn namespaces_of(&self, local_name: AvmString<'gc>) -> SmallVec<[Namespace<'gc>; 2]> {
         self.0
             .get(&local_name)
             .map(|vals| vals.iter().map(|(ns, _v)| *ns).collect())

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -1,7 +1,103 @@
 //! Property map
 
-use crate::avm2::names::QName;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::AvmString;
+use gc_arena::Collect;
 use std::collections::HashMap;
+use std::mem::swap;
 
 /// Type which represents named properties on an object.
-pub type PropertyMap<'gc, V> = HashMap<QName<'gc>, V>;
+///
+/// This type exposes interfaces akin to `HashMap<QName<'gc>, V>`, and is
+/// intended to serve as a drop-in replacement optimized for objects where few
+/// properties have overlapping local names. However, we have made slight
+/// changes to the API in the following cases:
+///
+///  * Iterators return tuples of namespace, local-name, and value; rather than
+///    a qualified name and value pair.
+///  * Only `HashMap` methods and traits that we need are implemented.
+///
+/// The internal structure of the `PropertyMap` technically allows storage of
+/// multiple values per `QName`. It's implementation enforces the invariant
+/// that each `QName` only have one associated `V`.
+#[derive(Clone, Collect, Debug)]
+#[collect(no_drop)]
+pub struct PropertyMap<'gc, V>(HashMap<AvmString<'gc>, Vec<(Namespace<'gc>, V)>>);
+
+impl<'gc, V> Default for PropertyMap<'gc, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'gc, V> PropertyMap<'gc, V> {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn get(&self, name: &QName<'gc>) -> Option<&V> {
+        self.0
+            .get(&name.local_name())
+            .iter()
+            .filter_map(|v| {
+                v.iter()
+                    .filter(|(n, _)| n == name.namespace())
+                    .map(|(_, v)| v)
+                    .next()
+            })
+            .next()
+    }
+
+    pub fn get_mut(&mut self, name: &QName<'gc>) -> Option<&mut V> {
+        if let Some(bucket) = self.0.get_mut(&name.local_name()) {
+            if let Some((_, old_value)) = bucket.iter_mut().find(|(n, _)| n == name.namespace()) {
+                return Some(old_value);
+            }
+        }
+
+        None
+    }
+
+    pub fn contains_key(&self, name: &QName<'gc>) -> bool {
+        self.0
+            .get(&name.local_name())
+            .iter()
+            .any(|v| v.iter().any(|(n, _)| n == name.namespace()))
+    }
+
+    pub fn insert(&mut self, name: QName<'gc>, mut value: V) -> Option<V> {
+        let bucket = self.0.entry(name.local_name()).or_default();
+
+        if let Some((_, old_value)) = bucket.iter_mut().find(|(n, _)| n == name.namespace()) {
+            swap(old_value, &mut value);
+
+            Some(value)
+        } else {
+            bucket.push((name.namespace().clone(), value));
+
+            None
+        }
+    }
+
+    pub fn remove(&mut self, name: &QName<'gc>) -> Option<V> {
+        let bucket = self.0.get_mut(&name.local_name());
+
+        if let Some(bucket) = bucket {
+            let position = bucket
+                .iter_mut()
+                .enumerate()
+                .find(|(_, (n, _))| n == name.namespace());
+            if let Some((position, _)) = position {
+                return Some(bucket.remove(position).1);
+            }
+        }
+
+        None
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&Namespace<'gc>, &AvmString<'gc>, &V)> {
+        self.0
+            .iter()
+            .flat_map(|(s, b)| b.iter().map(move |(n, v)| (n, s, v)))
+    }
+}

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::AvmString;
+use fnv::FnvBuildHasher;
 use gc_arena::Collect;
 use std::collections::HashMap;
 use std::mem::swap;
@@ -22,7 +23,7 @@ use std::mem::swap;
 /// that each `QName` only have one associated `V`.
 #[derive(Clone, Collect, Debug)]
 #[collect(no_drop)]
-pub struct PropertyMap<'gc, V>(HashMap<AvmString<'gc>, Vec<(Namespace<'gc>, V)>>);
+pub struct PropertyMap<'gc, V>(HashMap<AvmString<'gc>, Vec<(Namespace<'gc>, V)>, FnvBuildHasher>);
 
 impl<'gc, V> Default for PropertyMap<'gc, V> {
     fn default() -> Self {
@@ -32,7 +33,7 @@ impl<'gc, V> Default for PropertyMap<'gc, V> {
 
 impl<'gc, V> PropertyMap<'gc, V> {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(Default::default())
     }
 
     pub fn get(&self, name: QName<'gc>) -> Option<&V> {

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -95,9 +95,10 @@ impl<'gc, V> PropertyMap<'gc, V> {
         None
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&Namespace<'gc>, &AvmString<'gc>, &V)> {
+    pub fn namespaces_of(&self, local_name: AvmString<'gc>) -> Vec<Namespace<'gc>> {
         self.0
-            .iter()
-            .flat_map(|(s, b)| b.iter().map(move |(n, v)| (n, s, v)))
+            .get(&local_name)
+            .map(|vals| vals.iter().map(|(ns, _v)| ns.clone()).collect())
+            .unwrap_or_default()
     }
 }

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -114,7 +114,7 @@ impl<'gc, V> PropertyMap<'gc, V> {
         None
     }
 
-    pub fn namespaces_of(&self, local_name: AvmString<'gc>) -> SmallVec<[Namespace<'gc>; 2]> {
+    pub fn namespaces_of(&self, local_name: AvmString<'gc>) -> SmallVec<[Namespace<'gc>; 1]> {
         self.0
             .get(&local_name)
             .map(|vals| vals.iter().map(|(ns, _v)| *ns).collect())

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -132,8 +132,8 @@ impl<'gc> ScopeChain<'gc> {
                     // 2. We are at depth 0 (global scope)
                     //
                     // But no matter what, we always search traits first.
-                    if values.has_trait(&qname)?
-                        || ((scope.with() || depth == 0) && values.has_property(&qname)?)
+                    if values.has_trait(qname)?
+                        || ((scope.with() || depth == 0) && values.has_property(qname)?)
                     {
                         return Ok(Some(values));
                     }
@@ -202,8 +202,8 @@ impl<'gc> ScopeStack<'gc> {
                 // We search the dynamic properties if either conditions are met:
                 // 1. Scope is a `with` scope
                 // 2. We are at depth 0 AND we are at global$init (script initializer).
-                if values.has_trait(&qname)?
-                    || ((scope.with() || (global && depth == 0)) && values.has_property(&qname)?)
+                if values.has_trait(qname)?
+                    || ((scope.with() || (global && depth == 0)) && values.has_property(qname)?)
                 {
                     return Ok(Some(values));
                 }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -346,7 +346,7 @@ impl<'gc> Script<'gc> {
             let newtrait = Trait::from_abc_trait(unit, abc_trait, activation)?;
             if !newtrait.name().namespace().is_private() {
                 write.domain.export_definition(
-                    newtrait.name().clone(),
+                    newtrait.name(),
                     *self,
                     activation.context.gc_context,
                 )?;

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -102,7 +102,7 @@ pub enum TraitKind<'gc> {
 
 impl<'gc> Trait<'gc> {
     pub fn from_class(class: GcCell<'gc, Class<'gc>>) -> Self {
-        let name = class.read().name().clone();
+        let name = class.read().name();
 
         Trait {
             name,
@@ -273,8 +273,8 @@ impl<'gc> Trait<'gc> {
         })
     }
 
-    pub fn name(&self) -> &QName<'gc> {
-        &self.name
+    pub fn name(&self) -> QName<'gc> {
+        self.name
     }
 
     pub fn kind(&self) -> &TraitKind<'gc> {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -595,7 +595,7 @@ impl<'gc> MovieClip<'gc> {
                 .library_for_movie_mut(movie.clone());
             let domain = library.avm2_domain();
             let class_object = domain
-                .get_defined_value(&mut activation, name.clone())
+                .get_defined_value(&mut activation, name)
                 .and_then(|v| v.coerce_to_object(&mut activation))
                 .and_then(|v| {
                     v.as_class_object().ok_or_else(|| {


### PR DESCRIPTION
This PR aims to improve the performance of AVM2 property operations by restructuring `PropertyMap`. This type is no longer an alias for a hashmap keyed by `QName`, but instead stores values in a two-level structure of local name and `Namespace`. This is done under the assumption that local name conflicts across namespaces are rare. To further exploit this we also store conflicting names in a `SmallVec` with inline size 1. This saves on both allocations and hash lookups.

The structure of this map also makes it far easier to get the information that multiname resolution needs to work - namely, a list of all namespaces that a local name may appear in. `resolve_any` is gone, instead replaced with a method that returns *all* matching namespaces. This allows us to just check that list against the multiname's list to resolve a name.

(One idea for future performance would be to treat the `Multiname`'s namespace set as a hash set; this requires further object interning in order to be effective.)

Further performance was obtained by moving trait lookups into a `PropertyMap`; we also pre-calculate "flattened" lists of instance traits on each class. The old system used linear scans of one `Vec` per superclass in order to do trait lookups. In contrast, the new system only requires one `PropertyMap` lookup in total.

Several unnecessary `clone` operations were also removed. Notably, `Namespace` and `QName` are now copy types. This may provide more optimization opportunities for the compiler, but I'm not sure about this.

Finally, we switch `PropertyMap` and a few related hashtables to use `FnvHashBuilder`. This was already done in AVM1 a while back and provided notably performance improvements. The default Siphash that Rust uses is intended to guard against DDoS attacks against remote network services, which is an attack we do not need to worry about.