### PR TITLE
avm1: `Number(function)` in SWFv5 returns 0

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -154,7 +154,12 @@ impl<'gc> Value<'gc> {
             Value::Bool(false) => return 0.0,
             Value::Bool(true) => return 1.0,
             Value::Number(v) => return *v,
-            Value::Object(_) => return f64::NAN,
+            Value::Object(v) => {
+                if activation.swf_version() < 6 && v.as_executable().is_some() {
+                    return 0.0;
+                }
+                return f64::NAN;
+            }
             Value::String(v) => v,
         };
 


### PR DESCRIPTION
Closes #6285.

```
// Function
function f(){}
trace(Number(f)); // 0 (NaN before this PR)
trace(int(f)); // 0
trace(123 + f); // 123 (NaN before this PR)

// Object
var o = new Sound();
trace(Number(o)); // NaN
trace(int(o)); // 0
trace(123 + o); // NaN

// Movieclip
trace(Number(_root)); // NaN
trace(int(_root)); // 0
trace(123 + _root); // NaN
```