### PR TITLE
core: Stub out remaining PlaceObject data

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1274,14 +1274,6 @@ pub trait TDisplayObject<'gc>:
             if let Some(color_transform) = &place_object.color_transform {
                 self.set_color_transform(context.gc_context, &color_transform.clone().into());
             }
-            if let Some(name) = &place_object.name {
-                let encoding = swf::SwfStr::encoding_for_version(self.swf_version());
-                let name = name.to_str_lossy(encoding);
-                self.set_name(
-                    context.gc_context,
-                    AvmString::new_utf8(context.gc_context, name),
-                );
-            }
             if let Some(clip_depth) = place_object.clip_depth {
                 self.set_clip_depth(context.gc_context, clip_depth.into());
             }
@@ -1335,6 +1327,9 @@ pub trait TDisplayObject<'gc>:
                     self.set_opaque_background(context.gc_context, color);
                 }
             }
+            // Purposely omitted: name
+            // These properties are only set on initial placement in `MovieClip::instantiate_child`
+            // and can not be modified by subsequent PlaceObject tags.
             // TODO: Others will go here eventually.
         }
     }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1274,9 +1274,6 @@ pub trait TDisplayObject<'gc>:
             if let Some(color_transform) = &place_object.color_transform {
                 self.set_color_transform(context.gc_context, &color_transform.clone().into());
             }
-            if let Some(clip_depth) = place_object.clip_depth {
-                self.set_clip_depth(context.gc_context, clip_depth.into());
-            }
             if let Some(ratio) = place_object.ratio {
                 if let Some(mut morph_shape) = self.as_morph_shape() {
                     morph_shape.set_ratio(context.gc_context, ratio);
@@ -1327,7 +1324,7 @@ pub trait TDisplayObject<'gc>:
                     self.set_opaque_background(context.gc_context, color);
                 }
             }
-            // Purposely omitted: name
+            // Purposely omitted: name, clip_depth
             // These properties are only set on initial placement in `MovieClip::instantiate_child`
             // and can not be modified by subsequent PlaceObject tags.
             // TODO: Others will go here eventually.

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1298,10 +1298,11 @@ pub trait TDisplayObject<'gc>:
                     self.set_opaque_background(context.gc_context, color);
                 }
             }
-            // Purposely omitted: name, clip_depth, clip_actions
+            // Purposely omitted properties:
+            // name, clip_depth, clip_actions
             // These properties are only set on initial placement in `MovieClip::instantiate_child`
             // and can not be modified by subsequent PlaceObject tags.
-            // TODO: Others will go here eventually.
+            // TODO: Filters need to be applied here.
         }
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3303,6 +3303,9 @@ impl<'a> GotoPlaceObject<'a> {
                 if place_object.clip_depth.is_none() {
                     place_object.clip_depth = Some(Default::default());
                 }
+                if place_object.is_bitmap_cached.is_none() {
+                    place_object.is_bitmap_cached = Some(Default::default());
+                }
                 if place_object.class_name.is_none() {
                     place_object.class_name = Some(Default::default());
                 }
@@ -3354,6 +3357,9 @@ impl<'a> GotoPlaceObject<'a> {
         }
         if next_place.background_color.is_some() {
             cur_place.background_color = next_place.background_color.take();
+        }
+        if next_place.is_bitmap_cached.is_some() {
+            cur_place.is_bitmap_cached = next_place.is_bitmap_cached.take();
         }
         if next_place.is_visible.is_some() {
             cur_place.is_visible = next_place.is_visible.take();

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3303,6 +3303,9 @@ impl<'a> GotoPlaceObject<'a> {
                 if place_object.clip_depth.is_none() {
                     place_object.clip_depth = Some(Default::default());
                 }
+                if place_object.blend_mode.is_none() {
+                    place_object.blend_mode = Some(Default::default());
+                }
                 if place_object.is_bitmap_cached.is_none() {
                     place_object.is_bitmap_cached = Some(Default::default());
                 }
@@ -3357,6 +3360,9 @@ impl<'a> GotoPlaceObject<'a> {
         }
         if next_place.background_color.is_some() {
             cur_place.background_color = next_place.background_color.take();
+        }
+        if next_place.blend_mode.is_some() {
+            cur_place.blend_mode = next_place.blend_mode.take();
         }
         if next_place.is_bitmap_cached.is_some() {
             cur_place.is_bitmap_cached = next_place.is_bitmap_cached.take();

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3315,6 +3315,7 @@ impl<'a> GotoPlaceObject<'a> {
                 if place_object.background_color.is_none() {
                     place_object.background_color = Some(Color::from_rgba(0));
                 }
+                // `is_visible` purposely skipped; flag carries over during rewind.
             }
         }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1165,6 +1165,7 @@ impl<'gc> MovieClip<'gc> {
                             log::error!("No movie when trying to set clip event");
                         }
                     }
+                    // TODO: Missing PlaceObject properties: amf_data, filters
 
                     // Run first frame.
                     child.construct_frame(context);
@@ -3340,15 +3341,16 @@ impl<'a> GotoPlaceObject<'a> {
                 if place_object.is_bitmap_cached.is_none() {
                     place_object.is_bitmap_cached = Some(Default::default());
                 }
-                if place_object.class_name.is_none() {
-                    place_object.class_name = Some(Default::default());
-                }
                 if place_object.background_color.is_none() {
                     place_object.background_color = Some(Color::from_rgba(0));
                 }
-                // Deliberately omitted:
-                // clip_depth: Can only be set on initial creation
-                // `is_visible` purposely skipped; flag carries over during rewind.
+                // Purposely omitted properties:
+                // name, clip_depth, clip_actions, amf_data
+                // These properties are only set on initial placement in `MovieClip::instantiate_child`
+                // and can not be modified by subsequent PlaceObject tags.
+                // Also, is_visible flag persists during rewind unlike all other properties.
+                // TODO: Filters need to be applied here. Rewinding will erase filters if initial
+                // PlaceObject tag has none.
             }
         }
 
@@ -3386,12 +3388,6 @@ impl<'a> GotoPlaceObject<'a> {
         if next_place.ratio.is_some() {
             cur_place.ratio = next_place.ratio.take();
         }
-        if next_place.clip_depth.is_some() {
-            cur_place.clip_depth = next_place.clip_depth.take();
-        }
-        if next_place.class_name.is_some() {
-            cur_place.class_name = next_place.class_name.take();
-        }
         if next_place.blend_mode.is_some() {
             cur_place.blend_mode = next_place.blend_mode.take();
         }
@@ -3404,11 +3400,11 @@ impl<'a> GotoPlaceObject<'a> {
         if next_place.background_color.is_some() {
             cur_place.background_color = next_place.background_color.take();
         }
-        // Deliberately omitted: (can only be set once on instantiation)
-        // clip_actions
-        // clip_depth
-        // name:
-        // TODO: Other stuff.
+        // Purposely omitted properties:
+        // name, clip_depth, clip_actions, amf_data
+        // These properties are only set on initial placement in `MovieClip::instantiate_child`
+        // and can not be modified by subsequent PlaceObject tags.
+        // TODO: Filters need to be applied here. New filters will overwrite old filters.
     }
 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3312,6 +3312,9 @@ impl<'a> GotoPlaceObject<'a> {
                 if place_object.class_name.is_none() {
                     place_object.class_name = Some(Default::default());
                 }
+                if place_object.background_color.is_none() {
+                    place_object.background_color = Some(Color::from_rgba(0));
+                }
             }
         }
 
@@ -3358,9 +3361,6 @@ impl<'a> GotoPlaceObject<'a> {
         if next_place.class_name.is_some() {
             cur_place.class_name = next_place.class_name.take();
         }
-        if next_place.background_color.is_some() {
-            cur_place.background_color = next_place.background_color.take();
-        }
         if next_place.blend_mode.is_some() {
             cur_place.blend_mode = next_place.blend_mode.take();
         }
@@ -3369,6 +3369,9 @@ impl<'a> GotoPlaceObject<'a> {
         }
         if next_place.is_visible.is_some() {
             cur_place.is_visible = next_place.is_visible.take();
+        }
+        if next_place.background_color.is_some() {
+            cur_place.background_color = next_place.background_color.take();
         }
         // TODO: Other stuff.
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1138,6 +1138,9 @@ impl<'gc> MovieClip<'gc> {
                             AvmString::new_utf8(context.gc_context, name),
                         );
                     }
+                    if let Some(clip_depth) = place_object.clip_depth {
+                        child.set_clip_depth(context.gc_context, clip_depth.into());
+                    }
 
                     // Run first frame.
                     child.construct_frame(context);
@@ -3319,6 +3322,8 @@ impl<'a> GotoPlaceObject<'a> {
                 if place_object.background_color.is_none() {
                     place_object.background_color = Some(Color::from_rgba(0));
                 }
+                // Deliberately omitted:
+                // clip_depth: Can only be set on initial creation
                 // `is_visible` purposely skipped; flag carries over during rewind.
             }
         }
@@ -3376,7 +3381,8 @@ impl<'a> GotoPlaceObject<'a> {
             cur_place.background_color = next_place.background_color.take();
         }
         // Deliberately omitted: (can only be set once on instantiation)
-        // name
+        // clip_depth
+        // name:
         // TODO: Other stuff.
     }
 }

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -767,6 +767,12 @@ impl BlendMode {
     }
 }
 
+impl Default for BlendMode {
+    fn default() -> Self {
+        BlendMode::Normal
+    }
+}
+
 /// An clip action (a.k.a. clip event) placed on a MovieClip instance.
 /// Created in the Flash IDE using `onClipEvent` or `on` blocks.
 ///


### PR DESCRIPTION
 * Stub out the following PlaceObject parameters and corresponding properties in `DisplayObject`:
   * Blend mode
   * Cache-as-bitmap
   * Background color
 * Improve accuracy of PlaceObject behavior.
   * Some properties only take effect on initial creation of an object: name, clip depth, clip actions, ...
   * Attempts to modify these properties in a subsequent PlaceObject are ignored.
   * Move initialization of these properties from `DisplayObject::apply_place_object` to `MovieClip::instantiate_child`.
   * Also removed these from `GotoPlaceObject::merge` (because they can't be modified after initial creation)
   * This should have no effect on most content, because Flash IDE would generally not export modify PlaceObject tags in this way, instead doing a RemoveObject followed by a fresh PlaceObject tag if necessary. Only malformed or third-party SWF files might do this. I had to modify SWFs in JPEXS to deduce this behavior.

TODO: Filters are a little more involved and will be done in the next PR.
No actual functionality is implemented yet, just beginning to wire everything up.