### PR TITLE
avm1: Introduce `ScriptObject::new`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -873,7 +873,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             self.base_clip(),
         );
         let name = func.name();
-        let prototype = ScriptObject::object(
+        let prototype = ScriptObject::new(
             self.context.gc_context,
             Some(self.context.avm1.prototypes.object),
         )
@@ -1416,7 +1416,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             // InitArray pops no args and pushes undefined if num_props is out of range.
             Value::Undefined
         } else {
-            let object = ScriptObject::object(
+            let object = ScriptObject::new(
                 self.context.gc_context,
                 Some(self.context.avm1.prototypes.object),
             );

--- a/core/src/avm1/debug.rs
+++ b/core/src/avm1/debug.rs
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn dump_empty_object() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::object(activation.context.gc_context, None);
+            let object = ScriptObject::new(activation.context.gc_context, None);
             assert_eq!(
                 VariableDumper::dump(&object.into(), " ", activation),
                 "[object #0] {}"
@@ -273,8 +273,8 @@ mod tests {
     #[test]
     fn dump_object() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::object(activation.context.gc_context, None);
-            let child = ScriptObject::object(activation.context.gc_context, None);
+            let object = ScriptObject::new(activation.context.gc_context, None);
+            let child = ScriptObject::new(activation.context.gc_context, None);
             object.set("self", object.into(), activation)?;
             object.set("test", "value".into(), activation)?;
             object.set("child", child.into(), activation)?;
@@ -291,8 +291,8 @@ mod tests {
     #[test]
     fn dump_variables() {
         with_avm(19, |activation, _root| -> Result<(), Error> {
-            let object = ScriptObject::object(activation.context.gc_context, None);
-            let child = ScriptObject::object(activation.context.gc_context, None);
+            let object = ScriptObject::new(activation.context.gc_context, None);
+            let child = ScriptObject::new(activation.context.gc_context, None);
             object.set("self", object.into(), activation)?;
             object.set("test", "value".into(), activation)?;
             object.set("child", child.into(), activation)?;

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -506,7 +506,7 @@ impl<'gc> FunctionObject<'gc> {
         constructor: Option<Executable<'gc>>,
         fn_proto: Option<Object<'gc>>,
     ) -> Self {
-        let base = ScriptObject::object(gc_context, fn_proto);
+        let base = ScriptObject::new(gc_context, fn_proto);
 
         FunctionObject {
             base,
@@ -741,7 +741,7 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         prototype: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        let base = ScriptObject::object(activation.context.gc_context, Some(prototype));
+        let base = ScriptObject::new(activation.context.gc_context, Some(prototype));
         let fn_object = FunctionObject {
             base,
             data: GcCell::allocate(

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -693,11 +693,11 @@ pub fn create_globals<'gc>(
     let boolean = boolean::create_boolean_object(gc_context, boolean_proto, Some(function_proto));
     let date = date::create_date_object(gc_context, date_proto, function_proto);
 
-    let flash = ScriptObject::object(gc_context, Some(object_proto));
+    let flash = ScriptObject::new(gc_context, Some(object_proto));
 
-    let geom = ScriptObject::object(gc_context, Some(object_proto));
-    let filters = ScriptObject::object(gc_context, Some(object_proto));
-    let display = ScriptObject::object(gc_context, Some(object_proto));
+    let geom = ScriptObject::new(gc_context, Some(object_proto));
+    let filters = ScriptObject::new(gc_context, Some(object_proto));
+    let display = ScriptObject::new(gc_context, Some(object_proto));
 
     let matrix = matrix::create_matrix_object(gc_context, matrix_proto, Some(function_proto));
     let point = point::create_point_object(gc_context, point_proto, function_proto);
@@ -921,7 +921,7 @@ pub fn create_globals<'gc>(
         Attribute::empty(),
     );
 
-    let external = ScriptObject::object(gc_context, Some(object_proto));
+    let external = ScriptObject::new(gc_context, Some(object_proto));
     let external_interface = external_interface::create_external_interface_object(
         gc_context,
         external_interface_proto,

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -534,7 +534,7 @@ pub fn create_globals<'gc>(
     Object<'gc>,
     as_broadcaster::BroadcasterFunctions<'gc>,
 ) {
-    let object_proto = ScriptObject::object_cell(gc_context, None);
+    let object_proto = ScriptObject::new(gc_context, None).into();
     let function_proto = function::create_proto(gc_context, object_proto);
 
     object::fill_proto(gc_context, object_proto, function_proto);

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -936,7 +936,7 @@ pub fn create_globals<'gc>(
         Attribute::empty(),
     );
 
-    let globals = ScriptObject::bare_object(gc_context);
+    let globals = ScriptObject::new(gc_context, None);
     globals.define_value(
         gc_context,
         "AsBroadcaster",

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -44,7 +44,7 @@ pub fn create_accessibility_object<'gc>(
     proto: Option<Object<'gc>>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let accessibility = ScriptObject::object(gc_context, proto);
+    let accessibility = ScriptObject::new(gc_context, proto);
     define_properties_on(OBJECT_DECLS, gc_context, accessibility, fn_proto);
     accessibility.into()
 }

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -20,7 +20,7 @@ pub fn create<'gc>(
     proto: Option<Object<'gc>>,
     fn_proto: Object<'gc>,
 ) -> (BroadcasterFunctions<'gc>, Object<'gc>) {
-    let object = ScriptObject::object(gc_context, proto);
+    let object = ScriptObject::new(gc_context, proto);
 
     let define_as_object = |index: usize| -> Object<'gc> {
         match OBJECT_DECLS[index].define_on(gc_context, object, fn_proto) {

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -277,7 +277,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -49,7 +49,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -41,7 +41,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }
@@ -89,7 +89,7 @@ fn get_transform<'gc>(
     if let Some(target) = target(activation, this)? {
         let base = target.base();
         let color_transform = base.color_transform();
-        let out = ScriptObject::object(
+        let out = ScriptObject::new(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.object),
         );

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -25,7 +25,7 @@ pub fn constructor<'gc>(
 
     this.set("onSelect", callback.into(), activation)?;
 
-    let built_in_items = ScriptObject::object(
+    let built_in_items = ScriptObject::new(
         activation.context.gc_context,
         Some(activation.context.avm1.prototypes.object),
     );
@@ -142,7 +142,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -94,7 +94,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -31,7 +31,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -80,12 +80,12 @@ pub fn create_external_interface_object<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
     object.into()
 }
 
 pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::object(gc_context, Some(proto)).into()
+    ScriptObject::new(gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -117,8 +117,12 @@ pub fn apply<'gc>(
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
 pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
-    let function_proto = ScriptObject::object_cell(gc_context, Some(proto));
-    let object = function_proto.as_script_object().unwrap();
-    define_properties_on(PROTO_DECLS, gc_context, object, function_proto);
-    function_proto
+    let function_proto = ScriptObject::new(gc_context, Some(proto));
+    define_properties_on(
+        PROTO_DECLS,
+        gc_context,
+        function_proto,
+        function_proto.into(),
+    );
+    function_proto.into()
 }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -31,7 +31,7 @@ pub fn function<'gc>(
         Ok(arg.to_owned())
     } else {
         // Calling `Function()` seems to give a prototypeless bare object.
-        Ok(ScriptObject::object(activation.context.gc_context, None).into())
+        Ok(ScriptObject::new(activation.context.gc_context, None).into())
     }
 }
 

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -72,7 +72,7 @@ pub fn create_key_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let key = ScriptObject::object(gc_context, proto);
+    let key = ScriptObject::new(gc_context, proto);
     broadcaster_functions.initialize(gc_context, key.into(), array_proto);
     define_properties_on(OBJECT_DECLS, gc_context, key, fn_proto);
     key.into()

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -41,7 +41,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -59,7 +59,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/math.rs
+++ b/core/src/avm1/globals/math.rs
@@ -161,7 +161,7 @@ pub fn create<'gc>(
     proto: Option<Object<'gc>>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let math = ScriptObject::object(gc_context, proto);
+    let math = ScriptObject::new(gc_context, proto);
     define_properties_on(OBJECT_DECLS, gc_context, math, fn_proto);
     math.into()
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -477,7 +477,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -37,7 +37,7 @@ pub fn create_mouse_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mouse = ScriptObject::object(gc_context, proto);
+    let mouse = ScriptObject::new(gc_context, proto);
     broadcaster_functions.initialize(gc_context, mouse.into(), array_proto);
     define_properties_on(OBJECT_DECLS, gc_context, mouse, fn_proto);
     mouse.into()

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -170,7 +170,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }
@@ -1213,7 +1213,7 @@ fn get_bounds<'gc>(
             bounds.transform(&bounds_transform)
         };
 
-        let out = ScriptObject::object(
+        let out = ScriptObject::new(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.object),
         );

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -131,7 +131,7 @@ fn get_progress<'gc>(
             }
             _ => return Ok(Value::Undefined),
         };
-        let result = ScriptObject::bare_object(activation.context.gc_context);
+        let result = ScriptObject::new(activation.context.gc_context, None);
         if let Some(target) = target {
             if let Some(movie) = target.movie() {
                 result.define_value(

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -161,7 +161,7 @@ pub fn create_proto<'gc>(
     array_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let mcl_proto = ScriptObject::object(gc_context, Some(proto));
+    let mcl_proto = ScriptObject::new(gc_context, Some(proto));
     broadcaster_functions.initialize(gc_context, mcl_proto.into(), array_proto);
     define_properties_on(PROTO_DECLS, gc_context, mcl_proto, fn_proto);
     mcl_proto.into()

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -46,7 +46,7 @@ pub fn object_function<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let obj = match args.get(0).unwrap_or(&Value::Undefined) {
         Value::Undefined | Value::Null => {
-            Object::from(ScriptObject::object(activation.context.gc_context, None))
+            Object::from(ScriptObject::new(activation.context.gc_context, None))
         }
         val => val.coerce_to_object(activation),
     };

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -305,7 +305,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -708,7 +708,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -148,7 +148,7 @@ pub fn create_selection_object<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     broadcaster_functions.initialize(gc_context, object.into(), array_proto);
     define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
     object.into()
@@ -156,5 +156,5 @@ pub fn create_selection_object<'gc>(
 
 pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::object(gc_context, Some(proto)).into()
+    ScriptObject::new(gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -145,7 +145,7 @@ fn deserialize_value<'gc>(activation: &mut Activation<'_, 'gc, '_>, val: &AmfVal
         }
         AmfValue::Object(elements, _) => {
             // Deserialize Object
-            let obj = ScriptObject::object(
+            let obj = ScriptObject::new(
                 activation.context.gc_context,
                 Some(activation.context.avm1.prototypes.object),
             );
@@ -195,7 +195,7 @@ fn deserialize_lso<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     lso: &Lso,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let obj = ScriptObject::object(
+    let obj = ScriptObject::new(
         activation.context.gc_context,
         Some(activation.context.avm1.prototypes.object),
     );
@@ -362,7 +362,7 @@ pub fn get_local<'gc>(
 
     if data == Value::Undefined {
         // No data; create a fresh data object.
-        data = ScriptObject::object(
+        data = ScriptObject::new(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.object),
         )

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -193,7 +193,7 @@ fn get_transform<'gc>(
     });
 
     if let Some(transform) = transform {
-        let obj = ScriptObject::object(
+        let obj = ScriptObject::new(
             activation.context.gc_context,
             Some(activation.context.avm1.prototypes.object),
         );

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -27,7 +27,7 @@ pub fn create_stage_object<'gc>(
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let stage = ScriptObject::object(gc_context, proto);
+    let stage = ScriptObject::new(gc_context, proto);
     broadcaster_functions.initialize(gc_context, stage.into(), array_proto.unwrap());
     define_properties_on(OBJECT_DECLS, gc_context, stage, fn_proto);
     stage.into()

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -523,7 +523,7 @@ pub fn create<'gc>(
     capabilities: Object<'gc>,
     ime: Object<'gc>,
 ) -> Object<'gc> {
-    let system = ScriptObject::object(gc_context, proto);
+    let system = ScriptObject::new(gc_context, proto);
     define_properties_on(OBJECT_DECLS, gc_context, system, fn_proto);
     system.define_value(gc_context, "IME", ime.into(), Attribute::empty());
     system.define_value(gc_context, "security", security.into(), Attribute::empty());

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -254,7 +254,7 @@ pub fn create<'gc>(
     proto: Option<Object<'gc>>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let capabilities = ScriptObject::object(gc_context, proto);
+    let capabilities = ScriptObject::new(gc_context, proto);
     define_properties_on(OBJECT_DECLS, gc_context, capabilities, fn_proto);
     capabilities.into()
 }

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -86,7 +86,7 @@ pub fn create<'gc>(
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let ime = ScriptObject::object(gc_context, proto);
+    let ime = ScriptObject::new(gc_context, proto);
     broadcaster_functions.initialize(gc_context, ime.into(), array_proto);
     define_properties_on(OBJECT_DECLS, gc_context, ime, fn_proto);
     ime.into()

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -100,7 +100,7 @@ pub fn create<'gc>(
     proto: Option<Object<'gc>>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let security = ScriptObject::object(gc_context, proto);
+    let security = ScriptObject::new(gc_context, proto);
     define_properties_on(OBJECT_DECLS, gc_context, security, fn_proto);
     security.into()
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -99,7 +99,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -21,6 +21,6 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     _fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::object(gc_context, Some(proto));
+    let object = ScriptObject::new(gc_context, Some(proto));
     object.into()
 }

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -397,7 +397,7 @@ pub fn create_proto<'gc>(
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_node_proto = ScriptObject::object(gc_context, Some(proto));
+    let xml_node_proto = ScriptObject::new(gc_context, Some(proto));
     define_properties_on(PROTO_DECLS, gc_context, xml_node_proto, fn_proto);
     xml_node_proto.into()
 }

--- a/core/src/avm1/object/array_object.rs
+++ b/core/src/avm1/object/array_object.rs
@@ -40,7 +40,7 @@ impl<'gc> ArrayObject<'gc> {
         proto: Object<'gc>,
         elements: impl IntoIterator<Item = Value<'gc>>,
     ) -> Self {
-        let base = ScriptObject::object(gc_context, Some(proto));
+        let base = ScriptObject::new(gc_context, Some(proto));
         let mut length: i32 = 0;
         for value in elements.into_iter() {
             let length_str = AvmString::new_utf8(gc_context, length.to_string());

--- a/core/src/avm1/object/bevel_filter.rs
+++ b/core/src/avm1/object/bevel_filter.rs
@@ -101,7 +101,7 @@ impl<'gc> BevelFilterObject<'gc> {
         BevelFilterObject(GcCell::allocate(
             gc_context,
             BevelFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 angle: 44.9999999772279,
                 blur_x: 4.0,
                 blur_y: 4.0,

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -48,7 +48,7 @@ impl<'gc> BitmapDataObject<'gc> {
         Self(GcCell::allocate(
             gc_context,
             BitmapDataData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 disposed: false,
                 data: GcCell::allocate(gc_context, bitmap_data),
             },

--- a/core/src/avm1/object/blur_filter.rs
+++ b/core/src/avm1/object/blur_filter.rs
@@ -43,7 +43,7 @@ impl<'gc> BlurFilterObject<'gc> {
         BlurFilterObject(GcCell::allocate(
             gc_context,
             BlurFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 blur_x: 4.0,
                 blur_y: 4.0,
                 quality: 1,

--- a/core/src/avm1/object/color_matrix_filter.rs
+++ b/core/src/avm1/object/color_matrix_filter.rs
@@ -35,7 +35,7 @@ impl<'gc> ColorMatrixFilterObject<'gc> {
         ColorMatrixFilterObject(GcCell::allocate(
             gc_context,
             ColorMatrixFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 matrix: [
                     1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
                     0.0, 0.0, 1.0, 0.0,

--- a/core/src/avm1/object/color_transform_object.rs
+++ b/core/src/avm1/object/color_transform_object.rs
@@ -42,7 +42,7 @@ impl<'gc> ColorTransformObject<'gc> {
         ColorTransformObject(GcCell::allocate(
             gc_context,
             ColorTransformData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 params: ColorTransformParams {
                     red_multiplier: 0.0,
                     green_multiplier: 0.0,

--- a/core/src/avm1/object/convolution_filter.rs
+++ b/core/src/avm1/object/convolution_filter.rs
@@ -83,7 +83,7 @@ impl<'gc> ConvolutionFilterObject<'gc> {
         ConvolutionFilterObject(GcCell::allocate(
             gc_context,
             ConvolutionFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 alpha: 0.0,
                 bias: 0.0,
                 clamp: true,

--- a/core/src/avm1/object/date_object.rs
+++ b/core/src/avm1/object/date_object.rs
@@ -44,7 +44,7 @@ impl<'gc> DateObject<'gc> {
         DateObject(GcCell::allocate(
             gc_context,
             DateObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 date_time,
             },
         ))

--- a/core/src/avm1/object/displacement_map_filter.rs
+++ b/core/src/avm1/object/displacement_map_filter.rs
@@ -97,7 +97,7 @@ impl<'gc> DisplacementMapFilterObject<'gc> {
         DisplacementMapFilterObject(GcCell::allocate(
             gc_context,
             DisplacementMapFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 alpha: 0.0,
                 color: 0,
                 component_x: 0,

--- a/core/src/avm1/object/drop_shadow_filter.rs
+++ b/core/src/avm1/object/drop_shadow_filter.rs
@@ -67,7 +67,7 @@ impl<'gc> DropShadowFilterObject<'gc> {
         DropShadowFilterObject(GcCell::allocate(
             gc_context,
             DropShadowFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 distance: 4.0,
                 hide_object: false,
                 angle: 44.9999999772279,

--- a/core/src/avm1/object/glow_filter.rs
+++ b/core/src/avm1/object/glow_filter.rs
@@ -58,7 +58,7 @@ impl<'gc> GlowFilterObject<'gc> {
         GlowFilterObject(GcCell::allocate(
             gc_context,
             GlowFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 alpha: 1.0,
                 blur_x: 6.0,
                 blur_y: 6.0,

--- a/core/src/avm1/object/gradient_bevel_filter.rs
+++ b/core/src/avm1/object/gradient_bevel_filter.rs
@@ -80,7 +80,7 @@ impl<'gc> GradientBevelFilterObject<'gc> {
         GradientBevelFilterObject(GcCell::allocate(
             gc_context,
             GradientBevelFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 alphas: vec![],
                 angle: 0.0,
                 blur_x: 0.0,

--- a/core/src/avm1/object/gradient_glow_filter.rs
+++ b/core/src/avm1/object/gradient_glow_filter.rs
@@ -80,7 +80,7 @@ impl<'gc> GradientGlowFilterObject<'gc> {
         GradientGlowFilterObject(GcCell::allocate(
             gc_context,
             GradientGlowFilterData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 alphas: vec![],
                 angle: 0.0,
                 blur_x: 0.0,

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -87,15 +87,6 @@ impl<'gc> ScriptObject<'gc> {
         object
     }
 
-    /// Constructs an object with no properties, not even builtins.
-    ///
-    /// Intended for constructing scope chains, since they exclusively use the
-    /// object properties, but can't just have a hashmap because of `with` and
-    /// friends.
-    pub fn bare_object(gc_context: MutationContext<'gc, '_>) -> Self {
-        Self::new(gc_context, None)
-    }
-
     /// Gets the value of a data property on this object.
     ///
     /// Doesn't look up the prototype chain and ignores virtual properties, thus cannot cause

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -87,14 +87,6 @@ impl<'gc> ScriptObject<'gc> {
         object
     }
 
-    /// Constructs and allocates an empty but normal object in one go.
-    pub fn object_cell(
-        gc_context: MutationContext<'gc, '_>,
-        proto: Option<Object<'gc>>,
-    ) -> Object<'gc> {
-        Self::new(gc_context, proto).into()
-    }
-
     /// Constructs an object with no properties, not even builtins.
     ///
     /// Intended for constructing scope chains, since they exclusively use the

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -67,7 +67,7 @@ impl fmt::Debug for ScriptObjectData<'_> {
 }
 
 impl<'gc> ScriptObject<'gc> {
-    pub fn object(gc_context: MutationContext<'gc, '_>, proto: Option<Object<'gc>>) -> Self {
+    pub fn new(gc_context: MutationContext<'gc, '_>, proto: Option<Object<'gc>>) -> Self {
         let object = Self(GcCell::allocate(
             gc_context,
             ScriptObjectData {
@@ -92,7 +92,7 @@ impl<'gc> ScriptObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         proto: Option<Object<'gc>>,
     ) -> Object<'gc> {
-        Self::object(gc_context, proto).into()
+        Self::new(gc_context, proto).into()
     }
 
     /// Constructs an object with no properties, not even builtins.
@@ -101,7 +101,7 @@ impl<'gc> ScriptObject<'gc> {
     /// object properties, but can't just have a hashmap because of `with` and
     /// friends.
     pub fn bare_object(gc_context: MutationContext<'gc, '_>) -> Self {
-        Self::object(gc_context, None)
+        Self::new(gc_context, None)
     }
 
     /// Gets the value of a data property on this object.
@@ -265,7 +265,7 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         activation: &mut Activation<'_, 'gc, '_>,
         this: Object<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        Ok(ScriptObject::object(activation.context.gc_context, Some(this)).into())
+        Ok(ScriptObject::new(activation.context.gc_context, Some(this)).into())
     }
 
     /// Delete a named property from the object.
@@ -558,7 +558,7 @@ mod tests {
         F: for<'a, 'gc> FnOnce(&mut Activation<'_, 'gc, '_>, Object<'gc>),
     {
         crate::avm1::test_utils::with_avm(swf_version, |activation, _root| {
-            let object = ScriptObject::object(
+            let object = ScriptObject::new(
                 activation.context.gc_context,
                 Some(activation.context.avm1.prototypes().object),
             )

--- a/core/src/avm1/object/shared_object.rs
+++ b/core/src/avm1/object/shared_object.rs
@@ -37,7 +37,7 @@ impl<'gc> SharedObject<'gc> {
         SharedObject(GcCell::allocate(
             gc_context,
             SharedObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 name: None,
             },
         ))

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -58,7 +58,7 @@ impl<'gc> SoundObject<'gc> {
         SoundObject(GcCell::allocate(
             gc_context,
             SoundObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 sound: None,
                 sound_instance: None,
                 owner: None,

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -43,7 +43,7 @@ impl<'gc> StageObject<'gc> {
         Self(GcCell::allocate(
             gc_context,
             StageObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 display_object,
                 text_field_bindings: Vec::new(),
             },

--- a/core/src/avm1/object/text_format_object.rs
+++ b/core/src/avm1/object/text_format_object.rs
@@ -32,7 +32,7 @@ impl<'gc> TextFormatObject<'gc> {
         Self(GcCell::allocate(
             gc_context,
             TextFormatData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 text_format: TextFormat::default(),
             },
         ))
@@ -42,7 +42,7 @@ impl<'gc> TextFormatObject<'gc> {
         Self(GcCell::allocate(
             activation.context.gc_context,
             TextFormatData {
-                base: ScriptObject::object(
+                base: ScriptObject::new(
                     activation.context.gc_context,
                     Some(activation.context.avm1.prototypes.text_format),
                 ),

--- a/core/src/avm1/object/transform_object.rs
+++ b/core/src/avm1/object/transform_object.rs
@@ -31,7 +31,7 @@ impl<'gc> TransformObject<'gc> {
         Self(GcCell::allocate(
             gc_context,
             TransformData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 clip: None,
             },
         ))

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -51,7 +51,7 @@ impl<'gc> ValueObject<'gc> {
             let obj = ValueObject(GcCell::allocate(
                 activation.context.gc_context,
                 ValueObjectData {
-                    base: ScriptObject::object(activation.context.gc_context, proto),
+                    base: ScriptObject::new(activation.context.gc_context, proto),
                     value: Value::Undefined,
                 },
             ));
@@ -86,7 +86,7 @@ impl<'gc> ValueObject<'gc> {
         ValueObject(GcCell::allocate(
             gc_context,
             ValueObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 value: Value::Undefined,
             },
         ))

--- a/core/src/avm1/object/xml_node_object.rs
+++ b/core/src/avm1/object/xml_node_object.rs
@@ -31,7 +31,7 @@ impl<'gc> XmlNodeObject<'gc> {
         let object = Self(GcCell::allocate(
             gc_context,
             XmlNodeObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 node,
             },
         ));

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -89,7 +89,7 @@ impl<'gc> XmlObject<'gc> {
                 root,
                 xml_decl: None,
                 doctype: None,
-                id_map: ScriptObject::bare_object(gc_context),
+                id_map: ScriptObject::new(gc_context, None),
                 status: XmlStatus::NoError,
             },
         ));

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -85,7 +85,7 @@ impl<'gc> XmlObject<'gc> {
         let object = Self(GcCell::allocate(
             gc_context,
             XmlObjectData {
-                base: ScriptObject::object(gc_context, proto),
+                base: ScriptObject::new(gc_context, proto),
                 root,
                 xml_decl: None,
                 doctype: None,

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -52,7 +52,7 @@ impl<'gc> Scope<'gc> {
         Scope {
             parent: Some(parent),
             class: ScopeClass::Local,
-            values: ScriptObject::object_cell(mc, None),
+            values: ScriptObject::new(mc, None).into(),
         }
     }
 
@@ -104,7 +104,7 @@ impl<'gc> Scope<'gc> {
                 Self {
                     parent: None,
                     class: ScopeClass::Global,
-                    values: ScriptObject::object_cell(mc, None),
+                    values: ScriptObject::new(mc, None).into(),
                 },
             )
         })

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -889,7 +889,7 @@ mod test {
                 protos.function,
             );
 
-            let o = ScriptObject::object_cell(activation.context.gc_context, Some(protos.object));
+            let o = ScriptObject::new(activation.context.gc_context, Some(protos.object));
             o.define_value(
                 activation.context.gc_context,
                 "valueOf",
@@ -898,7 +898,7 @@ mod test {
             );
 
             assert_eq!(
-                Value::Object(o).to_primitive_num(activation).unwrap(),
+                Value::from(o).to_primitive_num(activation).unwrap(),
                 5.into()
             );
 

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -920,9 +920,9 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert!(n.coerce_to_f64(activation).unwrap().is_nan());
 
-            let bo = Value::Object(ScriptObject::bare_object(activation.context.gc_context).into());
+            let o = ScriptObject::new(activation.context.gc_context, None);
 
-            assert!(bo.coerce_to_f64(activation).unwrap().is_nan());
+            assert!(Value::from(o).coerce_to_f64(activation).unwrap().is_nan());
 
             Ok(())
         });
@@ -942,9 +942,9 @@ mod test {
             assert_eq!(f.coerce_to_f64(activation).unwrap(), 0.0);
             assert_eq!(n.coerce_to_f64(activation).unwrap(), 0.0);
 
-            let bo = Value::Object(ScriptObject::bare_object(activation.context.gc_context).into());
+            let o = ScriptObject::new(activation.context.gc_context, None);
 
-            assert_eq!(bo.coerce_to_f64(activation).unwrap(), 0.0);
+            assert_eq!(Value::from(o).coerce_to_f64(activation).unwrap(), 0.0);
 
             Ok(())
         });

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -162,7 +162,7 @@ impl Value {
                 Avm1Value::String(AvmString::new_utf8(activation.context.gc_context, value))
             }
             Value::Object(values) => {
-                let object = Avm1ScriptObject::object(
+                let object = Avm1ScriptObject::new(
                     activation.context.gc_context,
                     Some(activation.context.avm1.prototypes().object),
                 );

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -302,7 +302,7 @@ impl Player {
 
             root.set_depth(context.gc_context, 0);
             let flashvars = if !context.swf.parameters().is_empty() {
-                let object = ScriptObject::object(context.gc_context, None);
+                let object = ScriptObject::new(context.gc_context, None);
                 for (key, value) in context.swf.parameters().iter() {
                     object.define_value(
                         context.gc_context,

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -65,7 +65,7 @@ impl<'gc> XmlNode<'gc> {
                 next_sibling: None,
                 node_type,
                 node_value,
-                attributes: ScriptObject::bare_object(mc),
+                attributes: ScriptObject::new(mc, None),
                 children: Vec::new(),
             },
         ))
@@ -379,7 +379,7 @@ impl<'gc> XmlNode<'gc> {
     ///
     /// If the `deep` flag is set true, then the entire node tree will be cloned.
     pub fn duplicate(self, gc_context: MutationContext<'gc, '_>, deep: bool) -> Self {
-        let attributes = ScriptObject::bare_object(gc_context);
+        let attributes = ScriptObject::new(gc_context, None);
         for (key, value) in self.attributes().own_properties() {
             attributes.define_value(gc_context, key, value, Attribute::empty());
         }


### PR DESCRIPTION
1. Rename `ScriptObject::object` to `ScriptObject::new`.
2. Replace the few `ScriptObject::object_cell` and `ScriptObject::bare_object` callers to use `ScriptObject::new` instead.