### PR TITLE
render: Handle gradient/bitmap strokes

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -291,21 +291,20 @@ fn line_style<'gc>(
             Some(v) if v == b"bevel" => LineJoinStyle::Bevel,
             _ => LineJoinStyle::Round,
         };
+        let line_style = LineStyle::new()
+            .with_width(width)
+            .with_color(color)
+            .with_start_cap(cap_style)
+            .with_end_cap(cap_style)
+            .with_join_style(join_style)
+            .with_allow_scale_x(allow_scale_x)
+            .with_allow_scale_y(allow_scale_y)
+            .with_is_pixel_hinted(is_pixel_hinted)
+            .with_allow_close(false);
         movie_clip
             .as_drawing(activation.context.gc_context)
             .unwrap()
-            .set_line_style(Some(LineStyle {
-                width,
-                color,
-                start_cap: cap_style,
-                end_cap: cap_style,
-                join_style,
-                fill_style: None,
-                allow_scale_x,
-                allow_scale_y,
-                is_pixel_hinted,
-                allow_close: false,
-            }));
+            .set_line_style(Some(line_style));
     } else {
         movie_clip
             .as_drawing(activation.context.gc_context)

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -248,18 +248,16 @@ fn line_style<'gc>(
             let join_style = joints_to_join_style(activation, joints, miter_limit)?;
             let (allow_scale_x, allow_scale_y) = scale_mode_to_allow_scale_bits(&scale_mode)?;
 
-            let line_style = LineStyle {
-                width,
-                color,
-                start_cap: caps,
-                end_cap: caps,
-                join_style,
-                fill_style: None,
-                allow_scale_x,
-                allow_scale_y,
-                is_pixel_hinted,
-                allow_close: true,
-            };
+            let line_style = LineStyle::new()
+                .with_width(width)
+                .with_color(color)
+                .with_start_cap(caps)
+                .with_end_cap(caps)
+                .with_join_style(join_style)
+                .with_allow_scale_x(allow_scale_x)
+                .with_allow_scale_y(allow_scale_y)
+                .with_is_pixel_hinted(is_pixel_hinted)
+                .with_allow_close(false);
 
             if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
                 draw.set_line_style(Some(line_style));

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -705,10 +705,11 @@ impl<'gc> EditText<'gc> {
             let background_color = write.background_color;
 
             if write.has_border {
-                write.drawing.set_line_style(Some(swf::LineStyle::new_v1(
-                    Twips::new(1),
-                    swf::Color::from_rgb(border_color, 0xFF),
-                )));
+                write.drawing.set_line_style(Some(
+                    swf::LineStyle::new()
+                        .with_width(Twips::new(1))
+                        .with_color(swf::Color::from_rgb(border_color, 0xFF)),
+                ));
             } else {
                 write.drawing.set_line_style(None);
             }

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -204,17 +204,11 @@ impl MorphShapeStatic {
             .line_styles
             .iter()
             .zip(self.end.line_styles.iter())
-            .map(|(start, end)| LineStyle {
-                width: lerp_twips(start.width, end.width, a, b),
-                color: lerp_color(&start.color, &end.color, a, b),
-                start_cap: start.start_cap,
-                end_cap: start.end_cap,
-                join_style: start.join_style,
-                fill_style: None,
-                allow_scale_x: start.allow_scale_x,
-                allow_scale_y: start.allow_scale_y,
-                is_pixel_hinted: start.is_pixel_hinted,
-                allow_close: start.allow_close,
+            .map(|(start, end)| {
+                start
+                    .clone()
+                    .with_width(lerp_twips(start.width(), end.width(), a, b))
+                    .with_fill_style(lerp_fill(start.fill_style(), end.fill_style(), a, b))
             })
             .collect();
 

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -177,7 +177,7 @@ impl Drawing {
         // Add command to current line.
         let stroke_width = if let Some(line) = &mut self.current_line {
             line.commands.push(command.clone());
-            line.style.width
+            line.style.width()
         } else {
             Twips::ZERO
         };
@@ -310,7 +310,7 @@ impl Drawing {
                 DrawingPath::Line(line) => {
                     if shape_utils::draw_command_stroke_hit_test(
                         &line.commands,
-                        line.style.width,
+                        line.style.width(),
                         point,
                         local_matrix,
                     ) {
@@ -330,7 +330,7 @@ impl Drawing {
         for line in &self.pending_lines {
             if shape_utils::draw_command_stroke_hit_test(
                 &line.commands,
-                line.style.width,
+                line.style.width(),
                 point,
                 local_matrix,
             ) {
@@ -341,7 +341,7 @@ impl Drawing {
         if let Some(line) = &self.current_line {
             if shape_utils::draw_command_stroke_hit_test(
                 &line.commands,
-                line.style.width,
+                line.style.width(),
                 point,
                 local_matrix,
             ) {
@@ -362,7 +362,7 @@ impl Drawing {
                             y: self.fill_start.1,
                         },
                     ],
-                    line.style.width,
+                    line.style.width(),
                     point,
                     local_matrix,
                 )

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -145,10 +145,11 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
         let mut line_drawing = Drawing::new();
         let mut has_underline: bool = false;
 
-        line_drawing.set_line_style(Some(swf::LineStyle::new_v1(
-            Twips::new(1),
-            swf::Color::from_rgb(0, 255),
-        )));
+        line_drawing.set_line_style(Some(
+            swf::LineStyle::new()
+                .with_width(Twips::new(1))
+                .with_color(swf::Color::from_rgb(0, 255)),
+        ));
 
         if let Some(linelist) = self.boxes.get(self.current_line..) {
             for linebox in linelist {

--- a/core/src/shape_utils.rs
+++ b/core/src/shape_utils.rs
@@ -761,7 +761,7 @@ pub fn shape_hit_test(
                     stroke_width = if i > 0 {
                         // Flash renders strokes with a 1px minimum width.
                         if let Some(line_style) = line_styles.get(i as usize - 1) {
-                            let width = line_style.width.get() as f64;
+                            let width = line_style.width().get() as f64;
                             let scaled_width = 0.5 * width.max(min_width);
                             Some((scaled_width, scaled_width * scaled_width))
                         } else {

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -1219,20 +1219,22 @@ fn swf_shape_to_svg(
                 // strokes end up rendering very faintly if we use the actual width of 1 twip.
                 // Therefore, we clamp the stroke width to 1 pixel (20 twips). This won't be 100% accurate
                 // if the shape is scaled, but it looks much closer to the Flash Player.
-                let stroke_width = std::cmp::max(style.width.get(), 20);
+                let stroke_width = std::cmp::max(style.width().get(), 20);
+                let color = if let FillStyle::Color(color) = style.fill_style() {
+                    color.clone()
+                } else {
+                    Color::from_rgba(0)
+                };
                 let mut svg_path = SvgPath::new()
                     .set("fill", "none")
                     .set(
                         "stroke",
-                        format!(
-                            "rgba({},{},{},{})",
-                            style.color.r, style.color.g, style.color.b, style.color.a
-                        ),
+                        format!("rgba({},{},{},{})", color.r, color.g, color.b, color.a),
                     )
                     .set("stroke-width", stroke_width)
                     .set(
                         "stroke-linecap",
-                        match style.start_cap {
+                        match style.start_cap() {
                             LineCapStyle::Round => "round",
                             LineCapStyle::Square => "square",
                             LineCapStyle::None => "butt",
@@ -1240,14 +1242,14 @@ fn swf_shape_to_svg(
                     )
                     .set(
                         "stroke-linejoin",
-                        match style.join_style {
+                        match style.join_style() {
                             LineJoinStyle::Round => "round",
                             LineJoinStyle::Bevel => "bevel",
                             LineJoinStyle::Miter(_) => "miter",
                         },
                     );
 
-                if let LineJoinStyle::Miter(miter_limit) = style.join_style {
+                if let LineJoinStyle::Miter(miter_limit) = style.join_style() {
                     svg_path = svg_path.set("stroke-miterlimit", miter_limit.to_f32());
                 }
 
@@ -1480,23 +1482,25 @@ fn swf_shape_to_canvas_commands(
                 // strokes end up rendering very faintly if we use the actual width of 1 twip.
                 // Therefore, we clamp the stroke width to 1 pixel (20 twips). This won't be 100% accurate
                 // if the shape is scaled, but it looks much closer to the Flash Player.
-                let line_width = std::cmp::max(style.width.get(), 20);
+                let line_width = std::cmp::max(style.width().get(), 20);
+                let color = if let FillStyle::Color(color) = style.fill_style() {
+                    color.clone()
+                } else {
+                    Color::from_rgba(0)
+                };
                 let stroke_style = CanvasColor(
-                    format!(
-                        "rgba({},{},{},{})",
-                        style.color.r, style.color.g, style.color.b, style.color.a
-                    ),
-                    style.color.r,
-                    style.color.g,
-                    style.color.b,
-                    style.color.a,
+                    format!("rgba({},{},{},{})", color.r, color.g, color.b, color.a),
+                    color.r,
+                    color.g,
+                    color.b,
+                    color.a,
                 );
-                let line_cap = match style.start_cap {
+                let line_cap = match style.start_cap() {
                     LineCapStyle::Round => "round",
                     LineCapStyle::Square => "square",
                     LineCapStyle::None => "butt",
                 };
-                let (line_join, miter_limit) = match style.join_style {
+                let (line_join, miter_limit) = match style.join_style() {
                     LineJoinStyle::Round => ("round", 999_999.0),
                     LineJoinStyle::Bevel => ("bevel", 999_999.0),
                     LineJoinStyle::Miter(ml) => ("miter", ml.to_f32()),

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -11,6 +11,8 @@ use ruffle_core::shape_utils::{DistilledShape, DrawCommand, DrawPath};
 pub struct ShapeTessellator {
     fill_tess: FillTessellator,
     stroke_tess: StrokeTessellator,
+    mesh: Vec<Draw>,
+    lyon_mesh: VertexBuffers<Vertex, u32>,
 }
 
 impl ShapeTessellator {
@@ -18,6 +20,8 @@ impl ShapeTessellator {
         Self {
             fill_tess: FillTessellator::new(),
             stroke_tess: StrokeTessellator::new(),
+            mesh: Vec::new(),
+            lyon_mesh: VertexBuffers::new(),
         }
     }
 
@@ -26,197 +30,101 @@ impl ShapeTessellator {
         shape: DistilledShape,
         bitmap_source: &dyn BitmapSource,
     ) -> Mesh {
-        let mut mesh = Vec::new();
-
-        let mut lyon_mesh: VertexBuffers<_, u32> = VertexBuffers::new();
-
-        fn flush_draw(draw: DrawType, mesh: &mut Mesh, lyon_mesh: &mut VertexBuffers<Vertex, u32>) {
-            if lyon_mesh.vertices.is_empty() || lyon_mesh.indices.len() < 3 {
-                return;
-            }
-
-            let draw_mesh = std::mem::replace(lyon_mesh, VertexBuffers::new());
-            mesh.push(Draw {
-                draw_type: draw,
-                vertices: draw_mesh.vertices,
-                indices: draw_mesh.indices,
-            });
-        }
-
+        self.mesh = Vec::new();
+        self.lyon_mesh = VertexBuffers::new();
         for path in shape.paths {
-            match path {
-                DrawPath::Fill { style, commands } => match style {
-                    swf::FillStyle::Color(color) => {
-                        let mut buffers_builder = BuffersBuilder::new(
-                            &mut lyon_mesh,
-                            RuffleVertexCtor {
-                                color: color.clone(),
-                            },
-                        );
-
-                        if let Err(e) = self.fill_tess.tessellate_path(
-                            &ruffle_path_to_lyon_path(commands, true),
-                            &FillOptions::even_odd(),
-                            &mut buffers_builder,
-                        ) {
-                            // This may just be a degenerate path; skip it.
-                            log::error!("Tessellation failure: {:?}", e);
-                            continue;
-                        }
-                    }
-                    swf::FillStyle::LinearGradient(gradient) => {
-                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                        let mut buffers_builder = BuffersBuilder::new(
-                            &mut lyon_mesh,
-                            RuffleVertexCtor {
-                                color: swf::Color::from_rgb(0xffffff, 255),
-                            },
-                        );
-
-                        if let Err(e) = self.fill_tess.tessellate_path(
-                            &ruffle_path_to_lyon_path(commands, true),
-                            &FillOptions::even_odd(),
-                            &mut buffers_builder,
-                        ) {
-                            // This may just be a degenerate path; skip it.
-                            log::error!("Tessellation failure: {:?}", e);
-                            continue;
-                        }
-
-                        flush_draw(
-                            DrawType::Gradient(swf_gradient_to_uniforms(
-                                GradientType::Linear,
-                                gradient,
-                                swf::Fixed8::ZERO,
-                            )),
-                            &mut mesh,
-                            &mut lyon_mesh,
-                        );
-                    }
-                    swf::FillStyle::RadialGradient(gradient) => {
-                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                        let mut buffers_builder = BuffersBuilder::new(
-                            &mut lyon_mesh,
-                            RuffleVertexCtor {
-                                color: swf::Color::from_rgb(0xffffff, 255),
-                            },
-                        );
-
-                        if let Err(e) = self.fill_tess.tessellate_path(
-                            &ruffle_path_to_lyon_path(commands, true),
-                            &FillOptions::even_odd(),
-                            &mut buffers_builder,
-                        ) {
-                            // This may just be a degenerate path; skip it.
-                            log::error!("Tessellation failure: {:?}", e);
-                            continue;
-                        }
-
-                        flush_draw(
-                            DrawType::Gradient(swf_gradient_to_uniforms(
-                                GradientType::Radial,
-                                gradient,
-                                swf::Fixed8::ZERO,
-                            )),
-                            &mut mesh,
-                            &mut lyon_mesh,
-                        );
-                    }
-                    swf::FillStyle::FocalGradient {
-                        gradient,
-                        focal_point,
-                    } => {
-                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                        let mut buffers_builder = BuffersBuilder::new(
-                            &mut lyon_mesh,
-                            RuffleVertexCtor {
-                                color: swf::Color::from_rgb(0xffffff, 255),
-                            },
-                        );
-
-                        if let Err(e) = self.fill_tess.tessellate_path(
-                            &ruffle_path_to_lyon_path(commands, true),
-                            &FillOptions::even_odd(),
-                            &mut buffers_builder,
-                        ) {
-                            // This may just be a degenerate path; skip it.
-                            log::error!("Tessellation failure: {:?}", e);
-                            continue;
-                        }
-
-                        flush_draw(
-                            DrawType::Gradient(swf_gradient_to_uniforms(
-                                GradientType::Focal,
-                                gradient,
-                                *focal_point,
-                            )),
-                            &mut mesh,
-                            &mut lyon_mesh,
-                        );
-                    }
-                    swf::FillStyle::Bitmap {
-                        id,
-                        matrix,
-                        is_smoothed,
-                        is_repeating,
-                    } => {
-                        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
-
-                        let mut buffers_builder = BuffersBuilder::new(
-                            &mut lyon_mesh,
-                            RuffleVertexCtor {
-                                color: swf::Color::from_rgb(0xffffff, 255),
-                            },
-                        );
-
-                        if let Err(e) = self.fill_tess.tessellate_path(
-                            &ruffle_path_to_lyon_path(commands, true),
-                            &FillOptions::even_odd(),
-                            &mut buffers_builder,
-                        ) {
-                            // This may just be a degenerate path; skip it.
-                            log::error!("Tessellation failure: {:?}", e);
-                            continue;
-                        }
-
-                        if let Some(bitmap) = bitmap_source.bitmap(*id) {
-                            flush_draw(
-                                DrawType::Bitmap(Bitmap {
-                                    matrix: swf_bitmap_to_gl_matrix(
-                                        (*matrix).into(),
-                                        bitmap.width.into(),
-                                        bitmap.height.into(),
-                                    ),
-                                    bitmap: bitmap.handle,
-                                    is_smoothed: *is_smoothed,
-                                    is_repeating: *is_repeating,
-                                }),
-                                &mut mesh,
-                                &mut lyon_mesh,
-                            );
-                        }
-                    }
-                },
+            let (fill_style, lyon_path) = match &path {
+                DrawPath::Fill { style, commands } => {
+                    (*style, ruffle_path_to_lyon_path(commands, true))
+                }
                 DrawPath::Stroke {
                     style,
                     commands,
                     is_closed,
-                } => {
-                    let color = if let swf::FillStyle::Color(color) = &style.fill_style() {
-                        color.clone()
-                    } else {
-                        swf::Color::from_rgba(0)
-                    };
-                    let mut buffers_builder =
-                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
+                } => (
+                    style.fill_style(),
+                    ruffle_path_to_lyon_path(&commands, *is_closed),
+                ),
+            };
 
+            const WHITE: swf::Color = swf::Color::from_rgba(0xffffffff);
+            let (draw, color, needs_flush) = match fill_style {
+                swf::FillStyle::Color(color) => (DrawType::Color, color.clone(), false),
+                swf::FillStyle::LinearGradient(gradient) => (
+                    DrawType::Gradient(swf_gradient_to_uniforms(
+                        GradientType::Linear,
+                        gradient,
+                        swf::Fixed8::ZERO,
+                    )),
+                    WHITE,
+                    true,
+                ),
+                swf::FillStyle::RadialGradient(gradient) => (
+                    DrawType::Gradient(swf_gradient_to_uniforms(
+                        GradientType::Radial,
+                        gradient,
+                        swf::Fixed8::ZERO,
+                    )),
+                    WHITE,
+                    true,
+                ),
+                swf::FillStyle::FocalGradient {
+                    gradient,
+                    focal_point,
+                } => (
+                    DrawType::Gradient(swf_gradient_to_uniforms(
+                        GradientType::Focal,
+                        gradient,
+                        *focal_point,
+                    )),
+                    WHITE,
+                    true,
+                ),
+                swf::FillStyle::Bitmap {
+                    id,
+                    matrix,
+                    is_smoothed,
+                    is_repeating,
+                } => {
+                    if let Some(bitmap) = bitmap_source.bitmap(*id) {
+                        (
+                            DrawType::Bitmap(Bitmap {
+                                matrix: swf_bitmap_to_gl_matrix(
+                                    (*matrix).into(),
+                                    bitmap.width.into(),
+                                    bitmap.height.into(),
+                                ),
+                                bitmap: bitmap.handle,
+                                is_smoothed: *is_smoothed,
+                                is_repeating: *is_repeating,
+                            }),
+                            WHITE,
+                            true,
+                        )
+                    } else {
+                        // Missing bitmap -- incorrect character ID in SWF?
+                        continue;
+                    }
+                }
+            };
+
+            if needs_flush {
+                // Non-solid color fills are isolated draw calls, so flush any pending color fill.
+                self.flush_draw(DrawType::Color);
+            }
+
+            let mut buffers_builder =
+                BuffersBuilder::new(&mut self.lyon_mesh, RuffleVertexCtor { color });
+            let result = match path {
+                DrawPath::Fill { .. } => self.fill_tess.tessellate_path(
+                    &lyon_path,
+                    &FillOptions::even_odd(),
+                    &mut buffers_builder,
+                ),
+                DrawPath::Stroke { style, .. } => {
                     // TODO(Herschel): 0 width indicates "hairline".
                     let width = (style.width().to_pixels() as f32).max(1.0);
-
-                    let mut options = StrokeOptions::default()
+                    let mut stroke_options = StrokeOptions::default()
                         .with_line_width(width)
                         .with_start_cap(match style.start_cap() {
                             swf::LineCapStyle::None => tessellation::LineCap::Butt,
@@ -236,31 +144,53 @@ impl ShapeTessellator {
                             // Avoid lyon assert with small miter limits.
                             let limit = limit.to_f32();
                             if limit >= StrokeOptions::MINIMUM_MITER_LIMIT {
-                                options = options.with_miter_limit(limit);
+                                stroke_options = stroke_options.with_miter_limit(limit);
                                 tessellation::LineJoin::MiterClip
                             } else {
                                 tessellation::LineJoin::Bevel
                             }
                         }
                     };
-                    options = options.with_line_join(line_join);
-
-                    if let Err(e) = self.stroke_tess.tessellate_path(
-                        &ruffle_path_to_lyon_path(commands, is_closed),
-                        &options,
+                    stroke_options = stroke_options.with_line_join(line_join);
+                    self.stroke_tess.tessellate_path(
+                        &lyon_path,
+                        &stroke_options,
                         &mut buffers_builder,
-                    ) {
-                        // This may just be a degenerate path; skip it.
-                        log::error!("Tessellation failure: {:?}", e);
-                        continue;
+                    )
+                }
+            };
+            match result {
+                Ok(_) => {
+                    if needs_flush {
+                        // Non-solid color fills are isolated draw calls; flush immediately.
+                        self.flush_draw(draw);
                     }
+                }
+                Err(e) => {
+                    // This may simply be a degenerate path.
+                    log::error!("Tessellation failure: {:?}", e);
                 }
             }
         }
 
-        flush_draw(DrawType::Color, &mut mesh, &mut lyon_mesh);
+        // Flush the final pending draw.
+        self.flush_draw(DrawType::Color);
 
-        mesh
+        self.lyon_mesh = VertexBuffers::new();
+        std::mem::take(&mut self.mesh)
+    }
+
+    fn flush_draw(&mut self, draw: DrawType) {
+        if self.lyon_mesh.vertices.is_empty() || self.lyon_mesh.indices.len() < 3 {
+            // Ignore degenerate fills
+            return;
+        }
+        let draw_mesh = std::mem::replace(&mut self.lyon_mesh, VertexBuffers::new());
+        self.mesh.push(Draw {
+            draw_type: draw,
+            vertices: draw_mesh.vertices,
+            indices: draw_mesh.indices,
+        });
     }
 }
 
@@ -375,7 +305,7 @@ fn swf_bitmap_to_gl_matrix(
     [[a, d, 0.0], [b, e, 0.0], [c, f, 1.0]]
 }
 
-fn ruffle_path_to_lyon_path(commands: Vec<DrawCommand>, is_closed: bool) -> Path {
+fn ruffle_path_to_lyon_path(commands: &[DrawCommand], is_closed: bool) -> Path {
     fn point(x: swf::Twips, y: swf::Twips) -> lyon::math::Point {
         lyon::math::Point::new(x.to_pixels() as f32, y.to_pixels() as f32)
     }
@@ -383,7 +313,7 @@ fn ruffle_path_to_lyon_path(commands: Vec<DrawCommand>, is_closed: bool) -> Path
     let mut builder = Path::builder();
     let mut move_to = Some((swf::Twips::default(), swf::Twips::default()));
     for cmd in commands {
-        match cmd {
+        match *cmd {
             DrawCommand::MoveTo { x, y } => {
                 if move_to.is_none() {
                     builder.end(false);

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -205,30 +205,31 @@ impl ShapeTessellator {
                     commands,
                     is_closed,
                 } => {
-                    let mut buffers_builder = BuffersBuilder::new(
-                        &mut lyon_mesh,
-                        RuffleVertexCtor {
-                            color: style.color.clone(),
-                        },
-                    );
+                    let color = if let swf::FillStyle::Color(color) = &style.fill_style() {
+                        color.clone()
+                    } else {
+                        swf::Color::from_rgba(0)
+                    };
+                    let mut buffers_builder =
+                        BuffersBuilder::new(&mut lyon_mesh, RuffleVertexCtor { color });
 
                     // TODO(Herschel): 0 width indicates "hairline".
-                    let width = (style.width.to_pixels() as f32).max(1.0);
+                    let width = (style.width().to_pixels() as f32).max(1.0);
 
                     let mut options = StrokeOptions::default()
                         .with_line_width(width)
-                        .with_start_cap(match style.start_cap {
+                        .with_start_cap(match style.start_cap() {
                             swf::LineCapStyle::None => tessellation::LineCap::Butt,
                             swf::LineCapStyle::Round => tessellation::LineCap::Round,
                             swf::LineCapStyle::Square => tessellation::LineCap::Square,
                         })
-                        .with_end_cap(match style.end_cap {
+                        .with_end_cap(match style.end_cap() {
                             swf::LineCapStyle::None => tessellation::LineCap::Butt,
                             swf::LineCapStyle::Round => tessellation::LineCap::Round,
                             swf::LineCapStyle::Square => tessellation::LineCap::Square,
                         });
 
-                    let line_join = match style.join_style {
+                    let line_join = match style.join_style() {
                         swf::LineJoinStyle::Round => tessellation::LineJoin::Round,
                         swf::LineJoinStyle::Bevel => tessellation::LineJoin::Bevel,
                         swf::LineJoinStyle::Miter(limit) => {

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -737,15 +737,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             },
                         ],
                     })],
-                    line_styles: vec![LineStyle::new_v1(
-                        Twips::from_pixels(10.0),
-                        Color {
-                            r: 0,
-                            g: 255,
-                            b: 0,
-                            a: 255,
-                        },
-                    )],
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::from_pixels(10.0))
+                        .with_color(Color::from_rgba(0xff00ff00))],
                     shape: vec![
                         ShapeRecord::StyleChange(Box::new(StyleChangeData {
                             move_to: Some((Twips::from_pixels(20.0), Twips::from_pixels(20.0))),
@@ -840,15 +834,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             },
                         ],
                     })],
-                    line_styles: vec![LineStyle::new_v1(
-                        Twips::from_pixels(2.0),
-                        Color {
-                            r: 255,
-                            g: 255,
-                            b: 0,
-                            a: 255,
-                        },
-                    )],
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::from_pixels(2.0))
+                        .with_color(Color::from_rgba(0xffffff00))],
                     shape: vec![
                         ShapeRecord::StyleChange(Box::new(StyleChangeData {
                             move_to: Some((Twips::from_pixels(20.0), Twips::from_pixels(60.0))),
@@ -969,23 +957,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                         },
                         focal_point: Fixed8::from_f64(0.97265625),
                     }],
-                    line_styles: vec![LineStyle {
-                        width: Twips::from_pixels(10.0),
-                        color: Color {
-                            r: 0,
-                            g: 255,
-                            b: 0,
-                            a: 255,
-                        },
-                        start_cap: LineCapStyle::Round,
-                        end_cap: LineCapStyle::Round,
-                        join_style: LineJoinStyle::Round,
-                        fill_style: None,
-                        allow_scale_x: true,
-                        allow_scale_y: true,
-                        is_pixel_hinted: false,
-                        allow_close: true,
-                    }],
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::from_pixels(10.0))
+                        .with_color(Color::from_rgba(0xff00ff00))],
                     shape: vec![
                         ShapeRecord::StyleChange(Box::new(StyleChangeData {
                             move_to: Some((Twips::from_pixels(20.0), Twips::from_pixels(20.0))),
@@ -1092,23 +1066,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                         },
                         focal_point: Fixed8::from_f64(-0.9921875),
                     }],
-                    line_styles: vec![LineStyle {
-                        width: Twips::from_pixels(2.0),
-                        color: Color {
-                            r: 255,
-                            g: 255,
-                            b: 0,
-                            a: 255,
-                        },
-                        start_cap: LineCapStyle::Round,
-                        end_cap: LineCapStyle::Round,
-                        join_style: LineJoinStyle::Round,
-                        fill_style: None,
-                        allow_scale_x: true,
-                        allow_scale_y: true,
-                        is_pixel_hinted: false,
-                        allow_close: true,
-                    }],
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::from_pixels(2.0))
+                        .with_color(Color::from_rgba(0xffffff00))],
                     shape: vec![
                         ShapeRecord::StyleChange(Box::new(StyleChangeData {
                             move_to: Some((Twips::from_pixels(26.0), Twips::from_pixels(147.35))),
@@ -1217,23 +1177,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             },
                         ],
                     })],
-                    line_styles: vec![LineStyle {
-                        width: Twips::from_pixels(0.0),
-                        color: Color {
-                            r: 0,
-                            g: 0,
-                            b: 0,
-                            a: 0,
-                        },
-                        start_cap: LineCapStyle::Round,
-                        end_cap: LineCapStyle::Round,
-                        join_style: LineJoinStyle::Round,
-                        fill_style: None,
-                        allow_scale_x: true,
-                        allow_scale_y: true,
-                        is_pixel_hinted: false,
-                        allow_close: true,
-                    }],
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::ZERO)
+                        .with_color(Color::from_rgba(0x00000000))],
                     shape: vec![
                         ShapeRecord::StyleChange(Box::new(StyleChangeData {
                             move_to: None,
@@ -1305,23 +1251,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             },
                         ],
                     })],
-                    line_styles: vec![LineStyle {
-                        width: Twips::from_pixels(0.0),
-                        color: Color {
-                            r: 0,
-                            g: 0,
-                            b: 0,
-                            a: 0,
-                        },
-                        start_cap: LineCapStyle::Round,
-                        end_cap: LineCapStyle::Round,
-                        join_style: LineJoinStyle::Round,
-                        fill_style: None,
-                        allow_scale_x: true,
-                        allow_scale_y: true,
-                        is_pixel_hinted: false,
-                        allow_close: true,
-                    }],
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::from_pixels(0.0))
+                        .with_color(Color::from_rgba(0x00000000))],
                     shape: vec![
                         ShapeRecord::StraightEdge {
                             delta_x: Twips::from_pixels(200.0),
@@ -1641,35 +1573,23 @@ pub fn tag_tests() -> Vec<TagTestData> {
                         },
                     ],
                     line_styles: vec![
-                        LineStyle {
-                            width: Twips::from_pixels(20.0),
-                            color: Color {
+                        LineStyle::new()
+                            .with_width(Twips::from_pixels(20.0))
+                            .with_color(Color {
                                 r: 0,
                                 g: 153,
                                 b: 0,
                                 a: 255,
-                            },
-                            start_cap: LineCapStyle::None,
-                            end_cap: LineCapStyle::None,
-                            join_style: LineJoinStyle::Bevel,
-                            fill_style: None,
-                            allow_scale_x: false,
-                            allow_scale_y: false,
-                            is_pixel_hinted: true,
-                            allow_close: true,
-                        },
-                        LineStyle {
-                            width: Twips::from_pixels(20.0),
-                            color: Color {
-                                r: 0,
-                                g: 0,
-                                b: 0,
-                                a: 0,
-                            },
-                            start_cap: LineCapStyle::Round,
-                            end_cap: LineCapStyle::Round,
-                            join_style: LineJoinStyle::Round,
-                            fill_style: Some(FillStyle::LinearGradient(Gradient {
+                            })
+                            .with_allow_scale_x(false)
+                            .with_allow_scale_y(false)
+                            .with_is_pixel_hinted(true)
+                            .with_join_style(LineJoinStyle::Bevel)
+                            .with_start_cap(LineCapStyle::None)
+                            .with_end_cap(LineCapStyle::None),
+                        LineStyle::new()
+                            .with_width(Twips::from_pixels(20.0))
+                            .with_fill_style(FillStyle::LinearGradient(Gradient {
                                 matrix: Matrix {
                                     tx: Twips::from_pixels(50.0),
                                     ty: Twips::from_pixels(50.0),
@@ -1700,29 +1620,20 @@ pub fn tag_tests() -> Vec<TagTestData> {
                                         },
                                     },
                                 ],
-                            })),
-                            allow_scale_x: true,
-                            allow_scale_y: false,
-                            is_pixel_hinted: true,
-                            allow_close: true,
-                        },
-                        LineStyle {
-                            width: Twips::from_pixels(20.0),
-                            color: Color {
+                            }))
+                            .with_allow_scale_y(false)
+                            .with_is_pixel_hinted(true),
+                        LineStyle::new()
+                            .with_width(Twips::from_pixels(20.0))
+                            .with_color(Color {
                                 r: 0,
                                 g: 153,
                                 b: 0,
                                 a: 255,
-                            },
-                            start_cap: LineCapStyle::Round,
-                            end_cap: LineCapStyle::Round,
-                            join_style: LineJoinStyle::Miter(Fixed8::from_f32(56.0)),
-                            fill_style: None,
-                            allow_scale_x: true,
-                            allow_scale_y: false,
-                            is_pixel_hinted: true,
-                            allow_close: true,
-                        },
+                            })
+                            .with_join_style(LineJoinStyle::Miter(Fixed8::from_f32(56.0)))
+                            .with_allow_scale_y(false)
+                            .with_is_pixel_hinted(true),
                     ],
                 },
                 shape: vec![
@@ -2572,18 +2483,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 has_scaling_strokes: true,
                 styles: ShapeStyles {
                     fill_styles: vec![],
-                    line_styles: vec![LineStyle {
-                        width: Twips::from_pixels(40.0),
-                        color: Color {
-                            r: 0,
-                            g: 0,
-                            b: 0,
-                            a: 0,
-                        },
-                        start_cap: LineCapStyle::Round,
-                        end_cap: LineCapStyle::Round,
-                        join_style: LineJoinStyle::Round,
-                        fill_style: Some(FillStyle::Bitmap {
+                    line_styles: vec![LineStyle::new()
+                        .with_width(Twips::from_pixels(40.0))
+                        .with_fill_style(FillStyle::Bitmap {
                             id: 1,
                             matrix: Matrix {
                                 a: Fixed16::from_f32(20.0),
@@ -2594,12 +2496,7 @@ pub fn tag_tests() -> Vec<TagTestData> {
                             },
                             is_smoothed: false,
                             is_repeating: true,
-                        }),
-                        allow_scale_x: true,
-                        allow_scale_y: true,
-                        is_pixel_hinted: false,
-                        allow_close: true,
-                    }],
+                        })],
                 },
                 shape: vec![
                     ShapeRecord::StyleChange(Box::new(StyleChangeData {


### PR DESCRIPTION
Clean up `swf::LineStyle` and add support for strokes with gradient and bitmap styles (LineStyle2) on all backends.

 * Remove `LineStyle::color`, instead using `FillStyle::Color` to indicate solid color.
 * Store `LineStyle::flags` bitflags instead of separate bools/values.
 * Add builder-style getters/setters methods for ease of use.
 * Fix misnamed `ALLOW_CLOSE` flag to `NO_CLOSE.`
 * Clean up  `common_tess::ShapeTessellator::tessellate_shape`
 * Handle gradient/bitmap strokes in `common_tess` and `canvas` backends.
