### PR TITLE
Allow new `unused_macro_rules` lint on `declare_properties`

### DIFF
--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -128,6 +128,7 @@ impl Declaration {
 ///     "hidden" => string("shh!"; DONT_ENUM | DONT_DELETE | READ_ONLY);
 /// };
 /// ```
+#[allow(unused_macro_rules)]
 macro_rules! declare_properties {
     ( $($name:literal => $kind:ident($($args:tt)*);)* ) => {
         &[ $(


### PR DESCRIPTION
This was recently added in https://github.com/rust-lang/rust/pull/96150
Some of the `__version` rules are currently unused, but I assume
that we still want to keep them for potential future use.