### PR TITLE
avm1: Remove `Function.prototype.toString`

### DIFF
--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -10,7 +10,6 @@ use gc_arena::MutationContext;
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "call" => method(call);
     "apply" => method(apply);
-    "toString" => method(to_string);
 };
 
 /// Implements `new Function()`
@@ -108,15 +107,6 @@ pub fn apply<'gc>(
         ),
         _ => Ok(Value::Undefined),
     }
-}
-
-/// Implements `Function.prototype.toString`
-fn to_string<'gc>(
-    _: &mut Activation<'_, 'gc, '_>,
-    _: Object<'gc>,
-    _: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok("[type Function]".into())
 }
 
 /// Partially construct `Function.prototype`.

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -110,10 +110,14 @@ pub fn has_own_property<'gc>(
 /// Implements `Object.prototype.toString`
 fn to_string<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
-    _: Object<'gc>,
-    _: &[Value<'gc>],
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok("[object Object]".into())
+    if this.as_executable().is_some() {
+        Ok("[type Function]".into())
+    } else {
+        Ok("[object Object]".into())
+    }
 }
 
 /// Implements `Object.prototype.isPropertyEnumerable`


### PR DESCRIPTION
`Function.prototype` doesn't have its own `toString` method, but
rather inherts it from `Object.prototype`. So remove `Function.prototype.toString`
and move its logic to `Object.prototype.toString`.