### PR TITLE
core: Don't use `saturating_sub` for `width` / `height`

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -715,12 +715,11 @@ pub trait TDisplayObject<'gc>:
         self.base_mut(gc_context).set_scale_y(value);
     }
 
-    /// Sets the pixel width of this display object in local space.
-    /// The width is based on the AABB of the object.
+    /// Gets the pixel width of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_width`/`width` properties.
     fn width(&self) -> f64 {
         let bounds = self.local_bounds();
-        (bounds.x_max.saturating_sub(bounds.x_min)).to_pixels()
+        (bounds.x_max - bounds.x_min).to_pixels()
     }
 
     /// Sets the pixel width of this display object in local space.
@@ -769,7 +768,7 @@ pub trait TDisplayObject<'gc>:
     /// Returned by the ActionScript `_height`/`height` properties.
     fn height(&self) -> f64 {
         let bounds = self.local_bounds();
-        (bounds.y_max.saturating_sub(bounds.y_min)).to_pixels()
+        (bounds.y_max - bounds.y_min).to_pixels()
     }
 
     /// Sets the pixel height of this display object in local space.

--- a/swf/src/types/twips.rs
+++ b/swf/src/types/twips.rs
@@ -105,23 +105,6 @@ impl Twips {
     pub fn to_pixels(self) -> f64 {
         f64::from(self.0) / Self::TWIPS_PER_PIXEL
     }
-
-    /// Saturating integer subtraction. Computes `self - rhs`, saturating at the numeric bounds
-    /// of [`i32`] instead of overflowing.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use swf::Twips;
-    ///
-    /// assert_eq!(Twips::new(40).saturating_sub(Twips::new(20)), Twips::new(20));
-    /// assert_eq!(Twips::new(i32::MIN).saturating_sub(Twips::new(5)), Twips::new(i32::MIN));
-    /// assert_eq!(Twips::new(i32::MAX).saturating_sub(Twips::new(-100)), Twips::new(i32::MAX));
-    /// ```
-    #[must_use]
-    pub const fn saturating_sub(self, rhs: Self) -> Self {
-        Self(self.0.saturating_sub(rhs.0))
-    }
 }
 
 impl std::ops::Add for Twips {


### PR DESCRIPTION
Use regular subtraction, since it should never overflow.
Also remove `swf::Twips::saturating_sub`, which is now unused.