### PR TITLE
chore: Appease clippy

### DIFF
--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -9,7 +9,7 @@ use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::Ref;
 
 /// Indicates what kind of scope a scope is.
-#[derive(Copy, Clone, Debug, PartialEq, Collect)]
+#[derive(Clone, Collect, Copy, Debug, Eq, PartialEq)]
 #[collect(require_static)]
 pub enum ScopeClass {
     /// Scope represents global scope.

--- a/core/src/bounding_box.rs
+++ b/core/src/bounding_box.rs
@@ -2,7 +2,7 @@ use crate::matrix::Matrix;
 use gc_arena::Collect;
 use swf::Twips;
 
-#[derive(Clone, Debug, PartialEq, Collect, Default)]
+#[derive(Clone, Collect, Debug, Default, Eq, PartialEq)]
 #[collect(require_static)]
 pub struct BoundingBox {
     pub x_min: Twips,

--- a/core/src/color_transform.rs
+++ b/core/src/color_transform.rs
@@ -1,6 +1,6 @@
 use swf::Fixed8;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ColorTransform {
     pub r_mult: Fixed8,
     pub g_mult: Fixed8,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -33,7 +33,7 @@ pub type Handle = Index;
 /// Enumeration of all content types that `Loader` can handle.
 ///
 /// This is a superset of `JpegTagFormat`.
-#[derive(PartialEq, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ContentType {
     Swf,
     Jpeg,
@@ -84,7 +84,7 @@ impl ContentType {
     }
 }
 
-#[derive(Collect, Copy, Clone)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub enum DataFormat {
     Binary,
@@ -92,7 +92,7 @@ pub enum DataFormat {
     Variables,
 }
 
-#[derive(Error, Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
     #[error("Load cancelled")]
     Cancelled,
@@ -304,7 +304,7 @@ impl<'gc> Default for LoadManager<'gc> {
 }
 
 /// The completion status of a `Loader` loading a movie.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Collect)]
+#[derive(Clone, Collect, Copy, Debug, Eq, PartialEq)]
 #[collect(require_static)]
 pub enum LoaderStatus {
     /// The movie hasn't been loaded yet.

--- a/core/src/shape_utils.rs
+++ b/core/src/shape_utils.rs
@@ -61,7 +61,7 @@ pub fn calculate_shape_bounds(shape_records: &[swf::ShapeRecord]) -> swf::Rectan
 /// `DrawPath` represents a solid fill or a stroke.
 /// Fills are always closed paths, while strokes may be open or closed.
 /// Closed paths will have the first point equal to the last point.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DrawPath<'a> {
     Stroke {
         style: &'a LineStyle,
@@ -76,7 +76,7 @@ pub enum DrawPath<'a> {
 
 /// `DistilledShape` represents a ready-to-be-consumed collection of paths (both fills and strokes)
 /// that has been converted down from another source (such as SWF's `swf::Shape` format).
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DistilledShape<'a> {
     pub paths: Vec<DrawPath<'a>>,
     pub shape_bounds: BoundingBox,
@@ -97,7 +97,7 @@ impl<'a> From<&'a swf::Shape> for DistilledShape<'a> {
 
 /// `DrawCommands` trace the outline of a path.
 /// Fills follow the even-odd fill rule, with opposite winding for holes.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DrawCommand {
     MoveTo {
         x: Twips,
@@ -125,7 +125,7 @@ impl DrawCommand {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 struct Point {
     x: Twips,
     y: Twips,

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -97,7 +97,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
 
         let processed_url = self.pre_process_url(modified_url);
 
-        match webbrowser::open(&processed_url.to_string()) {
+        match webbrowser::open(processed_url.as_ref()) {
             Ok(_output) => {}
             Err(e) => log::error!("Could not open URL {}: {}", processed_url.as_str(), e),
         };

--- a/render/wgpu/src/clap.rs
+++ b/render/wgpu/src/clap.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, PartialEq, Debug, clap::ArgEnum)]
+#[derive(clap::ArgEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GraphicsBackend {
     Default,
     Vulkan,
@@ -19,7 +19,7 @@ impl From<GraphicsBackend> for wgpu::Backends {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug, clap::ArgEnum)]
+#[derive(clap::ArgEnum, Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PowerPreference {
     Low = 1,
     High = 2,

--- a/swf/src/avm1/opcode.rs
+++ b/swf/src/avm1/opcode.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum OpCode {
     End = 0x00,
 

--- a/swf/src/avm1/types.rs
+++ b/swf/src/avm1/types.rs
@@ -107,19 +107,19 @@ pub enum Action<'a> {
     Unknown(Unknown<'a>),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConstantPool<'a> {
     pub strings: Vec<&'a SwfStr>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineFunction<'a> {
     pub name: &'a SwfStr,
     pub params: Vec<&'a SwfStr>,
     pub actions: &'a [u8],
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineFunction2<'a> {
     pub name: &'a SwfStr,
     pub register_count: u8,
@@ -149,7 +149,7 @@ impl<'a> From<DefineFunction<'a>> for DefineFunction2<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FunctionParam<'a> {
     pub name: &'a SwfStr,
     pub register_index: Option<NonZeroU8>,
@@ -175,13 +175,13 @@ impl Default for FunctionFlags {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetUrl<'a> {
     pub url: &'a SwfStr,
     pub target: &'a SwfStr,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetUrl2(pub(crate) GetUrlFlags);
 
 impl GetUrl2 {
@@ -253,7 +253,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum SendVarsMethod {
     None = 0,
@@ -261,28 +261,28 @@ pub enum SendVarsMethod {
     Post = 2,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GotoFrame {
     pub frame: u16,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GotoFrame2 {
     pub set_playing: bool,
     pub scene_offset: u16,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GotoLabel<'a> {
     pub label: &'a SwfStr,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct If {
     pub offset: i16,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Jump {
     pub offset: i16,
 }
@@ -305,24 +305,24 @@ pub enum Value<'a> {
     ConstantPool(u16),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SetTarget<'a> {
     pub target: &'a SwfStr,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct StoreRegister {
     pub register: u8,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Try<'a> {
     pub try_body: &'a [u8],
     pub catch_body: Option<(CatchVar<'a>, &'a [u8])>,
     pub finally_body: Option<&'a [u8]>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CatchVar<'a> {
     Var(&'a SwfStr),
     Register(u8),
@@ -336,23 +336,23 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WaitForFrame {
     pub frame: u16,
     pub num_actions_to_skip: u8,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WaitForFrame2 {
     pub num_actions_to_skip: u8,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct With<'a> {
     pub actions: &'a [u8],
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Unknown<'a> {
     pub opcode: u8,
     pub data: &'a [u8],

--- a/swf/src/avm2/opcode.rs
+++ b/swf/src/avm2/opcode.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum OpCode {
     Add = 0xA0,
     AddI = 0xC5,

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -24,6 +24,8 @@ pub struct ConstantPool {
     pub multinames: Vec<Multiname>,
 }
 
+// clippy false positive: https://github.com/rust-lang/rust-clippy/issues/8867
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Index<T>(pub u32, pub PhantomData<T>);
 
@@ -121,7 +123,7 @@ pub struct MethodBody {
     pub traits: Vec<Trait>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Exception {
     pub from_offset: u32,
     pub to_offset: u32,
@@ -130,7 +132,7 @@ pub struct Exception {
     pub type_name: Index<Multiname>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Opcode;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -152,13 +154,13 @@ pub enum DefaultValue {
     Private(Index<Namespace>),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Metadata {
     pub name: Index<String>,
     pub items: Vec<MetadataItem>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MetadataItem {
     pub key: Index<String>,
     pub value: Index<String>,

--- a/swf/src/tag_code.rs
+++ b/swf/src/tag_code.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum TagCode {
     End = 0,
     ShowFrame = 1,

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -35,7 +35,7 @@ pub struct SwfBuf {
 /// Notably contains the compression format used by the rest of the SWF data.
 ///
 /// [SWF19 p.27](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=27)
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Header {
     pub compression: Compression,
     pub version: u8,
@@ -175,7 +175,7 @@ impl HeaderExt {
 ///
 /// The vast majority of SWFs will use zlib compression.
 /// [SWF19 p.27](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=27)
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Compression {
     None,
     Zlib,
@@ -193,7 +193,7 @@ pub enum Compression {
 ///
 /// [`from_pixels`]: Twips::from_pixels
 /// [`to_pixels`]: Twips::to_pixels
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Twips(i32);
 
 impl Twips {
@@ -369,7 +369,7 @@ impl std::fmt::Display for Twips {
 /// A rectangular region defined by minimum
 /// and maximum x- and y-coordinate positions
 /// measured in [`Twips`].
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Rectangle {
     /// The minimum x-position of the rectangle.
     pub x_min: Twips,
@@ -387,7 +387,7 @@ pub struct Rectangle {
 /// An RGBA (red, green, blue, alpha) color.
 ///
 /// All components are stored as [`u8`] and have a color range of 0-255.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Color {
     /// The red component value.
     pub r: u8,
@@ -488,7 +488,7 @@ impl Color {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ColorTransform {
     pub r_multiply: Fixed8,
     pub g_multiply: Fixed8,
@@ -521,7 +521,7 @@ impl Default for ColorTransform {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum Language {
     Unknown = 0,
     Latin = 1,
@@ -569,19 +569,19 @@ impl Default for FileAttributes {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FrameLabel<'a> {
     pub label: &'a SwfStr,
     pub is_anchor: bool,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DefineSceneAndFrameLabelData<'a> {
     pub scenes: Vec<FrameLabelData<'a>>,
     pub frame_labels: Vec<FrameLabelData<'a>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct FrameLabelData<'a> {
     pub frame_num: u32,
     pub label: &'a SwfStr,
@@ -590,7 +590,7 @@ pub struct FrameLabelData<'a> {
 pub type Depth = u16;
 pub type CharacterId = u16;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct PlaceObject<'a> {
     pub version: u8,
     pub action: PlaceObjectAction,
@@ -633,14 +633,14 @@ bitflags! {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PlaceObjectAction {
     Place(CharacterId),
     Modify,
     Replace(CharacterId),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Filter {
     DropShadowFilter(Box<DropShadowFilter>),
     BlurFilter(Box<BlurFilter>),
@@ -652,7 +652,7 @@ pub enum Filter {
     GradientBevelFilter(Box<GradientBevelFilter>),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DropShadowFilter {
     pub color: Color,
     pub blur_x: Fixed16,
@@ -665,14 +665,14 @@ pub struct DropShadowFilter {
     pub num_passes: u8,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BlurFilter {
     pub blur_x: Fixed16,
     pub blur_y: Fixed16,
     pub num_passes: u8,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GlowFilter {
     pub color: Color,
     pub blur_x: Fixed16,
@@ -683,7 +683,7 @@ pub struct GlowFilter {
     pub num_passes: u8,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BevelFilter {
     pub shadow_color: Color,
     pub highlight_color: Color,
@@ -698,7 +698,7 @@ pub struct BevelFilter {
     pub num_passes: u8,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GradientGlowFilter {
     pub colors: Vec<GradientRecord>,
     pub blur_x: Fixed16,
@@ -712,7 +712,7 @@ pub struct GradientGlowFilter {
     pub num_passes: u8,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConvolutionFilter {
     pub num_matrix_rows: u8,
     pub num_matrix_cols: u8,
@@ -724,12 +724,12 @@ pub struct ConvolutionFilter {
     pub is_preserve_alpha: bool,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ColorMatrixFilter {
     pub matrix: [Fixed16; 20],
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GradientBevelFilter {
     pub colors: Vec<GradientRecord>,
     pub blur_x: Fixed16,
@@ -743,7 +743,7 @@ pub struct GradientBevelFilter {
     pub num_passes: u8,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum BlendMode {
     Normal = 0,
     Layer = 2,
@@ -780,7 +780,7 @@ impl Default for BlendMode {
 /// Created in the Flash IDE using `onClipEvent` or `on` blocks.
 ///
 /// [SWF19 pp.37-38 ClipActionRecord](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=39)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClipAction<'a> {
     pub events: ClipEventFlag,
     pub key_code: Option<KeyCode>,
@@ -931,13 +931,13 @@ pub enum Tag<'a> {
 
 pub type ExportAssets<'a> = Vec<ExportedAsset<'a>>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExportedAsset<'a> {
     pub id: CharacterId,
     pub name: &'a SwfStr,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RemoveObject {
     pub depth: Depth,
     pub character_id: Option<CharacterId>,
@@ -945,13 +945,13 @@ pub struct RemoveObject {
 
 pub type SetBackgroundColor = Color;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SymbolClassLink<'a> {
     pub id: CharacterId,
     pub class_name: &'a SwfStr,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShapeContext {
     pub swf_version: u8,
     pub shape_version: u8,
@@ -959,7 +959,7 @@ pub struct ShapeContext {
     pub num_line_bits: u8,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Shape {
     pub version: u8,
     pub id: CharacterId,
@@ -972,7 +972,7 @@ pub struct Shape {
     pub shape: Vec<ShapeRecord>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Sound<'a> {
     pub id: CharacterId,
     pub format: SoundFormat,
@@ -980,7 +980,7 @@ pub struct Sound<'a> {
     pub data: &'a [u8],
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SoundInfo {
     pub event: SoundEvent,
     pub in_sample: Option<u32>,
@@ -989,7 +989,7 @@ pub struct SoundInfo {
     pub envelope: Option<SoundEnvelope>,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum SoundEvent {
     Event = 0,
     Start = 1,
@@ -1007,7 +1007,7 @@ impl SoundEvent {
 
 pub type SoundEnvelope = Vec<SoundEnvelopePoint>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SoundEnvelopePoint {
     pub sample: u32,
     pub left_volume: f32,
@@ -1027,13 +1027,13 @@ pub struct Sprite<'a> {
     pub tags: Vec<Tag<'a>>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShapeStyles {
     pub fill_styles: Vec<FillStyle>,
     pub line_styles: Vec<LineStyle>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ShapeRecord {
     StyleChange(Box<StyleChangeData>),
     StraightEdge {
@@ -1048,7 +1048,7 @@ pub enum ShapeRecord {
     },
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StyleChangeData {
     pub move_to: Option<(Twips, Twips)>,
     pub fill_style_0: Option<u32>,
@@ -1057,7 +1057,7 @@ pub struct StyleChangeData {
     pub new_styles: Option<ShapeStyles>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FillStyle {
     Color(Color),
     LinearGradient(Gradient),
@@ -1074,7 +1074,7 @@ pub enum FillStyle {
     },
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Gradient {
     pub matrix: Matrix,
     pub spread: GradientSpread,
@@ -1082,7 +1082,7 @@ pub struct Gradient {
     pub records: Vec<GradientRecord>,
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum GradientSpread {
     Pad = 0,
     Reflect = 1,
@@ -1100,7 +1100,7 @@ impl GradientSpread {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum GradientInterpolation {
     Rgb = 0,
     LinearRgb = 1,
@@ -1117,13 +1117,13 @@ impl GradientInterpolation {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GradientRecord {
     pub ratio: u8,
     pub color: Color,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LineStyle {
     pub(crate) width: Twips,
     pub(crate) fill_style: FillStyle,
@@ -1304,7 +1304,7 @@ impl Default for LineStyleFlag {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum LineCapStyle {
     Round = 0,
     None = 1,
@@ -1325,7 +1325,7 @@ impl Default for LineCapStyle {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LineJoinStyle {
     Round,
     Bevel,
@@ -1339,7 +1339,7 @@ impl Default for LineJoinStyle {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum AudioCompression {
     UncompressedUnknownEndian = 0,
     Adpcm = 1,
@@ -1357,7 +1357,7 @@ impl AudioCompression {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SoundFormat {
     pub compression: AudioCompression,
     pub sample_rate: u16,
@@ -1365,7 +1365,7 @@ pub struct SoundFormat {
     pub is_16_bit: bool,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SoundStreamHead {
     pub stream_format: SoundFormat,
     pub playback_format: SoundFormat,
@@ -1375,7 +1375,7 @@ pub struct SoundStreamHead {
 
 pub type SoundStreamBlock<'a> = &'a [u8];
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Button<'a> {
     pub id: CharacterId,
     pub is_track_as_menu: bool,
@@ -1383,7 +1383,7 @@ pub struct Button<'a> {
     pub actions: Vec<ButtonAction<'a>>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ButtonRecord {
     pub states: ButtonState,
     pub id: CharacterId,
@@ -1403,13 +1403,13 @@ bitflags! {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ButtonColorTransform {
     pub id: CharacterId,
     pub color_transforms: Vec<ColorTransform>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ButtonSounds {
     pub id: CharacterId,
     pub over_to_up_sound: Option<ButtonSound>,
@@ -1420,7 +1420,7 @@ pub struct ButtonSounds {
 
 pub type ButtonSound = (CharacterId, SoundInfo);
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ButtonAction<'a> {
     pub conditions: ButtonActionCondition,
     pub key_code: Option<u8>,
@@ -1442,7 +1442,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineMorphShape {
     pub version: u8,
     pub id: CharacterId,
@@ -1452,7 +1452,7 @@ pub struct DefineMorphShape {
     pub end: MorphShape,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MorphShape {
     pub shape_bounds: Rectangle,
     pub edge_bounds: Rectangle,
@@ -1461,13 +1461,13 @@ pub struct MorphShape {
     pub shape: Vec<ShapeRecord>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FontV1 {
     pub id: CharacterId,
     pub glyphs: Vec<Vec<ShapeRecord>>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Font<'a> {
     pub version: u8,
     pub id: CharacterId,
@@ -1491,7 +1491,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Font4<'a> {
     pub id: CharacterId,
     pub is_italic: bool,
@@ -1500,7 +1500,7 @@ pub struct Font4<'a> {
     pub data: Option<&'a [u8]>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Glyph {
     pub shape_records: Vec<ShapeRecord>,
     pub code: u16,
@@ -1523,7 +1523,7 @@ pub struct KerningRecord {
     pub adjustment: Twips,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FontInfo<'a> {
     pub id: CharacterId,
     pub version: u8,
@@ -1544,13 +1544,13 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineBinaryData<'a> {
     pub id: CharacterId,
     pub data: &'a [u8],
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Text {
     pub id: CharacterId,
     pub bounds: Rectangle,
@@ -1558,7 +1558,7 @@ pub struct Text {
     pub records: Vec<TextRecord>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TextRecord {
     pub font_id: Option<CharacterId>,
     pub color: Option<Color>,
@@ -1568,13 +1568,13 @@ pub struct TextRecord {
     pub glyphs: Vec<GlyphEntry>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GlyphEntry {
     pub index: u32,
     pub advance: i32,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EditText<'a> {
     pub id: CharacterId,
     pub bounds: Rectangle,
@@ -1598,7 +1598,7 @@ pub struct EditText<'a> {
     pub is_device_font: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TextLayout {
     pub align: TextAlign,
     pub left_margin: Twips,
@@ -1607,7 +1607,7 @@ pub struct TextLayout {
     pub leading: Twips,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum TextAlign {
     Left = 0,
     Right = 1,
@@ -1621,7 +1621,7 @@ impl TextAlign {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FontAlignZone {
     // TODO(Herschel): Read these as f16s.
     pub left: i16,
@@ -1630,7 +1630,7 @@ pub struct FontAlignZone {
     pub height: i16,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum FontThickness {
     Thin = 0,
     Medium = 1,
@@ -1652,7 +1652,7 @@ pub struct CsmTextSettings {
     pub sharpness: f32,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum TextGridFit {
     None = 0,
     Pixel = 1,
@@ -1665,7 +1665,7 @@ impl TextGridFit {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineBitsLossless<'a> {
     pub version: u8,
     pub id: CharacterId,
@@ -1675,14 +1675,14 @@ pub struct DefineBitsLossless<'a> {
     pub data: &'a [u8],
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BitmapFormat {
     ColorMap8 { num_colors: u8 },
     Rgb15,
     Rgb32,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineVideoStream {
     pub id: CharacterId,
     pub num_frames: u16,
@@ -1693,7 +1693,7 @@ pub struct DefineVideoStream {
     pub codec: VideoCodec,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum VideoDeblocking {
     UseVideoPacketValue = 0,
     None = 1,
@@ -1709,7 +1709,7 @@ impl VideoDeblocking {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, FromPrimitive)]
+#[derive(Clone, Copy, Debug, Eq, FromPrimitive, PartialEq)]
 pub enum VideoCodec {
     H263 = 2,
     ScreenVideo = 3,
@@ -1724,14 +1724,14 @@ impl VideoCodec {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VideoFrame<'a> {
     pub stream_id: CharacterId,
     pub frame_num: u16,
     pub data: &'a [u8],
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DefineBitsJpeg3<'a> {
     pub id: CharacterId,
     pub version: u8,
@@ -1740,7 +1740,7 @@ pub struct DefineBitsJpeg3<'a> {
     pub alpha_data: &'a [u8],
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DoAbc<'a> {
     pub name: &'a SwfStr,
     pub is_lazy_initialize: bool,
@@ -1754,7 +1754,7 @@ pub type JpegTables<'a> = &'a [u8];
 /// `ProductInfo` contains information about the software used to generate the SWF.
 /// Not documented in the SWF19 reference. Emitted by mxmlc.
 /// See http://wahlers.com.br/claus/blog/undocumented-swf-tags-written-by-mxmlc/
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProductInfo {
     pub product_id: u32,
     pub edition: u32,


### PR DESCRIPTION
 * Fix an unneeded `to_string`.
 * Add a bunch of `Eq` to satiate `clippy:derive_partial_eq_without_eq` (one [false positive](https://github.com/rust-lang/rust-clippy/issues/8867) case).
 * Alphabetize the order of derives in these files as well to satiate my own compulsiveness.