### PR TITLE
core: Mark DisplayObject as non-removed when added to display list

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -459,6 +459,7 @@ macro_rules! impl_display_object_container {
 
             child.set_place_frame(context.gc_context, 0);
             child.set_parent(context.gc_context, Some((*self).into()));
+            child.set_removed(context.gc_context, false);
 
             self.0
                 .write(context.gc_context)


### PR DESCRIPTION
An AVM2 movie can repeatedly remove and add a DisplayObject from/to a parent. This was causing SolarMax to stop working after advancing to the next level.