### PR TITLE
avm2: Stub flash.accessibility.AccessibilityProperties

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -961,5 +961,12 @@ pub fn load_player_globals<'gc>(
         script,
     )?;
 
+    // package `flash.accessibility`
+    class(
+        activation,
+        flash::accessibility::accessibilityproperties::create_class(mc),
+        script,
+    )?;
+
     Ok(())
 }

--- a/core/src/avm2/globals/flash.rs
+++ b/core/src/avm2/globals/flash.rs
@@ -1,5 +1,6 @@
 //! `flash` namespace
 
+pub mod accessibility;
 pub mod crypto;
 pub mod display;
 pub mod events;

--- a/core/src/avm2/globals/flash/accessibility.rs
+++ b/core/src/avm2/globals/flash/accessibility.rs
@@ -1,0 +1,3 @@
+//! `flash.accessibility` namespace
+
+pub mod accessibilityproperties;

--- a/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
+++ b/core/src/avm2/globals/flash/accessibility/accessibilityproperties.rs
@@ -1,0 +1,68 @@
+//! `flash.accessibility.AccessibilityProperties` builtin/prototype
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::Method;
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        activation.super_init(this, &[])?;
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Construct `flash.accessibility.AccessibilityProperties`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(
+            Namespace::package("flash.accessibility"),
+            "AccessibilityProperties",
+        ),
+        Some(QName::new(Namespace::public(), "Object").into()),
+        Method::from_builtin(
+            instance_init,
+            "<AccessibilityProperties instance initializer>",
+            mc,
+        ),
+        Method::from_builtin(
+            class_init,
+            "<AccessibilityProperties class initializer>",
+            mc,
+        ),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+    write.set_attributes(ClassAttributes::SEALED);
+
+    const PUBLIC_INSTANCE_SLOTS: &[(&str, &str, &str)] = &[
+        ("description", "", "String"),
+        ("forceSimple", "", "Boolean"),
+        ("name", "", "String"),
+        ("noAutoLabeling", "", "Boolean"),
+        ("shortcut", "", "String"),
+        ("silent", "", "Boolean"),
+    ];
+
+    write.define_public_slot_instance_traits(PUBLIC_INSTANCE_SLOTS);
+
+    class
+}


### PR DESCRIPTION
A lot of z0r loops complained about it being missing.
Now they don't, even if it does nothing.

I'm not sure whether there's a point in calling `super_init` in `instance_init` in this case, and whether this class should have the `FINAL` attribute as well.
EDIT: @adrian17 answered that it shouldn't be `FINAL`, and that technically `super_init` should indeed always be called, even if in this case it most likely does nothing.