### PR TITLE
extension: Allow loading SWFs in frames (fix #6582)

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -49,7 +49,7 @@ function enable() {
         onHeadersReceived,
         {
             urls: ["<all_urls>"],
-            types: ["main_frame"],
+            types: ["main_frame", "sub_frame"],
         },
         ["blocking", "responseHeaders"]
     );


### PR DESCRIPTION
If a frame directly loaded an SWF, it would not display in Ruffle.
Add `subframe` to the types intercepted by the `onHeaderReceived`
event in the background script so that Ruffle will display the SWF
in the frame.

Fixes #6582.