### PR TITLE
core: Fix incorrect rendering of word-wrap text boxes (close #1095)

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -789,21 +789,25 @@ impl<'gc> EditText<'gc> {
         edit_text.scroll = 1;
 
         if autosize != AutoSizeMode::None {
-            // The edit text's bounds needs to have the padding baked in.
-            let width = intrinsic_bounds.width() + padding;
-            let height = intrinsic_bounds.height() + padding;
-            let new_x = match autosize {
-                AutoSizeMode::Left => edit_text.bounds.x_min,
-                AutoSizeMode::Center => {
-                    (edit_text.bounds.x_min + edit_text.bounds.x_max - width) / 2
-                }
-                AutoSizeMode::Right => edit_text.bounds.x_max - width,
-                AutoSizeMode::None => unreachable!(),
-            };
             if !is_word_wrap {
+                // The edit text's bounds needs to have the padding baked in.
+                let width = intrinsic_bounds.width() + padding;
+                let new_x = match autosize {
+                    AutoSizeMode::Left => edit_text.bounds.x_min,
+                    AutoSizeMode::Center => {
+                        (edit_text.bounds.x_min + edit_text.bounds.x_max - width) / 2
+                    }
+                    AutoSizeMode::Right => edit_text.bounds.x_max - width,
+                    AutoSizeMode::None => unreachable!(),
+                };
                 edit_text.bounds.set_x(new_x);
                 edit_text.bounds.set_width(width);
+            } else {
+                let width = edit_text.static_data.text.bounds.x_max
+                    - edit_text.static_data.text.bounds.x_min;
+                edit_text.bounds.set_width(width);
             }
+            let height = intrinsic_bounds.height() + padding;
             edit_text.bounds.set_height(height);
             drop(edit_text);
             self.redraw_border(context.gc_context);


### PR DESCRIPTION
This PR fixes the way word-wrap text boxes are rendered. Here are some "before-and-after" snapshots demonstrating the effects of this fix for the game "Sonny":

## Before
<img width="912" alt="Screen Shot 2022-08-22 at 4 19 31 PM" src="https://user-images.githubusercontent.com/5777094/186013730-d5aa235d-1b2a-4005-9528-dd2ba7d694bd.png">
<img width="912" alt="Screen Shot 2022-08-22 at 4 39 40 PM" src="https://user-images.githubusercontent.com/5777094/186014635-6a213662-a14c-4b02-b99a-e95ade11277c.png">


## After
<img width="912" alt="Screen Shot 2022-08-22 at 4 18 39 PM" src="https://user-images.githubusercontent.com/5777094/186013738-f1d759f5-67f9-4f81-b24f-d4b49d3c5017.png">
<img width="912" alt="Screen Shot 2022-08-22 at 4 37 51 PM" src="https://user-images.githubusercontent.com/5777094/186014655-e23b2f6a-a94e-419d-a0e1-5fc5c3582d19.png">

