### PR TITLE
web: Hide loading screen when root movie download fails

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1401,6 +1401,7 @@ export class RufflePlayer extends HTMLElement {
             return;
         }
 
+        this.hidePreloader();
         const div = document.createElement("div");
         div.id = "message_overlay";
         div.innerHTML = `<div class="message">


### PR DESCRIPTION
When `displayRootMovieDownloadFailedMessage()` shows the CORS workaround screen, it should also hide the loading screen, otherwise the CORS workaround screen won't actually be visible.