### PR TITLE
avm2: Set correct(-ish) value type in op_convert_u/i

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1829,27 +1829,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn op_convert_b(&mut self) -> Result<FrameControl<'gc>, Error> {
-        let value = self.context.avm2.pop().coerce_to_boolean();
-
-        self.context.avm2.push(value);
-
-        Ok(FrameControl::Continue)
+        self.op_coerce_b()
     }
 
     fn op_convert_i(&mut self) -> Result<FrameControl<'gc>, Error> {
-        let value = self.context.avm2.pop().coerce_to_i32(self)?;
-
-        self.context.avm2.push(Value::Number(value.into()));
-
-        Ok(FrameControl::Continue)
+        self.op_coerce_i()
     }
 
     fn op_convert_d(&mut self) -> Result<FrameControl<'gc>, Error> {
-        let value = self.context.avm2.pop().coerce_to_number(self)?;
-
-        self.context.avm2.push(Value::Number(value));
-
-        Ok(FrameControl::Continue)
+        self.op_coerce_d()
     }
 
     fn op_convert_o(&mut self) -> Result<FrameControl<'gc>, Error> {
@@ -1861,11 +1849,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn op_convert_u(&mut self) -> Result<FrameControl<'gc>, Error> {
-        let value = self.context.avm2.pop().coerce_to_u32(self)?;
-
-        self.context.avm2.push(Value::Number(value.into()));
-
-        Ok(FrameControl::Continue)
+        self.op_coerce_u()
     }
 
     fn op_convert_s(&mut self) -> Result<FrameControl<'gc>, Error> {


### PR DESCRIPTION
Actually, the reality is much more complex: (assuming 32-bit FP build):
```
    var num_val : uint = 0x0FFFFFFF;
    trace(getQualifiedClassName(num_val)); // int

    var num_val : uint = 0x10000000;
    trace(getQualifiedClassName(num_val)); // Number
```

(Not to mention, FP does "live" conversions, like `trace(getQualifiedClassName(1.5 + 1.5)); // int`)
(_Not to mention_, well... `uint` as a primitive doesn't actually exist in AVM2; all integral values are `int`s, and `uint` type exists only for typechecking purposes)

```
trace(getQualifiedClassName(uint.MIN_VALUE)); // int
trace(getQualifiedClassName(uint.MAX_VALUE)); // Number
trace(getQualifiedClassName(new uint())); // int
trace(getQualifiedClassName(new int())); // int
```
So this PR doesn't really fix much; just changes the `op_convert_u/i` opcode from being barely correct-ish to being slightly more correct-ish and more often do what the script expects it to.
(The real motivation is that this will help the future fast-path-array-uint-access PR, as indexing is often preceded by an `convert_i`, and we want the incoming index to be an (u)int instead of a float.)