### PR TITLE
text: Use bitflags for edit text flags

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -245,25 +245,12 @@ impl<'gc> EditText<'gc> {
                     context.gc_context,
                     EditTextStatic {
                         swf: swf_movie,
-                        text: EditTextStaticData {
-                            id: swf_tag.id(),
-                            bounds: swf_tag.bounds().clone(),
-                            font_id: swf_tag.font_id(),
-                            font_class_name: swf_tag
-                                .font_class()
-                                .map(|s| s.to_string_lossy(encoding)),
-                            height: swf_tag.height(),
-                            color: swf_tag.color().cloned(),
-                            max_length: swf_tag.max_length(),
-                            layout: swf_tag.layout().cloned(),
-                            variable_name: WString::from_utf8_owned(
-                                swf_tag.variable_name().to_string_lossy(encoding),
-                            ),
-                            initial_text: swf_tag
-                                .initial_text()
-                                .map(|s| WString::from_utf8_owned(s.to_string_lossy(encoding))),
-                            flags: swf_tag.flags(),
-                        },
+                        id: swf_tag.id(),
+                        bounds: swf_tag.bounds().clone(),
+                        layout: swf_tag.layout().cloned(),
+                        initial_text: swf_tag
+                            .initial_text()
+                            .map(|s| WString::from_utf8_owned(s.to_string_lossy(encoding))),
                     },
                 ),
                 flags,
@@ -576,7 +563,7 @@ impl<'gc> EditText<'gc> {
 
         let mut base_width = Twips::from_pixels(self.width());
 
-        if let Some(layout) = &static_data.text.layout {
+        if let Some(layout) = &static_data.layout {
             base_width -= layout.left_margin;
             base_width -= layout.indent;
             base_width -= layout.right_margin;
@@ -620,7 +607,6 @@ impl<'gc> EditText<'gc> {
             .0
             .read()
             .static_data
-            .text
             .initial_text
             .clone()
             .unwrap_or_default();
@@ -748,8 +734,7 @@ impl<'gc> EditText<'gc> {
                 edit_text.bounds.set_x(new_x);
                 edit_text.bounds.set_width(width);
             } else {
-                let width = edit_text.static_data.text.bounds.x_max
-                    - edit_text.static_data.text.bounds.x_min;
+                let width = edit_text.static_data.bounds.x_max - edit_text.static_data.bounds.x_min;
                 edit_text.bounds.set_width(width);
             }
             let height = intrinsic_bounds.height() + padding;
@@ -1418,7 +1403,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     fn id(&self) -> CharacterId {
-        self.0.read().static_data.text.id
+        self.0.read().static_data.id
     }
 
     fn movie(&self) -> Option<Arc<SwfMovie>> {
@@ -1795,27 +1780,13 @@ bitflags::bitflags! {
 
 /// Static data shared between all instances of a text object.
 #[derive(Debug, Clone, Collect)]
-#[collect(no_drop)]
+#[collect(require_static)]
 struct EditTextStatic {
     swf: Arc<SwfMovie>,
-    text: EditTextStaticData,
-}
-
-#[allow(dead_code)]
-#[derive(Debug, Clone, Collect)]
-#[collect(require_static)]
-struct EditTextStaticData {
     id: CharacterId,
     bounds: swf::Rectangle,
-    font_id: Option<CharacterId>, // TODO(Herschel): Combine with height
-    font_class_name: Option<String>,
-    height: Option<Twips>,
-    color: Option<Color>,
-    max_length: Option<u16>,
     layout: Option<swf::TextLayout>,
-    variable_name: WString,
     initial_text: Option<WString>,
-    flags: swf::EditTextFlag,
 }
 
 #[derive(Copy, Clone, Debug, Collect)]

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -142,26 +142,26 @@ impl TextFormat {
     ) -> Self {
         let encoding = swf_movie.encoding();
         let movie_library = context.library.library_for_movie_mut(swf_movie);
-        let font = et.font_id.and_then(|fid| movie_library.get_font(fid));
+        let font = et.font_id().and_then(|fid| movie_library.get_font(fid));
         let font_class = et
-            .font_class_name
+            .font_class()
             .map(|s| WString::from_utf8(&s.to_string_lossy(encoding)))
             .or_else(|| font.map(|font| WString::from_utf8(font.descriptor().class())))
             .unwrap_or_else(|| WString::from_utf8("Times New Roman"));
-        let align = et.layout.as_ref().map(|l| l.align);
-        let left_margin = et.layout.as_ref().map(|l| l.left_margin.to_pixels());
-        let right_margin = et.layout.as_ref().map(|l| l.right_margin.to_pixels());
-        let indent = et.layout.as_ref().map(|l| l.indent.to_pixels());
-        let leading = et.layout.map(|l| l.leading.to_pixels());
+        let align = et.layout().map(|l| l.align);
+        let left_margin = et.layout().map(|l| l.left_margin.to_pixels());
+        let right_margin = et.layout().map(|l| l.right_margin.to_pixels());
+        let indent = et.layout().map(|l| l.indent.to_pixels());
+        let leading = et.layout().map(|l| l.leading.to_pixels());
 
         // TODO: Text fields that don't specify a font are assumed to be 12px
         // Times New Roman non-bold, non-italic. This will need to be revised
         // when we start supporting device fonts.
         Self {
             font: Some(font_class),
-            size: et.height.map(|h| h.to_pixels()),
+            size: et.height().map(|h| h.to_pixels()),
             color: et
-                .color
+                .color()
                 .map(|color| swf::Color::from_rgb(color.to_rgb(), 0)),
             align,
             bold: Some(font.map(|font| font.descriptor().bold()).unwrap_or(false)),

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2359,7 +2359,9 @@ impl<'a> Reader<'a> {
         } else {
             Default::default()
         };
-        let height = if flags.contains(EditTextFlag::HAS_FONT) {
+        let height = if flags.intersects(EditTextFlag::HAS_FONT | EditTextFlag::HAS_FONT_CLASS) {
+            // SWF19 errata: The specs say this field is only present if the HasFont flag is set,
+            // but it's also present when the HasFontClass flag is set.
             Twips::new(self.read_u16()?)
         } else {
             Twips::ZERO

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -359,44 +359,40 @@ pub fn tag_tests() -> Vec<TagTestData> {
         ),
         (
             4,
-            Tag::DefineEditText(Box::new(EditText {
-                id: 2,
-                bounds: Rectangle {
-                    x_min: Twips::from_pixels(-2.0),
-                    x_max: Twips::from_pixels(77.9),
-                    y_min: Twips::from_pixels(-2.0),
-                    y_max: Twips::from_pixels(23.9),
-                },
-                font_id: Some(1),
-                font_class_name: None,
-                height: Some(Twips::from_pixels(18.0)),
-                color: Some(Color {
-                    r: 0,
-                    g: 255,
-                    b: 0,
-                    a: 255,
-                }),
-                max_length: None,
-                layout: Some(TextLayout {
-                    align: TextAlign::Justify,
-                    left_margin: Twips::from_pixels(3.0),
-                    right_margin: Twips::from_pixels(4.0),
-                    indent: Twips::from_pixels(1.0),
-                    leading: Twips::from_pixels(2.0),
-                }),
-                variable_name: SwfStr::from_str_with_encoding("foo", WINDOWS_1252).unwrap(),
-                initial_text: Some(SwfStr::from_str_with_encoding("-_-", WINDOWS_1252).unwrap()),
-                is_word_wrap: false,
-                is_multiline: true,
-                is_password: false,
-                is_read_only: true,
-                is_auto_size: false,
-                is_selectable: true,
-                has_border: true,
-                was_static: false,
-                is_html: false,
-                is_device_font: true,
-            })),
+            Tag::DefineEditText(Box::new(
+                EditText::new()
+                    .with_id(2)
+                    .with_font_id(1, Twips::from_pixels(18.0))
+                    .with_bounds(Rectangle {
+                        x_min: Twips::from_pixels(-2.0),
+                        x_max: Twips::from_pixels(77.9),
+                        y_min: Twips::from_pixels(-2.0),
+                        y_max: Twips::from_pixels(23.9),
+                    })
+                    .with_color(Some(Color {
+                        r: 0,
+                        g: 255,
+                        b: 0,
+                        a: 255,
+                    }))
+                    .with_layout(Some(TextLayout {
+                        align: TextAlign::Justify,
+                        left_margin: Twips::from_pixels(3.0),
+                        right_margin: Twips::from_pixels(4.0),
+                        indent: Twips::from_pixels(1.0),
+                        leading: Twips::from_pixels(2.0),
+                    }))
+                    .with_variable_name(
+                        SwfStr::from_str_with_encoding("foo", WINDOWS_1252).unwrap(),
+                    )
+                    .with_initial_text(Some(
+                        SwfStr::from_str_with_encoding("-_-", WINDOWS_1252).unwrap(),
+                    ))
+                    .with_is_read_only(true)
+                    .with_has_border(true)
+                    .with_is_multiline(true)
+                    .with_use_outlines(false),
+            )),
             read_tag_bytes_from_file("tests/swfs/DefineEditText-MX.swf", TagCode::DefineEditText),
         ),
         (

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -1385,28 +1385,6 @@ impl<'a> EditText<'a> {
             .then_some(self.font_id)
     }
 
-    // The height of the font in twips.
-    #[inline]
-    pub fn height(&self) -> Option<Twips> {
-        self.flags
-            .contains(EditTextFlag::HAS_FONT)
-            .then_some(self.height)
-    }
-
-    #[inline]
-    pub fn with_default_font(mut self) -> Self {
-        self.flags -= EditTextFlag::HAS_FONT;
-        self
-    }
-
-    #[inline]
-    pub fn with_font_id(mut self, font_id: CharacterId, height: Twips) -> Self {
-        self.flags |= EditTextFlag::HAS_FONT;
-        self.font_id = font_id;
-        self.height = height;
-        self
-    }
-
     #[inline]
     pub fn font_class(&self) -> Option<&'a SwfStr> {
         self.flags
@@ -1414,14 +1392,35 @@ impl<'a> EditText<'a> {
             .then_some(self.font_class)
     }
 
+    // The height of the font in twips.
     #[inline]
-    pub fn with_font_class(mut self, font_class_name: Option<&'a SwfStr>) -> Self {
-        if let Some(font_class_name) = font_class_name {
-            self.flags |= EditTextFlag::HAS_FONT_CLASS;
-            self.font_class = font_class_name;
-        } else {
-            self.flags -= EditTextFlag::HAS_FONT_CLASS;
-        }
+    pub fn height(&self) -> Option<Twips> {
+        self.flags
+            .intersects(EditTextFlag::HAS_FONT | EditTextFlag::HAS_FONT_CLASS)
+            .then_some(self.height)
+    }
+
+    #[inline]
+    pub fn with_default_font(mut self) -> Self {
+        self.flags -= EditTextFlag::HAS_FONT | EditTextFlag::HAS_FONT_CLASS;
+        self
+    }
+
+    #[inline]
+    pub fn with_font_id(mut self, font_id: CharacterId, height: Twips) -> Self {
+        self.flags |= EditTextFlag::HAS_FONT;
+        self.flags -= EditTextFlag::HAS_FONT_CLASS;
+        self.font_id = font_id;
+        self.height = height;
+        self
+    }
+
+    #[inline]
+    pub fn with_font_class(mut self, font_class: &'a SwfStr, height: Twips) -> Self {
+        self.flags |= EditTextFlag::HAS_FONT_CLASS;
+        self.flags -= EditTextFlag::HAS_FONT;
+        self.font_class = font_class;
+        self.height = height;
         self
     }
 

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2273,7 +2273,6 @@ impl<W: Write> Writer<W> {
                 writer.write_string(class)?;
             }
 
-            // TODO(Herschel): Height only exists iff HasFontId, maybe for HasFontClass too?
             if let Some(height) = edit_text.height() {
                 writer.write_u16(height.get() as u16)?
             }

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -2262,63 +2262,31 @@ impl<W: Write> Writer<W> {
             let mut writer = Writer::new(&mut buf, self.version);
             writer.write_character_id(edit_text.id)?;
             writer.write_rectangle(&edit_text.bounds)?;
-            let flags = if edit_text.initial_text.is_some() {
-                0b10000000
-            } else {
-                0
-            } | if edit_text.is_word_wrap { 0b1000000 } else { 0 }
-                | if edit_text.is_multiline { 0b100000 } else { 0 }
-                | if edit_text.is_password { 0b10000 } else { 0 }
-                | if edit_text.is_read_only { 0b1000 } else { 0 }
-                | if edit_text.color.is_some() { 0b100 } else { 0 }
-                | if edit_text.max_length.is_some() {
-                    0b10
-                } else {
-                    0
-                }
-                | if edit_text.font_id.is_some() { 0b1 } else { 0 };
-            let flags2 = if edit_text.font_class_name.is_some() {
-                0b10000000
-            } else {
-                0
-            } | if edit_text.is_auto_size { 0b1000000 } else { 0 }
-                | if edit_text.layout.is_some() {
-                    0b100000
-                } else {
-                    0
-                }
-                | if !edit_text.is_selectable { 0b10000 } else { 0 }
-                | if edit_text.has_border { 0b1000 } else { 0 }
-                | if edit_text.was_static { 0b100 } else { 0 }
-                | if edit_text.is_html { 0b10 } else { 0 }
-                | if !edit_text.is_device_font { 0b1 } else { 0 };
+            writer.write_u16(edit_text.flags.bits() as u16)?;
 
-            writer.write_u8(flags)?;
-            writer.write_u8(flags2)?;
-
-            if let Some(font_id) = edit_text.font_id {
+            if let Some(font_id) = edit_text.font_id() {
                 writer.write_character_id(font_id)?;
             }
 
             // TODO(Herschel): Check SWF version.
-            if let Some(class) = edit_text.font_class_name {
+            if let Some(class) = edit_text.font_class() {
                 writer.write_string(class)?;
             }
 
             // TODO(Herschel): Height only exists iff HasFontId, maybe for HasFontClass too?
-            if let Some(height) = edit_text.height {
+            if let Some(height) = edit_text.height() {
                 writer.write_u16(height.get() as u16)?
             }
 
-            if let Some(ref color) = edit_text.color {
+            if let Some(color) = edit_text.color() {
                 writer.write_rgba(color)?
             }
 
-            if let Some(len) = edit_text.max_length {
+            if let Some(len) = edit_text.max_length() {
                 writer.write_u16(len)?;
             }
 
-            if let Some(ref layout) = edit_text.layout {
+            if let Some(layout) = edit_text.layout() {
                 writer.write_u8(layout.align as u8)?;
                 writer.write_u16(layout.left_margin.get() as u16)?; // TODO: Handle overflow
                 writer.write_u16(layout.right_margin.get() as u16)?;
@@ -2327,7 +2295,8 @@ impl<W: Write> Writer<W> {
             }
 
             writer.write_string(edit_text.variable_name)?;
-            if let Some(text) = edit_text.initial_text {
+
+            if let Some(text) = edit_text.initial_text() {
                 writer.write_string(text)?;
             }
         }


### PR DESCRIPTION
Clean up the massive set of bools used by `swf::EditText` and `core::edit_text::EditText`.

 * Add `swf::EditTextFlag` for the bits used by the DefineEditText SWF tag.
 * Add builder-like methods to `swf::EditText` to allow setting these flags and values.
 * Add `core::edit_text::EditTextFlag` that extends this with additional flags used by core/ActionScript.
 * Simplify `EditTextStatic` as it was mostly unused fields.
 * Fix a bug where height should be read in DefineEditText when the `HAS_FONT_CLASS` flag is set.

Shaves off 8 bytes or so from `EditText`. This is a small step to make #7749 nicer.