### PR TITLE
extension: Change unsafe-eval to wasm-eval in CSP

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -22,7 +22,10 @@
             "run_at": "document_start",
         }
     ],
-    "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'unsafe-inline'; connect-src *; img-src data:;",
+
+    // 'wasm-eval' added by Webpack for Chrome extension.
+    "content_security_policy": "default-src 'self'; script-src 'self'; style-src 'unsafe-inline'; connect-src *; img-src data:;",
+
     "icons": {
         "16": "images/icon16.png",
         "32": "images/icon32.png",

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -30,6 +30,15 @@ function transformManifest(content, env) {
             versionChannel === "nightly"
                 ? `${packageVersion} nightly ${buildDate}`
                 : packageVersion;
+
+        // Add `wasm-eval` to the `script-src` directive in the Content Security Policy.
+        // This setting is required by Chrome to allow Wasm in the extension.
+        // Eventually this may change to `wasm-unsafe-eval`, and we may need this for all browsers.
+        manifest.content_security_policy =
+            manifest.content_security_policy.replace(
+                /(script-src\s+[^;]*)(;|$)/i,
+                "$1 'wasm-eval'$2"
+            );
     }
 
     return JSON.stringify(manifest);


### PR DESCRIPTION
In Chrome, `unsafe-eval` was needed in the extension Content Security Policy for Wasm compilation. Other browsers seemed to work regardless of this setting.

Unfortunately, this CSP setting causes the extension to get flagged in the Mozilla Add-On Marketplace, which discourages the use of `unsafe-eval`. Chrome specifically has a `wasm-eval` for allowing Wasm in extensions, so let's switch to that instead.

The CSP spec has added a `wasm-unsafe-eval` setting, and Chrome will deprecate `wasm-eval` eventually; we may need this for all browsers as they start to support it.
https://github.com/w3c/webappsec-csp/pull/293