### PR TITLE
web: Run tests on Node.js 18

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["16"]
+        node_version: ["16", "18"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-latest, windows-latest]
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["16"]
+        node_version: ["16", "18"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-latest, windows-latest]
 

--- a/web/README.md
+++ b/web/README.md
@@ -50,7 +50,7 @@ For the compiler to be able to output WebAssembly, an additional target has to b
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.
 
-We recommend using the currently active LTS 16, other versions are not tested.
+We recommend using the currently active LTS 16, but we do also run tests with current Node.js 18.
 
 Note that npm 7 or newer is required. It should come bundled with Node.js 15 or newer, but can be upgraded with older Node.js versions using `npm install -g npm` as root/Administrator.
 


### PR DESCRIPTION
Which is the "current" release per https://nodejs.org/en/about/releases/.
This is in order to be prepared for potentially incoming breaking changes.