### PR TITLE
extension: Fix base for direct swf links

### DIFF
--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -33,5 +33,9 @@ window.addEventListener("DOMContentLoaded", async () => {
         letterbox: Letterbox.On,
         ...options,
     };
-    player.load({ url: swfUrl, base: swfUrl, ...config });
+    player.load({
+        url: swfUrl,
+        base: swfUrl.substring(0, swfUrl.lastIndexOf("/") + 1),
+        ...config,
+    });
 });


### PR DESCRIPTION
Fixes http://iqtest.dk/main.swf (after clicking the second Start button, which loads another swf), probably others. Update to #5144, which I believe worked prior to #5290.