### PR TITLE
Write out tag header for `DebugId` tag

### DIFF
--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2376,6 +2376,7 @@ impl<W: Write> Writer<W> {
     }
 
     fn write_debug_id(&mut self, debug_id: &DebugId) -> Result<()> {
+        self.write_tag_header(TagCode::DebugId, debug_id.len() as u32)?;
         self.output.write_all(debug_id)?;
         Ok(())
     }


### PR DESCRIPTION
The implementation of `write_debug_id` was previously
not writing the header, causing a malformed SWF to be produced
whenever a `DebugId` tag was included.