### PR TITLE
demo: Small improvements

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -42,8 +42,8 @@
         "build": "npm run build --workspaces",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
         "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
-        "demo": "npm run serve --workspace ruffle-demo",
-        "test": "npm run test --workspaces --if-present",
+        "demo": "npm start --workspace ruffle-demo",
+        "test": "npm test --workspaces --if-present",
         "docs": "npm run docs --workspaces --if-present",
         "lint": "eslint . && stylelint **.css",
         "format": "eslint . --fix && stylelint --fix **.css"

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -6,7 +6,7 @@
     "private": true,
     "scripts": {
         "build": "webpack",
-        "serve": "webpack serve"
+        "start": "webpack serve"
     },
     "dependencies": {
         "ruffle-core": "^0.1.0"

--- a/web/packages/demo/webpack.config.js
+++ b/web/packages/demo/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = (_env, _argv) => {
             new CopyPlugin({
                 patterns: [
                     { from: path.resolve(__dirname, "www/index.html") },
+                    { from: "swfs.json", noErrorOnMissing: true },
                     { from: "LICENSE*" },
                     { from: "README.md" },
                 ],


### PR DESCRIPTION
*  Copy `swfs.json` to `dist` directory - Currently it doesn't work at all. I have no idea if it got broken at some point.
* Rename `serve` command to `start` - Allows running `npm start` inside the `demo` directory. `npm run demo` in the `web` directory should still work as usual.