### PR TITLE
Fix swapped 'width' and 'height' in wgpu `register_bitmap_raw`

### DIFF
--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -1448,7 +1448,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         rgba: Vec<u8>,
     ) -> Result<BitmapHandle, Error> {
         Ok(self
-            .register_bitmap(Bitmap::new(height, width, BitmapFormat::Rgba, rgba), "RAW")
+            .register_bitmap(Bitmap::new(width, height, BitmapFormat::Rgba, rgba), "RAW")
             .handle)
     }
 


### PR DESCRIPTION
These arguments were being passed in the wrong order, leading to a crash
when the width and height are not equal.