### PR TITLE
chore: Add .cargo/config.toml for workspace-level lint config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,19 @@
+[target.'cfg(all())']
+rustflags = [
+    # CLIPPY LINT SETTINGS
+    # This is a workaround to configure lints for the entire workspace, pending the ability to configure this via TOML.
+    # See: https://github.com/rust-lang/cargo/issues/5034
+    #      https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395
+
+    # Clippy nightly often adds new/buggy lints that we want to ignore.
+    # Don't warn about these new lints on stable.
+    "-Arenamed_and_removed_lints", 
+    "-Aunknown_lints",
+
+    # LONG-TERM: These lints are unhelpful.
+    "-Aclippy::manual_map",                  # Less readable: Suggests `opt.map(..)` instsead of `if let Some(opt) { .. }`
+    "-Aclippy::manual_range_contains",       # Less readable: Suggests `(a..b).contains(n)` instead of `n >= a && n < b`
+
+    # TEMPORARY: Buggy lints that will hopefully be fixed soon.
+    "-Aclippy::needless_borrow",             # https://github.com/rust-lang/rust-clippy/pull/8355
+]

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1242,7 +1242,6 @@ fn get_rect<'gc>(
     get_bounds(movie_clip, activation, args)
 }
 
-#[allow(unused_must_use)] //can't use errors yet
 pub fn get_url<'gc>(
     _movie_clip: MovieClip<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
@@ -1256,7 +1255,7 @@ pub fn get_url<'gc>(
         if let Some(fscommand) = fscommand::parse(&url) {
             let fsargs_val = args.get(1).cloned().unwrap_or(Value::Undefined);
             let fsargs = fsargs_val.coerce_to_string(activation)?;
-            fscommand::handle(fscommand, &fsargs, activation);
+            let _ = fscommand::handle(fscommand, &fsargs, activation);
             return Ok(Value::Undefined);
         }
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -455,6 +455,7 @@ impl<'gc> Value<'gc> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unreadable_literal)] // Large numeric literals in tests
 mod test {
     use crate::avm1::activation::Activation;
     use crate::avm1::error::Error;
@@ -637,7 +638,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::unreadable_literal)]
 
     fn wrapping_u16() {
         use super::f64_to_wrapping_u16;
@@ -654,7 +654,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::unreadable_literal)]
 
     fn wrapping_i16() {
         use super::f64_to_wrapping_i16;
@@ -672,7 +671,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::unreadable_literal)]
     fn wrapping_u32() {
         use super::f64_to_wrapping_u32;
         assert_eq!(f64_to_wrapping_u32(0.0), 0);
@@ -688,7 +686,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::unreadable_literal)]
     fn wrapping_i32() {
         use super::f64_to_wrapping_i32;
         assert_eq!(f64_to_wrapping_i32(0.0), 0);

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -45,7 +45,7 @@ pub mod minimp3 {
         type Item = [i16; 2];
 
         #[inline]
-        #[allow(unknown_lints, clippy::branches_sharing_code)]
+        #[allow(clippy::branches_sharing_code)]
         fn next(&mut self) -> Option<Self::Item> {
             if self.cur_sample >= self.frame.data.len() {
                 self.next_frame();

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -1019,8 +1019,6 @@ impl Display for StageQuality {
 impl FromStr for StageQuality {
     type Err = ParseEnumError;
 
-    // clippy: False positive pending https://github.com/rust-lang/rust-clippy/pull/7865
-    #[allow(unknown_lints, clippy::match_str_case_mismatch)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let quality = match s.to_ascii_lowercase().as_str() {
             "low" => StageQuality::Low,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,14 +1,3 @@
-#![allow(
-    renamed_and_removed_lints,
-    unknown_lints,
-    clippy::unknown_clippy_lints,
-    clippy::inconsistent_struct_constructor,
-    clippy::manual_map,
-    clippy::manual_range_contains,
-    clippy::same_item_push,
-    clippy::unnecessary_wraps
-)]
-
 #[macro_use]
 mod display_object;
 pub use display_object::StageDisplayState;

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -1,8 +1,4 @@
-#![allow(
-    renamed_and_removed_lints,
-    clippy::unknown_clippy_lints,
-    clippy::suspicious_operation_groupings
-)]
+#![allow(clippy::suspicious_operation_groupings)]
 
 use swf::{Fixed16, Twips};
 

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -269,7 +269,7 @@ fn capture_single_swf(descriptors: Descriptors, opt: &Opt) -> Result<(), Box<dyn
     Ok(())
 }
 
-#[allow(unknown_lints, clippy::branches_sharing_code)]
+#[allow(clippy::branches_sharing_code)]
 fn capture_multiple_swfs(mut descriptors: Descriptors, opt: &Opt) -> Result<(), Box<dyn Error>> {
     let output = opt.output_path.clone().unwrap();
     let files = find_files(&opt.swf, !opt.silent);

--- a/swf/src/types/matrix.rs
+++ b/swf/src/types/matrix.rs
@@ -1,8 +1,4 @@
-#![allow(
-    renamed_and_removed_lints,
-    clippy::unknown_clippy_lints,
-    clippy::suspicious_operation_groupings
-)]
+#![allow(clippy::suspicious_operation_groupings)]
 
 use crate::{Fixed16, Twips};
 use std::ops;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,9 +1,3 @@
-#![allow(
-    renamed_and_removed_lints,
-    clippy::same_item_push,
-    clippy::unknown_clippy_lints
-)]
-
 //! Ruffle web frontend.
 mod audio;
 mod locale;


### PR DESCRIPTION
Currently it is not directly possible to configure lints for the entire workspace via TOML, which forced us to repeat `#![allow]` blocks in each crate.

embark pointed out this workaround to configure lints at the workspace level via RUSTFLAGS:

https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395

Remove the common `#![allow]` blocks and switch to this method for global lint config. I was also able to remove a few `allows` that are no longer problematic.

Temporarily allow `needless_borrow` lint to fix CI. This lint is buggy pending this fix:
https://github.com/rust-lang/rust-clippy/pull/8355