### PR TITLE
avm2: Start of Mouse Cursor APIs

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -947,6 +947,9 @@ pub fn load_player_globals<'gc>(
         script,
     )?;
     class(activation, flash::ui::mouse::create_class(mc), script)?;
+    class(activation, flash::ui::mouse::create_class(mc), script)?;
+    class(activation, flash::ui::mousecursor::create_class(mc), script)?;
+    class(activation, flash::ui::mousecursordata::create_class(mc), script)?;
     class(activation, flash::ui::keyboard::create_class(mc), script)?;
 
     // package `flash.net`

--- a/core/src/avm2/globals/flash/ui.rs
+++ b/core/src/avm2/globals/flash/ui.rs
@@ -4,3 +4,4 @@ pub mod contextmenu;
 pub mod contextmenuitem;
 pub mod keyboard;
 pub mod mouse;
+pub mod mousecursor;

--- a/core/src/avm2/globals/flash/ui.rs
+++ b/core/src/avm2/globals/flash/ui.rs
@@ -5,3 +5,4 @@ pub mod contextmenuitem;
 pub mod keyboard;
 pub mod mouse;
 pub mod mousecursor;
+pub mod mousecursordata;

--- a/core/src/avm2/globals/flash/ui/mouse.rs
+++ b/core/src/avm2/globals/flash/ui/mouse.rs
@@ -25,6 +25,40 @@ fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
+fn cursor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Mouse.cursor: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn set_cursor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Mouse.cursor: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn supports_cursor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Bool(false))
+}
+
+fn supports_native_cursor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Bool(false))
+}
+
 fn hide<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
@@ -34,12 +68,30 @@ fn hide<'gc>(
     Ok(Value::Undefined)
 }
 
+fn register_cursor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Mouse.registerCursor: not yet implemented");
+    Ok(Value::Undefined)
+}
+
 fn show<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     activation.context.ui.set_mouse_visible(true);
+    Ok(Value::Undefined)
+}
+
+fn unregister_cursor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("Mouse.unregisterCursor: not yet implemented");
     Ok(Value::Undefined)
 }
 
@@ -56,7 +108,20 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
 
     write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
 
-    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[("show", show), ("hide", hide)];
+    const PUBLIC_CLASS_PROPERTIES: &[(&str, Option<NativeMethodImpl>, Option<NativeMethodImpl>)] =
+        &[
+            ("cursor", Some(cursor), Some(set_cursor)),
+            ("supportsCursor", Some(supports_cursor), None),
+            ("supportsNativeCursor", Some(supports_native_cursor), None),
+        ];
+    write.define_public_builtin_class_properties(mc, PUBLIC_CLASS_PROPERTIES);
+
+    const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[
+        ("show", show),
+        ("registerCursor", register_cursor),
+        ("hide", hide),
+        ("unregisterCursor", unregister_cursor),
+    ];
     write.define_public_builtin_class_methods(mc, PUBLIC_CLASS_METHODS);
 
     class

--- a/core/src/avm2/globals/flash/ui/mousecursor.rs
+++ b/core/src/avm2/globals/flash/ui/mousecursor.rs
@@ -1,0 +1,50 @@
+//! `flash.ui.MouseCursor` builtin
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Err("The MouseCursor class cannot be constructed.".into())
+}
+
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.ui"), "MouseCursor"),
+        Some(QName::new(Namespace::package(""), "Object").into()),
+        Method::from_builtin(instance_init, "<MouseCursor instance initializer>", mc),
+        Method::from_builtin(class_init, "<MouseCursor class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::SEALED | ClassAttributes::FINAL);
+
+    const CONSTANTS: &[(&str, &str)] = &[
+        ("ARROW", "arrow"),
+        ("AUTO", "auto"),
+        ("BUTTON", "button"),
+        ("HAND", "hand"),
+        ("IBEAM", "ibeam"),
+    ];
+    write.define_public_constant_string_class_traits(CONSTANTS);
+
+    class
+}

--- a/core/src/avm2/globals/flash/ui/mousecursor.rs
+++ b/core/src/avm2/globals/flash/ui/mousecursor.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::Method;
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;

--- a/core/src/avm2/globals/flash/ui/mousecursordata.rs
+++ b/core/src/avm2/globals/flash/ui/mousecursordata.rs
@@ -1,0 +1,106 @@
+//! `flash.ui.MouseCursor` builtin
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::names::{Namespace, QName};
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use gc_arena::{GcCell, MutationContext};
+
+fn instance_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+fn class_init<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    Ok(Value::Undefined)
+}
+
+fn data<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("MouseCursorData.data: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn set_data<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("MouseCursorData.data: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn frame_rate<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("MouseCursorData.frameRate: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn set_frame_rate<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("MouseCursorData.frameRate: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn hot_spot<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("MouseCursorData.hotSpot: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+fn set_hot_spot<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    log::warn!("MouseCursorData.hotSpot: not yet implemented");
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+    let class = Class::new(
+        QName::new(Namespace::package("flash.ui"), "MouseCursorData"),
+        Some(QName::new(Namespace::package(""), "Object").into()),
+        Method::from_builtin(instance_init, "<MouseCursorData instance initializer>", mc),
+        Method::from_builtin(class_init, "<MouseCursorData class initializer>", mc),
+        mc,
+    );
+
+    let mut write = class.write(mc);
+
+    write.set_attributes(ClassAttributes::FINAL);
+
+    const PUBLIC_INSTANCE_PROPERTIES: &[(
+        &str,
+        Option<NativeMethodImpl>,
+        Option<NativeMethodImpl>,
+    )] = &[
+        ("data", Some(data), Some(set_data)),
+        ("frameRate", Some(frame_rate), Some(set_frame_rate)),
+        ("hotSpot", Some(hot_spot), Some(set_hot_spot)),
+    ];
+    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+
+    class
+}

--- a/core/src/avm2/globals/flash/ui/mousecursordata.rs
+++ b/core/src/avm2/globals/flash/ui/mousecursordata.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
+use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;

--- a/core/src/avm2/globals/flash/ui/mousecursordata.rs
+++ b/core/src/avm2/globals/flash/ui/mousecursordata.rs
@@ -1,4 +1,4 @@
-//! `flash.ui.MouseCursor` builtin
+//! `flash.ui.MouseCursorData` builtin
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};


### PR DESCRIPTION
I'll try to see if I can get these properly implemented, for the native cursors it should be fairly straight forward, as there are good equivalents for all of them and seems to be mostly implemented already.
As for custom/animated cursors, the mouse cursor can be hidden with `Window::set_cursor_visible` on desktop and `cursor: none;` CSS on web, and then it has to be drawn (on top of everything) separately which is a bit more complex.