### PR TITLE
fix: don't include query parameters in downloaded SWF name

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -132,7 +132,7 @@ export class RufflePlayer extends HTMLElement {
     // Set to true when a touch event is encountered.
     private isTouch = false;
 
-    private swfUrl?: string;
+    private swfUrl?: URL;
     private instance: Ruffle | null;
     private options: BaseLoadOptions | null;
     private lastActivePlayingState: boolean;
@@ -578,14 +578,7 @@ export class RufflePlayer extends HTMLElement {
 
             if ("url" in options) {
                 console.log(`Loading SWF file ${options.url}`);
-                try {
-                    this.swfUrl = new URL(
-                        options.url,
-                        document.location.href
-                    ).href;
-                } catch {
-                    this.swfUrl = options.url;
-                }
+                this.swfUrl = new URL(options.url, document.location.href);
 
                 const parameters = {
                     ...sanitizeParameters(
@@ -594,7 +587,7 @@ export class RufflePlayer extends HTMLElement {
                     ...sanitizeParameters(options.parameters),
                 };
 
-                this.instance!.stream_from(this.swfUrl, parameters);
+                this.instance!.stream_from(this.swfUrl.href, parameters);
             } else if ("data" in options) {
                 console.log("Loading SWF data");
                 this.instance!.load_data(
@@ -712,7 +705,7 @@ export class RufflePlayer extends HTMLElement {
         try {
             if (this.swfUrl) {
                 console.log("Downloading SWF: " + this.swfUrl);
-                const response = await fetch(this.swfUrl);
+                const response = await fetch(this.swfUrl.href);
                 if (!response.ok) {
                     console.error("SWF download failed");
                     return;
@@ -1303,9 +1296,8 @@ export class RufflePlayer extends HTMLElement {
     }
 
     displayRootMovieDownloadFailedMessage(): void {
-        const swfUrl = new URL(this.swfUrl!);
         if (
-            window.location.origin == swfUrl.origin ||
+            window.location.origin == this.swfUrl!.origin ||
             !this.isExtension ||
             !window.location.protocol.includes("http")
         ) {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -13,6 +13,7 @@ import {
 } from "./load-options";
 import { MovieMetadata } from "./movie-metadata";
 import { InternalContextMenuItem } from "./context-menu";
+import { swfFileName } from "./swf-file-name";
 
 export const FLASH_MIMETYPE = "application/x-shockwave-flash";
 export const FUTURESPLASH_MIMETYPE = "application/futuresplash";
@@ -721,9 +722,7 @@ export class RufflePlayer extends HTMLElement {
                 const swfDownloadA = document.createElement("a");
                 swfDownloadA.style.display = "none";
                 swfDownloadA.href = blobUrl;
-                swfDownloadA.download = this.swfUrl.substring(
-                    this.swfUrl.lastIndexOf("/") + 1
-                );
+                swfDownloadA.download = swfFileName(this.swfUrl);
                 document.body.appendChild(swfDownloadA);
                 swfDownloadA.click();
                 document.body.removeChild(swfDownloadA);

--- a/web/packages/core/src/swf-file-name.ts
+++ b/web/packages/core/src/swf-file-name.ts
@@ -1,0 +1,14 @@
+/**
+ * Create a filename to save a downloaded SWF into.
+ *
+ * @param swfUrl The URL of the SWF file.
+ * @returns The filename the SWF file can be saved at.
+ */
+export function swfFileName(swfUrl: string): string {
+    let name = swfUrl.substring(swfUrl.lastIndexOf("/") + 1);
+    const qMark = name.indexOf("?");
+    if (qMark > 0) {
+        name = name.substring(0, qMark);
+    }
+    return name;
+}

--- a/web/packages/core/src/swf-file-name.ts
+++ b/web/packages/core/src/swf-file-name.ts
@@ -4,11 +4,8 @@
  * @param swfUrl The URL of the SWF file.
  * @returns The filename the SWF file can be saved at.
  */
-export function swfFileName(swfUrl: string): string {
-    let name = swfUrl.substring(swfUrl.lastIndexOf("/") + 1);
-    const qMark = name.indexOf("?");
-    if (qMark > 0) {
-        name = name.substring(0, qMark);
-    }
+export function swfFileName(swfUrl: URL): string {
+    const pathName = swfUrl.pathname;
+    const name = pathName.substring(pathName.lastIndexOf("/") + 1);
     return name;
 }

--- a/web/packages/core/test/swf-file-name.ts
+++ b/web/packages/core/test/swf-file-name.ts
@@ -1,0 +1,19 @@
+import { strict as assert } from "assert";
+import { swfFileName } from "../src/swf-file-name";
+
+describe("swfFileName", function () {
+    it("should extract simple SWF name", function () {
+        assert.deepEqual(
+            swfFileName("http://example.com/file.swf"),
+            "file.swf"
+        );
+    });
+    it("should not include query parameters", function () {
+        assert.deepEqual(
+            swfFileName(
+                "https://uploads.ungrounded.net/574000/574241_DiamondNGSP.swf?123"
+            ),
+            "574241_DiamondNGSP.swf"
+        );
+    });
+});

--- a/web/packages/core/test/swf-file-name.ts
+++ b/web/packages/core/test/swf-file-name.ts
@@ -3,17 +3,18 @@ import { swfFileName } from "../src/swf-file-name";
 
 describe("swfFileName", function () {
     it("should extract simple SWF name", function () {
-        assert.deepEqual(
-            swfFileName("http://example.com/file.swf"),
-            "file.swf"
-        );
+        assert.deepEqual(nameFor("http://example.com/file.swf"), "file.swf");
     });
     it("should not include query parameters", function () {
         assert.deepEqual(
-            swfFileName(
+            nameFor(
                 "https://uploads.ungrounded.net/574000/574241_DiamondNGSP.swf?123"
             ),
             "574241_DiamondNGSP.swf"
         );
     });
 });
+
+function nameFor(url: string): string {
+    return swfFileName(new URL(url));
+}


### PR DESCRIPTION
Any query string parameters in the SWF URL would be inserted into the `download` parameter as a filename suggestion, which would convert the actual filename in strange ways (e.g. `574241_DiamondNGSP.swf?123` -> `574241_DiamondNGSP.swf 123.swf123`).

This change ignores any query string parameters, avoiding that problem.