### PR TITLE
chore: Random cleanups

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -397,9 +397,7 @@ pub fn escape<'gc>(
             // ECMA-262 violation: Avm1 does not support unicode escapes.
             _ => {
                 const DIGITS: &[u8; 16] = b"0123456789ABCDEF";
-                buffer.push(b'%');
-                buffer.push(DIGITS[(c / 16) as usize]);
-                buffer.push(DIGITS[(c % 16) as usize]);
+                buffer.extend([b'%', DIGITS[(c / 16) as usize], DIGITS[(c % 16) as usize]]);
             }
         };
     }

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -565,8 +565,7 @@ fn f64_to_string(mut n: f64) -> Cow<'static, str> {
                 // 1.2345e+15
                 // This case fails to push an extra 0 to handle the rounding 9.9999 -> 10, which
                 // causes the -9999999999999999.0 -> "-e+16" bug later.
-                buf.push(digit());
-                buf.push(b'.');
+                buf.extend([digit(), b'.']);
                 for _ in 0..MAX_DECIMAL_PLACES - 1 {
                     buf.push(digit());
                 }

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -1269,9 +1269,7 @@ fn solve_cubic(a: f64, b: f64, c: f64, d: f64) -> SmallVec<[f64; 3]> {
         let t0 = r * f64::cos(theta / 3.0) - offset;
         let t1 = r * f64::cos((theta + 2.0 * std::f64::consts::PI) / 3.0) - offset;
         let t2 = r * f64::cos((theta + 4.0 * std::f64::consts::PI) / 3.0) - offset;
-        roots.push(t0);
-        roots.push(t1);
-        roots.push(t2);
+        roots.extend([t0, t1, t2]);
     } else {
         let gamma1 = f64::cbrt(q + f64::sqrt(-disc));
         let gamma2 = f64::cbrt(q - f64::sqrt(-disc));


### PR DESCRIPTION
* Replace consecutive `push`es with `extend` - This should be slightly more efficient.
* Avoid some `Vec::with_capacity`.
* De-duplicate code.