### PR TITLE
web: Construct relative SWF URLs using document base

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -589,7 +589,7 @@ export class RufflePlayer extends HTMLElement {
 
             if ("url" in options) {
                 console.log(`Loading SWF file ${options.url}`);
-                this.swfUrl = new URL(options.url, document.location.href);
+                this.swfUrl = new URL(options.url, document.baseURI);
 
                 const parameters = {
                     ...sanitizeParameters(


### PR DESCRIPTION
The [HTML `<base>` tag](https://www.w3schools.com/TAGs/tag_base.asp) changes the base URL of all relative links on a page, including links in `src` attributes of `embed` tags and `movie` params of `object` tags. Ruffle was using `document.location.href` to construct relative SWF URLs, which does not account for the document base being changed by the `<base>` tag. Use `document.baseURI` instead.

Fixes #7357.