### PR TITLE
web: Build two WASM modules, with/without extensions, load the appropriate one

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags=["--cfg=web_sys_unstable_apis"]

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -268,7 +268,7 @@ jobs:
         shell: bash -l {0}
         run: |
           npm ci
-          npm run build
+          npm run build:dual-wasm
           npm run docs
 
       - name: Sign Firefox extension

--- a/web/README.md
+++ b/web/README.md
@@ -85,6 +85,8 @@ In this project, you may run the following commands to build all packages:
     -   Output will be available in the `dist/` of each package (for example, `./packages/selfhosted/dist`),
         save for the extension which is directory `build/`.
     -   You may also use `npm run build:debug` to disable Webpack optimizations and activate the (extremely verbose) ActionScript debugging output.
+    -   There is `npm run build:dual-wasm` as well, to build a second WebAssembly module that makes use of some WebAssembly extensions,
+        potentially resulting in better performance in browsers that support them, at the expense of longer build time.
 
 From here, you may follow the instructions to [use Ruffle on your website](packages/selfhosted/README.md),
 or run a demo locally with `npm run demo`.

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "scripts": {
         "build": "npm run build --workspaces",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
+        "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
         "demo": "npm run serve --workspace ruffle-demo",
         "test": "npm run test --workspaces --if-present",
         "docs": "npm run docs --workspaces --if-present",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -9,14 +9,29 @@
         "pkg/"
     ],
     "scripts": {
-        "build": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt && npm run build:ts",
+        "build": "npm run build:ruffle_web && npm run build:ruffle_web-wasm_extensions && npm run build:ts",
+
+        "//1": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
+        "//2": "# Enabling 'build-std' would also be great, but it's not stable yet.",
+
+        "build:ruffle_web": "cross-env OUT_NAME=ruffle_web RUSTFLAGS=\"--cfg=web_sys_unstable_apis\" npm run build:cargo_bindgen_opt",
+        "build:ruffle_web-wasm_extensions": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext\" npm run build:cargo_bindgen_opt",
+
+        "//3": "# This just chains together the three commands after it.",
+        "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
+
         "build:cargo": "cross-env-shell \"cargo build --release --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\"\"",
-        "build:wasm-bindgen": "wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name ruffle_web",
-        "build:wasm-opt": "wasm-opt -o ./pkg/ruffle_web_bg.wasm -O -g ./pkg/ruffle_web_bg.wasm || npm run build:wasm-opt-failed",
+        "build:wasm-bindgen": "cross-env-shell \"wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name $OUT_NAME\"",
+        "build:wasm-opt": "cross-env-shell \"wasm-opt -o ./pkg/${OUT_NAME}_bg.wasm -O -g ./pkg/${OUT_NAME}_bg.wasm || npm run build:wasm-opt-failed\"",
+
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
+
         "build:ts": "tsc -d && node tools/set_version.js",
         "docs": "typedoc",
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha"
+    },
+    "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
     },
     "devDependencies": {
         "@types/mocha": "^9.0.0",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -11,18 +11,23 @@
     "scripts": {
         "build": "npm run build:ruffle_web && npm run build:ruffle_web-wasm_extensions && npm run build:ts",
 
-        "//1": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
-        "//2": "# Enabling 'build-std' would also be great, but it's not stable yet.",
+        "//1": "# Setting ENABLE_WASM_EXTENSIONS=true causes a second module to be built as well, that utilizes WebAssembly extensions, instead of it just being a 'fake' - a copy of the 'vanilla' one.",
+        "//2": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
+        "//3": "# Enabling 'build-std' would also be great, but it's not stable yet.",
 
         "build:ruffle_web": "cross-env OUT_NAME=ruffle_web RUSTFLAGS=\"--cfg=web_sys_unstable_apis\" npm run build:cargo_bindgen_opt",
-        "build:ruffle_web-wasm_extensions": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext\" npm run build:cargo_bindgen_opt",
 
-        "//3": "# This just chains together the three commands after it.",
+        "//4": "# Dispatches to either building the real, or copying the fake (stand-in), 'with-extensions' module.",
+        "build:ruffle_web-wasm_extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:ruffle_web-wasm_extensions-real || npm run build:ruffle_web-wasm_extensions-fake",
+        "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext\" npm run build:cargo_bindgen_opt",
+        "build:ruffle_web-wasm_extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp ./pkg/ruffle_web_bg.wasm ./pkg/ruffle_web-wasm_extensions_bg.wasm && shx cp ./pkg/ruffle_web_bg.wasm.d.ts ./pkg/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp ./pkg/ruffle_web.js ./pkg/ruffle_web-wasm_extensions.js && shx cp ./pkg/ruffle_web.d.ts ./pkg/ruffle_web-wasm_extensions.d.ts",
+
+        "//5": "# This just chains together the three commands after it.",
         "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
 
         "build:cargo": "cross-env-shell \"cargo build --release --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\"\"",
-        "build:wasm-bindgen": "cross-env-shell \"wasm-bindgen ../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm --target web --out-dir ./pkg --out-name $OUT_NAME\"",
-        "build:wasm-opt": "cross-env-shell \"wasm-opt -o ./pkg/${OUT_NAME}_bg.wasm -O -g ./pkg/${OUT_NAME}_bg.wasm || npm run build:wasm-opt-failed\"",
+        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm\" --target web --out-dir ./pkg --out-name \"$OUT_NAME\"",
+        "build:wasm-opt": "cross-env-shell wasm-opt -o \"./pkg/${OUT_NAME}_bg.wasm\" -O -g \"./pkg/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
 
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
 
@@ -41,6 +46,7 @@
         "eslint-plugin-jsdoc": "^37.1.0",
         "mocha": "^9.1.3",
         "replace-in-file": "^6.3.2",
+        "shx": "^0.3.3",
         "ts-node": "^10.4.0",
         "typedoc": "^0.22.10",
         "typescript": "^4.5.2"

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -427,7 +427,11 @@ export class RufflePlayer extends HTMLElement {
             this,
             config
         );
-        console.log("New Ruffle instance created.");
+        console.log(
+            "New Ruffle instance created (WebAssembly extensions: " +
+                (ruffleConstructor.is_wasm_simd_used() ? "ON" : "OFF") +
+                ")"
+        );
 
         // In Firefox, AudioContext.state is always "suspended" when the object has just been created.
         // It may change by itself to "running" some milliseconds later. So we need to wait a little

--- a/web/packages/core/tsconfig.json
+++ b/web/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "target": "es2017",
-        "module": "es2015",
+        "module": "es2020",
         "moduleResolution": "node",
         "strict": true,
         "outDir": "pkg",

--- a/web/packages/extension/tsconfig.json
+++ b/web/packages/extension/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "@tsconfig/recommended/tsconfig.json",
     "compilerOptions": {
         "target": "es2017",
-        "module": "es2015",
+        "module": "es2020",
         "moduleResolution": "node",
         "strict": true,
     },

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -454,6 +454,15 @@ impl Ruffle {
         })
         .unwrap_or_default()
     }
+
+    /// Returns whether the `simd128` target feature was enabled at build time.
+    /// This is intended to discriminate between the two WebAssembly module
+    /// versions, one of which uses WebAssembly extensions, and the other one
+    /// being "vanilla". `simd128` is used as proxy for most extensions, since
+    /// no other WebAssembly target feature is exposed to `cfg!`.
+    pub fn is_wasm_simd_used() -> bool {
+        cfg!(target_feature = "simd128")
+    }
 }
 
 impl Ruffle {


### PR DESCRIPTION
This includes, "unblocks", and extends https://github.com/ruffle-rs/ruffle/pull/5225.

Also adds dynamic fallback to an additional, non-extension-enabled WebAssembly module, mostly for compatibility with ~poor~ Safari.

~The `simd128` extension is not yet directly utilized by us (it possibly is by some dependencies), but I have a few ideas where to use it, improving video decoding performance significantly.~
**EDIT**: The `simd128` feature should help a lot with the color conversion of both H.263 and VP6 videos since https://github.com/ruffle-rs/h263-rs/pull/15 got merged. The IDCT in the H.263 decoder could also potentially benefit from it with some tweaking, but I haven't found/made any speedups there yet.

This also roughly (but not quite) doubles both the time it takes to build the web version, and the size of all web-based release packages.

~What I don't like is that completely blanking out `RUSTFLAGS` also disables the `web_sys_unstable_apis` config option, which is needed for WebGPU.
We could just brush over this, saying that if browser compatibility is the entire reason for this fallback module, then surely WebGPU is not important. (Even though, Safari does have experimental support for it.)~
**EDIT**: `RUSTFLAGS` is now set locally and properly for both modules, always setting the `web_sys_unstable_apis` config option.