### PR TITLE
avm2: Remove Object::derive() machinery for AS3 prototypes

### DIFF
--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -649,12 +649,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         ctor.construct(activation, args)
     }
 
-    /// Construct a host object prototype of some kind and return it.
-    ///
-    /// This is called specifically to allocate old-style ES3 instances. The
-    /// returned object should have no properties upon it.
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error>;
-
     /// Construct a parameterization of this particular type and return it.
     ///
     /// This is called specifically to parameterize generic types, of which

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -247,18 +247,4 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
     ) -> Option<RefMut<ArrayStorage<'gc>>> {
         Some(RefMut::map(self.0.write(mc), |aod| &mut aod.array))
     }
-
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::ArrayObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(ArrayObject(GcCell::allocate(
-            activation.context.gc_context,
-            ArrayObjectData {
-                base,
-                array: ArrayStorage::new(0),
-            },
-        ))
-        .into())
-    }
 }

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -79,19 +79,6 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(BitmapDataObject(GcCell::allocate(
-            activation.context.gc_context,
-            BitmapDataObjectData {
-                base,
-                bitmap_data: None,
-            },
-        ))
-        .into())
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -181,19 +181,6 @@ impl<'gc> TObject<'gc> for ByteArrayObject<'gc> {
         self.0.read().base.has_own_property(name)
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::ByteArrayObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(ByteArrayObject(GcCell::allocate(
-            activation.context.gc_context,
-            ByteArrayObjectData {
-                base,
-                storage: ByteArrayStorage::new(),
-            },
-        ))
-        .into())
-    }
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -777,14 +777,6 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         Ok(instance)
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        Ok(ClassObject(GcCell::allocate(
-            activation.context.gc_context,
-            self.0.read().clone(),
-        ))
-        .into())
-    }
-
     fn has_own_property(self, name: &Multiname<'gc>) -> bool {
         let read = self.0.read();
 

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -65,20 +65,6 @@ impl<'gc> TObject<'gc> for DateObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::DateObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(DateObject(GcCell::allocate(
-            activation.context.gc_context,
-            DateObjectData {
-                base,
-                date_time: None,
-            },
-        ))
-        .into())
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         if let Some(date) = self.date_time() {
             Ok((date.timestamp_millis() as f64).into())

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -94,19 +94,6 @@ impl<'gc> TObject<'gc> for DictionaryObject<'gc> {
         Ok(Object::from(*self).into())
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(DictionaryObject(GcCell::allocate(
-            activation.context.gc_context,
-            DictionaryObjectData {
-                base,
-                object_space: Default::default(),
-            },
-        ))
-        .into())
-    }
-
     fn as_dictionary_object(self) -> Option<DictionaryObject<'gc>> {
         Some(self)
     }

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -85,10 +85,6 @@ impl<'gc> TObject<'gc> for DispatchObject<'gc> {
         Err("Cannot construct internal event dispatcher structures.".into())
     }
 
-    fn derive(&self, _activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        Err("Cannot subclass internal event dispatcher structures.".into())
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Err("Cannot subclass internal event dispatcher structures.".into())
     }

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -2,7 +2,6 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::domain::Domain;
-use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
@@ -86,19 +85,5 @@ impl<'gc> TObject<'gc> for DomainObject<'gc> {
         let this: Object<'gc> = Object::DomainObject(*self);
 
         Ok(this.into())
-    }
-
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::DomainObject(*self);
-        let constr = this
-            .get_property(
-                &QName::new(Namespace::public(), "constructor").into(),
-                activation,
-            )?
-            .coerce_to_object(activation)?;
-
-        let constr = constr.as_class_object().unwrap(); // XXXXX TODO
-
-        appdomain_allocator(constr, this, activation)
     }
 }

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -82,19 +82,6 @@ impl<'gc> TObject<'gc> for EventObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(EventObject(GcCell::allocate(
-            activation.context.gc_context,
-            EventObjectData {
-                base,
-                event: Event::new(""),
-            },
-        ))
-        .into())
-    }
-
     fn value_of(&self, mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         let read = self.0.read();
         let event_type = read.event.event_type();

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -136,27 +136,10 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     ) -> Result<Object<'gc>, Error> {
         let prototype = self.prototype().unwrap();
 
-        let instance = prototype.derive(activation)?;
+        let instance = ScriptObject::object(activation.context.gc_context, prototype);
 
         self.call(Some(instance), arguments, activation)?;
 
         Ok(instance)
-    }
-
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::FunctionObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-        let exec = self.0.read().exec.clone();
-
-        Ok(FunctionObject(GcCell::allocate(
-            activation.context.gc_context,
-            // todo: should this be None?
-            FunctionObjectData {
-                base,
-                exec,
-                prototype: None,
-            },
-        ))
-        .into())
     }
 }

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -136,20 +136,6 @@ impl<'gc> TObject<'gc> for LoaderInfoObject<'gc> {
         }
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::LoaderInfoObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(LoaderInfoObject(GcCell::allocate(
-            activation.context.gc_context,
-            LoaderInfoObjectData {
-                base,
-                loaded_stream: None,
-            },
-        ))
-        .into())
-    }
-
     /// Unwrap this object's loader stream
     fn as_loader_stream(&self) -> Option<Ref<LoaderStream<'gc>>> {
         if self.0.read().loaded_stream.is_some() {

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -89,18 +89,4 @@ impl<'gc> TObject<'gc> for NamespaceObject<'gc> {
     fn as_namespace(&self) -> Option<Ref<Namespace<'gc>>> {
         Some(Ref::map(self.0.read(), |s| &s.namespace))
     }
-
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::NamespaceObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(NamespaceObject(GcCell::allocate(
-            activation.context.gc_context,
-            NamespaceObjectData {
-                base,
-                namespace: Namespace::public(),
-            },
-        ))
-        .into())
-    }
 }

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -134,20 +134,6 @@ impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
         Ok(self.0.read().primitive)
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::PrimitiveObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(PrimitiveObject(GcCell::allocate(
-            activation.context.gc_context,
-            PrimitiveObjectData {
-                base,
-                primitive: Value::Undefined,
-            },
-        ))
-        .into())
-    }
-
     fn as_primitive_mut(&self, mc: MutationContext<'gc, '_>) -> Option<RefMut<Value<'gc>>> {
         Some(RefMut::map(self.0.write(mc), |pod| &mut pod.primitive))
     }

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -53,16 +53,6 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         Ok(Object::from(*self).into())
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(ProxyObject(GcCell::allocate(
-            activation.context.gc_context,
-            ProxyObjectData { base },
-        ))
-        .into())
-    }
-
     fn get_property_local(
         self,
         multiname: &Multiname<'gc>,

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -96,15 +96,4 @@ impl<'gc> TObject<'gc> for QNameObject<'gc> {
     fn as_qname_object(self) -> Option<QNameObject<'gc>> {
         Some(self)
     }
-
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::QNameObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(QNameObject(GcCell::allocate(
-            activation.context.gc_context,
-            QNameObjectData { base, qname: None },
-        ))
-        .into())
-    }
 }

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -76,19 +76,6 @@ impl<'gc> TObject<'gc> for RegExpObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(RegExpObject(GcCell::allocate(
-            activation.context.gc_context,
-            RegExpObjectData {
-                base,
-                regexp: RegExp::new(""),
-            },
-        ))
-        .into())
-    }
-
     fn to_string(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -73,11 +73,6 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::ScriptObject(*self);
-        Ok(ScriptObject::object(activation.context.gc_context, this))
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -86,16 +86,6 @@ impl<'gc> TObject<'gc> for SoundObject<'gc> {
         Ok(Object::from(*self).into())
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(SoundObject(GcCell::allocate(
-            activation.context.gc_context,
-            SoundObjectData { base, sound: None },
-        ))
-        .into())
-    }
-
     fn as_sound(self) -> Option<SoundHandle> {
         self.0.read().sound
     }

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -104,20 +104,6 @@ impl<'gc> TObject<'gc> for SoundChannelObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(SoundChannelObject(GcCell::allocate(
-            activation.context.gc_context,
-            SoundChannelObjectData {
-                base,
-                sound: None,
-                position: 0.0,
-            },
-        ))
-        .into())
-    }
-
     fn as_sound_channel(self) -> Option<SoundChannelObject<'gc>> {
         Some(self)
     }

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -131,20 +131,6 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
         self.0.write(mc).display_object = Some(obj);
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::StageObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(StageObject(GcCell::allocate(
-            activation.context.gc_context,
-            StageObjectData {
-                base,
-                display_object: None,
-            },
-        ))
-        .into())
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -73,19 +73,6 @@ impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let base = ScriptObjectData::base_new(Some((*self).into()), None);
-
-        Ok(Self(GcCell::allocate(
-            activation.context.gc_context,
-            TextFormatObjectData {
-                base,
-                text_format: Default::default(),
-            },
-        ))
-        .into())
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -244,23 +244,6 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
         Ok(Value::Object(Object::from(*self)))
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::VectorObject(*self);
-
-        //TODO: Pull the parameter out of the class object
-        let param_type = activation.avm2().classes().object;
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(VectorObject(GcCell::allocate(
-            activation.context.gc_context,
-            VectorObjectData {
-                base,
-                vector: VectorStorage::new(0, false, param_type, activation),
-            },
-        ))
-        .into())
-    }
-
     fn as_vector_storage(&self) -> Option<Ref<VectorStorage<'gc>>> {
         Some(Ref::map(self.0.read(), |vod| &vod.vector))
     }

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -47,17 +47,6 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn derive(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
-        let this: Object<'gc> = Object::XmlObject(*self);
-        let base = ScriptObjectData::base_new(Some(this), None);
-
-        Ok(XmlObject(GcCell::allocate(
-            activation.context.gc_context,
-            XmlObjectData { base },
-        ))
-        .into())
-    }
-
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error> {
         Ok(Value::Object(Object::from(*self)))
     }


### PR DESCRIPTION
After https://github.com/ruffle-rs/ruffle/pull/5791 , prototypes are always ScriptObjects* , so only its `derive()` was ever called. This means that `new MyOldStyleObject()` will always produce a ScriptObject.

For reviewers: only real change is in `function_object.rs` :)

(* there's an exception we don't have implemented but also don't test for: Function.prototype is itself a function. I'm still keeping this out of scope)