### PR TITLE
core: Fix incorrect fill and stroke rendering order (fix #6129)

### DIFF
--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -18,6 +18,7 @@ pub struct Drawing {
     bitmaps: Vec<BitmapInfo>,
     current_fill: Option<DrawingFill>,
     current_line: Option<DrawingLine>,
+    pending_lines: Vec<DrawingLine>,
     cursor: (Twips, Twips),
     fill_start: (Twips, Twips),
 }
@@ -40,6 +41,7 @@ impl Drawing {
             bitmaps: Vec::new(),
             current_fill: None,
             current_line: None,
+            pending_lines: Vec::new(),
             cursor: (Twips::ZERO, Twips::ZERO),
             fill_start: (Twips::ZERO, Twips::ZERO),
         }
@@ -56,6 +58,7 @@ impl Drawing {
             bitmaps: Vec::new(),
             current_fill: None,
             current_line: None,
+            pending_lines: Vec::new(),
             cursor: (Twips::ZERO, Twips::ZERO),
             fill_start: (Twips::ZERO, Twips::ZERO),
         };
@@ -280,6 +283,17 @@ impl Drawing {
         // The pending fill will auto-close.
         if let Some(fill) = &self.current_fill {
             if shape_utils::draw_command_fill_hit_test(&fill.commands, point) {
+                return true;
+            }
+        }
+
+        for line in &self.pending_lines {
+            if shape_utils::draw_command_stroke_hit_test(
+                &line.commands,
+                line.style.width,
+                point,
+                local_matrix,
+            ) {
                 return true;
             }
         }


### PR DESCRIPTION
Ruffle didn't honor the proper rendering order of fills and strokes, causing issues such as #6129. Ruffle was storing the paths associated with each stroke style in a map, but this causes the final draw order to be arbitrary. Instead, for each layer, Flash draws the fills and strokes in order of their style ID -- all fills are drawn first, then strokes. This doesn't necessarily match the order of shape record commands in the data.

This is mainly noticeable with large overlapping strokes of different colors. It affects fills as well, although Flash will almost always export art with non-overlapping fills on each layer.

 * In `ShapeConverter`, change the `FnvHashMap` storing the style's paths to a `Vec` and iterate in order.
 * In `Drawing`, merge the separate list of fills and lines into a single list of commands. Defer lines until any pending fill is closed.

Fixes #6129 and #3186.