### PR TITLE
avm1: Split `XML` and `XMLNode` definitions

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -59,6 +59,7 @@ mod text_format;
 mod transform;
 mod video;
 mod xml;
+mod xml_node;
 
 const GLOBAL_DECLS: &[Declaration] = declare_properties! {
     "isFinite" => method(is_finite; DONT_ENUM);
@@ -592,9 +593,9 @@ pub fn create_globals<'gc>(
 
     let error_proto = error::create_proto(gc_context, object_proto, function_proto);
 
-    let xmlnode_proto = xml::create_xmlnode_proto(gc_context, object_proto, function_proto);
+    let xmlnode_proto = xml_node::create_proto(gc_context, object_proto, function_proto);
 
-    let xml_proto = xml::create_xml_proto(gc_context, xmlnode_proto, function_proto);
+    let xml_proto = xml::create_proto(gc_context, xmlnode_proto, function_proto);
 
     let string_proto = string::create_proto(gc_context, object_proto, function_proto);
     let number_proto = number::create_proto(gc_context, object_proto, function_proto);
@@ -705,15 +706,15 @@ pub fn create_globals<'gc>(
     let array = array::create_array_object(gc_context, array_proto, function_proto);
     let xmlnode = FunctionObject::constructor(
         gc_context,
-        Executable::Native(xml::xmlnode_constructor),
-        constructor_to_fn!(xml::xmlnode_constructor),
+        Executable::Native(xml_node::constructor),
+        constructor_to_fn!(xml_node::constructor),
         Some(function_proto),
         xmlnode_proto,
     );
     let xml = FunctionObject::constructor(
         gc_context,
-        Executable::Native(xml::xml_constructor),
-        constructor_to_fn!(xml::xml_constructor),
+        Executable::Native(xml::constructor),
+        constructor_to_fn!(xml::constructor),
         Some(function_proto),
         xml_proto,
     );

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -82,7 +82,7 @@ fn serialize_value<'gc>(
                 Some(AmfValue::ECMAArray(vec![], values, length as u32))
             } else if let Some(xml_node) = o.as_xml_node() {
                 xml_node
-                    .into_string(&mut |_| true)
+                    .into_string(&|_| true)
                     .map(|xml_string| AmfValue::XML(xml_string, true))
                     .ok()
             } else if let Some(date) = o.as_date_object() {

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -1,0 +1,527 @@
+//! XMLNode class
+
+use crate::avm1::activation::Activation;
+use crate::avm1::error::Error;
+use crate::avm1::object::xml_object::XmlObject;
+use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::{ArrayObject, Object, TObject, Value};
+use crate::avm_warn;
+use crate::string::AvmString;
+use crate::xml;
+use crate::xml::{XmlDocument, XmlNode};
+use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "localName" => property(local_name; READ_ONLY);
+    "nodeName" => property(node_name; READ_ONLY);
+    "nodeType" => property(node_type; READ_ONLY);
+    "nodeValue" => property(node_value; READ_ONLY);
+    "prefix" => property(prefix; READ_ONLY);
+    "childNodes" => property(child_nodes; READ_ONLY);
+    "firstChild" => property(first_child; READ_ONLY);
+    "lastChild" => property(last_child; READ_ONLY);
+    "parentNode" => property(parent_node; READ_ONLY);
+    "previousSibling" => property(previous_sibling; READ_ONLY);
+    "nextSibling" => property(next_sibling; READ_ONLY);
+    "attributes" => property(attributes; READ_ONLY);
+    "namespaceURI" => property(namespace_uri; READ_ONLY);
+    "appendChild" => method(append_child);
+    "insertBefore" => method(insert_before);
+    "cloneNode" => method(clone_node);
+    "getNamespaceForPrefix" => method(get_namespace_for_prefix);
+    "getPrefixForNamespace" => method(get_prefix_for_namespace);
+    "hasChildNodes" => method(has_child_nodes);
+    "removeNode" => method(remove_node);
+    "toString" => method(to_string);
+};
+
+/// XMLNode constructor
+pub fn constructor<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let blank_document = XmlDocument::new(activation.context.gc_context);
+
+    match (
+        args.get(0)
+            .map(|v| v.coerce_to_f64(activation).map(|v| v as u32)),
+        args.get(1).map(|v| v.coerce_to_string(activation)),
+        this.as_xml_node(),
+    ) {
+        (Some(Ok(1)), Some(Ok(ref strval)), Some(ref mut this_node)) => {
+            let mut xmlelement =
+                XmlNode::new_element(activation.context.gc_context, *strval, blank_document);
+            xmlelement.introduce_script_object(activation.context.gc_context, this);
+            this_node.swap(activation.context.gc_context, xmlelement);
+        }
+        (Some(Ok(3)), Some(Ok(ref strval)), Some(ref mut this_node)) => {
+            let mut xmlelement =
+                XmlNode::new_text(activation.context.gc_context, *strval, blank_document);
+            xmlelement.introduce_script_object(activation.context.gc_context, this);
+            this_node.swap(activation.context.gc_context, xmlelement);
+        }
+        //Invalid nodetype ID, string value missing, or not an XMLElement
+        _ => {}
+    };
+
+    Ok(this.into())
+}
+
+fn append_child<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let (Some(mut xmlnode), Some(child_xmlnode)) = (
+        this.as_xml_node(),
+        args.get(0)
+            .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
+    ) {
+        if !xmlnode.has_child(child_xmlnode) {
+            let position = xmlnode.children_len();
+            if let Err(e) =
+                xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode)
+            {
+                avm_warn!(
+                    activation,
+                    "Couldn't insert_child inside of XMLNode.appendChild: {}",
+                    e
+                );
+            }
+        }
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn insert_before<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let (Some(mut xmlnode), Some(child_xmlnode), Some(insertpoint_xmlnode)) = (
+        this.as_xml_node(),
+        args.get(0)
+            .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
+        args.get(1)
+            .and_then(|n| n.coerce_to_object(activation).as_xml_node()),
+    ) {
+        if !xmlnode.has_child(child_xmlnode) {
+            if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {
+                if let Err(e) =
+                    xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode)
+                {
+                    avm_warn!(
+                        activation,
+                        "Couldn't insert_child inside of XMLNode.insertBefore: {}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn clone_node<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let (Some(xmlnode), deep) = (
+        this.as_xml_node(),
+        args.get(0)
+            .map(|v| v.as_bool(activation.swf_version()))
+            .unwrap_or(false),
+    ) {
+        let mut clone_node = xmlnode.duplicate(activation.context.gc_context, deep);
+
+        return Ok(clone_node
+            .script_object(
+                activation.context.gc_context,
+                Some(activation.context.avm1.prototypes.xml_node),
+            )
+            .into());
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn get_namespace_for_prefix<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let (Some(xmlnode), Some(prefix_string)) = (
+        this.as_xml_node(),
+        args.get(0).map(|v| v.coerce_to_string(activation)),
+    ) {
+        if let Some(uri) =
+            xmlnode.lookup_uri_for_namespace(activation.context.gc_context, &prefix_string?)
+        {
+            Ok(uri.into())
+        } else {
+            Ok(Value::Null)
+        }
+    } else {
+        Ok(Value::Undefined)
+    }
+}
+
+fn get_prefix_for_namespace<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let (Some(xmlnode), Some(uri_string)) = (
+        this.as_xml_node(),
+        args.get(0).map(|v| v.coerce_to_string(activation)),
+    ) {
+        if let Some(prefix) = xmlnode.lookup_namespace_for_uri(&uri_string?) {
+            Ok(AvmString::new(activation.context.gc_context, prefix).into())
+        } else {
+            Ok(Value::Null)
+        }
+    } else {
+        Ok(Value::Undefined)
+    }
+}
+
+fn has_child_nodes<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(xmlnode) = this.as_xml_node() {
+        Ok((xmlnode.children_len() > 0).into())
+    } else {
+        Ok(Value::Undefined)
+    }
+}
+
+fn remove_node<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        if let Some(mut parent) = node.parent() {
+            if let Err(e) = parent.remove_child(activation.context.gc_context, node) {
+                avm_warn!(activation, "Error in XML.removeNode: {}", e);
+            }
+        }
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn to_string<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        let result = node.into_string(&XmlNode::is_as2_compatible);
+
+        return Ok(AvmString::new_utf8(
+            activation.context.gc_context,
+            result.unwrap_or_else(|e| {
+                avm_warn!(activation, "XMLNode toString failed: {}", e);
+                "".to_string()
+            }),
+        )
+        .into());
+    }
+
+    Ok("".into())
+}
+
+fn local_name<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this
+        .as_xml_node()
+        .and_then(|n| n.tag_name())
+        .map(|n| AvmString::new(activation.context.gc_context, n.local_name()).into())
+        .unwrap_or_else(|| Value::Null))
+}
+
+fn node_name<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this
+        .as_xml_node()
+        .and_then(|n| n.tag_name())
+        .map(|n| Value::from(n.node_name()))
+        .unwrap_or_else(|| Value::Null))
+}
+
+fn node_type<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this
+        .as_xml_node()
+        .map(|n| {
+            match n.node_type() {
+                xml::DOCUMENT_NODE => xml::ELEMENT_NODE,
+                xml::DOCUMENT_TYPE_NODE => xml::TEXT_NODE,
+                xml::COMMENT_NODE => xml::TEXT_NODE,
+                n => n,
+            }
+            .into()
+        })
+        .unwrap_or_else(|| Value::Undefined))
+}
+
+fn node_value<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this
+        .as_xml_node()
+        .and_then(|n| n.node_value())
+        .map(|v| v.into())
+        .unwrap_or_else(|| Value::Null))
+}
+
+fn prefix<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this
+        .as_xml_node()
+        .and_then(|n| n.tag_name())
+        .map(|n| {
+            n.prefix()
+                .map(|n| AvmString::new(activation.context.gc_context, n))
+                .unwrap_or_default()
+                .into()
+        })
+        .unwrap_or_else(|| Value::Null))
+}
+
+fn child_nodes<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        return Ok(ArrayObject::new(
+            activation.context.gc_context,
+            activation.context.avm1.prototypes().array,
+            node.children()
+                .filter(XmlNode::is_as2_compatible)
+                .map(|mut child| {
+                    child
+                        .script_object(
+                            activation.context.gc_context,
+                            Some(activation.context.avm1.prototypes.xml_node),
+                        )
+                        .into()
+                }),
+        )
+        .into());
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn first_child<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        let mut children = node.children();
+        let mut next = children.next();
+        while let Some(my_next) = next {
+            if my_next.is_as2_compatible() {
+                break;
+            }
+
+            next = my_next.next_sibling();
+        }
+
+        return Ok(next
+            .map(|mut child| {
+                child
+                    .script_object(
+                        activation.context.gc_context,
+                        Some(activation.context.avm1.prototypes.xml_node),
+                    )
+                    .into()
+            })
+            .unwrap_or_else(|| Value::Null));
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn last_child<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        let mut children = node.children();
+        let mut prev = children.next_back();
+        while let Some(my_prev) = prev {
+            if my_prev.is_as2_compatible() {
+                break;
+            }
+
+            prev = my_prev.prev_sibling();
+        }
+        return Ok(prev
+            .map(|mut child| {
+                child
+                    .script_object(
+                        activation.context.gc_context,
+                        Some(activation.context.avm1.prototypes.xml_node),
+                    )
+                    .into()
+            })
+            .unwrap_or_else(|| Value::Null));
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn parent_node<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        return Ok(node
+            .parent()
+            .map(|mut parent| {
+                parent
+                    .script_object(
+                        activation.context.gc_context,
+                        Some(activation.context.avm1.prototypes.xml_node),
+                    )
+                    .into()
+            })
+            .unwrap_or_else(|| Value::Null));
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn previous_sibling<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        let mut prev = node.prev_sibling();
+        while let Some(my_prev) = prev {
+            if my_prev.is_as2_compatible() {
+                break;
+            }
+
+            prev = my_prev.prev_sibling();
+        }
+
+        return Ok(prev
+            .map(|mut prev| {
+                prev.script_object(
+                    activation.context.gc_context,
+                    Some(activation.context.avm1.prototypes.xml_node),
+                )
+                .into()
+            })
+            .unwrap_or_else(|| Value::Null));
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn next_sibling<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        let mut next = node.next_sibling();
+        while let Some(my_next) = next {
+            if my_next.is_as2_compatible() {
+                break;
+            }
+
+            next = my_next.next_sibling();
+        }
+
+        return Ok(next
+            .map(|mut next| {
+                next.script_object(
+                    activation.context.gc_context,
+                    Some(activation.context.avm1.prototypes.xml_node),
+                )
+                .into()
+            })
+            .unwrap_or_else(|| Value::Null));
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn attributes<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(mut node) = this.as_xml_node() {
+        return Ok(node
+            .attribute_script_object(activation.context.gc_context)
+            .map(|o| o.into())
+            .unwrap_or_else(|| Value::Undefined));
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn namespace_uri<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(node) = this.as_xml_node() {
+        if let Some(name) = node.tag_name() {
+            return Ok(node
+                .lookup_uri_for_namespace(
+                    activation.context.gc_context,
+                    name.prefix().unwrap_or_default(),
+                )
+                .unwrap_or_default()
+                .into());
+        }
+
+        return Ok(Value::Null);
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Construct the prototype for `XMLNode`.
+pub fn create_proto<'gc>(
+    gc_context: MutationContext<'gc, '_>,
+    proto: Object<'gc>,
+    fn_proto: Object<'gc>,
+) -> Object<'gc> {
+    let xmlnode_proto = XmlObject::empty_node(gc_context, Some(proto));
+    let object = xmlnode_proto.as_script_object().unwrap();
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    xmlnode_proto
+}

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -417,7 +417,7 @@ impl<'gc> EditText<'gc> {
     pub fn html_text(self, context: &mut UpdateContext<'_, 'gc, '_>) -> WString {
         if self.is_html() {
             let html_tree = self.html_tree(context).as_node();
-            let html_string_result = html_tree.into_string(&mut |_node| true);
+            let html_string_result = html_tree.into_string(&|_node| true);
 
             if let Err(err) = &html_string_result {
                 log::warn!(

--- a/core/src/xml/tests.rs
+++ b/core/src/xml/tests.rs
@@ -82,7 +82,7 @@ fn round_trip_tostring() {
 
         let result = xml
             .as_node()
-            .into_string(&mut |_| true)
+            .into_string(&|_| true)
             .expect("Successful toString");
 
         assert_eq!(std::str::from_utf8(test_string).unwrap(), result);
@@ -102,7 +102,7 @@ fn round_trip_filtered_tostring() {
 
         let result = xml
             .as_node()
-            .into_string(&mut |node| !node.is_comment())
+            .into_string(&|node| !node.is_comment())
             .expect("Successful toString");
 
         assert_eq!("<test>This is a text node</test>", result);


### PR DESCRIPTION
This reduces the file size of the previous `xml.rs` file, and makes
the code a bit more organized.