### PR TITLE
chore: Update copyright

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,7 +9,7 @@ at your option.
 
 ## MIT License
 
-Copyright (c) 2018-2021 Michael R. Welsh <mwelsh@gmail.com> and Ruffle contributors
+Copyright (c) 2018-2022 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors
                         (https://github.com/ruffle-rs/ruffle/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any
@@ -551,7 +551,7 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [strsim](https://github.com/dguo/strsim-rs) | [MIT](#MIT) | Copyright (c) 2015 Danny Guo Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>  | 
 | [strsim](https://github.com/dguo/strsim-rs) | [MIT](#MIT) | Copyright (c) 2015 Danny Guo Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> Copyright (c) 2018 Akash Kurdekar  | 
 | [svg](https://github.com/bodoni/svg) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright 2015–2021 The svg Developers Copyright 2015–2021 The svg Developers  | 
-| [swf](https://github.com/ruffle-rs/ruffle) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>  | 
+| [swf](https://github.com/ruffle-rs/ruffle) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors | 
 | [syn](https://github.com/dtolnay/syn) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) David Tolnay <dtolnay@gmail.com> | 
 | [synstructure](https://github.com/mystor/synstructure) | [MIT](#MIT) | Copyright 2016 Nika Layzell  | 
 | [tar](https://github.com/alexcrichton/tar-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton  | 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_core"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_macros"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 
 [lib]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_desktop"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 default-run = "ruffle_desktop"
 license = "MIT OR Apache-2.0"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_render_canvas"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/render/common_tess/Cargo.toml
+++ b/render/common_tess/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_render_common_tess"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_render_webgl"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "swf"
 version = "0.1.2"
 edition = "2021"
-authors = ["Mike Welsh"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 repository = "https://github.com/ruffle-rs/ruffle"
 homepage = "https://github.com/ruffle-rs/ruffle"
 license = "MIT OR Apache-2.0"

--- a/web/LICENSE.md
+++ b/web/LICENSE.md
@@ -549,7 +549,7 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [strsim](https://github.com/dguo/strsim-rs) | [MIT](#MIT) | Copyright (c) 2015 Danny Guo Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>  | 
 | [strsim](https://github.com/dguo/strsim-rs) | [MIT](#MIT) | Copyright (c) 2015 Danny Guo Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> Copyright (c) 2018 Akash Kurdekar  | 
 | [svg](https://github.com/bodoni/svg) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright 2015–2021 The svg Developers Copyright 2015–2021 The svg Developers  | 
-| [swf](https://github.com/ruffle-rs/ruffle) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>  | 
+| [swf](https://github.com/ruffle-rs/ruffle) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors  | 
 | [syn](https://github.com/dtolnay/syn) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) David Tolnay <dtolnay@gmail.com> | 
 | [synstructure](https://github.com/mystor/synstructure) | [MIT](#MIT) | Copyright 2016 Nika Layzell  | 
 | [tar](https://github.com/alexcrichton/tar-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton  | 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_web_common"
 version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/web/packages/demo/LICENSE_MIT
+++ b/web/packages/demo/LICENSE_MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/web/packages/extension/LICENSE_MIT
+++ b/web/packages/extension/LICENSE_MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs>
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/web/packages/selfhosted/LICENSE_MIT
+++ b/web/packages/selfhosted/LICENSE_MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Mike Welsh <mwelsh@gmail.com>
+Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Updating authors metadata and copyright notices to mention Ruffle LLC.

I assign to Ruffle LLC all rights, title, and interest to copyrights of my personal contributions to Ruffle, effective March 26, 2022.

See attached PDF for full copyright assignment and legalese:
[CopyrightAssignment.zip](https://github.com/ruffle-rs/ruffle/files/8356351/CopyrightAssignment.zip)

All other contributors continue to have copyright over their own contributions; no change there.