### PR TITLE
swf: `Matrix`-related cleanups

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1621,11 +1621,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
         let edit_text = self.0.read();
         context.transform_stack.push(&Transform {
-            matrix: Matrix {
-                tx: edit_text.bounds.x_min,
-                ty: edit_text.bounds.y_min,
-                ..Default::default()
-            },
+            matrix: Matrix::translate(edit_text.bounds.x_min, edit_text.bounds.y_min),
             ..Default::default()
         });
 
@@ -1659,12 +1655,10 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         // TODO: Where does this come from? How is this different than INTERNAL_PADDING? Does this apply to y as well?
         // If this is actually right, offset the border in `redraw_border` instead of doing an extra push.
         context.transform_stack.push(&Transform {
-            matrix: Matrix {
-                tx: Twips::from_pixels(Self::INTERNAL_PADDING)
-                    - Twips::from_pixels(edit_text.hscroll),
-                ty: Twips::from_pixels(Self::INTERNAL_PADDING) - scroll_offset,
-                ..Default::default()
-            },
+            matrix: Matrix::translate(
+                Twips::from_pixels(Self::INTERNAL_PADDING) - Twips::from_pixels(edit_text.hscroll),
+                Twips::from_pixels(Self::INTERNAL_PADDING) - scroll_offset,
+            ),
             ..Default::default()
         });
 

--- a/core/src/transform.rs
+++ b/core/src/transform.rs
@@ -15,14 +15,7 @@ pub struct Transform {
 impl From<Position<Twips>> for Transform {
     fn from(pos: Position<Twips>) -> Self {
         Self {
-            matrix: Matrix {
-                a: 1.0,
-                b: 0.0,
-                c: 0.0,
-                d: 1.0,
-                tx: pos.x(),
-                ty: pos.y(),
-            },
+            matrix: Matrix::translate(pos.x(), pos.y()),
             color_transform: Default::default(),
         }
     }

--- a/swf/src/types/matrix.rs
+++ b/swf/src/types/matrix.rs
@@ -51,11 +51,11 @@ impl Matrix {
 
     /// Returns a scale matrix.
     #[inline]
-    pub fn scale(scale_x: Fixed16, scale_y: Fixed16) -> Self {
+    pub const fn scale(scale_x: Fixed16, scale_y: Fixed16) -> Self {
         Self {
             a: scale_x,
             d: scale_y,
-            ..Default::default()
+            ..Self::IDENTITY
         }
     }
 
@@ -73,11 +73,11 @@ impl Matrix {
 
     /// Returns a translation matrix.
     #[inline]
-    pub fn translate(x: Twips, y: Twips) -> Self {
+    pub const fn translate(x: Twips, y: Twips) -> Self {
         Self {
             tx: x,
             ty: y,
-            ..Default::default()
+            ..Self::IDENTITY
         }
     }
 


### PR DESCRIPTION
* Mark some `swf::Matrix` functions as `const` - Because why not?
* Use `swf::Matrix::translate` in more places - Replace direct instatiations of `swf::Matrix` where only `tx` and `ty` are specified, and other fields are default. This results in a slightly more shorter, readable code.