### PR TITLE
canvas: Use canvas drawing commands for gradients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,7 +3090,6 @@ dependencies = [
  "png",
  "ruffle_core",
  "ruffle_web_common",
- "svg",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -3470,12 +3469,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "svg"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72d8b19ab05827afefcca66bf47040c1e66a0901eb814784c77d4ec118bd309"
 
 [[package]]
 name = "swf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,6 @@ dependencies = [
 name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
- "base64",
  "fnv",
  "jpeg-decoder 0.2.6",
  "js-sys",

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-base64 = "0.13.0"
 fnv = "1.0.7"
 js-sys = "0.3.57"
 log = "0.4"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -31,6 +31,6 @@ default-features = false
 version = "0.3.57"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
-    "Document", "Element", "HtmlCanvasElement", "HtmlImageElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",
-    "SvgsvgElement",
+    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "HtmlImageElement", "ImageData", "Navigator", "Path2d",
+    "SvgMatrix", "SvgsvgElement",
 ]

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -14,7 +14,6 @@ fnv = "1.0.7"
 js-sys = "0.3.57"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
-svg = "0.10.0"
 percent-encoding = "2.1.0"
 png = "0.17.5"
 wasm-bindgen = "=0.2.80"


### PR DESCRIPTION
This is an attempt to remove the SVG drawing paths from the canvas renderer. The SVG path is necessary because the canvas drawing API does not easily support all of the features Flash needs, such as arbitrarily transformed gradients. In those cases, we were falling back to generating an SVG image and drawing that to the canvas (SVG has all of the necessary features). However, this is problematic because the browser's loading of the SVG image is async, which causes a delay between when we create the shape and when we can actually draw it to a canvas (#6969). It's also quite a bit slower.

For the case of "simple" gradients (no skewing in the transform), we can use the `CanvasGradient` directly. For complex cases, we can push the gradient transform with `canvas.transform`, and then draw the path using the gradient transform's inverse. This should transform the gradient while still drawing the un-transformed path.

JSFiddle example:
https://jsfiddle.net/mwelsh/jundgr70/11/
Seems like this works on Chrome and FF (need to test Safari).

 - [x] For "simple" gradients, use standard `CanvasGradient` fills
 - [x] For "complex" gradients, use `CanvasGradient`, transform the canvas by the gradient matrix, then un-transform the path
 - [x] Handle repeat/pad modes (add extra color stops to mimic these?)

Fixes #6969.