### PR TITLE
core: Make audio backend more optional

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.3.23"
 version = "0.4.32"
 
 [features]
-default = ["minimp3"]
+default = []
 h263 = ["h263-rs", "h263-rs-yuv"]
 vp6 = ["nihav_core", "nihav_codec_support", "nihav_duck", "h263-rs-yuv"]
 screenvideo = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,7 +41,7 @@ h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e5
 regress = "0.4"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd07b9888c4bdaa66771c468095783b52bed" }
 lzma-rs = {version = "0.2.0", optional = true }
-dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"] }
+dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.1", default-features = false, features = ["mp3"], optional = true }
 nihav_core = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_codec_support = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
@@ -64,6 +64,7 @@ avm_debug = []
 deterministic = []
 timeline_debug = []
 nellymoser = ["nellymoser-rs"]
+audio = ["dasp"]
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,7 @@ encoding_rs = "0.8.31"
 rand = { version = "0.8.5", features = ["std", "small_rng"], default-features = false }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a33521c29a918950df8ae9fe07e527ac65553f5" }
+nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a33521c29a918950df8ae9fe07e527ac65553f5", optional = true }
 h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
 regress = "0.4"
@@ -63,6 +63,7 @@ wasm-bindgen = [ "instant/wasm-bindgen" ]
 avm_debug = []
 deterministic = []
 timeline_debug = []
+nellymoser = ["nellymoser-rs"]
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -7,6 +7,7 @@ use downcast_rs::Downcast;
 use gc_arena::Collect;
 use generational_arena::{Arena, Index};
 
+#[cfg(feature = "audio")]
 pub mod decoders;
 pub mod swf {
     pub use swf::{
@@ -15,9 +16,18 @@ pub mod swf {
     };
 }
 
+#[cfg(feature = "audio")]
 mod mixer;
-use instant::Duration;
+#[cfg(feature = "audio")]
 pub use mixer::*;
+
+#[cfg(not(feature = "audio"))]
+mod decoders {
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {}
+}
+
+use instant::Duration;
 use thiserror::Error;
 
 pub type SoundHandle = Index;

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -3,6 +3,7 @@
 mod adpcm;
 #[cfg(any(feature = "minimp3", feature = "symphonia"))]
 mod mp3;
+#[cfg(feature = "nellymoser")]
 mod nellymoser;
 mod pcm;
 
@@ -11,6 +12,7 @@ pub use adpcm::AdpcmDecoder;
 pub use mp3::minimp3::Mp3Decoder;
 #[cfg(all(feature = "symphonia", not(feature = "minimp3")))]
 pub use mp3::symphonia::Mp3Decoder;
+#[cfg(feature = "nellymoser")]
 pub use nellymoser::NellymoserDecoder;
 pub use pcm::PcmDecoder;
 
@@ -75,6 +77,7 @@ pub fn make_decoder<R: 'static + Read + Send + Sync>(
         )?),
         #[cfg(any(feature = "minimp3", feature = "symphonia"))]
         AudioCompression::Mp3 => Box::new(Mp3Decoder::new(data)?),
+        #[cfg(feature = "nellymoser")]
         AudioCompression::Nellymoser => {
             Box::new(NellymoserDecoder::new(data, format.sample_rate.into()))
         }

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -1,6 +1,4 @@
-use super::decoders::{
-    self, AdpcmDecoder, Decoder, NellymoserDecoder, PcmDecoder, SeekableDecoder,
-};
+use super::decoders::{self, AdpcmDecoder, Decoder, PcmDecoder, SeekableDecoder};
 use super::{SoundHandle, SoundInstanceHandle, SoundTransform};
 use crate::backend::audio::{DecodeError, RegisterError};
 use crate::tag_utils::SwfSlice;
@@ -224,9 +222,11 @@ impl AudioMixer {
             AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new(data)?),
             #[cfg(all(feature = "symphonia", not(feature = "minimp3")))]
             AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new_seekable(data)?),
-            AudioCompression::Nellymoser => {
-                Box::new(NellymoserDecoder::new(data, format.sample_rate.into()))
-            }
+            #[cfg(feature = "nellymoser")]
+            AudioCompression::Nellymoser => Box::new(decoders::NellymoserDecoder::new(
+                data,
+                format.sample_rate.into(),
+            )),
             _ => return Err(decoders::Error::UnhandledCompression(format.compression)),
         };
         Ok(decoder)

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
 cpal = "0.13.5"
-ruffle_core = { path = "../core", features = ["minimp3", "nellymoser"] }
+ruffle_core = { path = "../core", features = ["audio", "minimp3", "nellymoser"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 env_logger = { version = "0.9", default-features = false, features = ["humantime"] }
 generational-arena = "0.2.8"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
 cpal = "0.13.5"
-ruffle_core = { path = "../core", features = ["minimp3"] }
+ruffle_core = { path = "../core", features = ["minimp3", "nellymoser"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 env_logger = { version = "0.9", default-features = false, features = ["humantime"] }
 generational-arena = "0.2.8"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 clap = { version = "3.2.17", features = ["derive"] }
 cpal = "0.13.5"
-ruffle_core = { path = "../core" }
+ruffle_core = { path = "../core", features = ["minimp3"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 env_logger = { version = "0.9", default-features = false, features = ["humantime"] }
 generational-arena = "0.2.8"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -48,7 +48,7 @@ base64 = "0.13.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["h263", "vp6", "screenvideo", "symphonia", "wasm-bindgen", "nellymoser"]
+features = ["h263", "vp6", "screenvideo", "symphonia", "wasm-bindgen", "audio", "nellymoser"]
 
 [dependencies.web-sys]
 version = "0.3.58"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -48,7 +48,7 @@ base64 = "0.13.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["h263", "vp6", "screenvideo", "symphonia", "wasm-bindgen"]
+features = ["h263", "vp6", "screenvideo", "symphonia", "wasm-bindgen", "nellymoser"]
 
 [dependencies.web-sys]
 version = "0.3.58"


### PR DESCRIPTION
Shaves up to 3 seconds from test time for me, because we were compiling a lot of dependencies that we didn't need.

I wanted to go with a separate crate like render & video, but it's a little too tangled in our code right now.

Benchmarks:

| Command          | Mean [s] | Min [s] | Max [s] | Relative |
|:-----------------|---:|---:|---:|---------:|
| `cargo test`     | 96.985 ± 0.430 | 96.231 | 97.940 |     1.00 |
| + without mp3    | 96.574 ± 0.386 | 96.067 | 97.416 |     0.99 |
| + without nelly  | 95.431 ± 0.946 | 94.551 | 97.471 |     0.98 |
| + without audio  | 94.184 ± 0.199 | 93.848 | 94.417 |     0.97 |

