### PR TITLE
avm2: Add `Loader.loadBytes()`

### DIFF
--- a/core/src/avm2/globals/flash/display/Loader.as
+++ b/core/src/avm2/globals/flash/display/Loader.as
@@ -4,6 +4,7 @@ package flash.display {
 		import flash.display.DisplayObject;
 		import flash.errors.IllegalOperationError;
 		import flash.system.LoaderContext;
+		import flash.utils.ByteArray;
 		import flash.net.URLRequest;
 
 		private var _contentLoaderInfo: LoaderInfo;
@@ -26,6 +27,8 @@ package flash.display {
 		}
 
 		public native function load(request: URLRequest, context: LoaderContext = null):void;
+
+		public native function loadBytes(data: ByteArray, context: LoaderContext = null):void;
 
 		override public function addChild(child:DisplayObject):void {
 			throw new IllegalOperationError("Error #2069: The Loader class does not implement this method.", 2069);

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -90,3 +90,46 @@ pub fn load<'gc>(
     }
     Ok(Value::Undefined)
 }
+
+pub fn load_bytes<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error> {
+    if let Some(this) = this {
+        let arg0 = args[0].as_object().unwrap();
+        let bytearray = arg0.as_bytearray().unwrap();
+
+        if let Some(context) = args.get(1) {
+            if !matches!(context, Value::Null) {
+                log::warn!(
+                    "Loader.load: 'context' argument is not yet implemented: {:?}",
+                    context
+                );
+            }
+        }
+
+        // This is a dummy MovieClip, which will get overwritten in `Loader`
+        let content = MovieClip::new(
+            Arc::new(SwfMovie::empty(activation.context.swf.version())),
+            activation.context.gc_context,
+        );
+
+        let loader_info = this
+            .get_property(
+                &QName::new(Namespace::private(""), "_contentLoaderInfo").into(),
+                activation,
+            )?
+            .as_object()
+            .unwrap();
+
+        let future = activation.context.load_manager.load_movie_into_clip_bytes(
+            activation.context.player.clone(),
+            content.into(),
+            bytearray.bytes().to_vec(),
+            Some(MovieLoaderEventHandler::Avm2LoaderInfo(loader_info)),
+        );
+        activation.context.navigator.spawn_future(future);
+    }
+    Ok(Value::Undefined)
+}


### PR DESCRIPTION
~~There is a build error I couldn't figure out yet.~~ EDIT: Making `Loader` `Clone + Copy` helped with this a lot, thanks for the tip, @EmperorBale!

This method is used by a number of z0r.de loops, for example:

 - 4030
 - 4073
 - 4075
 - 4076
 - 4846
 - 4870
