### PR TITLE
chore: Bump to wgpu 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.33.3+1.2.191"
+version = "0.34.0+1.2.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
+checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
 dependencies = [
  "libloading",
 ]
@@ -1528,9 +1528,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "glow"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f04649123493bc2483cbef4daddb45d40bbdae5adb221a63a23efdb0cc99520"
+checksum = "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2125,18 +2125,18 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63765d243f5d32ece09b2ff95c1f50ec7353266024a2ce89619a09e1b6aa4cce"
+checksum = "a4419062f8aa39fb25938169486341945758679e260ddbc1f94bfd1f33924dc2"
 dependencies = [
  "bit-set",
  "bitflags",
  "codespan-reporting",
- "fxhash",
  "hexf-parse",
  "indexmap",
  "log",
  "num-traits",
+ "rustc-hash",
  "serde",
  "spirv",
  "thiserror",
@@ -2828,16 +2828,6 @@ checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 
 [[package]]
 name = "raw-window-handle"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76"
-dependencies = [
- "libc",
- "raw-window-handle 0.4.2",
-]
-
-[[package]]
-name = "raw-window-handle"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fba75eee94a9d5273a68c9e1e105d9cffe1ef700532325788389e5a83e2522b7"
@@ -2935,9 +2925,9 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "ron"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
  "base64",
  "bitflags",
@@ -3073,7 +3063,7 @@ dependencies = [
  "futures",
  "image",
  "log",
- "raw-window-handle 0.3.4",
+ "raw-window-handle",
  "ruffle_core",
  "ruffle_render_common_tess",
  "wasm-bindgen-futures",
@@ -3944,15 +3934,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7181fe6ba5f4b632a9079cc9e922a64555156c87def72c063f94b180c7d68"
+checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
 dependencies = [
  "arrayvec 0.7.2",
  "js-sys",
  "log",
+ "naga",
  "parking_lot",
- "raw-window-handle 0.3.4",
+ "raw-window-handle",
  "serde",
  "smallvec",
  "wasm-bindgen",
@@ -3965,20 +3956,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.11.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35600627b6c718ad0e23ed75fb6140bfe32cdf21c8f539ce3c9ab8180e2cb38e"
+checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
 dependencies = [
  "arrayvec 0.7.2",
  "bitflags",
  "cfg_aliases",
+ "codespan-reporting",
  "copyless",
  "fxhash",
  "log",
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.3.4",
+ "raw-window-handle",
  "ron",
  "serde",
  "smallvec",
@@ -3989,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.11.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af28b29ef0b44cd22dd9895d4349b9d5a687df42f58da234871198637eabe328"
+checksum = "92e33cb9c380dd1166f316dfc511ad9646f72cf2deb47e90bd714db3617a6998"
 dependencies = [
  "arrayvec 0.7.2",
  "ash",
@@ -4016,7 +4008,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.3.4",
+ "raw-window-handle",
  "renderdoc-sys",
  "thiserror",
  "wasm-bindgen",
@@ -4027,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15e44ba88ec415466e18e91881319e7c9e96cb905dc623305168aea65b85ccc"
+checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
 dependencies = [
  "bitflags",
  "bitflags_serde_shim",
@@ -4106,7 +4098,7 @@ dependencies = [
  "objc",
  "parking_lot",
  "percent-encoding",
- "raw-window-handle 0.4.2",
+ "raw-window-handle",
  "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4"
 ruffle_core = { path = "../../core", default-features = false }
 ruffle_render_common_tess = { path = "../common_tess" }
 bytemuck = { version = "1.7.3", features = ["derive"] }
-raw-window-handle = "0.3.3"
+raw-window-handle = "0.4"
 clap = { version = "3.0.6", features = ["derive"], optional = true }
 enum-map = "2.0.0"
 
@@ -23,7 +23,7 @@ version = "0.23.14"
 default-features = false
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu]
-version = "0.11"
+version = "0.12"
 
 # wasm
 [target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen-futures]
@@ -34,7 +34,7 @@ version = "0.3"
 features = ["HtmlCanvasElement"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]
-version = "0.11"
+version = "0.12"
 
 [features]
 render_debug_labels = []

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -2,14 +2,12 @@
 /// Ruffle prepends this file onto every shader at runtime.
 
 /// Global uniforms that are constant throughout a frame.
-[[block]]
 struct Globals {
     // The view matrix determined by the viewport and stage.
     view_matrix: mat4x4<f32>;
 };
 
 /// Transform uniforms that are changed per object.
-[[block]]
 struct Transforms {
     /// The world matrix that transforms this object into stage space.
     world_matrix: mat4x4<f32>;
@@ -22,7 +20,6 @@ struct Transforms {
 };
 
 /// Uniforms used by texture draws (bitmaps and gradients).
-[[block]]
 struct TextureTransforms {
     /// The transform matrix of the gradient or texture.
     /// Transforms from object space to UV space.

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -1,6 +1,5 @@
 /// Shader used for drawing all flavors of gradients.
 
-[[block]]
 struct Gradient {
     colors: array<vec4<f32>,16u>;
     ratios: array<f32,16u>;

--- a/render/wgpu/src/bitmaps.rs
+++ b/render/wgpu/src/bitmaps.rs
@@ -47,10 +47,7 @@ impl BitmapSamplers {
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
                 visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler {
-                    comparison: false,
-                    filtering: true,
-                },
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                 count: None,
             }],
         });

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -212,6 +212,7 @@ struct GradientUniforms {
     repeat_mode: i32,
     interpolation: i32,
     focal_point: f32,
+    _padding: [f32; 3],
 }
 
 impl From<TessGradient> for GradientUniforms {
@@ -237,6 +238,7 @@ impl From<TessGradient> for GradientUniforms {
             },
             interpolation: (gradient.interpolation == swf::GradientInterpolation::LinearRgb) as i32,
             focal_point: gradient.focal_point.to_f32(),
+            _padding: Default::default(),
         }
     }
 }

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -226,7 +226,7 @@ fn create_pipeline_descriptor<'a>(
             front_face: wgpu::FrontFace::Ccw,
             cull_mode: None,
             polygon_mode: wgpu::PolygonMode::default(),
-            clamp_depth: false,
+            unclipped_depth: false,
             conservative: false,
         },
         depth_stencil: depth_stencil_state,
@@ -235,6 +235,7 @@ fn create_pipeline_descriptor<'a>(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
+        multiview: None,
     }
 }
 


### PR DESCRIPTION
Bump to wgpu 0.12. Allows wgpu backend to work again on Firefox Nightly and Chrome Canary.

 * ``[[block]]`` removed from shaders (removed from WGSL spec).
 * Update `wgpu::BindingType::Sampler` and `wgpu::RenderPipelineDescriptor` to match latest wgpu API.
 * Add padding to `GradientUniforms` (I tried `#[repr(align(16))]`, but bytemuck didn't like this)