### PR TITLE
avm2: Fire KeyboardEvent.KEY_UP and KeyboardEvent.KEY_DOWN

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -100,6 +100,7 @@ pub struct SystemClasses<'gc> {
     pub illegaloperationerror: ClassObject<'gc>,
     pub eventdispatcher: ClassObject<'gc>,
     pub rectangle: ClassObject<'gc>,
+    pub keyboardevent: ClassObject<'gc>,
 }
 
 impl<'gc> SystemClasses<'gc> {
@@ -169,6 +170,7 @@ impl<'gc> SystemClasses<'gc> {
             illegaloperationerror: object,
             eventdispatcher: object,
             rectangle: object,
+            keyboardevent: object,
         }
     }
 }
@@ -711,6 +713,7 @@ fn load_playerglobal<'gc>(
             ("flash.events", "Event", event),
             ("flash.events", "TextEvent", textevent),
             ("flash.events", "ErrorEvent", errorevent),
+            ("flash.events", "KeyboardEvent", keyboardevent),
             ("flash.events", "ProgressEvent", progressevent),
             ("flash.events", "SecurityErrorEvent", securityerrorevent),
             ("flash.events", "IOErrorEvent", ioerrorevent),

--- a/core/src/avm2/globals/flash/events/KeyboardEvent.as
+++ b/core/src/avm2/globals/flash/events/KeyboardEvent.as
@@ -4,11 +4,28 @@ package flash.events
     {
         public static const KEY_DOWN:String = "keyDown";
         public static const KEY_UP:String = "keyUp";
+        private var _charCode:uint;
+        private var _keyCode:uint;
 
         public function KeyboardEvent(type:String, bubbles:Boolean = true, cancelable:Boolean = false, charCodeValue:uint = 0, keyCodeValue:uint = 0, keyLocationValue:uint = 0, ctrlKeyValue:Boolean = false, altKeyValue:Boolean = false, shiftKeyValue:Boolean = false)
         {
             super(type,bubbles,cancelable);
-            // TODO: fill this up
+            this._charCode = charCodeValue;
+            this._keyCode = keyCodeValue;
+        }
+
+        public function get charCode():uint {
+            return this._charCode;
+        }
+        public function set charCode(val:uint) {
+            this._charCode = val;
+        }
+
+        public function get keyCode():uint {
+            return this._keyCode;
+        }
+        public function set keyCode(val:uint) {
+            this._keyCode = val;
         }
     }
 }


### PR DESCRIPTION
The 'charCode' and 'keyCode' properties are now implemented
on `KeyboardEvent`

The input injection code we use does not support keyboard events,
so we can't yet write a regression test for this. However,
both 'You need to burn the rope' and 'This is the Only Level TOO'
now properly handle keyboard events with this PR.