### PR TITLE
text: Lazily layout text

### DIFF
--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -753,8 +753,8 @@ fn set_visible<'gc>(
     Ok(())
 }
 
-fn width<'gc>(_activation: &mut Activation<'_, 'gc, '_>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.width().into()
+fn width<'gc>(activation: &mut Activation<'_, 'gc, '_>, this: DisplayObject<'gc>) -> Value<'gc> {
+    this.width(&mut activation.context).into()
 }
 
 fn set_width<'gc>(
@@ -768,8 +768,8 @@ fn set_width<'gc>(
     Ok(())
 }
 
-fn height<'gc>(_activation: &mut Activation<'_, 'gc, '_>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.height().into()
+fn height<'gc>(activation: &mut Activation<'_, 'gc, '_>, this: DisplayObject<'gc>) -> Value<'gc> {
+    this.height(&mut activation.context).into()
 }
 
 fn set_height<'gc>(

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -107,12 +107,12 @@ pub fn set_alpha<'gc>(
 
 /// Implements `height`'s getter.
 pub fn height<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
-        return Ok(dobj.height().into());
+        return Ok(dobj.height(&mut activation.context).into());
     }
 
     Ok(Value::Undefined)
@@ -175,12 +175,12 @@ pub fn set_scale_y<'gc>(
 
 /// Implements `width`'s getter.
 pub fn width<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
-        return Ok(dobj.width().into());
+        return Ok(dobj.width(&mut activation.context).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -415,7 +415,7 @@ impl<'gc> Default for ActionQueue<'gc> {
 
 /// Shared data used during rendering.
 /// `Player` creates this when it renders a frame and passes it down to display objects.
-pub struct RenderContext<'a, 'gc> {
+pub struct RenderContext<'a, 'gc, 'gc_context> {
     /// The renderer, used by the display objects to draw themselves.
     pub renderer: &'a mut dyn RenderBackend,
 
@@ -437,6 +437,9 @@ pub struct RenderContext<'a, 'gc> {
     /// Whether to allow pushing a new mask. A masker-inside-a-masker does not work in Flash, instead
     /// causing the inner mask to be included as part of the outer mask. Maskee-inside-a-maskee works as one expects.
     pub allow_mask: bool,
+
+    /// The mutation context to allocate and mutate `GcCell` types.
+    pub gc_context: MutationContext<'gc, 'gc_context>,
 }
 
 /// The type of action being run.

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -704,7 +704,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Gets the pixel width of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_width`/`width` properties.
-    fn width(&self) -> f64 {
+    fn width(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
         let bounds = self.local_bounds();
         (bounds.x_max - bounds.x_min).to_pixels()
     }
@@ -753,7 +753,7 @@ pub trait TDisplayObject<'gc>:
 
     /// Gets the pixel height of the AABB containing this display object in local space.
     /// Returned by the ActionScript `_height`/`height` properties.
-    fn height(&self) -> f64 {
+    fn height(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
         let bounds = self.local_bounds();
         (bounds.y_max - bounds.y_min).to_pixels()
     }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -469,7 +469,7 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 }
 
-pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_, 'gc>) {
+pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_, 'gc, '_>) {
     if this.maskee().is_some() {
         return;
     }
@@ -1187,9 +1187,9 @@ pub trait TDisplayObject<'gc>:
         }
     }
 
-    fn render_self(&self, _context: &mut RenderContext<'_, 'gc>) {}
+    fn render_self(&self, _context: &mut RenderContext<'_, 'gc, '_>) {}
 
-    fn render(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         render_base((*self).into(), context)
     }
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -331,7 +331,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         self.render_children(context);
     }
 

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -606,7 +606,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         let state = self.0.read().state;
         let current_state = self.get_state_child(state.into());
 

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -279,7 +279,7 @@ pub trait TDisplayObjectContainer<'gc>:
     }
 
     /// Renders the children of this container in render list order.
-    fn render_children(self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_children(self, context: &mut RenderContext<'_, 'gc, '_>) {
         let mut clip_depth = 0;
         let mut clip_depth_stack: Vec<(Depth, DisplayObject<'_>)> = vec![];
         for child in self.iter_render_list() {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -784,10 +784,6 @@ impl<'gc> EditText<'gc> {
                 };
                 edit_text.bounds.set_x(new_x);
                 edit_text.bounds.set_width(width);
-            } else {
-                let width = edit_text.static_data.text.bounds.x_max
-                    - edit_text.static_data.text.bounds.x_min;
-                edit_text.bounds.set_width(width);
             }
             let height = intrinsic_bounds.height() + padding;
             edit_text.bounds.set_height(height);

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -809,7 +809,8 @@ impl<'gc> EditText<'gc> {
     /// Measure the width and height of the `EditText`'s current text load.
     ///
     /// The returned tuple should be interpreted as width, then height.
-    pub fn measure_text(self, _context: &mut UpdateContext<'_, 'gc, '_>) -> (Twips, Twips) {
+    pub fn measure_text(self, context: &mut UpdateContext<'_, 'gc, '_>) -> (Twips, Twips) {
+        self.relayout(context.gc_context, context.library);
         let edit_text = self.0.read();
 
         (

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -244,16 +244,6 @@ impl<'gc> EditText<'gc> {
 
         let bounds: BoundingBox = swf_tag.bounds.clone().into();
 
-        let (layout, intrinsic_bounds) = LayoutBox::lower_from_text_spans(
-            &text_spans,
-            context.library,
-            swf_movie.clone(),
-            bounds.width() - Twips::from_pixels(Self::INTERNAL_PADDING * 2.0),
-            swf_tag.is_word_wrap,
-            swf_tag.is_device_font,
-        );
-        let line_data = get_line_data(&layout);
-
         let has_background = swf_tag.has_border;
         let background_color = 0xFFFFFF; // Default is white
         let has_border = swf_tag.has_border;
@@ -323,8 +313,8 @@ impl<'gc> EditText<'gc> {
                 is_html,
                 drawing: Drawing::new(),
                 object: None,
-                layout,
-                intrinsic_bounds,
+                layout: Default::default(),
+                intrinsic_bounds: Default::default(),
                 bounds,
                 autosize,
                 variable: variable.map(|s| s.to_string_lossy(encoding)),
@@ -334,7 +324,7 @@ impl<'gc> EditText<'gc> {
                 has_focus: false,
                 render_settings: Default::default(),
                 hscroll: 0.0,
-                line_data,
+                line_data: Default::default(),
                 scroll: 1,
                 is_layout_dirty: true,
             },

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -631,21 +631,6 @@ impl<'gc> EditText<'gc> {
         transform
     }
 
-    pub fn line_width(self) -> Twips {
-        let edit_text = self.0.read();
-        let static_data = &edit_text.static_data;
-
-        let mut base_width = Twips::from_pixels(self.width());
-
-        if let Some(layout) = &static_data.text.layout {
-            base_width -= layout.left_margin;
-            base_width -= layout.indent;
-            base_width -= layout.right_margin;
-        }
-
-        base_width
-    }
-
     /// Returns the variable that this text field is bound to.
     pub fn variable(&self) -> Option<Ref<str>> {
         let text = self.0.read();

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1565,7 +1565,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn width(&self) -> f64 {
+    fn width(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
         let edit_text = self.0.read();
         edit_text
             .bounds
@@ -1584,7 +1584,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn height(&self) -> f64 {
+    fn height(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
         let edit_text = self.0.read();
         edit_text
             .bounds

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1580,6 +1580,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
         write.bounds.set_width(Twips::from_pixels(value));
         write.base.base.set_transformed_by_script(true);
+        write.is_layout_dirty = true;
 
         drop(write);
         self.redraw_border(gc_context);
@@ -1600,6 +1601,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 
         write.bounds.set_height(Twips::from_pixels(value));
         write.base.base.set_transformed_by_script(true);
+        write.is_layout_dirty = true;
 
         drop(write);
         self.redraw_border(gc_context);

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -896,7 +896,7 @@ impl<'gc> EditText<'gc> {
     }
 
     /// Render a layout box, plus its children.
-    fn render_layout_box(self, context: &mut RenderContext<'_, 'gc>, lbox: &LayoutBox<'gc>) {
+    fn render_layout_box(self, context: &mut RenderContext<'_, 'gc, '_>, lbox: &LayoutBox<'gc>) {
         let origin = lbox.bounds().origin();
         context.transform_stack.push(&Transform {
             matrix: Matrix::translate(origin.x(), origin.y()),
@@ -1616,7 +1616,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         if !self.world_bounds().intersects(&context.stage.view_bounds()) {
             // Off-screen; culled
             return;

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1565,7 +1565,8 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn width(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
+    fn width(&self, context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
+        self.relayout(context.gc_context, context.library);
         let edit_text = self.0.read();
         edit_text
             .bounds
@@ -1584,7 +1585,8 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn height(&self, _context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
+    fn height(&self, context: &mut UpdateContext<'_, 'gc, '_>) -> f64 {
+        self.relayout(context.gc_context, context.library);
         let edit_text = self.0.read();
         edit_text
             .bounds

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -61,7 +61,7 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
         u16::MAX
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         self.render_children(context);
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2021,7 +2021,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         self.0.read().drawing.render(context);
         self.render_children(context);
     }

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -486,7 +486,7 @@ impl<'gc> Stage<'gc> {
     }
 
     /// Draw the stage's letterbox.
-    fn draw_letterbox(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn draw_letterbox(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         let ViewportDimensions {
             width: viewport_width,
             height: viewport_height,
@@ -694,11 +694,11 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
         Some(*self)
     }
 
-    fn render_self(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render_self(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         self.render_children(context);
     }
 
-    fn render(&self, context: &mut RenderContext<'_, 'gc>) {
+    fn render(&self, context: &mut RenderContext<'_, 'gc, '_>) {
         let background_color =
             if self.window_mode() != WindowMode::Transparent || self.is_fullscreen() {
                 self.background_color().unwrap_or(Color::WHITE)

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1293,11 +1293,12 @@ impl Player {
         let (renderer, ui, transform_stack) =
             (&mut self.renderer, &mut self.ui, &mut self.transform_stack);
 
-        self.gc_arena.mutate(|_gc_context, gc_root| {
+        self.gc_arena.mutate(|gc_context, gc_root| {
             let root_data = gc_root.0.read();
             let mut render_context = RenderContext {
                 renderer: renderer.deref_mut(),
                 ui: ui.deref_mut(),
+                gc_context,
                 library: &root_data.library,
                 transform_stack,
                 stage: root_data.stage,


### PR DESCRIPTION
Continuing from #7735, reflow text lazily instead of every time a text parameter is changed.

When a text field property is modified (such as changing the text or font size), Flash marks the text layout as dirty. The layout is then recalculated lazily when the textfield is rendered, or when a value that depends on the layout is accessed via ActionScript.

* Add `RenderContext::gc_context` to allow mutating the `EditText` during render.
  * This adds a lifetime parameter to `RenderContext`.
  * We want this for other places such as caching bitmaps as well.
  * We probably want to unify our Contexts some eventually, but that's orthogonal to this PR.
* Change `LayoutContext` to only require the `Library` instead of a full `UpdateContext`.
  * It only needs the library to grab fonts.
* Store a dirty flag for the text layout, and relayout the text on demand.
  * Changing various text field parameters like `text`, `autoSize`, `_width` marks the layout as dirty.
  * The layout will be recalculated when the text is rendered, or when AS accesses specific values.

This is more efficient and necessary for accuracy, as the layout will be calculated at different times depending on the order of property access.

TODO:
 * Don't relayout on getting `_width`/`_height` if autosize is disabled.
 * Check for any other properties that should trigger layout (`scroll`, etc.)
 * Use bitflags for various `EditText` bools.
 * Add a separate dirty flag for `redraw_border`?
 * Add tests.