### PR TITLE
core: Remove morph shape preloading

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -6,9 +6,7 @@ use crate::avm2::{Activation as Avm2Activation, Domain as Avm2Domain};
 use crate::backend::navigator::{OwnedFuture, RequestOptions};
 use crate::backend::render::{determine_jpeg_tag_format, JpegTagFormat};
 use crate::context::{ActionQueue, ActionType, UpdateContext};
-use crate::display_object::{
-    Bitmap, DisplayObject, MorphShape, TDisplayObject, TDisplayObjectContainer,
-};
+use crate::display_object::{Bitmap, DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use crate::player::{Player, NEWEST_PLAYER_VERSION};
 use crate::string::AvmString;
 use crate::tag_utils::SwfMovie;
@@ -472,22 +470,9 @@ impl<'gc> Loader<'gc> {
                                 .set_avm2_domain(domain);
 
                             if let Some(mut mc) = clip.as_movie_clip() {
-                                mc.replace_with_movie(uc.gc_context, Some(movie.clone()));
+                                mc.replace_with_movie(uc.gc_context, Some(movie));
                                 mc.post_instantiation(uc, None, Instantiator::Movie, false);
-
-                                let mut morph_shapes = fnv::FnvHashMap::default();
-                                mc.preload(uc, &mut morph_shapes);
-
-                                // Finalize morph shapes.
-                                for (id, static_data) in morph_shapes {
-                                    let morph_shape = MorphShape::new(uc.gc_context, static_data);
-                                    uc.library
-                                        .library_for_movie_mut(movie.clone())
-                                        .register_character(
-                                            id,
-                                            crate::character::Character::MorphShape(morph_shape),
-                                        );
-                                }
+                                mc.preload(uc);
                             }
                         }
                         ContentType::Gif | ContentType::Jpeg | ContentType::Png => {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -18,8 +18,8 @@ use crate::config::Letterbox;
 use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
 use crate::context_menu::{ContextMenuCallback, ContextMenuItem, ContextMenuState};
 use crate::display_object::{
-    EditText, InteractiveObject, MorphShape, MovieClip, Stage, StageAlign, StageDisplayState,
-    StageQuality, StageScaleMode, TInteractiveObject,
+    EditText, InteractiveObject, MovieClip, Stage, StageAlign, StageDisplayState, StageQuality,
+    StageScaleMode, TInteractiveObject,
 };
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, MouseButton, PlayerEvent};
 use crate::external::Value as ExternalValue;
@@ -1318,21 +1318,8 @@ impl Player {
     /// specific `MovieClip` referenced.
     fn preload(&mut self) {
         self.mutate_with_update_context(|context| {
-            let mut morph_shapes = fnv::FnvHashMap::default();
             let root = context.stage.root_clip();
-            root.as_movie_clip()
-                .unwrap()
-                .preload(context, &mut morph_shapes);
-
-            let lib = context
-                .library
-                .library_for_movie_mut(root.as_movie_clip().unwrap().movie().unwrap());
-
-            // Finalize morph shapes.
-            for (id, static_data) in morph_shapes {
-                let morph_shape = MorphShape::new(context.gc_context, static_data);
-                lib.register_character(id, crate::character::Character::MorphShape(morph_shape));
-            }
+            root.as_movie_clip().unwrap().preload(context);
         });
         if self.swf.avm_type() == AvmType::Avm2 && self.warn_on_unsupported_content {
             self.ui.display_unsupported_message();


### PR DESCRIPTION
Remove the preload step that would pre-create the shapes for each morph shape ratio on SWF load. Instead, lazily crate the shapes as they are needed. We already do similar for the drawing API, so it doesn't seem necessary to create these shapes ahead of time.

This removes a large amount of complex code from `MovieClip::preload`, as all timelines had to be scanned to determine what ratios of a morph shape were used.