### PR TITLE
avm1: Correct `Action::RandomNumber`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1770,9 +1770,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn action_random_number(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
-        // A max value < 0 will always return 0,
-        // and the max value gets converted into an i32, so any number > 2^31 - 1 will return 0.
-        let max = self.context.avm1.pop().into_number_v1() as i32;
+        // The max value is clamped to the range [0, 2^31 - 1).
+        let max = self.context.avm1.pop().coerce_to_f64(self)? as i32;
         let result = if max > 0 {
             self.context.rng.gen_range(0..max)
         } else {


### PR DESCRIPTION
Fixes the following cases:

`random("12345ABC")`
Flash SWF6: 0
Flash SWF4: a value between 0  and (12345 - 1)
Ruffle (master): always 0

`random("0x500")`
Flash SWF6: a value between 0 and (0x500 - 1)
Flash SWF5: 0
Ruffle: always 0

`random("010")`
Flash SWF6: a value between 0 and (8 - 1)
Flahs SWF5: a value between 0 and (10 - 1)
Ruffle: always a value between 0 and (10 - 1)

`random({valueOf: function() { return 100; }})`
Flash: always a value between 0 and (100 - 1)
Ruffle: always 0