### PR TITLE
canvas: Reimplement masking

### DIFF
--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -20,5 +20,4 @@ version = "0.3.57"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
     "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",
-    "SvgsvgElement",
 ]


### PR DESCRIPTION
Reimplement masking on the canvas backend using the native [`CanvasRenderinContext2d.clip`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clip) method.

When I first implemented masking in canvas, I didn't think `clip` could handle all of the nuances of Flash masking, so I ended up with a hacky+slow solution of drawing to off-screen canvases and using `globalCompositeOperation` to blend onto the main canvas. But I think we can handle nearly all of the cases natively using `clip` now:
 * [`clip(Path2D)`](https://caniuse.com/mdn-api_canvasrenderingcontext2d_clip_path_parameter) is now supported in all major browsers.
 * Strokes aren't considered when masking. Originally I was worried that strokes could mask content as well, which would be impossible with `clip`. But Flash operates the same as canvas and omits strokes.
 * "Layered" art (multiple layers in a single Shape) is still a problem. 
   *  The layers should be unioned to generate the mask area, but with the canvas API, we can only really intersect using successive `clip` calls.
   * I settled on using a "non-zero" winding rule to handle this case, but this won't be completely correct in other cases (such as self-intersecting shapes).
   * But Flash IDE actively avoids exporting mask art in the above ways (multiple layers or self-intersecting), because the Flash Player itself doesn't handle these cases completely correctly either, sometimes producing artifacts. It's still possible to hit these cases using the drawing API + dynamic masks though. This should be rare, and hopefully the non-zero winding rule operates decently enough in these cases.

Fixes Gridlock drawing a blank screen in canvas backend (#6976).