### PR TITLE
web: Use `Uint8Array::to_vec()` over `Uint8Array::copy_to()`

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -240,19 +240,14 @@ impl Ruffle {
     ///
     /// This method should only be called once per player.
     pub fn load_data(&mut self, swf_data: Uint8Array, parameters: &JsValue) -> Result<(), JsValue> {
-        let movie = Arc::new({
-            let mut data = vec![0; swf_data.length() as usize];
-            swf_data.copy_to(&mut data[..]);
-            let mut movie = SwfMovie::from_data(&data, None, None)
-                .map_err(|e| format!("Error loading movie: {}", e))?;
-            movie.append_parameters(parse_movie_parameters(parameters));
-            movie
-        });
+        let mut movie = SwfMovie::from_data(&swf_data.to_vec(), None, None)
+            .map_err(|e| format!("Error loading movie: {}", e))?;
+        movie.append_parameters(parse_movie_parameters(parameters));
 
         self.on_metadata(movie.header());
 
         let _ = self.with_core_mut(move |core| {
-            core.set_root_movie(movie);
+            core.set_root_movie(Arc::new(movie));
         });
 
         Ok(())

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -219,11 +219,7 @@ impl NavigatorBackend for WebNavigatorBackend {
                 .dyn_into()
                 .unwrap();
 
-            let jsarray = Uint8Array::new(&data);
-            let mut rust_array = vec![0; jsarray.length() as usize];
-            jsarray.copy_to(&mut rust_array);
-
-            Ok(rust_array)
+            Ok(Uint8Array::new(&data).to_vec())
         })
     }
 


### PR DESCRIPTION
It's shorter and should be more efficient (allocates an uninitialized
buffer instead of a zeroed one).