### PR TITLE
avm2: Introduce StackFrame

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -3,6 +3,7 @@
 use crate::avm2::class::AllocatorFn;
 use crate::avm2::globals::SystemClasses;
 use crate::avm2::method::{Method, NativeMethodImpl};
+use crate::avm2::scope::Scope;
 use crate::avm2::script::{Script, TranslationUnit};
 use crate::context::UpdateContext;
 use crate::string::AvmString;
@@ -70,6 +71,8 @@ pub type Error = Box<dyn std::error::Error>;
 pub struct Avm2<'gc> {
     /// Values currently present on the operand stack.
     stack: Vec<Value<'gc>>,
+
+    scope_stack: Vec<Scope<'gc>>,
 
     /// Global scope object.
     globals: Domain<'gc>,
@@ -150,6 +153,7 @@ impl<'gc> Avm2<'gc> {
 
         Self {
             stack: Vec::new(),
+            scope_stack: Vec::new(),
             globals,
             system_classes: None,
             native_method_table: Default::default(),

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -72,6 +72,7 @@ pub struct Avm2<'gc> {
     /// Values currently present on the operand stack.
     stack: Vec<Value<'gc>>,
 
+    /// Scopes currently present of the scope stack.
     scope_stack: Vec<Scope<'gc>>,
 
     /// Global scope object.

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -371,6 +371,21 @@ impl<'gc> Avm2<'gc> {
         self.globals
     }
 
+    /// Ensures the next stack frame has enough capacity for `max` elements.
+    fn prepare_stack_frame(&mut self, max: usize) {
+        if self.stack.capacity() - self.stack.len() < max {
+            self.stack.reserve(max);
+        }
+    }
+
+    /// Ensures the next scope frame has enough capacity for `max` elements.
+    fn prepare_scope_frame(&mut self, max: usize) {
+        if self.scope_stack.capacity() - self.scope_stack.len() < max {
+            self.scope_stack.reserve(max);
+        }
+    }
+
+    /// Creates a new stack frame at a specific depth with a maximum size.
     fn create_stack_frame<'a>(&'a mut self, depth: usize, max: usize) -> ValueStackFrame<'a, 'gc> {
         debug_assert!(depth <= self.stack.len());
         let show_debug = self.show_debug_output();

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -211,6 +211,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             .get_mut(0)
             .unwrap() = global_object.into();
 
+        context.avm2.prepare_stack_frame(max_stack as usize);
+        context.avm2.prepare_scope_frame(max_scope as usize);
+
         Ok(Self {
             this: Some(global_object),
             arguments: None,
@@ -448,6 +451,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         } else {
             None
         };
+        context.avm2.prepare_stack_frame(body.max_stack as usize);
+        context
+            .avm2
+            .prepare_scope_frame((body.max_scope_depth - body.init_scope_depth) as usize);
 
         let mut activation = Self {
             this,

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -136,12 +136,16 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     /// and we will not allocate a class for one.
     activation_class: Option<ClassObject<'gc>>,
 
+    /// The index where the stack frame starts.
     stack_depth: usize,
 
+    /// The index where the scope frame starts.
     scope_depth: usize,
 
+    /// Maximum size for the stack frame.
     max_stack_size: usize,
 
+    /// Maximum size for the scope frame.
     max_scope_size: usize,
 
     pub context: UpdateContext<'a, 'gc, 'gc_context>,

--- a/core/src/avm2/frame.rs
+++ b/core/src/avm2/frame.rs
@@ -1,0 +1,41 @@
+#[derive(Debug)]
+pub struct StackFrame<'a, T> {
+    stack: &'a mut Vec<T>,
+    depth: usize,
+    max: usize,
+}
+
+impl<'a, T> StackFrame<'a, T> {
+    pub fn new(stack: &'a mut Vec<T>, depth: usize, max: usize) -> Self {
+        Self { stack, depth, max }
+    }
+    pub fn len(&self) -> usize {
+        self.stack.len() - self.depth
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn clear(&mut self) {
+        self.stack.truncate(self.depth);
+    }
+
+    pub fn push(&mut self, value: T) {
+        // TODO: Currently we push anyways when the stack frame exceeds its max size.
+        // This is fine because the worst that can happen is the stack reallocates, but it might
+        // be better to return an error.
+        if self.len() > self.max {
+            log::warn!("Avm2::StackFrame::push overflow");
+        }
+        self.stack.push(value);
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        if !self.is_empty() {
+            self.stack.pop()
+        } else {
+            None
+        }
+    }
+}

--- a/core/src/avm2/names.rs
+++ b/core/src/avm2/names.rs
@@ -398,7 +398,7 @@ impl<'gc> Multiname<'gc> {
                 }
             }
             AbcMultiname::RTQName { name } | AbcMultiname::RTQNameA { name } => {
-                let ns_value = activation.avm2().pop();
+                let ns_value = activation.stack_frame().pop();
                 let ns = ns_value.as_namespace()?;
                 Self {
                     ns: vec![*ns],
@@ -408,8 +408,11 @@ impl<'gc> Multiname<'gc> {
                 }
             }
             AbcMultiname::RTQNameL | AbcMultiname::RTQNameLA => {
-                let name = activation.avm2().pop().coerce_to_string(activation)?;
-                let ns_value = activation.avm2().pop();
+                let name = activation
+                    .stack_frame()
+                    .pop()
+                    .coerce_to_string(activation)?;
+                let ns_value = activation.stack_frame().pop();
                 let ns = ns_value.as_namespace()?;
                 Self {
                     ns: vec![*ns],
@@ -434,7 +437,7 @@ impl<'gc> Multiname<'gc> {
                 params: Vec::new(),
             },
             AbcMultiname::MultinameL { .. } | AbcMultiname::MultinameLA { .. } => {
-                let name = activation.avm2().pop();
+                let name = activation.stack_frame().pop();
                 Self::from_multiname_late(translation_unit, abc_multiname, name, activation)?
             }
             AbcMultiname::TypeName { .. } => {

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -162,65 +162,30 @@ impl<'gc> ScopeChain<'gc> {
     }
 }
 
-/// Represents a ScopeStack to be used in the AVM2 activation. A new ScopeStack should be created
-/// per activation. A ScopeStack allows mutations, such as pushing new scopes, or popping scopes off.
-/// A ScopeStack should only ever be accessed by the activation it was created in.
-#[derive(Debug, Collect, Clone)]
-#[collect(no_drop)]
-pub struct ScopeStack<'gc> {
-    scopes: Vec<Scope<'gc>>,
-}
+/// Searches for a scope in this ScopeStack by a multiname.
+///
+/// The `global` parameter indicates whether we are on global$init (script initializer).
+/// When the `global` parameter is true, the scope at depth 0 is considered the global scope, and is
+/// searched for dynamic properties.
+#[allow(clippy::collapsible_if)]
+pub fn search_scope_stack<'gc>(
+    scopes: &[Scope<'gc>],
+    multiname: &Multiname<'gc>,
+    global: bool,
+) -> Result<Option<Object<'gc>>, Error> {
+    for (depth, scope) in scopes.iter().enumerate().rev() {
+        let values = scope.values();
 
-impl<'gc> ScopeStack<'gc> {
-    pub fn new() -> Self {
-        Self { scopes: Vec::new() }
-    }
-
-    pub fn clear(&mut self) {
-        self.scopes.clear();
-    }
-
-    pub fn push(&mut self, scope: Scope<'gc>) {
-        self.scopes.push(scope);
-    }
-
-    pub fn pop(&mut self) -> Option<Scope<'gc>> {
-        self.scopes.pop()
-    }
-
-    pub fn get(&self, index: usize) -> Option<Scope<'gc>> {
-        self.scopes.get(index).cloned()
-    }
-
-    pub fn scopes(&self) -> &[Scope<'gc>] {
-        &self.scopes
-    }
-
-    /// Searches for a scope in this ScopeStack by a multiname.
-    ///
-    /// The `global` parameter indicates whether we are on global$init (script initializer).
-    /// When the `global` parameter is true, the scope at depth 0 is considered the global scope, and is
-    /// searched for dynamic properties.
-    #[allow(clippy::collapsible_if)]
-    pub fn find(
-        &self,
-        multiname: &Multiname<'gc>,
-        global: bool,
-    ) -> Result<Option<Object<'gc>>, Error> {
-        for (depth, scope) in self.scopes.iter().enumerate().rev() {
-            let values = scope.values();
-
-            if values.has_trait(multiname) {
+        if values.has_trait(multiname) {
+            return Ok(Some(values));
+        } else if scope.with() || (global && depth == 0) {
+            // We search the dynamic properties if either conditions are met:
+            // 1. Scope is a `with` scope
+            // 2. We are at depth 0 AND we are at global$init (script initializer).
+            if values.has_own_property(multiname) {
                 return Ok(Some(values));
-            } else if scope.with() || (global && depth == 0) {
-                // We search the dynamic properties if either conditions are met:
-                // 1. Scope is a `with` scope
-                // 2. We are at depth 0 AND we are at global$init (script initializer).
-                if values.has_own_property(multiname) {
-                    return Ok(Some(values));
-                }
             }
         }
-        Ok(None)
     }
+    Ok(None)
 }


### PR DESCRIPTION
This PR adds a new `StackFrame` type which can be used to represent a frame within a stack. Both the operand/value stack as well as the scope stack will now use this system for memory management. 

In terms of the value/operand stack, here are the differences in behavior this PR makes:
1. Previously in the case of a stack underflow, we had the chance of popping the value from a previous activation - this no longer happens and will now return undefined instead.
2. We now abide by the `max_stack` field in the method body by refusing to grow the stack frame above that maximum. We also use the maximum to guarantee the stack frame has enough room for the upcoming values, avoiding reallocations while the method is running.

In terms of the scope stack, here are the differences this PR makes (there are no differences in behavior, only memory management differences):
1. The scope stack is now shared across AVM2, instead of allocating a new stack per activation, same as the value stack.
2. Similarly to the value stack, we now use the `init_scope_depth` & `max_scope_depth` fields to calculate the maximum scope depth of the activation to guarantee we have enough room for the upcoming values.