### PR TITLE
web: Add custom profiles to separate the build cache for the two wasm modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,14 @@ opt-level = 3
 
 [profile.dev.package.nihav_duck]
 opt-level = 3
+
+
+# TODO: Set rustflags here instead of in web/core/package.json, when that
+# feature becomes stable. See: https://github.com/rust-lang/cargo/issues/10271
+# Until then, these custom profiles let cargo keep the build cache alive
+# across "dual-wasm" builds, separating it for the two .wasm modules.
+[profile.web-vanilla-wasm]
+inherits = "release"
+
+[profile.web-wasm-extensions]
+inherits = "release"

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -16,18 +16,18 @@
         "//2": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
         "//3": "# Enabling 'build-std' would also be great, but it's not stable yet.",
 
-        "build:ruffle_web": "cross-env OUT_NAME=ruffle_web RUSTFLAGS=\"--cfg=web_sys_unstable_apis\" npm run build:cargo_bindgen_opt",
+        "build:ruffle_web": "cross-env OUT_NAME=ruffle_web CARGO_PROFILE=web-vanilla-wasm RUSTFLAGS=\"--cfg=web_sys_unstable_apis\" npm run build:cargo_bindgen_opt",
 
         "//4": "# Dispatches to either building the real, or copying the fake (stand-in), 'with-extensions' module.",
         "build:ruffle_web-wasm_extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:ruffle_web-wasm_extensions-real || npm run build:ruffle_web-wasm_extensions-fake",
-        "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext\" npm run build:cargo_bindgen_opt",
+        "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext\" npm run build:cargo_bindgen_opt",
         "build:ruffle_web-wasm_extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp ./pkg/ruffle_web_bg.wasm ./pkg/ruffle_web-wasm_extensions_bg.wasm && shx cp ./pkg/ruffle_web_bg.wasm.d.ts ./pkg/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp ./pkg/ruffle_web.js ./pkg/ruffle_web-wasm_extensions.js && shx cp ./pkg/ruffle_web.d.ts ./pkg/ruffle_web-wasm_extensions.d.ts",
 
         "//5": "# This just chains together the three commands after it.",
         "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
 
-        "build:cargo": "cross-env-shell \"cargo build --release --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\"\"",
-        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/release/ruffle_web.wasm\" --target web --out-dir ./pkg --out-name \"$OUT_NAME\"",
+        "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\"",
+        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir ./pkg --out-name \"$OUT_NAME\"",
         "build:wasm-opt": "cross-env-shell wasm-opt -o \"./pkg/${OUT_NAME}_bg.wasm\" -O -g \"./pkg/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
 
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",


### PR DESCRIPTION
A bit of an improvement over #5834.

This avoids always nuking the build cache (twice) when running `npm run build:dual-wasm`.
While `wasm-opt` is still doing the work twice, that is a lot faster and less "harmful" - not cache-polluting.

A somewhat related note: I _think_ `\\\"$CARGO_FEATURES\\\"` causes the `--features`  argument to be passed as literally `$CARGO_FEATURES` to `cargo`. Does it then substitute the envvar internally?
EDIT: FWIW setting `CARGO_FEATURES=whatever` for `npm run ...` does work, at least on Linux, so I guess it's okay.