### PR TITLE
avm1: Fire `onReleaseOutside` event even when the button is invisible

### DIFF
--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -423,7 +423,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
     }
 
     fn filter_clip_event(self, event: ClipEvent) -> ClipEventResult {
-        if !self.visible() {
+        if !self.visible() && !matches!(event, ClipEvent::ReleaseOutside) {
             return ClipEventResult::NotHandled;
         }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2043,7 +2043,8 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     }
 
     fn filter_clip_event(self, event: ClipEvent) -> ClipEventResult {
-        if event.is_button_event() && !self.visible() {
+        if event.is_button_event() && !self.visible() && !matches!(event, ClipEvent::ReleaseOutside)
+        {
             return ClipEventResult::NotHandled;
         }
 


### PR DESCRIPTION
Fixes #6169 and [this sample](https://github.com/ruffle-rs/ruffle/files/7966764/sample.zip).