### PR TITLE
ci: Run cargo in locked mode

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -77,13 +77,14 @@ jobs:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
         with:
           command: test
-          args: --features imgtests
+          args: --locked --features imgtests
 
       - name: Run tests without image tests
         if: ${{ !(runner.os == 'Linux' || runner.os == 'Windows') }}
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --locked
 
       - name: Upload images
         if: failure()


### PR DESCRIPTION
Per https://doc.rust-lang.org/cargo/commands/cargo-test.html#manifest-options,
`cargo --locked` assumes that `Cargo.lock` is up-to-date, and otherwise
exits with an error.
Besides the nice validation, this might hopefully speed-up CI a bit.

This could be done on Web as well, but I'm not sure what's the best
way of doing it.