### PR TITLE
core: register non-ascii fonts lazily

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -973,9 +973,10 @@ impl<'gc> EditText<'gc> {
                     }
 
                     // Render glyph.
+                    let glyph_shape_handle = glyph.shape_handle(context.renderer);
                     context
                         .renderer
-                        .render_shape(glyph.shape_handle, context.transform_stack.transform());
+                        .render_shape(glyph_shape_handle, context.transform_stack.transform());
                     context.transform_stack.pop();
 
                     if let Some((caret_pos, length)) = caret {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2834,6 +2834,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             })
             .collect::<Vec<_>>();
 
+        let font_id = font.id;
         let font = swf::Font {
             id: font.id,
             version: 0,
@@ -2850,14 +2851,14 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let font_object = Font::from_swf_tag(
             context.gc_context,
             context.renderer,
-            &font,
+            font,
             reader.encoding(),
         )
         .unwrap();
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(font.id, Character::Font(font_object));
+            .register_character(font_id, Character::Font(font_object));
         Ok(())
     }
 
@@ -2868,17 +2869,18 @@ impl<'gc, 'a> MovieClipData<'gc> {
         reader: &mut SwfStream<'a>,
     ) -> DecodeResult {
         let font = reader.read_define_font_2(2)?;
+        let font_id = font.id;
         let font_object = Font::from_swf_tag(
             context.gc_context,
             context.renderer,
-            &font,
+            font,
             reader.encoding(),
         )
         .unwrap();
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(font.id, Character::Font(font_object));
+            .register_character(font_id, Character::Font(font_object));
         Ok(())
     }
 
@@ -2889,17 +2891,18 @@ impl<'gc, 'a> MovieClipData<'gc> {
         reader: &mut SwfStream<'a>,
     ) -> DecodeResult {
         let font = reader.read_define_font_2(3)?;
+        let font_id = font.id;
         let font_object = Font::from_swf_tag(
             context.gc_context,
             context.renderer,
-            &font,
+            font,
             reader.encoding(),
         )
         .unwrap();
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(font.id, Character::Font(font_object));
+            .register_character(font_id, Character::Font(font_object));
 
         Ok(())
     }

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -134,9 +134,10 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
                 for c in &block.glyphs {
                     if let Some(glyph) = font.get_glyph(c.index as usize) {
                         context.transform_stack.push(&transform);
+                        let glyph_shape_handle = glyph.shape_handle(context.renderer);
                         context
                             .renderer
-                            .render_shape(glyph.shape_handle, context.transform_stack.transform());
+                            .render_shape(glyph_shape_handle, context.transform_stack.transform());
                         context.transform_stack.pop();
                         transform.matrix.tx += Twips::new(c.advance);
                     }
@@ -197,10 +198,11 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
                             let mut matrix = glyph_matrix;
                             matrix.invert();
                             let point = matrix * point;
-                            let glyph_bounds: BoundingBox = (&glyph.shape.shape_bounds).into();
+                            let glyph_shape = glyph.as_shape();
+                            let glyph_bounds: BoundingBox = (&glyph_shape.shape_bounds).into();
                             if glyph_bounds.contains(point)
                                 && crate::shape_utils::shape_hit_test(
-                                    &glyph.shape,
+                                    &glyph_shape,
                                     point,
                                     &local_matrix,
                                 )

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1590,7 +1590,7 @@ impl Player {
         let device_font = crate::font::Font::from_swf_tag(
             gc_context,
             renderer,
-            &reader.read_define_font_2(3)?,
+            reader.read_define_font_2(3)?,
             reader.encoding(),
         )?;
         Ok(device_font)


### PR DESCRIPTION
Motivating examples:
https://www.newgrounds.com/portal/view/561860?emulate=flash
https://frepy.eu/games/Frepy15ee/
And possibly some other big SWFs.

These happen to have full fonts with (tens of) thousands of characters, that are all tessellated and loaded to GPU (on wgpu/webgl) at launch time.
This patch makes them register lazily, which can save up to 1-2GB of memory and speed up initial load by 2-3x. This can also reduce runtime GC pauses on Chrome (which tbh I'd consider a Chrome bug...).

This also makes the "glyph as shape" load lazily, as it's only used for collision detection.

Technically this can worst-case slightly increase memory use; previously we only long-term stored the "glyph as shape" and the GPU buffer; now, assuming every lazy load gets reached, we will store the `swf::Glyph`, "glyph as shape" _and_ the GPU buffer. In practice, I don't think this is a practical issue, though it'd be nice to resolve - either by refactoring hittests to support raw Vecs of ShapeRecords instead of Shapes, or by storing `Vec<ShapeRecord>` behind an `Rc` or `Gc`, so that the lists are shared.
The latter idea would help with performance in more cases, as currently every `register_glyph_shape()/swf_glyph_to_shape()` call does `glyph.shape_records.clone()` for no good reason.
Final alternative is parsing the entire tag lazily, I guess?

If you have a preference or better idea for above issue, let me know :) But I don't consider it a blocker.