### PR TITLE
avm2: Fix the stub for `Vector` + some related cleanup

### DIFF
--- a/core/src/avm2/globals/Date.as
+++ b/core/src/avm2/globals/Date.as
@@ -1,5 +1,5 @@
 // This is a stub - the actual class is defined in `date.rs`
 package {
-    public class Date extends Object {
+    public class Date {
     }
 }

--- a/core/src/avm2/globals/Vector.as
+++ b/core/src/avm2/globals/Vector.as
@@ -1,5 +1,8 @@
 // This is a stub - the actual class is defined in `vector.rs`
-package {
-    public class Vector extends Object {
+
+// See this for the explanation of the weird package name:
+// https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/VectorClass.h#L18-L65
+package __AS3__.vec {
+    public final dynamic class Vector {
     }
 }

--- a/core/src/avm2/globals/flash/events/ShaderEvent.as
+++ b/core/src/avm2/globals/flash/events/ShaderEvent.as
@@ -12,11 +12,11 @@ package flash.events
     {
         public static const COMPLETE:String = "complete"; // Defines the value of the type property of a complete event object.
 
-        public var vector: Vector; // The Vector.<Number> object that was passed to the ShaderJob.start() method.
+        public var vector: Vector.<Number>; // The Vector.<Number> object that was passed to the ShaderJob.start() method.
         public var bitmapData: BitmapData; // The BitmapData object that was passed to the ShaderJob.start() method.
         public var byteArray: ByteArray; // The ByteArray object that was passed to the ShaderJob.start() method.
 
-        public function ShaderEvent(type:String, bubbles:Boolean = false, cancelable:Boolean = false, bitmap:BitmapData = null, array:ByteArray = null, vector:Vector = null)
+        public function ShaderEvent(type:String, bubbles:Boolean = false, cancelable:Boolean = false, bitmap:BitmapData = null, array:ByteArray = null, vector:Vector.<Number> = null)
         {
             super(type,bubbles,cancelable);
             this.bitmapData = bitmap;

--- a/core/src/avm2/globals/flash/utils/Dictionary.as
+++ b/core/src/avm2/globals/flash/utils/Dictionary.as
@@ -1,5 +1,5 @@
 // This is a stub - the actual class is defined in `dictionary.rs`
 package flash.utils {
-    public class Dictionary extends Object {
+    public class Dictionary {
     }
 }


### PR DESCRIPTION
As per our (not so) recent Discord discussion.

EDIT: Plus some related cleanup following #7597.