### PR TITLE
demo: Improve Sample SWF dropdown

### DIFF
--- a/web/packages/demo/README.md
+++ b/web/packages/demo/README.md
@@ -29,43 +29,77 @@ To use this, add a new file `swfs.json` in this directory. The contents should l
 
 ```json
 {
-    "swfs": [
-        {
-            "location": "swfs/alien_hominid.swf",
-            "title": "Alien Hominid",
-            "author": "Tom Fulp and Dan Paladin",
-            "authorLink": "https://www.newgrounds.com",
-            "type": "Game"
-        },
-        {
-            "location": "swfs/saturday_morning_watchmen.swf",
-            "title": "Saturday Morning Watchmen",
-            "author": "Harry Partridge",
-            "authorLink": "https://twitter.com/HappyHarryToons",
-            "type": "Animation"
-        },
-        {
-            "location": "swfs/synj1.swf",
-            "title": "Synj vs. Horrid Part 1",
-            "author": "Dan Paladin",
-            "authorLink": "https://www.thebehemoth.com",
-            "type": "Animation"
-        },
-        {
-            "location": "swfs/synj2.swf",
-            "title": "Synj vs. Horrid Part 2",
-            "author": "Dan Paladin",
-            "authorLink": "https://www.thebehemoth.com",
-            "type": "Animation"
-        },
-        {
-            "location": "swfs/wasted_sky.swf",
-            "title": "Wasted Sky",
-            "author": "Tom Fulp",
-            "authorLink": "https://www.newgrounds.com",
-            "type": "Game"
-        }
-    ]
+  "swfs": [
+    {
+      "location": "logo-anim.swf",
+      "title": "Ruffle Logo",
+      "author": "Ruffle contributors",
+      "authorLink": "https://ruffle.rs",
+      "config": {
+        "autoplay": "on",
+        "backgroundColor": "#31497D",
+        "letterbox": "off",
+        "unmuteOverlay": "hidden"
+      }
+    },
+    {
+      "location": "swfs/bitey1.swf",
+      "title": "Bitey of Brackenwood",
+      "author": "Adam Phillips",
+      "authorLink": "https://bitey.com",
+      "type": "Animation"
+    },
+    {
+      "location": "swfs/saturday_morning_watchmen.swf",
+      "title": "Saturday Morning Watchmen",
+      "author": "Harry Partridge",
+      "authorLink": "https://twitter.com/HappyHarryToons",
+      "type": "Animation"
+    },
+    {
+      "location": "swfs/synj1.swf",
+      "title": "Synj vs. Horrid Part 1",
+      "author": "Dan Paladin",
+      "authorLink": "https://www.thebehemoth.com",
+      "type": "Animation"
+    },
+    {
+      "location": "swfs/synj2.swf",
+      "title": "Synj vs. Horrid Part 2",
+      "author": "Dan Paladin",
+      "authorLink": "https://www.thebehemoth.com",
+      "type": "Animation"
+    },
+
+    {
+      "location": "swfs/alien_hominid.swf",
+      "title": "Alien Hominid",
+      "author": "Tom Fulp and Dan Paladin",
+      "authorLink": "https://www.newgrounds.com",
+      "type": "Game"
+    },
+    {
+      "location": "swfs/flyguy.swf",
+      "title": "FlyGuy",
+      "author": "Trevor van Meter",
+      "authorLink": "https://www.heytvm.com",
+      "type": "Game"
+    },
+    {
+      "location": "swfs/marvin_spectrum.swf",
+      "title": "Marvin Spectrum",
+      "author": "Bryan Singh",
+      "authorLink": "https://www.hotbryan.com",
+      "type": "Game"
+    },
+    {
+      "location": "swfs/wasted_sky.swf",
+      "title": "Wasted Sky",
+      "author": "Tom Fulp",
+      "authorLink": "https://www.newgrounds.com",
+      "type": "Game"
+    }
+  ]
 }
 ```
 

--- a/web/packages/demo/www/index.css
+++ b/web/packages/demo/www/index.css
@@ -42,19 +42,6 @@ body {
     transition-timing-function: ease-out;
 }
 
-#prompt {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    color: var(--ruffle-orange);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: large;
-}
-
 #player {
     position: absolute;
     top: 0;
@@ -103,7 +90,9 @@ body {
 }
 
 #local-file {
-    display: none;
+    width: 0;
+    opacity: 0;
+    position: absolute;
 }
 
 #local-file-label {

--- a/web/packages/demo/www/index.html
+++ b/web/packages/demo/www/index.html
@@ -23,14 +23,14 @@
             <div id="file-picker">
                 <div id="local-file-container">
                     <span id="local-file-static-label">Local SWF:</span>
-                    <input type="file" accept=".swf,.spl" id="local-file" />
+                    <input type="file" accept=".swf,.spl" id="local-file" 
+                        aria-describedby="local-file-static-label" />
                     <label for="local-file" id="local-file-label">Select File</label>
                     <span id="local-file-name">No file selected.</span>
                 </div>
                 <div id="sample-swfs-container" class="hidden">
                     <span id="sample-swfs-label">Sample SWF:</span>
-                    <select id="sample-swfs">
-                        <option value="none">None</option>
+                    <select id="sample-swfs" aria-describedby="sample-swfs-label">
                         <optgroup id="anim-optgroup" label="Animations"></optgroup>
                         <optgroup id="games-optgroup" label="Games"></optgroup>
                     </select>
@@ -40,9 +40,8 @@
                 </div>
             </div>
         </div>
-        <div id="main">
+        <div id="main" aria-label="Select a demo or drag an SWF">
             <div id="overlay" class="hidden"></div>
-            <div id="prompt">Select a demo or drag an SWF</div>
         </div>
         <script src="index.js"></script>
     </body>

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -154,7 +154,10 @@ window.addEventListener("load", () => {
             if (swfData.type) {
                 optionGroups[swfData.type].append(option);
             } else {
-                sampleFileInput.insertBefore(option, sampleFileInput.firstChild);
+                sampleFileInput.insertBefore(
+                    option,
+                    sampleFileInput.firstChild
+                );
             }
         }
         sampleFileInputContainer.classList.remove("hidden");


### PR DESCRIPTION
**Requires new swfs.json!** See changes to the demo README.
Change the Sample SWF dropdown to reflect that the Ruffle logo is shown by default:
![image](https://user-images.githubusercontent.com/71368227/178581093-0e67238f-4b24-435f-8d85-028a9b1697b0.png)
Remove the "None" option from the dropdown and the associated placeholder HTML/CSS. When a local SWF file is loaded, the dropdown will appear blank.
Add support for an optional `config` for each SWF in swfs.json. Also make the `type` value optional; if omitted, the SWF will be shown above the Animations and Games in the dropdown.
Also change the styling of the local file input to make it tabbable.