### PR TITLE
Display `Muliname` when trying to lookup a non-public property

### DIFF
--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -138,7 +138,9 @@ impl<'gc> ScriptObjectData<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
     ) -> Result<Value<'gc>, Error> {
         if !multiname.contains_public_namespace() {
-            return Err("Non-public property not found on Object".into());
+            return Err(
+                format!("Non-public property `{:?}` not found on Object", multiname).into(),
+            );
         }
 
         let local_name = match multiname.local_name() {


### PR DESCRIPTION
This will make these errors easier to debug.