### PR TITLE
macOS notarization & set minimum macOS version

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -83,10 +83,12 @@ jobs:
           - build_name: macos-x86_64
             os: macos-latest
             target: x86_64-apple-darwin
+            MACOSX_DEPLOYMENT_TARGET: 10.7
 
           - build_name: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
+            MACOSX_DEPLOYMENT_TARGET: 11.0
 
           - build_name: windows-x86_32
             os: windows-latest
@@ -127,6 +129,7 @@ jobs:
           args: --package ruffle_desktop --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
 
       - name: Package common
         run: |

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -218,6 +218,17 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k correct-horse-battery-staple build.keychain
           codesign -s ${{ secrets.APPLE_DEVELOPER_IDENTITY }} -f --entitlements desktop/assets/macOSEntitlements.plist --options runtime package/Ruffle.app
           codesign --verify -vvvv package/Ruffle.app
+      
+      - name: Notarize bundle
+        continue-on-error: true
+        run: |
+          xcrun notarytool store-credentials "Ruffle" --apple-id ${{ secrets.APPLE_ID }} --team-id ${{ secrets.APPLE_TEAM }} --password ${{ secrets.APPLE_APP_PASSWORD }}
+          cd package
+          zip -r Ruffle.zip Ruffle.app
+          mv Ruffle.zip ..
+          cd ..
+          xcrun notarytool submit Ruffle.zip --keychain-profile Ruffle --wait
+          xcrun stapler staple package/Ruffle.app
 
       - name: Package macOS
         run: |


### PR DESCRIPTION
This enables notarization. I tested the process on my local machine and it was entirely painless; in fact the current nightly is already notarized if you're online. This also adds stapling so it should work offline as well.

Since we need to talk to Apple's developer servers, this introduces another three secrets:

 * `APPLE_ID` - The username of an Apple ID to log into. Must be a member of `APPLE_TEAM`.
 * `APPLE_APP_PASSWORD` - An app-specific password to authenticate `notarytool` with.
 * `APPLE_TEAM` - The Team ID to notarize under. Must be the same team used to issue the Developer ID cert stored in `APPLE_DEVELOPER_KEY`.

Fortunately I was able to do this myself. This documentation is purely for anyone who needs to rotate these credentials.

This also sets a lower `MACOSX_DEPLOYMENT_TARGET` on Intel. Our current build system was setting both architectures to 11.0 on Intel, which shut out Catalina users as of #6451. (Finder does not enforce `minos` on bare executables for some reason?) We lower it to `10.7` because that's the lowest that Rust supports. (I tried `10.4` but the linker refuses to link in Rust toolchain libraries if we do this.)