### PR TITLE
Free render backend resources on `BitmapData.dispose`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,7 @@ dependencies = [
 name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
+ "fnv",
  "js-sys",
  "log",
  "ruffle_core",
@@ -3110,6 +3111,7 @@ name = "ruffle_render_webgl"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "fnv",
  "js-sys",
  "log",
  "ruffle_core",
@@ -3126,6 +3128,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "enum-map",
+ "fnv",
  "futures",
  "image",
  "log",

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -405,7 +405,7 @@ pub fn dispose<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            bitmap_data.dispose(activation.context.gc_context);
+            bitmap_data.dispose(&mut activation.context);
             return Ok(Value::Undefined);
         }
     }

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -1,5 +1,6 @@
 use crate::add_field_accessors;
 use crate::avm1::{Object, ScriptObject, TObject};
+use crate::context::UpdateContext;
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
@@ -54,9 +55,11 @@ impl<'gc> BitmapDataObject<'gc> {
         ))
     }
 
-    pub fn dispose(&self, gc_context: MutationContext<'gc, '_>) {
-        self.bitmap_data().write(gc_context).dispose();
-        self.0.write(gc_context).disposed = true;
+    pub fn dispose(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
+        self.bitmap_data()
+            .write(context.gc_context)
+            .dispose(context.renderer);
+        self.0.write(context.gc_context).disposed = true;
     }
 }
 

--- a/core/src/backend/render.rs
+++ b/core/src/backend/render.rs
@@ -86,6 +86,9 @@ pub trait RenderBackend: Downcast {
 
     fn get_bitmap_pixels(&mut self, bitmap: BitmapHandle) -> Option<Bitmap>;
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;
+    // Frees memory used by the bitmap. After this call, `handle` can no longer
+    // be used.
+    fn unregister_bitmap(&mut self, handle: BitmapHandle) -> Result<(), Error>;
     fn update_texture(
         &mut self,
         bitmap: BitmapHandle,
@@ -176,6 +179,9 @@ impl RenderBackend for NullRenderer {
     }
     fn register_bitmap(&mut self, _bitmap: Bitmap) -> Result<BitmapHandle, Error> {
         Ok(BitmapHandle(0))
+    }
+    fn unregister_bitmap(&mut self, _bitmap: BitmapHandle) -> Result<(), Error> {
+        Ok(())
     }
 
     fn update_texture(

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -168,11 +168,18 @@ impl<'gc> BitmapData<'gc> {
         self.dirty = true;
     }
 
-    pub fn dispose(&mut self) {
+    pub fn dispose(&mut self, renderer: &mut dyn RenderBackend) {
         self.width = 0;
         self.height = 0;
         self.pixels.clear();
-        self.dirty = true;
+        if let Some(handle) = self.bitmap_handle {
+            if let Err(e) = renderer.unregister_bitmap(handle) {
+                log::warn!("Failed to unregister bitmap {:?}: {:?}", handle, e);
+            }
+            self.bitmap_handle = None;
+        }
+        // There's no longer a handle to update
+        self.dirty = false;
     }
 
     pub fn bitmap_handle(&mut self, renderer: &mut dyn RenderBackend) -> Option<BitmapHandle> {

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -10,6 +10,7 @@ js-sys = "0.3.57"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 wasm-bindgen = "=0.2.80"
+fnv = "1.0.7"
 
 [dependencies.ruffle_core]
 path = "../../core"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -12,6 +12,7 @@ ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
 wasm-bindgen = "=0.2.80"
 bytemuck = { version = "1.9.1", features = ["derive"] }
+fnv = "1.0.7"
 
 [dependencies.ruffle_core]
 path = "../../core"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -13,6 +13,7 @@ bytemuck = { version = "1.9.1", features = ["derive"] }
 raw-window-handle = "0.4"
 clap = { version = "3.2.2", features = ["derive"], optional = true }
 enum-map = "2.4.0"
+fnv = "1.0.7"
 
 # desktop
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.futures]


### PR DESCRIPTION
Currently, all three render backends hold on texture-related
resources indefinitely (`register_bitmap` pushes to a `Vec`,
and never removes anything). As a result, the resources used
by the render backend (which may include GPU memory) will grow
over time, even if the corresponding `BitmapData` has been deallocated.

This commit adds a new `unregister_bitmap` method, which is called from
`BitmapData.dispose`. All render backs are changed to now use an
`FnvHashMap<BitmapHandle, _>` instead of a `Vec`, allowing us to
remove individual entries.

Currently, we only call `unregister_bitmap` in response to
`BitmapData.dispose` - when `BitmapData` is freed by the
garbage collector, `unregister_bitmap` is *not* called.
This will be addressed in a future PR.