### PR TITLE
core: Simplify `DisplayObjectContainer::highest_depth`

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -983,13 +983,10 @@ fn get_next_highest_depth<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.swf_version() >= 7 {
-        let depth = std::cmp::max(
-            movie_clip
-                .highest_depth(Depth::MAX)
-                .unwrap_or(0)
-                .wrapping_sub(AVM_DEPTH_BIAS - 1),
-            0,
-        );
+        let depth = movie_clip
+            .highest_depth()
+            .wrapping_sub(AVM_DEPTH_BIAS - 1)
+            .max(0);
         Ok(depth.into())
     } else {
         Ok(Value::Undefined)

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -174,9 +174,8 @@ pub trait TDisplayObjectContainer<'gc>:
     /// Returns the number of children on the render list.
     fn num_children(self) -> usize;
 
-    /// Returns the highest depth on the render list, or `None` if no children
-    /// have a depth less than the provided value.
-    fn highest_depth(self, less_than: Depth) -> Option<Depth>;
+    /// Returns the highest depth among children.
+    fn highest_depth(self) -> Depth;
 
     /// Insert a child display object into the container at a specific position
     /// in the depth list, removing any child already at that position.
@@ -349,8 +348,8 @@ macro_rules! impl_display_object_container {
             self.0.read().$field.num_children()
         }
 
-        fn highest_depth(self, less_than: Depth) -> Option<Depth> {
-            self.0.read().$field.highest_depth(less_than)
+        fn highest_depth(self) -> Depth {
+            self.0.read().$field.highest_depth()
         }
 
         fn replace_at_depth(
@@ -669,14 +668,9 @@ impl<'gc> ChildContainer<'gc> {
         }
     }
 
-    /// Returns the highest depth on the render list, or `None` if no children
-    /// have a depth less than the provided value.
-    pub fn highest_depth(&self, less_than: Depth) -> Option<Depth> {
-        self.depth_list
-            .range(..less_than)
-            .rev()
-            .map(|(k, _v)| *k)
-            .next()
+    /// Returns the highest depth among children.
+    pub fn highest_depth(&self) -> Depth {
+        self.depth_list.keys().next_back().copied().unwrap_or(0)
     }
 
     /// Determine if the render list is empty.


### PR DESCRIPTION
The `less_than` parameter remained just `Depth::MAX` since #7199,
which makes it useless. As such it can be removed.