### PR TITLE
core: Remove `url_from_relative_path`

### DIFF
--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -9,45 +9,6 @@ use std::pin::Pin;
 use swf::avm1::types::SendVarsMethod;
 use url::{ParseError, Url};
 
-/// Attempt to convert a relative filesystem path into an absolute `file:///`
-/// URL.
-///
-/// If the relative path is an absolute path, the base will not be used, but it
-/// will still be parsed into a `Url`.
-///
-/// This is the desktop version of this function, which actually carries out
-/// the above instructions. On non-Unix, non-Windows, non-Redox environments,
-/// this function always yields an error.
-#[cfg(any(unix, windows, target_os = "redox"))]
-pub fn url_from_relative_path<P: AsRef<Path>>(base: P, relative: &str) -> Result<Url, ParseError> {
-    let parsed = Url::from_file_path(relative);
-    if let Err(()) = parsed {
-        let base =
-            Url::from_directory_path(base).map_err(|_| ParseError::RelativeUrlWithoutBase)?;
-
-        return base.join(relative);
-    }
-
-    Ok(parsed.unwrap())
-}
-
-/// Attempt to convert a relative filesystem path into an absolute `file:///`
-/// URL.
-///
-/// If the relative path is an absolute path, the base will not be used, but it
-/// will still be parsed into a `Url`.
-///
-/// This is the web version of this function, which always yields an error. On
-/// Unix, Windows, or Redox, this function actually carries out the above
-/// instructions.
-#[cfg(not(any(unix, windows, target_os = "redox")))]
-pub fn url_from_relative_path<P: AsRef<Path>>(
-    _base: P,
-    _relative: &str,
-) -> Result<Url, ParseError> {
-    Err(ParseError::RelativeUrlWithoutBase)
-}
-
 /// Attempt to convert a relative URL into an absolute URL, using the base URL
 /// if necessary.
 ///

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -1,9 +1,9 @@
-use crate::backend::navigator::url_from_relative_path;
 use crate::vminterface::AvmType;
 use gc_arena::Collect;
 use std::path::Path;
 use std::sync::Arc;
 use swf::{Fixed8, HeaderExt, Rectangle, TagCode, Twips};
+use url::Url;
 
 pub type Error = Box<dyn std::error::Error>;
 pub type DecodeResult = Result<(), Error>;
@@ -52,15 +52,14 @@ impl SwfMovie {
     }
 
     /// Utility method to construct a movie from a file on disk.
+    #[cfg(any(unix, windows, target_os = "redox"))]
     pub fn from_path<P: AsRef<Path>>(path: P, loader_url: Option<String>) -> Result<Self, Error> {
-        let mut url = path.as_ref().to_string_lossy().to_owned().to_string();
-        let cwd = std::env::current_dir()?;
-        if let Ok(abs_url) = url_from_relative_path(cwd, &url) {
-            url = abs_url.into();
-        }
+        let data = std::fs::read(&path)?;
 
-        let data = std::fs::read(path)?;
-        Self::from_data(&data, Some(url), loader_url)
+        let abs_path = path.as_ref().canonicalize()?;
+        let url = Url::from_file_path(abs_path).map_err(|()| "Invalid SWF URL")?;
+
+        Self::from_data(&data, Some(url.into()), loader_url)
     }
 
     /// Construct a movie based on the contents of the SWF datastream.


### PR DESCRIPTION
The remaining caller was `SwfMovie::from_path`, which is now changed
to be simpler, and a little stricter (panics if `Url::from_file_path`
fails, though it shouldn't happen with canonicalized paths).