### PR TITLE
wgpu: WIP precompiled shaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
 name = "flash-lso"
 version = "0.5.0"
 source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=19fecd07b9888c4bdaa66771c468095783b52bed#19fecd07b9888c4bdaa66771c468095783b52bed"
@@ -2155,6 +2161,7 @@ dependencies = [
  "indexmap",
  "log",
  "num-traits",
+ "petgraph",
  "rustc-hash",
  "serde",
  "spirv",
@@ -2613,6 +2620,16 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -3085,6 +3102,7 @@ dependencies = [
  "futures",
  "image",
  "log",
+ "naga",
  "raw-window-handle",
  "ruffle_core",
  "ruffle_render_common_tess",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 clap = { version = "3.1.6", features = ["derive"] }
 cpal = "0.13.5"
 ruffle_core = { path = "../core" }
-ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
+ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap", "build_shaders"] }
 env_logger = { version = "0.9", default-features = false, features = ["humantime"] }
 generational-arena = "0.2.8"
 log = "0.4"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -36,6 +36,10 @@ features = ["HtmlCanvasElement"]
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]
 version = "0.12"
 
+[build-dependencies]
+naga = { version = "0.8.5", features = ["wgsl-in", "spv-out"], optional = true }
+
 [features]
 render_debug_labels = []
 render_trace = ["wgpu/trace"]
+build_shaders = ["naga", "wgpu/spirv"]

--- a/render/wgpu/build.rs
+++ b/render/wgpu/build.rs
@@ -1,0 +1,95 @@
+// #[cfg(feature = "build_shaders")]
+use naga;
+
+fn print_error(e: &Box<dyn std::error::Error>) {
+    eprint!("{}", e);
+
+    let mut e = e.source();
+    if e.is_some() {
+        eprintln!(": ");
+    } else {
+        eprintln!();
+    }
+
+    while let Some(source) = e {
+        eprintln!("\t{}", source);
+        e = source.source();
+    }
+}
+
+fn compile_shader(src: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    // Parse WGSL shader.
+    let result = naga::front::wgsl::parse_str(&src);
+    let module = result.map_err(|e| {
+        // TODO: Use `emit_to_stderr_with_path` once it arrives.
+        e.emit_to_stderr(&src);
+        e
+    })?;
+
+    // Validate the IR.
+    let info = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::all(),
+    )
+    .validate(&module)?;
+
+    // Output compiled SPIR-V shader.
+    let options = naga::back::spv::Options::default();
+    /*options.bounds_check_policies = params.bounds_check_policies;
+    options.flags.set(
+        spv::WriterFlags::ADJUST_COORDINATE_SPACE,
+        !params.keep_coordinate_space,
+    );*/
+    let spv = naga::back::spv::write_vec(&module, &info, &options, None)?;
+    let bytes = spv
+        .iter()
+        .fold(Vec::with_capacity(spv.len() * 4), |mut v, w| {
+            v.extend_from_slice(&w.to_le_bytes());
+            v
+        });
+    Ok(bytes)
+}
+
+// #[cfg(feature = "build_shaders")]
+fn build_shader(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed={}", "shaders/common.wgsl");
+    const COMMON_SRC: &str = include_str!("shaders/common.wgsl");
+
+    println!("cargo:rerun-if-changed={}", "shaders/output_linear.wgsl");
+    const OUTPUT_LINEAR_SRC: &str = include_str!("shaders/output_linear.wgsl");
+
+    println!("cargo:rerun-if-changed={}", "shaders/output_srgb.wgsl");
+    const OUTPUT_SRGB_SRC: &str = include_str!("shaders/output_srgb.wgsl");
+
+    let path = std::path::Path::new("shaders")
+        .join(name)
+        .with_extension("wgsl");
+    println!("cargo:rerun-if-changed={}", path.display());
+    let src = std::fs::read_to_string(path)?;
+
+    let out_dir = std::env::var_os("OUT_DIR").ok_or("OUT_DIR not defined")?;
+    let out_path = std::path::Path::new(&out_dir);
+
+    let bytes = compile_shader(&[COMMON_SRC, OUTPUT_SRGB_SRC, &src].concat())?;
+    std::fs::write(out_path.join(format!("{}_srgb.spv", name)), &bytes)?;
+
+    let bytes = compile_shader(&[COMMON_SRC, OUTPUT_LINEAR_SRC, &src].concat())?;
+    std::fs::write(out_path.join(format!("{}_linear.spv", name)), &bytes)?;
+
+    Ok(())
+}
+
+fn build_shaders() -> Result<(), Box<dyn std::error::Error>> {
+    build_shader("color")?;
+    build_shader("bitmap")?;
+    build_shader("gradient")?;
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    build_shaders().map_err(|e| {
+        print_error(&e);
+        e
+    })
+}


### PR DESCRIPTION
Introduce a `build_shaders` feature in Ruffle's `wgpu` backend and
enable it on desktop. When enabled, the WGSL shaders are precompiled
using `naga` in a build script to the SPIR-V format. Then, those
SPIR-V modules are used directly instead of the WGSL sources.

This approach has 2 major advantages:
1. It should reduce Ruffle's executable size by a decent amount of KBs
(I expect 100KB-200KB), because the binary SPIR-V modules are much smaller
than the WGSL textual source code, plus hopefully the Rust compiler
will be smart enough to eliminate `naga`'s WGSL parsing code, which
is pretty high on the `cargo bloat` list.
2. It should improve the startup time, as less logic is involved when
loading precompiled SPIR-V modules.

However, I'm almost sure this feature won't work for WebGPU as it only supports WGSL. But maybe we can still minify the  WGSL source code to reduce the WebAssembly binary size.