### PR TITLE
chore: Bump approx to 0.5.1, remove clippy lint suppressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "approx"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072df7202e63b127ab55acfe16ce97013d5b97bf160489336d3f1840fd78e99e"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ version = "0.2.1"
 default-features = false # can't use rayon on web
 
 [dev-dependencies]
-approx = "0.5.0"
+approx = "0.5.1"
 
 [features]
 default = ["minimp3", "serde"]

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -191,7 +191,6 @@ impl std::ops::MulAssign for Matrix {
 }
 
 #[cfg(test)]
-#[allow(clippy::if_then_panic)] // TODO: Remove when https://github.com/brendanzab/approx/pull/72 is merged.
 mod tests {
     use super::*;
     use approx::{assert_ulps_eq, AbsDiffEq, UlpsEq};

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -81,7 +81,6 @@ macro_rules! swf_tests_approx {
     ($($(#[$attr:meta])* ($name:ident, $path:expr, $num_frames:literal $(, $opt:ident = $val:expr)*),)*) => {
         $(
         #[test]
-        #[allow(clippy::if_then_panic)] // TODO: Remove when https://github.com/brendanzab/approx/pull/72 is merged.
         $(#[$attr])*
         fn $name() -> Result<(), Error> {
             set_logger();


### PR DESCRIPTION
Just a bit of cleanup, as https://github.com/brendanzab/approx/pull/72 recently got merged, and a fixed version released.