### PR TITLE
avm2: Pull methods' scopes from vtable, not class

### DIFF
--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -303,14 +303,13 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
             }
             Some(Property::Method { disp_id }) => {
                 let vtable = self.vtable().unwrap();
-                if let Some((superclass, method)) = vtable.get_full_method(disp_id) {
+                if let Some((superclass, scope, method)) = vtable.get_full_method(disp_id) {
                     if !method.needs_arguments_object() {
-                        let scope = superclass.unwrap().instance_scope();
-                        Executable::from_method(method, scope, None, superclass).exec(
+                        Executable::from_method(method, scope, None, Some(superclass)).exec(
                             Some(self.into()),
                             arguments,
                             activation,
-                            superclass.unwrap().into(), //Deliberately invalid.
+                            superclass.into(), //Deliberately invalid.
                         )
                     } else {
                         if let Some(bound_method) = self.get_bound_method(disp_id) {

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -11,7 +11,7 @@ use crate::avm2::object::{Multiname, Object, ObjectPtr, TObject};
 use crate::avm2::property::Property;
 use crate::avm2::scope::{Scope, ScopeChain};
 use crate::avm2::value::Value;
-use crate::avm2::vtable::VTable;
+use crate::avm2::vtable::{ClassBoundMethod, VTable};
 use crate::avm2::Error;
 use crate::string::AvmString;
 use fnv::FnvHashMap;
@@ -542,14 +542,17 @@ impl<'gc> ClassObject<'gc> {
         }
         if let Some(Property::Method { disp_id, .. }) = property {
             // todo: handle errors
-            let (superclass_object, scope, method) =
-                self.instance_vtable().get_full_method(disp_id).unwrap();
+            let ClassBoundMethod {
+                class,
+                scope,
+                method,
+            } = self.instance_vtable().get_full_method(disp_id).unwrap();
             let callee = FunctionObject::from_method(
                 activation,
                 method.clone(),
                 scope,
                 Some(reciever),
-                Some(superclass_object),
+                Some(class),
             );
 
             callee.call(Some(reciever), arguments, activation)
@@ -601,14 +604,17 @@ impl<'gc> ClassObject<'gc> {
         }) = property
         {
             // todo: handle errors
-            let (superclass_object, scope, method) =
-                self.instance_vtable().get_full_method(disp_id).unwrap();
+            let ClassBoundMethod {
+                class,
+                scope,
+                method,
+            } = self.instance_vtable().get_full_method(disp_id).unwrap();
             let callee = FunctionObject::from_method(
                 activation,
                 method.clone(),
                 scope,
                 Some(reciever),
-                Some(superclass_object),
+                Some(class),
             );
 
             callee.call(Some(reciever), &[], activation)
@@ -662,14 +668,17 @@ impl<'gc> ClassObject<'gc> {
         }) = property
         {
             // todo: handle errors
-            let (superclass_object, scope, method) =
-                self.instance_vtable().get_full_method(disp_id).unwrap();
+            let ClassBoundMethod {
+                class,
+                scope,
+                method,
+            } = self.instance_vtable().get_full_method(disp_id).unwrap();
             let callee = FunctionObject::from_method(
                 activation,
                 method.clone(),
                 scope,
                 Some(reciever),
-                Some(superclass_object),
+                Some(class),
             );
 
             callee.call(Some(reciever), &[value], activation)?;

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -245,7 +245,7 @@ impl<'gc> ClassObject<'gc> {
         class.read().validate_class(self.superclass_object())?;
 
         self.instance_vtable().init_vtable(
-            Some(self),
+            self,
             class.read().instance_traits(),
             self.instance_scope(),
             self.superclass_object().map(|cls| cls.instance_vtable()),
@@ -254,7 +254,7 @@ impl<'gc> ClassObject<'gc> {
 
         // class vtable == class traits + Class instance traits
         self.class_vtable().init_vtable(
-            Some(self),
+            self,
             class.read().class_traits(),
             self.class_scope(),
             Some(self.instance_of().unwrap().instance_vtable()),
@@ -542,15 +542,14 @@ impl<'gc> ClassObject<'gc> {
         }
         if let Some(Property::Method { disp_id, .. }) = property {
             // todo: handle errors
-            let (superclass_object, method) =
+            let (superclass_object, scope, method) =
                 self.instance_vtable().get_full_method(disp_id).unwrap();
-            let scope = superclass_object.unwrap().instance_scope();
             let callee = FunctionObject::from_method(
                 activation,
                 method.clone(),
                 scope,
                 Some(reciever),
-                superclass_object,
+                Some(superclass_object),
             );
 
             callee.call(Some(reciever), arguments, activation)
@@ -602,15 +601,14 @@ impl<'gc> ClassObject<'gc> {
         }) = property
         {
             // todo: handle errors
-            let (superclass_object, method) =
+            let (superclass_object, scope, method) =
                 self.instance_vtable().get_full_method(disp_id).unwrap();
-            let scope = superclass_object.unwrap().class_scope();
             let callee = FunctionObject::from_method(
                 activation,
                 method.clone(),
                 scope,
                 Some(reciever),
-                superclass_object,
+                Some(superclass_object),
             );
 
             callee.call(Some(reciever), &[], activation)
@@ -664,15 +662,14 @@ impl<'gc> ClassObject<'gc> {
         }) = property
         {
             // todo: handle errors
-            let (superclass_object, method) =
+            let (superclass_object, scope, method) =
                 self.instance_vtable().get_full_method(disp_id).unwrap();
-            let scope = superclass_object.unwrap().class_scope();
             let callee = FunctionObject::from_method(
                 activation,
                 method.clone(),
                 scope,
                 Some(reciever),
-                superclass_object,
+                Some(superclass_object),
             );
 
             callee.call(Some(reciever), &[value], activation)?;
@@ -904,7 +901,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
             .validate_class(class_object.superclass_object())?;
 
         class_object.instance_vtable().init_vtable(
-            Some(class_object),
+            class_object,
             parameterized_class.read().instance_traits(),
             class_object.instance_scope(),
             class_object
@@ -915,7 +912,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
 
         // class vtable == class traits + Class instance traits
         class_object.class_vtable().init_vtable(
-            Some(class_object),
+            class_object,
             parameterized_class.read().class_traits(),
             class_object.class_scope(),
             Some(class_object.instance_of().unwrap().instance_vtable()),

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -379,7 +379,7 @@ impl<'gc> Script<'gc> {
             let scope = ScopeChain::new(domain);
 
             globals.vtable().unwrap().init_vtable(
-                None,
+                globals.instance_of().unwrap(),
                 &self.traits()?,
                 scope,
                 None,


### PR DESCRIPTION
~~The only reason this is a draft, is because I want to test this on more GH issues first.~~ I'm also admittedly not 100% sure this is entirely correct (but feels way better by instinct).

This is supposed to fix https://github.com/ruffle-rs/ruffle/issues/5897 , https://github.com/ruffle-rs/ruffle/issues/7079 and possibly all issues involving the panic
```
panicked at 'called `Option::unwrap()` on a `None` value', core/src/avm2/object.rs:308
```

The issue was that "top-level functions" (scripts containing `method trait`s*) were created while resolving vtable of the global object, which is subtly different than resolving vtables of normal classes, as the `global`'s class is weird. In general, since all the global objects belong to the same class but have different vtables and scopes, this means we need to use the object's vtable's scope instead of relying on the class.

While I was there, I also made some `init_vtable` params non-optional.

This PR also happens to extend @Aaron1011 's fix from https://github.com/ruffle-rs/ruffle/pull/7084 to `get_super` and `set_super`.

The most important change here is in `object.rs`, everything else is refactors to make it work.

Another equivalent way to implement this would be to instead write
```rs
method_table: Vec<(VTable<'gc>, Method<'gc>)>,
```
and grab the fields from the vtable - this is equivalent to the current code and would have slightly less reference duplication, but that way would need more jumping through `GcCell` and `unwrap()`s after initialization, which I wasn't a fan of.

(*note: `function trait`s are technically a thing, but FP doesn't appear to actually support them. All functions use the `method` trait type. So we might want to consider removing support for this too, for simplicity.)