### PR TITLE
avm1: Fire `onData` function and event when calling `loadVariables`

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -298,10 +298,14 @@ impl<'gc> ClipEvent<'gc> {
     }
 
     /// Returns the method name of the event handler for this event.
+    ///
+    /// `ClipEvent::Data` returns `None` rather than `onData` because its behavior
+    /// differs from the other events: the method must fire before the SWF-defined
+    /// event handler, so we'll explicitly call `onData` in the appropriate places.
     pub const fn method_name(self) -> Option<&'static str> {
         match self {
             ClipEvent::Construct => None,
-            ClipEvent::Data => Some("onData"),
+            ClipEvent::Data => None,
             ClipEvent::DragOut { .. } => Some("onDragOut"),
             ClipEvent::DragOver { .. } => Some("onDragOver"),
             ClipEvent::EnterFrame => Some("onEnterFrame"),


### PR DESCRIPTION
Fixes part of #2693: triggering `onClipEvent(data)` makes the buttons visible and clickable but the text will always display "Exercice 1" - I believe this is the same issue as #2181 which has nothing to with onData.

I made [this test](https://github.com/ruffle-rs/ruffle/files/9005721/test_ondata.zip) which passes when run manually but fails when added to `regression_tests.rs` for some reason.

