### PR TITLE
core: Fix detection of button events

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -286,7 +286,7 @@ impl<'gc> ClipEvent<'gc> {
     /// Indicates whether this is an event type used by Buttons (i.e., on that can be used in an `on` handler in Flash).
     pub const fn is_button_event(self) -> bool {
         if let Some(flag) = self.flag() {
-            flag.contains(Self::BUTTON_EVENT_FLAGS)
+            flag.intersects(Self::BUTTON_EVENT_FLAGS)
         } else {
             false
         }


### PR DESCRIPTION
Fixes #5577 and #5958, these files stop triggering the actions of invisible buttons.

I have to admit that I'm not sure about this fix, it was made based on the following lines that already use `intersects`:
https://github.com/ruffle-rs/ruffle/blob/d9bedffb9f9a00ea7ad38db0edca527952ed5d33/core/src/display_object/movie_clip.rs#L1700-L1708