### PR TITLE
audio: Switch to symphonia by default

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 clap = { version = "3.2.20", features = ["derive"] }
 cpal = "0.14.0"
-ruffle_core = { path = "../core", features = ["audio", "minimp3", "nellymoser"] }
+ruffle_core = { path = "../core", features = ["audio", "symphonia", "nellymoser"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 env_logger = { version = "0.9", default-features = false, features = ["humantime"] }


### PR DESCRIPTION
Deprecate minimp3 for MP3 decoding and switch to symphonia on desktop by default. This allows both desktop and web to use the same MP3 decoder for consistent behavior.

Let's see how this works out for a week or so, then we can remove the minimp3 feature.

Fixes #7070.