### PR TITLE
chore: Remove unused `image` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,7 +3053,6 @@ dependencies = [
  "futures",
  "gc-arena",
  "generational-arena",
- "image",
  "indexmap",
  "instant",
  "log",
@@ -3130,7 +3129,6 @@ dependencies = [
  "downcast-rs",
  "flate2",
  "gif",
- "image",
  "jpeg-decoder",
  "log",
  "lyon",
@@ -3146,7 +3144,6 @@ name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
  "fnv",
- "image",
  "js-sys",
  "log",
  "ruffle_render",
@@ -3162,7 +3159,6 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "fnv",
- "image",
  "js-sys",
  "log",
  "ruffle_render",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,6 @@ flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "19fecd
 lzma-rs = {version = "0.2.0", optional = true }
 dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.1", default-features = false, features = ["mp3"], optional = true }
-image = "0.24.2"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.24"

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -16,7 +16,6 @@ downcast-rs = "1.2.0"
 lyon = { version = "1.0.0", optional = true }
 thiserror = "1.0"
 wasm-bindgen = { version = "=0.2.82", optional = true }
-image = "0.24.3"
 
 [dependencies.jpeg-decoder]
 version = "0.2.6"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -13,7 +13,6 @@ wasm-bindgen = "=0.2.82"
 fnv = "1.0.7"
 ruffle_render = { path = "..", features = ["web"] }
 swf = { path = "../../swf" }
-image = "0.24.2"
 
 [dependencies.web-sys]
 version = "0.3.58"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -15,7 +15,6 @@ bytemuck = { version = "1.12.1", features = ["derive"] }
 fnv = "1.0.7"
 swf = { path = "../../swf" }
 thiserror = "1.0"
-image = "0.24.3"
 
 [dependencies.web-sys]
 version = "0.3.58"


### PR DESCRIPTION
This basically reverts #7254 for all `.toml` files, except for `wgpu`
where it's actually needed on both desktop and web.
