### PR TITLE
wgpu: Switch `Bgra` over to `Rgba`

### DIFF
--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -449,16 +449,9 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
             )
             .await?;
         let info = adapter.get_info();
-        // Prefer a linear surface format, when available.
-        let surface_format = if info.backend == wgpu::Backend::Gl {
-            // GL often only supports sRGB, so use the adapter's preferred format.
-            surface
-                .and_then(|surface| surface.get_preferred_format(&adapter))
-                .unwrap_or(wgpu::TextureFormat::Bgra8Unorm)
-        } else {
-            wgpu::TextureFormat::Bgra8Unorm
-        };
-
+        let surface_format = surface
+            .and_then(|surface| surface.get_preferred_format(&adapter))
+            .unwrap_or(wgpu::TextureFormat::Rgba8Unorm);
         Descriptors::new(device, queue, info, surface_format)
     }
 


### PR DESCRIPTION
The `image` crate removed `Bgra` in version 0.24.0:
https://github.com/image-rs/image/blob/master/CHANGES.md#version-0240
So stop using it, and start using `Rgba` instead. The affected code
is mostly only relevant for tests (image capturing), however there was
a real usage of `wgpu::TextureFormat::Bgra8Unorm` in `build_descriptors`,
which is now changed to `wgpu::TextureFormat::Rgba8Unorm`. Seems harmless
at a glance, though it might have some implications, as the reason
for choosing `Bgra8Unorm` in the first place is that per the `wgpu`
documentation, the only formats that are guaranteed are `Bgra8Unorm`
and `Bgra8UnormSrgb`:
https://docs.rs/wgpu/0.10.1/wgpu/struct.SurfaceConfiguration.html#structfield.format

Should allow #6328 to be merged.