### PR TITLE
canvas: Scale stroke width based on shape transform

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -261,10 +261,10 @@ fn line_style<'gc>(
             .and_then(|v| v.coerce_to_string(activation).ok())
             .as_deref()
         {
-            Some(v) if v == b"normal" => (true, true),
+            Some(v) if v == b"none" => (false, false),
             Some(v) if v == b"vertical" => (true, false),
             Some(v) if v == b"horizontal" => (false, true),
-            _ => (false, false),
+            _ => (true, true),
         };
         let cap_style = match args
             .get(5)


### PR DESCRIPTION
Render strokes with the proper width in the canvas backend:
 * Stroke width gets scaled based on the shape's transform and line style scaling settings
 * Minimum 1 pixel width (1 twip hairline strokes get scaled to 1 pixel)

TODO:
 - [x] Move the line scale calculation to `core::shape_utils` because other renderers will want it as well
 - [x] Handle complex fill styles in strokes (need to create a fresh `CanvasGradient` instance per draw)
 - [x] Only calculate line scales if necessary (slight optimization)

Fixes the line widths in #751 in the canvas backend.