### PR TITLE
chore: `.filter_map(..).next()` -> `.find_map(..)`

### DIFF
--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -55,30 +55,22 @@ impl<'gc, V> PropertyMap<'gc, V> {
     }
 
     pub fn get(&self, name: QName<'gc>) -> Option<&V> {
-        self.0
-            .get(&name.local_name())
-            .iter()
-            .filter_map(|v| {
-                v.iter()
-                    .filter(|(n, _)| *n == name.namespace())
-                    .map(|(_, v)| v)
-                    .next()
-            })
-            .next()
+        self.0.get(&name.local_name()).iter().find_map(|v| {
+            v.iter()
+                .filter(|(n, _)| *n == name.namespace())
+                .map(|(_, v)| v)
+                .next()
+        })
     }
 
     pub fn get_for_multiname(&self, name: &Multiname<'gc>) -> Option<&V> {
         if let Some(local_name) = name.local_name() {
-            self.0
-                .get(&local_name)
-                .iter()
-                .filter_map(|v| {
-                    v.iter()
-                        .filter(|(n, _)| name.namespace_set().any(|ns| *ns == *n))
-                        .map(|(_, v)| v)
-                        .next()
-                })
-                .next()
+            self.0.get(&local_name).iter().find_map(|v| {
+                v.iter()
+                    .filter(|(n, _)| name.namespace_set().any(|ns| *ns == *n))
+                    .map(|(_, v)| v)
+                    .next()
+            })
         } else {
             None
         }
@@ -86,16 +78,12 @@ impl<'gc, V> PropertyMap<'gc, V> {
 
     pub fn get_with_ns_for_multiname(&self, name: &Multiname<'gc>) -> Option<(Namespace<'gc>, &V)> {
         if let Some(local_name) = name.local_name() {
-            self.0
-                .get(&local_name)
-                .iter()
-                .filter_map(|v| {
-                    v.iter()
-                        .filter(|(n, _)| name.namespace_set().any(|ns| *ns == *n))
-                        .map(|(ns, v)| (*ns, v))
-                        .next()
-                })
-                .next()
+            self.0.get(&local_name).iter().find_map(|v| {
+                v.iter()
+                    .filter(|(n, _)| name.namespace_set().any(|ns| *ns == *n))
+                    .map(|(ns, v)| (*ns, v))
+                    .next()
+            })
         } else {
             None
         }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -461,7 +461,7 @@ impl<'gc> AudioManager<'gc> {
             .sounds
             .iter()
             .enumerate()
-            .filter_map(|(i, instance)| {
+            .find_map(|(i, instance)| {
                 let start_frame = instance.stream_start_frame?;
                 let clip = instance
                     .display_object
@@ -476,7 +476,6 @@ impl<'gc> AudioManager<'gc> {
                     + offset_ms / 1000.0;
                 Some((i, stream_pos / 1000.0 - timeline_pos))
             })
-            .next()
             .unwrap_or_default();
 
         if skew.abs() >= Self::STREAM_RESTART_THRESHOLD {


### PR DESCRIPTION
Per the rust-analyzer diagnostic: https://rust-analyzer.github.io/manual.html#replace-filter-map-next-with-find-map