### PR TITLE
xml: Remove remaining `Error` enum members

### DIFF
--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -5,7 +5,6 @@ use crate::avm1::error::Error;
 use crate::avm1::object::xml_node_object::XmlNodeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use crate::avm_warn;
 use crate::string::AvmString;
 use crate::xml;
 use crate::xml::XmlNode;
@@ -76,15 +75,7 @@ fn append_child<'gc>(
     ) {
         if !xmlnode.has_child(child_xmlnode) {
             let position = xmlnode.children_len();
-            if let Err(e) =
-                xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode)
-            {
-                avm_warn!(
-                    activation,
-                    "Couldn't insert_child inside of XMLNode.appendChild: {}",
-                    e
-                );
-            }
+            xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode);
         }
     }
 
@@ -105,15 +96,7 @@ fn insert_before<'gc>(
     ) {
         if !xmlnode.has_child(child_xmlnode) {
             if let Some(position) = xmlnode.child_position(insertpoint_xmlnode) {
-                if let Err(e) =
-                    xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode)
-                {
-                    avm_warn!(
-                        activation,
-                        "Couldn't insert_child inside of XMLNode.insertBefore: {}",
-                        e
-                    );
-                }
+                xmlnode.insert_child(activation.context.gc_context, position, child_xmlnode);
             }
         }
     }

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -174,7 +174,7 @@ impl<'gc> XmlObject<'gc> {
                     open_tags
                         .last_mut()
                         .unwrap()
-                        .append_child(activation.context.gc_context, child)?;
+                        .append_child(activation.context.gc_context, child);
                     open_tags.push(child);
                 }
                 Event::Empty(bs) => {
@@ -187,7 +187,7 @@ impl<'gc> XmlObject<'gc> {
                     open_tags
                         .last_mut()
                         .unwrap()
-                        .append_child(activation.context.gc_context, child)?;
+                        .append_child(activation.context.gc_context, child);
                 }
                 Event::End(_) => {
                     open_tags.pop();
@@ -204,7 +204,7 @@ impl<'gc> XmlObject<'gc> {
                         open_tags
                             .last_mut()
                             .unwrap()
-                            .append_child(activation.context.gc_context, child)?;
+                            .append_child(activation.context.gc_context, child);
                     }
                 }
                 Event::DocType(bt) => {

--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -15,9 +15,6 @@ pub enum Error {
     #[error("Invalid XML")]
     InvalidXml(#[from] ParseError),
 
-    #[error("Cannot adopt child into itself")]
-    CannotAdoptSelf,
-
     #[error("Cannot adopt other document roots")]
     CannotAdoptRoot,
 
@@ -26,9 +23,6 @@ pub enum Error {
 
     #[error("Cannot insert child into itself")]
     CannotInsertIntoSelf,
-
-    #[error("Not an element")]
-    NotAnElement,
 }
 
 impl From<FromUtf8Error> for Error {

--- a/core/src/xml/error.rs
+++ b/core/src/xml/error.rs
@@ -14,15 +14,6 @@ use thiserror::Error;
 pub enum Error {
     #[error("Invalid XML")]
     InvalidXml(#[from] ParseError),
-
-    #[error("Cannot adopt other document roots")]
-    CannotAdoptRoot,
-
-    #[error("Cannot adopt children into non-child-bearing node")]
-    CannotAdoptHere,
-
-    #[error("Cannot insert child into itself")]
-    CannotInsertIntoSelf,
 }
 
 impl From<FromUtf8Error> for Error {


### PR DESCRIPTION
Remove all remaining `Error` enum members, leaving only `Error::InvalidXml`. This allows us to replace `Error` with `quick_xml::Error`, as shown in #6315.