### PR TITLE
web: Support transparent wmode

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -46,7 +46,7 @@ pub use graphic::Graphic;
 pub use interactive::{InteractiveObject, TInteractiveObject};
 pub use morph_shape::{MorphShape, MorphShapeStatic};
 pub use movie_clip::{MovieClip, Scene};
-pub use stage::{Stage, StageAlign, StageDisplayState, StageQuality, StageScaleMode};
+pub use stage::{Stage, StageAlign, StageDisplayState, StageQuality, StageScaleMode, WindowMode};
 pub use text::Text;
 pub use video::Video;
 

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -95,6 +95,11 @@ pub struct StageData<'gc> {
     /// The bounds of the current viewport in twips, used for culling.
     view_bounds: BoundingBox,
 
+    /// The window mode of the viewport.
+    ///
+    /// Only used on web to control how the Flash content layers with other content on the page.
+    window_mode: WindowMode,
+
     /// Whether to show default context menu items
     show_menu: bool,
 
@@ -121,6 +126,7 @@ impl<'gc> Stage<'gc> {
                 viewport_size: (width, height),
                 viewport_scale_factor: 1.0,
                 view_bounds: Default::default(),
+                window_mode: Default::default(),
                 show_menu: true,
                 avm2_object: Avm2ScriptObject::bare_object(gc_context),
             },
@@ -319,6 +325,22 @@ impl<'gc> Stage<'gc> {
         self.build_matrices(context);
     }
 
+    /// Get the stage mode.
+    /// This controls how the content layers with other content on the page.
+    /// Only used on web.
+    pub fn window_mode(self) -> WindowMode {
+        self.0.read().window_mode
+    }
+
+    /// Sets the window mode.
+    pub fn set_window_mode(
+        self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        window_mode: WindowMode,
+    ) {
+        self.0.write(context.gc_context).window_mode = window_mode;
+    }
+
     pub fn view_bounds(self) -> BoundingBox {
         self.0.read().view_bounds.clone()
     }
@@ -334,12 +356,13 @@ impl<'gc> Stage<'gc> {
 
     /// Determine if we should letterbox the stage content.
     fn should_letterbox(self) -> bool {
-        // Only enable letterbox is the default `ShowAll` scale mode.
+        // Only enable letterbox in the default `ShowAll` scale mode.
         // If content changes the scale mode or alignment, it signals that it is size-aware.
         // For example, `NoScale` is used to make responsive layouts; don't letterbox over it.
         let stage = self.0.read();
         stage.scale_mode == StageScaleMode::ShowAll
             && stage.align.is_empty()
+            && stage.window_mode != WindowMode::Transparent
             && (stage.letterbox == Letterbox::On
                 || (stage.letterbox == Letterbox::Fullscreen && self.is_fullscreen()))
     }
@@ -673,9 +696,13 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
     }
 
     fn render(&self, context: &mut RenderContext<'_, 'gc>) {
-        let background_color = self
-            .background_color()
-            .unwrap_or_else(|| Color::from_rgb(0xffffff, 255));
+        let background_color =
+            if self.window_mode() != WindowMode::Transparent || self.is_fullscreen() {
+                self.background_color()
+                    .unwrap_or_else(|| Color::from_rgb(0xffffff, 255))
+            } else {
+                Color::from_rgba(0)
+            };
 
         context.renderer.begin_frame(background_color);
 
@@ -1058,5 +1085,75 @@ impl FromWStr for StageQuality {
         } else {
             Err(ParseEnumError)
         }
+    }
+}
+
+/// The window mode of the Ruffle player.
+///
+/// This setting controls how the Ruffle container is layered and rendered with other content on
+/// the page. This setting is only used on web.
+///
+/// [Apply OBJECT and EMBED tag attributes in Adobe Flash Professional](https://helpx.adobe.com/flash/kb/flash-object-embed-tag-attributes.html)
+#[derive(Clone, Collect, Copy, Debug, Eq, PartialEq)]
+#[collect(require_static)]
+pub enum WindowMode {
+    /// The Flash content is rendered in its own window and layering is done with the browser's
+    /// default behavior.
+    ///
+    /// In Ruffle, this mode functions like `WindowMode::Opaque` and will layer the Flash content
+    /// together with other HTML elements.
+    Window,
+
+    /// The Flash content is layered together with other HTML elements, and the stage color is
+    /// opaque. Content can render above or below Ruffle based on CSS rendering order.
+    Opaque,
+
+    /// The Flash content is layered together with other HTML elements, and the stage color is
+    /// transparent. Content beneath Ruffle will be visible through transparent areas.
+    Transparent,
+
+    /// Request compositing with hardware acceleration when possible.
+    ///
+    /// This mode has no effect in Ruffle and will function like `WindowMode::Opaque`.
+    Gpu,
+
+    /// Request a direct rendering path, bypassing browser compositing when possible.
+    ///
+    /// This mode has no effect in Ruffle and will function like `WindowMode::Opaque`.
+    Direct,
+}
+
+impl Default for WindowMode {
+    fn default() -> WindowMode {
+        WindowMode::Window
+    }
+}
+
+impl Display for WindowMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let s = match *self {
+            WindowMode::Window => "window",
+            WindowMode::Opaque => "opaque",
+            WindowMode::Transparent => "transparent",
+            WindowMode::Direct => "direct",
+            WindowMode::Gpu => "gpu",
+        };
+        f.write_str(s)
+    }
+}
+
+impl FromStr for WindowMode {
+    type Err = ParseEnumError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let window_mode = match s.to_ascii_lowercase().as_str() {
+            "window" => WindowMode::Window,
+            "opaque" => WindowMode::Opaque,
+            "transparent" => WindowMode::Transparent,
+            "direct" => WindowMode::Direct,
+            "gpu" => WindowMode::Gpu,
+            _ => return Err(ParseEnumError),
+        };
+        Ok(window_mode)
     }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -19,7 +19,7 @@ use crate::context::{ActionQueue, ActionType, RenderContext, UpdateContext};
 use crate::context_menu::{ContextMenuCallback, ContextMenuItem, ContextMenuState};
 use crate::display_object::{
     EditText, InteractiveObject, MovieClip, Stage, StageAlign, StageDisplayState, StageQuality,
-    StageScaleMode, TInteractiveObject,
+    StageScaleMode, TInteractiveObject, WindowMode,
 };
 use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode, MouseButton, PlayerEvent};
 use crate::external::Value as ExternalValue;
@@ -809,6 +809,15 @@ impl Player {
             let stage = context.stage;
             if let Ok(scale_mode) = StageScaleMode::from_str(scale_mode) {
                 stage.set_scale_mode(context, scale_mode);
+            }
+        })
+    }
+
+    pub fn set_window_mode(&mut self, scale_mode: &str) {
+        self.mutate_with_update_context(|context| {
+            let stage = context.stage;
+            if let Ok(window_mode) = WindowMode::from_str(scale_mode) {
+                stage.set_window_mode(context, window_mode);
             }
         })
     }

--- a/render/webgl/shaders/color.frag
+++ b/render/webgl/shaders/color.frag
@@ -14,5 +14,5 @@ uniform vec4 add_color;
 varying vec4 frag_color;
 
 void main() {
-    gl_FragColor = frag_color;
+    gl_FragColor = vec4(frag_color.rgb * frag_color.a, frag_color.a);
 }

--- a/render/webgl/shaders/gradient.frag
+++ b/render/webgl/shaders/gradient.frag
@@ -129,6 +129,7 @@ void main() {
         color = vec4(linear_to_srgb(vec3(color)), color.a);
     }
 
-    gl_FragColor = mult_color * color + add_color;
+    color = mult_color * color + add_color;
+    gl_FragColor = vec4(color.rgb * color.a, color.a);
 }
 

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -13,5 +13,6 @@ fn main_vertex(in: VertexInput) -> VertexOutput {
 
 [[stage(fragment)]]
 fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    return in.color * transforms.mult_color + transforms.add_color;
+    let out = in.color * transforms.mult_color + transforms.add_color;
+    return vec4<f32>(out.rgb * out.a, out.a);
 }

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -43,16 +43,24 @@ var<uniform> transforms: Transforms;
 
 /// Converts a color from linear to sRGB color space.
 fn linear_to_srgb(linear: vec4<f32>) -> vec4<f32> {
-    let a = 12.92 * linear.rgb;
-    let b = 1.055 * pow(linear.rgb, vec3<f32>(1.0 / 2.4)) - 0.055;
-    let c = step(vec3<f32>(0.0031308), linear.rgb);
-    return vec4<f32>(mix(a, b, c), linear.a);
+    var rgb: vec3<f32> = linear.rgb;
+    if( linear.a > 0.0 ) {
+        rgb = rgb / linear.a;
+    }
+    let a = 12.92 * rgb;
+    let b = 1.055 * pow(rgb, vec3<f32>(1.0 / 2.4)) - 0.055;
+    let c = step(vec3<f32>(0.0031308), rgb);
+    return vec4<f32>(mix(a, b, c) * linear.a, linear.a);
 }
 
 /// Converts a color from sRGB to linear color space.
 fn srgb_to_linear(srgb: vec4<f32>) -> vec4<f32> {
-    let a = srgb.rgb / 12.92;
-    let b = pow((srgb.rgb + vec3<f32>(0.055)) / 1.055, vec3<f32>(2.4));
-    let c = step(vec3<f32>(0.04045), srgb.rgb);
-    return vec4<f32>(mix(a, b, c), srgb.a);
+    var rgb: vec3<f32> = srgb.rgb;
+    if( srgb.a > 0.0 ) {
+        rgb = rgb / srgb.a;
+    }
+    let a = rgb / 12.92;
+    let b = pow((rgb + vec3<f32>(0.055)) / 1.055, vec3<f32>(2.4));
+    let c = step(vec3<f32>(0.04045), rgb);
+    return vec4<f32>(mix(a, b, c) * srgb.a, srgb.a);
 }

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -101,5 +101,6 @@ fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     if( gradient.interpolation != 0 ) {
         color = linear_to_srgb(color);
     }
-    return color * transforms.mult_color + transforms.add_color;
+    let out = color * transforms.mult_color + transforms.add_color;
+    return vec4<f32>(out.rgb * out.a, out.a);
 }

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -306,7 +306,7 @@ fn create_color_pipelines(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_description,
@@ -330,7 +330,7 @@ fn create_color_pipelines(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_description,
@@ -354,7 +354,7 @@ fn create_color_pipelines(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_description,
@@ -378,7 +378,7 @@ fn create_color_pipelines(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_description,
@@ -554,7 +554,7 @@ fn create_gradient_pipeline(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_layout,
@@ -578,7 +578,7 @@ fn create_gradient_pipeline(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_layout,
@@ -603,7 +603,7 @@ fn create_gradient_pipeline(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_layout,
@@ -627,7 +627,7 @@ fn create_gradient_pipeline(
                 }),
                 &[wgpu::ColorTargetState {
                     format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
                 }],
                 vertex_buffers_layout,

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -77,6 +77,44 @@ export const enum LogLevel {
 }
 
 /**
+ * The window mode of a Ruffle player.
+ */
+export const enum WindowMode {
+    /*
+     * The Flash content is rendered in its own window and layering is done with the browser's
+     * default behavior.
+     *
+     * In Ruffle, this mode functions like `WindowMode::Opaque` and will layer the Flash content
+     * together with other HTML elements.
+     */
+    Window = "window",
+
+    /*
+     * The Flash content is layered together with other HTML elements, and the stage color is
+     * opaque. Content can render above or below Ruffle based on CSS rendering order.
+     */
+    Opaque = "opaque",
+
+    /*
+     * The Flash content is layered together with other HTML elements, and the SWF stage color is
+     * transparent. Content beneath Ruffle will be visible through transparent areas.
+     */
+    Transparent = "transparent",
+
+    /*
+     * Request compositing with hardware acceleration when possible.
+     * This mode has no effect in Ruffle and will function like `WindowMode.Opaque`.
+     */
+    Direct = "direct",
+
+    /*
+     * Request a direct rendering path, bypassing browser compositing when possible.
+     * This mode has no effect in Ruffle and will function like `WindowMode::Opaque`.
+     */
+    Gpu = "gpu",
+}
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -227,6 +265,15 @@ export interface BaseLoadOptions {
      * @default "showAll"
      */
     scale?: string;
+
+    /**
+     * The window mode of the Ruffle player.
+     *
+     * This setting controls how the Ruffle container is layered and rendered with other content on the page.
+     *
+     * @default WindowMode.Window
+     */
+    wmode?: WindowMode;
 }
 
 /**

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -11,6 +11,7 @@ import {
     workaroundYoutubeMixedContent,
     RufflePlayer,
 } from "./ruffle-player";
+import { WindowMode } from "./load-options";
 import { registerElement } from "./register-element";
 
 /**
@@ -61,6 +62,9 @@ export class RuffleEmbed extends RufflePlayer {
                     this.attributes.getNamedItem("quality")?.value ?? "high",
                 scale:
                     this.attributes.getNamedItem("scale")?.value ?? "showAll",
+                wmode:
+                    (this.attributes.getNamedItem("wmode")
+                        ?.value as WindowMode) ?? WindowMode.Window,
             });
         }
     }

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -13,7 +13,7 @@ import {
     RufflePlayer,
 } from "./ruffle-player";
 import { registerElement } from "./register-element";
-import { URLLoadOptions } from "./load-options";
+import { URLLoadOptions, WindowMode } from "./load-options";
 import { RuffleEmbed } from "./ruffle-embed";
 
 /**
@@ -126,6 +126,7 @@ export class RuffleObject extends RufflePlayer {
         const salign = findCaseInsensitive(this.params, "salign", "");
         const quality = findCaseInsensitive(this.params, "quality", "high");
         const scale = findCaseInsensitive(this.params, "scale", "showAll");
+        const wmode = findCaseInsensitive(this.params, "wmode", "window");
 
         if (url) {
             const options: URLLoadOptions = { url };
@@ -151,6 +152,9 @@ export class RuffleObject extends RufflePlayer {
             }
             if (scale) {
                 options.scale = scale;
+            }
+            if (wmode) {
+                options.wmode = wmode as WindowMode;
             }
 
             // Kick off the SWF download.

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1244,7 +1244,7 @@ async fn create_renderer(
             .into_js_result()?
             .dyn_into()
             .map_err(|_| "Expected HtmlCanvasElement")?;
-        match ruffle_render_webgl::WebGlRenderBackend::new(&canvas) {
+        match ruffle_render_webgl::WebGlRenderBackend::new(&canvas, true) {
             Ok(renderer) => return Ok((canvas, Box::new(renderer))),
             Err(error) => log::error!("Error creating WebGL renderer: {}", error),
         }


### PR DESCRIPTION
![Recording 2022-04-13 at 15 40 33](https://user-images.githubusercontent.com/36278/163281655-8298f5a7-dabf-4be2-98ec-af5ffa974ce2.gif)

 * Change wgpu/WebGL shaders to output premultiplied alpha.
   * Browser engines themselves work in premultiplied alpha, so output this for proper alpha blending on a transparent canvas.
   * This will help with #6629 because Flash bitmaps are stored with premultiplied alpha.
 * Add "wmode" Flash embed parameter to web config.
   * Currently only "transparent" has an effect.
   * Perhaps we can simulate "window" vs. "opaque" using something like `z-index: 999`.
   * "gpu"/"direct" will always be ignored.

Fixes #1752.