### PR TITLE
avm2: Fix invalid option

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -781,7 +781,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
         let instruction_start = reader.pos(full_data);
         let op = reader.read_op();
-        if let Ok(Some(op)) = op {
+        if let Ok(op) = op {
             avm_debug!(self.avm2(), "Opcode: {:?}", op);
 
             let result = match op {
@@ -971,9 +971,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 return Err(e);
             }
             result
-        } else if let Ok(None) = op {
-            log::error!("Unknown opcode!");
-            Err("Unknown opcode!".into())
         } else if let Err(e) = op {
             log::error!("Parse error: {:?}", e);
             Err(e.into())

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -501,7 +501,7 @@ impl<'a> Reader<'a> {
         })
     }
 
-    pub fn read_op(&mut self) -> Result<Option<Op>> {
+    pub fn read_op(&mut self) -> Result<Op> {
         use crate::avm2::opcode::OpCode;
         use num_traits::FromPrimitive;
 
@@ -858,7 +858,7 @@ impl<'a> Reader<'a> {
             OpCode::URShift => Op::URShift,
         };
 
-        Ok(Some(op))
+        Ok(op)
     }
 
     fn read_exception(&mut self) -> Result<Exception> {


### PR DESCRIPTION
There is an option in reading the op code of the swf lib but the value can never be None. So I removed the option on the read_op method.