### PR TITLE
desktop: Don't swallow Escape key (fix #6135)

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -375,12 +375,9 @@ impl App {
                                         ..
                                     },
                                 ..
-                            } => {
-                                player.lock().unwrap().update(|uc| {
-                                    uc.stage.set_display_state(uc, StageDisplayState::Normal);
-                                });
-                                return;
-                            }
+                            } => player.lock().unwrap().update(|uc| {
+                                uc.stage.set_display_state(uc, StageDisplayState::Normal);
+                            }),
                             _ => (),
                         },
                         _ => (),


### PR DESCRIPTION
The "exit fullscreen" shortcut was swallowing Escape presses on desktop. Allow the Escape press to reach the content.

Long term we'll probably want a setting that allows for enabling/disabling Ruffle's shortcuts, because content may have its own escape/alt+enter/etc. behavior.