### PR TITLE
desktop: Add fullscreen command line option

### DIFF
--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -108,7 +108,12 @@ pub struct StageData<'gc> {
 }
 
 impl<'gc> Stage<'gc> {
-    pub fn empty(gc_context: MutationContext<'gc, '_>, width: u32, height: u32) -> Stage<'gc> {
+    pub fn empty(
+        gc_context: MutationContext<'gc, '_>,
+        width: u32,
+        height: u32,
+        fullscreen: bool,
+    ) -> Stage<'gc> {
         let stage = Self(GcCell::allocate(
             gc_context,
             StageData {
@@ -120,7 +125,11 @@ impl<'gc> Stage<'gc> {
                 quality: Default::default(),
                 stage_size: (width, height),
                 scale_mode: Default::default(),
-                display_state: Default::default(),
+                display_state: if fullscreen {
+                    StageDisplayState::FullScreen
+                } else {
+                    StageDisplayState::Normal
+                },
                 align: Default::default(),
                 use_bitmap_downsampling: false,
                 viewport_size: (width, height),

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1655,6 +1655,7 @@ pub struct PlayerBuilder {
 
     // Misc. player configuration
     autoplay: bool,
+    fullscreen: bool,
     letterbox: Letterbox,
     max_execution_duration: Duration,
     viewport_width: u32,
@@ -1682,6 +1683,7 @@ impl PlayerBuilder {
             video: None,
 
             autoplay: false,
+            fullscreen: false,
             // Disable script timeout in debug builds by default.
             letterbox: Letterbox::Fullscreen,
             max_execution_duration: Duration::from_secs(if cfg!(debug_assertions) {
@@ -1801,6 +1803,12 @@ impl PlayerBuilder {
         self
     }
 
+    // Sets whether the stage is fullscreen.
+    pub fn with_fullscreen(mut self, fullscreen: bool) -> Self {
+        self.fullscreen = fullscreen;
+        self
+    }
+
     /// Builds the player, wiring up the backends and configuring the specified settings.
     pub fn build(self) -> Arc<Mutex<Player>> {
         use crate::backend::*;
@@ -1892,6 +1900,7 @@ impl PlayerBuilder {
                                 gc_context,
                                 self.viewport_width,
                                 self.viewport_height,
+                                self.fullscreen,
                             ),
                             timers: Timers::new(),
                             unbound_text_fields: Vec::new(),

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -36,7 +36,7 @@ use winit::event::{
     WindowEvent,
 };
 use winit::event_loop::{ControlFlow, EventLoop};
-use winit::window::{Icon, Window, WindowBuilder};
+use winit::window::{Fullscreen, Icon, Window, WindowBuilder};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -84,6 +84,10 @@ struct Opt {
     /// Replace all embedded HTTP URLs with HTTPS.
     #[clap(long, takes_value = false)]
     upgrade_to_https: bool,
+
+    /// Start application in fullscreen.
+    #[clap(long, takes_value = false)]
+    fullscreen: bool,
 
     #[clap(long, takes_value = false)]
     timedemo: bool,
@@ -226,6 +230,11 @@ impl App {
             .with_window_icon(Some(icon))
             .with_inner_size(window_size)
             .with_max_inner_size(LogicalSize::new(i16::MAX, i16::MAX))
+            .with_fullscreen(if opt.fullscreen {
+                Some(Fullscreen::Borderless(None))
+            } else {
+                None
+            })
             .build(&event_loop)?;
 
         let viewport_size = window.inner_size();
@@ -268,7 +277,8 @@ impl App {
                 viewport_size.width,
                 viewport_size.height,
                 viewport_scale_factor,
-            );
+            )
+            .with_fullscreen(opt.fullscreen);
 
         let loaded = if let Some(movie) = movie {
             builder = builder.with_movie(movie);


### PR DESCRIPTION
Adds the `--fullscreen` flag.
This can be especially useful with launchers or scripts, e.g. Steam.
With the current behavior a black window opens until the content loads, ideally the window shouldn't be shown but I think that's outside the scope of this pr, and will probably depend on how we choose to do UI going forward.