### PR TITLE
core: Remove `From<Position<Twips>> for Transform`

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -893,8 +893,11 @@ impl<'gc> EditText<'gc> {
 
     /// Render a layout box, plus its children.
     fn render_layout_box(self, context: &mut RenderContext<'_, 'gc>, lbox: &LayoutBox<'gc>) {
-        let box_transform: Transform = lbox.bounds().origin().into();
-        context.transform_stack.push(&box_transform);
+        let origin = lbox.bounds().origin();
+        context.transform_stack.push(&Transform {
+            matrix: Matrix::translate(origin.x(), origin.y()),
+            ..Default::default()
+        });
 
         let edit_text = self.0.read();
         let selection = edit_text.selection;
@@ -1190,8 +1193,8 @@ impl<'gc> EditText<'gc> {
         );
 
         for layout_box in text.layout.iter() {
-            let transform: Transform = layout_box.bounds().origin().into();
-            let mut matrix = transform.matrix;
+            let origin = layout_box.bounds().origin();
+            let mut matrix = Matrix::translate(origin.x(), origin.y());
             matrix.invert();
             let local_position = matrix * position;
 

--- a/core/src/transform.rs
+++ b/core/src/transform.rs
@@ -1,24 +1,13 @@
-use crate::html::Position;
 use crate::prelude::*;
 use gc_arena::Collect;
 
 /// Represents the transform for a DisplayObject.
 /// This includes both the transformation matrix and the color transform.
-///
 #[derive(Clone, Collect, Debug, Default)]
 #[collect(require_static)]
 pub struct Transform {
     pub matrix: Matrix,
     pub color_transform: ColorTransform,
-}
-
-impl From<Position<Twips>> for Transform {
-    fn from(pos: Position<Twips>) -> Self {
-        Self {
-            matrix: Matrix::translate(pos.x(), pos.y()),
-            color_transform: Default::default(),
-        }
-    }
 }
 
 pub struct TransformStack(Vec<Transform>);


### PR DESCRIPTION
Simply use `Matrix::translate` directly, which is more explicit and
intuitive.