### PR TITLE
avm1: Fix `Number(String | Object)` in SWFv4

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -149,6 +149,15 @@ impl<'gc> Value<'gc> {
         let v = match self {
             Value::Undefined if activation.swf_version() < 7 => return 0.0,
             Value::Null if activation.swf_version() < 7 => return 0.0,
+            Value::Object(_) if activation.swf_version() < 5 => return 0.0,
+            Value::String(v) if activation.swf_version() < 5 => {
+                use crate::avm1::globals::parse_float_impl;
+                let result = parse_float_impl(v.trim_start(), true);
+                if result.is_nan() {
+                    return 0.0;
+                }
+                return result;
+            }
             Value::Undefined => return f64::NAN,
             Value::Null => return f64::NAN,
             Value::Bool(false) => return 0.0,


### PR DESCRIPTION
Closes #6286.

This also fixes `int(String)` in SWFv4 when the string is something like "345ABC" (it now returns 345).

[Here is a test](https://github.com/ruffle-rs/ruffle/files/8446418/swf4_test.zip) made with JPEXS (includes the .swf, code as .txt and output) that could eventually be added (a .fla would be better but I don't know if the Flash editor would let you use `ToNumber` as this action code was only added in SWFv5).

