### PR TITLE
core: `Loader` cleanup

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1217,14 +1217,13 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     &url,
                     NavigationMethod::from_send_vars_method(action.send_vars_method()),
                 );
-                let fetch = self.context.navigator.fetch(&url, opts);
-                let process = self.context.load_manager.load_form_into_object(
+                let future = self.context.load_manager.load_form_into_object(
                     self.context.player.clone().unwrap(),
                     target_obj,
-                    fetch,
+                    &url,
+                    opts,
                 );
-
-                self.context.navigator.spawn_future(process);
+                self.context.navigator.spawn_future(future);
             }
 
             return Ok(FrameControl::Continue);

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1140,7 +1140,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         if target.starts_with("_level") && target.len() > 6 {
             match target[6..].parse::<i32>() {
                 Ok(level_id) => {
-                    let fetch = self.context.navigator.fetch(&url, RequestOptions::get());
                     let level = self.resolve_level(level_id);
 
                     if url.is_empty() {
@@ -1149,15 +1148,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                             mc.replace_with_movie(self.context.gc_context, None)
                         }
                     } else {
-                        let process = self.context.load_manager.load_movie_into_clip(
+                        let future = self.context.load_manager.load_movie_into_clip(
                             self.context.player.clone().unwrap(),
                             level,
-                            fetch,
-                            url,
+                            &url,
+                            RequestOptions::get(),
                             None,
                             None,
                         );
-                        self.context.navigator.spawn_future(process);
+                        self.context.navigator.spawn_future(future);
                     }
                 }
                 Err(e) => avm_warn!(
@@ -1242,16 +1241,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                         mc.replace_with_movie(self.context.gc_context, None)
                     }
                 } else {
-                    let fetch = self.context.navigator.fetch(&url, opts);
-                    let process = self.context.load_manager.load_movie_into_clip(
+                    let future = self.context.load_manager.load_movie_into_clip(
                         self.context.player.clone().unwrap(),
                         clip_target,
-                        fetch,
-                        url.to_string(),
+                        &url,
+                        opts,
                         None,
                         None,
                     );
-                    self.context.navigator.spawn_future(process);
+                    self.context.navigator.spawn_future(future);
                 }
             }
             return Ok(FrameControl::Continue);
@@ -1261,21 +1259,17 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             // target of `_level#` indicates a `loadMovieNum` call.
             match window_target[6..].parse::<i32>() {
                 Ok(level_id) => {
-                    let fetch = self
-                        .context
-                        .navigator
-                        .fetch(&url.to_utf8_lossy(), RequestOptions::get());
                     let level = self.resolve_level(level_id);
 
-                    let process = self.context.load_manager.load_movie_into_clip(
+                    let future = self.context.load_manager.load_movie_into_clip(
                         self.context.player.clone().unwrap(),
                         level,
-                        fetch,
-                        url.to_string(),
+                        &url.to_utf8_lossy(),
+                        RequestOptions::get(),
                         None,
                         None,
                     );
-                    self.context.navigator.spawn_future(process);
+                    self.context.navigator.spawn_future(future);
                 }
                 Err(e) => avm_warn!(
                     self,

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -254,12 +254,13 @@ fn spawn_load_var_fetch<'gc>(
         (url.to_utf8_lossy(), RequestOptions::get())
     };
 
-    let fetch = activation.context.navigator.fetch(&url, request_options);
-    let process = activation.context.load_manager.load_form_into_load_vars(
+    let future = activation.context.load_manager.load_form_into_load_vars(
         activation.context.player.clone().unwrap(),
         loader_object,
-        fetch,
+        &url,
+        request_options,
     );
+    activation.context.navigator.spawn_future(future);
 
     // Create hidden properties on object.
     if !loader_object.has_property(activation, "_bytesLoaded".into()) {
@@ -283,8 +284,6 @@ fn spawn_load_var_fetch<'gc>(
     } else {
         loader_object.set("loaded", false.into(), activation)?;
     }
-
-    activation.context.navigator.spawn_future(process);
 
     Ok(true.into())
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1322,17 +1322,15 @@ fn load_movie<'gc>(
     let method = args.get(1).cloned().unwrap_or(Value::Undefined);
     let method = NavigationMethod::from_method_str(&method.coerce_to_string(activation)?);
     let (url, opts) = activation.locals_into_request_options(&url, method);
-    let fetch = activation.context.navigator.fetch(&url, opts);
-    let process = activation.context.load_manager.load_movie_into_clip(
+    let future = activation.context.load_manager.load_movie_into_clip(
         activation.context.player.clone().unwrap(),
         DisplayObject::MovieClip(target),
-        fetch,
-        url.to_string(),
+        &url,
+        opts,
         None,
         None,
     );
-
-    activation.context.navigator.spawn_future(process);
+    activation.context.navigator.spawn_future(future);
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1345,15 +1345,14 @@ fn load_variables<'gc>(
     let method = args.get(1).cloned().unwrap_or(Value::Undefined);
     let method = NavigationMethod::from_method_str(&method.coerce_to_string(activation)?);
     let (url, opts) = activation.locals_into_request_options(&url, method);
-    let fetch = activation.context.navigator.fetch(&url, opts);
     let target = target.object().coerce_to_object(activation);
-    let process = activation.context.load_manager.load_form_into_object(
+    let future = activation.context.load_manager.load_form_into_object(
         activation.context.player.clone().unwrap(),
         target,
-        fetch,
+        &url,
+        opts,
     );
-
-    activation.context.navigator.spawn_future(process);
+    activation.context.navigator.spawn_future(future);
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -58,19 +58,15 @@ fn load_clip<'gc>(
                 _ => None,
             };
             if let Some(target) = target {
-                let fetch = activation
-                    .context
-                    .navigator
-                    .fetch(&url.to_utf8_lossy(), RequestOptions::get());
-                let process = activation.context.load_manager.load_movie_into_clip(
+                let future = activation.context.load_manager.load_movie_into_clip(
                     activation.context.player.clone().unwrap(),
                     target,
-                    fetch,
-                    url.to_string(),
+                    &url.to_utf8_lossy(),
+                    RequestOptions::get(),
                     None,
                     Some(this),
                 );
-                activation.context.navigator.spawn_future(process);
+                activation.context.navigator.spawn_future(future);
 
                 return Ok(true.into());
             }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -262,17 +262,13 @@ fn spawn_xml_fetch<'gc>(
 
     this.set("loaded", false.into(), activation)?;
 
-    let fetch = activation
-        .context
-        .navigator
-        .fetch(&url.to_utf8_lossy(), request_options);
-    let process = activation.context.load_manager.load_form_into_load_vars(
+    let future = activation.context.load_manager.load_form_into_load_vars(
         activation.context.player.clone().unwrap(),
         loader_object,
-        fetch,
+        &url.to_utf8_lossy(),
+        request_options,
     );
-
-    activation.context.navigator.spawn_future(process);
+    activation.context.navigator.spawn_future(future);
 
     Ok(true.into())
 }

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -183,7 +183,8 @@ impl<'gc> LoadManager<'gc> {
         &mut self,
         player: Weak<Mutex<Player>>,
         target_object: Object<'gc>,
-        fetch: OwnedFuture<Vec<u8>, Error>,
+        url: &str,
+        options: RequestOptions,
     ) -> OwnedFuture<(), Error> {
         let loader = Loader::LoadVars {
             self_handle: None,
@@ -191,8 +192,7 @@ impl<'gc> LoadManager<'gc> {
         };
         let handle = self.add_loader(loader);
         let loader = self.get_loader_mut(handle).unwrap();
-
-        loader.load_vars_loader(player, fetch)
+        loader.load_vars_loader(player, url.to_owned(), options)
     }
 }
 
@@ -570,10 +570,11 @@ impl<'gc> Loader<'gc> {
     }
 
     /// Creates a future for a LoadVars load call.
-    pub fn load_vars_loader(
+    fn load_vars_loader(
         &mut self,
         player: Weak<Mutex<Player>>,
-        fetch: OwnedFuture<Vec<u8>, Error>,
+        url: String,
+        options: RequestOptions,
     ) -> OwnedFuture<(), Error> {
         let handle = match self {
             Loader::LoadVars { self_handle, .. } => {
@@ -587,6 +588,16 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
+            // clippy reports a false positive for explicitly dropped guards:
+            // https://github.com/rust-lang/rust-clippy/issues/6446
+            // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
+            let fetch;
+            {
+                let player_lock = player.lock().unwrap();
+                let url = player_lock.navigator().resolve_relative_url(&url);
+                fetch = player_lock.navigator().fetch(&url, options);
+            }
+
             let data = fetch.await;
 
             // Fire the load handler.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -353,16 +353,14 @@ impl Player {
         on_metadata: Box<dyn FnOnce(&swf::HeaderExt)>,
     ) {
         self.mutate_with_update_context(|context| {
-            let fetch = context.navigator.fetch(movie_url, RequestOptions::get());
-            let process = context.load_manager.load_root_movie(
+            let future = context.load_manager.load_root_movie(
                 context.player.clone().unwrap(),
-                fetch,
-                movie_url.to_string(),
+                movie_url,
+                RequestOptions::get(),
                 parameters,
                 on_metadata,
             );
-
-            context.navigator.spawn_future(process);
+            context.navigator.spawn_future(future);
         });
     }
 
@@ -1411,6 +1409,10 @@ impl Player {
 
     pub fn audio_mut(&mut self) -> &mut Audio {
         &mut self.audio
+    }
+
+    pub fn navigator(&self) -> &Navigator {
+        &self.navigator
     }
 
     // The frame rate of the current movie in FPS.


### PR DESCRIPTION
This PR moves all `navigator.fetch()` calls to `Loader`. This will allow moving the logic of `NavigatorBackend::resolve_relative_url` and `NavigatorBackend::pre_process_url` to there as well. Then, we'll be able to create a new `ExternalNavigatorBackend` without specifying a movie URL, which will help improving Ruffle on desktop by not requiring a movie URL on startup.