### PR TITLE
avm1: Fix `onLoadInit` event order

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1275,6 +1275,11 @@ impl Player {
                             clip.run_frame(context);
                         }
                     }
+
+                    // Fire "onLoadInit" events.
+                    context
+                        .load_manager
+                        .movie_clip_on_load(context.action_queue);
                 }
                 AvmType::Avm2 => {
                     stage.exit_frame(context);


### PR DESCRIPTION
`onLoadInit` is queued after all `DoAction`s of the loaded clips.
That is, if clip1, clip2, clip3 are loaded in the same frame
(in this order), then actions will be executed as follows:

* `DoAction` of clip3
* `DoAction` of clip2
* `DoAction` of clip1
* `onLoadInit` of clip3
* `onLoadInit` of clip2
* `onLoadInit` of clip1

Previously, those were incorrectly executed as follows:

* `DoAction` of clip3
* `onLoadInit` of clip3
* `DoAction` of clip2
* `onLoadInit` of clip2
* `DoAction` of clip1
* `onLoadInit` of clip1

Discovered while working on #6004. Will add tests for this PR in #6004.