### PR TITLE
core: Remove unnecessary parameter from `post_instantiation`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2691,7 +2691,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             self.context
                 .stage
                 .replace_at_depth(&mut self.context, level, level_id);
-            level.post_instantiation(&mut self.context, level, None, Instantiator::Movie, false);
+            level.post_instantiation(&mut self.context, None, Instantiator::Movie, false);
 
             level
         }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -221,7 +221,6 @@ fn attach_bitmap<'gc>(
                     );
                     display_object.post_instantiation(
                         &mut activation.context,
-                        display_object.into(),
                         None,
                         Instantiator::Avm1,
                         true,
@@ -649,7 +648,6 @@ fn attach_movie<'gc>(
         };
         new_clip.post_instantiation(
             &mut activation.context,
-            new_clip,
             init_object,
             Instantiator::Avm1,
             true,
@@ -693,13 +691,7 @@ fn create_empty_movie_clip<'gc>(
     // Set name and attach to parent.
     new_clip.set_name(activation.context.gc_context, new_instance_name);
     movie_clip.replace_at_depth(&mut activation.context, new_clip.into(), depth);
-    new_clip.post_instantiation(
-        &mut activation.context,
-        new_clip.into(),
-        None,
-        Instantiator::Avm1,
-        true,
-    );
+    new_clip.post_instantiation(&mut activation.context, None, Instantiator::Avm1, true);
 
     Ok(new_clip.object())
 }
@@ -748,13 +740,7 @@ fn create_text_field<'gc>(
         text_field,
         (depth as Depth).wrapping_add(AVM_DEPTH_BIAS),
     );
-    text_field.post_instantiation(
-        &mut activation.context,
-        text_field,
-        None,
-        Instantiator::Avm1,
-        false,
-    );
+    text_field.post_instantiation(&mut activation.context, None, Instantiator::Avm1, false);
 
     if activation.swf_version() >= 8 {
         //SWF8+ returns the `TextField` instance here
@@ -850,7 +836,6 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
         let init_object = init_object.map(|v| v.coerce_to_object(activation));
         new_clip.post_instantiation(
             &mut activation.context,
-            new_clip,
             init_object,
             Instantiator::Avm1,
             true,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -629,7 +629,7 @@ mod tests {
             };
             context.stage.replace_at_depth(&mut context, root, 0);
 
-            root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
+            root.post_instantiation(&mut context, None, Instantiator::Movie, false);
             root.set_name(context.gc_context, "".into());
 
             let swf_version = context.swf.version();

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -86,7 +86,7 @@ where
         };
         context.stage.replace_at_depth(&mut context, root, 0);
 
-        root.post_instantiation(&mut context, root, None, Instantiator::Movie, false);
+        root.post_instantiation(&mut context, None, Instantiator::Movie, false);
         root.set_name(context.gc_context, "".into());
 
         fn run_test<'a, 'gc: 'a, F>(

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -51,13 +51,7 @@ pub fn native_instance_init<'gc>(
                 this.init_display_object(activation.context.gc_context, child);
                 child.set_object2(activation.context.gc_context, this);
 
-                child.post_instantiation(
-                    &mut activation.context,
-                    child,
-                    None,
-                    Instantiator::Avm2,
-                    false,
-                );
+                child.post_instantiation(&mut activation.context, None, Instantiator::Avm2, false);
                 child.construct_frame(&mut activation.context);
             }
         }

--- a/core/src/avm2/globals/flash/display/simplebutton.rs
+++ b/core/src/avm2/globals/flash/display/simplebutton.rs
@@ -25,13 +25,7 @@ pub fn instance_init<'gc>(
         if this.as_display_object().is_none() {
             let mut new_do = Avm2Button::empty_button(&mut activation.context);
 
-            new_do.post_instantiation(
-                &mut activation.context,
-                new_do.into(),
-                None,
-                Instantiator::Avm2,
-                false,
-            );
+            new_do.post_instantiation(&mut activation.context, None, Instantiator::Avm2, false);
             this.init_display_object(activation.context.gc_context, new_do.into());
             new_do.set_object2(activation.context.gc_context, this);
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1292,7 +1292,6 @@ pub trait TDisplayObject<'gc>:
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        _display_object: DisplayObject<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -193,7 +193,7 @@ impl<'gc> Avm1Button<'gc> {
 
         for (child, depth) in children {
             // Initialize new child.
-            child.post_instantiation(context, child, None, Instantiator::Movie, false);
+            child.post_instantiation(context, None, Instantiator::Movie, false);
             child.run_frame(context);
             let removed_child = self.replace_at_depth(context, child, depth.into());
             dispatch_added_event(self.into(), child, false, context);
@@ -255,7 +255,6 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        display_object: DisplayObject<'gc>,
         _init_object: Option<Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,
@@ -272,7 +271,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         if mc.object.is_none() {
             let object = StageObject::for_display_object(
                 context.gc_context,
-                display_object,
+                (*self).into(),
                 Some(context.avm1.prototypes().button),
             );
             mc.object = Some(object.into());
@@ -326,7 +325,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
             drop(read);
 
             for (child, depth) in new_children {
-                child.post_instantiation(context, child, None, Instantiator::Movie, false);
+                child.post_instantiation(context, None, Instantiator::Movie, false);
                 self.0
                     .write(context.gc_context)
                     .hit_area

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -223,7 +223,7 @@ impl<'gc> Avm2Button<'gc> {
             let child = children.first().cloned().unwrap().0;
 
             child.set_parent(context.gc_context, Some(self.into()));
-            child.post_instantiation(context, child, None, Instantiator::Movie, false);
+            child.post_instantiation(context, None, Instantiator::Movie, false);
             child.construct_frame(context);
 
             (child, false)
@@ -241,7 +241,7 @@ impl<'gc> Avm2Button<'gc> {
                 // and then properly set the parent to the state Sprite afterwards.
                 state_sprite.replace_at_depth(context, child, depth.into());
                 child.set_parent(context.gc_context, Some(self.into()));
-                child.post_instantiation(context, child, None, Instantiator::Movie, false);
+                child.post_instantiation(context, None, Instantiator::Movie, false);
                 child.construct_frame(context);
                 child.set_parent(context.gc_context, Some(state_sprite.into()));
             }
@@ -415,7 +415,6 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        _display_object: DisplayObject<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,
@@ -479,7 +478,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             drop(write);
 
             if up_should_fire {
-                up_state.post_instantiation(context, up_state, None, Instantiator::Movie, false);
+                up_state.post_instantiation(context, None, Instantiator::Movie, false);
 
                 if let Some(up_container) = up_state.as_container() {
                     for (_depth, child) in up_container.iter_depth_list() {
@@ -489,13 +488,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             }
 
             if over_should_fire {
-                over_state.post_instantiation(
-                    context,
-                    over_state,
-                    None,
-                    Instantiator::Movie,
-                    false,
-                );
+                over_state.post_instantiation(context, None, Instantiator::Movie, false);
 
                 if let Some(over_container) = over_state.as_container() {
                     for (_depth, child) in over_container.iter_depth_list() {
@@ -505,13 +498,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             }
 
             if down_should_fire {
-                down_state.post_instantiation(
-                    context,
-                    down_state,
-                    None,
-                    Instantiator::Movie,
-                    false,
-                );
+                down_state.post_instantiation(context, None, Instantiator::Movie, false);
 
                 if let Some(down_container) = down_state.as_container() {
                     for (_depth, child) in down_container.iter_depth_list() {
@@ -521,7 +508,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
             }
 
             if hit_should_fire {
-                hit_area.post_instantiation(context, hit_area, None, Instantiator::Movie, false);
+                hit_area.post_instantiation(context, None, Instantiator::Movie, false);
 
                 if let Some(hit_container) = hit_area.as_container() {
                     for (_depth, child) in hit_container.iter_depth_list() {

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -219,7 +219,6 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        _display_object: DisplayObject<'gc>,
         _init_object: Option<avm1::Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1399,17 +1399,12 @@ impl<'gc> EditText<'gc> {
     }
 
     /// Construct the text field's AVM1 representation.
-    fn construct_as_avm1_object(
-        &self,
-        context: &mut UpdateContext<'_, 'gc, '_>,
-        display_object: DisplayObject<'gc>,
-        run_frame: bool,
-    ) {
+    fn construct_as_avm1_object(&self, context: &mut UpdateContext<'_, 'gc, '_>, run_frame: bool) {
         let mut text = self.0.write(context.gc_context);
         if text.object.is_none() {
             let object: Avm1Object<'gc> = Avm1StageObject::for_display_object(
                 context.gc_context,
-                display_object,
+                (*self).into(),
                 Some(context.avm1.prototypes().text_field),
             )
             .into();
@@ -1512,7 +1507,6 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        display_object: DisplayObject<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,
@@ -1530,7 +1524,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         let vm_type = library.avm_type();
 
         if vm_type == AvmType::Avm1 {
-            self.construct_as_avm1_object(context, display_object, run_frame);
+            self.construct_as_avm1_object(context, run_frame);
         }
     }
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -202,7 +202,6 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        _display_object: DisplayObject<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1168,7 +1168,7 @@ impl<'gc> MovieClip<'gc> {
                     // Run first frame.
                     child.apply_place_object(context, self.movie(), place_object);
                     child.construct_frame(context);
-                    child.post_instantiation(context, child, None, Instantiator::Movie, false);
+                    child.post_instantiation(context, None, Instantiator::Movie, false);
                     // In AVM1, children are added in `run_frame` so this is necessary.
                     // In AVM2 we add them in `construct_frame` so calling this causes
                     // duplicate frames
@@ -1413,7 +1413,6 @@ impl<'gc> MovieClip<'gc> {
     fn construct_as_avm1_object(
         self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        display_object: DisplayObject<'gc>,
         init_object: Option<Avm1Object<'gc>>,
         instantiated_by: Instantiator,
         run_frame: bool,
@@ -1466,7 +1465,7 @@ impl<'gc> MovieClip<'gc> {
 
             let object: Avm1Object<'gc> = StageObject::for_display_object(
                 context.gc_context,
-                display_object,
+                self.into(),
                 Some(context.avm1.prototypes().movie_clip),
             )
             .into();
@@ -1502,7 +1501,7 @@ impl<'gc> MovieClip<'gc> {
             {
                 if event_handler.events.contains(ClipEventFlag::INITIALIZE) {
                     context.action_queue.queue_actions(
-                        display_object,
+                        self.into(),
                         ActionType::Initialize {
                             bytecode: event_handler.action_data.clone(),
                         },
@@ -1515,7 +1514,7 @@ impl<'gc> MovieClip<'gc> {
             }
 
             context.action_queue.queue_actions(
-                display_object,
+                self.into(),
                 ActionType::Construct {
                     constructor: avm1_constructor,
                     events,
@@ -1997,7 +1996,6 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        display_object: DisplayObject<'gc>,
         init_object: Option<Avm1Object<'gc>>,
         instantiated_by: Instantiator,
         run_frame: bool,
@@ -2009,13 +2007,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                 .avm1
                 .add_to_exec_list(context.gc_context, (*self).into());
 
-            self.construct_as_avm1_object(
-                context,
-                display_object,
-                init_object,
-                instantiated_by,
-                run_frame,
-            );
+            self.construct_as_avm1_object(context, init_object, instantiated_by, run_frame);
         }
     }
 

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -617,7 +617,6 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        _display_object: DisplayObject<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         _run_frame: bool,

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -301,7 +301,6 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
     fn post_instantiation(
         &self,
         context: &mut UpdateContext<'_, 'gc, '_>,
-        display_object: DisplayObject<'gc>,
         _init_object: Option<Avm1Object<'gc>>,
         _instantiated_by: Instantiator,
         run_frame: bool,
@@ -379,7 +378,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
             if vm_type == AvmType::Avm1 {
                 let object: Avm1Object<'_> = Avm1StageObject::for_display_object(
                     context.gc_context,
-                    display_object,
+                    (*self).into(),
                     Some(context.avm1.prototypes().video),
                 )
                 .into();

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -452,7 +452,7 @@ impl<'gc> Loader<'gc> {
 
                         if let Some(mut mc) = clip.as_movie_clip() {
                             mc.replace_with_movie(uc.gc_context, Some(movie.clone()));
-                            mc.post_instantiation(uc, clip, None, Instantiator::Movie, false);
+                            mc.post_instantiation(uc, None, Instantiator::Movie, false);
 
                             let mut morph_shapes = fnv::FnvHashMap::default();
                             mc.preload(uc, &mut morph_shapes);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -320,19 +320,13 @@ impl Player {
         player.mutate_with_update_context(|context| {
             // Instantiate an empty root before the main movie loads.
             let fake_root = MovieClip::from_movie(context.gc_context, fake_movie);
-            fake_root.post_instantiation(
-                context,
-                fake_root.into(),
-                None,
-                Instantiator::Movie,
-                false,
-            );
+            fake_root.post_instantiation(context, None, Instantiator::Movie, false);
             context.stage.replace_at_depth(context, fake_root.into(), 0);
 
             let result = Avm2::load_player_globals(context);
 
             let stage = context.stage;
-            stage.post_instantiation(context, stage.into(), None, Instantiator::Movie, false);
+            stage.post_instantiation(context, None, Instantiator::Movie, false);
             stage.build_matrices(context);
 
             result
@@ -427,7 +421,7 @@ impl Player {
                 None
             };
 
-            root.post_instantiation(context, root, flashvars, Instantiator::Movie, false);
+            root.post_instantiation(context, flashvars, Instantiator::Movie, false);
             root.set_default_root_name(context);
             context.stage.replace_at_depth(context, root, 0);
 


### PR DESCRIPTION
`display_object` was always equivalent to `self`, there's no need to pass both.