### PR TITLE
Fix Clippy lints and allow `clippy::bool_to_int_with_if`

### DIFF
--- a/core/src/avm1/object/shared_object.rs
+++ b/core/src/avm1/object/shared_object.rs
@@ -48,12 +48,7 @@ impl<'gc> SharedObject<'gc> {
     }
 
     pub fn get_name(&self) -> String {
-        self.0
-            .read()
-            .name
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| "".to_string())
+        self.0.read().name.as_ref().cloned().unwrap_or_default()
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bool_to_int_with_if)]
+
 #[macro_use]
 mod display_object;
 pub use display_object::StageDisplayState;

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bool_to_int_with_if)]
+
 use bytemuck::{Pod, Zeroable};
 use fnv::FnvHashMap;
 use ruffle_render::backend::null::NullBitmapSource;

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -7,6 +7,8 @@
 //! This library consists of a `read` module for decoding SWF data, and a `write` library for
 //! writing SWF data.
 
+#![allow(clippy::bool_to_int_with_if)]
+
 #[cfg(feature = "flate2")]
 extern crate flate2;
 #[cfg(feature = "libflate")]


### PR DESCRIPTION
In several cases, the current code seems preferable to the code required by `clippy::bool_to_int_with_if`. Let's suppress this for now to get the build passing, and decide later if this is something that we want to enable.