### PR TITLE
avm2: Pass `-optimize` to `asc`

### DIFF
--- a/core/build_playerglobal/src/lib.rs
+++ b/core/build_playerglobal/src/lib.rs
@@ -37,6 +37,7 @@ pub fn build_playerglobal(
         "-classpath",
         &asc_path.to_string_lossy(),
         "macromedia.asc.embedding.ScriptCompiler",
+        "-optimize",
         "-outdir",
         &out_dir.to_string_lossy(),
         "-out",


### PR DESCRIPTION
In order to reduce builtins size even further.