### PR TITLE
web: Add `isPlaying` property to rufflePlayer

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -144,6 +144,8 @@ export class RufflePlayer extends HTMLElement {
 
     private isExtension = false;
 
+    private isPlaying = false;
+
     /**
      * Triggered when a movie metadata has been loaded (such as movie width and height).
      *
@@ -613,6 +615,7 @@ export class RufflePlayer extends HTMLElement {
     play(): void {
         if (this.instance) {
             this.instance.play();
+            this.isPlaying = true;
             if (this.playButton) {
                 this.playButton.style.display = "none";
             }
@@ -875,6 +878,7 @@ export class RufflePlayer extends HTMLElement {
     pause(): void {
         if (this.instance) {
             this.instance.pause();
+            this.isPlaying = false;
             if (this.playButton) {
                 this.playButton.style.display = "block";
             }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -618,10 +618,12 @@ export class RufflePlayer extends HTMLElement {
             }
         }
     }
-    
+
     /**
-    * Whether this player is currently playing.
-    */
+     * Whether this player is currently playing.
+     *
+     * @returns True if this player is playing, false if it's paused or hasn't started yet.
+     */
     get isPlaying(): boolean {
         if (this.instance) {
             return this.instance.is_playing();

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -144,8 +144,6 @@ export class RufflePlayer extends HTMLElement {
 
     private isExtension = false;
 
-    private isPlaying = false;
-
     /**
      * Triggered when a movie metadata has been loaded (such as movie width and height).
      *
@@ -615,11 +613,20 @@ export class RufflePlayer extends HTMLElement {
     play(): void {
         if (this.instance) {
             this.instance.play();
-            this.isPlaying = true;
             if (this.playButton) {
                 this.playButton.style.display = "none";
             }
         }
+    }
+    
+    /**
+    * Whether this player is currently playing.
+    */
+    get isPlaying(): boolean {
+        if (this.instance) {
+            return this.instance.is_playing();
+        }
+        return false;
     }
 
     /**
@@ -878,7 +885,6 @@ export class RufflePlayer extends HTMLElement {
     pause(): void {
         if (this.instance) {
             this.instance.pause();
-            this.isPlaying = false;
             if (this.playButton) {
                 this.playButton.style.display = "block";
             }


### PR DESCRIPTION
This is a small PR, which adds a little property called isPlaying that is true if the movie is playing, and is false if the movie is paused. I wasn't able to find a thing like this in the Ruffle API already, so I added it, since needed a feature like this for a website I am working on, and I thought I'd submit it here just incase it is helpful.

By the way, I am quite new to this whole project/repo, so if I did anything wrong here please let me know. Thanks!