### PR TITLE
web: Bump wasm-bindgen to 0.2.79

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -237,7 +237,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: wasm-bindgen-cli --version 0.2.78
+          args: wasm-bindgen-cli --version 0.2.79
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -61,7 +61,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.78
+        run: cargo install wasm-bindgen-cli --version 0.2.79
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,9 +1803,9 @@ checksum = "fbcf0244f6597be39ab8d9203f574cafb529ae8c698afa2182f7b3c3205a4a9c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3751,9 +3751,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3778,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3790,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3800,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3813,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wayland-client"
@@ -3898,9 +3898,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 base64 = "0.13.0"
 fnv = "1.0.7"
-js-sys = "0.3.55"
+js-sys = "0.3.56"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 svg = "0.10.0"
 percent-encoding = "2.1.0"
 png = "0.17.2"
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = "=0.2.79"
 
 [dependencies.jpeg-decoder]
 version = "0.2.1"
@@ -28,7 +28,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.56"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
     "Document", "Element", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "ImageData", "Navigator",

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.55"
+js-sys = "0.3.56"
 log = "0.4"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = "=0.2.79"
 bytemuck = { version = "1.7.3", features = ["derive"] }
 
 [dependencies.ruffle_core]
@@ -18,7 +18,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.56"
 features = ["HtmlCanvasElement", "HtmlElement", "Node", "OesVertexArrayObject", "WebGlBuffer", "WebglDebugRendererInfo",
             "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGl2RenderingContext",
             "WebGlShader", "WebGlTexture", "WebGlUniformLocation", "WebGlVertexArrayObject"]

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -27,10 +27,10 @@ version = "0.12"
 
 # wasm
 [target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen-futures]
-version = "0.4"
+version = "0.4.29"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3"
+version = "0.3.56"
 features = ["HtmlCanvasElement"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -32,15 +32,15 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"
 generational-arena = "0.2.8"
-js-sys = "0.3.55"
+js-sys = "0.3.56"
 log = { version = "0.4", features = ["serde"] }
 ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 url = "2.2.2"
-wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.28"
+wasm-bindgen = { version = "=0.2.79", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.29"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.133", features = ["derive"] }
@@ -53,7 +53,7 @@ default-features = false
 features = ["h263", "vp6", "screenvideo", "serde", "wasm-bindgen"]
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.56"
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioParam", "AudioProcessingEvent", "AudioContext", "AudioDestinationNode",
     "AudioNode", "CanvasRenderingContext2d", "ChannelMergerNode", "ChannelSplitterNode", "CssStyleDeclaration", "Document",

--- a/web/README.md
+++ b/web/README.md
@@ -58,7 +58,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.78`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.79`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.55"
+js-sys = "0.3.56"
 log = "0.4"
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = "=0.2.79"
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.56"
 features = ["Window"]


### PR DESCRIPTION
Also bump its helper crates (`js-sys`, `web-sys` and `wasm-bindgen-futures`)
to the latest versions.