### PR TITLE
AVM2: Remove SystemPrototypes, refactor ScriptObject creation API

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -1,6 +1,6 @@
 //! ActionScript Virtual Machine 2 (AS3) support
 
-use crate::avm2::globals::{SystemClasses, SystemPrototypes};
+use crate::avm2::globals::SystemClasses;
 use crate::avm2::method::Method;
 use crate::avm2::object::EventObject;
 use crate::avm2::script::{Script, TranslationUnit};
@@ -72,9 +72,6 @@ pub struct Avm2<'gc> {
     /// Global scope object.
     globals: Domain<'gc>,
 
-    /// System prototypes.
-    system_prototypes: Option<SystemPrototypes<'gc>>,
-
     /// System classes.
     system_classes: Option<SystemClasses<'gc>>,
 
@@ -100,7 +97,6 @@ impl<'gc> Avm2<'gc> {
         Self {
             stack: Vec::new(),
             globals,
-            system_prototypes: None,
             system_classes: None,
             broadcast_list: Default::default(),
 
@@ -113,13 +109,6 @@ impl<'gc> Avm2<'gc> {
         let globals = context.avm2.globals;
         let mut activation = Activation::from_nothing(context.reborrow());
         globals::load_player_globals(&mut activation, globals)
-    }
-
-    /// Return the current set of system prototypes.
-    ///
-    /// This function panics if the interpreter has not yet been initialized.
-    pub fn prototypes(&self) -> &SystemPrototypes<'gc> {
-        self.system_prototypes.as_ref().unwrap()
     }
 
     /// Return the current set of system classes.

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1737,7 +1737,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let instance = if let Some(activation_class) = self.activation_class {
             activation_class.construct(self, &[])?
         } else {
-            ScriptObject::bare_object(self.context.gc_context)
+            // TODO: we might want this to be a proper Object instance, just in case
+            ScriptObject::custom_object(self.context.gc_context, None, None)
         };
 
         self.context.avm2.push(instance);

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -116,13 +116,9 @@ pub(crate) use define_indirect_properties;
 ///  * `class` - The class object that is being allocated. This must be the
 ///  current class (using a superclass will cause the wrong class to be
 ///  read for traits).
-///  * `proto` - The prototype attached to the class object.
 ///  * `activation` - The current AVM2 activation.
-pub type AllocatorFn = for<'gc> fn(
-    ClassObject<'gc>,
-    Object<'gc>,
-    &mut Activation<'_, 'gc, '_>,
-) -> Result<Object<'gc>, Error>;
+pub type AllocatorFn =
+    for<'gc> fn(ClassObject<'gc>, &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error>;
 
 #[derive(Clone, Collect)]
 #[collect(require_static)]

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -303,7 +303,7 @@ pub fn load_player_globals<'gc>(
 ) -> Result<(), Error> {
     let mc = activation.context.gc_context;
 
-    let globals = ScriptObject::bare_object(activation.context.gc_context);
+    let globals = ScriptObject::custom_object(activation.context.gc_context, None, None);
     let gs = ScopeChain::new(domain).chain(mc, &[Scope::new(globals)]);
     let script = Script::empty_script(mc, globals, domain);
 
@@ -328,21 +328,21 @@ pub fn load_player_globals<'gc>(
     // and partial initialization.
     let object_classdef = object::create_class(mc);
     let object_class = ClassObject::from_class_partial(activation, object_classdef, None)?;
-    let object_proto = ScriptObject::bare_instance(mc, object_class);
+    let object_proto = ScriptObject::custom_object(mc, Some(object_class), None);
 
     let fn_classdef = function::create_class(mc);
     let fn_class = ClassObject::from_class_partial(activation, fn_classdef, Some(object_class))?;
-    let fn_proto = ScriptObject::instance(mc, fn_class, object_proto);
+    let fn_proto = ScriptObject::custom_object(mc, Some(fn_class), Some(object_proto));
 
     let class_classdef = class::create_class(mc);
     let class_class =
         ClassObject::from_class_partial(activation, class_classdef, Some(object_class))?;
-    let class_proto = ScriptObject::instance(mc, object_class, object_proto);
+    let class_proto = ScriptObject::custom_object(mc, Some(object_class), Some(object_proto));
 
     let global_classdef = global_scope::create_class(mc);
     let global_class =
         ClassObject::from_class_partial(activation, global_classdef, Some(object_class))?;
-    let global_proto = ScriptObject::instance(mc, object_class, object_proto);
+    let global_proto = ScriptObject::custom_object(mc, Some(object_class), Some(object_proto));
 
     // Now to weave the Gordian knot...
     object_class.link_prototype(activation, object_proto)?;

--- a/core/src/avm2/globals/flash/events/eventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/eventdispatcher.rs
@@ -235,7 +235,7 @@ pub fn to_string<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
-    let object_proto = activation.avm2().prototypes().object;
+    let object_proto = activation.avm2().classes().object.prototype();
     let name = QName::dynamic_name("toString").into();
     object_proto
         .get_property(&name, activation)?

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -14,10 +14,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates array objects.
 pub fn array_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(ArrayObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -58,8 +58,7 @@ impl<'gc> ArrayObject<'gc> {
         array: ArrayStorage<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().array;
-        let proto = activation.avm2().prototypes().array;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut instance: Object<'gc> = ArrayObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates BitmapData objects.
 pub fn bitmapdata_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(BitmapDataObject(GcCell::allocate(
         activation.context.gc_context,
@@ -46,12 +45,10 @@ impl<'gc> BitmapDataObject<'gc> {
         bitmap_data: GcCell<'gc, BitmapData<'gc>>,
         class: ClassObject<'gc>,
     ) -> Result<Object<'gc>, Error> {
-        let proto = class.prototype();
-
         let mut instance = Self(GcCell::allocate(
             activation.context.gc_context,
             BitmapDataObjectData {
-                base: ScriptObjectData::base_new(Some(proto), Some(class)),
+                base: ScriptObjectData::new(class),
                 bitmap_data: Some(bitmap_data),
             },
         ));

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -11,10 +11,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates ByteArray objects.
 pub fn bytearray_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(ByteArrayObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -45,8 +45,7 @@ impl<'gc> ByteArrayObject<'gc> {
         bytes: ByteArrayStorage,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().bytearray;
-        let proto = activation.avm2().prototypes().bytearray;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut instance: Object<'gc> = ByteArrayObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -134,7 +134,7 @@ impl<'gc> ClassObject<'gc> {
         class_object.link_prototype(activation, class_proto)?;
 
         let class_class = activation.avm2().classes().class;
-        let class_class_proto = activation.avm2().prototypes().class;
+        let class_class_proto = class_class.prototype();
 
         class_object.link_type(activation, class_class_proto, class_class);
         class_object.into_finished_class(activation)
@@ -877,7 +877,6 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         let class_proto = self.allocate_prototype(activation, superclass_object)?;
 
         let class_class = activation.avm2().classes().class;
-        let class_class_proto = activation.avm2().prototypes().class;
 
         let constructor = self.0.read().constructor.clone();
         let native_constructor = self.0.read().native_constructor.clone();
@@ -886,7 +885,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         let mut class_object = ClassObject(GcCell::allocate(
             activation.context.gc_context,
             ClassObjectData {
-                base: ScriptObjectData::base_new(Some(class_class_proto), Some(class_class)),
+                base: ScriptObjectData::new(class_class),
                 class: parameterized_class,
                 prototype: None,
                 class_scope,

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -185,7 +185,7 @@ impl<'gc> ClassObject<'gc> {
         let class_object = ClassObject(GcCell::allocate(
             activation.context.gc_context,
             ClassObjectData {
-                base: ScriptObjectData::base_new(None, None),
+                base: ScriptObjectData::custom_new(None, None),
                 class,
                 prototype: None,
                 class_scope: scope,
@@ -785,9 +785,8 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         arguments: &[Value<'gc>],
     ) -> Result<Object<'gc>, Error> {
         let instance_allocator = self.0.read().instance_allocator.0;
-        let prototype = self.0.read().prototype.unwrap();
 
-        let mut instance = instance_allocator(self, prototype, activation)?;
+        let mut instance = instance_allocator(self, activation)?;
 
         instance.install_instance_slots(activation);
 

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -10,10 +10,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Date objects.
 pub fn date_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(DateObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -13,10 +13,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Dictionary objects.
 pub fn dictionary_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(DictionaryObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -51,7 +51,8 @@ pub struct DispatchObjectData<'gc> {
 impl<'gc> DispatchObject<'gc> {
     /// Construct an empty dispatch list.
     pub fn empty_list(mc: MutationContext<'gc, '_>) -> Object<'gc> {
-        let base = ScriptObjectData::base_new(None, None);
+        // TODO: we might want this to be a proper Object instance, just in case
+        let base = ScriptObjectData::custom_new(None, None);
 
         DispatchObject(GcCell::allocate(
             mc,

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -12,11 +12,10 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates AppDomain objects.
 pub fn appdomain_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
     let domain = activation.domain();
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(DomainObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -49,8 +49,7 @@ impl<'gc> DomainObject<'gc> {
         domain: Domain<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().application_domain;
-        let proto = activation.avm2().prototypes().application_domain;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
         let mut this: Object<'gc> = DomainObject(GcCell::allocate(
             activation.context.gc_context,
             DomainObjectData { base, domain },

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Event objects.
 pub fn event_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(EventObject(GcCell::allocate(
         activation.context.gc_context,
@@ -60,8 +59,7 @@ impl<'gc> EventObject<'gc> {
             EventData::Text { .. } => activation.avm2().classes().textevent,
         };
 
-        let proto = class.prototype();
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut event_object: Object<'gc> = EventObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -42,7 +42,7 @@ impl<'gc> FunctionObject<'gc> {
         let this = Self::from_method(activation, method, scope, None, None);
         let es3_proto = ScriptObject::object(
             activation.context.gc_context,
-            activation.avm2().prototypes().object,
+            activation.avm2().classes().object.prototype(),
         );
 
         this.0.write(activation.context.gc_context).prototype = Some(es3_proto);
@@ -61,14 +61,13 @@ impl<'gc> FunctionObject<'gc> {
         receiver: Option<Object<'gc>>,
         subclass_object: Option<ClassObject<'gc>>,
     ) -> FunctionObject<'gc> {
-        let fn_proto = activation.avm2().prototypes().function;
         let fn_class = activation.avm2().classes().function;
         let exec = Executable::from_method(method, scope, receiver, subclass_object);
 
         FunctionObject(GcCell::allocate(
             activation.context.gc_context,
             FunctionObjectData {
-                base: ScriptObjectData::base_new(Some(fn_proto), Some(fn_class)),
+                base: ScriptObjectData::new(fn_class),
                 exec,
                 prototype: None,
             },

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -40,9 +40,12 @@ impl<'gc> FunctionObject<'gc> {
         scope: ScopeChain<'gc>,
     ) -> Result<FunctionObject<'gc>, Error> {
         let this = Self::from_method(activation, method, scope, None, None);
-        let es3_proto = ScriptObject::object(
+        let es3_proto = ScriptObject::custom_object(
             activation.context.gc_context,
-            activation.avm2().classes().object.prototype(),
+            // TODO: is this really a class-less object?
+            // (also: how much of "ES3 class-less object" is even true?)
+            None,
+            Some(activation.avm2().classes().object.prototype()),
         );
 
         this.0.write(activation.context.gc_context).prototype = Some(es3_proto);
@@ -135,7 +138,8 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
     ) -> Result<Object<'gc>, Error> {
         let prototype = self.prototype().unwrap();
 
-        let instance = ScriptObject::object(activation.context.gc_context, prototype);
+        let instance =
+            ScriptObject::custom_object(activation.context.gc_context, None, Some(prototype));
 
         self.call(Some(instance), arguments, activation)?;
 

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -71,8 +71,7 @@ impl<'gc> LoaderInfoObject<'gc> {
         root: DisplayObject<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().loaderinfo;
-        let proto = activation.avm2().prototypes().loaderinfo;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
         let loaded_stream = Some(LoaderStream::Swf(movie, root));
 
         let mut this: Object<'gc> = LoaderInfoObject(GcCell::allocate(
@@ -93,8 +92,7 @@ impl<'gc> LoaderInfoObject<'gc> {
     /// Create a loader info object for the stage.
     pub fn from_stage(activation: &mut Activation<'_, 'gc, '_>) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().loaderinfo;
-        let proto = activation.avm2().prototypes().loaderinfo;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut this: Object<'gc> = LoaderInfoObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -15,10 +15,9 @@ use std::sync::Arc;
 /// A class instance allocator that allocates LoaderInfo objects.
 pub fn loaderinfo_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(LoaderInfoObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -49,8 +49,7 @@ impl<'gc> NamespaceObject<'gc> {
         namespace: Namespace<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().namespace;
-        let proto = activation.avm2().prototypes().namespace;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut this: Object<'gc> = NamespaceObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates namespace objects.
 pub fn namespace_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(NamespaceObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -65,14 +65,6 @@ impl<'gc> PrimitiveObject<'gc> {
             return Err("Cannot box a null value".into());
         }
 
-        let proto = match primitive {
-            Value::Bool(_) => activation.avm2().prototypes().boolean,
-            Value::Number(_) => activation.avm2().prototypes().number,
-            Value::Unsigned(_) => activation.avm2().prototypes().uint,
-            Value::Integer(_) => activation.avm2().prototypes().int,
-            Value::String(_) => activation.avm2().prototypes().string,
-            _ => unreachable!(),
-        };
         let class = match primitive {
             Value::Bool(_) => activation.avm2().classes().boolean,
             Value::Number(_) => activation.avm2().classes().number,
@@ -82,7 +74,7 @@ impl<'gc> PrimitiveObject<'gc> {
             _ => unreachable!(),
         };
 
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
         let mut this: Object<'gc> = PrimitiveObject(GcCell::allocate(
             activation.context.gc_context,
             PrimitiveObjectData { base, primitive },

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -13,10 +13,9 @@ use gc_arena::{Collect, GcCell, MutationContext};
 /// A class instance allocator that allocates primitive objects.
 pub fn primitive_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(PrimitiveObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -13,10 +13,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Proxy objects.
 pub fn proxy_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(ProxyObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -46,8 +46,7 @@ impl<'gc> QNameObject<'gc> {
         qname: QName<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().qname;
-        let proto = activation.avm2().prototypes().qname;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut this: Object<'gc> = QNameObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates QName objects.
 pub fn qname_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(QNameObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -13,10 +13,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates RegExp objects.
 pub fn regexp_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(RegExpObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -47,8 +47,7 @@ impl<'gc> RegExpObject<'gc> {
         regexp: RegExp<'gc>,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().regexp;
-        let proto = activation.avm2().prototypes().regexp;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut this: Object<'gc> = RegExpObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -132,6 +132,18 @@ impl<'gc> ScriptObjectData<'gc> {
         }
     }
 
+    pub fn new(instance_of: ClassObject<'gc>) -> Self {
+        ScriptObjectData {
+            values: Default::default(),
+            slots: Vec::new(),
+            bound_methods: Vec::new(),
+            proto: Some(instance_of.prototype()),
+            instance_of: Some(instance_of),
+            vtable: Some(instance_of.instance_vtable()),
+            enumerants: Vec::new(),
+        }
+    }
+
     pub fn get_property_local(
         &self,
         multiname: &Multiname<'gc>,

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Sound objects.
 pub fn sound_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(SoundObject(GcCell::allocate(
         activation.context.gc_context,
@@ -50,8 +49,7 @@ impl<'gc> SoundObject<'gc> {
         class: ClassObject<'gc>,
         sound: SoundHandle,
     ) -> Result<Object<'gc>, Error> {
-        let proto = class.prototype();
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut sound_object: Object<'gc> = SoundObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates SoundChannel objects.
 pub fn soundchannel_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(SoundChannelObject(GcCell::allocate(
         activation.context.gc_context,
@@ -53,8 +52,7 @@ impl<'gc> SoundChannelObject<'gc> {
         sound: SoundInstanceHandle,
     ) -> Result<Self, Error> {
         let class = activation.avm2().classes().soundchannel;
-        let proto = class.prototype();
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut sound_object = SoundChannelObject(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -94,11 +94,10 @@ impl<'gc> StageObject<'gc> {
         display_object: DisplayObject<'gc>,
     ) -> Result<Self, Error> {
         let class = activation.avm2().classes().graphics;
-        let proto = activation.avm2().prototypes().graphics;
         let mut this = Self(GcCell::allocate(
             activation.context.gc_context,
             StageObjectData {
-                base: ScriptObjectData::base_new(Some(proto), Some(class)),
+                base: ScriptObjectData::new(class),
                 display_object: Some(display_object),
             },
         ));

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Stage objects.
 pub fn stage_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(StageObject(GcCell::allocate(
         activation.context.gc_context,
@@ -57,12 +56,10 @@ impl<'gc> StageObject<'gc> {
         display_object: DisplayObject<'gc>,
         class: ClassObject<'gc>,
     ) -> Result<Self, Error> {
-        let proto = class.prototype();
-
         let mut instance = Self(GcCell::allocate(
             activation.context.gc_context,
             StageObjectData {
-                base: ScriptObjectData::base_new(Some(proto), Some(class)),
+                base: ScriptObjectData::new(class),
                 display_object: Some(display_object),
             },
         ));

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -12,10 +12,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates TextFormat objects.
 pub fn textformat_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(TextFormatObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -46,8 +46,7 @@ impl<'gc> TextFormatObject<'gc> {
         text_format: TextFormat,
     ) -> Result<Object<'gc>, Error> {
         let class = activation.avm2().classes().textformat;
-        let proto = activation.avm2().prototypes().textformat;
-        let base = ScriptObjectData::base_new(Some(proto), Some(class));
+        let base = ScriptObjectData::new(class);
 
         let mut this: Object<'gc> = Self(GcCell::allocate(
             activation.context.gc_context,

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -14,10 +14,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates Vector objects.
 pub fn vector_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     //Because allocators are still called to build prototypes, especially for
     //the unspecialized Vector class, we have to fall back to Object when
@@ -62,12 +61,11 @@ impl<'gc> VectorObject<'gc> {
         let vector_class = activation.avm2().classes().vector;
 
         let applied_class = vector_class.apply(activation, &[value_type.into()])?;
-        let applied_proto = applied_class.prototype();
 
         let mut object: Object<'gc> = VectorObject(GcCell::allocate(
             activation.context.gc_context,
             VectorObjectData {
-                base: ScriptObjectData::base_new(Some(applied_proto), Some(applied_class)),
+                base: ScriptObjectData::new(applied_class),
                 vector,
             },
         ))

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -11,10 +11,9 @@ use std::cell::{Ref, RefMut};
 /// A class instance allocator that allocates XML objects.
 pub fn xml_allocator<'gc>(
     class: ClassObject<'gc>,
-    proto: Object<'gc>,
     activation: &mut Activation<'_, 'gc, '_>,
 ) -> Result<Object<'gc>, Error> {
-    let base = ScriptObjectData::base_new(Some(proto), Some(class));
+    let base = ScriptObjectData::new(class);
 
     Ok(XmlObject(GcCell::allocate(
         activation.context.gc_context,

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -137,7 +137,7 @@ impl<'gc> Stage<'gc> {
                 view_bounds: Default::default(),
                 window_mode: Default::default(),
                 show_menu: true,
-                avm2_object: Avm2ScriptObject::bare_object(gc_context),
+                avm2_object: Avm2ScriptObject::custom_object(gc_context, None, None),
             },
         ));
         stage.set_is_root(gc_context, true);


### PR DESCRIPTION
No functional changed intended.
During this work, I noticed some minor inconsistencies (pretty sure `(function(){}).prototype` shouldn't be class-less - in fact I kinda doubt the entire idea of "class-less ES3 objects"; also most "bare objects" probably shouldn't be bare) but I didn't fix them here; I left TODOs for these.

tldr of the changes:
- removed `SystemPrototypes`, as 99% of time we can use `class.prototype()`, and the other times (in `globals.rs`) we happen to have access to prototype objects at hand anyway
- folded all the similar weird object creation functions (`ScriptObject::bare_object/object/instance/bare_instance`) into one more explicit `ScriptObject::custom_object` with the intention to _not use it at all_ outside of low-level code
- introduced a simpler API `ScriptObjectData::new`, as again we didn't really need to be this explicit about prototypes most of the time
- added comments for the above refactored APIs, mostly discouraging from using them in higher-level code
- removed `proto` argument from instance allocator API.