### PR TITLE
xml: Cleanup (part 3)

### DIFF
--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -57,7 +57,7 @@ pub fn constructor<'gc>(
             .get("ignoreWhite", activation)?
             .as_bool(activation.swf_version());
 
-        if let Err(e) = document.as_node().replace_with_str(
+        if let Err(e) = document.replace_with_str(
             activation.context.gc_context,
             string,
             true,
@@ -129,8 +129,7 @@ fn parse_xml<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(document) = this.as_xml() {
-        let mut node = document.as_node();
+    if let Some(mut document) = this.as_xml() {
         let xmlstring =
             if let Some(Ok(xmlstring)) = args.get(0).map(|s| s.coerce_to_string(activation)) {
                 xmlstring
@@ -138,6 +137,7 @@ fn parse_xml<'gc>(
                 "".into()
             };
 
+        let mut node = document.as_node();
         for child in node.children().rev() {
             let result = node.remove_child(activation.context.gc_context, child);
             if let Err(e) = result {
@@ -154,7 +154,7 @@ fn parse_xml<'gc>(
             .get("ignoreWhite", activation)?
             .as_bool(activation.swf_version());
 
-        let result = node.replace_with_str(
+        let result = document.replace_with_str(
             activation.context.gc_context,
             &xmlstring,
             true,

--- a/core/src/xml/tests.rs
+++ b/core/src/xml/tests.rs
@@ -9,9 +9,8 @@ use gc_arena::rootless_arena;
 #[test]
 fn parse_single_element() {
     rootless_arena(|mc| {
-        let xml = XmlDocument::new(mc);
-        xml.as_node()
-            .replace_with_str(mc, WStr::from_units(b"<test></test>"), true, false)
+        let mut xml = XmlDocument::new(mc);
+        xml.replace_with_str(mc, WStr::from_units(b"<test></test>"), true, false)
             .expect("Parsed document");
         let mut roots = xml.as_node().children();
 
@@ -30,17 +29,16 @@ fn parse_single_element() {
 #[test]
 fn double_ended_children() {
     rootless_arena(|mc| {
-        let xml = XmlDocument::new(mc);
-        xml.as_node()
-            .replace_with_str(
-                mc,
-                WStr::from_units(
-                    b"<test></test><test2></test2><test3></test3><test4></test4><test5></test5>",
-                ),
-                true,
-                false,
-            )
-            .expect("Parsed document");
+        let mut xml = XmlDocument::new(mc);
+        xml.replace_with_str(
+            mc,
+            WStr::from_units(
+                b"<test></test><test2></test2><test3></test3><test4></test4><test5></test5>",
+            ),
+            true,
+            false,
+        )
+        .expect("Parsed document");
 
         let mut roots = xml.as_node().children();
 
@@ -75,9 +73,8 @@ fn round_trip_tostring() {
     let test_string = b"<test><!-- Comment -->This is a text node</test>";
 
     rootless_arena(|mc| {
-        let xml = XmlDocument::new(mc);
-        xml.as_node()
-            .replace_with_str(mc, WStr::from_units(test_string), true, false)
+        let mut xml = XmlDocument::new(mc);
+        xml.replace_with_str(mc, WStr::from_units(test_string), true, false)
             .expect("Parsed document");
 
         let result = xml
@@ -95,9 +92,8 @@ fn round_trip_filtered_tostring() {
     let test_string = b"<test><!-- Comment -->This is a text node</test>";
 
     rootless_arena(|mc| {
-        let xml = XmlDocument::new(mc);
-        xml.as_node()
-            .replace_with_str(mc, WStr::from_units(test_string), true, false)
+        let mut xml = XmlDocument::new(mc);
+        xml.replace_with_str(mc, WStr::from_units(test_string), true, false)
             .expect("Parsed document");
 
         let result = xml
@@ -113,15 +109,14 @@ fn round_trip_filtered_tostring() {
 #[test]
 fn ignore_white() {
     rootless_arena(|mc| {
-        let xml = XmlDocument::new(mc);
-        xml.as_node()
-            .replace_with_str(
-                mc,
-                WStr::from_units(b"<test>   <test2>   <test3> foo </test3>   </test2>   </test>"),
-                true,
-                true,
-            )
-            .expect("Parsed document");
+        let mut xml = XmlDocument::new(mc);
+        xml.replace_with_str(
+            mc,
+            WStr::from_units(b"<test>   <test2>   <test3> foo </test3>   </test2>   </test>"),
+            true,
+            true,
+        )
+        .expect("Parsed document");
 
         let mut root = xml.as_node().children();
 


### PR DESCRIPTION
This is a pure non-functional refactor that moves `XmlNode::replace_with_str` to `XmlDocument`, as it only makes sense to call this method on document roots. Besides that, it enables some further simplification (see 2nd commit).