### PR TITLE
core: Fix divide-by-zero in Video::seek (fix #6605)

### DIFF
--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -175,7 +175,11 @@ impl<'gc> Video<'gc> {
         };
 
         if let Some(num_frames) = num_frames {
-            frame_id %= num_frames as u32;
+            frame_id = if num_frames > 0 {
+                frame_id % num_frames as u32
+            } else {
+                0
+            }
         }
 
         let last_frame = read.decoded_frame.as_ref().map(|(lf, _)| *lf);


### PR DESCRIPTION
This SWF contains a video stream with zero frames, which caused a divide-by-zero in `Video::seek`.