### PR TITLE
web: Fix `publicPath` when loaded from a CDN

### DIFF
--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -10,7 +10,15 @@ try {
         "src" in document.currentScript &&
         document.currentScript.src !== ""
     ) {
-        currentScriptURL = new URL(".", document.currentScript.src).href;
+        let src = document.currentScript.src;
+
+        // CDNs allow omitting the filename. If it's omitted, append a slash to
+        // prevent the last component from being dropped.
+        if (!src.endsWith(".js") && !src.endsWith("/")) {
+            src += "/";
+        }
+
+        currentScriptURL = new URL(".", src).href;
     }
 } catch (e) {
     console.warn("Unable to get currentScript URL");


### PR DESCRIPTION
CDNs allow omitting the filename:

* https://unpkg.com/@ruffle-rs/ruffle
* https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle

That caused `currentScriptURL` to be determined incorrectly:

```js
new URL(".", "https://unpkg.com/@ruffle-rs/ruffle").href
// "https://unpkg.com/@ruffle-rs/"
```

If the filename is omitted, append a slash to prevent the last
component from being dropped:

```js
new URL(".", "https://unpkg.com/@ruffle-rs/ruffle/").href
// "https://unpkg.com/@ruffle-rs/ruffle/"
```