### PR TITLE
wstr: Implement `ToOwned` for `WStr`

### DIFF
--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -373,13 +373,13 @@ pub fn set_blur_y<'gc>(
 }
 
 pub fn get_type<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_bevel_filter_object() {
         let type_: &WStr = filter.get_type().into();
-        return Ok(AvmString::new(activation.context.gc_context, type_).into());
+        return Ok(AvmString::from(type_).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -219,13 +219,13 @@ pub fn set_map_point<'gc>(
 }
 
 pub fn mode<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(object) = this.as_displacement_map_filter_object() {
         let mode: &WStr = object.mode().into();
-        return Ok(AvmString::new(activation.context.gc_context, mode).into());
+        return Ok(AvmString::from(mode).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -387,13 +387,13 @@ pub fn set_quality<'gc>(
 }
 
 pub fn get_type<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_bevel_filter_object() {
         let type_: &WStr = filter.get_type().into();
-        return Ok(AvmString::new(activation.context.gc_context, type_).into());
+        return Ok(AvmString::from(type_).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -387,13 +387,13 @@ pub fn set_quality<'gc>(
 }
 
 pub fn get_type<'gc>(
-    activation: &mut Activation<'_, 'gc, '_>,
+    _activation: &mut Activation<'_, 'gc, '_>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(filter) = this.as_gradient_glow_filter_object() {
         let type_: &WStr = filter.get_type().into();
-        return Ok(AvmString::new(activation.context.gc_context, type_).into());
+        return Ok(AvmString::from(type_).into());
     }
 
     Ok(Value::Undefined)

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -361,9 +361,7 @@ impl DerefMut for WString {
 impl<'a> From<&'a WStr> for WString {
     #[inline]
     fn from(s: &'a WStr) -> Self {
-        let mut buf = Self::new();
-        buf.push_str(s);
-        buf
+        s.to_owned()
     }
 }
 

--- a/wstr/src/ptr.rs
+++ b/wstr/src/ptr.rs
@@ -1,7 +1,8 @@
+use alloc::borrow::ToOwned;
 use core::ops::Range;
 use core::ptr::{slice_from_raw_parts, slice_from_raw_parts_mut};
 
-use super::Units;
+use super::{Units, WString};
 
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("WStr only supports 32-bits and 64-bits targets");
@@ -44,6 +45,16 @@ pub struct WStr {
     /// One observable consequence of this is that `std::mem::size_of_val::<WStr>` won't return the actual
     /// byte length of the string contents, but will instead always return 0.
     _repr: [()],
+}
+
+impl ToOwned for WStr {
+    type Owned = WString;
+
+    fn to_owned(&self) -> Self::Owned {
+        let mut buf = WString::new();
+        buf.push_str(self);
+        buf
+    }
 }
 
 /// Convenience method to turn a `&T` into a `*mut T`.


### PR DESCRIPTION
Similarly to how `str` implements `ToOwned`, and `From<&str> for String` forwards to `to_owned()`.
    
This will allow defining `Cow<WStr>`.