### PR TITLE
AVM2: Manually fire late `added`/`addedToStage` events on root clips

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1771,6 +1771,19 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
             if needs_construction {
                 self.construct_as_avm2_object(context);
+
+                // AVM2 roots work exactly the same as any other timeline- or
+                // script-constructed object in terms of events received on
+                // them. However, because roots are added by the player itself,
+                // we can't fire the events until we run our first frame, so we
+                // have to actually check if we've just built the root and act
+                // like it just got added to the timeline.
+                let root = self.avm2_root(context);
+                let self_dobj: DisplayObject<'gc> = (*self).into();
+                if DisplayObject::option_ptr_eq(Some(self_dobj), root) {
+                    dispatch_added_event_only(self_dobj, context);
+                    dispatch_added_to_stage_event_only(self_dobj, context);
+                }
             }
         }
     }


### PR DESCRIPTION
AS3 display objects *always* get `added` and `addedToStage` events, even the root movie clip. We actually add the root clip *before* its constructor runs, so it will miss those events. This minor hack fixes that by checking if we just constructed the root clip and, if so, fires those events.

There are no tests because the only tests that revealed this behavior are part of #5876 and test other behaviors