### PR TITLE
web: Add specific error message for disabled WASM on Microsoft Edge

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -418,7 +418,10 @@ export class RufflePlayer extends HTMLElement {
                     e.ruffleIndexError = PanicError.WasmDownload;
                 } else if (e.name === "TypeError") {
                     e.ruffleIndexError = PanicError.JavascriptConflict;
-                } else if (navigator.userAgent.includes("Edg")) {
+                } else if (
+                    navigator.userAgent.includes("Edg") &&
+                    message.includes("webassembly is not defined")
+                ) {
                     // Microsoft Edge detection.
                     e.ruffleIndexError = PanicError.WasmDisabledMicrosoftEdge;
                 }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -38,6 +38,7 @@ const enum PanicError {
     WasmDownload,
     WasmMimeType,
     WasmNotFound,
+    WasmDisabledMicrosoftEdge,
     SwfFetchError,
 }
 
@@ -417,6 +418,9 @@ export class RufflePlayer extends HTMLElement {
                     e.ruffleIndexError = PanicError.WasmDownload;
                 } else if (e.name === "TypeError") {
                     e.ruffleIndexError = PanicError.JavascriptConflict;
+                } else if (navigator.userAgent.includes("Edg")) {
+                    // Microsoft Edge detection.
+                    e.ruffleIndexError = PanicError.WasmDisabledMicrosoftEdge;
                 }
             }
             this.panic(e);
@@ -1241,6 +1245,20 @@ export class RufflePlayer extends HTMLElement {
                     <p>Otherwise, please contact the website administrator.</p>
                 `;
                 errorFooter = `
+                    <li><a href="#" id="panic-view-details">View Error Details</a></li>
+                `;
+                break;
+            case PanicError.WasmDisabledMicrosoftEdge:
+                // Self hosted: User has disabled WebAssembly in Microsoft Edge through the
+                // "Enhance your Security on the web" setting.
+                errorBody = `
+                    <p>Ruffle failed to load the required ".wasm" file component.</p>
+                    <p>To fix this, try opening your browser's settings, clicking "Privacy, search, and services", scrolling down, and turning off "Enhance your security on the web".</p>
+                    <p>This will allow your browser to load the required ".wasm" files.</p>
+                    <p>If the issue persists, you might have to use a different browser.</p>
+                `;
+                errorFooter = `
+                    <li><a target="_top" href="https://github.com/ruffle-rs/ruffle/issues/6395#issuecomment-1058952356">More Information</a></li>
                     <li><a href="#" id="panic-view-details">View Error Details</a></li>
                 `;
                 break;

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1261,7 +1261,7 @@ export class RufflePlayer extends HTMLElement {
                     <p>If the issue persists, you might have to use a different browser.</p>
                 `;
                 errorFooter = `
-                    <li><a target="_top" href="https://github.com/ruffle-rs/ruffle/issues/6395#issuecomment-1058952356">More Information</a></li>
+                    <li><a target="_top" href="https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users#edge-webassembly-error">More Information</a></li>
                     <li><a href="#" id="panic-view-details">View Error Details</a></li>
                 `;
                 break;


### PR DESCRIPTION
Related to #6395.

This PR adds a specific error message that pops up when the user has the "Enhance your security on the web" setting enabled on Microsoft Edge, which disables `.WASM` files from loading. 

Screenshot of the error message:
![Screenshot 2022-03-08 105732](https://user-images.githubusercontent.com/75391956/157288485-e404f8e1-1429-4c12-9e84-061d069d82bf.png)

The "More Information" link goes to [here](https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users#edge-webassembly-error).
