### PR TITLE
[wip] chore: Bump to wgpu master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.34.0+1.2.203"
+version = "0.37.0+1.3.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
 dependencies = [
  "libloading",
 ]
@@ -841,8 +841,7 @@ dependencies = [
 [[package]]
 name = "d3d12"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+source = "git+https://github.com/gfx-rs/d3d12-rs.git?rev=ffe5e261da0a6cb85332b82ab310abd2a7e849f6#ffe5e261da0a6cb85332b82ab310abd2a7e849f6"
 dependencies = [
  "bitflags",
  "libloading",
@@ -1874,6 +1873,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2095,8 +2095,7 @@ dependencies = [
 [[package]]
 name = "metal"
 version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+source = "git+https://github.com/gfx-rs/metal-rs?rev=1aaa903#1aaa9033a22b2af7ff8cae2ed412a4733799c3d3"
 dependencies = [
  "bitflags",
  "block",
@@ -2172,9 +2171,8 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705"
+version = "0.8.0"
+source = "git+https://github.com/gfx-rs/naga?rev=7aaac25f#7aaac25fbf64c0f77f0e2deba2963293f3632dad"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -4037,8 +4035,7 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+source = "git+https://github.com/gfx-rs/wgpu?rev=759e7ff8c59600a850f8dfd539d1287243027717#759e7ff8c59600a850f8dfd539d1287243027717"
 dependencies = [
  "arrayvec 0.7.2",
  "js-sys",
@@ -4058,9 +4055,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
+version = "0.12.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=759e7ff8c59600a850f8dfd539d1287243027717#759e7ff8c59600a850f8dfd539d1287243027717"
 dependencies = [
  "arrayvec 0.7.2",
  "bitflags",
@@ -4083,9 +4079,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b1a9400e8d7f32dd4dd909bb9a391015d70633d639775ddd3f14d1104bc970"
+version = "0.12.0"
+source = "git+https://github.com/gfx-rs/wgpu?rev=759e7ff8c59600a850f8dfd539d1287243027717#759e7ff8c59600a850f8dfd539d1287243027717"
 dependencies = [
  "arrayvec 0.7.2",
  "ash",
@@ -4122,8 +4117,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+source = "git+https://github.com/gfx-rs/wgpu?rev=759e7ff8c59600a850f8dfd539d1287243027717#759e7ff8c59600a850f8dfd539d1287243027717"
 dependencies = [
  "bitflags",
  "bitflags_serde_shim",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -23,7 +23,8 @@ version = "0.24.1"
 default-features = false
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu]
-version = "0.12"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "759e7ff8c59600a850f8dfd539d1287243027717"
 
 # wasm
 [target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen-futures]
@@ -34,7 +35,8 @@ version = "0.3.57"
 features = ["HtmlCanvasElement"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]
-version = "0.12"
+git = "https://github.com/gfx-rs/wgpu"
+rev = "759e7ff8c59600a850f8dfd539d1287243027717"
 
 [features]
 render_debug_labels = []

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -1,18 +1,15 @@
 /// Shader used for drawing bitmap fills.
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec2<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
-[[group(2), binding(0)]]
-var<uniform> textureTransforms: TextureTransforms;
-[[group(2), binding(1)]]
-var texture: texture_2d<f32>;
-[[group(3), binding(0)]]
-var texture_sampler: sampler;
+@group(2) @binding(0) var<uniform> textureTransforms: TextureTransforms;
+@group(2) @binding(1) var texture: texture_2d<f32>;
+@group(3) @binding(0) var texture_sampler: sampler;
 
-[[stage(vertex)]]
+@stage(vertex)
 fn main_vertex(in: VertexInput) -> VertexOutput {
     let matrix = textureTransforms.matrix;
     let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
@@ -20,8 +17,8 @@ fn main_vertex(in: VertexInput) -> VertexOutput {
     return VertexOutput(pos, uv);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color: vec4<f32> = textureSample(texture, texture_sampler, in.uv);
     // Texture is premultiplied by alpha.
     // Unmultiply alpha, apply color transform, remultiply alpha.

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -1,18 +1,17 @@
 /// Shader used for drawing solid color fills.
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] color: vec4<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
 };
 
-[[stage(vertex)]]
+@stage(vertex)
 fn main_vertex(in: VertexInput) -> VertexOutput {
     let pos: vec4<f32> = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     return VertexOutput(pos, in.color);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    let out = in.color * transforms.mult_color + transforms.add_color;
-    return vec4<f32>(out.rgb * out.a, out.a);
+@stage(fragment)
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color * transforms.mult_color + transforms.add_color;
 }

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -4,42 +4,40 @@
 /// Global uniforms that are constant throughout a frame.
 struct Globals {
     // The view matrix determined by the viewport and stage.
-    view_matrix: mat4x4<f32>;
+    view_matrix: mat4x4<f32>,
 };
 
 /// Transform uniforms that are changed per object.
 struct Transforms {
     /// The world matrix that transforms this object into stage space.
-    world_matrix: mat4x4<f32>;
+    world_matrix: mat4x4<f32>,
 
     /// The multiplicative color transform of this object.
-    mult_color: vec4<f32>;
+    mult_color: vec4<f32>,
 
     /// The additive color transform of this object.
-    add_color: vec4<f32>;
+    add_color: vec4<f32>,
 };
 
 /// Uniforms used by texture draws (bitmaps and gradients).
 struct TextureTransforms {
     /// The transform matrix of the gradient or texture.
     /// Transforms from object space to UV space.
-    matrix: mat4x4<f32>;
+    matrix: mat4x4<f32>,
 };
 
 /// The vertex format shared among all shaders.
 struct VertexInput {
     /// The position of the vertex in object space.
-    [[location(0)]] position: vec2<f32>;
+    @location(0) position: vec2<f32>,
 
     /// The color of this vertex (only used by the color shader).
-    [[location(1)]] color: vec4<f32>;
+    @location(1) color: vec4<f32>,
 };
 
 /// Common uniform layout shared by all shaders.
-[[group(0), binding(0)]]
-var<uniform> globals: Globals;
-[[group(1), binding(0)]]
-var<uniform> transforms: Transforms;
+@group(0) @binding(0) var<uniform> globals: Globals;
+@group(1) @binding(0) var<uniform> transforms: Transforms;
 
 /// Converts a color from linear to sRGB color space.
 fn linear_to_srgb(linear: vec4<f32>) -> vec4<f32> {

--- a/render/wgpu/shaders/copy_srgb.wgsl
+++ b/render/wgpu/shaders/copy_srgb.wgsl
@@ -1,18 +1,15 @@
 /// Shader used for drawing bitmap fills.
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec2<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
-[[group(2), binding(0)]]
-var<uniform> textureTransforms: TextureTransforms;
-[[group(2), binding(1)]]
-var texture: texture_2d<f32>;
-[[group(3), binding(0)]]
-var texture_sampler: sampler;
+@group(2) @binding(0) var<uniform> textureTransforms: TextureTransforms;
+@group(2) @binding(1) var texture: texture_2d<f32>;
+@group(3) @binding(0) var texture_sampler: sampler;
 
-[[stage(vertex)]]
+@stage(vertex)
 fn main_vertex(in: VertexInput) -> VertexOutput {
     let matrix = textureTransforms.matrix;
     let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
@@ -20,7 +17,7 @@ fn main_vertex(in: VertexInput) -> VertexOutput {
     return VertexOutput(pos, uv);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     return srgb_to_linear(textureSample(texture, texture_sampler, in.uv));
 }

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -1,26 +1,24 @@
 /// Shader used for drawing all flavors of gradients.
 
 struct Gradient {
-    colors: array<vec4<f32>,16u>;
-    ratios: array<f32,16u>;
-    gradient_type: i32;
-    num_colors: u32;
-    repeat_mode: i32;
-    interpolation: i32;
-    focal_point: f32;
+    colors: array<vec4<f32>,16u>,
+    ratios: array<f32,16u>,
+    gradient_type: i32,
+    num_colors: u32,
+    repeat_mode: i32,
+    interpolation: i32,
+    focal_point: f32,
 };
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec2<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
-[[group(2), binding(0)]]
-var<uniform> textureTransforms: TextureTransforms;
-[[group(2), binding(1)]]
-var<storage> gradient: Gradient;
+@group(2) @binding(0) var<uniform> textureTransforms: TextureTransforms;
+@group(2) @binding(1) var<storage> gradient: Gradient;
 
-[[stage(vertex)]]
+@stage(vertex)
 fn main_vertex(in: VertexInput) -> VertexOutput {
     let matrix = textureTransforms.matrix;
     let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
@@ -28,8 +26,8 @@ fn main_vertex(in: VertexInput) -> VertexOutput {
     return VertexOutput(pos, uv);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let last = gradient.num_colors - 1u;
 
     // Calculate normalized `t` position in gradient, [0.0, 1.0] being the bounds of the ratios.

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -98,20 +98,13 @@ impl Descriptors {
             wgpu::TextureFormat::Etc2Rgb8UnormSrgb => wgpu::TextureFormat::Etc2Rgb8Unorm,
             wgpu::TextureFormat::Etc2Rgb8A1UnormSrgb => wgpu::TextureFormat::Etc2Rgb8A1Unorm,
             wgpu::TextureFormat::Etc2Rgba8UnormSrgb => wgpu::TextureFormat::Etc2Rgba8Unorm,
-            wgpu::TextureFormat::Astc4x4RgbaUnormSrgb => wgpu::TextureFormat::Astc4x4RgbaUnorm,
-            wgpu::TextureFormat::Astc5x4RgbaUnormSrgb => wgpu::TextureFormat::Astc5x4RgbaUnorm,
-            wgpu::TextureFormat::Astc5x5RgbaUnormSrgb => wgpu::TextureFormat::Astc5x5RgbaUnorm,
-            wgpu::TextureFormat::Astc6x5RgbaUnormSrgb => wgpu::TextureFormat::Astc6x5RgbaUnorm,
-            wgpu::TextureFormat::Astc6x6RgbaUnormSrgb => wgpu::TextureFormat::Astc6x6RgbaUnorm,
-            wgpu::TextureFormat::Astc8x5RgbaUnormSrgb => wgpu::TextureFormat::Astc8x5RgbaUnorm,
-            wgpu::TextureFormat::Astc8x6RgbaUnormSrgb => wgpu::TextureFormat::Astc8x6RgbaUnorm,
-            wgpu::TextureFormat::Astc10x5RgbaUnormSrgb => wgpu::TextureFormat::Astc10x5RgbaUnorm,
-            wgpu::TextureFormat::Astc10x6RgbaUnormSrgb => wgpu::TextureFormat::Astc10x6RgbaUnorm,
-            wgpu::TextureFormat::Astc8x8RgbaUnormSrgb => wgpu::TextureFormat::Astc8x8RgbaUnorm,
-            wgpu::TextureFormat::Astc10x8RgbaUnormSrgb => wgpu::TextureFormat::Astc10x8RgbaUnorm,
-            wgpu::TextureFormat::Astc10x10RgbaUnormSrgb => wgpu::TextureFormat::Astc10x10RgbaUnorm,
-            wgpu::TextureFormat::Astc12x10RgbaUnormSrgb => wgpu::TextureFormat::Astc12x10RgbaUnorm,
-            wgpu::TextureFormat::Astc12x12RgbaUnormSrgb => wgpu::TextureFormat::Astc12x12RgbaUnorm,
+            wgpu::TextureFormat::Astc {
+                block,
+                channel: wgpu::AstcChannel::UnormSrgb,
+            } => wgpu::TextureFormat::Astc {
+                block,
+                channel: wgpu::AstcChannel::Unorm,
+            },
             _ => surface_format,
         };
 


### PR DESCRIPTION
Preemptive PR, to be merged when wgpu makes a new release.

Update the shaders to match the latest WGSL spec:
 * `@attribute` instead of `[[attribute]]`
 * `,` separator in structs instead of `;`
