### PR TITLE
core: Remove `NavigatorBackend::time_since_launch`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -17,6 +17,7 @@ use crate::vminterface::Instantiator;
 use crate::{avm_error, avm_warn};
 use gc_arena::{Gc, GcCell, MutationContext};
 use indexmap::IndexMap;
+use instant::Instant;
 use rand::Rng;
 use smallvec::SmallVec;
 use std::borrow::Cow;
@@ -1114,7 +1115,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             *self.context.time_offset += 1;
         }
 
-        let time = self.context.navigator.time_since_launch().as_millis() as u32;
+        let time = Instant::now()
+            .duration_since(self.context.start_time)
+            .as_millis() as u32;
         let result = time.wrapping_add(*self.context.time_offset);
         self.context.avm1.push(result.into());
         Ok(FrameControl::Continue)

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -618,6 +618,7 @@ mod tests {
                 avm1: &mut avm1,
                 avm2: &mut avm2,
                 external_interface: &mut Default::default(),
+                start_time: Instant::now(),
                 update_start: Instant::now(),
                 max_execution_duration: Duration::from_secs(15),
                 focus_tracker: FocusTracker::new(gc_context),

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -74,6 +74,7 @@ where
             avm1: &mut avm1,
             avm2: &mut avm2,
             external_interface: &mut Default::default(),
+            start_time: Instant::now(),
             update_start: Instant::now(),
             max_execution_duration: Duration::from_secs(15),
             focus_tracker: FocusTracker::new(gc_context),

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -3,6 +3,7 @@
 use crate::avm2::object::TObject;
 use crate::avm2::QName;
 use crate::avm2::{Activation, Error, Object, Value};
+use instant::Instant;
 
 pub mod bytearray;
 pub mod compression_algorithm;
@@ -20,7 +21,10 @@ pub fn get_timer<'gc>(
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
-    Ok((activation.context.navigator.time_since_launch().as_millis() as u32).into())
+    Ok((Instant::now()
+        .duration_since(activation.context.start_time)
+        .as_millis() as u32)
+        .into())
 }
 
 /// Implements `flash.utils.getQualifiedClassName`

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -12,7 +12,6 @@ use std::pin::Pin;
 use std::ptr::null;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
-use std::time::Duration;
 use swf::avm1::types::SendVarsMethod;
 use url::{ParseError, Url};
 
@@ -177,10 +176,6 @@ pub trait NavigatorBackend {
 
     /// Fetch data at a given URL and return it some time in the future.
     fn fetch(&self, url: &str, request_options: RequestOptions) -> OwnedFuture<Vec<u8>, Error>;
-
-    /// Get the amount of time since the SWF was launched.
-    /// Used by the `getTimer` ActionScript call.
-    fn time_since_launch(&mut self) -> Duration;
 
     /// Arrange for a future to be run at some point in the... well, future.
     ///
@@ -367,10 +362,6 @@ impl NavigatorBackend for NullNavigatorBackend {
         path.push(url);
 
         Box::pin(async move { fs::read(path).map_err(Error::NetworkError) })
-    }
-
-    fn time_since_launch(&mut self) -> Duration {
-        Duration::from_millis(0)
     }
 
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>) {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -146,6 +146,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
     /// External interface for (for example) JavaScript <-> ActionScript interaction
     pub external_interface: &'a mut ExternalInterface<'gc>,
 
+    /// The instant at which the SWF was launched.
+    pub start_time: Instant,
+
     /// The instant at which the current update started.
     pub update_start: Instant,
 
@@ -315,6 +318,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             avm1: self.avm1,
             avm2: self.avm2,
             external_interface: self.external_interface,
+            start_time: self.start_time,
             update_start: self.update_start,
             max_execution_duration: self.max_execution_duration,
             focus_tracker: self.focus_tracker,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -216,6 +216,9 @@ pub struct Player {
     /// Time remaining until the next timer will fire.
     time_til_next_timer: Option<f64>,
 
+    /// The instant at which the SWF was launched.
+    start_time: Instant,
+
     /// The maximum amount of time that can be called before a `Error::ExecutionTimeout`
     /// is raised. This defaults to 15 seconds but can be changed.
     max_execution_duration: Duration,
@@ -309,6 +312,7 @@ impl Player {
             instance_counter: 0,
             time_til_next_timer: None,
             storage,
+            start_time: Instant::now(),
             max_execution_duration: Duration::from_secs(max_execution_duration),
             current_frame: None,
         };
@@ -1622,6 +1626,7 @@ impl Player {
                 avm1,
                 avm2,
                 external_interface,
+                start_time: self.start_time,
                 update_start: Instant::now(),
                 max_execution_duration: self.max_execution_duration,
                 focus_tracker,

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -11,7 +11,6 @@ use std::borrow::Cow;
 use std::fs;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
-use std::time::{Duration, Instant};
 use url::Url;
 use winit::event_loop::EventLoopProxy;
 
@@ -27,9 +26,6 @@ pub struct ExternalNavigatorBackend {
     /// The url to use for all relative fetches.
     movie_url: Url,
 
-    /// The time that the SWF was launched.
-    start_time: Instant,
-
     // Client to use for network requests
     client: Option<Rc<HttpClient>>,
 
@@ -37,7 +33,6 @@ pub struct ExternalNavigatorBackend {
 }
 
 impl ExternalNavigatorBackend {
-    #[allow(dead_code)]
     /// Construct a navigator backend with fetch and async capability.
     pub fn new(
         movie_url: Url,
@@ -58,7 +53,6 @@ impl ExternalNavigatorBackend {
             event_loop,
             client,
             movie_url,
-            start_time: Instant::now(),
             upgrade_to_https,
         }
     }
@@ -163,10 +157,6 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                 Ok(buffer)
             }),
         }
-    }
-
-    fn time_since_launch(&mut self) -> Duration {
-        Instant::now().duration_since(self.start_time)
     }
 
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>) {

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -58,6 +58,6 @@ features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioParam", "AudioProcessingEvent", "AudioContext", "AudioDestinationNode",
     "AudioNode", "CanvasRenderingContext2d", "ChannelMergerNode", "ChannelSplitterNode", "CssStyleDeclaration", "Document",
     "Element", "Event", "EventTarget", "GainNode", "Gpu", "HtmlCanvasElement", "HtmlElement", "HtmlImageElement", "MouseEvent",
-    "Navigator", "Node", "Performance", "PointerEvent", "ScriptProcessorNode", "UiEvent", "Window", "Location", "HtmlFormElement",
+    "Navigator", "Node", "PointerEvent", "ScriptProcessorNode", "UiEvent", "Window", "Location", "HtmlFormElement",
     "KeyboardEvent", "Path2d", "CanvasGradient", "CanvasPattern", "SvgMatrix", "SvgsvgElement", "Response", "Request", "RequestInit",
     "Blob", "BlobPropertyBag", "Storage", "WheelEvent", "ImageData"]

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -6,17 +6,12 @@ use ruffle_core::backend::navigator::{
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
 use std::borrow::Cow;
-use std::time::Duration;
 use url::Url;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
-use web_sys::{
-    window, Blob, BlobPropertyBag, Document, Performance, Request, RequestInit, Response,
-};
+use web_sys::{window, Blob, BlobPropertyBag, Document, Request, RequestInit, Response};
 
 pub struct WebNavigatorBackend {
-    performance: Performance,
-    start_time: f64,
     allow_script_access: bool,
     upgrade_to_https: bool,
     base_url: Option<String>,
@@ -29,7 +24,6 @@ impl WebNavigatorBackend {
         mut base_url: Option<String>,
     ) -> Self {
         let window = web_sys::window().expect("window()");
-        let performance = window.performance().expect("window.performance()");
 
         // Upgrade to HTTPS takes effect if the current page is hosted on HTTPS.
         let upgrade_to_https =
@@ -60,9 +54,7 @@ impl WebNavigatorBackend {
             }
         }
 
-        WebNavigatorBackend {
-            start_time: performance.now(),
-            performance,
+        Self {
             allow_script_access,
             upgrade_to_https,
             base_url,
@@ -163,11 +155,6 @@ impl NavigatorBackend for WebNavigatorBackend {
                 }
             };
         }
-    }
-
-    fn time_since_launch(&mut self) -> Duration {
-        let dt = self.performance.now() - self.start_time;
-        Duration::from_millis(dt as u64)
     }
 
     fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {


### PR DESCRIPTION
`core` already depends on the `instant` crate which abstracts
`std::instant::Instant` and polyfills it on Web. Use it to replace
`NavigatorBackend::time_since_launch` in order to make `NavigatorBackend`
a little smaller and more simple.