### PR TITLE
POC: avm2: basic peephole optimization of getproperty->getslot/callmethod

### DIFF
--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -128,7 +128,7 @@ impl<'gc> PropertyClass<'gc> {
     }
 }
 
-enum ResolveOutcome<'gc> {
+pub enum ResolveOutcome<'gc> {
     Class(ClassObject<'gc>),
     Any,
     NotFound,
@@ -140,7 +140,7 @@ enum ResolveOutcome<'gc> {
 ///
 /// This is an internal operation used to resolve property type names.
 /// It does not correspond to any opcode or native method.
-fn resolve_class_private<'gc>(
+pub fn resolve_class_private<'gc>(
     name: &Multiname<'gc>,
     unit: Option<TranslationUnit<'gc>>,
     activation: &mut Activation<'_, 'gc, '_>,

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -33,7 +33,7 @@ pub struct VTableData<'gc> {
 
     /// Stores the `PropertyClass` for each slot,
     /// indexed by `slot_id`
-    slot_classes: Vec<PropertyClass<'gc>>,
+    pub slot_classes: Vec<PropertyClass<'gc>>,
 
     method_table: Vec<ClassBoundMethod<'gc>>,
 
@@ -148,6 +148,10 @@ impl<'gc> VTable<'gc> {
 
     pub fn default_slots(&self) -> Ref<Vec<Option<Value<'gc>>>> {
         Ref::map(self.0.read(), |v| &v.default_slots)
+    }
+
+    pub fn slot_classes(&self) -> Ref<Vec<PropertyClass<'gc>>> {
+        Ref::map(self.0.read(), |v| &v.slot_classes)
     }
 
     /// Calculate the flattened list of instance traits that this class

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -590,7 +590,7 @@ impl<W: Write> Writer<W> {
     }
 
     #[allow(dead_code)]
-    fn write_op(&mut self, op: &Op) -> Result<()> {
+    pub fn write_op(&mut self, op: &Op) -> Result<()> {
         match *op {
             Op::Add => self.write_opcode(OpCode::Add)?,
             Op::AddI => self.write_opcode(OpCode::AddI)?,


### PR DESCRIPTION
Given a function:
```as
class C {
    public function f(arg1: SomeClass, arg2) {
          trace(this.stuff); // <---
          trace(arg1.stuff); // <---
          trace(arg2.stuff);
          var local1: SomeClass = (...);
          var local2 = (...);
          trace(local1.stuff); // <---
          trace(local2.stuff);
    }
}
```

In the marked places, the `getproperty` opcode can be relatively easily resolved statically - we know the type of the variable (in case of `local1`, it can be deduced from compiler-generated `coerce` opcodes), so we can calculate vtable lookup in advance and replace the opcode by a corresponding `getslot` or `callmethod` (if it's a getter). This basic version also doesn't require any dataflow analysis or building a control flow graph.

This PR implements such an optimization.

This is a very minimal proof of concept with very rough edges (you can see more extensive analysis in the long comment in `method.rs`), but it's good enough to eliminate 80% of `getproperty` opcode invocations in the box2d demo SWF.
That said, the runtime benefit is much smaller than I expected, so I think this kind of thing should wait until other, more important optimizations are performed.

Due to that, I'm gonna make this PR and immediately close it, just to keep it for posterity.