### PR TITLE
Fix Safari web extension

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -239,7 +239,7 @@ jobs:
           mkdir package/Ruffle.app/Contents/PlugIns/Ruffle\ Web.appex/Contents/Resources
           mkdir package/Ruffle.app/Contents/PlugIns/Ruffle\ Web.appex/Contents/MacOS
           mv package/ruffle_web_safari package/Ruffle.app/Contents/PlugIns/Ruffle\ Web.appex/Contents/MacOS/ruffle_web_safari
-          cp ./web/packages/extension/dist/ruffle_extension.zip package/Ruffle.app/Contents/PlugIns/Ruffle\ Web.appex/Contents/Resources
+          cp ruffle_extension.zip package/Ruffle.app/Contents/PlugIns/Ruffle\ Web.appex/Contents/Resources
           cd package/Ruffle.app/Contents/PlugIns/Ruffle\ Web.appex/Contents/Resources
           unzip ruffle_extension.zip
           rm ruffle_extension.zip


### PR DESCRIPTION
`actions/download-artifact` puts the asset in the wrong spot, which means we generate an app extension with no resources. This generates an extension that reliably crashes Safari in infinite recursion if you try to load it. This PR fixes the command that builds the appex bundle to copy from the place `download-artifact` puts the ZIP.