### PR TITLE
core: Replace `json` with `serde_json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "a538f217be4d405ff4719a283ca68323cc2384003eca5baaa87501e821c81dda"
 dependencies = [
  "bitflags",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1732,6 +1732,12 @@ dependencies = [
  "bytemuck",
  "wide",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hashbrown"
@@ -1824,12 +1830,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
@@ -1954,12 +1960,6 @@ checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "khronos-egl"
@@ -3133,7 +3133,6 @@ dependencies = [
  "indexmap",
  "instant",
  "jpeg-decoder 0.2.2",
- "json",
  "log",
  "lzma-rs",
  "minimp3",
@@ -3150,6 +3149,7 @@ dependencies = [
  "regress",
  "ruffle_macros",
  "serde",
+ "serde_json",
  "smallvec",
  "swf",
  "symphonia",
@@ -3409,6 +3409,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
+ "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,7 @@ chrono = "0.4"
 instant = "0.1"
 encoding_rs = "0.8.30"
 rand = { version = "0.8.5", features = ["std", "small_rng"], default-features = false }
-serde = { version = "1.0.136", features = ["derive"], optional = true }
+serde = { version = "1.0.136", features = ["derive"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
 h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
@@ -55,7 +55,7 @@ default-features = false # can't use rayon on web
 approx = "0.5.1"
 
 [features]
-default = ["minimp3", "serde"]
+default = ["minimp3"]
 h263 = ["h263-rs", "h263-rs-yuv"]
 vp6 = ["nihav_core", "nihav_codec_support", "nihav_duck", "h263-rs-yuv"]
 screenvideo = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,9 @@ fnv = "1.0.7"
 gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
 generational-arena = "0.2.8"
 gif = "0.11.3"
-indexmap = "1.8.0"
+# TODO: From some reason newer indexmap versions cause a cyclic package dependency.
+# This is a workaround from: https://github.com/tkaitchuck/aHash/issues/95#issuecomment-903560879
+indexmap = "~1.6.2"
 log = "0.4"
 minimp3 = { version = "0.5.1", optional = true }
 png = { version = "0.17.3" }
@@ -34,12 +36,12 @@ instant = "0.1"
 encoding_rs = "0.8.30"
 rand = { version = "0.8.5", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
 h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
-json = "0.12.4"
 lzma-rs = {version = "0.2.0", optional = true }
 dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"] }
 symphonia = { version = "0.5.0", default-features = false, features = ["mp3"], optional = true }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,5 +1,4 @@
 use gc_arena::Collect;
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Controls whether the content is letterboxed or pillarboxed when the
@@ -7,21 +6,20 @@ use serde::{Deserialize, Serialize};
 ///
 /// When letterboxed, black bars will be rendered around the exterior
 /// margins of the content.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Collect)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Collect, Serialize, Deserialize)]
 #[collect(require_static)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename = "letterbox"))]
+#[serde(rename = "letterbox")]
 pub enum Letterbox {
     /// The content will never be letterboxed.
-    #[cfg_attr(feature = "serde", serde(rename = "off"))]
+    #[serde(rename = "off")]
     Off,
 
     /// The content will only be letterboxed if the content is running fullscreen.
-    #[cfg_attr(feature = "serde", serde(rename = "fullscreen"))]
+    #[serde(rename = "fullscreen")]
     Fullscreen,
 
     /// The content will always be letterboxed.
-    #[cfg_attr(feature = "serde", serde(rename = "on"))]
+    #[serde(rename = "on")]
     On,
 }
 

--- a/core/src/context_menu.rs
+++ b/core/src/context_menu.rs
@@ -6,7 +6,6 @@
 
 use crate::avm1;
 use gc_arena::Collect;
-#[cfg(feature = "serde")]
 use serde::Serialize;
 
 #[derive(Collect, Default)]
@@ -32,12 +31,11 @@ impl<'gc> ContextMenuState<'gc> {
     }
 }
 
-#[derive(Collect, Clone)]
+#[derive(Collect, Clone, Serialize)]
 #[collect(require_static)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct ContextMenuItem {
     pub enabled: bool,
-    #[cfg_attr(feature = "serde", serde(rename = "separatorBefore"))]
+    #[serde(rename = "separatorBefore")]
     pub separator_before: bool,
     pub checked: bool,
     pub caption: String,

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -50,7 +50,7 @@ base64 = "0.13.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["h263", "vp6", "screenvideo", "serde", "wasm-bindgen"]
+features = ["h263", "vp6", "screenvideo", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.50"


### PR DESCRIPTION
The `json` crate seems unmaintained, and recently also causes compile errors with stable Rust 1.59.0. On the other hand, `serde_json` is very maintained and more popular.

There were 2 usages of `json`:
1. AVM1 used it for a legacy `SharedObject` format. As it turns out to never been working, it's now removed.
2. AVM2 used it for its `JSON` implementation. Here `serde_json` is used instead.

However, from some reason a cyclic package dependency has introduced by this change. For now use a workaround from: https://github.com/tkaitchuck/aHash/issues/95#issuecomment-903560879 (I didn't find any better solution)