### PR TITLE
Codesign macOS bundles

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -204,6 +204,21 @@ jobs:
           mkdir package/Ruffle.app/Contents/Resources
           xcrun actool --compile package/Ruffle.app/Contents/Resources desktop/assets/Assets.xcassets --minimum-deployment-target 10.0 --platform macosx --warnings --errors --notices --include-all-app-icons
 
+      - name: Sign bundle
+        continue-on-error: true
+        env:
+          APPLE_DEVELOPER_KEY: ${{ secrets.APPLE_DEVELOPER_KEY }}
+          APPLE_DEVELOPER_KEY_PASSWORD: ${{ secrets.APPLE_DEVELOPER_KEY_PASSWORD }}
+        run: |
+          echo $APPLE_DEVELOPER_KEY | base64 -decode > certificate.p12
+          security create-keychain -p correct-horse-battery-staple build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p correct-horse-battery-staple build.keychain
+          security import certificate.p12 -k build.keychain -P $APPLE_DEVELOPER_KEY_PASSWORD -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k correct-horse-battery-staple build.keychain
+          codesign -s ${{ secrets.APPLE_DEVELOPER_IDENTITY }} -f --entitlements desktop/assets/macOSEntitlements.plist package/Ruffle.app
+          codesign --verify -vvvv package/Ruffle.app
+
       - name: Package macOS
         run: |
           # We must enter the package/ directory in order to create a flat tarball (i.e. without a directory in it).

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           cp -r desktop/packages/macOS package/Ruffle.app
           mkdir package/Ruffle.app/Contents/MacOS
-          cp package/ruffle package/Ruffle.app/Contents/MacOS/ruffle
+          mv package/ruffle package/Ruffle.app/Contents/MacOS/ruffle
 
       - name: Compile asset catalog
         run: |

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -216,7 +216,7 @@ jobs:
           security unlock-keychain -p correct-horse-battery-staple build.keychain
           security import certificate.p12 -k build.keychain -P $APPLE_DEVELOPER_KEY_PASSWORD -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k correct-horse-battery-staple build.keychain
-          codesign -s ${{ secrets.APPLE_DEVELOPER_IDENTITY }} -f --entitlements desktop/assets/macOSEntitlements.plist package/Ruffle.app
+          codesign -s ${{ secrets.APPLE_DEVELOPER_IDENTITY }} -f --entitlements desktop/assets/macOSEntitlements.plist --options runtime package/Ruffle.app
           codesign --verify -vvvv package/Ruffle.app
 
       - name: Package macOS

--- a/desktop/assets/macOSEntitlements.plist
+++ b/desktop/assets/macOSEntitlements.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plist version="1.0">
+    <dict>
+    </dict>
+</plist>


### PR DESCRIPTION
This PR adds a codesigning step to the macOS bundler, using the same methodology as in [this blog post](https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions).

It requires three new secrets:

 * `APPLE_DEVELOPER_IDENTITY` - the ID of the Developer ID cert (the 10-letter string you see in parenthesis in Keychain Assistant or `security find-identity`)
 * `APPLE_DEVELOPER_KEY` - The Developer ID signing key and certificate itself, exported from Keychain Assistant in `.p12` format and then base64 encoded
 * `APPLE_DEVELOPER_KEY_PASSWORD` - Unlock key for the above secret. `.p12` files have to have a decryption key, so this secret needs to be populated.

All of these are ultimately derived from a Developer ID cert that I need @Herschel to generate for me, which is blocking the PR from being merged in. Once we get those established we can sign the binary.

(Note: the codesigning step also sets a Keychain password to allow unattended signing; as far as I'm aware this doesn't actually need to be a secret.)

This also adds an entitlements list. The list is at `desktop/assets/macOSEntitlements.plist` and is currently empty; I intend to enable app sandboxing in the future.

Finally, we're removing the legacy bare executable, as it's no longer necessary. The code signing step is marked as `continue-on-error` so signing failures won't break the build.