### PR TITLE
avm1: `String(function)` returns `[type Function]`

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -406,7 +406,13 @@ impl<'gc> Value<'gc> {
             Value::Object(object) => {
                 match object.call_method("toString".into(), &[], activation)? {
                     Value::String(s) => s,
-                    _ => "[type Object]".into(),
+                    _ => {
+                        if object.as_executable().is_some() {
+                            "[type Function]".into()
+                        } else {
+                            "[type Object]".into()
+                        }
+                    }
                 }
             }
             Value::Undefined => {


### PR DESCRIPTION
```
var o = new Object();
o.toString = undefined;
trace(String(o)); // "[type Object]"

function f() {}
trace(String(f)); // "[type Function]" (returns "[type Object]" in the current builds)
```