### PR TITLE
web: Don't set container bgcolor in transparent wmode

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -10,6 +10,7 @@ import {
     URLLoadOptions,
     AutoPlay,
     UnmuteOverlay,
+    WindowMode,
 } from "./load-options";
 import { MovieMetadata } from "./movie-metadata";
 import { InternalContextMenuItem } from "./context-menu";
@@ -577,7 +578,10 @@ export class RufflePlayer extends HTMLElement {
             this.hasContextMenu = config.contextMenu !== false;
 
             // Pre-emptively set background color of container while Ruffle/SWF loads.
-            if (config.backgroundColor) {
+            if (
+                config.backgroundColor &&
+                config.wmode != WindowMode.Transparent
+            ) {
                 this.container.style.backgroundColor = config.backgroundColor;
             }
 


### PR DESCRIPTION
If a Flash embed set both the `bgcolor` param and transparent
`wmode`, the Ruffle polyfill would incorrectly set the container
to use the background color. Keep the background transparent instead.