### PR TITLE
ci: Don't test web build on Windows

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -80,6 +80,8 @@ jobs:
         run: npm run lint
 
       - name: Run tests
+        # MIKE: Don't run web tests on Windows because it's flaky for unknown reasons. :-(
+        if: runner.os == 'Linux'
         working-directory: web
         run: npm test
 


### PR DESCRIPTION
For unknown reasons, tests on the Windows web build continue to be flaky on GitHub CI. Disable them for now. Tests continue to be run on Ubuntu.