### PR TITLE
render: Disable most blend modes

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -374,7 +374,7 @@ impl<'gc> DisplayObjectBase<'gc> {
     fn set_blend_mode(&mut self, value: BlendMode) {
         if value != BlendMode::Normal {
             log::warn!(
-                "Blend mode '{}' is experimental and will not render 100% correctly.",
+                "Blend mode '{}' is unsupported and will not render correctly.",
                 value
             );
         }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -666,64 +666,17 @@ impl WebGlRenderBackend {
                 // src + (1-a)
                 (Gl::FUNC_ADD, Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA)
             }
-            BlendMode::Layer => {
-                // TODO: Needs intermediate buffer.
-                (Gl::FUNC_ADD, Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA)
-            }
-            BlendMode::Multiply => {
-                // src * dst
-                (Gl::FUNC_ADD, Gl::DST_COLOR, Gl::ZERO)
-            }
-            BlendMode::Screen => {
-                // 1 - (1 - src) * (1 - dst)
-                // TODO: Needs shader. Rendering as additive for now
-                (Gl::FUNC_ADD, Gl::ONE, Gl::ONE)
-            }
-            BlendMode::Lighten => {
-                // max(src, dst)
-                (Gl2::MAX, Gl::ONE, Gl::ONE)
-            }
-            BlendMode::Darken => {
-                // min(src, dst)
-                (Gl2::MIN, Gl::ONE, Gl::ONE)
-            }
-            BlendMode::Difference => {
-                // abs(src - dst)
-                (Gl::FUNC_REVERSE_SUBTRACT, Gl::ONE, Gl::ONE)
-            }
             BlendMode::Add => {
-                // abs(src - dst)
+                // src + dst
                 (Gl::FUNC_ADD, Gl::ONE, Gl::ONE)
             }
             BlendMode::Subtract => {
-                // abs(src - dst)
+                // dst - src
                 (Gl::FUNC_REVERSE_SUBTRACT, Gl::ONE, Gl::ONE)
             }
-            BlendMode::Invert => {
-                // 1 - dst
-                (Gl::FUNC_ADD, Gl::ONE, Gl::ONE)
-            }
-            BlendMode::Alpha => {
-                // dst.a = src.a
-                // TODO: Unimplemeneted, needs intermediate buffer.
-                // Parent display object needs to have Layer blend mode.
+            _ => {
+                // TODO: Unsupported blend mode. Default to normal for now.
                 (Gl::FUNC_ADD, Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA)
-            }
-            BlendMode::Erase => {
-                // dst.a = 1 - src.a
-                // TODO: Unimplemeneted, needs intermediate buffer.
-                // Parent display object needs to have Layer blend mode.
-                (Gl::FUNC_ADD, Gl::ONE, Gl::ONE_MINUS_SRC_ALPHA)
-            }
-            BlendMode::HardLight => {
-                // if src > .5 { 1 - (1 - dst) * (1 - src) } else { dst * src }
-                // TODO: Needs shader, rendered as multiply for now.
-                (Gl::FUNC_ADD, Gl::DST_COLOR, Gl::ZERO)
-            }
-            BlendMode::Overlay => {
-                // if dst > .5 { 1 - (1 - dst) * (1 - src) } else { dst * src }
-                // TODO: Needs shader, rendered as multiply for now.
-                (Gl::FUNC_ADD, Gl::DST_COLOR, Gl::ZERO)
             }
         };
         self.gl.blend_equation_separate(blend_op, Gl::FUNC_ADD);

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -65,64 +65,6 @@ fn blend_mode_to_state(mode: BlendMode) -> Option<wgpu::BlendState> {
     match mode {
         BlendMode::Normal => Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
 
-        // TODO: Needs intermediate buffer.
-        BlendMode::Layer => Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-
-        // dst * src
-        BlendMode::Multiply => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::Dst,
-                dst_factor: wgpu::BlendFactor::Zero,
-                operation: wgpu::BlendOperation::Add,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
-
-        // 1 - (1 - dst) * (1 - src)
-        // TODO: Needs shader. Rendererd as additive for now.
-        BlendMode::Screen => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::One,
-                dst_factor: wgpu::BlendFactor::One,
-                operation: wgpu::BlendOperation::Add,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
-
-        // max(dst, src)
-        BlendMode::Lighten => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::One,
-                dst_factor: wgpu::BlendFactor::One,
-                operation: wgpu::BlendOperation::Max,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
-
-        // min(dst, src)
-        BlendMode::Darken => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::One,
-                dst_factor: wgpu::BlendFactor::One,
-                operation: wgpu::BlendOperation::Min,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
-
-        // abs(dst - src)
-        // TODO: Needs shader. Rendererd as subtract for now.
-        BlendMode::Difference => {
-            Some(wgpu::BlendState {
-                // Add src and dst RGB values together
-                color: wgpu::BlendComponent {
-                    src_factor: wgpu::BlendFactor::One,
-                    dst_factor: wgpu::BlendFactor::One,
-                    operation: wgpu::BlendOperation::ReverseSubtract,
-                },
-                alpha: wgpu::BlendComponent::OVER,
-            })
-        }
-
         // dst + src
         BlendMode::Add => Some(wgpu::BlendState {
             color: wgpu::BlendComponent {
@@ -143,47 +85,10 @@ fn blend_mode_to_state(mode: BlendMode) -> Option<wgpu::BlendState> {
             alpha: wgpu::BlendComponent::OVER,
         }),
 
-        // 1 - dst
-        BlendMode::Invert => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::Zero,
-                dst_factor: wgpu::BlendFactor::OneMinusDst,
-                operation: wgpu::BlendOperation::Add,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
-
-        // TODO: Requires intermediate buffer.
-        // dst.alpha = src.alpha
-        // Parent display object needs to have Layer blend mode.
-        BlendMode::Alpha => Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-
-        // TODO: Requires intermediate buffer.
-        // dst.alpha = 1 - src.alpha
-        // Parent display object needs to have Layer blend mode.
-        BlendMode::Erase => Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
-
-        // if src > .5 { 1 - (1 - dst) * (1 - src) } else { dst * src }
-        // TODO: Needs shader, rendered as multiply for now.
-        BlendMode::HardLight => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::Dst,
-                dst_factor: wgpu::BlendFactor::Zero,
-                operation: wgpu::BlendOperation::Add,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
-
-        // if dst > .5 { 1 - (1 - dst) * (1 - src) } else { dst * src }
-        // TODO: Needs shader, rendered as multiply for now.
-        BlendMode::Overlay => Some(wgpu::BlendState {
-            color: wgpu::BlendComponent {
-                src_factor: wgpu::BlendFactor::Dst,
-                dst_factor: wgpu::BlendFactor::Zero,
-                operation: wgpu::BlendOperation::Add,
-            },
-            alpha: wgpu::BlendComponent::OVER,
-        }),
+        _ => {
+            // Unsupported blend mode. Default to normal for now.
+            Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING)
+        }
     }
 }
 


### PR DESCRIPTION
Got a little too zealous in #7484. Avoid blend modes except ADD and SUBTRACT until they can be implemented properly.