### PR TITLE
avm2: Stub URLRequest.data

### DIFF
--- a/core/src/avm2/globals/flash/net/URLRequest.as
+++ b/core/src/avm2/globals/flash/net/URLRequest.as
@@ -6,6 +6,7 @@ package flash.net {
 		// FIXME - this should be a getter/setter for consistency with Flash
 		public var url:String;
 		private var _method:String;
+		private var _data:Object;
 
 		public function URLRequest(url:String = null) {
 			this.url = url;
@@ -18,6 +19,17 @@ package flash.net {
 		public function set method(newMethod:String):void {
 			// FIXME - perform validation here
 			this._method = newMethod;
+		}
+
+		public function get data():Object {
+			return this._data;
+		}
+
+		public function set data(newData:Object):void {
+			if (newData !== null) {
+				throw new Error("URLRequest.data setter is not yet implemented!");
+			}
+			this._data = newData;
 		}
 	}
 }


### PR DESCRIPTION
This allows Wonderputt to get further (it deliberately assigns
'null' to 'URLRequest.data'). We throw an exception for any other
value, to prevent confusing errors caused by attempting an
unexpected request to a web server with a missig body.