### PR TITLE
ci: Use windows-latest again

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -89,12 +89,12 @@ jobs:
             target: aarch64-apple-darwin
 
           - build_name: windows-x86_32
-            os: windows-2022
+            os: windows-latest
             target: i686-pc-windows-msvc
             RUSTFLAGS: -Ctarget-feature=+crt-static
 
           - build_name: windows-x86_64
-            os: windows-2022
+            os: windows-latest
             target: x86_64-pc-windows-msvc
             RUSTFLAGS: -Ctarget-feature=+crt-static
 

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-latest, windows-2022, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - rust_version: nightly
             os: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-latest, windows-2022, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - rust_version: nightly
             os: ubuntu-latest

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         node_version: ["16"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
-        os: [ubuntu-latest, windows-2022]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -92,7 +92,7 @@ jobs:
       matrix:
         node_version: ["16"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
-        os: [ubuntu-latest, windows-2022]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: No-op


### PR DESCRIPTION
Revert #6297. This can wait until migration is finished (March 6 per https://github.com/actions/virtual-environments/issues/4856), but since https://github.com/actions/virtual-environments/pull/5129 was merged this can be merged immediately since that updated Windows-2019 to Chrome 98. Required check needs a change once again (from either @kmeisthax or @Herschel).