### PR TITLE
core: Track 'actions since timeout check' globally

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -229,9 +229,6 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     /// This can be changed with `tellTarget` (via `ActionSetTarget` and `ActionSetTarget2`).
     target_clip: Option<DisplayObject<'gc>>,
 
-    /// Amount of actions performed since the last timeout check
-    actions_since_timeout_check: u16,
-
     /// Whether the base clip was removed when we started this frame.
     base_clip_unloaded: bool,
 
@@ -274,7 +271,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             this,
             callee,
             local_registers: None,
-            actions_since_timeout_check: 0,
         }
     }
 
@@ -298,7 +294,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             this: self.this,
             callee: self.callee,
             local_registers: self.local_registers,
-            actions_since_timeout_check: 0,
         }
     }
 
@@ -333,7 +328,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             this: globals.into(),
             callee: None,
             local_registers: None,
-            actions_since_timeout_check: 0,
         }
     }
 
@@ -445,9 +439,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         data: &'b SwfSlice,
         reader: &mut Reader<'b>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        self.actions_since_timeout_check += 1;
-        if self.actions_since_timeout_check >= 2000 {
-            self.actions_since_timeout_check = 0;
+        *self.context.actions_since_timeout_check += 1;
+        if *self.context.actions_since_timeout_check >= 2000 {
+            *self.context.actions_since_timeout_check = 0;
             if self.context.update_start.elapsed() >= self.context.max_execution_duration {
                 return Err(Error::ExecutionTimeout);
             }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -166,6 +166,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// The current stage frame rate.
     pub frame_rate: &'a mut f64,
+
+    /// Amount of actions performed since the last timeout check
+    pub actions_since_timeout_check: &'a mut u16,
 }
 
 /// Convenience methods for controlling audio.
@@ -324,6 +327,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             times_get_time_called: self.times_get_time_called,
             time_offset: self.time_offset,
             frame_rate: self.frame_rate,
+            actions_since_timeout_check: self.actions_since_timeout_check,
         }
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -192,6 +192,7 @@ pub struct Player {
     gc_arena: GcArena,
 
     frame_rate: f64,
+    actions_since_timeout_check: u16,
 
     /// A time budget for executing frames.
     /// Gained by passage of time between host frames, spent by executing SWF frames.
@@ -1515,6 +1516,7 @@ impl Player {
                 time_offset: &mut self.time_offset,
                 audio_manager,
                 frame_rate: &mut self.frame_rate,
+                actions_since_timeout_check: &mut self.actions_since_timeout_check,
             };
 
             let old_frame_rate = *update_context.frame_rate;
@@ -1870,6 +1872,7 @@ impl PlayerBuilder {
                 time_offset: 0,
                 time_til_next_timer: None,
                 max_execution_duration: self.max_execution_duration,
+                actions_since_timeout_check: 0,
 
                 // Input
                 input: Default::default(),


### PR DESCRIPTION
We're missing cases (like #554) where the infinite loop is across multiple AVM activations. They'll eat all the memory and crash, instead of being caught by our timeout check.

This seems to match the Flash Player's behaviour more closely too.



(also hi <3)