### PR TITLE
chore: Bump h263-rs git reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "h263-rs"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=b810e8c3fdb8ea5df0b7808891076e774bee40a9#b810e8c3fdb8ea5df0b7808891076e774bee40a9"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=023e14c73e565c4c778d41f66cfbac5ece6419b2#023e14c73e565c4c778d41f66cfbac5ece6419b2"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1591,7 +1591,7 @@ dependencies = [
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=b810e8c3fdb8ea5df0b7808891076e774bee40a9#b810e8c3fdb8ea5df0b7808891076e774bee40a9"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=023e14c73e565c4c778d41f66cfbac5ece6419b2#023e14c73e565c4c778d41f66cfbac5ece6419b2"
 dependencies = [
  "bytemuck",
  "wide",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,8 +35,8 @@ encoding_rs = "0.8.30"
 rand = { version = "0.8.4", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.133", features = ["derive"], optional = true }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "b810e8c3fdb8ea5df0b7808891076e774bee40a9", optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "b810e8c3fdb8ea5df0b7808891076e774bee40a9", optional = true }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 json = "0.12.4"


### PR DESCRIPTION
To make use of https://github.com/ruffle-rs/h263-rs/pull/17