### PR TITLE
ci: Bump mocha timeout length

### DIFF
--- a/web/packages/selfhosted/wdio.conf.js
+++ b/web/packages/selfhosted/wdio.conf.js
@@ -160,7 +160,7 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: "bdd",
-        timeout: 60000,
+        timeout: 120000,
     },
     //
     // =====


### PR DESCRIPTION
Bump mocha's timeout from 60 secs to 120 secs to attempt to improve the reliability of our Windows node tests.