### PR TITLE
desktop: Disable `env_logger`'s `regex` feature

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "3.1.6", features = ["derive"] }
 cpal = "0.13.5"
 ruffle_core = { path = "../core" }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
-env_logger = { version = "0.9", default-features = false, features = ["humantime", "regex"] }
+env_logger = { version = "0.9", default-features = false, features = ["humantime"] }
 generational-arena = "0.2.8"
 log = "0.4"
 winit = "0.26.1"


### PR DESCRIPTION
This feature allows `RUST_LOG` to include a regex filter. While
it's nice to have, it's not worth over 440KB added to the release
binary. `grep` / `findstr` are great and even better alternatives.