### PR TITLE
webgl: Use `clamp(x, 0.0, 1.0)` instead of `saturate(x)`

### DIFF
--- a/render/webgl/shaders/bitmap.frag
+++ b/render/webgl/shaders/bitmap.frag
@@ -23,7 +23,7 @@ void main() {
     if( color.a > 0.0 ) {
         color.rgb /= color.a;
         color = mult_color * color + add_color;
-        float alpha = saturate(color.a);
+        float alpha = clamp(color.a, 0.0, 1.0);
         color = vec4(color.rgb * alpha, alpha);
     }
 

--- a/render/webgl/shaders/color.vert
+++ b/render/webgl/shaders/color.vert
@@ -17,7 +17,7 @@ varying vec4 frag_color;
 
 void main() {
     frag_color = color * mult_color + add_color;
-    float alpha = saturate(frag_color.a);
+    float alpha = clamp(frag_color.a, 0.0, 1.0);
     frag_color = vec4(frag_color.rgb * alpha, alpha);
     gl_Position = view_matrix * world_matrix * vec4(position, 0.0, 1.0);
 }

--- a/render/webgl/shaders/gradient.frag
+++ b/render/webgl/shaders/gradient.frag
@@ -130,7 +130,7 @@ void main() {
     }
 
     color = mult_color * color + add_color;
-    float alpha = saturate(color.a);
+    float alpha = clamp(color.a, 0.0, 1.0);
     gl_FragColor = vec4(color.rgb * alpha, alpha);
 }
 


### PR DESCRIPTION
The latter seems to not exist in GLSL.

This is a fixup for #6959, in accordance with https://github.com/ruffle-rs/ruffle/pull/6959#issuecomment-1125829201=.