### PR TITLE
Avm2: refactor Multinames, pool them in TranslationUnit

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -355,6 +355,23 @@ impl<'gc> Avm2<'gc> {
         value
     }
 
+    /// Peek the n-th value from the end of the operand stack.
+    #[allow(clippy::let_and_return)]
+    fn peek(&mut self, index: usize) -> Value<'gc> {
+        let value = self
+            .stack
+            .get(self.stack.len() - index - 1)
+            .copied()
+            .unwrap_or_else(|| {
+                log::warn!("Avm1::pop: Stack underflow");
+                Value::Undefined
+            });
+
+        avm_debug!(self, "Stack peek {}: {:?}", self.stack.len(), value);
+
+        value
+    }
+
     fn pop_args(&mut self, arg_count: u32) -> Vec<Value<'gc>> {
         let mut args = vec![Value::Undefined; arg_count as usize];
         for arg in args.iter_mut().rev() {

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -13,6 +13,7 @@ use crate::avm2::QName;
 use bitflags::bitflags;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
+use std::ops::Deref;
 use swf::avm2::types::{
     Class as AbcClass, Instance as AbcInstance, Method as AbcMethod, MethodBody as AbcMethodBody,
 };
@@ -321,11 +322,11 @@ impl<'gc> Class<'gc> {
         let super_class = if abc_instance.super_name.0 == 0 {
             None
         } else {
-            Some(Multiname::from_abc_multiname_static(
-                unit,
-                abc_instance.super_name,
-                activation.context.gc_context,
-            )?)
+            Some(
+                unit.pool_multiname_static(abc_instance.super_name, activation.context.gc_context)?
+                    .deref()
+                    .clone(),
+            )
         };
 
         let protected_namespace = if let Some(ns) = &abc_instance.protected_namespace {
@@ -340,11 +341,11 @@ impl<'gc> Class<'gc> {
 
         let mut interfaces = Vec::with_capacity(abc_instance.interfaces.len());
         for interface_name in &abc_instance.interfaces {
-            interfaces.push(Multiname::from_abc_multiname_static(
-                unit,
-                *interface_name,
-                activation.context.gc_context,
-            )?);
+            interfaces.push(
+                unit.pool_multiname_static(*interface_name, activation.context.gc_context)?
+                    .deref()
+                    .clone(),
+            );
         }
 
         let instance_init = unit.load_method(abc_instance.init_method, false, activation)?;

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -69,7 +69,7 @@ impl<'gc, V> PropertyMap<'gc, V> {
         if let Some(local_name) = name.local_name() {
             self.0.get(&local_name).iter().find_map(|v| {
                 v.iter()
-                    .filter(|(n, _)| name.namespace_set().any(|ns| *ns == *n))
+                    .filter(|(n, _)| name.namespace_set().iter().any(|ns| *ns == *n))
                     .map(|(_, v)| v)
                     .next()
             })
@@ -82,7 +82,7 @@ impl<'gc, V> PropertyMap<'gc, V> {
         if let Some(local_name) = name.local_name() {
             self.0.get(&local_name).iter().find_map(|v| {
                 v.iter()
-                    .filter(|(n, _)| name.namespace_set().any(|ns| *ns == *n))
+                    .filter(|(n, _)| name.namespace_set().iter().any(|ns| *ns == *n))
                     .map(|(ns, v)| (*ns, v))
                     .next()
             })

--- a/core/src/avm2/property_map.rs
+++ b/core/src/avm2/property_map.rs
@@ -66,6 +66,9 @@ impl<'gc, V> PropertyMap<'gc, V> {
     }
 
     pub fn get_for_multiname(&self, name: &Multiname<'gc>) -> Option<&V> {
+        if name.has_lazy_component() {
+            unreachable!("Lookup on lazy Multiname should never happen ({:?})", name);
+        }
         if let Some(local_name) = name.local_name() {
             self.0.get(&local_name).iter().find_map(|v| {
                 v.iter()
@@ -79,6 +82,9 @@ impl<'gc, V> PropertyMap<'gc, V> {
     }
 
     pub fn get_with_ns_for_multiname(&self, name: &Multiname<'gc>) -> Option<(Namespace<'gc>, &V)> {
+        if name.has_lazy_component() {
+            unreachable!("Lookup on lazy Multiname should never happen ({:?})", name);
+        }
         if let Some(local_name) = name.local_name() {
             self.0.get(&local_name).iter().find_map(|v| {
                 v.iter()

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -396,7 +396,7 @@ fn default_value_for_type<'gc>(type_name: &Multiname<'gc>) -> Value<'gc> {
     // The Multiname is guaranteed to be static by `Multiname::from_abc_multiname_static` earlier.
     if type_name.is_any() {
         Value::Undefined
-    } else if type_name.namespace_set().any(|ns| ns.is_public()) {
+    } else if type_name.contains_public_namespace() {
         let name = type_name.local_name().unwrap_or_default();
         if &name == b"Boolean" {
             false.into()

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -10,6 +10,7 @@ use crate::avm2::Multiname;
 use crate::avm2::QName;
 use bitflags::bitflags;
 use gc_arena::{Collect, GcCell};
+use std::ops::Deref;
 use swf::avm2::types::{
     DefaultValue as AbcDefaultValue, Trait as AbcTrait, TraitKind as AbcTraitKind,
 };
@@ -198,11 +199,10 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = if type_name.0 == 0 {
-                    Multiname::any()
-                } else {
-                    Multiname::from_abc_multiname_static(unit, *type_name, mc)?
-                };
+                let type_name = unit
+                    .pool_multiname_static_any(*type_name, mc)?
+                    .deref()
+                    .clone();
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
                 Trait {
                     name,
@@ -260,11 +260,10 @@ impl<'gc> Trait<'gc> {
                 type_name,
                 value,
             } => {
-                let type_name = if type_name.0 == 0 {
-                    Multiname::any()
-                } else {
-                    Multiname::from_abc_multiname_static(unit, *type_name, mc)?
-                };
+                let type_name = unit
+                    .pool_multiname_static_any(*type_name, mc)?
+                    .deref()
+                    .clone();
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
                 Trait {
                     name,
@@ -393,7 +392,7 @@ fn slot_default_value<'gc>(
 fn default_value_for_type<'gc>(type_name: &Multiname<'gc>) -> Value<'gc> {
     // TODO: It's technically possible to have a multiname in here, so this should go through something
     // like `Activation::resolve_type` to get an actual `Class` object, and then check something like `Class::built_in_type`.
-    // The Multiname is guaranteed to be static by `Multiname::from_abc_multiname_static` earlier.
+    // The Multiname is guaranteed to be static by `pool.pool_multiname_static` earlier.
     if type_name.is_any() {
         Value::Undefined
     } else if type_name.contains_public_namespace() {


### PR DESCRIPTION
This is a relatively major redesign of Multiname design.

Changes:
- ABC Multinames are now pooled.
- ABC-pooled Multinames can now be "uninitialized" ("lazy"), which means they shouldn't be used for lookups until the value/namespace are read from the AVM stack. (previously, this role was filled by matching on the "raw" AbcMultiname.) This produces a new Multiname instead of mutating existing one.
- Multinames with a single namespace now hold it without a `vec` - meaning, `QName`->`Multiname` conversions are effectively free.

Good:
- noticeable perf improvements - previously the box2d demo took 20-25% of time loading multinames, and all this work got removed.
- greatly simplified `multiname.rs` - we went from four `match`es on `abc_multiname` to one, and the complexity of resolving "multiname params" from stack went from being scattered across several functions to a single short `fill_with_runtime_params()`.

Bad:
- nothing? c:

Ugly:
- not a fan of a runtime check in `property_map.rs`, but that's the tradeoff of the refactor. In general, this PR moves some type-level safety to runtime.
- the `.deref().clone()` thing is ugly, but I decided that refactoring the unrelated data structures to hold `Gc<Multiname>` is out of scope (and not that big of a deal, considering `Multiname` is much cheaper to clone now).
- also not the biggest fan of `Gc::allocate` in `pool_multiname_and_initialize` - we don't really need to Gc-wrap the new multiname, as we're going to only pass it via reference.
- ~~even less of a fan of this thing; anyone has any ideas? It's not really bad, just very awkward.~~ fix'd
```rs
            // restore stack for fill_with_runtime_params
            self.context.avm2.push(object);
            self.context.avm2.push(name_value);
```

FYI Namespaces/NamespaceSets are still not pooled - this can be done for more potential memory savings, but probably won't noticeably help with perf.
Another followup could be to make `Multiname::params` a simple `Option` instead of a `Vec` - this would also make it possible to make the entire structure `Copy`.
