### PR TITLE
swf: Simplify `DoAbc` tag handling

### DIFF
--- a/core/build_playerglobal/src/lib.rs
+++ b/core/build_playerglobal/src/lib.rs
@@ -12,10 +12,7 @@ use std::process::Command;
 use std::str::FromStr;
 use swf::avm2::types::*;
 use swf::avm2::write::Writer;
-use swf::DoAbc;
-use swf::Header;
-use swf::SwfStr;
-use swf::Tag;
+use swf::{DoAbc, DoAbcFlag, Header, Tag};
 
 // The metadata name - all metadata in our .as files
 // should be of the form `[Ruffle(key1 = value1, key2 = value2)]`
@@ -77,9 +74,9 @@ pub fn build_playerglobal(
 
     bytes = write_native_table(&bytes, &out_dir)?;
 
-    let tags = vec![Tag::DoAbc(DoAbc {
-        name: SwfStr::from_utf8_str(""),
-        is_lazy_initialize: true,
+    let tags = [Tag::DoAbc(DoAbc {
+        flags: DoAbcFlag::LAZY_INITIALIZE,
+        name: "".into(),
         data: &bytes,
     })];
 

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -261,7 +261,7 @@ impl<'gc> Avm2<'gc> {
     }
 
     /// Load an ABC file embedded in a `DoAbc` tag.
-    pub fn load_abc(
+    pub fn do_abc(
         context: &mut UpdateContext<'_, 'gc, '_>,
         do_abc: DoAbc,
         domain: Domain<'gc>,

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -676,9 +676,13 @@ fn load_playerglobal<'gc>(
 
     let mut reader = slice.read_from(0);
 
-    let tag_callback = |reader: &mut SwfStream<'_>, tag_code, tag_len| {
+    let tag_callback = |reader: &mut SwfStream<'_>, tag_code, _tag_len| {
         if tag_code == TagCode::DoAbc {
-            Avm2::load_abc_from_do_abc(&mut activation.context, &slice, domain, reader, tag_len)?;
+            let do_abc = reader
+                .read_do_abc()
+                .expect("playerglobal.swf should be valid");
+            Avm2::load_abc(&mut activation.context, do_abc, domain)
+                .expect("playerglobal.swf should be valid");
         } else if tag_code != TagCode::End {
             panic!(
                 "playerglobal should only contain `DoAbc` tag - found tag {:?}",

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -681,7 +681,7 @@ fn load_playerglobal<'gc>(
             let do_abc = reader
                 .read_do_abc()
                 .expect("playerglobal.swf should be valid");
-            Avm2::load_abc(&mut activation.context, do_abc, domain)
+            Avm2::do_abc(&mut activation.context, do_abc, domain)
                 .expect("playerglobal.swf should be valid");
         } else if tag_code != TagCode::End {
             panic!(

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -579,7 +579,7 @@ impl<'gc> MovieClip<'gc> {
             let movie = self.movie().unwrap();
             let domain = context.library.library_for_movie_mut(movie).avm2_domain();
 
-            if let Err(e) = Avm2::load_abc(context, do_abc, domain) {
+            if let Err(e) = Avm2::do_abc(context, do_abc, domain) {
                 log::warn!("Error loading ABC file: {}", e);
             }
         }

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -22,10 +22,6 @@ pub enum Error {
 
     #[error("Invalid SWF url")]
     InvalidSwfUrl,
-
-    // TODO: Replace avm2 errors with something more substantial
-    #[error("Invalid ABC: {0}")]
-    InvalidABC(String),
 }
 
 pub type DecodeResult = Result<(), Error>;

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -506,16 +506,7 @@ impl<'a> Reader<'a> {
                 splitter_rect: tag_reader.read_rectangle()?,
             },
 
-            TagCode::DoAbc => {
-                let flags = tag_reader.read_u32()?;
-                let name = tag_reader.read_str()?;
-                let abc_data = tag_reader.read_slice_to_end();
-                Tag::DoAbc(DoAbc {
-                    name,
-                    is_lazy_initialize: flags & 1 != 0,
-                    data: abc_data,
-                })
-            }
+            TagCode::DoAbc => Tag::DoAbc(tag_reader.read_do_abc()?),
 
             TagCode::DoAction => {
                 let action_data = tag_reader.read_slice_to_end();
@@ -2548,6 +2539,13 @@ impl<'a> Reader<'a> {
             height,
             data,
         })
+    }
+
+    pub fn read_do_abc(&mut self) -> Result<DoAbc<'a>> {
+        let flags = DoAbcFlag::from_bits_truncate(self.read_u32()?);
+        let name = self.read_str()?;
+        let data = self.read_slice_to_end();
+        Ok(DoAbc { flags, name, data })
     }
 
     pub fn read_product_info(&mut self) -> Result<ProductInfo> {

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -1491,9 +1491,15 @@ pub struct DefineBitsJpeg3<'a> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DoAbc<'a> {
+    pub flags: DoAbcFlag,
     pub name: &'a SwfStr,
-    pub is_lazy_initialize: bool,
     pub data: &'a [u8],
+}
+
+bitflags! {
+    pub struct DoAbcFlag: u32 {
+        const LAZY_INITIALIZE = 1 << 0;
+    }
 }
 
 pub type DoAction<'a> = &'a [u8];

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -706,7 +706,7 @@ impl<W: Write> Writer<W> {
             Tag::DoAbc(ref do_abc) => {
                 let len = do_abc.data.len() + do_abc.name.len() + 5;
                 self.write_tag_header(TagCode::DoAbc, len as u32)?;
-                self.write_u32(if do_abc.is_lazy_initialize { 1 } else { 0 })?;
+                self.write_u32(do_abc.flags.bits())?;
                 self.write_string(do_abc.name)?;
                 self.output.write_all(do_abc.data)?;
             }


### PR DESCRIPTION
Extract `swf::Reader::read_do_abc()` which, as the name suggests,
reads a `DoAbc` tag, and use it before calling to `Avm2::load_abc`.
Finally, introduce `DoAbcFlag` using `bitflags`.
This greatly simplifies the ABC loading code.