### PR TITLE
Change property definition from `loaderUrl` to `loaderURL`

### DIFF
--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -327,7 +327,7 @@ pub fn bytes<'gc>(
     Ok(Value::Undefined)
 }
 
-/// `loaderUrl` getter
+/// `loaderURL` getter
 pub fn loader_url<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
@@ -427,7 +427,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("url", Some(url), None),
         ("width", Some(width), None),
         ("bytes", Some(bytes), None),
-        ("loaderUrl", Some(loader_url), None),
+        ("loaderURL", Some(loader_url), None),
         ("parameters", Some(parameters), None),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);


### PR DESCRIPTION
The actual property name is `loaderURL` - it looks like
a typo was made when this was originally defined in Ruffle.