### PR TITLE
avm2: Add stubs for `BitmapFilter`, `GlowFilter`, and `DisplayObject.filters`

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -828,6 +828,18 @@ pub fn load_player_globals<'gc>(
         script,
     )?;
 
+    // package `flash.filters`
+    class(
+        activation,
+        flash::filters::bitmapfilter::create_class(mc),
+        script,
+    )?;
+    class(
+        activation,
+        flash::filters::glowfilter::create_class(mc),
+        script,
+    )?;
+
     // package `flash.geom`
     class(activation, flash::geom::matrix::create_class(mc), script)?;
     avm2_system_class!(

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -4,6 +4,7 @@ pub mod crypto;
 pub mod display;
 pub mod events;
 pub mod external;
+pub mod filters;
 pub mod geom;
 pub mod media;
 pub mod net;

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -236,6 +236,26 @@ pub fn set_scale_x<'gc>(
     Ok(Value::Undefined)
 }
 
+/// Implements `filters`'s getter.
+pub fn filters<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("DisplayObject.filters getter - not yet implemented");
+    Ok(Value::Undefined)
+}
+
+/// Implements `filters`'s setter.
+pub fn set_filters<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("DisplayObject.filters setter - not yet implemented");
+    Ok(Value::Undefined)
+}
+
 /// Implements `x`'s getter.
 pub fn x<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
@@ -618,6 +638,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("mouseX", Some(mouse_x), None),
         ("mouseY", Some(mouse_y), None),
         ("loaderInfo", Some(loader_info), None),
+        ("filters", Some(filters), Some(set_filters)),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/filters.rs
+++ b/core/src/avm2/globals/flash/filters.rs
@@ -1,0 +1,4 @@
+//! `flash.filters` namespace
+
+pub mod bitmapfilter;
+pub mod glowfilter;

--- a/core/src/avm2/globals/flash/filters/bitmapfilter.rs
+++ b/core/src/avm2/globals/flash/filters/bitmapfilter.rs
@@ -1,0 +1,39 @@
+//! `flash.filters.BitmapFilter` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.filters.BitmapFilter`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.filters.BitmapFilter`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.filters"), "BitmapFilter"),
+        Some(QName::new(Namespace::public(), "Object").into()),
+        Method::from_builtin(instance_init, "<BitmapFilter instance initializer>", mc),
+        Method::from_builtin(class_init, "<BitmapFilter class initializer>", mc),
+        mc,
+    );
+
+    class
+}

--- a/core/src/avm2/globals/flash/filters/glowfilter.rs
+++ b/core/src/avm2/globals/flash/filters/glowfilter.rs
@@ -1,0 +1,42 @@
+//! `flash.filters.GlowFilter` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::value::Value;
+use crate::avm2::{Error, Object};
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.filters.GlowFilter`'s class constructor.
+pub fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.filters.GlowFilter`'s instance constructor.
+pub fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.filters"), "GlowFilter"),
+        Some(QName::new(Namespace::package("flash.filters"), "BitmapFilter").into()),
+        Method::from_builtin(instance_init, "<GlowFilter instance initializer>", mc),
+        Method::from_builtin(class_init, "<GlowFilter class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
+
+    class
+}


### PR DESCRIPTION
This gets 'Rolling Hero' further in the startup process,
since it just tries to set a filter on an object.