### PR TITLE
avm1: Simplify `XML.xmlDecl`

### DIFF
--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -8,7 +8,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::RequestOptions;
-use crate::string::{AvmString, WStr};
+use crate::string::WStr;
 use crate::xml::{XmlNode, ELEMENT_NODE, TEXT_NODE};
 use gc_arena::MutationContext;
 
@@ -211,21 +211,13 @@ fn doc_type_decl<'gc>(
 }
 
 fn xml_decl<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(document) = this.as_xml() {
-        let result = document.xmldecl_string();
-
-        if let Err(e) = result {
-            avm_warn!(
-                activation,
-                "Could not generate XML declaration for document: {}",
-                e
-            );
-        } else if let Ok(Some(result_str)) = result {
-            return Ok(AvmString::new_utf8(activation.context.gc_context, result_str).into());
+        if let Some(xml_decl) = document.xml_decl() {
+            return Ok(xml_decl.into());
         }
     }
 

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -773,7 +773,7 @@ swf_tests! {
     (xml_inspect_createmethods, "avm1/xml_inspect_createmethods", 1),
     (xml_inspect_doctype, "avm1/xml_inspect_doctype", 1),
     (xml_inspect_parsexml, "avm1/xml_inspect_parsexml", 1),
-    #[ignore] (xml_inspect_xmldecl, "avm1/xml_inspect_xmldecl", 1),
+    (xml_inspect_xmldecl, "avm1/xml_inspect_xmldecl", 1),
     (xml_load, "avm1/xml_load", 1),
     (xml_namespaces, "avm1/xml_namespaces", 1),
     (xml_parent_and_child, "avm1/xml_parent_and_child", 1),


### PR DESCRIPTION
Store just the XML declaration string itself, rather than the attributes
it consists of. Then simply return it in ActionScript's `XML.xmlDecl`
property, without using `quick_xml::Writer` at all. This also matches
Flash behavior by capturing the XML declaration as-is, preserving
whitespaces, quotes, casing etc.