### PR TITLE
html: Fixes

### DIFF
--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -583,27 +583,11 @@ impl FormatSpans {
         };
 
         let mut reader = Reader::from_reader(&raw_bytes[..]);
+        reader.expand_empty_elements(true);
         reader.check_end_names(false);
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Empty(ref e)) => match &e.name().to_ascii_lowercase()[..] {
-                    b"br" if is_multiline => {
-                        text.push_byte(b'\n');
-                        if let Some(span) = spans.last_mut() {
-                            span.span_length += 1;
-                        }
-                    }
-                    b"sbr" => {
-                        // TODO: <sbr> tags do not add a newline, but rather only break
-                        // the format span.
-                        text.push_byte(b'\n');
-                        if let Some(span) = spans.last_mut() {
-                            span.span_length += 1;
-                        }
-                    }
-                    _ => {}
-                },
                 Ok(Event::Start(ref e)) => {
                     let attributes: Result<Vec<_>, _> = e.attributes().with_checks(false).collect();
                     let attributes = match attributes {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -583,6 +583,7 @@ impl FormatSpans {
         };
 
         let mut reader = Reader::from_reader(&raw_bytes[..]);
+        reader.check_end_names(false);
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -762,7 +762,7 @@ impl FormatSpans {
                 Ok(Event::Eof) => break,
                 Err(e) => {
                     log::warn!("Error while parsing HTML: {}", e);
-                    return Default::default();
+                    break;
                 }
                 _ => {}
             }


### PR DESCRIPTION
* Fix #5873 by allowing mismatched closing tags (e.g. `<mytag></different_tag>`).
* Avoid code duplication by using `quick-xml`'s feature to split empty elements into an `Open` and a `Close` event.
* Return partially-processed text on error, as Flash does.