### PR TITLE
avm2: Set URLRequest.method default to GET

### DIFF
--- a/core/src/avm2/globals/flash/net/URLRequest.as
+++ b/core/src/avm2/globals/flash/net/URLRequest.as
@@ -5,7 +5,7 @@ package flash.net {
 
 		// FIXME - this should be a getter/setter for consistency with Flash
 		public var url:String;
-		private var _method:String;
+		private var _method:String = URLRequestMethod.GET;
 		private var _data:Object;
 
 		public function URLRequest(url:String = null) {


### PR DESCRIPTION
This was missed when I added 'method'