### PR TITLE
core: Don't panic when an error occurs in an AVM2 timer callback

### DIFF
--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -113,8 +113,7 @@ impl<'gc> Timers<'gc> {
                         Avm2Activation::from_nothing(activation.context.reborrow());
                     closure
                         .call(None, &params, &mut avm2_activation)
-                        .unwrap()
-                        .coerce_to_boolean()
+                        .map_or(false, |r| r.coerce_to_boolean())
                 }
             };
 


### PR DESCRIPTION
... instead default to `false`, to not cancel the timer. This might result in an error message spam in some cases, but it follows the "execution never stops due to an error" philosophy that AVM2 operates under, based on what I read on Discord.

This removes an `unwrap` added in #7428.
Should fix: https://github.com/ruffle-rs/ruffle/issues/7516,  https://github.com/ruffle-rs/ruffle/issues/7517, and https://github.com/ruffle-rs/ruffle/issues/7824