### PR TITLE
avm2: Fix "Property does not exist" error message

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1682,7 +1682,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         avm_debug!(self.context.avm2, "Resolving {:?}", multiname);
         let found: Result<Object<'gc>, Error> = self
             .find_definition(&multiname)?
-            .ok_or_else(|| format!("Property does not exist: {:?}", multiname).into());
+            .ok_or_else(|| format!("Property does not exist: {:?}", *multiname).into());
         let result: Value<'gc> = found?.into();
 
         self.context.avm2.push(result);
@@ -1699,7 +1699,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         avm_debug!(self.avm2(), "Resolving {:?}", multiname);
         let found: Result<Value<'gc>, Error> = self
             .resolve_definition(&multiname)?
-            .ok_or_else(|| format!("Property does not exist: {:?}", multiname).into());
+            .ok_or_else(|| format!("Property does not exist: {:?}", *multiname).into());
 
         self.context.avm2.push(found?);
 


### PR DESCRIPTION
The `multiname` is now a `Gc`, so we need to dereference it to get a useful Debug impl.