### PR TITLE
workflow: Temporarily downgrade stable to 2022-01-20 version

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -222,7 +222,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: stable-2022-01-20
           target: wasm32-unknown-unknown
 
       - name: Setup Node.js

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version: ["16"]
-        rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
+        rust_version: [stable-2022-01-20] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml. However, see https://github.com/rust-lang/rust/issues/89647.
         os: [ubuntu-latest, windows-2022]
 
     steps:

--- a/web/README.md
+++ b/web/README.md
@@ -41,7 +41,7 @@ Before you are able to build this project, you must first install a few dependen
 Follow the instructions [to install rust](https://www.rust-lang.org/tools/install) on your machine.
 
 We do not have a Minimum Supported Rust Version policy. If it fails to build, it's likely you may need
-to update to the latest stable version of rust. You may run `rustup update` to do this (if you installed
+to update or downgrade to version 1.58.1 of rust. You may run `rustup install 1.58.1` to do this (if you installed
 rust using the above instructions).
 
 For the compiler to be able to output WebAssembly, an additional target has to be added to it: `rustup target add wasm32-unknown-unknown`


### PR DESCRIPTION
According to adrian on Discord, https://github.com/rust-lang/rust/issues/89647 seems to have become stable in version 1.59.0