### PR TITLE
Remove repeated dependency causing build issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,12 +1784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
The dependency 'heck' was listed twice in the Cargo.lock file causing an inability to build.