### PR TITLE
ci: Migrate to Windows Server 2022

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -89,12 +89,12 @@ jobs:
             target: aarch64-apple-darwin
 
           - build_name: windows-x86_32
-            os: windows-latest
+            os: windows-2022
             target: i686-pc-windows-msvc
             RUSTFLAGS: -Ctarget-feature=+crt-static
 
           - build_name: windows-x86_64
-            os: windows-latest
+            os: windows-2022
             target: x86_64-pc-windows-msvc
             RUSTFLAGS: -Ctarget-feature=+crt-static
 

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
         include:
           - rust_version: nightly
             os: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
         include:
           - rust_version: nightly
             os: ubuntu-latest

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         node_version: ["14", "16"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
 
     steps:
       - uses: actions/checkout@v2
@@ -99,7 +99,7 @@ jobs:
         # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         rust_version: [stable]
         # MIKE: Turning off macOS-latest for now (flaky tests on CI).
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
 
     steps:
       - name: No-op


### PR DESCRIPTION
Per https://github.com/actions/virtual-environments/issues/4856,
`windows-latest` will default to `windows-2022` soon (not later than
March, 6). Since it seems like we still run on `windows-2019`, force the
migration by specifying `windows-2022` explicitly.

Since https://github.com/actions/virtual-environments/pull/5050 is
merged, this should fix the failing Web tests on mismatched Chrome and
chromedriver versions.

TODO: Once `windows-latest` defaults to `windows-2022` (again, March, 6),
change back to `windows-latest`.