### PR TITLE
core: Only store viewport dimensions in `RenderBackend`

### DIFF
--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -311,15 +311,21 @@ pub fn set_align<'gc>(
 
 /// Implement `browserZoomFactor`'s getter
 pub fn browser_zoom_factor<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
-    if let Some(dobj) = this
+    if this
         .and_then(|this| this.as_display_object())
         .and_then(|this| this.as_stage())
+        .is_some()
     {
-        return Ok(dobj.viewport_scale_factor().into());
+        return Ok(activation
+            .context
+            .renderer
+            .viewport_dimensions()
+            .scale_factor
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -367,15 +373,21 @@ pub fn set_color<'gc>(
 
 /// Implement `contentsScaleFactor`'s getter
 pub fn contents_scale_factor<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
-    if let Some(dobj) = this
+    if this
         .and_then(|this| this.as_display_object())
         .and_then(|this| this.as_stage())
+        .is_some()
     {
-        return Ok(dobj.viewport_scale_factor().into());
+        return Ok(activation
+            .context
+            .renderer
+            .viewport_dimensions()
+            .scale_factor
+            .into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -544,7 +544,7 @@ mod tests {
     use crate::player::{Player, DEVICE_FONT_TAG};
     use crate::string::WStr;
     use gc_arena::{rootless_arena, MutationContext};
-    use ruffle_render::backend::{null::NullRenderer, RenderBackend};
+    use ruffle_render::backend::{null::NullRenderer, RenderBackend, ViewportDimensions};
     use std::ops::DerefMut;
     use swf::Twips;
 
@@ -553,7 +553,12 @@ mod tests {
         F: for<'gc> FnOnce(MutationContext<'gc, '_>, Font<'gc>),
     {
         rootless_arena(|mc| {
-            let mut renderer: Box<dyn RenderBackend> = Box::new(NullRenderer::new());
+            let mut renderer: Box<dyn RenderBackend> =
+                Box::new(NullRenderer::new(ViewportDimensions {
+                    width: 0,
+                    height: 0,
+                    scale_factor: 1.0,
+                }));
             let device_font =
                 Player::load_device_font(mc, DEVICE_FONT_TAG, renderer.deref_mut()).unwrap();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -46,5 +46,6 @@ pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;
 pub use indexmap;
 pub use player::{Player, PlayerBuilder};
+pub use ruffle_render::backend::ViewportDimensions;
 pub use swf;
 pub use swf::Color;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -20,7 +20,7 @@ use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use rfd::FileDialog;
 use ruffle_core::{
     config::Letterbox, events::KeyCode, tag_utils::SwfMovie, Player, PlayerBuilder, PlayerEvent,
-    StageDisplayState,
+    StageDisplayState, ViewportDimensions,
 };
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use ruffle_render_wgpu::WgpuRenderBackend;
@@ -364,14 +364,11 @@ impl App {
 
                             let viewport_scale_factor = self.window.scale_factor();
                             let mut player_lock = self.player.lock().unwrap();
-                            player_lock.set_viewport_dimensions(
-                                size.width,
-                                size.height,
-                                viewport_scale_factor,
-                            );
-                            player_lock
-                                .renderer_mut()
-                                .set_viewport_dimensions(size.width, size.height);
+                            player_lock.set_viewport_dimensions(ViewportDimensions {
+                                width: size.width,
+                                height: size.height,
+                                scale_factor: viewport_scale_factor,
+                            });
                             self.window.request_redraw();
                         }
                         WindowEvent::CursorMoved { position, .. } => {
@@ -503,14 +500,11 @@ impl App {
                         let viewport_size = self.window.inner_size();
                         let viewport_scale_factor = self.window.scale_factor();
                         let mut player_lock = self.player.lock().unwrap();
-                        player_lock.set_viewport_dimensions(
-                            viewport_size.width,
-                            viewport_size.height,
-                            viewport_scale_factor,
-                        );
-                        player_lock
-                            .renderer_mut()
-                            .set_viewport_dimensions(viewport_size.width, viewport_size.height);
+                        player_lock.set_viewport_dimensions(ViewportDimensions {
+                            width: viewport_size.width,
+                            height: viewport_size.height,
+                            scale_factor: viewport_scale_factor,
+                        });
 
                         loaded = true;
                     }

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -1,6 +1,6 @@
 use fnv::FnvHashMap;
 use ruffle_render::backend::null::NullBitmapSource;
-use ruffle_render::backend::{RenderBackend, ShapeHandle};
+use ruffle_render::backend::{RenderBackend, ShapeHandle, ViewportDimensions};
 use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapSource};
 use ruffle_render::color_transform::ColorTransform;
 use ruffle_render::matrix::Matrix;
@@ -30,6 +30,10 @@ pub struct WebCanvasRenderBackend {
     mask_state: MaskState,
     next_bitmap_handle: BitmapHandle,
     blend_modes: Vec<BlendMode>,
+
+    // This is currnetly unused - we just store it to report
+    // in `get_viewport_dimensions`
+    viewport_scale_factor: f64,
 }
 
 /// Canvas-drawable shape data extracted from an SWF file.
@@ -287,6 +291,7 @@ impl WebCanvasRenderBackend {
             bitmaps: Default::default(),
             viewport_width: 0,
             viewport_height: 0,
+            viewport_scale_factor: 1.0,
             rect,
             mask_state: MaskState::DrawContent,
             next_bitmap_handle: BitmapHandle(0),
@@ -376,9 +381,18 @@ impl WebCanvasRenderBackend {
 }
 
 impl RenderBackend for WebCanvasRenderBackend {
-    fn set_viewport_dimensions(&mut self, width: u32, height: u32) {
-        self.viewport_width = width;
-        self.viewport_height = height;
+    fn set_viewport_dimensions(&mut self, dimensions: ViewportDimensions) {
+        self.viewport_width = dimensions.width;
+        self.viewport_height = dimensions.height;
+        self.viewport_scale_factor = dimensions.scale_factor;
+    }
+
+    fn viewport_dimensions(&self) -> ViewportDimensions {
+        ViewportDimensions {
+            width: self.viewport_width,
+            height: self.viewport_height,
+            scale_factor: self.viewport_scale_factor,
+        }
     }
 
     fn register_shape(

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -10,7 +10,10 @@ use downcast_rs::{impl_downcast, Downcast};
 use swf;
 
 pub trait RenderBackend: Downcast {
-    fn set_viewport_dimensions(&mut self, width: u32, height: u32);
+    fn viewport_dimensions(&self) -> ViewportDimensions;
+    // Do not call this method directly - use `player.set_viewport_dimensions`,
+    // which will ensure that the stage is properly updated as well.
+    fn set_viewport_dimensions(&mut self, dimensions: ViewportDimensions);
     fn register_shape(
         &mut self,
         shape: DistilledShape,
@@ -106,3 +109,14 @@ impl_downcast!(RenderBackend);
 
 #[derive(Copy, Clone, Debug)]
 pub struct ShapeHandle(pub usize);
+
+#[derive(Copy, Clone, Debug)]
+pub struct ViewportDimensions {
+    /// The dimensions of the stage's containing viewport.
+    pub width: u32,
+    pub height: u32,
+
+    /// The scale factor of the containing viewport from standard-size pixels
+    /// to device-scale pixels.
+    pub scale_factor: f64,
+}

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -1,4 +1,4 @@
-use crate::backend::{RenderBackend, ShapeHandle};
+use crate::backend::{RenderBackend, ShapeHandle, ViewportDimensions};
 use crate::bitmap::{Bitmap, BitmapHandle, BitmapInfo, BitmapSource};
 use crate::error::Error;
 use crate::matrix::Matrix;
@@ -14,22 +14,23 @@ impl BitmapSource for NullBitmapSource {
     }
 }
 
-pub struct NullRenderer;
-
-impl NullRenderer {
-    pub fn new() -> Self {
-        Self
-    }
+pub struct NullRenderer {
+    dimensions: ViewportDimensions,
 }
 
-impl Default for NullRenderer {
-    fn default() -> Self {
-        Self::new()
+impl NullRenderer {
+    pub fn new(dimensions: ViewportDimensions) -> Self {
+        Self { dimensions }
     }
 }
 
 impl RenderBackend for NullRenderer {
-    fn set_viewport_dimensions(&mut self, _width: u32, _height: u32) {}
+    fn viewport_dimensions(&self) -> ViewportDimensions {
+        self.dimensions
+    }
+    fn set_viewport_dimensions(&mut self, dimensions: ViewportDimensions) {
+        self.dimensions = dimensions;
+    }
     fn register_shape(
         &mut self,
         _shape: DistilledShape,

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -223,28 +223,8 @@ impl RenderTarget for TextureTarget {
     type Frame = TextureTargetFrame;
 
     fn resize(&mut self, device: &wgpu::Device, width: u32, height: u32) {
-        // TODO: find a way to bubble an error when the size is too large
-        self.size.width = width;
-        self.size.height = height;
-
-        let label = create_debug_label!("Render target texture");
-        self.texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: label.as_deref(),
-            size: self.size,
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: self.format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
-        });
-
-        let buffer_label = create_debug_label!("Render target buffer");
-        self.buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: buffer_label.as_deref(),
-            size: width as u64 * height as u64 * 4,
-            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-            mapped_at_creation: false,
-        });
+        *self =
+            TextureTarget::new(device, (width, height)).expect("Unable to resize texture target");
     }
 
     fn format(&self) -> wgpu::TextureFormat {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -14,7 +14,7 @@ use ruffle_core::events::MouseButton as RuffleMouseButton;
 use ruffle_core::external::Value as ExternalValue;
 use ruffle_core::external::{ExternalInterfaceMethod, ExternalInterfaceProvider};
 use ruffle_core::tag_utils::SwfMovie;
-use ruffle_core::{Player, PlayerBuilder, PlayerEvent};
+use ruffle_core::{Player, PlayerBuilder, PlayerEvent, ViewportDimensions};
 use ruffle_input_format::{AutomatedEvent, InputInjector, MouseButton as InputMouseButton};
 use ruffle_render_wgpu::target::TextureTarget;
 use ruffle_render_wgpu::wgpu;
@@ -1053,7 +1053,11 @@ fn stage_scale_mode() -> Result<(), Error> {
             player
                 .lock()
                 .unwrap()
-                .set_viewport_dimensions(900, 900, 1.0);
+                .set_viewport_dimensions(ViewportDimensions {
+                    width: 900,
+                    height: 900,
+                    scale_factor: 1.0,
+                });
             Ok(())
         },
         |_| Ok(()),
@@ -1287,16 +1291,14 @@ fn run_swf(
                 None,
             ))?;
 
-        let target = TextureTarget::new(
-            &descriptors.device,
-            (
-                movie.width().to_pixels() as u32,
-                movie.height().to_pixels() as u32,
-            ),
-        )?;
+        let width = movie.width().to_pixels() as u32;
+        let height = movie.height().to_pixels() as u32;
+
+        let target = TextureTarget::new(&descriptors.device, (width, height))?;
 
         builder = builder
             .with_renderer(WgpuRenderBackend::new(Arc::new(descriptors), target)?)
+            .with_viewport_dimensions(width, height, 1.0)
             .with_software_video();
     };
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -14,7 +14,7 @@ use ruffle_core::external::{
     ExternalInterfaceMethod, ExternalInterfaceProvider, Value as ExternalValue, Value,
 };
 use ruffle_core::tag_utils::SwfMovie;
-use ruffle_core::{Color, Player, PlayerBuilder, PlayerEvent};
+use ruffle_core::{Color, Player, PlayerBuilder, PlayerEvent, ViewportDimensions};
 use ruffle_web_common::JsResult;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -984,9 +984,11 @@ impl Ruffle {
                 canvas.set_width(viewport_width);
                 canvas.set_height(viewport_height);
 
-                core.set_viewport_dimensions(viewport_width, viewport_height, device_pixel_ratio);
-                core.renderer_mut()
-                    .set_viewport_dimensions(viewport_width, viewport_height);
+                core.set_viewport_dimensions(ViewportDimensions {
+                    width: viewport_width,
+                    height: viewport_height,
+                    scale_factor: device_pixel_ratio,
+                });
             }
 
             core.tick(dt);


### PR DESCRIPTION
Previously, the viewport height and width were stored in
both `Stage` and the `RenderBackend`. Any changes to the viewport
dimensions (e.g. due to window resizing) needed to be updated in both
places to keep our handling of the viewport consistent.

This PR adds a new `ViewportDimensions` type, which holds the
width, height, and scale factor. It is stored inside the
`RenderBackend` impl, and is retrieved using the newly added
method `RenderBackend.get_viewport_dimensions`. After a `Player`
has been constructed, any code that needes access to the viewport
dimensions will ultimate go through this method.

Unfortunately, `Stage` needs to use the viewport dimensions
in `build_matrices`. Therefore, any code modifying the viewport
dimensions should go through `player.set_viewport_dimensions`,
which ensures that the stage matrices are rebuilt after the render
backend is updated.