### PR TITLE
extension: Check for all octet-stream MIME types

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -22,7 +22,7 @@ function isSwf(
         .match(/^\s*(.*?)\s*(?:;.*)?$/)![1];
 
     // Some sites (e.g. swfchan.net) might (wrongly?) send octet-stream, so check file extension too.
-    if (mime === "application/octet-stream") {
+    if (mime.endsWith("octet-stream")) {
         const url = new URL(details.url);
         const extension = url.pathname.substring(url.pathname.lastIndexOf("."));
         return extension.toLowerCase() === ".swf";


### PR DESCRIPTION
When a server returns a `.swf` file with an octet-stream MIME type, Ruffle should treat it as an SWF. Right now the extension checks specifically for the `application/octet-stream` MIME type, which leaves out servers like [MaxGames](https://farm.maxgames.com/soldier-diary-13469MTU5MA==.swf) that use the `binary/octet-stream` type instead. Check if the MIME type ends with `octet-stream` to handle both cases.