### PR TITLE
macOS App Sandbox

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -84,11 +84,13 @@ jobs:
             os: macos-latest
             target: x86_64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 10.7
+            DESKTOP_FEATURES: sandbox
 
           - build_name: macos-aarch64
             os: macos-latest
             target: aarch64-apple-darwin
             MACOSX_DEPLOYMENT_TARGET: 11.0
+            DESKTOP_FEATURES: sandbox
 
           - build_name: windows-x86_32
             os: windows-latest
@@ -126,7 +128,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --package ruffle_desktop --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
+          args: --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -42,3 +42,5 @@ screenvideo =  ["ruffle_core/screenvideo"]
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]
 render_trace = ["ruffle_render_wgpu/render_trace"]
 
+# sandboxing
+sandbox = []

--- a/desktop/assets/macOSEntitlements.plist
+++ b/desktop/assets/macOSEntitlements.plist
@@ -5,5 +5,7 @@
         <true/>
         <key>com.apple.security.files.user-selected.read-only</key>
         <true/>
+        <key>com.apple.security.network.client</key>
+        <true/>
     </dict>
 </plist>

--- a/desktop/assets/macOSEntitlements.plist
+++ b/desktop/assets/macOSEntitlements.plist
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plist version="1.0">
     <dict>
+        <key>com.apple.security.app-sandbox</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-only</key>
+        <true/>
     </dict>
 </plist>


### PR DESCRIPTION
Enable App Sandbox on the release version of Ruffle.

This implies one major user-facing change: playing movies that load external files from the filesystem requires picking the containing directory. To facilitate this, we introduce a new `sandbox` feature that tells the user what the movie is trying to do, and asks if they want to allow it. This should be minimally disruptive.

Currently I'm only enabling the following two sandbox entitlements:

 * `com.apple.security.files.user-selected.read-only` - Ability to open file pickers and get access to files picked through them.
 * `com.apple.security.network.client` - Ability to open *outgoing* network connections. AFAIK this should allow HTTP movie loads from desktop but I haven't tested this yet. It should also work with #5160 and similar features.

If we implement some of Flash's other media features (e.g. webcam recording) we will need to expand our sandbox further.