### PR TITLE
avm1: Change the cursor to arrow when the `enabled` property is set to false on a button

### DIFF
--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -545,7 +545,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
     }
 
     fn mouse_cursor(self, _context: &mut UpdateContext<'_, 'gc, '_>) -> MouseCursor {
-        if self.use_hand_cursor() {
+        if self.use_hand_cursor() && self.enabled() {
             MouseCursor::Hand
         } else {
             MouseCursor::Arrow

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -805,6 +805,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
     }
 
     fn mouse_cursor(self, _context: &mut UpdateContext<'_, 'gc, '_>) -> MouseCursor {
+        // TODO: Should we also need to check for the `enabled` property like AVM1 buttons?
         if self.use_hand_cursor() {
             MouseCursor::Hand
         } else {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2211,7 +2211,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     }
 
     fn mouse_cursor(self, context: &mut UpdateContext<'_, 'gc, '_>) -> MouseCursor {
-        if self.use_hand_cursor() && self.is_button_mode(context) {
+        if self.use_hand_cursor() && self.enabled() && self.is_button_mode(context) {
             MouseCursor::Hand
         } else {
             MouseCursor::Arrow

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1235,6 +1235,7 @@ impl Player {
                     if released_inside {
                         // Released inside the clicked object.
                         if let Some(down_object) = context.mouse_down_object {
+                            new_cursor = down_object.mouse_cursor(context);
                             events.push((down_object, ClipEvent::Release));
                         } else {
                             events.push((context.stage.into(), ClipEvent::Release));


### PR DESCRIPTION
Fixes #6208, #6130.