### PR TITLE
core: Unify `Loader::Xml` into `Loader::LoadVars`

### DIFF
--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -330,7 +330,7 @@ fn spawn_xml_fetch<'gc>(
     send_object: Option<XmlNode<'gc>>,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let request_options = if let Some(node) = send_object {
-        // Send `node` as string
+        // Send `node` as string.
         RequestOptions::post(Some((
             node.into_string(&XmlNode::is_as2_compatible)
                 .unwrap_or_default()
@@ -348,22 +348,11 @@ fn spawn_xml_fetch<'gc>(
         .context
         .navigator
         .fetch(&url.to_utf8_lossy(), request_options);
-    let target_clip = activation.target_clip_or_root()?;
-    // given any defined loader object, sends the request. Will load into LoadVars if given.
-    let process = if let Some(document) = loader_object.as_xml() {
-        activation.context.load_manager.load_xml_into_node(
-            activation.context.player.clone().unwrap(),
-            document.as_node(),
-            target_clip,
-            fetch,
-        )
-    } else {
-        activation.context.load_manager.load_form_into_load_vars(
-            activation.context.player.clone().unwrap(),
-            loader_object,
-            fetch,
-        )
-    };
+    let process = activation.context.load_manager.load_form_into_load_vars(
+        activation.context.player.clone().unwrap(),
+        loader_object,
+        fetch,
+    );
 
     activation.context.navigator.spawn_future(process);
 


### PR DESCRIPTION
Since they are identical (they both load the URL as a string, then
fire the `onHTTPStatus` and `onData` events). In fact, AVM1's
`XML.prototype.load` and `LoadVars.prototype.load` functions are
both defined as `ASnative(301, 0)`, so they invoke the same native
code under the hood.