### PR TITLE
avm2: Handle invalid utf8 correctly in UrlLoader

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -721,13 +721,10 @@ impl<'gc> Loader<'gc> {
                                 ByteArrayObject::from_storage(activation, storage).unwrap();
                             bytearray.into()
                         }
-                        DataFormat::Text => {
-                            // FIXME - what do we do if the data is not UTF-8?
-                            Avm2Value::String(
-                                AvmString::new_utf8_bytes(activation.context.gc_context, body)
-                                    .unwrap(),
-                            )
-                        }
+                        DataFormat::Text => Avm2Value::String(AvmString::new_utf8_bytes_lossy(
+                            activation.context.gc_context,
+                            body,
+                        )),
                         DataFormat::Variables => {
                             log::warn!(
                                 "Support for URLLoaderDataFormat.VARIABLES not yet implemented"

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -723,7 +723,7 @@ impl<'gc> Loader<'gc> {
                         }
                         DataFormat::Text => Avm2Value::String(AvmString::new_utf8_bytes_lossy(
                             activation.context.gc_context,
-                            body,
+                            &body,
                         )),
                         DataFormat::Variables => {
                             log::warn!(

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -47,6 +47,13 @@ impl<'gc> AvmString<'gc> {
         Ok(Self::new_utf8(gc_context, utf8))
     }
 
+    pub fn new_utf8_bytes_lossy<'b, B: Into<Cow<'b, [u8]>>>(
+        gc_context: MutationContext<'gc, '_>,
+        bytes: B,
+    ) -> Self {
+        Self::new_utf8(gc_context, String::from_utf8_lossy(&bytes.into()))
+    }
+
     pub fn new<S: Into<WString>>(gc_context: MutationContext<'gc, '_>, string: S) -> Self {
         Self {
             source: Source::Owned(Gc::allocate(gc_context, OwnedWStr(string.into()))),

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -47,11 +47,8 @@ impl<'gc> AvmString<'gc> {
         Ok(Self::new_utf8(gc_context, utf8))
     }
 
-    pub fn new_utf8_bytes_lossy<'b, B: Into<Cow<'b, [u8]>>>(
-        gc_context: MutationContext<'gc, '_>,
-        bytes: B,
-    ) -> Self {
-        Self::new_utf8(gc_context, String::from_utf8_lossy(&bytes.into()))
+    pub fn new_utf8_bytes_lossy(gc_context: MutationContext<'gc, '_>, bytes: &[u8]) -> Self {
+        Self::new_utf8(gc_context, String::from_utf8_lossy(bytes))
     }
 
     pub fn new<S: Into<WString>>(gc_context: MutationContext<'gc, '_>, string: S) -> Self {


### PR DESCRIPTION
In flash, it just replaces the invalid UTF-8 with a replacement character, so we can do the same. Fixes error in #7361