### PR TITLE
web: Suppress Webpack's size limit for .wasm files

### DIFF
--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -24,6 +24,10 @@ module.exports = (_env, _argv) => {
                 },
             ],
         },
+        performance: {
+            assetFilter: (assetFilename) =>
+                !/\.(map|wasm)$/i.test(assetFilename),
+        },
         devtool: "source-map",
         plugins: [
             new CopyPlugin({

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -65,6 +65,10 @@ module.exports = (env, _argv) => {
         resolve: {
             extensions: [".ts", "..."],
         },
+        performance: {
+            assetFilter: (assetFilename) =>
+                !/\.(map|wasm)$/i.test(assetFilename),
+        },
         plugins: [
             new CopyPlugin({
                 patterns: [

--- a/web/packages/selfhosted/webpack.config.js
+++ b/web/packages/selfhosted/webpack.config.js
@@ -17,6 +17,10 @@ module.exports = (_env, _argv) => {
             chunkFilename: "core.ruffle.[contenthash].js",
             clean: true,
         },
+        performance: {
+            assetFilter: (assetFilename) =>
+                !/\.(map|wasm)$/i.test(assetFilename),
+        },
         devtool: "source-map",
         plugins: [
             new CopyPlugin({


### PR DESCRIPTION
Webpack warns on assets larger than 250KB by default. Our WebAssembly module exceeds this limit by far (it's a few MBs).