### PR TITLE
xml: Cleanup (part 5)

### DIFF
--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -82,7 +82,7 @@ fn serialize_value<'gc>(
                 Some(AmfValue::ECMAArray(vec![], values, length as u32))
             } else if let Some(xml_node) = o.as_xml_node() {
                 xml_node
-                    .into_string(&|_| true)
+                    .into_string()
                     .map(|xml_string| AmfValue::XML(xml_string, true))
                     .ok()
             } else if let Some(date) = o.as_date_object() {

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -234,22 +234,13 @@ fn on_data<'gc>(
 }
 
 fn doc_type_decl<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(document) = this.as_xml() {
         if let Some(doctype) = document.doctype() {
-            let result = doctype.into_string(&|_| true);
-
-            return Ok(AvmString::new_utf8(
-                activation.context.gc_context,
-                result.unwrap_or_else(|e| {
-                    avm_warn!(activation, "Error occurred when serializing DOCTYPE: {}", e);
-                    "".to_string()
-                }),
-            )
-            .into());
+            return Ok(doctype.into());
         }
     }
 

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -323,9 +323,7 @@ fn spawn_xml_fetch<'gc>(
     let request_options = if let Some(node) = send_object {
         // Send `node` as string
         RequestOptions::post(Some((
-            node.into_string(&XmlNode::is_as2_compatible)
-                .unwrap_or_default()
-                .into_bytes(),
+            node.into_string().unwrap_or_default().into_bytes(),
             "application/x-www-form-urlencoded".to_string(),
         )))
     } else {

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -217,7 +217,7 @@ fn to_string<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let result = node.into_string(&XmlNode::is_as2_compatible);
+        let result = node.into_string();
 
         return Ok(AvmString::new_utf8(
             activation.context.gc_context,
@@ -305,16 +305,14 @@ fn child_nodes<'gc>(
         return Ok(ArrayObject::new(
             activation.context.gc_context,
             activation.context.avm1.prototypes().array,
-            node.children()
-                .filter(XmlNode::is_as2_compatible)
-                .map(|mut child| {
-                    child
-                        .script_object(
-                            activation.context.gc_context,
-                            Some(activation.context.avm1.prototypes.xml_node),
-                        )
-                        .into()
-                }),
+            node.children().map(|mut child| {
+                child
+                    .script_object(
+                        activation.context.gc_context,
+                        Some(activation.context.avm1.prototypes.xml_node),
+                    )
+                    .into()
+            }),
         )
         .into());
     }
@@ -328,17 +326,9 @@ fn first_child<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let mut children = node.children();
-        let mut next = children.next();
-        while let Some(my_next) = next {
-            if my_next.is_as2_compatible() {
-                break;
-            }
-
-            next = my_next.next_sibling();
-        }
-
-        return Ok(next
+        return Ok(node
+            .children()
+            .next()
             .map(|mut child| {
                 child
                     .script_object(
@@ -359,16 +349,9 @@ fn last_child<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let mut children = node.children();
-        let mut prev = children.next_back();
-        while let Some(my_prev) = prev {
-            if my_prev.is_as2_compatible() {
-                break;
-            }
-
-            prev = my_prev.prev_sibling();
-        }
-        return Ok(prev
+        return Ok(node
+            .children()
+            .next_back()
             .map(|mut child| {
                 child
                     .script_object(
@@ -411,16 +394,8 @@ fn previous_sibling<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let mut prev = node.prev_sibling();
-        while let Some(my_prev) = prev {
-            if my_prev.is_as2_compatible() {
-                break;
-            }
-
-            prev = my_prev.prev_sibling();
-        }
-
-        return Ok(prev
+        return Ok(node
+            .prev_sibling()
             .map(|mut prev| {
                 prev.script_object(
                     activation.context.gc_context,
@@ -440,16 +415,8 @@ fn next_sibling<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let mut next = node.next_sibling();
-        while let Some(my_next) = next {
-            if my_next.is_as2_compatible() {
-                break;
-            }
-
-            next = my_next.next_sibling();
-        }
-
-        return Ok(next
+        return Ok(node
+            .next_sibling()
             .map(|mut next| {
                 next.script_object(
                     activation.context.gc_context,

--- a/core/src/xml/document.rs
+++ b/core/src/xml/document.rs
@@ -129,12 +129,6 @@ impl<'gc> XmlDocument<'gc> {
                         open_tags.last_mut().unwrap().append_child(mc, child)?;
                     }
                 }
-                Event::Comment(bt) => {
-                    let child = XmlNode::comment_from_text_event(mc, bt)?;
-                    if child.node_value() != Some(AvmString::default()) {
-                        open_tags.last_mut().unwrap().append_child(mc, child)?;
-                    }
-                }
                 Event::DocType(bt) => {
                     let child = XmlNode::doctype_from_text_event(mc, bt)?;
                     if child.node_value() != Some(AvmString::default()) {

--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -33,9 +33,6 @@ pub enum Error {
     #[error("Text node has no child nodes!")]
     TextNodeCantHaveChildren,
 
-    #[error("Comment node has no child nodes!")]
-    CommentNodeCantHaveChildren,
-
     #[error("DocType node has no child nodes!")]
     DocTypeCantHaveChildren,
 

--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -33,9 +33,6 @@ pub enum Error {
     #[error("Text node has no child nodes!")]
     TextNodeCantHaveChildren,
 
-    #[error("DocType node has no child nodes!")]
-    DocTypeCantHaveChildren,
-
     #[error("Cannot insert child into itself")]
     CannotInsertIntoSelf,
 

--- a/core/src/xml/tests.rs
+++ b/core/src/xml/tests.rs
@@ -77,29 +77,7 @@ fn round_trip_tostring() {
         xml.replace_with_str(mc, WStr::from_units(test_string), true, false)
             .expect("Parsed document");
 
-        let result = xml
-            .as_node()
-            .into_string(&|_| true)
-            .expect("Successful toString");
-
-        assert_eq!(std::str::from_utf8(test_string).unwrap(), result);
-    })
-}
-
-/// Tests filtered XML writing behavior.
-#[test]
-fn round_trip_filtered_tostring() {
-    let test_string = b"<test><!-- Comment -->This is a text node</test>";
-
-    rootless_arena(|mc| {
-        let mut xml = XmlDocument::new(mc);
-        xml.replace_with_str(mc, WStr::from_units(test_string), true, false)
-            .expect("Parsed document");
-
-        let result = xml
-            .as_node()
-            .into_string(&|node| !node.is_comment())
-            .expect("Successful toString");
+        let result = xml.as_node().into_string().expect("Successful toString");
 
         assert_eq!("<test>This is a text node</test>", result);
     })


### PR DESCRIPTION
This PR removes the non-AS2-compatible XML node types (comments and `DOCTYPE` declarations), because:
1. Comments are not included in the string representation, nor visible through the DOM methods, which effectively means they doesn't exist. On the other hand, the `DOCTYPE` declaration is not visible through DOM methods, but it should appear in the string representation. However, it doesn't both before and after this PR.
2. Due to significant differences between the XML implementations of AVM1 and AVM2, it makes more sense to have two separate implementations (as Flash did). Therefore, there's no reason for storing information that will never be observable to AVM1.