### PR TITLE
xml: Refactor `XmlNode` creation methods

### DIFF
--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -8,7 +8,7 @@ use crate::avm1::{Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::RequestOptions;
 use crate::string::{AvmString, WStr};
-use crate::xml::XmlNode;
+use crate::xml::{XmlNode, ELEMENT_NODE, TEXT_NODE};
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -58,12 +58,11 @@ fn create_element<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(_document) = this.as_xml() {
-        let nodename = args
-            .get(0)
-            .map(|v| v.coerce_to_string(activation).unwrap_or_default())
-            .unwrap_or_default();
-        let mut xml_node = XmlNode::new_element(activation.context.gc_context, nodename);
-        return Ok(xml_node.script_object(activation).into());
+        if let Some(name) = args.get(0) {
+            let name = name.coerce_to_string(activation)?;
+            let mut node = XmlNode::new(activation.context.gc_context, ELEMENT_NODE, Some(name));
+            return Ok(node.script_object(activation).into());
+        }
     }
 
     Ok(Value::Undefined)
@@ -75,12 +74,11 @@ fn create_text_node<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(_document) = this.as_xml() {
-        let text_node = args
-            .get(0)
-            .map(|v| v.coerce_to_string(activation).unwrap_or_default())
-            .unwrap_or_default();
-        let mut xml_node = XmlNode::new_text(activation.context.gc_context, text_node);
-        return Ok(xml_node.script_object(activation).into());
+        if let Some(text) = args.get(0) {
+            let text = text.coerce_to_string(activation)?;
+            let mut node = XmlNode::new(activation.context.gc_context, TEXT_NODE, Some(text));
+            return Ok(node.script_object(activation).into());
+        }
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/object/xml_node_object.rs
+++ b/core/src/avm1/object/xml_node_object.rs
@@ -5,8 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::TObject;
 use crate::avm1::{Object, ScriptObject};
 use crate::impl_custom_object;
-use crate::string::AvmString;
-use crate::xml::XmlNode;
+use crate::xml::{XmlNode, TEXT_NODE};
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
 
@@ -61,7 +60,7 @@ impl<'gc> TObject<'gc> for XmlNodeObject<'gc> {
     ) -> Result<Object<'gc>, Error<'gc>> {
         Ok(Self::from_xml_node(
             activation.context.gc_context,
-            XmlNode::new_text(activation.context.gc_context, AvmString::default()),
+            XmlNode::new(activation.context.gc_context, TEXT_NODE, Some("".into())),
             Some(this),
         )
         .into())

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -4,7 +4,7 @@ use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::{Object, TObject};
 use crate::ecma_conversions::{
     f64_to_string, f64_to_wrapping_i16, f64_to_wrapping_i32, f64_to_wrapping_u16,
-    f64_to_wrapping_u32,
+    f64_to_wrapping_u32, f64_to_wrapping_u8,
 };
 use crate::string::{AvmString, Integer, WStr};
 use gc_arena::Collect;
@@ -376,6 +376,10 @@ impl<'gc> Value<'gc> {
         } else {
             (value as i32).into()
         }
+    }
+
+    pub fn coerce_to_u8(&self, activation: &mut Activation<'_, 'gc, '_>) -> Result<u8, Error<'gc>> {
+        self.coerce_to_f64(activation).map(f64_to_wrapping_u8)
     }
 
     /// Coerce a number to an `u16` following the ECMAScript specifications for `ToUInt16`.

--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -31,6 +31,16 @@ pub fn f64_to_string(n: f64) -> Cow<'static, str> {
     }
 }
 
+/// Converts an `f64` to a `u8` with ECMAScript `ToUInt8` wrapping behavior.
+/// The value will be wrapped modulo 2^8.
+pub fn f64_to_wrapping_u8(n: f64) -> u8 {
+    if !n.is_finite() {
+        0
+    } else {
+        n.trunc().rem_euclid(256.0) as u8
+    }
+}
+
 /// Converts an `f64` to a `u16` with ECMAScript `ToUInt16` wrapping behavior.
 /// The value will be wrapped modulo 2^16.
 pub fn f64_to_wrapping_u16(n: f64) -> u16 {

--- a/core/src/xml.rs
+++ b/core/src/xml.rs
@@ -3,4 +3,4 @@
 mod iterators;
 mod tree;
 
-pub use tree::XmlNode;
+pub use tree::{XmlNode, ELEMENT_NODE, TEXT_NODE};


### PR DESCRIPTION
Unify the previous 3 creation methods to a single `XmlNode::new`.
This allows supporting arbitrary `nodeType` values passed to the
`XMLNode` constructor.