### PR TITLE
avm2: Add more Event classes' methods and properties

### DIFF
--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -87,9 +87,17 @@ impl KeyModifiers {
 #[collect(no_drop)]
 pub enum EventData<'gc> {
     Empty,
+    Error {
+        text: AvmString<'gc>,
+        error_id: i32,
+    },
     FullScreen {
         full_screen: bool,
         interactive: bool,
+    },
+    IOError {
+        text: AvmString<'gc>,
+        error_id: i32,
     },
     Mouse {
         local_x: f64,
@@ -101,10 +109,11 @@ pub enum EventData<'gc> {
         button_down: bool,
         delta: i32,
     },
-    // FIXME - define properties from 'ErrorEvent' and 'TextEvent'
-    IOError {
-        // FIXME - this should be inherited in some way from
-        // the (currently not declared) `TextEvent`
+    SecurityError {
+        text: AvmString<'gc>,
+        error_id: i32,
+    },
+    Text {
         text: AvmString<'gc>,
     },
 }

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -88,7 +88,10 @@ pub struct SystemPrototypes<'gc> {
     pub nativemenu: Object<'gc>,
     pub contextmenu: Object<'gc>,
     pub mouseevent: Object<'gc>,
+    pub textevent: Object<'gc>,
+    pub errorevent: Object<'gc>,
     pub ioerrorevent: Object<'gc>,
+    pub securityerrorevent: Object<'gc>,
 }
 
 impl<'gc> SystemPrototypes<'gc> {
@@ -151,7 +154,10 @@ impl<'gc> SystemPrototypes<'gc> {
             nativemenu: empty,
             contextmenu: empty,
             mouseevent: empty,
+            textevent: empty,
+            errorevent: empty,
             ioerrorevent: empty,
+            securityerrorevent: empty,
         }
     }
 }
@@ -204,7 +210,10 @@ pub struct SystemClasses<'gc> {
     pub nativemenu: ClassObject<'gc>,
     pub contextmenu: ClassObject<'gc>,
     pub mouseevent: ClassObject<'gc>,
+    pub textevent: ClassObject<'gc>,
+    pub errorevent: ClassObject<'gc>,
     pub ioerrorevent: ClassObject<'gc>,
+    pub securityerrorevent: ClassObject<'gc>,
 }
 
 impl<'gc> SystemClasses<'gc> {
@@ -267,7 +276,10 @@ impl<'gc> SystemClasses<'gc> {
             nativemenu: object,
             contextmenu: object,
             mouseevent: object,
+            textevent: object,
+            errorevent: object,
             ioerrorevent: object,
+            securityerrorevent: object,
         }
     }
 }
@@ -578,6 +590,24 @@ pub fn load_player_globals<'gc>(
         mouseevent,
         activation,
         flash::events::mouseevent::create_class(mc),
+        script
+    );
+    avm2_system_class!(
+        textevent,
+        activation,
+        flash::events::textevent::create_class(mc),
+        script
+    );
+    avm2_system_class!(
+        errorevent,
+        activation,
+        flash::events::errorevent::create_class(mc),
+        script
+    );
+    avm2_system_class!(
+        securityerrorevent,
+        activation,
+        flash::events::securityerrorevent::create_class(mc),
         script
     );
     avm2_system_class!(

--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -2,6 +2,7 @@
 
 pub mod activityevent;
 pub mod contextmenuevent;
+pub mod errorevent;
 pub mod event;
 pub mod eventdispatcher;
 pub mod eventphase;
@@ -11,3 +12,5 @@ pub mod ioerrorevent;
 pub mod keyboardevent;
 pub mod mouseevent;
 pub mod progressevent;
+pub mod securityerrorevent;
+pub mod textevent;

--- a/core/src/avm2/globals/flash/events/errorevent.rs
+++ b/core/src/avm2/globals/flash/events/errorevent.rs
@@ -1,0 +1,107 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::events::EventData;
+use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::{Object, TObject};
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.ErrorEvent`'s instance constructor.
+fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        activation.super_init(this, args)?; // TextEvent, Event uses these
+        if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
+            let id = args
+                .get(4)
+                .cloned()
+                .unwrap_or_else(|| 0.into())
+                .coerce_to_i32(activation)?;
+            let event_data = evt.event_data_mut();
+            match event_data {
+                EventData::Error {
+                    ref mut error_id, ..
+                } => {
+                    *error_id = id;
+                }
+                EventData::IOError {
+                    ref mut error_id, ..
+                } => {
+                    *error_id = id;
+                }
+                EventData::SecurityError {
+                    ref mut error_id, ..
+                } => {
+                    *error_id = id;
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.ErrorEvent`'s class constructor.
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `errorID`'s getter.
+fn error_id<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        if let Some(evt) = this.as_event() {
+            if let EventData::Error { error_id, .. } = evt.event_data() {
+                return Ok(Value::Integer(*error_id));
+            }
+            if let EventData::IOError { error_id, .. } = evt.event_data() {
+                return Ok(Value::Integer(*error_id));
+            }
+            if let EventData::SecurityError { error_id, .. } = evt.event_data() {
+                return Ok(Value::Integer(*error_id));
+            }
+        }
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Construct `ErrorEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.events"), "ErrorEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "TextEvent").into()),
+        Method::from_builtin(instance_init, "<ErrorEvent instance initializer>", mc),
+        Method::from_builtin(class_init, "<ErrorEvent class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED);
+
+    const CONSTANTS: &[(&str, &str)] = &[("ERROR", "error")];
+
+    write.define_public_constant_string_class_traits(CONSTANTS);
+
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &str,
+        Option<NativeMethodImpl>,
+        Option<NativeMethodImpl>,
+    )] = &[("errorID", Some(error_id), None)];
+    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+
+    class
+}

--- a/core/src/avm2/globals/flash/events/securityerrorevent.rs
+++ b/core/src/avm2/globals/flash/events/securityerrorevent.rs
@@ -7,8 +7,8 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use gc_arena::{GcCell, MutationContext};
 
-/// Implements `flash.events.IOErrorEvent`'s instance constructor.
-pub fn instance_init<'gc>(
+/// Implements `flash.events.SecurityErrorEvent`'s instance constructor.
+fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
@@ -19,8 +19,8 @@ pub fn instance_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Implements `flash.events.IOErrorEvent`'s class constructor.
-pub fn class_init<'gc>(
+/// Implements `flash.events.SecurityErrorEvent`'s class constructor.
+fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
@@ -28,13 +28,17 @@ pub fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Construct `IOErrorEvent`'s class.
+/// Construct `SecurityErrorEvent`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
-        QName::new(Namespace::package("flash.events"), "IOErrorEvent"),
+        QName::new(Namespace::package("flash.events"), "SecurityErrorEvent"),
         Some(QName::new(Namespace::package("flash.events"), "ErrorEvent").into()),
-        Method::from_builtin(instance_init, "<IOErrorEvent instance initializer>", mc),
-        Method::from_builtin(class_init, "<IOErrorEvent class initializer>", mc),
+        Method::from_builtin(
+            instance_init,
+            "<SecurityErrorEvent instance initializer>",
+            mc,
+        ),
+        Method::from_builtin(class_init, "<SecurityErrorEvent class initializer>", mc),
         mc,
     );
 
@@ -42,7 +46,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED);
 
-    const CONSTANTS: &[(&str, &str)] = &[("IO_ERROR", "ioError")];
+    const CONSTANTS: &[(&str, &str)] = &[("SECURITY_ERROR", "securityError")];
 
     write.define_public_constant_string_class_traits(CONSTANTS);
 

--- a/core/src/avm2/globals/flash/events/textevent.rs
+++ b/core/src/avm2/globals/flash/events/textevent.rs
@@ -1,0 +1,142 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::events::EventData;
+use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::{Object, TObject};
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+/// Implements `flash.events.TextEvent`'s instance constructor.
+fn instance_init<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        activation.super_init(this, args)?; // Event uses these
+        if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
+            let text_arg = args
+                .get(3)
+                .cloned()
+                .unwrap_or(Value::Undefined)
+                .coerce_to_string(activation)?;
+            let event_data = evt.event_data_mut();
+            match event_data {
+                EventData::Text { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                EventData::Error { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                EventData::IOError { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                EventData::SecurityError { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(Value::Undefined)
+}
+
+/// Implements `flash.events.TextEvent`'s class constructor.
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+/// Implements `text`'s setter.
+fn set_text<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
+            let text_arg = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Undefined)
+                .coerce_to_string(activation)?;
+            let event_data = evt.event_data_mut();
+            match event_data {
+                EventData::Text { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                EventData::Error { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                EventData::IOError { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                EventData::SecurityError { ref mut text, .. } => {
+                    *text = text_arg;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Implements `text`'s getter.
+fn text<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        if let Some(evt) = this.as_event() {
+            if let EventData::Text { text, .. } = evt.event_data() {
+                return Ok(Value::String(*text));
+            }
+            if let EventData::Error { text, .. } = evt.event_data() {
+                return Ok(Value::String(*text));
+            }
+            if let EventData::IOError { text, .. } = evt.event_data() {
+                return Ok(Value::String(*text));
+            }
+            if let EventData::SecurityError { text, .. } = evt.event_data() {
+                return Ok(Value::String(*text));
+            }
+        }
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Construct `TextEvent`'s class.
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.events"), "TextEvent"),
+        Some(QName::new(Namespace::package("flash.events"), "Event").into()),
+        Method::from_builtin(instance_init, "<TextEvent instance initializer>", mc),
+        Method::from_builtin(class_init, "<TextEvent class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED);
+
+    const CONSTANTS: &[(&str, &str)] = &[("LINK", "link"), ("TEXT_INPUT", "textInput")];
+
+    write.define_public_constant_string_class_traits(CONSTANTS);
+
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &str,
+        Option<NativeMethodImpl>,
+        Option<NativeMethodImpl>,
+    )] = &[("text", Some(text), Some(set_text))];
+    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+
+    class
+}

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -52,9 +52,12 @@ impl<'gc> EventObject<'gc> {
     ) -> Result<Object<'gc>, Error> {
         let class = match event.event_data() {
             EventData::Empty => activation.avm2().classes().event,
+            EventData::Error { .. } => activation.avm2().classes().errorevent,
             EventData::FullScreen { .. } => activation.avm2().classes().fullscreenevent,
-            EventData::Mouse { .. } => activation.avm2().classes().mouseevent,
             EventData::IOError { .. } => activation.avm2().classes().ioerrorevent,
+            EventData::Mouse { .. } => activation.avm2().classes().mouseevent,
+            EventData::SecurityError { .. } => activation.avm2().classes().securityerrorevent,
+            EventData::Text { .. } => activation.avm2().classes().textevent,
         };
 
         let proto = class.prototype();

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -787,6 +787,7 @@ impl<'gc> Loader<'gc> {
                                     activation.context.gc_context,
                                     "Error #2032: Stream Error",
                                 ),
+                                error_id: 2032,
                             },
                         );
                         io_error_evt.set_bubbles(false);


### PR DESCRIPTION
I ruined the commit history of #7025, so re-implement it. I believe collaborators can squash and merge, but it's easier for me to work with a normal branch as opposed to a messed up branch if I need to make any changes.

Implement the methods and constants for ErrorEvent, TextEvent, and SecurityErrorEvent and update IOErrorEvent to use proper inheritance.