### PR TITLE
web: Remove some unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,11 +3159,9 @@ name = "ruffle_web"
 version = "0.1.0"
 dependencies = [
  "base64",
- "byteorder",
  "chrono",
  "console_error_panic_hook",
  "console_log",
- "fnv",
  "generational-arena",
  "getrandom",
  "js-sys",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -27,10 +27,8 @@ webgl = ["ruffle_render_webgl"]
 wgpu = ["ruffle_render_wgpu"]
 
 [dependencies]
-byteorder = "1.4"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 console_log = { version = "0.2", optional = true }
-fnv = "1.0.7"
 generational-arena = "0.2.8"
 js-sys = "0.3.58"
 log = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Both `byteorder` and `fnv` are no longer used since #4273.