### PR TITLE
canvas: Remove some unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,12 +3081,8 @@ dependencies = [
 name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
- "fnv",
- "jpeg-decoder 0.2.6",
  "js-sys",
  "log",
- "percent-encoding",
- "png",
  "ruffle_core",
  "ruffle_web_common",
  "wasm-bindgen",

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -5,21 +5,11 @@ authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
-fnv = "1.0.7"
 js-sys = "0.3.57"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
-percent-encoding = "2.1.0"
-png = "0.17.5"
 wasm-bindgen = "=0.2.80"
-
-[dependencies.jpeg-decoder]
-version = "0.2.6"
-default-features = false # can't use rayon on web
 
 [dependencies.ruffle_core]
 path = "../../core"
@@ -29,6 +19,6 @@ default-features = false
 version = "0.3.57"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
-    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "HtmlImageElement", "ImageData", "Navigator", "Path2d",
-    "SvgMatrix", "SvgsvgElement",
+    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",
+    "SvgsvgElement",
 ]


### PR DESCRIPTION
They're now unused thanks to #6975.
Also remove the `crate-type` field from `Cargo.toml`. I'm not sure
exactly what it does and why it was introduced, but seems working
without it.