### PR TITLE
xml: Cleanup (part 2)

### DIFF
--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -26,9 +26,10 @@ use crate::avm1::object::transform_object::TransformObject;
 use crate::avm1::object::xml_attributes_object::XmlAttributesObject;
 use crate::avm1::object::xml_idmap_object::XmlIdMapObject;
 use crate::avm1::object::xml_node_object::XmlNodeObject;
+use crate::avm1::object::xml_object::XmlObject;
 use crate::avm1::{AvmString, ScriptObject, SoundObject, StageObject, Value};
 use crate::display_object::DisplayObject;
-use crate::xml::XmlNode;
+use crate::xml::{XmlDocument, XmlNode};
 use gc_arena::{Collect, MutationContext};
 use ruffle_macros::enum_trait_object;
 use std::fmt::Debug;
@@ -58,6 +59,7 @@ pub mod value_object;
 pub mod xml_attributes_object;
 pub mod xml_idmap_object;
 pub mod xml_node_object;
+pub mod xml_object;
 
 /// Represents an object that can be directly interacted with by the AVM
 /// runtime.
@@ -71,6 +73,7 @@ pub mod xml_node_object;
         SoundObject(SoundObject<'gc>),
         StageObject(StageObject<'gc>),
         SuperObject(SuperObject<'gc>),
+        XmlObject(XmlObject<'gc>),
         XmlNodeObject(XmlNodeObject<'gc>),
         XmlAttributesObject(XmlAttributesObject<'gc>),
         XmlIdMapObject(XmlIdMapObject<'gc>),
@@ -528,6 +531,11 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
     /// Get the underlying executable for this object, if it exists.
     fn as_executable(&self) -> Option<Executable<'gc>> {
+        None
+    }
+
+    /// Get the underlying XML document for this object, if it exists.
+    fn as_xml(&self) -> Option<XmlDocument<'gc>> {
         None
     }
 

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -1,0 +1,72 @@
+//! AVM1 object type to represent XML documents
+
+use crate::avm1::activation::Activation;
+use crate::avm1::error::Error;
+use crate::avm1::object::TObject;
+use crate::avm1::{Object, ScriptObject};
+use crate::impl_custom_object;
+use crate::xml::{XmlDocument, XmlNode};
+use gc_arena::{Collect, GcCell, MutationContext};
+use std::fmt;
+
+/// A ScriptObject that is inherently tied to an XML document.
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+pub struct XmlObject<'gc>(GcCell<'gc, XmlObjectData<'gc>>);
+
+#[derive(Clone, Collect)]
+#[collect(no_drop)]
+pub struct XmlObjectData<'gc> {
+    base: ScriptObject<'gc>,
+    document: XmlDocument<'gc>,
+}
+
+impl<'gc> XmlObject<'gc> {
+    /// Construct a new XML document and object pair.
+    pub fn empty(gc_context: MutationContext<'gc, '_>, proto: Option<Object<'gc>>) -> Self {
+        let document = XmlDocument::new(gc_context);
+        let object = Self(GcCell::allocate(
+            gc_context,
+            XmlObjectData {
+                base: ScriptObject::object(gc_context, proto),
+                document,
+            },
+        ));
+
+        document
+            .as_node()
+            .introduce_script_object(gc_context, object.into());
+
+        object
+    }
+}
+
+impl fmt::Debug for XmlObject<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let this = self.0.read();
+        f.debug_struct("XmlObject")
+            .field("base", &this.base)
+            .field("document", &this.document)
+            .finish()
+    }
+}
+
+impl<'gc> TObject<'gc> for XmlObject<'gc> {
+    impl_custom_object!(base);
+
+    fn create_bare_object(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+        this: Object<'gc>,
+    ) -> Result<Object<'gc>, Error<'gc>> {
+        Ok(Self::empty(activation.context.gc_context, Some(this)).into())
+    }
+
+    fn as_xml(&self) -> Option<XmlDocument<'gc>> {
+        Some(self.0.read().document)
+    }
+
+    fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
+        Some(self.0.read().document.as_node())
+    }
+}


### PR DESCRIPTION
Previously Ruffle's AVM1 runtime incorrectly permitted calling `XML` functions on `XMLNode` objects. For example:

```as
var xml = new XML("<a><b></b></a>");
trace(XML.prototype.createElement.call(xml.firstChild, "aaa")); // traces "undefined" in Flash, but "<aaa />" in Ruffle before this commit.
```

Disallow this by re-introducing `XmlObject` and using it to represent `XML` objects (rather than `XmlNodeObject` that represents also `XMLNode` object), and check for it in all `XML` builtins.