### PR TITLE
core: Require `target` in `NavigatorBackend::navigate_to_url`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1183,7 +1183,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         } else {
             self.context
                 .navigator
-                .navigate_to_url(url.to_owned(), Some(target.into_owned()), None);
+                .navigate_to_url(url.to_owned(), target.into_owned(), None);
         }
 
         Ok(FrameControl::Continue)
@@ -1311,7 +1311,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
         self.context
             .navigator
-            .navigate_to_url(url.to_string(), Some(target.to_string()), vars);
+            .navigate_to_url(url.to_string(), target.to_string(), vars);
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -158,8 +158,8 @@ fn send<'gc>(
     };
 
     let window = match args.get(1) {
-        Some(v) => Some(v.coerce_to_string(activation)?),
-        None => None,
+        Some(v) => v.coerce_to_string(activation)?.to_string(),
+        None => "".into(),
     };
 
     let method_name = args
@@ -186,13 +186,11 @@ fn send<'gc>(
         );
     }
 
-    if let Some(window) = window {
-        activation.context.navigator.navigate_to_url(
-            url.to_string(),
-            Some(window.to_string()),
-            Some((method, form_values)),
-        );
-    }
+    activation.context.navigator.navigate_to_url(
+        url.to_string(),
+        window,
+        Some((method, form_values)),
+    );
 
     Ok(true.into())
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1246,9 +1246,9 @@ pub fn get_url<'gc>(
         }
 
         let window = if let Some(window) = args.get(1) {
-            Some(window.coerce_to_string(activation)?.to_string())
+            window.coerce_to_string(activation)?.to_string()
         } else {
-            None
+            "".into()
         };
 
         let method = match args.get(2) {

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -125,8 +125,8 @@ pub trait NavigatorBackend {
     /// be meaningful for all environments: for example, `javascript:` URLs may
     /// not be executable in a desktop context.
     ///
-    /// The `window` parameter, if provided, should be treated identically to
-    /// the `window` parameter on an HTML `<a>nchor` tag.
+    /// The `target` parameter, should be treated identically to the `target`
+    /// parameter on an HTML `<a>nchor` tag.
     ///
     /// This function may be used to send variables to an eligible target. If
     /// desired, the `vars_method` will be specified with a suitable
@@ -144,7 +144,7 @@ pub trait NavigatorBackend {
     fn navigate_to_url(
         &self,
         url: String,
-        window: Option<String>,
+        target: String,
         vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     );
 
@@ -285,7 +285,7 @@ impl NavigatorBackend for NullNavigatorBackend {
     fn navigate_to_url(
         &self,
         _url: String,
-        _window: Option<String>,
+        _target: String,
         _vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     ) {
     }

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -62,7 +62,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
     fn navigate_to_url(
         &self,
         url: String,
-        _window_spec: Option<String>,
+        _target: String,
         vars_method: Option<(NavigationMethod, IndexMap<String, String>)>,
     ) {
         //TODO: Should we return a result for failed opens? Does Flash care?


### PR DESCRIPTION
Make the `target` parameter just a `String` instead of an `Option<String>`.
`None` is not needed as it's totally equivalent to an empty string.