### PR TITLE
render: Clamp alpha in shaders (fix #6954)

### DIFF
--- a/render/webgl/shaders/bitmap.frag
+++ b/render/webgl/shaders/bitmap.frag
@@ -23,7 +23,8 @@ void main() {
     if( color.a > 0.0 ) {
         color.rgb /= color.a;
         color = mult_color * color + add_color;
-        color.rgb *= color.a;
+        float alpha = saturate(color.a);
+        color = vec4(color.rgb * alpha, alpha);
     }
 
     gl_FragColor = color;

--- a/render/webgl/shaders/color.frag
+++ b/render/webgl/shaders/color.frag
@@ -14,5 +14,5 @@ uniform vec4 add_color;
 varying vec4 frag_color;
 
 void main() {
-    gl_FragColor = vec4(frag_color.rgb * frag_color.a, frag_color.a);
+    gl_FragColor = frag_color;
 }

--- a/render/webgl/shaders/color.vert
+++ b/render/webgl/shaders/color.vert
@@ -17,5 +17,7 @@ varying vec4 frag_color;
 
 void main() {
     frag_color = color * mult_color + add_color;
+    float alpha = saturate(frag_color.a);
+    frag_color = vec4(frag_color.rgb * alpha, alpha);
     gl_Position = view_matrix * world_matrix * vec4(position, 0.0, 1.0);
 }

--- a/render/webgl/shaders/gradient.frag
+++ b/render/webgl/shaders/gradient.frag
@@ -79,22 +79,22 @@ void main() {
     float a;
     if( t <= u_ratios[0] ) {
         color = u_colors[0];
-    } else if( t <= u_ratios[1] ) {    
+    } else if( t <= u_ratios[1] ) {
         a = (t - u_ratios[0]) / (u_ratios[1] - u_ratios[0]);
         color = mix(u_colors[0], u_colors[1], a);
-    } else if( t <= u_ratios[2] ) {    
+    } else if( t <= u_ratios[2] ) {
         a = (t - u_ratios[1]) / (u_ratios[2] - u_ratios[1]);
         color = mix(u_colors[1], u_colors[2], a);
-    } else if( t <= u_ratios[3] ) {    
+    } else if( t <= u_ratios[3] ) {
         a = (t - u_ratios[2]) / (u_ratios[3] - u_ratios[2]);
         color = mix(u_colors[2], u_colors[3], a);
-    } else if( t <= u_ratios[4] ) {    
+    } else if( t <= u_ratios[4] ) {
         a = (t - u_ratios[3]) / (u_ratios[4] - u_ratios[3]);
         color = mix(u_colors[3], u_colors[4], a);
-    } else if( t <= u_ratios[5] ) {    
+    } else if( t <= u_ratios[5] ) {
         a = (t - u_ratios[4]) / (u_ratios[5] - u_ratios[4]);
         color = mix(u_colors[4], u_colors[5], a);
-    } else if( t <= u_ratios[6] ) {    
+    } else if( t <= u_ratios[6] ) {
         a = (t - u_ratios[5]) / (u_ratios[6] - u_ratios[5]);
         color = mix(u_colors[5], u_colors[6], a);
     } else if( t <= u_ratios[7] ) {
@@ -130,6 +130,7 @@ void main() {
     }
 
     color = mult_color * color + add_color;
-    gl_FragColor = vec4(color.rgb * color.a, color.a);
+    float alpha = saturate(color.a);
+    gl_FragColor = vec4(color.rgb * alpha, alpha);
 }
 

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -28,7 +28,8 @@ fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     if( color.a > 0.0 ) {
         color = vec4<f32>(color.rgb / color.a, color.a);
         color = color * transforms.mult_color + transforms.add_color;
-        color = vec4<f32>(color.rgb * color.a, color.a);
+        let alpha = clamp(color.a, 0.0, 1.0);
+        color = vec4<f32>(color.rgb * alpha, alpha);
     }
     return color;
 }

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -7,12 +7,13 @@ struct VertexOutput {
 
 [[stage(vertex)]]
 fn main_vertex(in: VertexInput) -> VertexOutput {
-    let pos: vec4<f32> = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
-    return VertexOutput(pos, in.color);
+    let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
+    let color = in.color * transforms.mult_color + transforms.add_color;
+    let alpha = clamp(color.a, 0.0, 1.0);
+    return VertexOutput(pos, vec4<f32>(color.rgb * alpha, alpha));
 }
 
 [[stage(fragment)]]
 fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
-    let out = in.color * transforms.mult_color + transforms.add_color;
-    return vec4<f32>(out.rgb * out.a, out.a);
+    return in.color;
 }

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -102,5 +102,6 @@ fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
         color = linear_to_srgb(color);
     }
     let out = color * transforms.mult_color + transforms.add_color;
-    return vec4<f32>(out.rgb * out.a, out.a);
+    let alpha = clamp(out.a, 0.0, 1.0);
+    return vec4<f32>(out.rgb * alpha, alpha);
 }


### PR DESCRIPTION
Clamp the alpha value to [0.0, 1.0] before premultiplying in shaders to avoid colors getting out of wack when alpha isn't [0.0, 1.0]. Also a tiny optimization to the color shader to move the color adjustment from the fragment stage to the vertex stage.

Fixes #6954.