### PR TITLE
avm2: Declare 'Array.concat' as a public method

### DIFF
--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -1202,6 +1202,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_instance_allocator(array_allocator);
 
     const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
+        ("concat", concat),
         ("toString", to_string),
         ("toLocaleString", to_locale_string),
         ("valueOf", value_of),


### PR DESCRIPTION
Previously, it was only declared in the AS3 namespace. However,
some SWFs look it up as a public method.