### PR TITLE
chore: Publish npm package publicly

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -304,7 +304,9 @@ jobs:
 
       - name: Publish npm package
         if: ${{ !matrix.demo }}
-        run: npm publish
+        # npm scoped packages are private by default, explicitly make public
+        run: npm publish --access public
+        continue-on-error: true
         working-directory: web/packages/selfhosted/dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Scoped packages are private by default and require a paid plan for orgs. Switch to public.