### PR TITLE
AVM2: `loaderInfo` can be read from child movie clips, `stage.loaderInfo` allows access to `url`, `bytes`, and `parameters`

### DIFF
--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -565,14 +565,12 @@ pub fn loader_info<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
         if let Some(root) = dobj.avm2_root(&mut activation.context) {
-            if DisplayObject::ptr_eq(root, dobj) {
-                let movie = dobj.movie();
+            let movie = dobj.movie();
 
-                if let Some(movie) = movie {
-                    let obj = LoaderInfoObject::from_movie(activation, movie, root)?;
+            if let Some(movie) = movie {
+                let obj = LoaderInfoObject::from_movie(activation, movie, root)?;
 
-                    return Ok(obj.into());
-                }
+                return Ok(obj.into());
             }
         }
 

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -8,7 +8,7 @@ use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{loaderinfo_allocator, DomainObject, LoaderStream, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{AvmString, Error};
-use crate::display_object::TDisplayObject;
+use crate::display_object::{TDisplayObject, TDisplayObjectContainer};
 use gc_arena::{GcCell, MutationContext};
 use swf::{write_swf, Compression};
 
@@ -242,14 +242,18 @@ pub fn url<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         if let Some(loader_stream) = this.as_loader_stream() {
-            match &*loader_stream {
-                LoaderStream::Stage => {
-                    return Err("Error: The stage's loader info does not have a URL".into())
-                }
-                LoaderStream::Swf(root, _) => {
-                    let url = root.url().unwrap_or("");
-                    return Ok(AvmString::new_utf8(activation.context.gc_context, url).into());
-                }
+            let root = match &*loader_stream {
+                LoaderStream::Stage => activation
+                    .context
+                    .stage
+                    .child_by_index(0)
+                    .and_then(|c| c.movie()),
+                LoaderStream::Swf(root, _) => Some(root.clone()),
+            };
+
+            if let Some(root) = root {
+                let url = root.url().unwrap_or("");
+                return Ok(AvmString::new_utf8(activation.context.gc_context, url).into());
             }
         }
     }
@@ -287,44 +291,47 @@ pub fn bytes<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         if let Some(loader_stream) = this.as_loader_stream() {
-            match &*loader_stream {
-                LoaderStream::Stage => {
-                    return Err("Error: The stage's loader info does not have a bytestream".into())
-                }
-                LoaderStream::Swf(root, _) => {
-                    let ba_class = activation.context.avm2.classes().bytearray;
+            let root = match &*loader_stream {
+                LoaderStream::Stage => activation
+                    .context
+                    .stage
+                    .child_by_index(0)
+                    .and_then(|c| c.movie()),
+                LoaderStream::Swf(root, _) => Some(root.clone()),
+            };
 
-                    let ba = ba_class.construct(activation, &[])?;
-                    let mut ba_write = ba.as_bytearray_mut(activation.context.gc_context).unwrap();
+            if let Some(root) = root {
+                let ba_class = activation.context.avm2.classes().bytearray;
 
-                    // First, write a fake header corresponding to an
-                    // uncompressed SWF
-                    let mut header = root.header().swf_header().clone();
-                    header.compression = Compression::None;
+                let ba = ba_class.construct(activation, &[])?;
+                let mut ba_write = ba.as_bytearray_mut(activation.context.gc_context).unwrap();
 
-                    write_swf(&header, &[], &mut *ba_write).unwrap();
+                // First, write a fake header corresponding to an
+                // uncompressed SWF
+                let mut header = root.header().swf_header().clone();
+                header.compression = Compression::None;
 
-                    // `swf` always writes an implicit end tag, let's cut that
-                    // off. We scroll back 2 bytes before writing the actual
-                    // datastream as it is guaranteed to at least be as long as
-                    // the implicit end tag we want to get rid of.
-                    let correct_header_length = ba_write.len() - 2;
-                    ba_write.set_position(correct_header_length);
-                    ba_write.write_bytes(root.data())?;
+                write_swf(&header, &[], &mut *ba_write).unwrap();
 
-                    // `swf` wrote the wrong length (since we wrote the data
-                    // ourselves), so we need to overwrite it ourselves.
-                    ba_write.set_position(4);
-                    ba_write.set_endian(Endian::Little);
-                    ba_write
-                        .write_unsigned_int((root.data().len() + correct_header_length) as u32)?;
+                // `swf` always writes an implicit end tag, let's cut that
+                // off. We scroll back 2 bytes before writing the actual
+                // datastream as it is guaranteed to at least be as long as
+                // the implicit end tag we want to get rid of.
+                let correct_header_length = ba_write.len() - 2;
+                ba_write.set_position(correct_header_length);
+                ba_write.write_bytes(root.data())?;
 
-                    // Finally, reset the array to the correct state.
-                    ba_write.set_position(0);
-                    ba_write.set_endian(Endian::Big);
+                // `swf` wrote the wrong length (since we wrote the data
+                // ourselves), so we need to overwrite it ourselves.
+                ba_write.set_position(4);
+                ba_write.set_endian(Endian::Little);
+                ba_write.write_unsigned_int((root.data().len() + correct_header_length) as u32)?;
 
-                    return Ok(ba.into());
-                }
+                // Finally, reset the array to the correct state.
+                ba_write.set_position(0);
+                ba_write.set_endian(Endian::Big);
+
+                return Ok(ba.into());
             }
         }
     }
@@ -365,30 +372,34 @@ pub fn parameters<'gc>(
 ) -> Result<Value<'gc>, Error> {
     if let Some(this) = this {
         if let Some(loader_stream) = this.as_loader_stream() {
-            match &*loader_stream {
-                LoaderStream::Stage => {
-                    return Err("Error: The stage's loader info does not have parameters".into())
-                }
-                LoaderStream::Swf(root, _) => {
-                    let mut params_obj = activation
-                        .avm2()
-                        .classes()
-                        .object
-                        .construct(activation, &[])?;
-                    let parameters = root.parameters();
+            let root = match &*loader_stream {
+                LoaderStream::Stage => activation
+                    .context
+                    .stage
+                    .child_by_index(0)
+                    .and_then(|c| c.movie()),
+                LoaderStream::Swf(root, _) => Some(root.clone()),
+            };
 
-                    for (k, v) in parameters.iter() {
-                        let avm_k = AvmString::new_utf8(activation.context.gc_context, k);
-                        let avm_v = AvmString::new_utf8(activation.context.gc_context, v);
-                        params_obj.set_property(
-                            &QName::new(Namespace::public(), avm_k).into(),
-                            avm_v.into(),
-                            activation,
-                        )?;
-                    }
+            if let Some(root) = root {
+                let mut params_obj = activation
+                    .avm2()
+                    .classes()
+                    .object
+                    .construct(activation, &[])?;
+                let parameters = root.parameters();
 
-                    return Ok(params_obj.into());
+                for (k, v) in parameters.iter() {
+                    let avm_k = AvmString::new_utf8(activation.context.gc_context, k);
+                    let avm_v = AvmString::new_utf8(activation.context.gc_context, v);
+                    params_obj.set_property(
+                        &QName::new(Namespace::public(), avm_k).into(),
+                        avm_v.into(),
+                        activation,
+                    )?;
                 }
+
+                return Ok(params_obj.into());
             }
         }
     }


### PR DESCRIPTION
Chalk another one up for the AS3 documentation lying. Or me misinterpreting it.

Any movie clip that isn't the root of a movie will give you the root clip's loader info, rather than throwing an error.

In a similar vein, the Stage's loader info actually has a few extra properties that can be read from it that we were also assuming couldn't. `url`, `bytes`, and `parameters` all work and return the same data that the root clip does.