### PR TITLE
chore: Fix `needless_borrow` clippy lints

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -150,7 +150,7 @@ impl<'gc> Value<'gc> {
             Value::Bool(true) => 1.0,
             Value::Number(v) => *v,
             Value::Object(_) => f64::NAN,
-            Value::String(v) => string_to_f64(&v, activation.swf_version()),
+            Value::String(v) => string_to_f64(v, activation.swf_version()),
         }
     }
 
@@ -424,7 +424,7 @@ impl<'gc> Value<'gc> {
                 if swf_version >= 7 {
                     !v.is_empty()
                 } else {
-                    let num = string_to_f64(&v, swf_version);
+                    let num = string_to_f64(v, swf_version);
                     !num.is_nan() && num != 0.0
                 }
             }

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -70,7 +70,7 @@ impl<'gc> PropertyClass<'gc> {
             PropertyClass::Class(class) => Some(*class),
             PropertyClass::Name(gc) => {
                 let (name, unit) = &**gc;
-                let class = resolve_class_private(&name, *unit, activation)?;
+                let class = resolve_class_private(name, *unit, activation)?;
                 *self = match class {
                     Some(class) => PropertyClass::Class(class),
                     None => PropertyClass::Any,

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -397,7 +397,7 @@ impl RenderBackend for WebCanvasRenderBackend {
                                     );
                                 }
                                 CanvasFillStyle::Gradient(gradient) => {
-                                    self.set_color_filter(&transform);
+                                    self.set_color_filter(transform);
                                     self.context.set_fill_style(gradient);
                                     self.context.fill_with_path_2d_and_winding(
                                         path,
@@ -409,7 +409,7 @@ impl RenderBackend for WebCanvasRenderBackend {
                                     // Canvas has no easy way to draw gradients with an arbitrary transform,
                                     // but we can fake it by pushing the gradient's transform to the canvas,
                                     // then transforming the path itself by the inverse.
-                                    self.set_color_filter(&transform);
+                                    self.set_color_filter(transform);
                                     self.context.set_fill_style(&gradient.gradient);
                                     let matrix = &gradient.gradient_matrix;
                                     self.context
@@ -440,7 +440,7 @@ impl RenderBackend for WebCanvasRenderBackend {
                                     self.clear_color_filter();
                                 }
                                 CanvasFillStyle::Pattern(patt, smoothed) => {
-                                    self.set_color_filter(&transform);
+                                    self.set_color_filter(transform);
                                     self.context.set_image_smoothing_enabled(*smoothed);
                                     self.context.set_fill_style(patt);
                                     self.context.fill_with_path_2d_and_winding(
@@ -470,13 +470,13 @@ impl RenderBackend for WebCanvasRenderBackend {
                                         self.context.stroke_with_path(path);
                                     }
                                     CanvasFillStyle::Gradient(gradient) => {
-                                        self.set_color_filter(&transform);
+                                        self.set_color_filter(transform);
                                         self.context.set_stroke_style(gradient);
                                         self.context.stroke_with_path(path);
                                         self.clear_color_filter();
                                     }
                                     CanvasFillStyle::TransformedGradient(gradient) => {
-                                        self.set_color_filter(&transform);
+                                        self.set_color_filter(transform);
                                         self.context.set_stroke_style(&gradient.gradient);
                                         self.context.stroke_with_path(path);
                                         self.context
@@ -573,7 +573,7 @@ impl RenderBackend for WebCanvasRenderBackend {
             // A possible improvement is to choose the winding rule based on whether the shape has
             // layers or not (via a flag in DistilledShape?)
             self.context
-                .clip_with_path_2d_and_winding(&mask_path, CanvasWindingRule::Nonzero);
+                .clip_with_path_2d_and_winding(mask_path, CanvasWindingRule::Nonzero);
             self.mask_state = MaskState::DrawContent;
         }
     }

--- a/render/common_tess/src/lib.rs
+++ b/render/common_tess/src/lib.rs
@@ -47,7 +47,7 @@ impl ShapeTessellator {
                     is_closed,
                 } => (
                     style.fill_style(),
-                    ruffle_path_to_lyon_path(&commands, *is_closed),
+                    ruffle_path_to_lyon_path(commands, *is_closed),
                     true,
                 ),
             };

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -1259,7 +1259,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
                 let mut render_pass = copy_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &frame.frame_data.1.view(),
+                        view: frame.frame_data.1.view(),
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                             store: true,


### PR DESCRIPTION
Though https://github.com/rust-lang/rust-clippy/pull/8355 has been
merged, it seems to still report false-positives on nightly channel.

For now just fix the instances reported by stable clippy, and keep
`needless_borrow` allowed.