### PR TITLE
audio: Remove minimp3 feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,26 +2490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minimp3"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985438f75febf74c392071a975a29641b420dd84431135a6e6db721de4b74372"
-dependencies = [
- "minimp3-sys",
- "slice-deque",
- "thiserror",
-]
-
-[[package]]
-name = "minimp3-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21c73734c69dc95696c9ed8926a2b393171d98b3f5f5935686a26a487ab9b90"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,7 +3376,6 @@ dependencies = [
  "instant",
  "log",
  "lzma-rs",
- "minimp3",
  "nellymoser-rs",
  "num-derive",
  "num-traits",
@@ -3938,17 +3917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "slice-deque"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ef6ee280cdefba6d2d0b4b78a84a1c1a3f3a4cec98c2d4231c8bc225de0f25"
-dependencies = [
- "libc",
- "mach",
- "winapi",
 ]
 
 [[package]]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -425,8 +425,6 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [memoffset](https://github.com/Gilnaa/memoffset) | [MIT](#MIT) | Copyright (c) 2017 Gilad Naaman  | 
 | [metal](https://github.com/gfx-rs/metal-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2010 The Rust Project Developers  | 
 | [mime](https://github.com/hyperium/mime) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Sean McArthur  | 
-| [minimp3](https://github.com/germangb/minimp3-rs.git) | [MIT](#MIT) | Copyright (c) 2018 German Gomez Bajo  | 
-| [minimp3-sys](https://github.com/germangb/minimp3-rs.git) | [MIT](#MIT) | Copyright (c) 2018 German Gomez Bajo  | 
 | [miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide) | [Apache-2.0](#Apache-20)/[MIT](#MIT)/[Zlib](#Zlib) | Copyright (c) 2017 Frommi  | 
 | [mio](https://github.com/tokio-rs/mio) | [MIT](#MIT) | Copyright (c) 2014 Carl Lerche and other MIO contributors  | 
 | [mio-extras](https://github.com/dimbleby/mio-extras) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2017 Mio authors  | 
@@ -552,6 +550,7 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [strsim](https://github.com/dguo/strsim-rs) | [MIT](#MIT) | Copyright (c) 2015 Danny Guo Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> Copyright (c) 2018 Akash Kurdekar  | 
 | [svg](https://github.com/bodoni/svg) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright 2015–2021 The svg Developers Copyright 2015–2021 The svg Developers  | 
 | [swf](https://github.com/ruffle-rs/ruffle) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors | 
+| [symphonia](https://github.com/pdeljanov/Symphonia) | [MPL-2.0](#MPL-20) | Copyright (c) Philip Deljanov | 
 | [syn](https://github.com/dtolnay/syn) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) David Tolnay <dtolnay@gmail.com> | 
 | [synstructure](https://github.com/mystor/synstructure) | [MIT](#MIT) | Copyright 2016 Nika Layzell  | 
 | [tar](https://github.com/alexcrichton/tar-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton  | 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
 generational-arena = "0.2.8"
 indexmap = "1.9.2"
 log = "0.4"
-minimp3 = { version = "0.5.1", optional = true }
 ruffle_render = { path = "../render" }
 ruffle_video = { path = "../video" }
 ruffle_macros = { path = "macros" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,6 +61,7 @@ wasm-bindgen = [ "instant/wasm-bindgen" ]
 avm_debug = []
 deterministic = []
 timeline_debug = []
+mp3 = ["symphonia"]
 nellymoser = ["nellymoser-rs"]
 audio = ["dasp"]
 

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -1,17 +1,15 @@
 //! Audio decoders.
 
 mod adpcm;
-#[cfg(any(feature = "minimp3", feature = "symphonia"))]
+#[cfg(feature = "symphonia")]
 mod mp3;
 #[cfg(feature = "nellymoser")]
 mod nellymoser;
 mod pcm;
 
 pub use adpcm::AdpcmDecoder;
-#[cfg(feature = "minimp3")]
-pub use mp3::minimp3::{mp3_metadata, Mp3Decoder};
-#[cfg(all(feature = "symphonia", not(feature = "minimp3")))]
-pub use mp3::symphonia::{mp3_metadata, Mp3Decoder};
+#[cfg(feature = "symphonia")]
+pub use mp3::{mp3_metadata, Mp3Decoder};
 #[cfg(feature = "nellymoser")]
 pub use nellymoser::NellymoserDecoder;
 pub use pcm::PcmDecoder;
@@ -23,13 +21,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[cfg(feature = "minimp3")]
-    #[error("Couldn't decode MP3 using minimp3")]
-    InvalidMp3(#[from] mp3::minimp3::Error),
-
-    #[cfg(all(feature = "symphonia", not(feature = "minimp3")))]
-    #[error("Couldn't decode MP3 using symphonia")]
-    InvalidMp3(#[from] mp3::symphonia::Error),
+    #[cfg(all(feature = "symphonia"))]
+    #[error("Couldn't decode MP3")]
+    InvalidMp3(#[from] mp3::Error),
 
     #[error("Couldn't decode ADPCM")]
     InvalidAdpcm(#[from] adpcm::Error),
@@ -75,7 +69,7 @@ pub fn make_decoder<R: 'static + Read + Send + Sync>(
             format.is_stereo,
             format.sample_rate,
         )?),
-        #[cfg(any(feature = "minimp3", feature = "symphonia"))]
+        #[cfg(feature = "symphonia")]
         AudioCompression::Mp3 => Box::new(Mp3Decoder::new(data)?),
         #[cfg(feature = "nellymoser")]
         AudioCompression::Nellymoser => {

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -1,14 +1,14 @@
 //! Audio decoders.
 
 mod adpcm;
-#[cfg(feature = "symphonia")]
+#[cfg(feature = "mp3")]
 mod mp3;
 #[cfg(feature = "nellymoser")]
 mod nellymoser;
 mod pcm;
 
 pub use adpcm::AdpcmDecoder;
-#[cfg(feature = "symphonia")]
+#[cfg(feature = "mp3")]
 pub use mp3::{mp3_metadata, Mp3Decoder};
 #[cfg(feature = "nellymoser")]
 pub use nellymoser::NellymoserDecoder;
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[cfg(all(feature = "symphonia"))]
+    #[cfg(all(feature = "mp3"))]
     #[error("Couldn't decode MP3")]
     InvalidMp3(#[from] mp3::Error),
 
@@ -69,7 +69,7 @@ pub fn make_decoder<R: 'static + Read + Send + Sync>(
             format.is_stereo,
             format.sample_rate,
         )?),
-        #[cfg(feature = "symphonia")]
+        #[cfg(feature = "mp3")]
         AudioCompression::Mp3 => Box::new(Mp3Decoder::new(data)?),
         #[cfg(feature = "nellymoser")]
         AudioCompression::Nellymoser => {

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -1,331 +1,201 @@
-#[cfg(feature = "minimp3")]
-pub mod minimp3 {
-    use crate::backend::audio::decoders::{Decoder, Mp3Metadata, SeekableDecoder};
-    use std::io::{Cursor, Read};
-    use thiserror::Error;
+use crate::backend::audio::decoders::{Decoder, Mp3Metadata, SeekableDecoder};
+use std::io::{Cursor, Read};
+use symphonia::{
+    core::{
+        self, audio, codecs, errors,
+        formats::{self, FormatReader},
+        io,
+    },
+    default::formats::Mp3Reader as SymphoniaMp3Reader,
+};
+use thiserror::Error;
 
-    #[derive(Debug, Error)]
-    pub enum Error {
-        #[error("Couldn't decode MP3 frame")]
-        FrameDecode(#[from] minimp3::Error),
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Couldn't decode MP3 frame")]
+    FrameDecode(#[from] errors::Error),
 
-        #[error("Invalid sample rate")]
-        InvalidSampleRate,
+    #[error("No default track")]
+    NoDefaultTrack,
 
-        #[error("Invalid channels")]
-        InvalidChannels,
-    }
+    #[error("Invalid sample rate")]
+    InvalidSampleRate,
 
-    pub struct Mp3Decoder<R: Read> {
-        decoder: minimp3::Decoder<R>,
-        frame: minimp3::Frame,
-        sample_rate: u16,
-        num_channels: u8,
-        cur_sample: usize,
-    }
+    #[error("Invalid channels")]
+    InvalidChannels,
+}
 
-    impl<R: Read> Mp3Decoder<R> {
-        pub fn new(reader: R) -> Result<Self, Error> {
-            let mut decoder = minimp3::Decoder::new(reader);
-            let frame = decoder.next_frame()?;
-            let sample_rate = frame
-                .sample_rate
+pub struct Mp3Decoder {
+    reader: SymphoniaMp3Reader,
+    decoder: Box<dyn codecs::Decoder>,
+    sample_buf: audio::SampleBuffer<i16>,
+    cur_sample: usize,
+    sample_rate: u16,
+    num_channels: u8,
+    stream_ended: bool,
+}
+
+impl Mp3Decoder {
+    // MP3 frames contain 1152 samples.
+    const SAMPLE_BUFFER_DURATION: u64 = 1152;
+
+    pub fn new<R: 'static + Read + Send + Sync>(reader: R) -> Result<Self, Error> {
+        let source = Box::new(io::ReadOnlySource::new(reader)) as Box<dyn io::MediaSource>;
+        let source = io::MediaSourceStream::new(source, Default::default());
+        let reader = SymphoniaMp3Reader::try_new(source, &Default::default())?;
+        let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
+        let codec_params = track.codec_params.clone();
+        let decoder = symphonia::default::get_codecs().make(&codec_params, &Default::default())?;
+        let sample_rate = codec_params.sample_rate.ok_or(Error::InvalidSampleRate)?;
+        let channels = codec_params.channels.ok_or(Error::InvalidChannels)?;
+        Ok(Mp3Decoder {
+            reader,
+            decoder,
+            sample_buf: audio::SampleBuffer::new(0, audio::SignalSpec::new(sample_rate, channels)),
+            cur_sample: 0,
+            num_channels: channels
+                .count()
                 .try_into()
-                .map_err(|_| Error::InvalidSampleRate)?;
-            let num_channels = frame
-                .channels
-                .try_into()
-                .map_err(|_| Error::InvalidChannels)?;
-            Ok(Mp3Decoder {
-                decoder,
-                frame,
-                sample_rate,
-                num_channels,
-                cur_sample: 0,
-            })
-        }
-
-        fn next_frame(&mut self) {
-            if let Ok(frame) = self.decoder.next_frame() {
-                self.frame = frame;
-            } else {
-                self.frame.data.clear();
-            }
-            self.cur_sample = 0;
-        }
-    }
-
-    impl<R: Read + Send + Sync> Iterator for Mp3Decoder<R> {
-        type Item = [i16; 2];
-
-        #[inline]
-        #[allow(clippy::branches_sharing_code)]
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.cur_sample >= self.frame.data.len() {
-                self.next_frame();
-            }
-
-            if !self.frame.data.is_empty() {
-                if self.num_channels() == 2 {
-                    let left = self.frame.data[self.cur_sample];
-                    let right = self.frame.data[self.cur_sample + 1];
-                    self.cur_sample += 2;
-                    Some([left, right])
-                } else {
-                    let sample = self.frame.data[self.cur_sample];
-                    self.cur_sample += 1;
-                    Some([sample, sample])
-                }
-            } else {
-                None
-            }
-        }
-    }
-
-    impl<R: AsRef<[u8]> + Default + Send + Sync> SeekableDecoder for Mp3Decoder<Cursor<R>> {
-        #[inline]
-        fn reset(&mut self) {
-            // TODO: This is funky.
-            // I want to reset the `BitStream` and `Cursor` to their initial positions,
-            // but have to work around the borrowing rules of Rust.
-            let mut cursor = std::mem::take(self.decoder.reader_mut());
-            cursor.set_position(0);
-            if let Ok(decoder) = Mp3Decoder::new(cursor) {
-                *self = decoder;
-            }
-        }
-    }
-
-    impl<R: Read + Send + Sync> Decoder for Mp3Decoder<R> {
-        #[inline]
-        fn num_channels(&self) -> u8 {
-            self.num_channels
-        }
-
-        #[inline]
-        fn sample_rate(&self) -> u16 {
-            self.sample_rate
-        }
-    }
-
-    /// Returns the number of samples frames in the given MP3 data.
-    pub fn mp3_metadata(data: &std::sync::Arc<[u8]>) -> Result<Mp3Metadata, Error> {
-        let decoder = Mp3Decoder::new(Cursor::new(data.clone()))?;
-        Ok(Mp3Metadata {
-            sample_rate: decoder.sample_rate(),
-            num_sample_frames: decoder.count() as u32,
+                .map_err(|_| Error::InvalidChannels)?,
+            sample_rate: sample_rate.try_into().map_err(|_| Error::InvalidChannels)?,
+            stream_ended: false,
         })
+    }
+
+    pub fn new_seekable<R: 'static + AsRef<[u8]> + Send + Sync>(
+        reader: Cursor<R>,
+    ) -> Result<Self, Error> {
+        let source = Box::new(reader) as Box<dyn io::MediaSource>;
+        let source = io::MediaSourceStream::new(source, Default::default());
+        let reader = SymphoniaMp3Reader::try_new(source, &Default::default()).unwrap();
+        let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
+        let codec_params = track.codec_params.clone();
+        let decoder = symphonia::default::get_codecs().make(&codec_params, &Default::default())?;
+        let sample_rate = codec_params.sample_rate.ok_or(Error::InvalidSampleRate)?;
+        let channels = codec_params.channels.ok_or(Error::InvalidChannels)?;
+        Ok(Mp3Decoder {
+            reader,
+            decoder,
+            sample_buf: audio::SampleBuffer::new(
+                Self::SAMPLE_BUFFER_DURATION,
+                audio::SignalSpec::new(sample_rate, channels),
+            ),
+            cur_sample: 0,
+            num_channels: channels.count() as u8,
+            sample_rate: sample_rate as u16,
+            stream_ended: false,
+        })
+    }
+
+    fn next_frame(&mut self) {
+        if self.stream_ended {
+            return;
+        }
+
+        self.cur_sample = 0;
+        while let Ok(packet) = self.reader.next_packet() {
+            match self.decoder.decode(&packet) {
+                Ok(decoded) => {
+                    if self.sample_buf.capacity() < decoded.capacity() {
+                        // Ensure our buffer has enough space for the decoded samples.
+                        self.sample_buf = audio::SampleBuffer::new(
+                            decoded.capacity() as core::units::Duration,
+                            *decoded.spec(),
+                        );
+                    }
+                    self.sample_buf.copy_interleaved_ref(decoded);
+                    return;
+                }
+                // Decode errors are not fatal.
+                Err(errors::Error::DecodeError(_)) => (),
+                Err(_) => break,
+            }
+        }
+        // EOF reached.
+        self.stream_ended = true;
     }
 }
 
-#[cfg(feature = "symphonia")]
-#[allow(dead_code)]
-pub mod symphonia {
-    use crate::backend::audio::decoders::{Decoder, Mp3Metadata, SeekableDecoder};
-    use std::io::{Cursor, Read};
-    use symphonia::{
-        core::{
-            self, audio, codecs, errors,
-            formats::{self, FormatReader},
-            io,
-        },
-        default::formats::Mp3Reader as SymphoniaMp3Reader,
-    };
-    use thiserror::Error;
+impl Iterator for Mp3Decoder {
+    type Item = [i16; 2];
 
-    #[derive(Debug, Error)]
-    pub enum Error {
-        #[error("Couldn't decode MP3 frame")]
-        FrameDecode(#[from] errors::Error),
-
-        #[error("No default track")]
-        NoDefaultTrack,
-
-        #[error("Invalid sample rate")]
-        InvalidSampleRate,
-
-        #[error("Invalid channels")]
-        InvalidChannels,
-    }
-
-    pub struct Mp3Decoder {
-        reader: SymphoniaMp3Reader,
-        decoder: Box<dyn codecs::Decoder>,
-        sample_buf: audio::SampleBuffer<i16>,
-        cur_sample: usize,
-        sample_rate: u16,
-        num_channels: u8,
-        stream_ended: bool,
-    }
-
-    impl Mp3Decoder {
-        // MP3 frames contain 1152 samples.
-        const SAMPLE_BUFFER_DURATION: u64 = 1152;
-
-        pub fn new<R: 'static + Read + Send + Sync>(reader: R) -> Result<Self, Error> {
-            let source = Box::new(io::ReadOnlySource::new(reader)) as Box<dyn io::MediaSource>;
-            let source = io::MediaSourceStream::new(source, Default::default());
-            let reader = SymphoniaMp3Reader::try_new(source, &Default::default())?;
-            let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
-            let codec_params = track.codec_params.clone();
-            let decoder =
-                symphonia::default::get_codecs().make(&codec_params, &Default::default())?;
-            let sample_rate = codec_params.sample_rate.ok_or(Error::InvalidSampleRate)?;
-            let channels = codec_params.channels.ok_or(Error::InvalidChannels)?;
-            Ok(Mp3Decoder {
-                reader,
-                decoder,
-                sample_buf: audio::SampleBuffer::new(
-                    0,
-                    audio::SignalSpec::new(sample_rate, channels),
-                ),
-                cur_sample: 0,
-                num_channels: channels
-                    .count()
-                    .try_into()
-                    .map_err(|_| Error::InvalidChannels)?,
-                sample_rate: sample_rate.try_into().map_err(|_| Error::InvalidChannels)?,
-                stream_ended: false,
-            })
-        }
-
-        pub fn new_seekable<R: 'static + AsRef<[u8]> + Send + Sync>(
-            reader: Cursor<R>,
-        ) -> Result<Self, Error> {
-            let source = Box::new(reader) as Box<dyn io::MediaSource>;
-            let source = io::MediaSourceStream::new(source, Default::default());
-            let reader = SymphoniaMp3Reader::try_new(source, &Default::default()).unwrap();
-            let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
-            let codec_params = track.codec_params.clone();
-            let decoder =
-                symphonia::default::get_codecs().make(&codec_params, &Default::default())?;
-            let sample_rate = codec_params.sample_rate.ok_or(Error::InvalidSampleRate)?;
-            let channels = codec_params.channels.ok_or(Error::InvalidChannels)?;
-            Ok(Mp3Decoder {
-                reader,
-                decoder,
-                sample_buf: audio::SampleBuffer::new(
-                    Self::SAMPLE_BUFFER_DURATION,
-                    audio::SignalSpec::new(sample_rate, channels),
-                ),
-                cur_sample: 0,
-                num_channels: channels.count() as u8,
-                sample_rate: sample_rate as u16,
-                stream_ended: false,
-            })
-        }
-
-        fn next_frame(&mut self) {
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cur_sample >= self.sample_buf.len() {
+            self.next_frame();
             if self.stream_ended {
-                return;
-            }
-
-            self.cur_sample = 0;
-            while let Ok(packet) = self.reader.next_packet() {
-                match self.decoder.decode(&packet) {
-                    Ok(decoded) => {
-                        if self.sample_buf.capacity() < decoded.capacity() {
-                            // Ensure our buffer has enough space for the decoded samples.
-                            self.sample_buf = audio::SampleBuffer::new(
-                                decoded.capacity() as core::units::Duration,
-                                *decoded.spec(),
-                            );
-                        }
-                        self.sample_buf.copy_interleaved_ref(decoded);
-                        return;
-                    }
-                    // Decode errors are not fatal.
-                    Err(errors::Error::DecodeError(_)) => (),
-                    Err(_) => break,
-                }
-            }
-            // EOF reached.
-            self.stream_ended = true;
-        }
-    }
-
-    impl Iterator for Mp3Decoder {
-        type Item = [i16; 2];
-
-        #[inline]
-        fn next(&mut self) -> Option<Self::Item> {
-            if self.cur_sample >= self.sample_buf.len() {
-                self.next_frame();
-                if self.stream_ended {
-                    return None;
-                }
-            }
-
-            let sample_buf = self.sample_buf.samples();
-            if self.num_channels == 2 {
-                let samples: [i16; 2] =
-                    [sample_buf[self.cur_sample], sample_buf[self.cur_sample + 1]];
-                self.cur_sample += 2;
-                Some(samples)
-            } else {
-                let sample = sample_buf[self.cur_sample];
-                self.cur_sample += 1;
-                Some([sample, sample])
+                return None;
             }
         }
-    }
 
-    impl SeekableDecoder for Mp3Decoder {
-        #[inline]
-        fn reset(&mut self) {
-            self.seek_to_sample_frame(0);
-        }
-
-        #[inline]
-        fn seek_to_sample_frame(&mut self, frame: u32) {
-            // Seek to the desired position,
-            let seek_result = self.reader.seek(
-                formats::SeekMode::Accurate,
-                formats::SeekTo::TimeStamp {
-                    track_id: 0,
-                    ts: frame.into(),
-                },
-            );
-            self.sample_buf.clear();
-            self.decoder.reset();
-            self.cur_sample = 0;
-            self.stream_ended = false;
-            // Seeking isn't exact, so we may end up slightly before our desired position.
-            // Pump samples until we get to the exact position.
-            let samples_remaining =
-                seek_result.map_or(0, |seek| seek.required_ts.saturating_sub(seek.actual_ts));
-            for _ in 0..samples_remaining {
-                self.next();
-            }
+        let sample_buf = self.sample_buf.samples();
+        if self.num_channels == 2 {
+            let samples: [i16; 2] = [sample_buf[self.cur_sample], sample_buf[self.cur_sample + 1]];
+            self.cur_sample += 2;
+            Some(samples)
+        } else {
+            let sample = sample_buf[self.cur_sample];
+            self.cur_sample += 1;
+            Some([sample, sample])
         }
     }
+}
 
-    impl Decoder for Mp3Decoder {
-        #[inline]
-        fn num_channels(&self) -> u8 {
-            self.num_channels
-        }
-
-        #[inline]
-        fn sample_rate(&self) -> u16 {
-            self.sample_rate
-        }
+impl SeekableDecoder for Mp3Decoder {
+    #[inline]
+    fn reset(&mut self) {
+        self.seek_to_sample_frame(0);
     }
 
-    /// Returns the sample rate and length of the given MP3.
-    pub fn mp3_metadata(data: &std::sync::Arc<[u8]>) -> Result<Mp3Metadata, Error> {
-        let source =
-            io::MediaSourceStream::new(Box::new(Cursor::new(data.clone())), Default::default());
-        let reader = SymphoniaMp3Reader::try_new(source, &Default::default())?;
-        let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
-        let num_sample_frames = track.codec_params.n_frames.unwrap_or_default() as u32;
-        let sample_rate = track
-            .codec_params
-            .sample_rate
-            .ok_or(Error::InvalidSampleRate)? as u16;
-        Ok(Mp3Metadata {
-            num_sample_frames,
-            sample_rate,
-        })
+    #[inline]
+    fn seek_to_sample_frame(&mut self, frame: u32) {
+        // Seek to the desired position,
+        let seek_result = self.reader.seek(
+            formats::SeekMode::Accurate,
+            formats::SeekTo::TimeStamp {
+                track_id: 0,
+                ts: frame.into(),
+            },
+        );
+        self.sample_buf.clear();
+        self.decoder.reset();
+        self.cur_sample = 0;
+        self.stream_ended = false;
+        // Seeking isn't exact, so we may end up slightly before our desired position.
+        // Pump samples until we get to the exact position.
+        let samples_remaining =
+            seek_result.map_or(0, |seek| seek.required_ts.saturating_sub(seek.actual_ts));
+        for _ in 0..samples_remaining {
+            self.next();
+        }
     }
+}
+
+impl Decoder for Mp3Decoder {
+    #[inline]
+    fn num_channels(&self) -> u8 {
+        self.num_channels
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> u16 {
+        self.sample_rate
+    }
+}
+
+/// Returns the sample rate and length of the given MP3.
+pub fn mp3_metadata(data: &std::sync::Arc<[u8]>) -> Result<Mp3Metadata, Error> {
+    let source =
+        io::MediaSourceStream::new(Box::new(Cursor::new(data.clone())), Default::default());
+    let reader = SymphoniaMp3Reader::try_new(source, &Default::default())?;
+    let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
+    let num_sample_frames = track.codec_params.n_frames.unwrap_or_default() as u32;
+    let sample_rate = track
+        .codec_params
+        .sample_rate
+        .ok_or(Error::InvalidSampleRate)? as u16;
+    Ok(Mp3Metadata {
+        num_sample_frames,
+        sample_rate,
+    })
 }

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -306,7 +306,7 @@ impl AudioMixer {
                 format.is_stereo,
                 format.sample_rate,
             )?),
-            #[cfg(feature = "symphonia")]
+            #[cfg(feature = "mp3")]
             AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new_seekable(data)?),
             #[cfg(feature = "nellymoser")]
             AudioCompression::Nellymoser => Box::new(decoders::NellymoserDecoder::new(
@@ -496,7 +496,7 @@ impl AudioMixer {
     }
 
     /// Registers an external MP3 with the audio mixer.
-    #[cfg(feature = "symphonia")]
+    #[cfg(feature = "mp3")]
     pub fn register_mp3(&mut self, data: &[u8]) -> Result<SoundHandle, DecodeError> {
         let data = Arc::from(data);
         // Validate that this is actually MP3 data, and calculate duration and sample rate.
@@ -515,7 +515,7 @@ impl AudioMixer {
         Ok(self.sounds.insert(sound))
     }
 
-    #[cfg(not(feature = "symphonia"))]
+    #[cfg(not(feature = "mp3"))]
     pub fn register_mp3(&mut self, data: &[u8]) -> Result<SoundHandle, DecodeError> {
         Err(decoders::Error::UnhandledCompression(AudioCompression::Mp3))
     }

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -306,9 +306,7 @@ impl AudioMixer {
                 format.is_stereo,
                 format.sample_rate,
             )?),
-            #[cfg(feature = "minimp3")]
-            AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new(data)?),
-            #[cfg(all(feature = "symphonia", not(feature = "minimp3")))]
+            #[cfg(feature = "symphonia")]
             AudioCompression::Mp3 => Box::new(decoders::Mp3Decoder::new_seekable(data)?),
             #[cfg(feature = "nellymoser")]
             AudioCompression::Nellymoser => Box::new(decoders::NellymoserDecoder::new(
@@ -498,7 +496,7 @@ impl AudioMixer {
     }
 
     /// Registers an external MP3 with the audio mixer.
-    #[cfg(any(feature = "symphonia", feature = "minimp3"))]
+    #[cfg(feature = "symphonia")]
     pub fn register_mp3(&mut self, data: &[u8]) -> Result<SoundHandle, DecodeError> {
         let data = Arc::from(data);
         // Validate that this is actually MP3 data, and calculate duration and sample rate.
@@ -517,7 +515,7 @@ impl AudioMixer {
         Ok(self.sounds.insert(sound))
     }
 
-    #[cfg(not(any(feature = "symphonia", feature = "minimp3")))]
+    #[cfg(not(feature = "symphonia"))]
     pub fn register_mp3(&mut self, data: &[u8]) -> Result<SoundHandle, DecodeError> {
         Err(decoders::Error::UnhandledCompression(AudioCompression::Mp3))
     }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 clap = { version = "4.0.27", features = ["derive"] }
 cpal = "0.14.2"
-ruffle_core = { path = "../core", features = ["audio", "symphonia", "nellymoser"] }
+ruffle_core = { path = "../core", features = ["audio", "mp3", "nellymoser"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 env_logger = { version = "0.10", default-features = false, features = ["humantime"] }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -49,7 +49,7 @@ base64 = "0.20.0"
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["audio", "nellymoser", "symphonia", "wasm-bindgen"]
+features = ["audio", "mp3", "nellymoser", "wasm-bindgen"]
 
 [dependencies.web-sys]
 version = "0.3.60"

--- a/web/LICENSE.md
+++ b/web/LICENSE.md
@@ -425,8 +425,6 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [memoffset](https://github.com/Gilnaa/memoffset) | [MIT](#MIT) | Copyright (c) 2017 Gilad Naaman  | 
 | [metal](https://github.com/gfx-rs/metal-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2010 The Rust Project Developers  | 
 | [mime](https://github.com/hyperium/mime) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Sean McArthur  | 
-| [minimp3](https://github.com/germangb/minimp3-rs.git) | [MIT](#MIT) | Copyright (c) 2018 German Gomez Bajo  | 
-| [minimp3-sys](https://github.com/germangb/minimp3-rs.git) | [MIT](#MIT) | Copyright (c) 2018 German Gomez Bajo  | 
 | [miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide) | [Apache-2.0](#Apache-20)/[MIT](#MIT)/[Zlib](#Zlib) | Copyright (c) 2017 Frommi  | 
 | [mio](https://github.com/tokio-rs/mio) | [MIT](#MIT) | Copyright (c) 2014 Carl Lerche and other MIO contributors  | 
 | [mio-extras](https://github.com/dimbleby/mio-extras) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2017 Mio authors  | 
@@ -550,6 +548,7 @@ Ruffle depends on third-party libraries with compatible licenses.
 | [strsim](https://github.com/dguo/strsim-rs) | [MIT](#MIT) | Copyright (c) 2015 Danny Guo Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> Copyright (c) 2018 Akash Kurdekar  | 
 | [svg](https://github.com/bodoni/svg) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright 2015–2021 The svg Developers Copyright 2015–2021 The svg Developers  | 
 | [swf](https://github.com/ruffle-rs/ruffle) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2018 Ruffle LLC <ruffle@ruffle.rs> and Ruffle contributors  | 
+| [symphonia](https://github.com/pdeljanov/Symphonia) | [MPL-2.0](#MPL-20) | Copyright (c) Philip Deljanov | 
 | [syn](https://github.com/dtolnay/syn) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) David Tolnay <dtolnay@gmail.com> | 
 | [synstructure](https://github.com/mystor/synstructure) | [MIT](#MIT) | Copyright 2016 Nika Layzell  | 
 | [tar](https://github.com/alexcrichton/tar-rs) | [Apache-2.0](#Apache-20)/[MIT](#MIT) | Copyright (c) 2014 Alex Crichton  | 


### PR DESCRIPTION
Remove the optional minimp3 feature now that symphonia is the default. Rename `symphonia` feature to `mp3`.

To be merged after a week or so once we've given some time for any regression to pop up in symphonia on desktop.