### PR TITLE
web: Rollback to web-sys 0.3.58

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -69,6 +69,9 @@ jobs:
         run: conda install -c conda-forge binaryen
 
       - name: Build
+        env:
+          # Verify that all features build.
+          CARGO_FLAGS: --all-features
         working-directory: web
         shell: bash -l {0}
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,9 +4005,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -17,7 +17,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.59"
+version = "0.3.58"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
     "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -19,7 +19,7 @@ path = "../../core"
 default-features = false
 
 [dependencies.web-sys]
-version = "0.3.59"
+version = "0.3.58"
 features = [
     "HtmlCanvasElement", "OesVertexArrayObject", "WebGl2RenderingContext", "WebGlBuffer", "WebglDebugRendererInfo",
     "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGlShader", "WebGlTexture",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -26,7 +26,7 @@ default-features = false
 
 # wasm
 [target.'cfg(target_family = "wasm")'.dependencies.web-sys]
-version = "0.3.59"
+version = "0.3.58"
 features = ["HtmlCanvasElement"]
 
 [features]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -51,7 +51,7 @@ default-features = false
 features = ["h263", "vp6", "screenvideo", "symphonia", "wasm-bindgen"]
 
 [dependencies.web-sys]
-version = "0.3.59"
+version = "0.3.58"
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext", "AudioDestinationNode",
     "AudioNode", "AudioParam", "Blob", "BlobPropertyBag", "ChannelMergerNode",

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -11,5 +11,5 @@ log = "0.4"
 wasm-bindgen = "=0.2.82"
 
 [dependencies.web-sys]
-version = "0.3.59"
+version = "0.3.58"
 features = ["Window"]

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -26,7 +26,7 @@
         "//5": "# This just chains together the three commands after it.",
         "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
 
-        "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\"",
+        "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\" $CARGO_FLAGS",
         "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir ./pkg --out-name \"$OUT_NAME\"",
         "build:wasm-opt": "cross-env-shell wasm-opt -o \"./pkg/${OUT_NAME}_bg.wasm\" -O -g \"./pkg/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
 


### PR DESCRIPTION
The [WebGPU spec removed `depth24unorm-stencil8`](https://github.com/gpuweb/gpuweb/pull/2950) texture format, and therefore `GpuTextureFormat::Depth24unormStencil8` binding is removed in `web-sys` 0.3.59.  The current published `wgpu` crate still expects this to exist.

`wgpu` master has updated (https://github.com/gfx-rs/wgpu/pull/2813), but we have to wait for a new version to be published. Thus is the life of relying on an unstable API. :-)

Adjust CI to ensure that the web tests build with --all-features to avoid this in the future.