### PR TITLE
avm2: Store PropertyClass in `VtableData`

### DIFF
--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -11,22 +11,11 @@ use gc_arena::{Collect, Gc};
 
 #[derive(Debug, Collect, Clone, Copy)]
 #[collect(no_drop)]
-pub enum Property<'gc> {
-    Virtual {
-        get: Option<u32>,
-        set: Option<u32>,
-    },
-    Method {
-        disp_id: u32,
-    },
-    Slot {
-        slot_id: u32,
-        class: PropertyClass<'gc>,
-    },
-    ConstSlot {
-        slot_id: u32,
-        class: PropertyClass<'gc>,
-    },
+pub enum Property {
+    Virtual { get: Option<u32>, set: Option<u32> },
+    Method { disp_id: u32 },
+    Slot { slot_id: u32 },
+    ConstSlot { slot_id: u32 },
 }
 
 /// The type of a `Slot`/`ConstSlot` property, represented
@@ -42,7 +31,7 @@ pub enum Property<'gc> {
 /// Additionally, property class resolution uses special
 /// logic, different from normal "runtime" class resolution,
 /// that allows private types to be referenced.
-#[derive(Debug, Collect, Clone, Copy)]
+#[derive(Debug, Collect, Clone)]
 #[collect(no_drop)]
 pub enum PropertyClass<'gc> {
     /// The type `*` (Multiname::is_any()). This allows
@@ -191,7 +180,7 @@ fn resolve_class_private<'gc>(
     }
 }
 
-impl<'gc> Property<'gc> {
+impl Property {
     pub fn new_method(disp_id: u32) -> Self {
         Property::Method { disp_id }
     }
@@ -210,11 +199,11 @@ impl<'gc> Property<'gc> {
         }
     }
 
-    pub fn new_slot(slot_id: u32, class: PropertyClass<'gc>) -> Self {
-        Property::Slot { slot_id, class }
+    pub fn new_slot(slot_id: u32) -> Self {
+        Property::Slot { slot_id }
     }
 
-    pub fn new_const_slot(slot_id: u32, class: PropertyClass<'gc>) -> Self {
-        Property::ConstSlot { slot_id, class }
+    pub fn new_const_slot(slot_id: u32) -> Self {
+        Property::ConstSlot { slot_id }
     }
 }

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -27,7 +27,11 @@ pub struct VTableData<'gc> {
 
     protected_namespace: Option<Namespace<'gc>>,
 
-    resolved_traits: PropertyMap<'gc, Property<'gc>>,
+    resolved_traits: PropertyMap<'gc, Property>,
+
+    /// Stores the `PropertyClass` for each slot,
+    /// indexed by `slot_id`
+    slot_classes: Vec<PropertyClass<'gc>>,
 
     method_table: Vec<ClassBoundMethod<'gc>>,
 
@@ -54,6 +58,7 @@ impl<'gc> VTable<'gc> {
                 scope: None,
                 protected_namespace: None,
                 resolved_traits: PropertyMap::new(),
+                slot_classes: vec![],
                 method_table: vec![],
                 default_slots: vec![],
             },
@@ -64,12 +69,31 @@ impl<'gc> VTable<'gc> {
         VTable(GcCell::allocate(mc, self.0.read().clone()))
     }
 
-    pub fn get_trait(self, name: &Multiname<'gc>) -> Option<Property<'gc>> {
+    pub fn get_trait(self, name: &Multiname<'gc>) -> Option<Property> {
         self.0
             .read()
             .resolved_traits
             .get_for_multiname(name)
             .cloned()
+    }
+
+    /// Coerces `value` to the type of the slot with id `slot_id`
+    pub fn coerce_trait_value(
+        &self,
+        slot_id: u32,
+        value: Value<'gc>,
+        activation: &mut Activation<'_, 'gc, '_>,
+    ) -> Result<Value<'gc>, Error> {
+        // Drop the `write()` guard, as 'slot_class.coerce' may need to access this vtable.
+        let mut slot_class =
+            { self.0.write(activation.context.gc_context).slot_classes[slot_id as usize].clone() };
+        let value = slot_class.coerce(activation, value);
+        // Calling coerce modifies `PropertyClass` to cache the class lookup,
+        // so store the new value back in the vtable.
+        {
+            self.0.write(activation.context.gc_context).slot_classes[slot_id as usize] = slot_class;
+        }
+        value
     }
 
     pub fn has_trait(self, name: &Multiname<'gc>) -> bool {
@@ -175,6 +199,7 @@ impl<'gc> VTable<'gc> {
 
         if let Some(superclass_vtable) = superclass_vtable {
             write.resolved_traits = superclass_vtable.0.read().resolved_traits.clone();
+            write.slot_classes = superclass_vtable.0.read().slot_classes.clone();
             write.method_table = superclass_vtable.0.read().method_table.clone();
             write.default_slots = superclass_vtable.0.read().default_slots.clone();
 
@@ -195,10 +220,11 @@ impl<'gc> VTable<'gc> {
             }
         }
 
-        let (resolved_traits, method_table, default_slots) = (
+        let (resolved_traits, method_table, default_slots, slot_classes) = (
             &mut write.resolved_traits,
             &mut write.method_table,
             &mut write.default_slots,
+            &mut write.slot_classes,
         );
 
         for trait_data in traits {
@@ -299,31 +325,38 @@ impl<'gc> VTable<'gc> {
                         slot_id
                     };
 
-                    let new_prop = match trait_data.kind() {
+                    if new_slot_id as usize >= slot_classes.len() {
+                        // We will overwrite `PropertyClass::Any` when we process the slots
+                        // with the ids that we just skipped over.
+                        slot_classes.resize(new_slot_id as usize + 1, PropertyClass::Any);
+                    }
+
+                    let (new_prop, new_class) = match trait_data.kind() {
                         TraitKind::Slot {
                             type_name, unit, ..
-                        } => Property::new_slot(
-                            new_slot_id,
+                        } => (
+                            Property::new_slot(new_slot_id),
                             PropertyClass::name(activation, type_name.clone(), *unit),
                         ),
-                        TraitKind::Function { .. } => Property::new_slot(
-                            new_slot_id,
+                        TraitKind::Function { .. } => (
+                            Property::new_slot(new_slot_id),
                             PropertyClass::Class(activation.avm2().classes().function),
                         ),
                         TraitKind::Const {
                             type_name, unit, ..
-                        } => Property::new_const_slot(
-                            new_slot_id,
+                        } => (
+                            Property::new_const_slot(new_slot_id),
                             PropertyClass::name(activation, type_name.clone(), *unit),
                         ),
-                        TraitKind::Class { .. } => Property::new_const_slot(
-                            new_slot_id,
+                        TraitKind::Class { .. } => (
+                            Property::new_const_slot(new_slot_id),
                             PropertyClass::Class(activation.avm2().classes().class),
                         ),
                         _ => unreachable!(),
                     };
 
                     resolved_traits.insert(trait_data.name(), new_prop);
+                    slot_classes[new_slot_id as usize] = new_class;
                 }
             }
         }
@@ -379,10 +412,10 @@ impl<'gc> VTable<'gc> {
 
         write.default_slots.push(Some(value));
         let new_slot_id = write.default_slots.len() as u32 - 1;
-        write.resolved_traits.insert(
-            name,
-            Property::new_slot(new_slot_id, PropertyClass::Class(class)),
-        );
+        write
+            .resolved_traits
+            .insert(name, Property::new_slot(new_slot_id));
+        write.slot_classes.push(PropertyClass::Class(class));
 
         new_slot_id
     }


### PR DESCRIPTION
Calling `get_trait` copies the returned `Property`, so the caching
we performed in `PropertyClass` was never actually getting used.

Instead, we now store our `PropertyClass` values in a `Vec`
indexed by slot id. `set_property` and `init_property` now perform
coercions by going through the `VTable,` which writes the updated
`PropertyClass` back into the array.