### PR TITLE
web: Try to embed content without Ruffle if it cannot load with Ruffle

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1390,19 +1390,8 @@ export class RufflePlayer extends HTMLElement {
         embed.height =
             this.attributes.getNamedItem("height")?.value ||
             String(this.clientHeight);
-        // Hide Ruffle specific content
-        const canvas_container =
-            this.container.querySelector<HTMLCanvasElement>("canvas");
-        if (canvas_container) {
-            canvas_container.style.display = "none";
-        }
-        const message_overlay =
-            this.container.querySelector<HTMLDivElement>("#message_overlay");
-        if (message_overlay) {
-            message_overlay.style.display = "none";
-        }
-        this.unmuteOverlay.style.display = "none";
-        this.playButton.style.display = "none";
+        // Replace RufflePlayer with sidestep embed
+        this.replaceWith(embed);
     }
     displayUnsupportedMessage(): void {
         const div = document.createElement("div");

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1329,27 +1329,6 @@ export class RufflePlayer extends HTMLElement {
     }
 
     displayRootMovieDownloadFailedMessage(): void {
-        if (
-            window.location.origin == this.swfUrl!.origin ||
-            !this.isExtension ||
-            !window.location.protocol.includes("http")
-        ) {
-            const error = new Error("Failed to fetch: " + this.swfUrl);
-            error.ruffleIndexError = PanicError.SwfFetchError;
-            this.panic(error);
-            return;
-        }
-
-        const div = document.createElement("div");
-        div.id = "message_overlay";
-        div.innerHTML = `<div class="message">
-            <p>Ruffle wasn't able to run the Flash embedded in this page.</p>
-            <p>You can try to open the file in a separate tab, to sidestep this issue.</p>
-            <div>
-                <a target="_blank" href="${this.swfUrl}">Open in a new tab</a>
-            </div>
-        </div>`;
-        this.container.prepend(div);
         // Get the config
         const config: BaseLoadOptions = {
             ...(window.RufflePlayer?.config ?? {}),
@@ -1376,7 +1355,29 @@ export class RufflePlayer extends HTMLElement {
         // If the content in the embed is able to load, show it and hide Ruffle content
         embed.addEventListener("load", this.showSidestepEmbed.bind(this));
         embed.setAttribute("src", swfUrl);
+        if (
+            window.location.origin == this.swfUrl!.origin ||
+            !this.isExtension ||
+            !window.location.protocol.includes("http")
+        ) {
+            const error = new Error("Failed to fetch: " + this.swfUrl);
+            error.ruffleIndexError = PanicError.SwfFetchError;
+            this.panic(error);
+            this.container.append(embed);
+            return;
+        }
+
+        const div = document.createElement("div");
+        div.id = "message_overlay";
+        div.innerHTML = `<div class="message">
+            <p>Ruffle wasn't able to run the Flash embedded in this page.</p>
+            <p>You can try to open the file in a separate tab, to sidestep this issue.</p>
+            <div>
+                <a target="_blank" href="${this.swfUrl}">Open in a new tab</a>
+            </div>
+        </div>`;
         this.container.append(embed);
+        this.container.prepend(div);
     }
 
     private showSidestepEmbed(e: Event): void {


### PR DESCRIPTION
Fix #6504 and fix #4030. This makes no noticeable changes for content that cannot be loaded without Ruffle either (such as http://www.notdoppler.com/theimpossiblequiz.php).