### PR TITLE
xml: Refactor `XmlNode::into_string`

### DIFF
--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -80,10 +80,10 @@ fn serialize_value<'gc>(
                 let length = o.length(activation).unwrap();
                 Some(AmfValue::ECMAArray(vec![], values, length as u32))
             } else if let Some(xml_node) = o.as_xml_node() {
-                xml_node
-                    .into_string()
-                    .map(|xml_string| AmfValue::XML(xml_string, true))
-                    .ok()
+                Some(AmfValue::XML(
+                    xml_node.into_string().to_utf8_lossy().into_owned(),
+                    true,
+                ))
             } else if let Some(date) = o.as_date_object() {
                 date.date_time()
                     .map(|date_time| AmfValue::Date(date_time.timestamp_millis() as f64, None))

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -294,7 +294,7 @@ fn spawn_xml_fetch<'gc>(
     let request_options = if let Some(node) = send_object {
         // Send `node` as string.
         RequestOptions::post(Some((
-            node.into_string().unwrap_or_default().into_bytes(),
+            node.into_string().to_utf8_lossy().into_owned().into_bytes(),
             "application/x-www-form-urlencoded".to_string(),
         )))
     } else {

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -211,16 +211,7 @@ fn to_string<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(node) = this.as_xml_node() {
-        let result = node.into_string();
-
-        return Ok(AvmString::new_utf8(
-            activation.context.gc_context,
-            result.unwrap_or_else(|e| {
-                avm_warn!(activation, "XMLNode toString failed: {}", e);
-                "".to_string()
-            }),
-        )
-        .into());
+        return Ok(AvmString::new(activation.context.gc_context, node.into_string()).into());
     }
 
     Ok("".into())


### PR DESCRIPTION
* Don't use `quick_xml::Writer` for formatting the XML, being much
more simple.
* Return `WString` instead of `String`, reducing `to_utf8_lossy()`
calls except when the string needs to be escaped (attribute values
and text contents).