### PR TITLE
avm1: Make `ArrayObject` proto non-`Option`

### DIFF
--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -599,7 +599,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let array = ArrayObject::empty_with_proto(gc_context, Some(proto));
+    let array = ArrayObject::empty_with_proto(gc_context, proto);
     let object = array.as_script_object().unwrap();
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -163,7 +163,7 @@ fn initialize_internal<'gc>(
     broadcaster.define_value(
         gc_context,
         "_listeners",
-        ArrayObject::empty_with_proto(gc_context, Some(array_proto)).into(),
+        ArrayObject::empty_with_proto(gc_context, array_proto).into(),
         Attribute::DONT_ENUM,
     );
     broadcaster.define_value(

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -23,10 +23,7 @@ impl<'gc> ArrayObject<'gc> {
         )
     }
 
-    pub fn empty_with_proto(
-        gc_context: MutationContext<'gc, '_>,
-        proto: Option<Object<'gc>>,
-    ) -> Self {
+    pub fn empty_with_proto(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Self {
         Self::new_internal(gc_context, proto, [])
     }
 
@@ -35,15 +32,15 @@ impl<'gc> ArrayObject<'gc> {
         array_proto: Object<'gc>,
         elements: impl IntoIterator<Item = Value<'gc>>,
     ) -> Self {
-        Self::new_internal(gc_context, Some(array_proto), elements)
+        Self::new_internal(gc_context, array_proto, elements)
     }
 
     fn new_internal(
         gc_context: MutationContext<'gc, '_>,
-        proto: Option<Object<'gc>>,
+        proto: Object<'gc>,
         elements: impl IntoIterator<Item = Value<'gc>>,
     ) -> Self {
-        let base = ScriptObject::object(gc_context, proto);
+        let base = ScriptObject::object(gc_context, Some(proto));
         let mut length: i32 = 0;
         for value in elements.into_iter() {
             let length_str = AvmString::new_utf8(gc_context, length.to_string());
@@ -129,7 +126,7 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(Self::empty_with_proto(activation.context.gc_context, Some(this)).into())
+        Ok(Self::empty_with_proto(activation.context.gc_context, this).into())
     }
 
     fn delete(&self, activation: &mut Activation<'_, 'gc, '_>, name: AvmString<'gc>) -> bool {


### PR DESCRIPTION
It was always passed as `Some`, so there's no reason for allowing
`None`.