### PR TITLE
AVM2: Get rid of all "undefined is not an Object" and "null is not an Object" errors

### DIFF
--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -482,9 +482,9 @@ pub fn dispatch_event_to_target<'gc>(
             &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list").into(),
             activation,
         )?
-        .coerce_to_object(activation);
+        .as_object();
 
-    if dispatch_list.is_err() {
+    if dispatch_list.is_none() {
         // Objects with no dispatch list act as if they had an empty one
         return Ok(());
     }
@@ -532,8 +532,7 @@ pub fn dispatch_event<'gc>(
             &QName::new(Namespace::private(NS_EVENT_DISPATCHER), "target").into(),
             activation,
         )?
-        .coerce_to_object(activation)
-        .ok()
+        .as_object()
         .unwrap_or(this);
 
     let mut ancestor_list = Vec::new();

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -319,13 +319,16 @@ fn class<'gc>(
     let class_read = class_def.read();
     let super_class = if let Some(sc_name) = class_read.super_class_name() {
         let super_class: Result<Object<'gc>, Error> = global
-            .get_property(sc_name, activation)?
-            .coerce_to_object(activation)
-            .map_err(|_e| {
+            .get_property(sc_name, activation)
+            .ok()
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| {
                 format!(
-                    "Could not resolve superclass {:?} when defining global class {:?}",
-                    sc_name.local_name(),
-                    class_read.name().local_name()
+                    "Could not resolve superclass {} when defining global class {}",
+                    sc_name.to_qualified_name(activation.context.gc_context),
+                    class_read
+                        .name()
+                        .to_qualified_name(activation.context.gc_context)
                 )
                 .into()
             });

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -23,8 +23,7 @@ pub fn instance_init<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Null)
-            .coerce_to_object(activation)
-            .ok()
+            .as_object()
             .and_then(|bd| bd.as_bitmap_data());
         //TODO: Pixel snapping is not supported
         let _pixel_snapping = args
@@ -132,8 +131,7 @@ pub fn set_bitmap_data<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Null)
-            .coerce_to_object(activation)
-            .ok()
+            .as_object()
             .and_then(|bd| bd.as_bitmap_data());
 
         bitmap.set_bitmap_data(&mut activation.context, bitmap_data);

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -552,7 +552,7 @@ pub fn hit_test_point<'gc>(
 
 /// Implements `hitTestObject`.
 pub fn hit_test_object<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -561,8 +561,8 @@ pub fn hit_test_object<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)?
-            .as_display_object()
+            .as_object()
+            .and_then(|o| o.as_display_object())
         {
             return Ok(dobj.hit_test_object(rhs_dobj).into());
         }

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -193,8 +193,8 @@ pub fn add_child<'gc>(
                 .get(0)
                 .cloned()
                 .unwrap_or(Value::Undefined)
-                .coerce_to_object(activation)?
-                .as_display_object()
+                .as_object()
+                .and_then(|o| o.as_display_object())
                 .ok_or("ArgumentError: Child not a valid display object")?;
             let target_index = ctr.num_children();
 
@@ -219,8 +219,8 @@ pub fn add_child_at<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)?
-            .as_display_object()
+            .as_object()
+            .and_then(|o| o.as_display_object())
             .ok_or("ArgumentError: Child not a valid display object")?;
         let target_index = args
             .get(1)
@@ -248,8 +248,8 @@ pub fn remove_child<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)?
-            .as_display_object()
+            .as_object()
+            .and_then(|o| o.as_display_object())
             .ok_or("ArgumentError: Child not a valid display object")?;
 
         validate_remove_operation(parent, child)?;
@@ -279,7 +279,7 @@ pub fn num_children<'gc>(
 
 /// Implements `DisplayObjectContainer.contains`
 pub fn contains<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -289,8 +289,8 @@ pub fn contains<'gc>(
                 .get(0)
                 .cloned()
                 .unwrap_or(Value::Undefined)
-                .coerce_to_object(activation)?
-                .as_display_object()
+                .as_object()
+                .and_then(|o| o.as_display_object())
             {
                 let mut maybe_child_parent = Some(child);
                 while let Some(child_parent) = maybe_child_parent {
@@ -309,7 +309,7 @@ pub fn contains<'gc>(
 
 /// Implements `DisplayObjectContainer.getChildIndex`
 pub fn get_child_index<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
@@ -319,8 +319,8 @@ pub fn get_child_index<'gc>(
                 .get(0)
                 .cloned()
                 .unwrap_or(Value::Undefined)
-                .coerce_to_object(activation)?
-                .as_display_object();
+                .as_object()
+                .and_then(|o| o.as_display_object());
 
             if let Some(target_child) = target_child {
                 for (i, child) in ctr.iter_render_list().enumerate() {
@@ -431,8 +431,8 @@ pub fn set_child_index<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)?
-            .as_display_object()
+            .as_object()
+            .and_then(|o| o.as_display_object())
             .ok_or("ArgumentError: Child not a valid display object")?;
         let target_index = args
             .get(1)
@@ -507,15 +507,15 @@ pub fn swap_children<'gc>(
                 .get(0)
                 .cloned()
                 .unwrap_or(Value::Undefined)
-                .coerce_to_object(activation)?
-                .as_display_object()
+                .as_object()
+                .and_then(|o| o.as_display_object())
                 .ok_or("ArgumentError: Child is not a display object")?;
             let child1 = args
                 .get(1)
                 .cloned()
                 .unwrap_or(Value::Undefined)
-                .coerce_to_object(activation)?
-                .as_display_object()
+                .as_object()
+                .and_then(|o| o.as_display_object())
                 .ok_or("ArgumentError: Child is not a display object")?;
 
             let index0 = ctr
@@ -551,8 +551,8 @@ pub fn stop_all_movie_clips<'gc>(
         if let Some(ctr) = parent.as_container() {
             for child in ctr.iter_render_list() {
                 if child.as_container().is_some() {
-                    let child_this = child.object2().coerce_to_object(activation)?;
-                    stop_all_movie_clips(activation, Some(child_this), &[])?;
+                    let child_this = child.object2().as_object();
+                    stop_all_movie_clips(activation, child_this, &[])?;
                 }
             }
         }

--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -59,7 +59,7 @@ pub fn add_frame_script<'gc>(
     {
         for (frame_id, callable) in args.chunks_exact(2).map(|s| (s[0], s[1])) {
             let frame_id = frame_id.coerce_to_u32(activation)? as u16 + 1;
-            let callable = callable.coerce_to_object(activation)?;
+            let callable = callable.as_callable(activation, None, None)?;
 
             mc.register_frame_script(frame_id, callable, &mut activation.context);
         }

--- a/core/src/avm2/globals/flash/display/simplebutton.rs
+++ b/core/src/avm2/globals/flash/display/simplebutton.rs
@@ -33,8 +33,7 @@ pub fn instance_init<'gc>(
                 .get(0)
                 .cloned()
                 .unwrap_or(Value::Null)
-                .coerce_to_object(activation)
-                .ok()
+                .as_object()
                 .and_then(|o| o.as_display_object());
             new_do.set_state_child(&mut activation.context, ButtonState::UP, up_state);
 
@@ -42,8 +41,7 @@ pub fn instance_init<'gc>(
                 .get(1)
                 .cloned()
                 .unwrap_or(Value::Null)
-                .coerce_to_object(activation)
-                .ok()
+                .as_object()
                 .and_then(|o| o.as_display_object());
             new_do.set_state_child(&mut activation.context, ButtonState::OVER, over_state);
 
@@ -51,8 +49,7 @@ pub fn instance_init<'gc>(
                 .get(2)
                 .cloned()
                 .unwrap_or(Value::Null)
-                .coerce_to_object(activation)
-                .ok()
+                .as_object()
                 .and_then(|o| o.as_display_object());
             new_do.set_state_child(&mut activation.context, ButtonState::DOWN, down_state);
 
@@ -60,8 +57,7 @@ pub fn instance_init<'gc>(
                 .get(3)
                 .cloned()
                 .unwrap_or(Value::Null)
-                .coerce_to_object(activation)
-                .ok()
+                .as_object()
                 .and_then(|o| o.as_display_object());
             new_do.set_state_child(&mut activation.context, ButtonState::HIT_TEST, hit_state);
         }
@@ -112,8 +108,7 @@ pub fn set_down_state<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)
-            .ok()
+            .as_object()
             .and_then(|val| val.as_display_object());
 
         btn.set_state_child(&mut activation.context, ButtonState::DOWN, new_state);
@@ -155,8 +150,7 @@ pub fn set_over_state<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)
-            .ok()
+            .as_object()
             .and_then(|val| val.as_display_object());
 
         btn.set_state_child(&mut activation.context, ButtonState::OVER, new_state);
@@ -198,8 +192,7 @@ pub fn set_hit_test_state<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)
-            .ok()
+            .as_object()
             .and_then(|val| val.as_display_object());
 
         btn.set_state_child(&mut activation.context, ButtonState::HIT_TEST, new_state);
@@ -241,8 +234,7 @@ pub fn set_up_state<'gc>(
             .get(0)
             .cloned()
             .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation)
-            .ok()
+            .as_object()
             .and_then(|val| val.as_display_object());
 
         btn.set_state_child(&mut activation.context, ButtonState::UP, new_state);

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -435,7 +435,7 @@ pub fn focus<'gc>(
         .context
         .focus_tracker
         .get()
-        .and_then(|focus_dobj| focus_dobj.object2().coerce_to_object(activation).ok())
+        .and_then(|focus_dobj| focus_dobj.object2().as_object())
         .map(|o| o.into())
         .unwrap_or(Value::Null))
 }
@@ -450,7 +450,7 @@ pub fn set_focus<'gc>(
     match args.get(0).cloned().unwrap_or(Value::Undefined) {
         Value::Null => focus.set(None, &mut activation.context),
         val => {
-            if let Some(dobj) = val.coerce_to_object(activation)?.as_display_object() {
+            if let Some(dobj) = val.as_object().and_then(|o| o.as_display_object()) {
                 focus.set(Some(dobj), &mut activation.context);
             } else {
                 return Err("Cannot set focus to non-DisplayObject".into());

--- a/core/src/avm2/globals/flash/events/mouseevent.rs
+++ b/core/src/avm2/globals/flash/events/mouseevent.rs
@@ -56,8 +56,7 @@ pub fn instance_init<'gc>(
                 .get(5)
                 .cloned()
                 .unwrap_or(Value::Null)
-                .coerce_to_object(activation)
-                .ok()
+                .as_object()
                 .and_then(|o| o.as_display_object())
                 .and_then(|o| o.as_interactive());
             let ctrl_key = args
@@ -580,7 +579,7 @@ pub fn set_related_object<'gc>(
                 let value = args
                     .get(0)
                     .cloned()
-                    .and_then(|o| o.coerce_to_object(activation).ok())
+                    .and_then(|o| o.as_object())
                     .and_then(|o| o.as_display_object())
                     .and_then(|o| o.as_interactive());
 
@@ -675,12 +674,9 @@ pub fn to_string<'gc>(
                         (local_x * 0.0, local_y * 0.0)
                     };
 
-                let related_object = if let Some(related_object) = related_object.and_then(|ro| {
-                    ro.as_displayobject()
-                        .object2()
-                        .coerce_to_object(activation)
-                        .ok()
-                }) {
+                let related_object = if let Some(related_object) =
+                    related_object.and_then(|ro| ro.as_displayobject().object2().as_object())
+                {
                     related_object
                         .to_string(activation.context.gc_context)?
                         .coerce_to_string(activation)?

--- a/core/src/avm2/globals/flash/media/sound.rs
+++ b/core/src/avm2/globals/flash/media/sound.rs
@@ -125,12 +125,7 @@ pub fn play<'gc>(
             .cloned()
             .unwrap_or_else(|| 0.into())
             .coerce_to_i32(activation)?;
-        let sound_transform = args
-            .get(2)
-            .cloned()
-            .unwrap_or(Value::Null)
-            .coerce_to_object(activation)
-            .ok();
+        let sound_transform = args.get(2).cloned().unwrap_or(Value::Null).as_object();
 
         if let Some(duration) = activation.context.audio.get_sound_duration(sound) {
             if position > duration {

--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -230,13 +230,13 @@ pub fn set_default_text_format<'gc>(
         .and_then(|this| this.as_display_object())
         .and_then(|this| this.as_edit_text())
     {
-        let new_text_format = args
-            .get(0)
-            .unwrap_or(&Value::Undefined)
-            .coerce_to_object(activation)?;
-        if let Some(new_text_format) = new_text_format.as_text_format() {
-            this.set_new_text_format(new_text_format.clone(), &mut activation.context);
-        };
+        let new_text_format = args.get(0).unwrap_or(&Value::Undefined).as_object();
+
+        if let Some(new_text_format) = new_text_format {
+            if let Some(new_text_format) = new_text_format.as_text_format() {
+                this.set_new_text_format(new_text_format.clone(), &mut activation.context);
+            }
+        }
     }
 
     Ok(Value::Undefined)
@@ -804,43 +804,42 @@ pub fn set_text_format<'gc>(
         .and_then(|this| this.as_display_object())
         .and_then(|this| this.as_edit_text())
     {
-        let tf = args
-            .get(0)
-            .unwrap_or(&Value::Undefined)
-            .coerce_to_object(activation)?;
-        if let Some(tf) = tf.as_text_format() {
-            let mut begin_index = args
-                .get(1)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_i32(activation)?;
-            let mut end_index = args
-                .get(2)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_i32(activation)?;
+        let tf = args.get(0).unwrap_or(&Value::Undefined).as_object();
+        if let Some(tf) = tf {
+            if let Some(tf) = tf.as_text_format() {
+                let mut begin_index = args
+                    .get(1)
+                    .unwrap_or(&Value::Undefined)
+                    .coerce_to_i32(activation)?;
+                let mut end_index = args
+                    .get(2)
+                    .unwrap_or(&Value::Undefined)
+                    .coerce_to_i32(activation)?;
 
-            if begin_index < 0 {
-                begin_index = 0;
+                if begin_index < 0 {
+                    begin_index = 0;
+                }
+
+                if begin_index as usize > this.text_length() {
+                    return Err("RangeError: The supplied index is out of bounds.".into());
+                }
+
+                if end_index < 0 {
+                    end_index = this.text_length() as i32;
+                }
+
+                if end_index as usize > this.text_length() {
+                    return Err("RangeError: The supplied index is out of bounds.".into());
+                }
+
+                this.set_text_format(
+                    begin_index as usize,
+                    end_index as usize,
+                    tf.clone(),
+                    &mut activation.context,
+                );
             }
-
-            if begin_index as usize > this.text_length() {
-                return Err("RangeError: The supplied index is out of bounds.".into());
-            }
-
-            if end_index < 0 {
-                end_index = this.text_length() as i32;
-            }
-
-            if end_index as usize > this.text_length() {
-                return Err("RangeError: The supplied index is out of bounds.".into());
-            }
-
-            this.set_text_format(
-                begin_index as usize,
-                end_index as usize,
-                tf.clone(),
-                &mut activation.context,
-            );
-        };
+        }
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -106,12 +106,8 @@ fn apply<'gc>(
         .or_else(|| activation.global_scope());
 
     if let Some(func) = func {
-        let arg_array = args
-            .get(1)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .coerce_to_object(activation);
-        let resolved_args = if let Ok(arg_array) = arg_array {
+        let arg_array = args.get(1).cloned().unwrap_or(Value::Undefined).as_object();
+        let resolved_args = if let Some(arg_array) = arg_array {
             let arg_storage: Vec<Option<Value<'gc>>> = arg_array
                 .as_array_storage()
                 .map(|a| a.iter().collect())
@@ -162,7 +158,8 @@ fn set_prototype<'gc>(
             let new_proto = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
-                .coerce_to_object(activation)?;
+                .as_object()
+                .ok_or("Cannot set prototype of class to null or undefined")?;
             function.set_prototype(new_proto, activation.context.gc_context);
         }
     }

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -292,8 +292,8 @@ fn replace<'gc>(
         let replacement = args.get(1).unwrap_or(&Value::Undefined);
 
         if replacement
-            .coerce_to_object(activation)?
-            .as_function_object()
+            .as_object()
+            .and_then(|o| o.as_function_object())
             .is_some()
         {
             log::warn!("string.replace(_, function) - not implemented");
@@ -306,10 +306,15 @@ fn replace<'gc>(
             return Err("NotImplemented".into());
         }
 
-        if let Some(mut regexp) = pattern
-            .coerce_to_object(activation)?
-            .as_regexp_mut(activation.context.gc_context)
+        if pattern
+            .as_object()
+            .map(|o| o.as_regexp().is_some())
+            .unwrap_or(false)
         {
+            let regexp_object = pattern.as_object().unwrap();
+            let mut regexp = regexp_object
+                .as_regexp_mut(activation.context.gc_context)
+                .unwrap();
             let mut ret = WString::new();
             let mut start = 0;
 
@@ -404,9 +409,9 @@ fn split<'gc>(
             );
         }
         if delimiter
-            .coerce_to_object(activation)?
-            .as_regexp()
-            .is_some()
+            .as_object()
+            .map(|o| o.as_regexp().is_some())
+            .unwrap_or(false)
         {
             log::warn!("string.split(regex) - not implemented");
         }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -815,6 +815,13 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         self.instance_of().map(|cls| cls.inner_class_definition())
     }
 
+    /// Get this object's class's name, formatted for debug output.
+    fn instance_of_class_name(&self, mc: MutationContext<'gc, '_>) -> AvmString<'gc> {
+        self.instance_of_class_definition()
+            .map(|r| r.read().name().to_qualified_name(mc))
+            .unwrap_or_else(|| "<Unknown type>".into())
+    }
+
     fn set_instance_of(&self, mc: MutationContext<'gc, '_>, instance_of: ClassObject<'gc>) {
         let instance_vtable = instance_of.instance_vtable();
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -274,7 +274,8 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         let result = self
             .base()
             .get_property_local(multiname, activation)?
-            .coerce_to_object(activation)?;
+            .as_callable(activation, Some(multiname), Some(self.into()))?;
+
         result.call(Some(self.into()), arguments, activation)
     }
 
@@ -292,10 +293,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ) -> Result<Value<'gc>, Error> {
         match self.vtable().and_then(|vtable| vtable.get_trait(multiname)) {
             Some(Property::Slot { slot_id }) | Some(Property::ConstSlot { slot_id }) => {
-                let obj = self
-                    .base()
-                    .get_slot(slot_id)?
-                    .coerce_to_object(activation)?;
+                let obj = self.base().get_slot(slot_id)?.as_callable(
+                    activation,
+                    Some(multiname),
+                    Some(self.into()),
+                )?;
+
                 obj.call(Some(self.into()), arguments, activation)
             }
             Some(Property::Method { disp_id }) => {
@@ -328,9 +331,12 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 }
             }
             Some(Property::Virtual { get: Some(get), .. }) => {
-                let obj = self
-                    .call_method(get, &[], activation)?
-                    .coerce_to_object(activation)?;
+                let obj = self.call_method(get, &[], activation)?.as_callable(
+                    activation,
+                    Some(multiname),
+                    Some(self.into()),
+                )?;
+
                 obj.call(Some(self.into()), arguments, activation)
             }
             Some(Property::Virtual { get: None, .. }) => {
@@ -642,9 +648,11 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         args: &[Value<'gc>],
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Object<'gc>, Error> {
-        let ctor = self
-            .get_property(multiname, activation)?
-            .coerce_to_object(activation)?;
+        let ctor = self.get_property(multiname, activation)?.as_callable(
+            activation,
+            Some(multiname),
+            Some(self.into()),
+        )?;
 
         ctor.construct(activation, args)
     }
@@ -739,9 +747,13 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     ) -> Result<bool, Error> {
         let type_proto = class
             .get_property(&QName::dynamic_name("prototype").into(), activation)?
-            .coerce_to_object(activation)?;
+            .as_object();
 
-        self.has_prototype_in_chain(type_proto)
+        if let Some(type_proto) = type_proto {
+            self.has_prototype_in_chain(type_proto)
+        } else {
+            Ok(false)
+        }
     }
 
     /// Determine if this object has a given prototype in its prototype chain.

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -314,9 +314,10 @@ impl<'gc> ClassObject<'gc> {
                 return Err(format!("Could not resolve interface {:?}", interface_name).into());
             }
 
-            let interface = interface.unwrap().coerce_to_object(activation)?;
             let iface_class = interface
-                .as_class_object()
+                .unwrap()
+                .as_object()
+                .and_then(|o| o.as_class_object())
                 .ok_or_else(|| Error::from("Object is not an interface"))?;
             if !iface_class.inner_class_definition().read().is_interface() {
                 return Err(format!(
@@ -840,7 +841,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         let object_param = match &nullable_params[0] {
             Value::Null => None,
             Value::Undefined => return Err("Undefined is not a valid type parameter".into()),
-            v => Some(v.coerce_to_object(activation)?),
+            v => Some(v.as_object().unwrap()),
         };
         let object_param = match object_param {
             None => None,

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -138,13 +138,21 @@ impl<'gc> ScriptObjectData<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         if !multiname.contains_public_namespace() {
-            return Err(
-                format!("Non-public property `{:?}` not found on Object", multiname).into(),
-            );
+            return Err(format!(
+                "Non-public property {} not found on Object",
+                multiname.to_qualified_name(activation.context.gc_context)
+            )
+            .into());
         }
 
         let local_name = match multiname.local_name() {
-            None => return Err("Unnamed property not found on Object".into()),
+            None => {
+                return Err(format!(
+                    "Unnamed property {} not found on Object",
+                    multiname.to_qualified_name(activation.context.gc_context)
+                )
+                .into())
+            }
             Some(name) => name,
         };
 
@@ -174,24 +182,36 @@ impl<'gc> ScriptObjectData<'gc> {
         &mut self,
         multiname: &Multiname<'gc>,
         value: Value<'gc>,
-        _activation: &mut Activation<'_, 'gc, '_>,
+        activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<(), Error> {
         if self
             .instance_of()
             .map(|cls| cls.inner_class_definition().read().is_sealed())
             .unwrap_or(false)
         {
-            return Err(
-                format!("Cannot set undefined property {:?}", multiname.local_name()).into(),
-            );
+            return Err(format!(
+                "Cannot set undefined property {}",
+                multiname.to_qualified_name(activation.context.gc_context)
+            )
+            .into());
         }
 
         if !multiname.contains_public_namespace() {
-            return Err("Non-public property not found on Object".into());
+            return Err(format!(
+                "Non-public property {} not found on Object",
+                multiname.to_qualified_name(activation.context.gc_context)
+            )
+            .into());
         }
 
         let local_name = match multiname.local_name() {
-            None => return Err("Unnamed property not found on Object".into()),
+            None => {
+                return Err(format!(
+                    "Unnamed property {} not found on Object",
+                    multiname.to_qualified_name(activation.context.gc_context)
+                )
+                .into())
+            }
             Some(name) => name,
         };
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -555,13 +555,17 @@ impl<'gc> MovieClip<'gc> {
             let domain = library.avm2_domain();
             let class_object = domain
                 .get_defined_value(&mut activation, name)
-                .and_then(|v| v.coerce_to_object(&mut activation))
                 .and_then(|v| {
-                    v.as_class_object().ok_or_else(|| {
-                        "Attempted to assign a non-class to symbol"
-                            .to_string()
+                    v.as_object()
+                        .and_then(|o| o.as_class_object())
+                        .ok_or_else(|| {
+                            format!(
+                                "Attempted to assign a non-class {} to symbol {}",
+                                class_name,
+                                name.to_qualified_name(activation.context.gc_context)
+                            )
                             .into()
-                    })
+                        })
                 });
 
             match class_object {


### PR DESCRIPTION
This PR attempts to remove all "undefined is not an Object" and "null is not an Object" errors by replacing `coerce_to_object` calls with `as_object` throughout the project.

There are only two remaining calls to `coerce_to_object`, mostly to facilitate the use of `PrimitiveObject`. Our new programming guidelines are:

 * If you want an object, use `as_object`, and return an appropriate error if you get `None`.
 * If you want a primitive value, use the various `coerce_*` functions to get one.