### PR TITLE
web: Disallow imports not used as values

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the various types of auto-play behaviours that are supported.
  */
-import { BaseLoadOptions } from "./load-options";
+import type { BaseLoadOptions } from "./load-options";
 
 /**
  * The configuration object to control Ruffle's behaviour on the website

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -10,7 +10,7 @@ import {
 } from "wasm-feature-detect";
 import { setPolyfillsOnLoad } from "./js-polyfills";
 import { publicPath } from "./public-path";
-import { Config } from "./config";
+import type { Config } from "./config";
 
 declare global {
     let __webpack_public_path__: string;

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -2,7 +2,7 @@ import { RuffleObject } from "./ruffle-object";
 import { RuffleEmbed } from "./ruffle-embed";
 import { installPlugin, FLASH_PLUGIN } from "./plugin-polyfill";
 import { publicPath } from "./public-path";
-import { Config } from "./config";
+import type { Config } from "./config";
 
 let isExtension: boolean;
 const globalConfig: Config = window.RufflePlayer?.config ?? {};

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -1,7 +1,7 @@
 import { Version } from "./version";
 import { VersionRange } from "./version-range";
 import { SourceAPI } from "./source-api";
-import { Config } from "./config";
+import type { Config } from "./config";
 
 declare global {
     interface Window {

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -1,4 +1,4 @@
-import { Config } from "./config";
+import type { Config } from "./config";
 
 // This must be in global scope because `document.currentScript`
 // works only while the script is initially being processed.

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -13,7 +13,7 @@ import {
     RufflePlayer,
 } from "./ruffle-player";
 import { registerElement } from "./register-element";
-import { URLLoadOptions, WindowMode } from "./load-options";
+import type { URLLoadOptions, WindowMode } from "./load-options";
 import { RuffleEmbed } from "./ruffle-embed";
 
 /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1,9 +1,9 @@
-import { Ruffle } from "../pkg/ruffle_web";
+import type { Ruffle } from "../pkg/ruffle_web";
 
 import { loadRuffle } from "./load-ruffle";
 import { ruffleShadowTemplate } from "./shadow-template";
 import { lookupElement } from "./register-element";
-import { Config } from "./config";
+import type { Config } from "./config";
 import {
     BaseLoadOptions,
     DataLoadOptions,
@@ -12,8 +12,8 @@ import {
     UnmuteOverlay,
     WindowMode,
 } from "./load-options";
-import { MovieMetadata } from "./movie-metadata";
-import { InternalContextMenuItem } from "./context-menu";
+import type { MovieMetadata } from "./movie-metadata";
+import type { InternalContextMenuItem } from "./context-menu";
 import { swfFileName } from "./swf-file-name";
 
 export const FLASH_MIMETYPE = "application/x-shockwave-flash";

--- a/web/packages/core/tsconfig.json
+++ b/web/packages/core/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "es2017",
         "module": "es2020",
         "moduleResolution": "node",
-        "strict": true,
+        "importsNotUsedAsValues": "error",
         "outDir": "pkg",
     },
     "include": ["src/**/*"],

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -1,4 +1,4 @@
-import { Options } from "./common";
+import type { Options } from "./common";
 import { LogLevel } from "ruffle-core";
 
 const DEFAULT_OPTIONS: Options = {

--- a/web/packages/extension/tsconfig.json
+++ b/web/packages/extension/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "es2017",
         "module": "es2020",
         "moduleResolution": "node",
-        "strict": true,
+        "importsNotUsedAsValues": "error",
     },
     "include": ["src/**/*"],
 }


### PR DESCRIPTION
Configure [`importsNotUsedAsValues`](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues)
to `error`, and switch from `import` to `import type` where needed.
Also remove the `strict` configuration, as it's inherited from
`@tsconfig/recommended`.