### PR TITLE
ci: Skip `publish-aur-package` job on forks

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -409,6 +409,7 @@ jobs:
     name: Publish AUR package
     needs: build
     runs-on: ubuntu-latest
+    if: github.repository == 'ruffle-rs/ruffle'
     steps:
       - uses: actions/checkout@v2
 
@@ -428,7 +429,6 @@ jobs:
         run: sed -e "s/@VERSION@/${{ steps.current_time_dots.outputs.formattedTime }}/" -i ./PKGBUILD
 
       - name: Publish AUR package
-        if: github.repository == 'ruffle-rs/ruffle'
         uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
         with:
           pkgname: ruffle-nightly-bin


### PR DESCRIPTION
Move the `if` condition that tests for the Ruffle official repository
to the job-level, so all steps of that job are skipped, rather than
only the publish step itself. This should have a very little effect,
but I just randomly noticed it.