### PR TITLE
render: Introduce `RenderBackend::register_bitmap`

### DIFF
--- a/core/src/backend/video/software/mod.rs
+++ b/core/src/backend/video/software/mod.rs
@@ -1,6 +1,6 @@
 //! Pure software video decoding backend.
 
-use crate::backend::render::{BitmapHandle, BitmapInfo, RenderBackend};
+use crate::backend::render::{Bitmap, BitmapFormat, BitmapHandle, BitmapInfo, RenderBackend};
 use crate::backend::video::{
     DecodedFrame, EncodedFrame, Error, FrameDependency, VideoBackend, VideoStreamHandle,
 };
@@ -91,7 +91,13 @@ impl VideoBackend for SoftwareVideoBackend {
         let handle = if let Some(bitmap) = stream.bitmap {
             renderer.update_texture(bitmap, frame.width.into(), frame.height.into(), frame.rgba)?
         } else {
-            renderer.register_bitmap_raw(frame.width.into(), frame.height.into(), frame.rgba)?
+            let bitmap = Bitmap::new(
+                frame.width.into(),
+                frame.height.into(),
+                BitmapFormat::Rgba,
+                frame.rgba,
+            );
+            renderer.register_bitmap(bitmap)?
         };
         stream.bitmap = Some(handle);
 

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -1,7 +1,7 @@
 use gc_arena::Collect;
 
 use crate::avm2::{Object as Avm2Object, Value as Avm2Value};
-use crate::backend::render::{BitmapHandle, RenderBackend};
+use crate::backend::render::{Bitmap, BitmapFormat, BitmapHandle, RenderBackend};
 use crate::bitmap::color_transform_params::ColorTransformParams;
 use crate::bitmap::turbulence::Turbulence;
 use bitflags::bitflags;
@@ -177,8 +177,13 @@ impl<'gc> BitmapData<'gc> {
 
     pub fn bitmap_handle(&mut self, renderer: &mut dyn RenderBackend) -> Option<BitmapHandle> {
         if self.bitmap_handle.is_none() {
-            let bitmap_handle =
-                renderer.register_bitmap_raw(self.width(), self.height(), self.pixels_rgba());
+            let bitmap = Bitmap::new(
+                self.width(),
+                self.height(),
+                BitmapFormat::Rgba,
+                self.pixels_rgba(),
+            );
+            let bitmap_handle = renderer.register_bitmap(bitmap);
             if let Err(e) = &bitmap_handle {
                 log::warn!("Failed to register raw bitmap for BitmapData: {:?}", e);
             }


### PR DESCRIPTION
Since all `RenderBackend::register_bitmap_*` implementations are
identical now, move them to the default implementation of `RenderBackend`.

Also, turn `RenderBackend::register_bitmap_raw` into `RenderBackend::register_bitmap`,
which accepts a single `Bitmap` parameter.