### PR TITLE
ci: Publish Chrome and Firefox extensions nightly

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -274,7 +274,7 @@ jobs:
           npm run build:dual-wasm
           npm run docs
 
-      - name: Sign Firefox extension
+      - name: Publish Firefox extension
         if: env.FIREFOX_EXTENSION_ID != '' && !matrix.demo
         id: sign-firefox
         continue-on-error: true
@@ -322,17 +322,6 @@ jobs:
           asset_name: ${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension.zip
           asset_content_type: application/zip
 
-      - name: Upload Firefox extension (signed)
-        if: steps.sign-firefox.outcome == 'success' && !matrix.demo
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-nightly-release.outputs.upload_url }}
-          asset_path: ./web/packages/extension/dist/firefox.xpi
-          asset_name: ${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-firefox.xpi
-          asset_content_type: application/x-xpinstall
-
       - name: Upload Firefox extension (unsigned)
         if: steps.sign-firefox.outcome != 'success' && !matrix.demo
         uses: actions/upload-release-asset@v1
@@ -343,6 +332,19 @@ jobs:
           asset_path: ./web/packages/extension/dist/firefox_unsigned.xpi
           asset_name: ${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-firefox-unsigned.xpi
           asset_content_type: application/x-xpinstall
+
+      - name: Publish Chrome extension
+        if: env.CHROME_EXTENSION_ID != '' && !matrix.demo
+        id: publish-chrome-extension
+        continue-on-error: true
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+        uses: mnao305/chrome-extension-upload@2.2.0
+        with:
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          file-path: ./web/packages/extension/dist/ruffle_extension.zip
 
       - name: Clone web demo
         if: matrix.demo


### PR DESCRIPTION
 * Add support for publishing Chrome Extension.
 * Secrets are set on Ruffle org for Chrome and Mozilla extension publishing.
    * Let's try doing this nightly; we may have to manually switch this off or switch to weekly if we get flagged for manual review (particularly on Mozilla).

TODO future PRs:
I'd like to organize things a little better by possibly splitting into more workflows; for example, the web nightly build can be its own workflow, and possibly the extension builds, too. Can use [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) and [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) to re-use the common parts.