### PR TITLE
core/mp3: More lenient MP3 buffer underrun detection

### DIFF
--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -338,7 +338,10 @@ impl Iterator for StreamTagReader {
             if found {
                 break Some(self.current_audio_data.clone());
             } else if compression != AudioCompression::Mp3
-                || self.mp3_samples_buffered <= 0
+                // FIXME: The next condition should logically end with `<= 0`.
+                // It was changed as a quick HACK to fix #7524 by not detecting an
+                // underrun too soon. We are still not yet sure what exactly to do here.
+                || self.mp3_samples_buffered <= -(self.mp3_samples_per_block as i32)
                 || reader.get_ref().is_empty()
             {
                 break None;


### PR DESCRIPTION
This should fix #7524.
Regression testing in progress, re: #5486 #6546

(Sorry for being so terse for now, I just had to get this out of my brain ASAP.)