### PR TITLE
web: Prefer using `Element` over `HTMLElement`

### DIFF
--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -136,7 +136,7 @@ export class RuffleEmbed extends RufflePlayer {
      * @param elem Element to check.
      * @returns True if the element looks like a flash embed.
      */
-    static isInterdictable(elem: HTMLElement): boolean {
+    static isInterdictable(elem: Element): boolean {
         // Don't polyfill if the element is inside a specific node.
         if (isFallbackElement(elem)) {
             return false;
@@ -176,7 +176,7 @@ export class RuffleEmbed extends RufflePlayer {
      * @param elem Element to replace.
      * @returns Created RuffleEmbed.
      */
-    static fromNativeEmbedElement(elem: HTMLElement): RuffleEmbed {
+    static fromNativeEmbedElement(elem: Element): RuffleEmbed {
         const externalName = registerElement("ruffle-embed", RuffleEmbed);
         const ruffleObj = <RuffleEmbed>document.createElement(externalName);
         ruffleObj.copyElement(elem);

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -45,7 +45,7 @@ function findCaseInsensitive(
  * @param elem Element to check.
  * @returns A record of every parameter.
  */
-function paramsOf(elem: HTMLElement): Record<string, string> {
+function paramsOf(elem: Element): Record<string, string> {
     const params: Record<string, string> = {};
 
     for (const param of elem.children) {
@@ -220,7 +220,7 @@ export class RuffleObject extends RufflePlayer {
      * @param elem Element to check.
      * @returns True if the element looks like a flash object.
      */
-    static isInterdictable(elem: HTMLElement): boolean {
+    static isInterdictable(elem: Element): boolean {
         // Don't polyfill if the element is inside a specific node.
         if (isFallbackElement(elem)) {
             return false;
@@ -250,9 +250,7 @@ export class RuffleObject extends RufflePlayer {
             // Don't polyfill when the file is a Youtube Flash source.
             if (isYoutubeFlashSource(params.movie)) {
                 // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well
-                const movie_elem = elem.querySelector(
-                    "param[name='movie']"
-                ) as HTMLElement;
+                const movie_elem = elem.querySelector("param[name='movie']");
                 if (movie_elem) {
                     workaroundYoutubeMixedContent(movie_elem, "value");
                     // The data attribute needs to be set for the re-fetch to happen
@@ -316,7 +314,7 @@ export class RuffleObject extends RufflePlayer {
      * @param elem Element to replace.
      * @returns Created RuffleObject.
      */
-    static fromNativeObjectElement(elem: HTMLElement): RuffleObject {
+    static fromNativeObjectElement(elem: Element): RuffleObject {
         const externalName = registerElement("ruffle-object", RuffleObject);
         const ruffleObj: RuffleObject = <RuffleObject>(
             document.createElement(externalName)

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -53,9 +53,9 @@ declare global {
         webkitExitFullscreen?: () => void;
         webkitCancelFullScreen?: () => void;
     }
-    interface HTMLElement {
-        webkitRequestFullscreen?: (arg0: unknown) => unknown;
-        webkitRequestFullScreen?: (arg0: unknown) => unknown;
+    interface Element {
+        webkitRequestFullscreen?: (options: unknown) => unknown;
+        webkitRequestFullScreen?: (options: unknown) => unknown;
     }
 }
 
@@ -980,7 +980,7 @@ export class RufflePlayer extends HTMLElement {
      * @param elem The element to copy all attributes from.
      * @protected
      */
-    protected copyElement(elem: HTMLElement): void {
+    protected copyElement(elem: Element): void {
         if (elem) {
             for (let i = 0; i < elem.attributes.length; i++) {
                 const attrib = elem.attributes[i];
@@ -1516,7 +1516,7 @@ export function isYoutubeFlashSource(filename: string | null): boolean {
  * @param attr The attribute to adjust.
  */
 export function workaroundYoutubeMixedContent(
-    elem: HTMLElement,
+    elem: Element,
     attr: string
 ): void {
     const elem_attr = elem.getAttribute(attr);
@@ -1571,7 +1571,7 @@ export function isSwfFilename(filename: string | null): boolean {
  * @param elem The element to test.
  * @returns True if the element is inside an <audio> or <video> node.
  */
-export function isFallbackElement(elem: HTMLElement): boolean {
+export function isFallbackElement(elem: Element): boolean {
     let parent = elem.parentElement;
     while (parent !== null) {
         switch (parent.tagName) {


### PR DESCRIPTION
`Element` is a slightly more general type, which is more common than
`HTMLElement`, and it satisfies our needs in most cases.