### PR TITLE
web: Fix compatibility with Rocket Loader

### DIFF
--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -83,7 +83,9 @@ export class PublicAPI {
         }
 
         if (document.readyState === "loading") {
-            window.addEventListener("DOMContentLoaded", this.init.bind(this));
+            // Cloudflare Rocket Loader interferes with the DOMContentLoaded event,
+            // so we listen for readystatechange instead
+            document.addEventListener("readystatechange", this.init.bind(this));
         } else {
             window.setTimeout(this.init.bind(this), 0);
         }


### PR DESCRIPTION
Cloudflare's Rocket Loader script [prevents the DOMContentLoaded event from firing](https://dev.to/hollowman6/solution-to-missing-domcontentloaded-event-when-enabling-both-html-auto-minify-and-rocket-loader-in-cloudflare-5ch8), which was preventing Ruffle's public API from initializing. Work around this by listening for the `readystatechange` event instead.

Fixes #2254 and #6583.