### PR TITLE
ci: Fix publishing of Firefox extension

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -255,6 +255,7 @@ jobs:
           BUILD_ID: ${{ github.run_number }}
           # Build web demo with WebGPU support for testing in Chrome origin trial on ruffle.rs
           CARGO_FEATURES: ${{ matrix.demo && 'wgpu' || '' }}
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
         working-directory: web
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Supply FIREFOX_EXTENSION_ID var to the web build step to ensure this gets correctly populated in the manifest.json.