### PR TITLE
build: require 'derive' feature for clap

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "ruffle_desktop"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-clap = "3.0.6"
+clap = { version = "3.0.6", features = ["derive"] }
 cpal = "0.13.4"
 ruffle_core = { path = "../core" }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-clap = "3.0.6"
+clap = { version = "3.0.6", features = ["derive"] }
 futures = "0.3"
 ruffle_core = { path = "../core" }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-clap = "3.0.6"
+clap = { version = "3.0.6", features = ["derive"] }
 ruffle_core = { path = "../core" }
 log = "0.4"
 walkdir = "2.3.2"


### PR DESCRIPTION
Pretty sure the only reason this worked on desktop was because `ruffle_render_wgpu` already happened to require this feature.

Should  fix https://github.com/ruffle-rs/ruffle/issues/6266 .