### PR TITLE
core: Cleanup DefineBitsJpeg

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -26,7 +26,7 @@ pub trait RenderBackend: Downcast {
         jpeg_tables: Option<&[u8]>,
     ) -> Result<BitmapInfo, Error>;
     fn register_bitmap_jpeg_2(&mut self, data: &[u8]) -> Result<BitmapInfo, Error>;
-    fn register_bitmap_jpeg_3(
+    fn register_bitmap_jpeg_3_or_4(
         &mut self,
         jpeg_data: &[u8],
         alpha_data: &[u8],
@@ -146,7 +146,7 @@ impl RenderBackend for NullRenderer {
             height: 0,
         })
     }
-    fn register_bitmap_jpeg_3(
+    fn register_bitmap_jpeg_3_or_4(
         &mut self,
         _data: &[u8],
         _alpha_data: &[u8],

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2667,7 +2667,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         reader.get_mut().read_exact(&mut alpha_data)?;
         let bitmap_info = context
             .renderer
-            .register_bitmap_jpeg_3(&jpeg_data, &alpha_data)?;
+            .register_bitmap_jpeg_3_or_4(&jpeg_data, &alpha_data)?;
         let bitmap = Bitmap::new(
             context,
             id,
@@ -2702,7 +2702,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         reader.get_mut().read_exact(&mut alpha_data)?;
         let bitmap_info = context
             .renderer
-            .register_bitmap_jpeg_3(&jpeg_data, &alpha_data)?;
+            .register_bitmap_jpeg_3_or_4(&jpeg_data, &alpha_data)?;
         let bitmap = Bitmap::new(
             context,
             id,

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -490,7 +490,7 @@ impl RenderBackend for WebCanvasRenderBackend {
         }
     }
 
-    fn register_bitmap_jpeg_3(
+    fn register_bitmap_jpeg_3_or_4(
         &mut self,
         jpeg_data: &[u8],
         alpha_data: &[u8],

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -776,7 +776,7 @@ impl RenderBackend for WebGlRenderBackend {
         self.register_bitmap(bitmap)
     }
 
-    fn register_bitmap_jpeg_3(
+    fn register_bitmap_jpeg_3_or_4(
         &mut self,
         jpeg_data: &[u8],
         alpha_data: &[u8],

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -858,7 +858,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         Ok(self.register_bitmap(bitmap, "JPEG2"))
     }
 
-    fn register_bitmap_jpeg_3(
+    fn register_bitmap_jpeg_3_or_4(
         &mut self,
         jpeg_data: &[u8],
         alpha_data: &[u8],


### PR DESCRIPTION
- Rename `register_bitmap_jpeg_3` to `register_bitmap_jpeg_3_or_4`.
- Unify `define_bits_jpeg_3` and `define_bits_jpeg_4`.