### PR TITLE
core: Made SwfSlice methods always return something valid

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -861,7 +861,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         parent_data: &SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let swf_version = self.swf_version();
-        let func_data = parent_data.to_unbounded_subslice(action.actions).unwrap();
+        let func_data = parent_data.to_unbounded_subslice(action.actions);
         let constant_pool = self.constant_pool();
         let func = Avm1Function::from_swf_function(
             self.context.gc_context,
@@ -2124,8 +2124,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         action: &Try,
         parent_data: &SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let mut result =
-            self.run_actions(parent_data.to_unbounded_subslice(action.try_body).unwrap());
+        let mut result = self.run_actions(parent_data.to_unbounded_subslice(action.try_body));
 
         if let Some((catch_vars, actions)) = &action.catch_body {
             if let Err(Error::ThrownValue(value)) = &result {
@@ -2151,14 +2150,13 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                     }
                 }
 
-                result =
-                    activation.run_actions(parent_data.to_unbounded_subslice(actions).unwrap());
+                result = activation.run_actions(parent_data.to_unbounded_subslice(actions));
             }
         }
 
         if let Some(actions) = action.finally_body {
             if let ReturnType::Explicit(value) =
-                self.run_actions(parent_data.to_unbounded_subslice(actions).unwrap())?
+                self.run_actions(parent_data.to_unbounded_subslice(actions))?
             {
                 return Ok(FrameControl::Return(ReturnType::Explicit(value)));
             }
@@ -2212,7 +2210,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         action: With,
         parent_data: &SwfSlice,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let code = parent_data.to_unbounded_subslice(action.actions).unwrap();
+        let code = parent_data.to_unbounded_subslice(action.actions);
         let value = self.context.avm1.pop();
         match value {
             // Undefined/null with is ignored.

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -279,16 +279,12 @@ impl<'gc> Avm2<'gc> {
         let num_read = reader.pos(start);
 
         // The rest of the tag is an ABC file so we can take our SwfSlice now.
-        let slice = swf
-            .resize_to_reader(reader, tag_len - num_read)
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Invalid source or tag length when running init action",
-                )
-            })?;
+        let slice = swf.resize_to_reader(reader, tag_len - num_read);
 
-        Avm2::load_abc(slice, &name, is_lazy_initialize, context, domain)?;
+        if !slice.is_empty() {
+            Avm2::load_abc(slice, &name, is_lazy_initialize, context, domain)?;
+        }
+
         Ok(())
     }
 

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -306,7 +306,7 @@ impl Iterator for StreamTagReader {
                             self.mp3_samples_buffered += i32::from(num_samples);
                             audio_block = &audio_block[4..];
                         }
-                        *audio_data = swf_data.to_subslice(audio_block).unwrap();
+                        *audio_data = swf_data.to_subslice(audio_block);
                         Ok(())
                     }
                     TagCode::ShowFrame if compression == AudioCompression::Mp3 => {

--- a/core/src/binary_data.rs
+++ b/core/src/binary_data.rs
@@ -5,6 +5,6 @@ pub type BinaryData = SwfSlice;
 
 impl BinaryData {
     pub fn from_swf_tag(movie: Arc<SwfMovie>, tag: &swf::DefineBinaryData) -> Self {
-        SwfSlice::from(movie).to_subslice(tag.data).unwrap()
+        SwfSlice::from(movie).to_subslice(tag.data)
     }
 }

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -46,9 +46,7 @@ impl<'gc> Avm1Button<'gc> {
     ) -> Self {
         let mut actions = vec![];
         for action in &button.actions {
-            let action_data = source_movie
-                .to_unbounded_subslice(action.action_data)
-                .unwrap();
+            let action_data = source_movie.to_unbounded_subslice(action.action_data);
             let bits = action.conditions.bits();
             let mut bit = 1u16;
             while bits & !(bit - 1) != 0 {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3563,9 +3563,7 @@ impl ClipEventHandler {
         } else {
             ButtonKeyCode::Unknown
         };
-        let action_data = SwfSlice::from(movie)
-            .to_unbounded_subslice(other.action_data)
-            .unwrap();
+        let action_data = SwfSlice::from(movie).to_unbounded_subslice(other.action_data);
         Self {
             events: other.events,
             key_code,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3291,13 +3291,7 @@ impl<'gc, 'a> MovieClip<'gc> {
                 let slice = mc
                     .static_data
                     .swf
-                    .to_start_and_end(mc.tag_stream_pos as usize, mc.tag_stream_len())
-                    .ok_or_else(|| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            "Invalid slice generated when constructing sound stream block",
-                        )
-                    })?;
+                    .to_start_and_end(mc.tag_stream_pos as usize, mc.tag_stream_len());
                 let audio_stream = context.start_stream(
                     mc.static_data.audio_stream_handle,
                     self,

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -143,11 +143,7 @@ impl<'gc> Video<'gc> {
                     log::warn!("Duplicate frame {}", tag.frame_num);
                 }
 
-                if let Some(subslice) = subslice {
-                    frames.insert(tag.frame_num.into(), (subslice.start, subslice.end));
-                } else {
-                    log::warn!("Invalid bitstream subslice on frame {}", tag.frame_num);
-                }
+                frames.insert(tag.frame_num.into(), (subslice.start, subslice.end));
             }
         }
     }

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -224,19 +224,19 @@ impl SwfSlice {
     ///
     /// This function allows subslices outside the current slice to be formed,
     /// as long as they are valid subslices of the movie itself.
-    pub fn to_unbounded_subslice(&self, slice: &[u8]) -> Option<Self> {
+    pub fn to_unbounded_subslice(&self, slice: &[u8]) -> Self {
         let self_pval = self.movie.data().as_ptr() as usize;
         let self_len = self.movie.data().len();
         let slice_pval = slice.as_ptr() as usize;
 
         if self_pval <= slice_pval && slice_pval < (self_pval + self_len) {
-            Some(Self {
+            Self {
                 movie: self.movie.clone(),
                 start: slice_pval - self_pval,
                 end: (slice_pval - self_pval) + slice.len(),
-            })
+            }
         } else {
-            None
+            self.copy_empty()
         }
     }
 

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -195,6 +195,12 @@ impl SwfSlice {
         }
     }
 
+    /// Creates an empty SwfSlice of the same movie.
+    #[inline]
+    pub fn copy_empty(&self) -> Self {
+        Self::empty(self.movie.clone())
+    }
+
     /// Construct a new SwfSlice from a regular slice.
     ///
     /// This function returns None if the given slice is not a subslice of the
@@ -273,17 +279,22 @@ impl SwfSlice {
     /// Construct a new SwfSlice from a start and an end.
     ///
     /// The start and end values will be relative to the current slice.
-    /// Furthermore, this function will yield None if the calculated slice
+    /// Furthermore, this function will yield an empty slice if the calculated slice
     /// would be invalid (e.g. negative length) or would extend past the end of
     /// the current slice.
-    pub fn to_start_and_end(&self, start: usize, end: usize) -> Option<Self> {
+    pub fn to_start_and_end(&self, start: usize, end: usize) -> Self {
         let new_start = self.start + start;
         let new_end = self.start + end;
 
         if new_start <= new_end {
-            self.to_subslice(self.movie.data().get(new_start..new_end)?)
+            if let Some(result) = self.movie.data().get(new_start..new_end) {
+                self.to_subslice(result)
+                    .unwrap_or_else(|| self.copy_empty())
+            } else {
+                self.copy_empty()
+            }
         } else {
-            None
+            self.copy_empty()
         }
     }
 

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -205,18 +205,18 @@ impl SwfSlice {
     ///
     /// This function returns None if the given slice is not a subslice of the
     /// current slice.
-    pub fn to_subslice(&self, slice: &[u8]) -> Option<Self> {
+    pub fn to_subslice(&self, slice: &[u8]) -> Self {
         let self_pval = self.movie.data().as_ptr() as usize;
         let slice_pval = slice.as_ptr() as usize;
 
         if (self_pval + self.start) <= slice_pval && slice_pval < (self_pval + self.end) {
-            Some(Self {
+            Self {
                 movie: self.movie.clone(),
                 start: slice_pval - self_pval,
                 end: (slice_pval - self_pval) + slice.len(),
-            })
+            }
         } else {
-            None
+            self.copy_empty()
         }
     }
 
@@ -289,7 +289,6 @@ impl SwfSlice {
         if new_start <= new_end {
             if let Some(result) = self.movie.data().get(new_start..new_end) {
                 self.to_subslice(result)
-                    .unwrap_or_else(|| self.copy_empty())
             } else {
                 self.copy_empty()
             }

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -249,8 +249,8 @@ impl SwfSlice {
     /// The returned slice may or may not be a subslice of the current slice.
     /// If the resulting slice would be outside the bounds of the underlying
     /// movie, or the given reader refers to a different underlying movie, this
-    /// function returns None.
-    pub fn resize_to_reader(&self, reader: &mut SwfStream<'_>, size: usize) -> Option<Self> {
+    /// function returns an empty slice.
+    pub fn resize_to_reader(&self, reader: &mut SwfStream<'_>, size: usize) -> Self {
         if self.movie.data().as_ptr() as usize <= reader.get_ref().as_ptr() as usize
             && (reader.get_ref().as_ptr() as usize)
                 < self.movie.data().as_ptr() as usize + self.movie.data().len()
@@ -263,16 +263,16 @@ impl SwfSlice {
             let len = self.movie.data().len();
 
             if new_start < len && new_end < len {
-                Some(Self {
+                Self {
                     movie: self.movie.clone(),
                     start: new_start,
                     end: new_end,
-                })
+                }
             } else {
-                None
+                self.copy_empty()
             }
         } else {
-            None
+            self.copy_empty()
         }
     }
 
@@ -306,6 +306,11 @@ impl SwfSlice {
     /// Get the version of the SWF this data comes from.
     pub fn version(&self) -> u8 {
         self.movie.header().version()
+    }
+
+    /// Checks if this slice is empty
+    pub fn is_empty(&self) -> bool {
+        self.end == self.start
     }
 
     /// Construct a reader for this slice.


### PR DESCRIPTION
This removes a bunch of unwraps. We had no good way of handling the None cases - but in theory operating on an empty slice is completely fine (and a technically valid situation regardless).


Although I can't reproduce these issues anymore, this fixes:
Fixes https://github.com/ruffle-rs/ruffle/issues/2737
Fixes https://github.com/ruffle-rs/ruffle/issues/5006
Fixes https://github.com/ruffle-rs/ruffle/issues/5830
Fixes https://github.com/ruffle-rs/ruffle/issues/6736