### PR TITLE
wgpu: Avoid panics when attempting to create a texture larger than the device supports

### DIFF
--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -107,7 +107,8 @@ fn take_screenshot(
         .unwrap_or_else(|| movie.height().to_pixels());
     let height = (height * size.scale).round() as u32;
 
-    let target = TextureTarget::new(&descriptors.device, (width, height));
+    let target = TextureTarget::new(&descriptors.device, (width, height))
+        .map_err(|e| anyhow!(e.to_string()))?;
     let player = PlayerBuilder::new()
         .with_renderer(
             WgpuRenderBackend::new(descriptors, target).map_err(|e| anyhow!(e.to_string()))?,

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -1232,7 +1232,7 @@ fn run_swf(
                 movie.width().to_pixels() as u32,
                 movie.height().to_pixels() as u32,
             ),
-        );
+        )?;
 
         builder = builder
             .with_renderer(WgpuRenderBackend::new(Arc::new(descriptors), target)?)


### PR DESCRIPTION
Hard to give test cases for this as it's very hardware dependent.