### PR TITLE
chore: App bundle also needs a Resources directory.

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -201,6 +201,7 @@ jobs:
 
       - name: Compile asset catalog
         run: |
+          mkdir package/Ruffle.app/Contents/Resources
           xcrun actool --compile package/Ruffle.app/Contents/Resources desktop/assets/Assets.xcassets --minimum-deployment-target 10.0 --platform macosx --warnings --errors --notices --include-all-app-icons
 
       - name: Package macOS


### PR DESCRIPTION
Noticed I forgot this step too when testing some codesigning stuff. I thought `actool` creates the target directory but it doesn't.