### PR TITLE
xml: Silently fail in `set_{prev,next}_sibling`

### DIFF
--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -27,9 +27,6 @@ pub enum Error {
     #[error("Document roots cannot have parents")]
     RootCantHaveParent,
 
-    #[error("Document roots cannot have siblings")]
-    RootCantHaveSiblings,
-
     #[error("Text node has no child nodes!")]
     TextNodeCantHaveChildren,
 


### PR DESCRIPTION
Instead of returning a `Result` which is anyway always handled with
a `log::warn!()`, simply `log::warn!()` in place of errors.

Split from https://github.com/ruffle-rs/ruffle/pull/6315 to ease code review.