### PR TITLE
avm1: Update drag in stopDrag() in case it wasn't called before

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -976,6 +976,11 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     }
 
     fn action_end_drag(&mut self) -> Result<FrameControl<'gc>, Error<'gc>> {
+        // we might not have had an opportunity to call `update_drag`
+        // if AS did `startDrag(mc);stopDrag();` in one go
+        // so let's do it here
+        crate::player::Player::update_drag(&mut self.context);
+
         *self.context.drag_object = None;
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1084,6 +1084,12 @@ fn stop_drag<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // It doesn't matter which clip we call this on; it simply stops any active drag.
+
+    // we might not have had an opportunity to call `update_drag`
+    // if AS did `startDrag(mc);stopDrag();` in one go
+    // so let's do it here
+    crate::player::Player::update_drag(&mut activation.context);
+
     *activation.context.drag_object = None;
     Ok(Value::Undefined)
 }


### PR DESCRIPTION
Fixes https://github.com/ruffle-rs/ruffle/issues/7587 .

The issue was that the script does
```js
   startDrag(obj,0);
   stopDrag();
   return eval(obj._dropTarget);
```
and we never got the opportunity to call `update_drag()` to set `obj._dropTarget`. I tested that FP7 sets `obj._dropTarget` after `stop` was called (but, weirdly, not immediately after `start` was called).