### PR TITLE
Fix warnings with cargo doc

### DIFF
--- a/core/src/bitmap.rs
+++ b/core/src/bitmap.rs
@@ -5,7 +5,7 @@ pub mod turbulence;
 /// Determine if a particular bitmap data size is valid.
 ///
 /// This enforces limits on BitmapData as specified in the Flash documentation.
-/// Specifically, from https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/BitmapData.html:
+/// Specifically, from <https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/BitmapData.html>:
 ///
 /// "In AIR 1.5 and Flash Player 10, the maximum size for a BitmapData object
 /// is 8,191 pixels in width or height, and the total number of pixels cannot

--- a/scanner/src/ser_bridge.rs
+++ b/scanner/src/ser_bridge.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 
 /// Parallel-to-serial iterator bridge trait
 ///
-/// Proposed in and copied from https://github.com/rayon-rs/rayon/issues/858
+/// Proposed in and copied from <https://github.com/rayon-rs/rayon/issues/858>
 pub trait SerBridge<T>
 where
     T: Send + 'static,
@@ -24,7 +24,7 @@ where
 
 /// Parallel-to-serial iterator bridge
 ///
-/// Proposed in and copied from https://github.com/rayon-rs/rayon/issues/858
+/// Proposed in and copied from <https://github.com/rayon-rs/rayon/issues/858>
 pub struct SerBridgeImpl<T> {
     rx: crossbeam_channel::Receiver<T>,
 }

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! These structures are documented in the Adobe SWF File Format Specification
 //! version 19 (henceforth SWF19):
-//! https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf
+//! <https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf>
 use crate::string::SwfStr;
 use bitflags::bitflags;
 
@@ -1452,7 +1452,7 @@ pub type JpegTables<'a> = &'a [u8];
 
 /// `ProductInfo` contains information about the software used to generate the SWF.
 /// Not documented in the SWF19 reference. Emitted by mxmlc.
-/// See http://wahlers.com.br/claus/blog/undocumented-swf-tags-written-by-mxmlc/
+/// See <http://wahlers.com.br/claus/blog/undocumented-swf-tags-written-by-mxmlc/>
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProductInfo {
     pub product_id: u32,

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -671,7 +671,7 @@ macro_rules! __wstr_impl_internal {
 
 /// Implements standard traits for `WStr`-like types.
 ///
-/// This macro requires a pre-existing [`Deref<Target=WStr>`][std::ops::Deref] impl, and will emit
+/// This macro requires a pre-existing [`Deref<Target=WStr>`][core::ops::Deref] impl, and will emit
 /// delegating impls for the following traits:
 ///
 ///   - [`AsRef<WStr>`], [`Borrow<WStr>`][core::borrow::Borrow];

--- a/wstr/src/parse.rs
+++ b/wstr/src/parse.rs
@@ -3,7 +3,7 @@ use core::num::Wrapping;
 
 use super::WStr;
 
-/// Analog of [`std::str::FromStr`], but for Ruffle's [`&WStr`].
+/// Analog of [`core::str::FromStr`], but for Ruffle's &[`WStr`].
 pub trait FromWStr: Sized {
     type Err;
 

--- a/wstr/src/pattern.rs
+++ b/wstr/src/pattern.rs
@@ -1,4 +1,4 @@
-//! Like [`std::str::Pattern`], but for [`WStr`].
+//! Like [`core::str::pattern::Pattern`], but for [`WStr`].
 
 // TODO: Is performance good? ideas for improvements:
 //  - add some inlines?


### PR DESCRIPTION
Fixes some warnings when running `cargo doc`, specifically some bare urls and broken intra doc links.