### PR TITLE
chore: Stop using traits available in prelude

### DIFF
--- a/core/src/avm2/array.rs
+++ b/core/src/avm2/array.rs
@@ -2,7 +2,6 @@
 
 use crate::avm2::value::Value;
 use gc_arena::Collect;
-use std::iter::{ExactSizeIterator, FromIterator};
 use std::ops::RangeBounds;
 
 /// The array storage portion of an array object.

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -1,10 +1,7 @@
 #[cfg(feature = "minimp3")]
 pub mod minimp3 {
     use crate::backend::audio::decoders::{Decoder, SeekableDecoder};
-    use std::{
-        convert::TryInto,
-        io::{Cursor, Read},
-    };
+    use std::io::{Cursor, Read};
 
     type Error = Box<dyn std::error::Error>;
 
@@ -99,10 +96,7 @@ pub mod minimp3 {
 #[allow(dead_code)]
 pub mod symphonia {
     use crate::backend::audio::decoders::{Decoder, SeekableDecoder};
-    use std::{
-        convert::TryInto,
-        io::{Cursor, Read},
-    };
+    use std::io::{Cursor, Read};
     use symphonia::{
         core::{
             self, audio, codecs, errors,

--- a/core/src/color_transform.rs
+++ b/core/src/color_transform.rs
@@ -71,7 +71,7 @@ impl ColorTransform {
     }
 }
 
-impl std::default::Default for ColorTransform {
+impl Default for ColorTransform {
     fn default() -> ColorTransform {
         ColorTransform {
             r_mult: Fixed8::ONE,

--- a/core/src/matrix.rs
+++ b/core/src/matrix.rs
@@ -162,7 +162,7 @@ impl std::ops::Mul<(Twips, Twips)> for Matrix {
     }
 }
 
-impl std::default::Default for Matrix {
+impl Default for Matrix {
     fn default() -> Matrix {
         Matrix::IDENTITY
     }

--- a/core/src/string/buf.rs
+++ b/core/src/string/buf.rs
@@ -383,7 +383,7 @@ impl<'a> From<&'a WStr> for WString {
     }
 }
 
-impl std::iter::FromIterator<u16> for WString {
+impl FromIterator<u16> for WString {
     fn from_iter<T: IntoIterator<Item = u16>>(iter: T) -> Self {
         let iter = iter.into_iter();
         let (min_size, _) = iter.size_hint();

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -7,10 +7,7 @@ use ruffle_core::color_transform::ColorTransform;
 use ruffle_core::matrix::Matrix;
 use ruffle_core::shape_utils::{DistilledShape, DrawCommand};
 use ruffle_web_common::JsResult;
-use std::{
-    cell::{Ref, RefCell},
-    convert::TryInto,
-};
+use std::cell::{Ref, RefCell};
 use wasm_bindgen::{Clamped, JsCast, JsValue};
 use web_sys::{
     CanvasGradient, CanvasPattern, CanvasRenderingContext2d, CanvasWindingRule, Element,

--- a/render/wgpu/src/uniform_buffer.rs
+++ b/render/wgpu/src/uniform_buffer.rs
@@ -1,5 +1,5 @@
 use bytemuck::Pod;
-use std::{convert::TryInto, marker::PhantomData, mem};
+use std::{marker::PhantomData, mem};
 use wgpu::util::StagingBelt;
 
 /// A simple chunked bump allacator for managing dynamic uniforms that change per-draw.


### PR DESCRIPTION
This commit does the same as 36353df7f741feadeebc89f3361c6adb980bda09,
cleaning up any leftovers and new code added since.