### PR TITLE
Fix broken macOS nightly build

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -175,6 +175,9 @@ jobs:
     env:
       PACKAGE_FILE: ${{ needs.create-nightly-release.outputs.package_prefix }}-macos-universal.tar.gz
     steps:
+      - name: Clone Ruffle repo
+        uses: actions/checkout@v2
+
       - name: Download aarch64 binary
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Guess who forgot to check if the packager task actually clones the Git repo I'm referencing?