### PR TITLE
chore: Add error-report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/error_report.md
+++ b/.github/ISSUE_TEMPLATE/error_report.md
@@ -1,0 +1,7 @@
+---
+name: Error report
+title: "Error"
+about:
+labels: ["error-report"]
+assignees: ""
+---

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1127,7 +1127,7 @@ export class RufflePlayer extends HTMLElement {
         const issueTitle = `Error on ${pageUrl}`;
         let issueLink = `https://github.com/ruffle-rs/ruffle/issues/new?title=${encodeURIComponent(
             issueTitle
-        )}&labels=error-report&body=`;
+        )}&template=error_report.md&labels=error-report&body=`;
         let issueBody = encodeURIComponent(errorText);
         if (
             errorArray.stackIndex > -1 &&


### PR DESCRIPTION
The `error-report` label was not being added to error reports submitted by panics in the web player, despite the `labels` query parameter in the URL. Users do not have triage/write access to the repo, which is required by GitHub to add a label to an issue, so the label was never added. Note that the issue creation page may actually lie and display the `error-report` label, but the label will disappear once the issue is submitted.

Add an issue template for error reports with the `error-report` label. This template is now added to the issue URL, which automatically adds the tag regardless of the user's access level.