### PR TITLE
render: Add `premultiplied_alpha` parameter for image capture

### DIFF
--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -79,6 +79,7 @@ struct Opt {
     skip_unsupported: bool,
 }
 
+/// Captures a screenshot. The resulting image uses straight alpha
 fn take_screenshot(
     descriptors: Arc<Descriptors>,
     swf_path: &Path,
@@ -136,7 +137,8 @@ fn take_screenshot(
                     .renderer_mut()
                     .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
                     .unwrap();
-                renderer.capture_frame()
+                // Use straight alpha
+                renderer.capture_frame(false)
             }) {
                 Ok(Some(image)) => result.push(image),
                 Ok(None) => return Err(anyhow!("Unable to capture frame {} of {:?}", i, swf_path)),

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -497,8 +497,9 @@ impl WgpuRenderBackend<target::TextureTarget> {
         Self::new(Arc::new(descriptors), target)
     }
 
-    pub fn capture_frame(&self) -> Option<image::RgbaImage> {
-        self.target.capture(&self.descriptors.device)
+    pub fn capture_frame(&self, premultiplied_alpha: bool) -> Option<image::RgbaImage> {
+        self.target
+            .capture(&self.descriptors.device, premultiplied_alpha)
     }
 }
 
@@ -1027,10 +1028,10 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         };
 
         let f_res = f(&mut texture_backend);
-
+        // Capture with premultiplied alpha, which is what we use for all textures
         let image = texture_backend
             .target
-            .capture(&texture_backend.descriptors.device);
+            .capture(&texture_backend.descriptors.device, true);
 
         let image = image.map(|image| {
             ruffle_render::bitmap::Bitmap::new(

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -1482,7 +1482,11 @@ fn run_swf(
             .renderer_mut()
             .downcast_mut::<WgpuRenderBackend<TextureTarget>>()
             .unwrap();
-        let actual_image = renderer.capture_frame().expect("Failed to capture image");
+
+        // Use straight alpha, since we want to save this as a PNG
+        let actual_image = renderer
+            .capture_frame(false)
+            .expect("Failed to capture image");
 
         let suffix = get_img_platform_suffix(&renderer.descriptors().info);
 


### PR DESCRIPTION
When rendering offscreen, we want the resulting image to use premultiplied alpha, since the image will be stored in a texture.

However, when capturing an image in the exporter or test framework, we want to use straight alpha, so that the resulting image can be saved as a PNG.

Previously, we incorrectly used straight alpha everywhere, resulting in incorrect output when using BitmapData.draw with transparency.