### PR TITLE
web: Only polyfill `<object>` with `classid` when it doesn't contain another polyfillable object tag

### DIFF
--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -219,8 +219,11 @@ export class RuffleObject extends RufflePlayer {
         if (isFallbackElement(elem)) {
             return false;
         }
-        // Don't polyfill if there's already a <ruffle-embed> inside the <object>.
-        if (elem.getElementsByTagName("ruffle-embed").length > 0) {
+        // Don't polyfill if there's already a <ruffle-object> or a <ruffle-embed> inside the <object>.
+        if (
+            elem.getElementsByTagName("ruffle-object").length > 0 ||
+            elem.getElementsByTagName("ruffle-embed").length > 0
+        ) {
             return false;
         }
 
@@ -245,9 +248,15 @@ export class RuffleObject extends RufflePlayer {
         if (classid === FLASH_ACTIVEX_CLASSID.toLowerCase()) {
             // classid is an old-IE style embed that would not work on modern browsers.
             // Often there will be an <embed> inside the <object> that would take precedence.
-            // Only polyfill this <object> if it doesn't contain a polyfillable <embed>.
-            return !Array.from(elem.getElementsByTagName("embed")).some(
-                RuffleEmbed.isInterdictable
+            // Only polyfill this <object> if it doesn't contain a polyfillable <embed> or
+            // another <object> that would be supported on modern browsers.
+            return (
+                !Array.from(elem.getElementsByTagName("object")).some(
+                    RuffleObject.isInterdictable
+                ) &&
+                !Array.from(elem.getElementsByTagName("embed")).some(
+                    RuffleEmbed.isInterdictable
+                )
             );
         } else if (classid != null && classid !== "") {
             // Non-Flash classid.

--- a/web/packages/selfhosted/test/polyfill/object_double_object/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_double_object/expected.html
@@ -1,9 +1,6 @@
 <ruffle-object
-    classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+    data="/test_assets/example.swf"
     width="550"
     height="400"
 >
-    <param name="movie" value="/test_assets/example.swf" />
-    <param name="quality" value="high" />
-    <param name="menu" value="false" />
 </ruffle-object>

--- a/web/packages/selfhosted/test/polyfill/object_double_object/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_double_object/index.html
@@ -8,13 +8,10 @@
     <body>
         <div id="test-container">
             <object
-                classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+                data="/test_assets/example.swf"
                 width="550"
                 height="400"
             >
-                <param name="movie" value="/test_assets/example.swf" />
-                <param name="quality" value="high" />
-                <param name="menu" value="false" />
                 <object
                     type="application/x-shockwave-flash"
                     width="550"

--- a/web/packages/selfhosted/test/polyfill/object_double_object_classid/expected.html
+++ b/web/packages/selfhosted/test/polyfill/object_double_object_classid/expected.html
@@ -1,0 +1,18 @@
+<object
+    classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+    width="550"
+    height="400"
+>
+    <param name="movie" value="/test_assets/example.swf" />
+    <param name="quality" value="high" />
+    <param name="menu" value="false" />
+    <ruffle-object
+        type="application/x-shockwave-flash"
+        width="550"
+        height="400"
+    >
+        <param name="movie" value="/test_assets/example.swf" />
+        <param name="quality" value="high" />
+        <param name="menu" value="false" />
+    </ruffle-object>
+</object>

--- a/web/packages/selfhosted/test/polyfill/object_double_object_classid/index.html
+++ b/web/packages/selfhosted/test/polyfill/object_double_object_classid/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>OBJECT WITH ANOTHER OBJECT</title>
+    </head>
+
+    <body>
+        <div id="test-container">
+            <object
+                classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
+                width="550"
+                height="400"
+            >
+                <param name="movie" value="/test_assets/example.swf" />
+                <param name="quality" value="high" />
+                <param name="menu" value="false" />
+                <object
+                    type="application/x-shockwave-flash"
+                    width="550"
+                    height="400"
+                >
+                    <param name="movie" value="/test_assets/example.swf" />
+                    <param name="quality" value="high" />
+                    <param name="menu" value="false" />
+                </object>
+            </object>
+        </div>
+    </body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.js
+++ b/web/packages/selfhosted/test/polyfill/object_double_object_classid/test.js
@@ -1,0 +1,30 @@
+const {
+    inject_ruffle_and_wait,
+    open_test,
+    play_and_monitor,
+} = require("../../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Object using classid with another object tag without classid", () => {
+    it("loads the test", async () => {
+        await open_test(browser, __dirname);
+    });
+
+    it("polyfills only the second tag with ruffle", async () => {
+        await inject_ruffle_and_wait(browser);
+        const actual = await browser.$("#test-container").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+
+    it("Plays a movie", async () => {
+        await play_and_monitor(
+            browser,
+            await browser.$("#test-container").$("<ruffle-object />")
+        );
+    });
+});


### PR DESCRIPTION
Fixes the second part of #2220 and closes the issue.