### PR TITLE
string: Hash and Eq performance improvements

### DIFF
--- a/core/src/string/ops.rs
+++ b/core/src/string/ops.rs
@@ -145,8 +145,14 @@ pub fn str_cmp_ignore_case(left: &WStr, right: &WStr) -> std::cmp::Ordering {
 
 pub fn str_hash<H: Hasher>(s: &WStr, state: &mut H) {
     match s.units() {
-        Units::Bytes(us) => us.iter().for_each(|u| state.write_u16(u16::from(*u))),
-        Units::Wide(us) => us.iter().for_each(|u| state.write_u16(*u)),
+        Units::Bytes(us) => us.iter().for_each(|u| state.write_u8(*u)),
+        Units::Wide(us) => us.iter().for_each(|u| {
+            if *u <= 0xFF {
+                state.write_u8(*u as u8)
+            } else {
+                state.write_u16(*u)
+            }
+        }),
     }
     state.write_u8(0xff);
 }

--- a/core/src/string/ops.rs
+++ b/core/src/string/ops.rs
@@ -145,7 +145,7 @@ pub fn str_cmp_ignore_case(left: &WStr, right: &WStr) -> std::cmp::Ordering {
 
 pub fn str_hash<H: Hasher>(s: &WStr, state: &mut H) {
     match s.units() {
-        Units::Bytes(us) => us.iter().for_each(|u| state.write_u8(*u)),
+        Units::Bytes(us) => state.write(us),
         Units::Wide(us) => us.iter().for_each(|u| {
             if *u <= 0xFF {
                 state.write_u8(*u as u8)

--- a/core/src/string/ops.rs
+++ b/core/src/string/ops.rs
@@ -96,6 +96,10 @@ pub fn str_debug_fmt(s: &WStr, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 }
 
 pub fn str_eq(left: &WStr, right: &WStr) -> bool {
+    if std::ptr::eq(left, right) {
+        return true;
+    }
+
     let (bytes, wide) = match (left.units(), right.units()) {
         (Units::Bytes(a), Units::Bytes(b)) => return a == b,
         (Units::Wide(a), Units::Wide(b)) => return a == b,


### PR DESCRIPTION
After merging the big string refactor, I noticed some performance regressions on AVM2; I was able to fix them as follows:

 - Hash bytes as bytes. This allows us to use `hash.write` in the common case of ASCII-only strings. Wide strings *cannot* use this, as wide strings with ASCII-only contents need to hash identically to byte strings. Hence, we still need to iterate over the whole string, which is still slower in that case.
 - Short-circuit string compare. In other words, when comparing for string equality, we first check for pointer equality. This was motivated by speeding up bucket scans in hashtable lookups.