### PR TITLE
core: Avoid some clones of `Matrix` and `ColorTransform`

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -873,15 +873,18 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
         parent.replace_at_depth(&mut activation.context, new_clip, depth);
 
         // Copy display properties from previous clip to new clip.
-        new_clip.set_matrix(activation.context.gc_context, movie_clip.base().matrix());
-        new_clip.set_color_transform(
-            activation.context.gc_context,
-            movie_clip.base().color_transform(),
-        );
-        new_clip.as_movie_clip().unwrap().set_clip_event_handlers(
-            activation.context.gc_context,
-            movie_clip.clip_actions().to_vec(),
-        );
+        let matrix = *movie_clip.base().matrix();
+        new_clip.set_matrix(activation.context.gc_context, matrix);
+
+        let color_transform = *movie_clip.base().color_transform();
+        new_clip.set_color_transform(activation.context.gc_context, color_transform);
+
+        let clip_actions = movie_clip.clip_actions().to_vec();
+        new_clip
+            .as_movie_clip()
+            .unwrap()
+            .set_clip_event_handlers(activation.context.gc_context, clip_actions);
+
         *new_clip.as_drawing(activation.context.gc_context).unwrap() = movie_clip
             .as_drawing(activation.context.gc_context)
             .unwrap()
@@ -1443,9 +1446,11 @@ fn set_transform<'gc>(
         if let Some(transform) = object.as_transform_object() {
             if let Some(clip) = transform.clip() {
                 let matrix = *clip.base().matrix();
-                this.set_matrix(activation.context.gc_context, &matrix);
+                this.set_matrix(activation.context.gc_context, matrix);
+
                 let color_transform = *clip.base().color_transform();
-                this.set_color_transform(activation.context.gc_context, &color_transform);
+                this.set_color_transform(activation.context.gc_context, color_transform);
+
                 this.set_transformed_by_script(activation.context.gc_context, true);
             }
         }

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -121,7 +121,7 @@ fn set_color_transform<'gc>(
     if as_color_transform.as_color_transform_object().is_some() {
         let swf_color_transform =
             color_transform::object_to_color_transform(as_color_transform, activation)?;
-        clip.set_color_transform(activation.context.gc_context, &swf_color_transform);
+        clip.set_color_transform(activation.context.gc_context, swf_color_transform);
         clip.set_transformed_by_script(activation.context.gc_context, true);
     }
 
@@ -148,7 +148,7 @@ fn set_matrix<'gc>(
         .all(|p| as_matrix.has_own_property(activation, (*p).into()));
     if is_matrix {
         let swf_matrix = matrix::object_to_matrix(as_matrix, activation)?;
-        clip.set_matrix(activation.context.gc_context, &swf_matrix);
+        clip.set_matrix(activation.context.gc_context, swf_matrix);
         clip.set_transformed_by_script(activation.context.gc_context, true);
     }
 

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -642,8 +642,8 @@ pub fn set_transform<'gc>(
 
         let dobj = this.as_display_object().unwrap();
         let mut write = dobj.base_mut(activation.context.gc_context);
-        write.set_color_transform(&color_transform);
-        write.set_matrix(&matrix);
+        write.set_matrix(matrix);
+        write.set_color_transform(color_transform);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -54,7 +54,7 @@ pub fn set_color_transform<'gc>(
     let ct = object_to_color_transform(args[0].coerce_to_object(activation)?, activation)?;
     get_display_object(this, activation)?
         .base_mut(activation.context.gc_context)
-        .set_color_transform(&ct);
+        .set_color_transform(ct);
     Ok(Value::Undefined)
 }
 
@@ -77,7 +77,7 @@ pub fn set_matrix<'gc>(
     let matrix = object_to_matrix(args[0].coerce_to_object(activation)?, activation)?;
     get_display_object(this, activation)?
         .base_mut(activation.context.gc_context)
-        .set_matrix(&matrix);
+        .set_matrix(matrix);
     Ok(Value::Undefined)
 }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -177,8 +177,8 @@ impl<'gc> DisplayObjectBase<'gc> {
         &mut self.transform.matrix
     }
 
-    pub fn set_matrix(&mut self, matrix: &Matrix) {
-        self.transform.matrix = *matrix;
+    pub fn set_matrix(&mut self, matrix: Matrix) {
+        self.transform.matrix = matrix;
         self.flags -= DisplayObjectFlags::SCALE_ROTATION_CACHED;
     }
 
@@ -190,8 +190,8 @@ impl<'gc> DisplayObjectBase<'gc> {
         &mut self.transform.color_transform
     }
 
-    pub fn set_color_transform(&mut self, color_transform: &ColorTransform) {
-        self.transform.color_transform = *color_transform;
+    pub fn set_color_transform(&mut self, color_transform: ColorTransform) {
+        self.transform.color_transform = color_transform;
     }
 
     fn x(&self) -> f64 {
@@ -670,14 +670,14 @@ pub trait TDisplayObject<'gc>:
         self.base_mut(gc_context).set_place_frame(frame)
     }
 
-    fn set_matrix(&self, gc_context: MutationContext<'gc, '_>, matrix: &Matrix) {
+    fn set_matrix(&self, gc_context: MutationContext<'gc, '_>, matrix: Matrix) {
         self.base_mut(gc_context).set_matrix(matrix);
     }
 
     fn set_color_transform(
         &self,
         gc_context: MutationContext<'gc, '_>,
-        color_transform: &ColorTransform,
+        color_transform: ColorTransform,
     ) {
         self.base_mut(gc_context)
             .set_color_transform(color_transform)
@@ -1365,10 +1365,10 @@ pub trait TDisplayObject<'gc>:
         // PlaceObject tags only apply if this object has not been dynamically moved by AS code.
         if !self.transformed_by_script() {
             if let Some(matrix) = place_object.matrix {
-                self.set_matrix(context.gc_context, &matrix.into());
+                self.set_matrix(context.gc_context, matrix.into());
             }
             if let Some(color_transform) = &place_object.color_transform {
-                self.set_color_transform(context.gc_context, &color_transform.clone().into());
+                self.set_color_transform(context.gc_context, color_transform.clone().into());
             }
             if let Some(ratio) = place_object.ratio {
                 if let Some(mut morph_shape) = self.as_morph_shape() {

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -172,11 +172,9 @@ impl<'gc> Avm1Button<'gc> {
                 };
 
                 // Set transform of child (and modify previous child if it already existed)
-                child.set_matrix(context.gc_context, &record.matrix.into());
-                child.set_color_transform(
-                    context.gc_context,
-                    &record.color_transform.clone().into(),
-                );
+                child.set_matrix(context.gc_context, record.matrix.into());
+                child
+                    .set_color_transform(context.gc_context, record.color_transform.clone().into());
             }
         }
         drop(write);
@@ -302,7 +300,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
                         .instantiate_by_id(record.id, context.gc_context)
                     {
                         Ok(child) => {
-                            child.set_matrix(context.gc_context, &record.matrix.into());
+                            child.set_matrix(context.gc_context, record.matrix.into());
                             child.set_parent(context.gc_context, Some(self_display_object));
                             child.set_depth(context.gc_context, record.depth.into());
                             new_children.push((child, record.depth.into()));

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -196,13 +196,13 @@ impl<'gc> Avm2Button<'gc> {
                     .instantiate_by_id(record.id, context.gc_context)
                 {
                     Ok(child) => {
-                        child.set_matrix(context.gc_context, &record.matrix.into());
+                        child.set_matrix(context.gc_context, record.matrix.into());
                         child.set_depth(context.gc_context, record.depth.into());
 
                         if swf_state != swf::ButtonState::HIT_TEST {
                             child.set_color_transform(
                                 context.gc_context,
-                                &record.color_transform.clone().into(),
+                                record.color_transform.clone().into(),
                             );
                         }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1597,7 +1597,7 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         self.redraw_border(gc_context);
     }
 
-    fn set_matrix(&self, gc_context: MutationContext<'gc, '_>, matrix: &Matrix) {
+    fn set_matrix(&self, gc_context: MutationContext<'gc, '_>, matrix: Matrix) {
         self.0.write(gc_context).base.base.set_matrix(matrix);
         self.redraw_border(gc_context);
     }


### PR DESCRIPTION
Change `set_matrix` and `set_color_transform` to accept owned structs,
instead of references. This allows callers that already have an owned
struct to pass it directly, thus saving an unnecessary borrow + clone.

This also aligns with other methods, such as `set_sound_transform`,
which currently accepts an owned struct.