### PR TITLE
web: Make `SourceAPI` a singleton

### DIFF
--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -9,7 +9,6 @@ export * from "./ruffle-imports";
 export * from "./ruffle-object";
 export * from "./ruffle-player";
 export * from "./shadow-template";
-export * from "./source-api";
 export * from "./version";
 export * from "./version-range";
 export * from "./config";

--- a/web/packages/core/src/source-api.ts
+++ b/web/packages/core/src/source-api.ts
@@ -10,28 +10,11 @@ import { RufflePlayer } from "./ruffle-player";
  * negotiator (see [[PublicAPI]]) what this particular version of Ruffle is and
  * how to control it.
  */
-export class SourceAPI {
-    private name: string;
-
+export const SourceAPI = {
     /**
-     * Construct a Source API.
-     *
-     * @param name The name of this particular source.
+     * The version of this particular API, as a string in a semver compatible format.
      */
-    constructor(name: string) {
-        this.name = name;
-    }
-
-    /**
-     * The version of this particular API.
-     *
-     * This is returned as a string in a semver compatible format.
-     *
-     * @returns The version of this Ruffle source
-     */
-    get version(): string {
-        return "%VERSION_NUMBER%";
-    }
+    version: "%VERSION_NUMBER%",
 
     /**
      * Start up the polyfills.
@@ -42,7 +25,7 @@ export class SourceAPI {
      */
     polyfill(isExt: boolean): void {
         polyfill(isExt);
-    }
+    },
 
     /**
      * Polyfill the plugin detection.
@@ -51,7 +34,7 @@ export class SourceAPI {
      */
     pluginPolyfill(): void {
         pluginPolyfill();
-    }
+    },
 
     /**
      * Create a Ruffle player element using this particular version of Ruffle.
@@ -62,5 +45,5 @@ export class SourceAPI {
     createPlayer(): RufflePlayer {
         const name = registerElement("ruffle-player", RufflePlayer);
         return <RufflePlayer>document.createElement(name);
-    }
-}
+    },
+};

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -1,12 +1,8 @@
 import "./index.css";
 
-import { SourceAPI, PublicAPI } from "ruffle-core";
+import { PublicAPI } from "ruffle-core";
 
-window.RufflePlayer = PublicAPI.negotiate(
-    window.RufflePlayer,
-    "local",
-    new SourceAPI("local")
-);
+window.RufflePlayer = PublicAPI.negotiate(window.RufflePlayer, "local");
 const ruffle = window.RufflePlayer.newest();
 
 let player;

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -1,11 +1,7 @@
 import * as utils from "./utils";
-import { PublicAPI, SourceAPI, Letterbox } from "ruffle-core";
+import { PublicAPI, Letterbox } from "ruffle-core";
 
-const api = PublicAPI.negotiate(
-    window.RufflePlayer!,
-    "local",
-    new SourceAPI("local")
-);
+const api = PublicAPI.negotiate(window.RufflePlayer!, "local");
 window.RufflePlayer = api;
 const ruffle = api.newest()!;
 

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -1,4 +1,4 @@
-import { PublicAPI, SourceAPI, Config } from "ruffle-core";
+import { PublicAPI, Config } from "ruffle-core";
 
 interface LoadMessage {
     type: "load";
@@ -21,8 +21,7 @@ function handleMessage(message: Message) {
             };
             window.RufflePlayer = PublicAPI.negotiate(
                 window.RufflePlayer!,
-                "extension",
-                new SourceAPI("extension")
+                "extension"
             );
             return {};
         case "ping":

--- a/web/packages/selfhosted/js/ruffle.js
+++ b/web/packages/selfhosted/js/ruffle.js
@@ -1,7 +1,3 @@
-import { PublicAPI, SourceAPI } from "ruffle-core";
+import { PublicAPI } from "ruffle-core";
 
-window.RufflePlayer = PublicAPI.negotiate(
-    window.RufflePlayer,
-    "local",
-    new SourceAPI("local")
-);
+window.RufflePlayer = PublicAPI.negotiate(window.RufflePlayer, "local");


### PR DESCRIPTION
As a first step towards a simpler Web API, convert `SourceAPI` from
a class to a constant object, under the assumption that `SourceAPI`
isn't a public Ruffle API and as such is safe to be changed.

As a result the different `ruffle-core` users don't need to construct
a new `SourceAPI` instance before calling `PublicAPI.negotiate()`.