### PR TITLE
web: Don't polyfill YouTube Flash embeds

### DIFF
--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -8,6 +8,7 @@ import {
     isScriptAccessAllowed,
     isSwfFilename,
     isYoutubeFlashSource,
+    workaroundYoutubeMixedContent,
     RufflePlayer,
 } from "./ruffle-player";
 import { registerElement } from "./register-element";
@@ -142,6 +143,8 @@ export class RuffleEmbed extends RufflePlayer {
         }
         // Don't polyfill when the file is a Youtube Flash source.
         if (isYoutubeFlashSource(elem.getAttribute("src"))) {
+            // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well
+            workaroundYoutubeMixedContent(elem, "src");
             return false;
         }
 

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -7,6 +7,7 @@ import {
     isFallbackElement,
     isScriptAccessAllowed,
     isSwfFilename,
+    isYoutubeFlashSource,
     RufflePlayer,
 } from "./ruffle-player";
 import { registerElement } from "./register-element";
@@ -137,6 +138,10 @@ export class RuffleEmbed extends RufflePlayer {
         }
         // Don't polyfill when no file is specified.
         if (!elem.getAttribute("src")) {
+            return false;
+        }
+        // Don't polyfill when the file is a Youtube Flash source.
+        if (isYoutubeFlashSource(elem.getAttribute("src"))) {
             return false;
         }
 

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -8,6 +8,7 @@ import {
     isFallbackElement,
     isScriptAccessAllowed,
     isSwfFilename,
+    isYoutubeFlashSource,
     RufflePlayer,
 } from "./ruffle-player";
 import { registerElement } from "./register-element";
@@ -233,8 +234,16 @@ export class RuffleObject extends RufflePlayer {
         let isSwf;
         // Check for SWF file.
         if (data) {
+            // Don't polyfill when the file is a Youtube Flash source.
+            if (isYoutubeFlashSource(data)) {
+                return false;
+            }
             isSwf = isSwfFilename(data);
         } else if (params && params.movie) {
+            // Don't polyfill when the file is a Youtube Flash source.
+            if (isYoutubeFlashSource(params.movie)) {
+                return false;
+            }
             isSwf = isSwfFilename(params.movie);
         } else {
             // Don't polyfill when no file is specified.

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -250,16 +250,12 @@ export class RuffleObject extends RufflePlayer {
                     "param[name='movie']"
                 ) as HTMLElement;
                 if (movie_elem) {
-                    const movie_src_before = movie_elem.getAttribute("value");
                     workaroundYoutubeMixedContent(movie_elem, "value");
                     // The data attribute needs to be set for the re-fetch to happen
-                    const movie_src_after = movie_elem.getAttribute("value");
-                    if (
-                        movie_src_before &&
-                        movie_src_after &&
-                        movie_src_before !== movie_src_after
-                    ) {
-                        elem.setAttribute("data", movie_src_after);
+                    // It also needs to be set on Firefox for the YouTube object rewrite to work, regardless of mixed content
+                    const movie_src = movie_elem.getAttribute("value");
+                    if (movie_src) {
+                        elem.setAttribute("data", movie_src);
                     }
                 }
                 return false;

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1484,20 +1484,20 @@ export function isBuiltInContextMenuVisible(menu: string | null): boolean {
 export function isYoutubeFlashSource(filename: string | null): boolean {
     if (filename) {
         let pathname = "";
-        let hostname = "";
+        let cleaned_hostname = "";
         try {
             // A base URL is required if `filename` is a relative URL, but we don't need to detect the real URL origin.
             const url = new URL(filename, RUFFLE_ORIGIN);
             pathname = url.pathname;
-            hostname = url.hostname;
+            cleaned_hostname = url.hostname.replace("www.", "");
         } catch (err) {
             // Some invalid filenames, like `///`, could raise a TypeError. Let's fail silently in this situation.
         }
         // See https://wiki.mozilla.org/QA/Youtube_Embedded_Rewrite
         if (
             pathname.startsWith("/v/") &&
-            (hostname.endsWith("youtube.com") ||
-                hostname.endsWith("youtube-nocookie.com"))
+            (cleaned_hostname === "youtube.com" ||
+                cleaned_hostname === "youtube-nocookie.com")
         ) {
             return true;
         }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1476,6 +1476,36 @@ export function isBuiltInContextMenuVisible(menu: string | null): boolean {
 }
 
 /**
+ * Returns whether the given filename is a Youtube Flash source.
+ *
+ * @param filename The filename to test.
+ * @returns True if the filename is a Youtube Flash source.
+ */
+export function isYoutubeFlashSource(filename: string | null): boolean {
+    if (filename) {
+        let pathname = "";
+        let hostname = "";
+        try {
+            // A base URL is required if `filename` is a relative URL, but we don't need to detect the real URL origin.
+            const url = new URL(filename, RUFFLE_ORIGIN);
+            pathname = url.pathname;
+            hostname = url.hostname;
+        } catch (err) {
+            // Some invalid filenames, like `///`, could raise a TypeError. Let's fail silently in this situation.
+        }
+        // See https://wiki.mozilla.org/QA/Youtube_Embedded_Rewrite
+        if (
+            pathname.startsWith("/v/") &&
+            (hostname.endsWith("youtube.com") ||
+                hostname.endsWith("youtube-nocookie.com"))
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
  * Returns whether the given filename ends in a known flash extension.
  *
  * @param filename The filename to test.

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1506,6 +1506,35 @@ export function isYoutubeFlashSource(filename: string | null): boolean {
 }
 
 /**
+ * Workaround Youtube mixed content if upgradeToHttps is true.
+ *
+ * @param elem The element to change.
+ * @param attr The attribute to adjust.
+ */
+export function workaroundYoutubeMixedContent(
+    elem: HTMLElement,
+    attr: string
+): void {
+    const elem_attr = elem.getAttribute(attr);
+    const window_config = window.RufflePlayer?.config ?? {};
+    if (elem_attr) {
+        try {
+            const url = new URL(elem_attr);
+            if (
+                url.protocol === "http:" &&
+                window.location.protocol === "https:" &&
+                window_config.upgradeToHttps !== false
+            ) {
+                url.protocol = "https:";
+                elem.setAttribute(attr, url.toString());
+            }
+        } catch (err) {
+            // Some invalid filenames, like `///`, could raise a TypeError. Let's fail silently in this situation.
+        }
+    }
+}
+
+/**
  * Returns whether the given filename ends in a known flash extension.
  *
  * @param filename The filename to test.

--- a/web/packages/selfhosted/test/polyfill/embed_youtube/expected.html
+++ b/web/packages/selfhosted/test/polyfill/embed_youtube/expected.html
@@ -1,0 +1,5 @@
+<embed
+    src="https://www.youtube.com/v/CquvDLrjgYU?version=3"
+    width="350"
+    height="289"
+/>

--- a/web/packages/selfhosted/test/polyfill/embed_youtube/index.html
+++ b/web/packages/selfhosted/test/polyfill/embed_youtube/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>EMBED - YOUTUBE</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <embed
+                src="https://www.youtube.com/v/CquvDLrjgYU?version=3"
+                width="350"
+                height="289"
+            />
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/embed_youtube/test.js
+++ b/web/packages/selfhosted/test/polyfill/embed_youtube/test.js
@@ -1,0 +1,19 @@
+const { open_test, inject_ruffle_and_wait } = require("../../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Embed with Flash YouTube video", () => {
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
+    });
+
+    it("doesn't polyfill with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});

--- a/web/packages/selfhosted/test/polyfill/object_youtube/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_youtube/expected.html
@@ -1,0 +1,8 @@
+<object
+    type="application/x-shockwave-flash"
+    data="https://www.youtube.com/v/ENumi96Btj0"
+    width="425"
+    height="350"
+>
+    <param name="movie" value="https://www.youtube.com/v/ENumi96Btj0"/>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_youtube/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_youtube/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>OBJECT - YOUTUBE</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <object
+                type="application/x-shockwave-flash"
+                data="https://www.youtube.com/v/ENumi96Btj0"
+                width="425"
+                height="350"
+            >
+                <param name="movie" value="https://www.youtube.com/v/ENumi96Btj0"/>
+            </object>
+		</div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/object_youtube/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_youtube/test.js
@@ -1,0 +1,19 @@
+const { open_test, inject_ruffle_and_wait } = require("../../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Object with Flash YouTube video", () => {
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
+    });
+
+    it("doesn't polyfill with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});


### PR DESCRIPTION
More accurate alternative to #6520. Fix #4030 and fix #6504.

This behavior is explained by https://wiki.mozilla.org/QA/Youtube_Embedded_Rewrite. See https://bugzilla.mozilla.org/attachment.cgi?id=8707266&action=diff and https://hg.mozilla.org/mozilla-central/rev/5125dbdcbcb2 for implementation in Firefox. See https://chromium.googlesource.com/chromium/src.git/+/e0135598f6bf547463bc943100da4574c5f89930%5E!/ for implementation in Chromium.

~~Edit: My 2nd commit is because this only happen for embeds.~~

Edit: I now change the src for Youtube Flash embeds on http to https if the window is on https and upgradeToHttps is not false, which is technically inaccurate behavior, but I thought was better anyway.