### PR TITLE
ci: Run cargo in locked mode

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build
         env:
           # Verify that all features build.
-          CARGO_FLAGS: --all-features
+          CARGO_FLAGS: --locked --all-features
         working-directory: web
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
As a follow-up for #7010, run cargo in locked mode on Web CI as well,
in order to validate that `Cargo.lock` is up-to-date and gain a slight
speed-up.