### PR TITLE
web: Bump wasm-bindgen to 0.2.80

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -282,7 +282,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: wasm-bindgen-cli --version 0.2.78
+          args: wasm-bindgen-cli --version 0.2.80
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -55,7 +55,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.78
+        run: cargo install wasm-bindgen-cli --version 0.2.80
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3852,9 +3852,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3864,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3879,9 +3879,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3891,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3901,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3914,9 +3914,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wayland-client"
@@ -3999,9 +3999,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,7 +58,7 @@ default-features = false # can't use rayon on web
 version = "0.3.21"
 
 [target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen-futures]
-version = "0.4"
+version = "0.4.30"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -11,13 +11,13 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 base64 = "0.13.0"
 fnv = "1.0.7"
-js-sys = "0.3.55"
+js-sys = "0.3.57"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 svg = "0.10.0"
 percent-encoding = "2.1.0"
 png = "0.17.5"
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = "=0.2.80"
 
 [dependencies.jpeg-decoder]
 version = "0.2.4"
@@ -28,7 +28,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.57"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
     "Document", "Element", "HtmlCanvasElement", "HtmlImageElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.55"
+js-sys = "0.3.57"
 log = "0.4"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = "=0.2.80"
 bytemuck = { version = "1.9.1", features = ["derive"] }
 
 [dependencies.ruffle_core]
@@ -18,7 +18,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.57"
 features = [
     "HtmlCanvasElement", "OesVertexArrayObject", "WebGl2RenderingContext", "WebGlBuffer", "WebglDebugRendererInfo",
     "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGlShader", "WebGlTexture",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -27,10 +27,10 @@ version = "0.12"
 
 # wasm
 [target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen-futures]
-version = "0.4"
+version = "0.4.30"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3"
+version = "0.3.57"
 features = ["HtmlCanvasElement"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -32,15 +32,15 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"
 generational-arena = "0.2.8"
-js-sys = "0.3.55"
+js-sys = "0.3.57"
 log = { version = "0.4", features = ["serde"] }
 ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 url = "2.2.2"
-wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.28"
+wasm-bindgen = { version = "=0.2.80", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.30"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.136", features = ["derive"] }
@@ -53,7 +53,7 @@ default-features = false
 features = ["h263", "vp6", "screenvideo", "wasm-bindgen"]
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.57"
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext", "AudioDestinationNode",
     "AudioNode", "AudioParam", "AudioProcessingEvent", "Blob", "BlobPropertyBag", "ChannelMergerNode",

--- a/web/README.md
+++ b/web/README.md
@@ -58,7 +58,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.78`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.80`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.55"
+js-sys = "0.3.57"
 log = "0.4"
-wasm-bindgen = "=0.2.78"
+wasm-bindgen = "=0.2.80"
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3.57"
 features = ["Window"]


### PR DESCRIPTION
As usual, also bump its helper crates (`js-sys`, `web-sys` and
`wasm-bindgen-futures`) to the latest versions.