### PR TITLE
webgl: Avoid zeroing `renderbuffer_{width,height}`

### DIFF
--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -671,8 +671,11 @@ impl RenderBackend for WebGlRenderBackend {
         ];
 
         // Setup GL viewport and renderbuffers clamped to reasonable sizes.
-        self.renderbuffer_width = (width as i32).min(self.gl.drawing_buffer_width());
-        self.renderbuffer_height = (height as i32).min(self.gl.drawing_buffer_height());
+        // We don't use `.clamp()` here because `self.gl.drawing_buffer_width()` and
+        // `self.gl.drawing_buffer_height()` return zero when the WebGL context is lost,
+        // then an assertion error would be triggered.
+        self.renderbuffer_width = (width as i32).max(1).min(self.gl.drawing_buffer_width());
+        self.renderbuffer_height = (height as i32).max(1).min(self.gl.drawing_buffer_height());
 
         // Recreate framebuffers with the new size.
         let _ = self.build_msaa_buffers();


### PR DESCRIPTION
This basically reverts #5737 and #6458 for the WebGL backend, which
regressed a bug where setting the style `display: none;` to a Ruffle
player logged many WebGL warnings to the console. This happened
because `renderbuffer_width` and `renderbuffer_height` were set to zero,
leading to problems when trying to pass them to WebGL APIs.

Avoid such situation by ensuring that `renderbuffer_width` and
`renderbuffer_height` are at least `1`, exactly as done before.
Also add a comment that explains why `.clamp()` isn't used.

Fixes #1264.