### PR TITLE
xml: Remove 2 more `Error` enum members

### DIFF
--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -99,17 +99,9 @@ fn parse_xml<'gc>(
                 "".into()
             };
 
-        let mut node = document.as_node();
-        for child in node.children().rev() {
-            let result = node.remove_child(activation.context.gc_context, child);
-            if let Err(e) = result {
-                avm_warn!(
-                    activation,
-                    "XML.parseXML: Error removing node contents: {}",
-                    e
-                );
-                return Ok(Value::Undefined);
-            }
+        let node = document.as_node();
+        for mut child in node.children().rev() {
+            child.remove_node(activation.context.gc_context);
         }
 
         let ignore_whitespace = this

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -194,12 +194,8 @@ fn remove_node<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(node) = this.as_xml_node() {
-        if let Some(mut parent) = node.parent() {
-            if let Err(e) = parent.remove_child(activation.context.gc_context, node) {
-                avm_warn!(activation, "Error in XML.removeNode: {}", e);
-            }
-        }
+    if let Some(mut node) = this.as_xml_node() {
+        node.remove_node(activation.context.gc_context);
     }
 
     Ok(Value::Undefined)

--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -24,9 +24,6 @@ pub enum Error {
     #[error("Cannot adopt children into non-child-bearing node")]
     CannotAdoptHere,
 
-    #[error("Text node has no child nodes!")]
-    TextNodeCantHaveChildren,
-
     #[error("Cannot insert child into itself")]
     CannotInsertIntoSelf,
 

--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -29,9 +29,6 @@ pub enum Error {
 
     #[error("Not an element")]
     NotAnElement,
-
-    #[error("Target node is not a child of this one!")]
-    CantRemoveNonChild,
 }
 
 impl From<FromUtf8Error> for Error {


### PR DESCRIPTION
This brings us closer towards removing `Error` entirely (#6315):
* `Error::TextNodeCantHaveChildren` was in fact unreachable.
* `Error::CantRemoveNonChild` is avoided by turning `remove_child` into `remove_node`, such that there's no way of trying to remove a non-child of a node.