### PR TITLE
core: Handle greyscale PNGs

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1165,15 +1165,17 @@ pub fn load_bitmap<'gc>(
                     Some(activation.context.avm1.prototypes.bitmap_data),
                 );
 
-                let pixels: Vec<i32> = bitmap.data.into();
+                let width = bitmap.width();
+                let height = bitmap.height();
+                let pixels: Vec<i32> = bitmap.into();
                 new_bitmap_data
                     .as_bitmap_data_object()
                     .unwrap()
                     .bitmap_data()
                     .write(activation.context.gc_context)
                     .set_pixels(
-                        bitmap.width,
-                        bitmap.height,
+                        width,
+                        height,
                         true,
                         pixels.into_iter().map(|p| p.into()).collect(),
                     );

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -50,7 +50,7 @@ pub fn instance_init<'gc>(
                 if let Some(bitmap_pixels) =
                     activation.context.renderer.get_bitmap_pixels(bitmap_handle)
                 {
-                    let bitmap_pixels: Vec<i32> = bitmap_pixels.data.into();
+                    let bitmap_pixels: Vec<i32> = bitmap_pixels.into();
                     new_bitmap_data
                         .write(activation.context.gc_context)
                         .set_pixels(

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -224,11 +224,8 @@ pub struct Bitmap {
 impl Bitmap {
     /// Ensures that `data` is the correct size for the given `width` and `height`.
     pub fn new(width: u32, height: u32, format: BitmapFormat, mut data: Vec<u8>) -> Self {
-        let expected_len = match format {
-            BitmapFormat::Rgb => width as usize * height as usize * 3,
-            BitmapFormat::Rgba => width as usize * height as usize * 4,
-        };
         // If the size is incorrect, either we screwed up or the decoder screwed up.
+        let expected_len = width as usize * height as usize * format.bytes_per_pixel();
         debug_assert_eq!(data.len(), expected_len);
         if data.len() != expected_len {
             log::warn!(
@@ -322,6 +319,16 @@ pub enum BitmapFormat {
 
     /// 32-bit RGBA with premultiplied alpha.
     Rgba,
+}
+
+impl BitmapFormat {
+    #[inline]
+    pub fn bytes_per_pixel(self) -> usize {
+        match self {
+            BitmapFormat::Rgb => 3,
+            BitmapFormat::Rgba => 4,
+        }
+    }
 }
 
 /// Determines the format of the image data in `data` from a DefineBitsJPEG2/3 tag.

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -247,6 +247,19 @@ impl Bitmap {
         }
     }
 
+    pub fn to_rgba(mut self) -> Self {
+        // Converts this bitmap to RGBA, if it is not already.
+        if self.format == BitmapFormat::Rgb {
+            self.data = self
+                .data
+                .chunks_exact(3)
+                .flat_map(|rgb| [rgb[0], rgb[1], rgb[2], 255])
+                .collect();
+            self.format = BitmapFormat::Rgba;
+        }
+        self
+    }
+
     #[inline]
     pub fn width(&self) -> u32 {
         self.width

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -129,11 +129,11 @@ impl BitmapData {
                 .context
                 .get_image_data(0.0, 0.0, self.width as f64, self.height as f64)
         {
-            Some(Bitmap {
-                width: self.width,
-                height: self.height,
-                data: BitmapFormat::Rgba(bitmap_pixels.data().to_vec()),
-            })
+            Some(Bitmap::from_data(
+                self.width,
+                self.height,
+                BitmapFormat::Rgba(bitmap_pixels.data().to_vec()),
+            ))
         } else {
             None
         }
@@ -753,11 +753,7 @@ impl RenderBackend for WebCanvasRenderBackend {
         rgba: Vec<u8>,
     ) -> Result<BitmapHandle, Error> {
         Ok(self
-            .register_bitmap_raw(Bitmap {
-                width,
-                height,
-                data: BitmapFormat::Rgba(rgba),
-            })?
+            .register_bitmap_raw(Bitmap::from_data(width, height, BitmapFormat::Rgba(rgba)))?
             .handle)
     }
 

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1260,11 +1260,7 @@ impl RenderBackend for WebGlRenderBackend {
         rgba: Vec<u8>,
     ) -> Result<BitmapHandle, Error> {
         Ok(self
-            .register_bitmap(Bitmap {
-                data: BitmapFormat::Rgba(rgba),
-                width,
-                height,
-            })?
+            .register_bitmap(Bitmap::from_data(width, height, BitmapFormat::Rgba(rgba)))?
             .handle)
     }
 

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -650,9 +650,9 @@ impl WebGlRenderBackend {
     }
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapInfo, Error> {
-        let (format, data) = match &bitmap.data {
-            BitmapFormat::Rgb(data) => (Gl::RGB, data),
-            BitmapFormat::Rgba(data) => (Gl::RGBA, data),
+        let format = match &bitmap.format() {
+            BitmapFormat::Rgb => Gl::RGB,
+            BitmapFormat::Rgba => Gl::RGBA,
         };
 
         let texture = self.gl.create_texture().unwrap();
@@ -662,12 +662,12 @@ impl WebGlRenderBackend {
                 Gl::TEXTURE_2D,
                 0,
                 format as i32,
-                bitmap.width as i32,
-                bitmap.height as i32,
+                bitmap.width() as i32,
+                bitmap.height() as i32,
                 0,
                 format,
                 Gl::UNSIGNED_BYTE,
-                Some(data),
+                Some(bitmap.data()),
             )
             .into_js_result()?;
 
@@ -682,8 +682,8 @@ impl WebGlRenderBackend {
             .tex_parameteri(Gl::TEXTURE_2D, Gl::TEXTURE_MAG_FILTER, Gl::LINEAR as i32);
 
         let handle = BitmapHandle(self.textures.len());
-        let width = bitmap.width;
-        let height = bitmap.height;
+        let width = bitmap.width();
+        let height = bitmap.height();
         self.bitmap_registry.insert(handle, bitmap);
 
         self.textures.push(Texture {
@@ -1260,7 +1260,7 @@ impl RenderBackend for WebGlRenderBackend {
         rgba: Vec<u8>,
     ) -> Result<BitmapHandle, Error> {
         Ok(self
-            .register_bitmap(Bitmap::from_data(width, height, BitmapFormat::Rgba(rgba)))?
+            .register_bitmap(Bitmap::new(width, height, BitmapFormat::Rgba, rgba))?
             .handle)
     }
 

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -1464,11 +1464,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     ) -> Result<BitmapHandle, Error> {
         Ok(self
             .register_bitmap(
-                Bitmap {
-                    height,
-                    width,
-                    data: BitmapFormat::Rgba(rgba),
-                },
+                Bitmap::from_data(height, width, BitmapFormat::Rgba(rgba)),
                 "RAW",
             )
             .handle)


### PR DESCRIPTION
 * Handle greyscale and greyscale+alpha PNGs in `render::decode_png`.
 * Add a `Bitmap::from_data` constructor that asserts that bitmap data has the expected length. Zero-pad or truncate the data to ensure the correct length.
   * This shouldn't happen, but let's do this to ease any burden on the backend in case our decoding screws up somehow.
   * For example, the canvas backend was panicking before greyscale was handled, because the data was an incorrect length.