### PR TITLE
exporter: Multithread exports of directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1218,7 @@ checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 name = "exporter"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "futures",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "image",
  "indicatif",
  "log",
+ "rayon",
  "ruffle_core",
  "ruffle_render_wgpu",
  "walkdir",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,7 +40,7 @@ pub mod tag_utils;
 pub mod timer;
 mod transform;
 mod types;
-mod vminterface;
+pub mod vminterface;
 mod xml;
 
 pub mod backend;

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -14,6 +14,7 @@ image = "0.24.2"
 log = "0.4"
 walkdir = "2.3.2"
 indicatif = "0.17"
+anyhow = "1.0"
 
 [features]
 avm_debug = ["ruffle_core/avm_debug"]

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 walkdir = "2.3.2"
 indicatif = "0.17"
 anyhow = "1.0"
+rayon = "1.5.3"
 
 [features]
 avm_debug = ["ruffle_core/avm_debug"]

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use image::RgbaImage;
 use indicatif::{ProgressBar, ProgressStyle};
+use rayon::prelude::*;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::PlayerBuilder;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
@@ -272,7 +273,7 @@ fn capture_multiple_swfs(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()>
         None
     };
 
-    for file in &files {
+    files.par_iter().try_for_each(|file| -> Result<()> {
         let frames = take_screenshot(
             descriptors.clone(),
             file.path(),
@@ -317,7 +318,9 @@ fn capture_multiple_swfs(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()>
                 image.save(&destination)?;
             }
         }
-    }
+
+        Ok(())
+    })?;
 
     let message = if opt.frames == 1 {
         format!(

--- a/render/wgpu/src/globals.rs
+++ b/render/wgpu/src/globals.rs
@@ -4,7 +4,6 @@ use wgpu::util::DeviceExt;
 
 #[derive(Debug)]
 pub struct Globals {
-    layout: wgpu::BindGroupLayout,
     bind_group: wgpu::BindGroup,
     buffer: wgpu::Buffer,
     viewport_width: u32,
@@ -19,22 +18,7 @@ struct GlobalsUniform {
 }
 
 impl Globals {
-    pub fn new(device: &wgpu::Device) -> Self {
-        let layout_label = create_debug_label!("Globals bind group layout");
-        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: layout_label.as_deref(),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-        });
-
+    pub fn new(device: &wgpu::Device, layout: &wgpu::BindGroupLayout) -> Self {
         let buffer_label = create_debug_label!("Globals buffer");
         let buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: buffer_label.as_deref(),
@@ -58,7 +42,6 @@ impl Globals {
         });
 
         Self {
-            layout,
             bind_group,
             buffer,
             viewport_width: 0,
@@ -101,10 +84,6 @@ impl Globals {
             0,
             std::mem::size_of::<GlobalsUniform>() as u64,
         );
-    }
-
-    pub fn layout(&self) -> &wgpu::BindGroupLayout {
-        &self.layout
     }
 
     pub fn bind_group(&self) -> &wgpu::BindGroup {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -1232,7 +1232,7 @@ fn run_swf(
         );
 
         builder = builder
-            .with_renderer(WgpuRenderBackend::new(descriptors, target)?)
+            .with_renderer(WgpuRenderBackend::new(Arc::new(descriptors), target)?)
             .with_software_video();
     };
 


### PR DESCRIPTION
This changes the Descriptor in wgpu to be immutable and global again, and that allows exporter to reuse it in multiple threads. This speeds it up... a bunch. :D

Error handling is a bit wonky because we're still using `Box<dyn std::error::Error>` a bunch of places in core - that needs to change at some point. I convert them to strings here, just so it can be `Send`.

A possible future change that this unlocks is to reuse a single Descriptor on web, to skip a bit of needless overhead on pages with more than one swf loaded.