### PR TITLE
core: Use response URL for loaded movies

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -3,7 +3,6 @@
 use crate::loader::Error;
 use crate::string::WStr;
 use indexmap::IndexMap;
-use std::borrow::Cow;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -191,16 +190,6 @@ pub trait NavigatorBackend {
     /// This seems highly limiting.
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>);
 
-    /// Resolve a relative URL.
-    ///
-    /// This function must not change URLs which are already protocol, domain,
-    /// and path absolute. For URLs that are relative, the implementer of
-    /// this function may opt to convert them to absolute using an implementor
-    /// defined base. For a web browser, the most obvious base would be the
-    /// current document's base URL, while the most obvious base for a desktop
-    /// client would be the file-URL form of the current path.
-    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str>;
-
     /// Handle any context specific pre-processing
     ///
     /// Changing http -> https for example. This function may alter any part of the
@@ -347,15 +336,6 @@ impl NavigatorBackend for NullNavigatorBackend {
 
     fn spawn_future(&mut self, future: OwnedFuture<(), Error>) {
         self.spawner.spawn_local(future);
-    }
-
-    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str> {
-        let relative = url_from_relative_path(&self.relative_base_path, url);
-        if let Ok(relative) = relative {
-            String::from(relative).into()
-        } else {
-            url.into()
-        }
     }
 
     fn pre_process_url(&self, url: Url) -> Url {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -352,14 +352,7 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
-            // clippy reports a false positive for explicitly dropped guards:
-            // https://github.com/rust-lang/rust-clippy/issues/6446
-            // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch = {
-                let player_lock = player.lock().unwrap();
-                let url = player_lock.navigator().resolve_relative_url(&url);
-                player_lock.navigator().fetch(&url, options)
-            };
+            let fetch = player.lock().unwrap().navigator().fetch(&url, options);
 
             let response = fetch.await.map_err(|error| {
                 player
@@ -402,14 +395,7 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
-            // clippy reports a false positive for explicitly dropped guards:
-            // https://github.com/rust-lang/rust-clippy/issues/6446
-            // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch = {
-                let player_lock = player.lock().unwrap();
-                let url = player_lock.navigator().resolve_relative_url(&url);
-                player_lock.navigator().fetch(&url, options)
-            };
+            let fetch = player.lock().unwrap().navigator().fetch(&url, options);
 
             let mut replacing_root_movie = false;
             player.lock().unwrap().update(|uc| -> Result<(), Error> {
@@ -517,14 +503,7 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
-            // clippy reports a false positive for explicitly dropped guards:
-            // https://github.com/rust-lang/rust-clippy/issues/6446
-            // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch = {
-                let player_lock = player.lock().unwrap();
-                let url = player_lock.navigator().resolve_relative_url(&url);
-                player_lock.navigator().fetch(&url, options)
-            };
+            let fetch = player.lock().unwrap().navigator().fetch(&url, options);
 
             let response = fetch.await?;
 
@@ -572,14 +551,7 @@ impl<'gc> Loader<'gc> {
             .expect("Could not upgrade weak reference to player");
 
         Box::pin(async move {
-            // clippy reports a false positive for explicitly dropped guards:
-            // https://github.com/rust-lang/rust-clippy/issues/6446
-            // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch = {
-                let player_lock = player.lock().unwrap();
-                let url = player_lock.navigator().resolve_relative_url(&url);
-                player_lock.navigator().fetch(&url, options)
-            };
+            let fetch = player.lock().unwrap().navigator().fetch(&url, options);
 
             let data = fetch.await;
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -355,12 +355,10 @@ impl<'gc> Loader<'gc> {
             // clippy reports a false positive for explicitly dropped guards:
             // https://github.com/rust-lang/rust-clippy/issues/6446
             // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch;
-            let url = {
+            let fetch = {
                 let player_lock = player.lock().unwrap();
                 let url = player_lock.navigator().resolve_relative_url(&url);
-                fetch = player_lock.navigator().fetch(&url, options);
-                url
+                player_lock.navigator().fetch(&url, options)
             };
 
             let response = fetch.await.map_err(|error| {
@@ -372,7 +370,7 @@ impl<'gc> Loader<'gc> {
                 error
             })?;
 
-            let mut movie = SwfMovie::from_data(&response.body, Some(url.into_owned()), None)?;
+            let mut movie = SwfMovie::from_data(&response.body, Some(response.url), None)?;
             on_metadata(movie.header());
             movie.append_parameters(parameters);
             player.lock().unwrap().set_root_movie(movie);
@@ -407,12 +405,10 @@ impl<'gc> Loader<'gc> {
             // clippy reports a false positive for explicitly dropped guards:
             // https://github.com/rust-lang/rust-clippy/issues/6446
             // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch;
-            let url = {
+            let fetch = {
                 let player_lock = player.lock().unwrap();
                 let url = player_lock.navigator().resolve_relative_url(&url);
-                fetch = player_lock.navigator().fetch(&url, options);
-                url
+                player_lock.navigator().fetch(&url, options)
             };
 
             let mut replacing_root_movie = false;
@@ -441,7 +437,7 @@ impl<'gc> Loader<'gc> {
                     sniffed_type.expect(ContentType::Swf)?;
 
                     let movie =
-                        SwfMovie::from_data(&response.body, Some(url.into_owned()), loader_url)?;
+                        SwfMovie::from_data(&response.body, Some(response.url), loader_url)?;
                     player.lock().unwrap().set_root_movie(movie);
                     return Ok(());
                 }
@@ -457,7 +453,7 @@ impl<'gc> Loader<'gc> {
                         ContentType::Swf => {
                             let movie = Arc::new(SwfMovie::from_data(
                                 &response.body,
-                                Some(url.into_owned()),
+                                Some(response.url),
                                 loader_url,
                             )?);
 
@@ -524,12 +520,11 @@ impl<'gc> Loader<'gc> {
             // clippy reports a false positive for explicitly dropped guards:
             // https://github.com/rust-lang/rust-clippy/issues/6446
             // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch;
-            {
+            let fetch = {
                 let player_lock = player.lock().unwrap();
                 let url = player_lock.navigator().resolve_relative_url(&url);
-                fetch = player_lock.navigator().fetch(&url, options);
-            }
+                player_lock.navigator().fetch(&url, options)
+            };
 
             let response = fetch.await?;
 
@@ -580,12 +575,11 @@ impl<'gc> Loader<'gc> {
             // clippy reports a false positive for explicitly dropped guards:
             // https://github.com/rust-lang/rust-clippy/issues/6446
             // A workaround for this is to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
-            let fetch;
-            {
+            let fetch = {
                 let player_lock = player.lock().unwrap();
                 let url = player_lock.navigator().resolve_relative_url(&url);
-                fetch = player_lock.navigator().fetch(&url, options);
-            }
+                player_lock.navigator().fetch(&url, options)
+            };
 
             let data = fetch.await;
 

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -7,7 +7,6 @@ use ruffle_core::backend::navigator::{
 };
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
-use std::borrow::Cow;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
 use url::Url;
@@ -106,7 +105,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
 
     fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Response, Error> {
         // TODO: honor sandbox type (local-with-filesystem, local-with-network, remote, ...)
-        let full_url = match self.movie_url.clone().join(url) {
+        let full_url = match self.movie_url.join(url) {
             Ok(url) => url,
             Err(e) => {
                 let msg = format!("Invalid URL {}: {}", url, e);
@@ -199,15 +198,6 @@ impl NavigatorBackend for ExternalNavigatorBackend {
             log::warn!(
                 "A task was queued on an event loop that has already ended. It will not be polled."
             );
-        }
-    }
-
-    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str> {
-        let relative = self.movie_url.join(url);
-        if let Ok(relative) = relative {
-            String::from(relative).into()
-        } else {
-            url.into()
         }
     }
 

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -73,6 +73,19 @@ impl WebNavigatorBackend {
             None
         }
     }
+
+    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str> {
+        let window = web_sys::window().expect("window()");
+        let document = window.document().expect("document()");
+
+        if let Some(base_uri) = self.base_uri(&document) {
+            if let Ok(new_url) = url_from_relative_url(&base_uri, url) {
+                return String::from(new_url).into();
+            }
+        }
+
+        url.into()
+    }
 }
 
 impl NavigatorBackend for WebNavigatorBackend {
@@ -235,19 +248,6 @@ impl NavigatorBackend for WebNavigatorBackend {
                 log::error!("Asynchronous error occurred: {}", e);
             }
         })
-    }
-
-    fn resolve_relative_url<'a>(&self, url: &'a str) -> Cow<'a, str> {
-        let window = web_sys::window().expect("window()");
-        let document = window.document().expect("document()");
-
-        if let Some(base_uri) = self.base_uri(&document) {
-            if let Ok(new_url) = url_from_relative_url(&base_uri, url) {
-                return String::from(new_url).into();
-            }
-        }
-
-        url.into()
     }
 
     fn pre_process_url(&self, mut url: Url) -> Url {

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -214,6 +214,8 @@ impl NavigatorBackend for WebNavigatorBackend {
                 )));
             }
 
+            let url = response.url();
+
             let body: ArrayBuffer = JsFuture::from(response.array_buffer().unwrap())
                 .await
                 .map_err(|_| {
@@ -223,7 +225,7 @@ impl NavigatorBackend for WebNavigatorBackend {
                 .unwrap();
             let body = Uint8Array::new(&body).to_vec();
 
-            Ok(Response { body })
+            Ok(Response { url, body })
         })
     }
 

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -2,6 +2,7 @@
 use js_sys::{Array, ArrayBuffer, Uint8Array};
 use ruffle_core::backend::navigator::{
     url_from_relative_url, NavigationMethod, NavigatorBackend, OwnedFuture, RequestOptions,
+    Response,
 };
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
@@ -9,7 +10,9 @@ use std::borrow::Cow;
 use url::Url;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
-use web_sys::{window, Blob, BlobPropertyBag, Document, Request, RequestInit, Response};
+use web_sys::{
+    window, Blob, BlobPropertyBag, Document, Request, RequestInit, Response as WebResponse,
+};
 
 pub struct WebNavigatorBackend {
     allow_script_access: bool,
@@ -157,7 +160,7 @@ impl NavigatorBackend for WebNavigatorBackend {
         }
     }
 
-    fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Vec<u8>, Error> {
+    fn fetch(&self, url: &str, options: RequestOptions) -> OwnedFuture<Response, Error> {
         let url = if let Ok(parsed_url) = Url::parse(url) {
             self.pre_process_url(parsed_url).to_string()
         } else {
@@ -203,23 +206,24 @@ impl NavigatorBackend for WebNavigatorBackend {
                 .await
                 .map_err(|_| Error::FetchError("Got JS error".to_string()))?;
 
-            let resp: Response = fetchval.dyn_into().unwrap();
-            if !resp.ok() {
+            let response: WebResponse = fetchval.dyn_into().unwrap();
+            if !response.ok() {
                 return Err(Error::FetchError(format!(
                     "HTTP status is not ok, got {}",
-                    resp.status_text()
+                    response.status_text()
                 )));
             }
 
-            let data: ArrayBuffer = JsFuture::from(resp.array_buffer().unwrap())
+            let body: ArrayBuffer = JsFuture::from(response.array_buffer().unwrap())
                 .await
                 .map_err(|_| {
                     Error::FetchError("Could not allocate array buffer for response".to_string())
                 })?
                 .dyn_into()
                 .unwrap();
+            let body = Uint8Array::new(&body).to_vec();
 
-            Ok(Uint8Array::new(&data).to_vec())
+            Ok(Response { body })
         })
     }
 


### PR DESCRIPTION
Previously, loaded movies had their URL the same as the requested URL. However this is incorrect, as they should have the final response URL, obtained after any redirects.

Solve this using a newly-introduced struct `Response`, which holds both response body bytes and response URL. Then, use it as the URL of loaded movies. In the future, `Response` could also hold the HTTP response code, instead of treating any fetch error as 404, if that makes sense.

Also, inline per-implementation `NavigatorBackend::resolve_relative_url` into `NavigatorBackend::fetch`, because no one else uses the resolved request URL anymore, which nicely simplifies the `NavigatorBackend` interface a bit.