### PR TITLE
wgpu: Bump to `0.13.0`

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -318,7 +318,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: wasm-bindgen-cli --version 0.2.80
+          args: wasm-bindgen-cli --version 0.2.81
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -55,7 +55,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.80
+        run: cargo install wasm-bindgen-cli --version 0.2.81
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20ae67ce26261f218e2b3f2f0d01887a9818283ca6fb260fa7c67e253d61c92"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.34.0+1.2.203"
+version = "0.37.0+1.3.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df"
+checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
 dependencies = [
  "libloading",
 ]
@@ -856,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c"
+checksum = "827914e1f53b1e0e025ecd3d967a7836b7bcb54520f90e21ef8df7b4d88a2759"
 dependencies = [
  "bitflags",
  "libloading",
@@ -1873,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1888,6 +1897,7 @@ checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
 dependencies = [
  "libc",
  "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1923,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libflate"
@@ -2108,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084"
+checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
  "bitflags",
  "block",
@@ -2186,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705"
+checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2200,7 +2210,9 @@ dependencies = [
  "rustc-hash",
  "serde",
  "spirv",
+ "termcolor",
  "thiserror",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3135,7 +3147,6 @@ dependencies = [
  "raw-window-handle",
  "ruffle_core",
  "ruffle_render_common_tess",
- "wasm-bindgen-futures",
  "web-sys",
  "wgpu",
 ]
@@ -3784,9 +3795,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "url"
@@ -3863,9 +3874,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3875,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3890,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3902,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3912,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3925,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wayland-client"
@@ -4010,9 +4021,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4049,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
+checksum = "fd28e7c69ffd19c02e609322e4170738ac3340e699d8adfa16f5745625e4aa8c"
 dependencies = [
  "arrayvec 0.7.2",
  "js-sys",
@@ -4071,11 +4082,12 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
+checksum = "0bb155661d02bf104303589fbf9206fa971c80dbb6d4763e66879253bd0a072c"
 dependencies = [
  "arrayvec 0.7.2",
+ "bit-vec",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
@@ -4090,16 +4102,18 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
+ "web-sys",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b1a9400e8d7f32dd4dd909bb9a391015d70633d639775ddd3f14d1104bc970"
+checksum = "a9f9cb367209e2ad214afa8d823348334994dc1579f4a521d53a3bc4d0848e73"
 dependencies = [
+ "android_system_properties",
  "arrayvec 0.7.2",
  "ash",
  "bit-set",
@@ -4134,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2"
+checksum = "f48d691b733b9d50ea8cb18f377fd1ed927c90c55ad1ec5b90f68885471977f7"
 dependencies = [
  "bitflags",
  "bitflags_serde_shim",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -56,7 +56,7 @@ default-features = false # can't use rayon on web
 version = "0.3.21"
 
 [target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen-futures]
-version = "0.4.30"
+version = "0.4.31"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -122,8 +122,7 @@ fn take_screenshot(
                 .renderer_mut()
                 .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
                 .unwrap();
-            let target = renderer.target();
-            if let Some(image) = target.capture(renderer.device()) {
+            if let Some(image) = renderer.target().capture() {
                 result.push(image);
             } else {
                 return Err(format!("Unable to capture frame {} of {:?}", i, swf_path).into());

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -122,7 +122,7 @@ fn take_screenshot(
                 .renderer_mut()
                 .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
                 .unwrap();
-            if let Some(image) = renderer.target().capture() {
+            if let Some(image) = renderer.capture_frame() {
                 result.push(image);
             } else {
                 return Err(format!("Unable to capture frame {} of {:?}", i, swf_path).into());

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.57"
+js-sys = "0.3.58"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.80"
+wasm-bindgen = "=0.2.81"
 fnv = "1.0.7"
 
 [dependencies.ruffle_core]
@@ -17,7 +17,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.58"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
     "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.57"
+js-sys = "0.3.58"
 log = "0.4"
 ruffle_render_common_tess = { path = "../common_tess" }
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.80"
+wasm-bindgen = "=0.2.81"
 bytemuck = { version = "1.9.1", features = ["derive"] }
 fnv = "1.0.7"
 
@@ -19,7 +19,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.58"
 features = [
     "HtmlCanvasElement", "OesVertexArrayObject", "WebGl2RenderingContext", "WebGlBuffer", "WebglDebugRendererInfo",
     "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGlShader", "WebGlTexture",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+wgpu = "0.13.0"
 log = "0.4"
 ruffle_core = { path = "../../core", default-features = false }
 ruffle_render_common_tess = { path = "../common_tess" }
@@ -16,26 +17,17 @@ enum-map = "2.4.0"
 fnv = "1.0.7"
 
 # desktop
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.futures]
+[target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.21"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.image]
+[target.'cfg(not(target_family = "wasm"))'.dependencies.image]
 version = "0.24.2"
 default-features = false
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wgpu]
-version = "0.12"
-
 # wasm
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen-futures]
-version = "0.4.30"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3.57"
+[target.'cfg(target_family = "wasm")'.dependencies.web-sys]
+version = "0.3.58"
 features = ["HtmlCanvasElement"]
-
-[target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]
-version = "0.12"
 
 [features]
 render_debug_labels = []

--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -1,27 +1,24 @@
 /// Shader used for drawing bitmap fills.
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec2<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
-[[group(2), binding(0)]]
-var<uniform> textureTransforms: TextureTransforms;
-[[group(2), binding(1)]]
-var texture: texture_2d<f32>;
-[[group(3), binding(0)]]
-var texture_sampler: sampler;
+@group(2) @binding(0) var<uniform> textureTransforms: TextureTransforms;
+@group(2) @binding(1) var texture: texture_2d<f32>;
+@group(3) @binding(0) var texture_sampler: sampler;
 
-[[stage(vertex)]]
+@vertex
 fn main_vertex(in: VertexInput) -> VertexOutput {
-    let matrix = textureTransforms.matrix;
-    let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
+    let matrix_ = textureTransforms.matrix_;
+    let uv = (mat3x3<f32>(matrix_[0].xyz, matrix_[1].xyz, matrix_[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
     let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     return VertexOutput(pos, uv);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color: vec4<f32> = textureSample(texture, texture_sampler, in.uv);
     // Texture is premultiplied by alpha.
     // Unmultiply alpha, apply color transform, remultiply alpha.

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -1,11 +1,11 @@
 /// Shader used for drawing solid color fills.
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] color: vec4<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
 };
 
-[[stage(vertex)]]
+@vertex
 fn main_vertex(in: VertexInput) -> VertexOutput {
     let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     let color = in.color * transforms.mult_color + transforms.add_color;
@@ -13,7 +13,7 @@ fn main_vertex(in: VertexInput) -> VertexOutput {
     return VertexOutput(pos, vec4<f32>(color.rgb * alpha, alpha));
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     return in.color;
 }

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -4,53 +4,51 @@
 /// Global uniforms that are constant throughout a frame.
 struct Globals {
     // The view matrix determined by the viewport and stage.
-    view_matrix: mat4x4<f32>;
+    view_matrix: mat4x4<f32>,
 };
 
 /// Transform uniforms that are changed per object.
 struct Transforms {
     /// The world matrix that transforms this object into stage space.
-    world_matrix: mat4x4<f32>;
+    world_matrix: mat4x4<f32>,
 
     /// The multiplicative color transform of this object.
-    mult_color: vec4<f32>;
+    mult_color: vec4<f32>,
 
     /// The additive color transform of this object.
-    add_color: vec4<f32>;
+    add_color: vec4<f32>,
 };
 
 /// Uniforms used by texture draws (bitmaps and gradients).
 struct TextureTransforms {
     /// The transform matrix of the gradient or texture.
     /// Transforms from object space to UV space.
-    matrix: mat4x4<f32>;
+    matrix_: mat4x4<f32>,
 };
 
 /// The vertex format shared among all shaders.
 struct VertexInput {
     /// The position of the vertex in object space.
-    [[location(0)]] position: vec2<f32>;
+    @location(0) position: vec2<f32>,
 
     /// The color of this vertex (only used by the color shader).
-    [[location(1)]] color: vec4<f32>;
+    @location(1) color: vec4<f32>,
 };
 
 /// Common uniform layout shared by all shaders.
-[[group(0), binding(0)]]
-var<uniform> globals: Globals;
-[[group(1), binding(0)]]
-var<uniform> transforms: Transforms;
+@group(0) @binding(0) var<uniform> globals: Globals;
+@group(1) @binding(0) var<uniform> transforms: Transforms;
 
 /// Converts a color from linear to sRGB color space.
-fn linear_to_srgb(linear: vec4<f32>) -> vec4<f32> {
-    var rgb: vec3<f32> = linear.rgb;
-    if( linear.a > 0.0 ) {
-        rgb = rgb / linear.a;
+fn linear_to_srgb(linear_: vec4<f32>) -> vec4<f32> {
+    var rgb: vec3<f32> = linear_.rgb;
+    if( linear_.a > 0.0 ) {
+        rgb = rgb / linear_.a;
     }
     let a = 12.92 * rgb;
     let b = 1.055 * pow(rgb, vec3<f32>(1.0 / 2.4)) - 0.055;
     let c = step(vec3<f32>(0.0031308), rgb);
-    return vec4<f32>(mix(a, b, c) * linear.a, linear.a);
+    return vec4<f32>(mix(a, b, c) * linear_.a, linear_.a);
 }
 
 /// Converts a color from sRGB to linear color space.

--- a/render/wgpu/shaders/copy_srgb.wgsl
+++ b/render/wgpu/shaders/copy_srgb.wgsl
@@ -1,26 +1,23 @@
 /// Shader used for drawing bitmap fills.
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec2<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
-[[group(2), binding(0)]]
-var<uniform> textureTransforms: TextureTransforms;
-[[group(2), binding(1)]]
-var texture: texture_2d<f32>;
-[[group(3), binding(0)]]
-var texture_sampler: sampler;
+@group(2) @binding(0) var<uniform> textureTransforms: TextureTransforms;
+@group(2) @binding(1) var texture: texture_2d<f32>;
+@group(3) @binding(0) var texture_sampler: sampler;
 
-[[stage(vertex)]]
+@vertex
 fn main_vertex(in: VertexInput) -> VertexOutput {
-    let matrix = textureTransforms.matrix;
-    let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
+    let matrix_ = textureTransforms.matrix_;
+    let uv = (mat3x3<f32>(matrix_[0].xyz, matrix_[1].xyz, matrix_[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
     let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     return VertexOutput(pos, uv);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     return srgb_to_linear(textureSample(texture, texture_sampler, in.uv));
 }

--- a/render/wgpu/shaders/gradient.wgsl
+++ b/render/wgpu/shaders/gradient.wgsl
@@ -1,35 +1,33 @@
 /// Shader used for drawing all flavors of gradients.
 
 struct Gradient {
-    colors: array<vec4<f32>,16u>;
-    ratios: array<f32,16u>;
-    gradient_type: i32;
-    num_colors: u32;
-    repeat_mode: i32;
-    interpolation: i32;
-    focal_point: f32;
+    colors: array<vec4<f32>,16u>,
+    ratios: array<f32,16u>,
+    gradient_type: i32,
+    num_colors: u32,
+    repeat_mode: i32,
+    interpolation: i32,
+    focal_point: f32,
 };
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec2<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
 };
 
-[[group(2), binding(0)]]
-var<uniform> textureTransforms: TextureTransforms;
-[[group(2), binding(1)]]
-var<storage> gradient: Gradient;
+@group(2) @binding(0) var<uniform> textureTransforms: TextureTransforms;
+@group(2) @binding(1) var<storage> gradient: Gradient;
 
-[[stage(vertex)]]
+@vertex
 fn main_vertex(in: VertexInput) -> VertexOutput {
-    let matrix = textureTransforms.matrix;
-    let uv = (mat3x3<f32>(matrix[0].xyz, matrix[1].xyz, matrix[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
+    let matrix_ = textureTransforms.matrix_;
+    let uv = (mat3x3<f32>(matrix_[0].xyz, matrix_[1].xyz, matrix_[2].xyz) * vec3<f32>(in.position, 1.0)).xy;
     let pos = globals.view_matrix * transforms.world_matrix * vec4<f32>(in.position.x, in.position.y, 0.0, 1.0);
     return VertexOutput(pos, uv);
 }
 
-[[stage(fragment)]]
-fn main_fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+@fragment
+fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let last = gradient.num_colors - 1u;
 
     // Calculate normalized `t` position in gradient, [0.0, 1.0] being the bounds of the ratios.

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -384,6 +384,10 @@ impl WgpuRenderBackend<target::TextureTarget> {
         let target = target::TextureTarget::new(&descriptors.device, size);
         Self::new(descriptors, target)
     }
+
+    pub fn capture_frame(&self) -> Option<image::RgbaImage> {
+        self.target.capture(&self.descriptors.device)
+    }
 }
 
 impl<T: RenderTarget> WgpuRenderBackend<T> {
@@ -745,10 +749,6 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         }
 
         Mesh { draws }
-    }
-
-    pub fn target(&self) -> &T {
-        &self.target
     }
 }
 

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -188,11 +188,11 @@ impl Pipelines {
             &copy_srgb_shader,
             &copy_texture_pipeline_layout,
             None,
-            &[wgpu::ColorTargetState {
+            &[Some(wgpu::ColorTargetState {
                 format: surface_format,
                 blend: Some(wgpu::BlendState::REPLACE),
                 write_mask: Default::default(),
-            }],
+            })],
             &vertex_buffers_description,
             1,
         ));
@@ -225,8 +225,7 @@ fn create_shader(
         label: label.as_deref(),
         source: wgpu::ShaderSource::Wgsl(src.into()),
     };
-
-    device.create_shader_module(&desc)
+    device.create_shader_module(desc)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -236,7 +235,7 @@ fn create_pipeline_descriptor<'a>(
     fragment_shader: &'a wgpu::ShaderModule,
     pipeline_layout: &'a wgpu::PipelineLayout,
     depth_stencil_state: Option<wgpu::DepthStencilState>,
-    color_target_state: &'a [wgpu::ColorTargetState],
+    color_target_state: &'a [Option<wgpu::ColorTargetState>],
     vertex_buffer_layout: &'a [wgpu::VertexBufferLayout<'a>],
     msaa_sample_count: u32,
 ) -> wgpu::RenderPipelineDescriptor<'a> {
@@ -304,11 +303,11 @@ fn create_color_pipelines(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_description,
                 msaa_sample_count,
             ))
@@ -328,11 +327,11 @@ fn create_color_pipelines(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_description,
                 msaa_sample_count,
             ))
@@ -352,11 +351,11 @@ fn create_color_pipelines(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_description,
                 msaa_sample_count,
             ))
@@ -376,11 +375,11 @@ fn create_color_pipelines(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_description,
                 msaa_sample_count,
             ))
@@ -429,11 +428,11 @@ fn create_bitmap_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -453,11 +452,11 @@ fn create_bitmap_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -477,11 +476,11 @@ fn create_bitmap_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -501,11 +500,11 @@ fn create_bitmap_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -552,11 +551,11 @@ fn create_gradient_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -576,11 +575,11 @@ fn create_gradient_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -601,11 +600,11 @@ fn create_gradient_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))
@@ -625,11 +624,11 @@ fn create_gradient_pipeline(
                     stencil,
                     bias: Default::default(),
                 }),
-                &[wgpu::ColorTargetState {
+                &[Some(wgpu::ColorTargetState {
                     format,
                     blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
                     write_mask,
-                }],
+                })],
                 vertex_buffers_layout,
                 msaa_sample_count,
             ))

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -58,7 +58,7 @@ impl SwapChainTarget {
             format,
             width: size.0,
             height: size.1,
-            present_mode: wgpu::PresentMode::Mailbox,
+            present_mode: wgpu::PresentMode::Fifo,
         };
         surface.configure(device, &surface_config);
         Self {
@@ -165,10 +165,19 @@ impl TextureTarget {
         }
     }
 
-    pub fn capture(&self, device: &wgpu::Device) -> Option<image::RgbaImage> {
-        let buffer_future = self.buffer.slice(..).map_async(wgpu::MapMode::Read);
-        device.poll(wgpu::Maintain::Wait);
-        match futures::executor::block_on(buffer_future) {
+    pub fn capture(&self) -> Option<image::RgbaImage> {
+        use std::sync::mpsc::channel;
+
+        let (sender, receiver) = channel();
+
+        self.buffer
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| {
+                sender.send(result).unwrap()
+            });
+
+        let result = receiver.recv().unwrap();
+        match result {
             Ok(()) => {
                 let map = self.buffer.slice(..).get_mapped_range();
                 let mut buffer = Vec::with_capacity(

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -1263,9 +1263,9 @@ fn run_swf(
             .renderer_mut()
             .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
             .unwrap();
-        let target = renderer.target();
-        let actual_image = target
-            .capture(renderer.device())
+        let actual_image = renderer
+            .target()
+            .capture()
             .expect("Failed to capture image");
 
         let expected_image_path = base_path.join("expected.png");

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -1263,10 +1263,7 @@ fn run_swf(
             .renderer_mut()
             .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
             .unwrap();
-        let actual_image = renderer
-            .target()
-            .capture()
-            .expect("Failed to capture image");
+        let actual_image = renderer.capture_frame().expect("Failed to capture image");
 
         let expected_image_path = base_path.join("expected.png");
         let expected_image =

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -32,15 +32,15 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
 fnv = "1.0.7"
 generational-arena = "0.2.8"
-js-sys = "0.3.57"
+js-sys = "0.3.58"
 log = { version = "0.4", features = ["serde"] }
 ruffle_render_canvas = { path = "../render/canvas", optional = true }
 ruffle_web_common = { path = "common" }
 ruffle_render_webgl = { path = "../render/webgl", optional = true }
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 url = "2.2.2"
-wasm-bindgen = { version = "=0.2.80", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.30"
+wasm-bindgen = { version = "=0.2.81", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.31"
 chrono = { version = "0.4", features = ["wasmbind"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.137", features = ["derive"] }
@@ -53,7 +53,7 @@ default-features = false
 features = ["h263", "vp6", "screenvideo", "wasm-bindgen"]
 
 [dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.58"
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext", "AudioDestinationNode",
     "AudioNode", "AudioParam", "AudioProcessingEvent", "Blob", "BlobPropertyBag", "ChannelMergerNode",

--- a/web/README.md
+++ b/web/README.md
@@ -58,7 +58,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.80`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.81`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-js-sys = "0.3.57"
+js-sys = "0.3.58"
 log = "0.4"
-wasm-bindgen = "=0.2.80"
+wasm-bindgen = "=0.2.81"
 
 [dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.58"
 features = ["Window"]

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1217,7 +1217,7 @@ async fn create_renderer(
     // Try to create a backend, falling through to the next backend on failure.
     // We must recreate the canvas each attempt, as only a single context may be created per canvas
     // with `getContext`.
-    #[cfg(all(feature = "wgpu", target_arch = "wasm32"))]
+    #[cfg(all(feature = "wgpu", target_family = "wasm"))]
     {
         // Check that we have access to WebGPU (navigator.gpu should exist).
         if web_sys::window()


### PR DESCRIPTION
Based on the work in #6717, plus additional adaptions mentioned in
https://github.com/gfx-rs/wgpu/blob/master/CHANGELOG.md#wgpu-013-2022-06-30,
and more not-mentioned but required changes.

Also bump `wasm-bindgen` to `0.2.81` (along with its helper crates), as
required by the new `wgpu` version.

Note that I don't fully understand some of the required changes, notably:
* `wgpu::PresentMode::Mailbox` no longer works on my machine (Windows 11) -
The `wgpu` documentation says that `wgpu::PresentMode::Fifo` is the
only guaranteed to be supported, so I switched over to it instead.
* `self.staging_belt.recall()` doesn't return a `Future` anymore -
I assume it became synchronous so I simply removed the `executor`
from there.