### PR TITLE
avm2: More filter-related stubs

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -889,6 +889,11 @@ pub fn load_player_globals<'gc>(
     )?;
     class(
         activation,
+        flash::filters::blurfilter::create_class(mc),
+        script,
+    )?;
+    class(
+        activation,
         flash::filters::glowfilter::create_class(mc),
         script,
     )?;

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -6,6 +6,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::names::{Namespace, QName};
 use crate::avm2::object::{stage_allocator, LoaderInfoObject, Object, TObject};
 use crate::avm2::value::Value;
+use crate::avm2::ArrayObject;
 use crate::avm2::Error;
 use crate::display_object::{DisplayObject, HitTestOptions, TDisplayObject};
 use crate::types::{Degrees, Percent};
@@ -238,12 +239,12 @@ pub fn set_scale_x<'gc>(
 
 /// Implements `filters`'s getter.
 pub fn filters<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     log::warn!("DisplayObject.filters getter - not yet implemented");
-    Ok(Value::Undefined)
+    Ok(ArrayObject::empty(activation)?.into())
 }
 
 /// Implements `filters`'s setter.

--- a/core/src/avm2/globals/flash/filters.rs
+++ b/core/src/avm2/globals/flash/filters.rs
@@ -1,4 +1,5 @@
 //! `flash.filters` namespace
 
 pub mod bitmapfilter;
+pub mod blurfilter;
 pub mod glowfilter;

--- a/core/src/avm2/globals/flash/filters/blurfilter.rs
+++ b/core/src/avm2/globals/flash/filters/blurfilter.rs
@@ -1,4 +1,4 @@
-//! `flash.filters.GlowFilter` builtin/prototype
+//! `flash.filters.BlurFilter` builtin/prototype
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::{Class, ClassAttributes};
@@ -8,7 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::{Error, Object};
 use gc_arena::{GcCell, MutationContext};
 
-/// Implements `flash.filters.GlowFilter`'s class constructor.
+/// Implements `flash.filters.BlurFilter`'s class constructor.
 pub fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
@@ -17,7 +17,7 @@ pub fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Implements `flash.filters.GlowFilter`'s instance constructor.
+/// Implements `flash.filters.BlurFilter`'s instance constructor.
 pub fn instance_init<'gc>(
     _activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
@@ -28,10 +28,10 @@ pub fn instance_init<'gc>(
 
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
-        QName::new(Namespace::package("flash.filters"), "GlowFilter"),
+        QName::new(Namespace::package("flash.filters"), "BlurFilter"),
         Some(QName::new(Namespace::package("flash.filters"), "BitmapFilter").into()),
-        Method::from_builtin(instance_init, "<GlowFilter instance initializer>", mc),
-        Method::from_builtin(class_init, "<GlowFilter class initializer>", mc),
+        Method::from_builtin(instance_init, "<BlurFilter instance initializer>", mc),
+        Method::from_builtin(class_init, "<BlurFilter class initializer>", mc),
         mc,
     );
 
@@ -39,14 +39,9 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
 
     const PUBLIC_INSTANCE_SLOTS: &[(&str, &str, &str)] = &[
-        ("alpha", "", "Number"),
         ("blurX", "", "Number"),
         ("blurY", "", "Number"),
-        ("color", "", "uint"),
-        ("inner", "", "Boolean"),
-        ("knockout", "", "Boolean"),
         ("quality", "", "int"),
-        ("strength", "", "Number"),
     ];
     write.define_public_slot_instance_traits(PUBLIC_INSTANCE_SLOTS);
 


### PR DESCRIPTION
This stubs out BlurFilter, adds properties to GlowFilter,
and make the getter for  DisplayObject.filters return
an empty array instead of Undefined.

This is all of the filter-related code that 'Solarmax'
needs in order to reach the main screen (combined with
other unrelated changes I have yet to submit)