### PR TITLE
core: Make `Player::load_device_font` infallible

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -539,7 +539,7 @@ impl From<swf::CsmTextSettings> for TextRenderSettings {
 #[cfg(test)]
 mod tests {
     use crate::font::{EvalParameters, Font};
-    use crate::player::{Player, DEVICE_FONT_TAG};
+    use crate::player::Player;
     use crate::string::WStr;
     use gc_arena::{rootless_arena, MutationContext};
     use ruffle_render::backend::{null::NullRenderer, ViewportDimensions};
@@ -555,7 +555,7 @@ mod tests {
                 height: 0,
                 scale_factor: 1.0,
             });
-            let device_font = Player::load_device_font(mc, DEVICE_FONT_TAG, &mut renderer).unwrap();
+            let device_font = Player::load_device_font(mc, &mut renderer);
 
             callback(mc, device_font);
         })

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -381,8 +381,8 @@ impl<'gc> Library<'gc> {
     }
 
     /// Sets the device font.
-    pub fn set_device_font(&mut self, font: Option<Font<'gc>>) {
-        self.device_font = font;
+    pub fn set_device_font(&mut self, font: Font<'gc>) {
+        self.device_font = Some(font);
     }
 
     /// Get the AVM2 class registry.


### PR DESCRIPTION
It is always called with the same known data, which should parse
successfully.