### PR TITLE
avm1: Format floating-point numbers

### DIFF
--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -1,36 +1,5 @@
 //! ECMA-262 compliant numerical conversions
 
-use std::borrow::Cow;
-
-/// Converts an `f64` to a String with (hopefully) the same output as Flash.
-/// For example, NAN returns `"NaN"`, and infinity returns `"Infinity"`.
-pub fn f64_to_string(n: f64) -> Cow<'static, str> {
-    if n.is_nan() {
-        Cow::Borrowed("NaN")
-    } else if n == f64::INFINITY {
-        Cow::Borrowed("Infinity")
-    } else if n == f64::NEG_INFINITY {
-        Cow::Borrowed("-Infinity")
-    } else if n != 0.0 && (n.abs() >= 1e15 || n.abs() < 1e-5) {
-        // Exponential notation.
-        // Cheating a bit here; Flash always put a sign in front of the exponent, e.g. 1e+15.
-        // Can't do this with rust format params, so shove it in there manually.
-        let mut s = format!("{:e}", n);
-        if let Some(i) = s.find('e') {
-            if s.as_bytes().get(i + 1) != Some(&b'-') {
-                s.insert(i + 1, '+');
-            }
-        }
-        Cow::Owned(s)
-    } else if n == 0.0 {
-        // As of Rust nightly 4/13, Rust can return "-0" for f64, which Flash doesn't want.
-        Cow::Borrowed("0")
-    } else {
-        // Normal number.
-        Cow::Owned(n.to_string())
-    }
-}
-
 /// Converts an `f64` to a `u8` with ECMAScript `ToUInt8` wrapping behavior.
 /// The value will be wrapped modulo 2^8.
 pub fn f64_to_wrapping_u8(n: f64) -> u8 {


### PR DESCRIPTION
This PR is an attempt at formatting floating-point numbers, trying to match what Flash does in AVM1. For instance:
- `(0.7 - 0.5)` equals to 0.19999999999999996 but is formatted as 0.2 (as the number of decimals is 15 at most).
- `100000.12345678912` is formatted as 100000.123456789 (the number of decimals is decreased here because of the number of digits in... the whole part).

There are unfortunately some cases that still fail with this PR:
- `0.8000000000000005` should be 0.800000000000001 but this PR formats it as 0.8.
- `0.8300000000000005` should be 0.83 but this PR formats it as 0.830000000000001.

[Here's a test](https://github.com/ruffle-rs/ruffle/files/8409951/numbers_test.zip) showing the improvements and the cases that are still incorrect.

There's definitely room for improvement - at least for code optimization.

Fixes the "broken" numbers in #1374.