### PR TITLE
render: Move `srgb_to_linear` to `common_tess`

### DIFF
--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -726,23 +726,6 @@ pub fn unmultiply_alpha_rgba(rgba: &mut [u8]) {
     })
 }
 
-/// Converts an RGBA color from sRGB space to linear color space.
-pub fn srgb_to_linear(color: [f32; 4]) -> [f32; 4] {
-    fn to_linear_channel(n: f32) -> f32 {
-        if n <= 0.04045 {
-            n / 12.92
-        } else {
-            f32::powf((n + 0.055) / 1.055, 2.4)
-        }
-    }
-    [
-        to_linear_channel(color[0]),
-        to_linear_channel(color[1]),
-        to_linear_channel(color[2]),
-        color[3],
-    ]
-}
-
 /// Decodes zlib-compressed data.
 fn decompress_zlib(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut out_data = Vec::new();

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -834,23 +834,6 @@ fn swf_shape_to_canvas_commands(
     canvas_data
 }
 
-/// Converts an SWF color from sRGB space to linear color space.
-pub fn srgb_to_linear(mut color: swf::Color) -> swf::Color {
-    fn to_linear_channel(n: u8) -> u8 {
-        let mut n = f32::from(n) / 255.0;
-        n = if n <= 0.04045 {
-            n / 12.92
-        } else {
-            f32::powf((n + 0.055) / 1.055, 2.4)
-        };
-        (n.clamp(0.0, 1.0) * 255.0).round() as u8
-    }
-    color.r = to_linear_channel(color.r);
-    color.g = to_linear_channel(color.g);
-    color.b = to_linear_channel(color.b);
-    color
-}
-
 fn create_linear_gradient(
     context: &CanvasRenderingContext2d,
     gradient: &swf::Gradient,


### PR DESCRIPTION
* Remove dead `srgb_to_linear` function in `canvas`. There's another similar function in `core/src/backend/render.rs`.
* Move remaining `srgb_to_linear` function from `core` to `common_tess`, since it's the only user of it. Also make it mutate the float array parameter instead of returning a new one, just to simply things a bit.