### PR TITLE
desktop: Always mark task as ready on wake

### DIFF
--- a/desktop/src/executor.rs
+++ b/desktop/src/executor.rs
@@ -198,9 +198,9 @@ impl GlutinAsyncExecutor {
     fn wake(&mut self, task: Index) {
         if let Some(task) = self.task_queue.get_mut(task) {
             if !task.is_completed() {
+                task.set_ready();
                 if !self.waiting_for_poll {
                     self.waiting_for_poll = true;
-                    task.set_ready();
                     if self.event_loop.send_event(RuffleEvent::TaskPoll).is_err() {
                         log::warn!("A task was queued on an event loop that has already ended. It will not be polled.");
                     }


### PR DESCRIPTION
We were incorrectly skipping the call to `task.set_ready` if `self.waiting_for_poll` was set. The `waiting_for_poll` flag should only be used to avoid redundant messages being sent into the event loop.

This was causing us to ignore wakeups if more than one wakup arrived in between calls to `poll_all`.