### PR TITLE
avm1: Store `status` in `XmlObject`, instead of `ParseError`

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -62,6 +62,12 @@ impl<'gc> From<f32> for Value<'gc> {
     }
 }
 
+impl<'gc> From<i8> for Value<'gc> {
+    fn from(value: i8) -> Self {
+        Value::Number(f64::from(value))
+    }
+}
+
 impl<'gc> From<u8> for Value<'gc> {
     fn from(value: u8) -> Self {
         Value::Number(f64::from(value))


### PR DESCRIPTION
The only use of `last_parse_error` was in the `XML.prototype.status`
property, where it was converted into a number. Avoid storing it by
storing just the number.

Split from #6315 to ease code review.