### PR TITLE
audio: Handle `AudioCompression::UncompressedUnknownEndian` in `AudioMixer`

### DIFF
--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -193,6 +193,16 @@ impl AudioMixer {
         data: Cursor<ArcAsRef>,
     ) -> Result<Box<dyn SeekableDecoder>, Error> {
         let decoder: Box<dyn SeekableDecoder> = match format.compression {
+            AudioCompression::UncompressedUnknownEndian => {
+                // Cross fingers that it's little endian.
+                log::warn!("make_decoder: PCM sound is unknown endian; assuming little endian");
+                Box::new(PcmDecoder::new(
+                    data,
+                    format.is_stereo,
+                    format.sample_rate,
+                    format.is_16_bit,
+                ))
+            }
             AudioCompression::Uncompressed => Box::new(PcmDecoder::new(
                 data,
                 format.is_stereo,


### PR DESCRIPTION
The same way as it is done in `decoders::make_decoder()`.

Fixes the regression caused by #4273 on https://z0r.de/3682 as reported in https://github.com/ruffle-rs/ruffle/issues/7524#issuecomment-1200464340.