### PR TITLE
wstr: Make WString 16 bytes on all targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,11 +399,12 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "js-sys",
+ "libc",
  "num-integer",
  "num-traits",
  "time",
@@ -3221,6 +3222,9 @@ dependencies = [
 [[package]]
 name = "ruffle_wstr"
 version = "0.1.0"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -3635,18 +3639,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/wstr/Cargo.toml
+++ b/wstr/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Arthur Heuillard <arthur.heuillard<orange.fr>"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+static_assertions = "1.1.0"

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -284,6 +284,14 @@ impl WString {
         })
     }
 
+    /// Truncates this `WString`, removing all contents.
+    pub fn clear(&mut self) {
+        // SAFETY: 0 is always a valid length.
+        unsafe {
+            self.meta = ptr::WStrMetadata::new(0, self.meta.is_wide());
+        }
+    }
+
     /// Appends a UTF-16 code unit to `self`.
     ///
     /// This will convert this `WString` into its wide form if necessary.
@@ -412,6 +420,11 @@ impl ToOwned for WStr {
         let mut buf = WString::new();
         buf.push_str(self);
         buf
+    }
+
+    fn clone_into(&self, target: &mut Self::Owned) {
+        target.clear();
+        target.push_str(self);
     }
 }
 

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
+use static_assertions::assert_eq_size;
 
 use super::utils::{encode_raw_utf16, split_ascii_prefix, split_ascii_prefix_bytes, DecodeAvmUtf8};
 use super::{ptr, Units, WStr, MAX_STRING_LEN};
@@ -15,6 +16,12 @@ pub struct WString {
     meta: ptr::WStrMetadata,
     capacity: u32,
 }
+
+#[cfg(target_pointer_width = "32")]
+assert_eq_size!(WString, [u8; 12]);
+
+#[cfg(target_pointer_width = "64")]
+assert_eq_size!(WString, [u8; 16]);
 
 impl WString {
     /// Creates a new empty `WString`.

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -150,14 +150,14 @@ impl WStr {
     #[inline]
     pub fn is_wide(&self) -> bool {
         // SAFETY: `self` is a valid `WStr`.
-        unsafe { ptr::is_wide(ptr::ptr_mut(self)) }
+        unsafe { ptr::metadata(ptr::ptr_mut(self)).is_wide() }
     }
 
     /// Returns the number of code units.
     #[inline]
     pub fn len(&self) -> usize {
         // SAFETY: `self` is a valid `WStr`.
-        unsafe { ptr::len(ptr::ptr_mut(self)) }
+        unsafe { ptr::metadata(ptr::ptr_mut(self)).len() }
     }
 
     /// Returns `true` if `self` contains no code units.

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -18,16 +18,6 @@ pub enum Units<T, U> {
     Wide(U),
 }
 
-impl<T: AsRef<[u8]>, U: AsRef<[u16]>> Units<T, U> {
-    #[inline]
-    pub(super) fn len(&self) -> usize {
-        match self {
-            Units::Bytes(buf) => buf.as_ref().len(),
-            Units::Wide(buf) => buf.as_ref().len(),
-        }
-    }
-}
-
 /// Generate `From` implementations for `Units` type.
 macro_rules! units_from {
     (impl[$($generics:tt)*] Units<$ty_bytes:ty, $ty_wide:ty>; $($rest:tt)*) => {


### PR DESCRIPTION
Shrink WString to 16 bytes on 64-bits targets by introducing an explicit `WStrMetadata` type that is always 4 bytes wide, even on 64-bits targets.

Note the trickier logic in `WString::from_buf`, to properly handle the case where the capacity is above the maximum allowed length.