### PR TITLE
avm2: Port toplevel constants to ActionScript

### DIFF
--- a/core/build_playerglobal/src/lib.rs
+++ b/core/build_playerglobal/src/lib.rs
@@ -47,6 +47,8 @@ pub fn build_playerglobal(
             "playerglobal",
             "-import",
             &classes_dir.join("stubs.as").to_string_lossy(),
+            // From some reason this has to be passed as a separate argument.
+            &classes_dir.join("Toplevel.as").to_string_lossy(),
             &classes_dir.join("globals.as").to_string_lossy(),
         ])
         .status();

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -422,17 +422,6 @@ pub fn load_player_globals<'gc>(
     function(activation, "", "parseInt", toplevel::parse_int, script)?;
     function(activation, "", "parseFloat", toplevel::parse_float, script)?;
     function(activation, "", "escape", toplevel::escape, script)?;
-    constant(mc, "", "undefined", Value::Undefined, script, object_class)?;
-    constant(mc, "", "null", Value::Null, script, object_class)?;
-    constant(mc, "", "NaN", f64::NAN.into(), script, object_class)?;
-    constant(
-        mc,
-        "",
-        "Infinity",
-        f64::INFINITY.into(),
-        script,
-        object_class,
-    )?;
 
     class(activation, json::create_class(mc), script)?;
     avm2_system_class!(regexp, activation, regexp::create_class(mc), script);

--- a/core/src/avm2/globals/Math.as
+++ b/core/src/avm2/globals/Math.as
@@ -28,9 +28,6 @@ package {
         // This is a hacky way to specify `-Infinity` as a default value.
         private static const NegInfinity: Number = -1 / 0;
         public static native function max(x: Number = NegInfinity, y: Number = NegInfinity, ...rest): Number;
-
-        // TODO: Remove this once `Infinity` is properly defined in ActionScript.
-        private static const Infinity: Number = 1 / 0;
         public static native function min(x: Number = Infinity, y: Number = Infinity, ...rest): Number;
 
         public static native function random(): Number;

--- a/core/src/avm2/globals/Toplevel.as
+++ b/core/src/avm2/globals/Toplevel.as
@@ -1,0 +1,9 @@
+package {
+    public namespace AS3 = "http://adobe.com/AS3/2006/builtin";
+
+    public const NaN: Number = 0 / 0;
+
+    public const Infinity: Number = 1 / 0;
+
+    public const undefined = void 0;
+}


### PR DESCRIPTION
Declare `NaN`, `Infinity` and `undefined` in ActionScript, similarly
to how `avmplus` does in its `actionscript.lang.as`.

Note that `null` is only removed, without an ActionScript declaration,
as it seems like `avmplus` neither declares it. Probably `null` is
only usable as a compile-time constant.