### PR TITLE
desktop: Use floats for audio start/endpoints calculation (fix #6569)

### DIFF
--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -565,12 +565,13 @@ impl EventSoundStream {
         skip_sample_frames: u16,
     ) -> Self {
         let skip_sample_frames: u32 = skip_sample_frames.into();
-        let sample_divisor = 44100 / u32::from(decoder.sample_rate());
-        let start_sample_frame =
-            settings.in_sample.unwrap_or(0) / sample_divisor + skip_sample_frames;
+        let sample_divisor = 44100.0 / f64::from(decoder.sample_rate());
+        let start_sample_frame = (f64::from(settings.in_sample.unwrap_or(0)) / sample_divisor)
+            as u32
+            + skip_sample_frames;
         let end_sample_frame = settings
             .out_sample
-            .map(|n| n / sample_divisor)
+            .map(|n| (f64::from(n) / sample_divisor) as u32)
             .unwrap_or(num_sample_frames)
             + skip_sample_frames;
 


### PR DESCRIPTION
Integer math was used when calculating a sound's start/endpoints,
because it was assumed that the sound sample rate was always an
even divisor of 44100Hz. However, some third party tools can embed
MP3s with other samples rates, such as #6569 which has a 16000Hz
MP3. This could also occur for dynamically loaded MP3s. This
results in the sound starting at an incorrect position.

Use floating point math to ensure the correct position is
caluclated.

Fixes #6569.