### PR TITLE
avm2: Fix parsing of methods with more than 127 arguments

### DIFF
--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -242,7 +242,7 @@ impl<'a> Reader<'a> {
     }
 
     fn read_method(&mut self) -> Result<Method> {
-        let num_params = self.read_u8()?;
+        let num_params = self.read_u30()?;
         let return_type = self.read_index()?;
         let mut params = Vec::with_capacity(num_params as usize);
         for _ in 0..num_params {


### PR DESCRIPTION
this change follows section 4.5 of https://www.adobe.com/content/dam/acom/en/devnet/pdf/avm2overview.pdf (dead link, use an archive)