### PR TITLE
extension: URL-encode the SWF URL for the player page

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -38,7 +38,7 @@ function onHeadersReceived(
 ) {
     if (isSwf(details)) {
         const baseUrl = utils.runtime.getURL("player.html");
-        return { redirectUrl: `${baseUrl}?url=${details.url}` };
+        return { redirectUrl: `${baseUrl}?url=${encodeURIComponent(details.url)}` };
     }
 }
 

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -38,7 +38,9 @@ function onHeadersReceived(
 ) {
     if (isSwf(details)) {
         const baseUrl = utils.runtime.getURL("player.html");
-        return { redirectUrl: `${baseUrl}?url=${encodeURIComponent(details.url)}` };
+        return {
+            redirectUrl: `${baseUrl}?url=${encodeURIComponent(details.url)}`,
+        };
     }
 }
 


### PR DESCRIPTION
When the user clicks the "Open in a new tab" button, the extension's internal `player.html` page opens, with a URL parameter `?url=[the SWF URL]`. Right now, this URL parameter is not properly encoded. This causes a problem when we get to https://github.com/ruffle-rs/ruffle/blob/master/web/packages/extension/src/player.ts#L14:
> `const swfUrl = url.searchParams.get("url");` 

Because the value of the "url" parameter was not properly encoded, any `&` character in the SWF URL would be interpreted as the start of a *new* parameter, instead of being part of the actual SWF URL. So anything after the first `&` symbol in the SWF URL would be chopped off.
On Itch.io Flash pages such as https://rarykos.itch.io/hug-me-im-cold, the SWF URL contains several important parameters - if they are not included, the server returns 403 Forbidden (it's a type of hotlinking protection). So when the user clicked the "Open in a new tab" button on Itch.io pages, the SWF would refuse to load in the player.
This PR fixes the problem - Itch.io SWFs load when opened in a new tab after my change is applied.