### PR TITLE
don't rely on a rustc bug

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1307,7 +1307,7 @@ impl<'gc> MovieClip<'gc> {
             frame_pos = reader.get_ref().as_ptr() as u64 - tag_stream_start;
 
             use swf::TagCode;
-            let tag_callback = |reader: &mut SwfStream<'gc>, tag_code, tag_len| match tag_code {
+            let tag_callback = |reader: &mut _, tag_code, tag_len| match tag_code {
                 TagCode::PlaceObject => {
                     index += 1;
                     let mut mc = self.0.write(context.gc_context);


### PR DESCRIPTION
Hi,

https://github.com/rust-lang/rust/pull/98835 fixes a rustc bug that makes it incorrectly accepts the following code:
```rust
fn test<'a: 'a>() { // 'a is longer than the entire function body
    let f = |_: &'a str| {}; // expects an argument that lives as long as 'a
    f(&String::new()); // the passed reference is shorter that `'a`
}
```

The crater run found that ruffle relies on this bug. I'm not sure when this change reaches stable, if ever, but it's better to not rely on such a bug. This PR tries to fix this.

If you have an opinion on this change, please let me know here or  by commenting on the PR.

You can install and test the toolchain locally by running the command: `rustup-toolchain-install-master cb1f7c96119295882e08b09b4bd01051669c071b`