### PR TITLE
webgl/wgpu: Omit strokes when drawing a mask stencil

### DIFF
--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -343,6 +343,7 @@ impl WebGlRenderBackend {
                 vertex_buffer,
                 index_buffer,
                 num_indices: 6,
+                num_mask_indices: 6,
             }],
         };
         Ok(quad_mesh)
@@ -496,6 +497,7 @@ impl WebGlRenderBackend {
         let mut draws = Vec::with_capacity(lyon_mesh.len());
         for draw in lyon_mesh {
             let num_indices = draw.indices.len() as i32;
+            let num_mask_indices = draw.mask_index_count as i32;
 
             let vao = self.create_vertex_array().unwrap();
             let vertex_buffer = self.gl.create_buffer().unwrap();
@@ -560,6 +562,7 @@ impl WebGlRenderBackend {
                     vertex_buffer,
                     index_buffer,
                     num_indices,
+                    num_mask_indices,
                 },
                 TessDrawType::Gradient(gradient) => Draw {
                     draw_type: DrawType::Gradient(Box::new(Gradient::from(gradient))),
@@ -567,6 +570,7 @@ impl WebGlRenderBackend {
                     vertex_buffer,
                     index_buffer,
                     num_indices,
+                    num_mask_indices,
                 },
                 TessDrawType::Bitmap(bitmap) => Draw {
                     draw_type: DrawType::Bitmap(BitmapDraw {
@@ -579,6 +583,7 @@ impl WebGlRenderBackend {
                     vertex_buffer,
                     index_buffer,
                     num_indices,
+                    num_mask_indices,
                 },
             });
 
@@ -941,6 +946,18 @@ impl RenderBackend for WebGlRenderBackend {
 
         let mesh = &self.meshes[shape.0];
         for draw in &mesh.draws {
+            // Ignore strokes when drawing a mask stencil.
+            let num_indices = if self.mask_state != MaskState::DrawMaskStencil
+                && self.mask_state != MaskState::ClearMaskStencil
+            {
+                draw.num_indices
+            } else {
+                draw.num_mask_indices
+            };
+            if num_indices == 0 {
+                continue;
+            }
+
             self.bind_vertex_array(Some(&draw.vao));
 
             let (program, src_blend, dst_blend) = match &draw.draw_type {
@@ -1062,7 +1079,7 @@ impl RenderBackend for WebGlRenderBackend {
 
             // Draw the triangles.
             self.gl
-                .draw_elements_with_i32(Gl::TRIANGLES, draw.num_indices, Gl::UNSIGNED_INT, 0);
+                .draw_elements_with_i32(Gl::TRIANGLES, num_indices, Gl::UNSIGNED_INT, 0);
         }
     }
 
@@ -1320,6 +1337,7 @@ struct Draw {
     index_buffer: WebGlBuffer,
     vao: WebGlVertexArrayObject,
     num_indices: i32,
+    num_mask_indices: i32,
 }
 
 enum DrawType {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -286,7 +286,8 @@ struct Draw {
     draw_type: DrawType,
     vertex_buffer: wgpu::Buffer,
     index_buffer: wgpu::Buffer,
-    index_count: u32,
+    num_indices: u32,
+    num_mask_indices: u32,
 }
 
 #[allow(dead_code)]
@@ -572,7 +573,8 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                     draw_type: DrawType::Color,
                     vertex_buffer,
                     index_buffer,
-                    index_count,
+                    num_indices: index_count,
+                    num_mask_indices: draw.mask_index_count,
                 },
                 TessDrawType::Gradient(gradient) => {
                     // TODO: Extract to function?
@@ -654,7 +656,8 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                         },
                         vertex_buffer,
                         index_buffer,
-                        index_count,
+                        num_indices: index_count,
+                        num_mask_indices: draw.mask_index_count,
                     }
                 }
                 TessDrawType::Bitmap(bitmap) => {
@@ -721,7 +724,8 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                         },
                         vertex_buffer,
                         index_buffer,
-                        index_count,
+                        num_indices: index_count,
+                        num_mask_indices: draw.mask_index_count,
                     }
                 }
             });
@@ -1072,6 +1076,18 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         );
 
         for draw in &mesh.draws {
+            let num_indices = if self.mask_state != MaskState::DrawMaskStencil
+                && self.mask_state != MaskState::ClearMaskStencil
+            {
+                draw.num_indices
+            } else {
+                // Omit strokes when drawing a mask stencil.
+                draw.num_mask_indices
+            };
+            if num_indices == 0 {
+                continue;
+            }
+
             match &draw.draw_type {
                 DrawType::Color => {
                     frame.render_pass.set_pipeline(
@@ -1132,7 +1148,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                 }
             };
 
-            frame.render_pass.draw_indexed(0..draw.index_count, 0, 0..1);
+            frame.render_pass.draw_indexed(0..num_indices, 0, 0..1);
         }
     }
 


### PR DESCRIPTION
Adjust `common_tess` to add an additional `mask_index_count` to
draws. This is used to not render strokes when drawing a shape as
a mask stencil.

Fixes #7027.