### PR TITLE
Add exclusions for sites broken by extension

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -17,6 +17,10 @@
     "content_scripts": [
         {
             "matches": ["<all_urls>"],
+            "exclude_matches": [
+                "https://sso.godaddy.com/*",
+                "https://authentication.td.com/*"
+            ],
             "js": ["dist/content.js"],
             "all_frames": true,
             "run_at": "document_start",


### PR DESCRIPTION
Sites such as godaddy.com and a bank referenced in #2158 do not allow users to sign in with the Ruffle extension active.
While we are uncertain of the cause, the best option may be to simply prevent Ruffle from executing on these domains.