### PR TITLE
render: Remove `gc-arena` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,7 +3125,6 @@ dependencies = [
  "approx",
  "downcast-rs",
  "flate2",
- "gc-arena",
  "gif",
  "jpeg-decoder",
  "log",

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -148,6 +148,7 @@ pub struct BitmapData<'gc> {
     ///
     /// This is lazily initialized; a value of `None` indicates that
     /// initialization has not yet happened.
+    #[collect(require_static)]
     bitmap_handle: Option<BitmapHandle>,
 
     /// The AVM2 side of this `BitmapData`.

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -58,6 +58,7 @@ pub struct DisplayObjectBase<'gc> {
     parent: Option<DisplayObject<'gc>>,
     place_frame: u16,
     depth: Depth,
+    #[collect(require_static)]
     transform: Transform,
     name: AvmString<'gc>,
     clip_depth: Depth,

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -39,6 +39,7 @@ pub struct BitmapData<'gc> {
     /// that it can be accessed without a mutation context.
     ///
     /// If this is `None`, then the bitmap does not render anything.
+    #[collect(require_static)]
     bitmap_handle: Option<BitmapHandle>,
 
     /// Whether or not bitmap smoothing is enabled.

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -120,6 +120,7 @@ pub struct EditTextData<'gc> {
     intrinsic_bounds: BoxBounds<Twips>,
 
     /// The current intrinsic bounds of the text field.
+    #[collect(require_static)]
     bounds: BoundingBox,
 
     /// The AVM1 object handle

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -86,6 +86,7 @@ pub struct StageData<'gc> {
     use_bitmap_downsampling: bool,
 
     /// The bounds of the current viewport in twips, used for culling.
+    #[collect(require_static)]
     view_bounds: BoundingBox,
 
     /// The window mode of the viewport.

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-swf = {path = "../swf"}
-gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
+swf = { path = "../swf"}
 log = "0.4"
 gif = "0.11.4"
 png = { version = "0.17.5" }

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -1,7 +1,4 @@
-use gc_arena::Collect;
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Collect)]
-#[collect(no_drop)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct BitmapHandle(pub usize);
 
 /// Info returned by the `register_bitmap` methods.

--- a/render/src/bounding_box.rs
+++ b/render/src/bounding_box.rs
@@ -1,9 +1,7 @@
 use crate::matrix::Matrix;
-use gc_arena::Collect;
 use swf::Twips;
 
-#[derive(Clone, Collect, Debug, Default, Eq, PartialEq)]
-#[collect(require_static)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct BoundingBox {
     pub x_min: Twips,
     pub y_min: Twips,

--- a/render/src/transform.rs
+++ b/render/src/transform.rs
@@ -1,11 +1,9 @@
 use crate::color_transform::ColorTransform;
 use crate::matrix::Matrix;
-use gc_arena::Collect;
 
 /// Represents the transform for a DisplayObject.
 /// This includes both the transformation matrix and the color transform.
-#[derive(Clone, Collect, Debug, Default)]
-#[collect(require_static)]
+#[derive(Clone, Debug, Default)]
 pub struct Transform {
     pub matrix: Matrix,
     pub color_transform: ColorTransform,


### PR DESCRIPTION
It was only used to make structs `#[derive(gc_arena::Collect)]`, and
generally it doesn't make much sense that `render` needs to be GC-aware.
So instead annotate `render` fields in `core` with `#[collect(require_static)]`.