### PR TITLE
core: Add `timeline_debug` feature that logs all gotos and asserts if they desync

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,6 +62,7 @@ lzma = ["lzma-rs", "swf/lzma"]
 wasm-bindgen = [ "instant/wasm-bindgen" ]
 avm_debug = []
 deterministic = []
+timeline_debug = []
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.23"
-ruffle_core = { path = "../core", features = ["deterministic"] }
+ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug"] }
 ruffle_render_wgpu = { path = "../render/wgpu" }
 ruffle_input_format = { path = "input-format" }
 image = "0.24.2"


### PR DESCRIPTION
Ruffle keeps track of all movie clips' timelines via a struct member called `tag_stream_pos`. This is updated whenever a clip runs a frame, loops back to the start, or is given a goto command from script code, and should always point to the end of the current frame's tags (with some exceptions). If this invariant is broken, the tag stream is said to have *desynchronized*. The timeline no longer works correctly in the presence of fast-forwarding operations until a rewind occurs. The current implementation of AVM2 timeline operations suffers from a number of goto-related bugs that trigger desyncs.

This PR adds a new feature called `timeline_debug`, analogous to the `avm_debug` feature that prints out every stack operation. When enabled, `timeline_debug` will print out every goto, as well as assert that the goto started and ended in the correct spot. We also run the entire test suite with this feature enabled so that those tests will assert if they desync.

As I mentioned above, there are exceptions to the invariants on `tag_stream_pos`. Specifically:

 * Gotos to frames that do not exist or have not loaded do not run the target frame (since it was never reached), and thus desync deliberately.
 * AVM2 introduces the concept of frame phases, in which the same tags are run in multiple passes. In certain phases the frame number is expected to update while we are still processing tags for the prior frame, and we cannot keep the two in sync.

For the time being, the first desync on the list is being explicitly checked for and corrected. My assumption is that, at least for a non-progressive-loading player like ours, there is no way to actually trigger a fast-forwarding goto off the back of one that didn't hit its target frame. It may make sense to correct for it *without* `timeline_debug` but that's probably outside the scope of this PR.

The second desync is a huge part of why the frame events fixes PR has been such a long-running project. I have made no attempt to account for it in this PR; as doing so requires the frame phase tracking logic from #7048. The existing suite of AVM2 tests work with the asserts enabled.