### PR TITLE
Add `define_indirect_properties` helper macro for property/slot pairs

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -34,6 +34,76 @@ bitflags! {
     }
 }
 
+/// A helper macro to define public instance properties backed by
+/// private instance slots.
+///
+/// For each (name, type_ns, type_name) pair, this macro
+/// will create a public property named `name` and a private
+/// slot property (in the namespace `NS_RUFFLE_INTERNAL`)
+/// also named `name`. The private slot property will
+/// have the type with namespace `type_ns` and type name `type_name`
+///
+/// The public property will have a generated getter, which passes through
+/// to the generated private slot property.
+/// No setter will be generated
+macro_rules! define_indirect_properties {
+    ($self:expr, $mc:expr, [$(($name:expr, $type_ns:expr, $type_name:expr)),* $(,)?]) => {
+        // Wrap everything in a block expression so that this macro
+        // can be used like a normal function call (e.g. called from any
+        // expression position)
+        {
+        $(
+
+            // We create a closure and immediately call it.
+            // This gives a new scope for imports and function definitions,
+            // which:
+            // * Prevents conflicts between our `use` statements and any
+            //   `use` statements written by the caller.
+            // * Prevents the `getter` function defined in one repetition
+            //   from conflicting with the `getter` function defined in the next
+            //   repetition.
+            (|| {
+                use crate::avm2::traits::Trait;
+                use crate::avm2::globals::NS_RUFFLE_INTERNAL;
+
+                // This needs to be a function pointer so that we can
+                // pass it to `Method::from_builtin`. Therefore, we substitute
+                // $name directly into the function body, rather than writing
+                // a closure and accessing `name` as an upvar.
+                fn getter<'gc>(
+                    activation: &mut Activation<'_, 'gc, '_>,
+                    this: Option<Object<'gc>>,
+                    _args: &[Value<'gc>]
+                ) -> Result<Value<'gc>, Error> {
+                    use crate::avm2::names::QName;
+                    use crate::avm2::globals::NS_RUFFLE_INTERNAL;
+
+                    if let Some(this) = this {
+                        return this.get_property(
+                            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), $name).into(),
+                            activation,
+                        );
+                    }
+                    Ok(Value::Undefined)
+                }
+
+                $self.define_instance_trait(Trait::from_getter(
+                    QName::new(Namespace::public(), $name),
+                    Method::from_builtin(getter, $name, $mc),
+                ));
+
+                $self.define_instance_trait(Trait::from_slot(
+                    QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), $name),
+                    QName::new(Namespace::Package($type_ns.into()), $type_name).into(),
+                    None,
+                ));
+            })();
+        )*
+        }
+    }
+}
+pub(crate) use define_indirect_properties;
+
 /// A function that can be used to allocate instances of a class.
 ///
 /// By default, the `implicit_allocator` is used, which attempts to use the base

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -35,7 +35,7 @@ mod vector;
 mod xml;
 mod xml_list;
 
-const NS_RUFFLE_INTERNAL: &str = "https://ruffle.rs/AS3/impl/";
+pub(crate) const NS_RUFFLE_INTERNAL: &str = "https://ruffle.rs/AS3/impl/";
 const NS_VECTOR: &str = "__AS3__.vec";
 
 pub use flash::utils::NS_FLASH_PROXY;

--- a/core/src/avm2/globals/flash/display/framelabel.rs
+++ b/core/src/avm2/globals/flash/display/framelabel.rs
@@ -1,9 +1,9 @@
 //! `flash.display.FrameLabel` impl
 
 use crate::avm2::activation::Activation;
-use crate::avm2::class::Class;
+use crate::avm2::class::{define_indirect_properties, Class};
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
@@ -53,39 +53,6 @@ pub fn class_init<'gc>(
 ) -> Result<Value<'gc>, Error> {
     Ok(Value::Undefined)
 }
-
-/// Implements `FrameLabel.name`.
-pub fn name<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
-    this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error> {
-    if let Some(this) = this {
-        return this.get_property(
-            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "name").into(),
-            activation,
-        );
-    }
-
-    Ok(Value::Undefined)
-}
-
-/// Implements `FrameLabel.frame`.
-pub fn frame<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
-    this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error> {
-    if let Some(this) = this {
-        return this.get_property(
-            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "frame").into(),
-            activation,
-        );
-    }
-
-    Ok(Value::Undefined)
-}
-
 /// Construct `FrameLabel`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
@@ -98,18 +65,6 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &str,
-        Option<NativeMethodImpl>,
-        Option<NativeMethodImpl>,
-    )] = &[("name", Some(name), None), ("frame", Some(frame), None)];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
-
-    const PRIVATE_INSTANCE_SLOTS: &[(&str, &str, &str, &str)] = &[
-        (NS_RUFFLE_INTERNAL, "name", "", "String"),
-        (NS_RUFFLE_INTERNAL, "frame", "", "int"),
-    ];
-    write.define_private_slot_instance_traits(PRIVATE_INSTANCE_SLOTS);
-
+    define_indirect_properties!(write, mc, [("name", "", "String"), ("frame", "", "int")]);
     class
 }

--- a/core/src/avm2/globals/flash/display/scene.rs
+++ b/core/src/avm2/globals/flash/display/scene.rs
@@ -1,9 +1,9 @@
 //! `flash.display.Scene` builtin/prototype
 
 use crate::avm2::activation::Activation;
-use crate::avm2::class::Class;
+use crate::avm2::class::{define_indirect_properties, Class};
 use crate::avm2::globals::NS_RUFFLE_INTERNAL;
-use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
@@ -60,54 +60,6 @@ pub fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Implements `Scene.labels`.
-pub fn labels<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
-    this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error> {
-    if let Some(this) = this {
-        this.get_property(
-            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "labels").into(),
-            activation,
-        )
-    } else {
-        Ok(Value::Undefined)
-    }
-}
-
-/// Implements `Scene.name`.
-pub fn name<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
-    this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error> {
-    if let Some(this) = this {
-        this.get_property(
-            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "name").into(),
-            activation,
-        )
-    } else {
-        Ok(Value::Undefined)
-    }
-}
-
-/// Implements `Scene.numFrames`.
-pub fn num_frames<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
-    this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error> {
-    if let Some(this) = this {
-        this.get_property(
-            &QName::new(Namespace::Private(NS_RUFFLE_INTERNAL.into()), "numFrames").into(),
-            activation,
-        )
-    } else {
-        Ok(Value::Undefined)
-    }
-}
-
 /// Construct `Scene`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
@@ -120,23 +72,15 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     let mut write = class.write(mc);
 
-    const PUBLIC_INSTANCE_PROPERTIES: &[(
-        &str,
-        Option<NativeMethodImpl>,
-        Option<NativeMethodImpl>,
-    )] = &[
-        ("labels", Some(labels), None),
-        ("name", Some(name), None),
-        ("numFrames", Some(num_frames), None),
-    ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
-
-    const PRIVATE_INSTANCE_SLOTS: &[(&str, &str, &str, &str)] = &[
-        (NS_RUFFLE_INTERNAL, "name", "", "String"),
-        (NS_RUFFLE_INTERNAL, "labels", "", "Array"),
-        (NS_RUFFLE_INTERNAL, "numFrames", "", "int"),
-    ];
-    write.define_private_slot_instance_traits(PRIVATE_INSTANCE_SLOTS);
+    define_indirect_properties!(
+        write,
+        mc,
+        [
+            ("name", "", "String"),
+            ("labels", "", "Array"),
+            ("numFrames", "", "int"),
+        ]
+    );
 
     class
 }


### PR DESCRIPTION
In both `FrameLabel` and `Scene`, we define multiple
'public property / private slot' pairs.
The public property has a getter which delegates to the private
property. There is no setter for the property, ensuring that
the private slot can only be modified from within Ruffle itself.

This PR adds a macro `define_indirect_properties` to abstract over
this pattern. Currently, it only supports the read-only property
pattern - however, it could be extended in the future to generate
a setter that invokes a caller-provided callback function.

This needs to be a macro (rather than a method) so that we can
generate a function with the property name hard-coded into it.
Using a closure that references an upvar will not work, since
`Method::from_builtin` requires a function pointer.