### PR TITLE
webgl: Avoid clamp assertion

### DIFF
--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -701,8 +701,8 @@ impl RenderBackend for WebGlRenderBackend {
         ];
 
         // Setup GL viewport and renderbuffers clamped to reasonable sizes.
-        self.renderbuffer_width = (width as i32).clamp(1, self.gl.drawing_buffer_width());
-        self.renderbuffer_height = (height as i32).clamp(1, self.gl.drawing_buffer_height());
+        self.renderbuffer_width = (width as i32).min(self.gl.drawing_buffer_width());
+        self.renderbuffer_height = (height as i32).min(self.gl.drawing_buffer_height());
 
         // Recreate framebuffers with the new size.
         let _ = self.build_msaa_buffers();


### PR DESCRIPTION
If `gl.drawingBufferWidth` returns `0`, then a `clamp` in
`WebGlRenderBackend::set_viewport_dimensions` hits an assertion that
`1 <= self.gl.drawing_buffer_width()` is `false`. I was able to
reproduce this on Chrome by creating many dummy WebGL contexts until
Ruffle's one is lost, and then resize the Ruffle player, but this may
happen in other cases as well.

Fix this by allowing `renderbuffer_width` and `renderbuffer_height`
to be `0`. From basic testing, this seems harmless.

Should fix all the following issues: https://github.com/ruffle-rs/ruffle/issues?q=is%3Aissue+is%3Aopen+set_viewport_dimensions