### PR TITLE
avm2: Stub TimerEvent.updateAfterEvent

### DIFF
--- a/core/src/avm2/globals/flash/events/TimerEvent.as
+++ b/core/src/avm2/globals/flash/events/TimerEvent.as
@@ -6,5 +6,9 @@ package flash.events {
 		public function TimerEvent(type:String, bubbles:Boolean = false, cancelable:Boolean= false) {
 			super(type, bubbles, cancelable);
 		}
+
+		public function updateAfterEvent():void {
+			// TODO - determine when we should actually force a frame to be rendered.
+		}
 	}
 }


### PR DESCRIPTION
This is the last stub needed for Wonderputt to reach the
main game screen.

As far as I know, ActionScript cannot observe a frame being rendered,
so implementing this method isn't actually necessary for correctness.

The benefit of implementing this would be to make certain animations
appear smoother, since we'll render changes to the scene without
needing to wait for the next frame. However, actually rendering
*immediately* after the event would require some refactoring -
we have a `&mut UpdateContext` while running timers, but we'd need
to bail out and obtain a `&mut Player`.