### PR TITLE
Implement `TextField.background` getter/setter

### DIFF
--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -101,6 +101,41 @@ pub fn set_autosize<'gc>(
     Ok(Value::Undefined)
 }
 
+pub fn background<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this
+        .and_then(|this| this.as_display_object())
+        .and_then(|this| this.as_edit_text())
+    {
+        return Ok((this.has_background()).into());
+    }
+
+    Ok(Value::Undefined)
+}
+
+pub fn set_background<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this
+        .and_then(|this| this.as_display_object())
+        .and_then(|this| this.as_edit_text())
+    {
+        let has_background = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_boolean();
+        this.set_has_background(activation.context.gc_context, has_background);
+    }
+
+    Ok(Value::Undefined)
+}
+
 pub fn background_color<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
@@ -865,6 +900,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         Option<NativeMethodImpl>,
     )] = &[
         ("autoSize", Some(autosize), Some(set_autosize)),
+        ("background", Some(background), Some(set_background)),
         (
             "backgroundColor",
             Some(background_color),


### PR DESCRIPTION
There's already a `has_background` field on the underlying object
data, so we can just map this property to it.