### PR TITLE
Declare AVM2 'Date' class methods in the AS3 namespace

### DIFF
--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -316,6 +316,7 @@ pub fn class_init<'gc>(
                 .into(),
                 activation,
             )?;
+            date_proto.set_local_property_is_enumerable(gc_context, (*name).into(), false)?;
         }
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -1320,11 +1320,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("toDateString", to_date_string),
         ("toLocaleDateString", to_date_string),
     ];
-    write.define_public_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
+    write.define_as3_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
 
     const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[("UTC", utc), ("parse", parse)];
 
-    write.define_public_builtin_class_methods(mc, PUBLIC_CLASS_METHODS);
+    write.define_as3_builtin_class_methods(mc, PUBLIC_CLASS_METHODS);
 
     class
 }


### PR DESCRIPTION
We now declare these methods in the 'http://adobe.com/AS3/2006/builtin'
namespace. This corresponds to the 'AS3' namespace modifier shown on the
docs page: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/Date.html

Previously, we would fail to lookup these methods, since the namespace
used by the SWF would not match the namespace defined by Ruffle.