### PR TITLE
Add more AVM2 'flash.' class stubs

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -624,6 +624,8 @@ pub fn load_player_globals<'gc>(
         script,
     )?;
 
+    class(activation, flash::utils::timer::create_class(mc), script)?;
+
     namespace(
         activation,
         "flash.utils",
@@ -744,6 +746,7 @@ pub fn load_player_globals<'gc>(
         flash::display::capsstyle::create_class(mc),
         script,
     )?;
+    class(activation, flash::display::loader::create_class(mc), script)?;
     avm2_system_class!(
         loaderinfo,
         activation,
@@ -858,6 +861,7 @@ pub fn load_player_globals<'gc>(
         script
     );
     class(activation, flash::ui::mouse::create_class(mc), script)?;
+    class(activation, flash::ui::keyboard::create_class(mc), script)?;
 
     // package `flash.net`
     avm2_system_class!(
@@ -870,6 +874,11 @@ pub fn load_player_globals<'gc>(
     class(
         activation,
         flash::net::object_encoding::create_class(mc),
+        script,
+    )?;
+    class(
+        activation,
+        flash::net::url_request::create_class(mc),
         script,
     )?;
 

--- a/core/src/avm2/globals/flash/display.rs
+++ b/core/src/avm2/globals/flash/display.rs
@@ -12,6 +12,7 @@ pub mod ibitmapdrawable;
 pub mod interactiveobject;
 pub mod jointstyle;
 pub mod linescalemode;
+pub mod loader;
 pub mod loaderinfo;
 pub mod movieclip;
 pub mod nativemenu;

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -1,0 +1,45 @@
+//! `flash.display.Loader` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.display.Loader`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.display.Loader`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.display"), "Loader"),
+        Some(
+            QName::new(
+                Namespace::package("flash.display"),
+                "DisplayObjectContainer",
+            )
+            .into(),
+        ),
+        Method::from_builtin(instance_init, "<Loader instance initializer>", mc),
+        Method::from_builtin(class_init, "<Loader class initializer>", mc),
+        mc,
+    );
+
+    class
+}

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -2,3 +2,4 @@
 
 pub mod object_encoding;
 pub mod sharedobject;
+pub mod url_request;

--- a/core/src/avm2/globals/flash/net/url_request.rs
+++ b/core/src/avm2/globals/flash/net/url_request.rs
@@ -1,0 +1,42 @@
+//! `flash.net.URLRequest` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.net.URLRequest`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.net.URLRequest`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.net"), "URLRequest"),
+        Some(QName::new(Namespace::public(), "Object").into()),
+        Method::from_builtin(instance_init, "<URLRequest instance initializer>", mc),
+        Method::from_builtin(class_init, "<URLRequest class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
+
+    class
+}

--- a/core/src/avm2/globals/flash/ui.rs
+++ b/core/src/avm2/globals/flash/ui.rs
@@ -1,4 +1,5 @@
 //! `flash.ui` namespace
 
 pub mod contextmenu;
+pub mod keyboard;
 pub mod mouse;

--- a/core/src/avm2/globals/flash/ui/keyboard.rs
+++ b/core/src/avm2/globals/flash/ui/keyboard.rs
@@ -1,0 +1,42 @@
+//! `flash.ui.Keyboard` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.ui.Keyboard`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.ui.Keyboard`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.ui"), "Keyboard"),
+        Some(QName::new(Namespace::public(), "Object").into()),
+        Method::from_builtin(instance_init, "<Keyboard instance initializer>", mc),
+        Method::from_builtin(class_init, "<Keyboard class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
+
+    class
+}

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -9,6 +9,7 @@ pub mod compression_algorithm;
 pub mod dictionary;
 pub mod endian;
 pub mod proxy;
+pub mod timer;
 
 /// `flash.utils.flash_proxy` namespace
 pub const NS_FLASH_PROXY: &str = "http://www.adobe.com/2006/actionscript/flash/proxy";

--- a/core/src/avm2/globals/flash/utils/timer.rs
+++ b/core/src/avm2/globals/flash/utils/timer.rs
@@ -1,0 +1,39 @@
+//! `flash.utils.Timer` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.utils.Timer`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.utils.Timer`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.utils"), "Timer"),
+        Some(QName::new(Namespace::package("flash.events"), "EventDispatcher").into()),
+        Method::from_builtin(instance_init, "<Timer instance initializer>", mc),
+        Method::from_builtin(class_init, "<Timer class initializer>", mc),
+        mc,
+    );
+
+    class
+}


### PR DESCRIPTION
This PR adds the following class stubs:

* 'flash.display.Loader'
* 'flash.net.URLRequest'
* 'flash.ui.Keyboard'
* 'flash.utils.Timer'

These are needed for 'This is the Only Level TOO' (though we'll need
actual implementations to get this game past the loading screen).