### PR TITLE
audio: Fix symphonia feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,10 +2300,11 @@ dependencies = [
 
 [[package]]
 name = "nellymoser-rs"
-version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/nellymoser#77000f763b58021295429ca5740e3dc3b5228cbd"
+version = "0.1.2"
+source = "git+https://github.com/ruffle-rs/nellymoser?rev=4a33521c29a918950df8ae9fe07e527ac65553f5#4a33521c29a918950df8ae9fe07e527ac65553f5"
 dependencies = [
  "bitstream-io",
+ "once_cell",
  "rustdct",
 ]
 
@@ -2399,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
 ]
@@ -3207,18 +3208,18 @@ dependencies = [
 
 [[package]]
 name = "rustdct"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadcb505b98aa64da1dadb1498b912e3642aae4606623cb3ae952cd8da33f80d"
+checksum = "620247053ace0eddd3e607c66423537e45c3ae36008e6d6fac1552f51ea1a63a"
 dependencies = [
  "rustfft",
 ]
 
 [[package]]
 name = "rustfft"
-version = "5.1.1"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1869bb2a6ff77380d52ff4bc631f165637035a55855c76aa462c85474dadc42f"
+checksum = "b1d089e5c57521629a59f5f39bca7434849ff89bd6873b521afe389c1c602543"
 dependencies = [
  "num-complex",
  "num-integer",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,7 +38,7 @@ encoding_rs = "0.8.31"
 rand = { version = "0.8.5", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser" }
+nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a33521c29a918950df8ae9fe07e527ac65553f5" }
 h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 regress = "0.4"

--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -146,7 +146,7 @@ impl<R: Read> Iterator for AdpcmDecoder<R> {
     }
 }
 
-impl<R: std::io::Read> Decoder for AdpcmDecoder<R> {
+impl<R: std::io::Read + Send + Sync> Decoder for AdpcmDecoder<R> {
     #[inline]
     fn num_channels(&self) -> u8 {
         self.channels.len() as u8
@@ -158,7 +158,7 @@ impl<R: std::io::Read> Decoder for AdpcmDecoder<R> {
     }
 }
 
-impl<R: AsRef<[u8]> + Default> SeekableDecoder for AdpcmDecoder<Cursor<R>> {
+impl<R: AsRef<[u8]> + Default + Send + Sync> SeekableDecoder for AdpcmDecoder<Cursor<R>> {
     #[inline]
     fn reset(&mut self) {
         // TODO: This is funky.

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -38,7 +38,7 @@ pub mod minimp3 {
         }
     }
 
-    impl<R: Read> Iterator for Mp3Decoder<R> {
+    impl<R: Read + Send + Sync> Iterator for Mp3Decoder<R> {
         type Item = [i16; 2];
 
         #[inline]
@@ -65,7 +65,7 @@ pub mod minimp3 {
         }
     }
 
-    impl<R: AsRef<[u8]> + Default> SeekableDecoder for Mp3Decoder<Cursor<R>> {
+    impl<R: AsRef<[u8]> + Default + Send + Sync> SeekableDecoder for Mp3Decoder<Cursor<R>> {
         #[inline]
         fn reset(&mut self) {
             // TODO: This is funky.
@@ -79,7 +79,7 @@ pub mod minimp3 {
         }
     }
 
-    impl<R: Read> Decoder for Mp3Decoder<R> {
+    impl<R: Read + Send + Sync> Decoder for Mp3Decoder<R> {
         #[inline]
         fn num_channels(&self) -> u8 {
             self.num_channels
@@ -121,7 +121,7 @@ pub mod symphonia {
     impl Mp3Decoder {
         const SAMPLE_BUFFER_DURATION: u64 = 4096;
 
-        pub fn new<R: 'static + Read + Send>(reader: R) -> Result<Self, Error> {
+        pub fn new<R: 'static + Read + Send + Sync>(reader: R) -> Result<Self, Error> {
             let source = Box::new(io::ReadOnlySource::new(reader)) as Box<dyn io::MediaSource>;
             let source = io::MediaSourceStream::new(source, Default::default());
             let reader = SymphoniaMp3Reader::try_new(source, &Default::default())?;
@@ -145,7 +145,7 @@ pub mod symphonia {
             })
         }
 
-        pub fn new_seekable<R: 'static + AsRef<[u8]> + Send>(
+        pub fn new_seekable<R: 'static + AsRef<[u8]> + Send + Sync>(
             reader: Cursor<R>,
         ) -> Result<Self, Error> {
             let source = Box::new(reader) as Box<dyn io::MediaSource>;

--- a/core/src/backend/audio/decoders/nellymoser.rs
+++ b/core/src/backend/audio/decoders/nellymoser.rs
@@ -22,7 +22,7 @@ impl<R: Read> Iterator for NellymoserDecoder<R> {
     }
 }
 
-impl<R: Read> Decoder for NellymoserDecoder<R> {
+impl<R: Read + Send + Sync> Decoder for NellymoserDecoder<R> {
     #[inline]
     fn num_channels(&self) -> u8 {
         1
@@ -34,7 +34,7 @@ impl<R: Read> Decoder for NellymoserDecoder<R> {
     }
 }
 
-impl<R: AsRef<[u8]>> SeekableDecoder for NellymoserDecoder<Cursor<R>> {
+impl<R: AsRef<[u8]> + Send + Sync> SeekableDecoder for NellymoserDecoder<Cursor<R>> {
     #[inline]
     fn reset(&mut self) {
         self.decoder.reset();

--- a/core/src/backend/audio/decoders/pcm.rs
+++ b/core/src/backend/audio/decoders/pcm.rs
@@ -47,7 +47,7 @@ impl<R: Read> Iterator for PcmDecoder<R> {
     }
 }
 
-impl<R: Read> Decoder for PcmDecoder<R> {
+impl<R: Read + Send + Sync> Decoder for PcmDecoder<R> {
     #[inline]
     fn num_channels(&self) -> u8 {
         if self.is_stereo {
@@ -63,7 +63,7 @@ impl<R: Read> Decoder for PcmDecoder<R> {
     }
 }
 
-impl<R: AsRef<[u8]>> SeekableDecoder for PcmDecoder<Cursor<R>> {
+impl<R: AsRef<[u8]> + Send + Sync> SeekableDecoder for PcmDecoder<Cursor<R>> {
     #[inline]
     fn reset(&mut self) {
         self.inner.set_position(0);


### PR DESCRIPTION
This feature stopped building with the bump to symphonia 0.5, which
added a `Sync` bound to its traits.

 * Add `Sync` bounds to our own internal audio traits to match.
 * nellymoser::Decoder was also tweaked to add a Sync bound.
 * Lock the nellymoser dependency to a specific git commit.