### PR TITLE
web: Allow modifying stage volume via JS

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -98,6 +98,12 @@ pub trait AudioBackend: Downcast {
     fn position_resolution(&self) -> Option<Duration> {
         None
     }
+
+    /// Returns the master volume of the audio backend.
+    fn volume(&self) -> f32;
+
+    /// Sets the master volume of the audio backend.
+    fn set_volume(&mut self, volume: f32);
 }
 
 impl_downcast!(AudioBackend);
@@ -117,12 +123,14 @@ struct NullSound {
 /// Audio backend that ignores all audio.
 pub struct NullAudioBackend {
     sounds: Arena<NullSound>,
+    volume: f32,
 }
 
 impl NullAudioBackend {
     pub fn new() -> NullAudioBackend {
         NullAudioBackend {
             sounds: Arena::new(),
+            volume: 1.0,
         }
     }
 }
@@ -194,6 +202,14 @@ impl AudioBackend for NullAudioBackend {
     }
 
     fn set_sound_transform(&mut self, _instance: SoundInstanceHandle, _transform: SoundTransform) {}
+
+    fn volume(&self) -> f32 {
+        self.volume
+    }
+
+    fn set_volume(&mut self, volume: f32) {
+        self.volume = volume;
+    }
 }
 
 impl Default for NullAudioBackend {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -481,6 +481,16 @@ impl Player {
         self.is_playing
     }
 
+    /// Returns the master volume of the player. 1.0 is 100% volume.
+    pub fn volume(&self) -> f32 {
+        self.audio.volume()
+    }
+
+    /// Sets the master volume of the player. 1.0 is 100% volume.
+    pub fn set_volume(&mut self, volume: f32) {
+        self.audio.set_volume(volume)
+    }
+
     pub fn prepare_context_menu(&mut self) -> Vec<ContextMenuItem> {
         self.mutate_with_update_context(|context| {
             if !context.stage.show_menu() {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -672,6 +672,29 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
+     * Returns the master volume of the player.
+     *
+     * @returns The volume. 1.0 is 100% volume.
+     */
+    get volume(): number {
+        if (this.instance) {
+            return this.instance.volume();
+        }
+        return 1.0;
+    }
+
+    /**
+     * Sets the master volume of the player.
+     *
+     * @param value The volume. 1.0 is 100% volume.
+     */
+    set volume(value: number) {
+        if (this.instance) {
+            this.instance.set_volume(value);
+        }
+    }
+
+    /**
      * Checks if this player is allowed to be fullscreen by the browser.
      *
      * @returns True if you may call [[enterFullscreen]].

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -268,6 +268,14 @@ impl Ruffle {
         self.with_core(|core| core.is_playing()).unwrap_or_default()
     }
 
+    pub fn volume(&self) -> f32 {
+        self.with_core(|core| core.volume()).unwrap_or_default()
+    }
+
+    pub fn set_volume(&mut self, value: f32) {
+        let _ = self.with_core_mut(|core| core.set_volume(value));
+    }
+
     // after the context menu is closed, remember to call `clear_custom_menu_items`!
     pub fn prepare_context_menu(&mut self) -> JsValue {
         self.with_core_mut(|core| {


### PR DESCRIPTION
It was requested by folks on Discord a couple times. Would also come in handy if we ever add a volume slider to extension or context menu.

Downside: this is not a _master_ player volume, it's the stage volume - it can be overridden by the movie with a simple AS `new Sound().setVolume(100);`. In the future, we might want the Player API to be able to set both "stage-visible volume" and "master player (invisible to AS) volume" independently.