### PR TITLE
core: Support AVM2 context menu (sans callbacks)

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -53,6 +53,7 @@ pub use crate::avm2::array::ArrayStorage;
 pub use crate::avm2::call_stack::{CallNode, CallStack};
 pub use crate::avm2::domain::Domain;
 pub use crate::avm2::error::Error;
+pub use crate::avm2::globals::flash::ui::context_menu::make_context_menu_state;
 pub use crate::avm2::multiname::Multiname;
 pub use crate::avm2::namespace::Namespace;
 pub use crate::avm2::object::{

--- a/core/src/avm2/globals/flash/ui/ContextMenuBuiltInItems.as
+++ b/core/src/avm2/globals/flash/ui/ContextMenuBuiltInItems.as
@@ -1,10 +1,6 @@
 package flash.ui
 {
 	public final class ContextMenuBuiltInItems {
-
-		// FIXME - implement setters for all of these,
-		// and actually hide the corresponding menu item.
-
 		public var forwardAndBack:Boolean = true;
 		public var loop:Boolean = true;
 		public var play:Boolean = true;
@@ -13,7 +9,5 @@ package flash.ui
 		public var rewind:Boolean = true;
 		public var save:Boolean = true;
 		public var zoom:Boolean = true;
-
-		public function ContextMenuBuiltInItems() {}
 	}
 }

--- a/core/src/avm2/globals/flash/ui/context_menu.rs
+++ b/core/src/avm2/globals/flash/ui/context_menu.rs
@@ -1,19 +1,148 @@
 use crate::avm2::activation::Activation;
-use crate::avm2::object::Object;
+use crate::avm2::multiname::Multiname;
+use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::context_menu;
 
 pub fn hide_built_in_items<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
-    _this: Option<Object<'gc>>,
+    this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    // TODO: replace this by a proper implementation.
-    log::warn!("flash.ui.ContextMenu is a stub");
-    activation
-        .context
-        .stage
-        .set_show_menu(&mut activation.context, false);
+    if let Some(this) = this {
+        if let Value::Object(mut items) =
+            this.get_property(&Multiname::public("builtInItems"), activation)?
+        {
+            // items is a ContextMenuBuiltInItems
+            items.set_property(
+                &Multiname::public("forwardAndBack"),
+                Value::Bool(false),
+                activation,
+            )?;
+            items.set_property(&Multiname::public("loop"), Value::Bool(false), activation)?;
+            items.set_property(&Multiname::public("play"), Value::Bool(false), activation)?;
+            items.set_property(&Multiname::public("print"), Value::Bool(false), activation)?;
+            items.set_property(
+                &Multiname::public("quality"),
+                Value::Bool(false),
+                activation,
+            )?;
+            items.set_property(&Multiname::public("rewind"), Value::Bool(false), activation)?;
+            items.set_property(&Multiname::public("save"), Value::Bool(false), activation)?;
+            items.set_property(&Multiname::public("zoom"), Value::Bool(false), activation)?;
+        }
+    }
 
     Ok(Value::Undefined)
+}
+
+pub fn make_context_menu_state<'gc>(
+    menu: Option<Object<'gc>>,
+    activation: &mut Activation<'_, 'gc, '_>,
+) -> context_menu::ContextMenuState<'gc> {
+    let mut result = context_menu::ContextMenuState::new();
+
+    let mut builtin_items = context_menu::BuiltInItemFlags::for_stage(activation.context.stage);
+    if let Some(menu) = menu {
+        if let Ok(Value::Object(builtins)) =
+            menu.get_property(&Multiname::public("builtInItems"), activation)
+        {
+            if matches!(
+                builtins.get_property(&Multiname::public("zoom"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.zoom = false;
+            }
+            if matches!(
+                builtins.get_property(&Multiname::public("quality"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.quality = false;
+            }
+            if matches!(
+                builtins.get_property(&Multiname::public("play"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.play = false;
+            }
+            if matches!(
+                builtins.get_property(&Multiname::public("loop"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.loop_ = false;
+            }
+            if matches!(
+                builtins.get_property(&Multiname::public("rewind"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.rewind = false;
+            }
+            if matches!(
+                builtins.get_property(&Multiname::public("forwardAndBack"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.forward_and_back = false;
+            }
+            if matches!(
+                builtins.get_property(&Multiname::public("print"), activation),
+                Ok(Value::Bool(false))
+            ) {
+                builtin_items.print = false;
+            }
+        }
+    }
+
+    result.build_builtin_items(builtin_items, activation.context.stage);
+
+    if let Some(menu) = menu {
+        if let Ok(Value::Object(custom_items)) =
+            menu.get_property(&Multiname::public("customItems"), activation)
+        {
+            // note: this borrows the array, but it shouldn't be possible for
+            // AS to get invoked here and cause BorrowMutError
+            if let Some(array) = custom_items.as_array_storage() {
+                for (i, item) in array.iter().enumerate() {
+                    // this is a CustomMenuItem
+                    if let Some(Value::Object(item)) = item {
+                        let caption = if let Ok(Value::String(s)) =
+                            item.get_property(&Multiname::public("caption"), activation)
+                        {
+                            s
+                        } else {
+                            // It's a CustomMenuItem, so this shouldn't happen
+                            continue;
+                        };
+                        let enabled = matches!(
+                            item.get_property(&Multiname::public("enabled"), activation),
+                            Ok(Value::Bool(true))
+                        );
+                        let visible = matches!(
+                            item.get_property(&Multiname::public("visible"), activation),
+                            Ok(Value::Bool(true))
+                        );
+                        let separator_before = matches!(
+                            item.get_property(&Multiname::public("separatorBefore"), activation),
+                            Ok(Value::Bool(true))
+                        );
+
+                        if !visible {
+                            continue;
+                        }
+
+                        result.push(
+                            context_menu::ContextMenuItem {
+                                enabled,
+                                separator_before: separator_before || i == 0,
+                                caption: caption.to_string(),
+                                checked: false,
+                            },
+                            context_menu::ContextMenuCallback::Avm2 { item },
+                        );
+                    }
+                }
+            }
+        }
+    }
+    result
 }

--- a/core/src/avm2/globals/flash/ui/context_menu.rs
+++ b/core/src/avm2/globals/flash/ui/context_menu.rs
@@ -43,51 +43,39 @@ pub fn make_context_menu_state<'gc>(
 ) -> context_menu::ContextMenuState<'gc> {
     let mut result = context_menu::ContextMenuState::new();
 
+    macro_rules! check_bool {
+        ( $obj:expr, $name:expr, $value:expr ) => {
+            matches!(
+                $obj.get_property(&Multiname::public($name), activation),
+                Ok(Value::Bool($value))
+            )
+        };
+    }
+
     let mut builtin_items = context_menu::BuiltInItemFlags::for_stage(activation.context.stage);
     if let Some(menu) = menu {
         if let Ok(Value::Object(builtins)) =
             menu.get_property(&Multiname::public("builtInItems"), activation)
         {
-            if matches!(
-                builtins.get_property(&Multiname::public("zoom"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "zoom", false) {
                 builtin_items.zoom = false;
             }
-            if matches!(
-                builtins.get_property(&Multiname::public("quality"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "quality", false) {
                 builtin_items.quality = false;
             }
-            if matches!(
-                builtins.get_property(&Multiname::public("play"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "play", false) {
                 builtin_items.play = false;
             }
-            if matches!(
-                builtins.get_property(&Multiname::public("loop"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "loop", false) {
                 builtin_items.loop_ = false;
             }
-            if matches!(
-                builtins.get_property(&Multiname::public("rewind"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "rewind", false) {
                 builtin_items.rewind = false;
             }
-            if matches!(
-                builtins.get_property(&Multiname::public("forwardAndBack"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "forwardAndBack", false) {
                 builtin_items.forward_and_back = false;
             }
-            if matches!(
-                builtins.get_property(&Multiname::public("print"), activation),
-                Ok(Value::Bool(false))
-            ) {
+            if check_bool!(builtins, "print", false) {
                 builtin_items.print = false;
             }
         }
@@ -113,18 +101,9 @@ pub fn make_context_menu_state<'gc>(
                             // It's a CustomMenuItem, so this shouldn't happen
                             continue;
                         };
-                        let enabled = matches!(
-                            item.get_property(&Multiname::public("enabled"), activation),
-                            Ok(Value::Bool(true))
-                        );
-                        let visible = matches!(
-                            item.get_property(&Multiname::public("visible"), activation),
-                            Ok(Value::Bool(true))
-                        );
-                        let separator_before = matches!(
-                            item.get_property(&Multiname::public("separatorBefore"), activation),
-                            Ok(Value::Bool(true))
-                        );
+                        let enabled = check_bool!(item, "enabled", true);
+                        let visible = check_bool!(item, "visible", true);
+                        let separator_before = check_bool!(item, "separatorBefore", true);
 
                         if !visible {
                             continue;

--- a/core/src/context_menu.rs
+++ b/core/src/context_menu.rs
@@ -5,6 +5,9 @@
 //! items work even if the movie changed `object.menu` in the meantime.
 
 use crate::avm1;
+use crate::avm2;
+use crate::display_object::Stage;
+use crate::display_object::TDisplayObject;
 use gc_arena::Collect;
 use serde::Serialize;
 
@@ -28,6 +31,54 @@ impl<'gc> ContextMenuState<'gc> {
     }
     pub fn callback(&self, index: usize) -> &ContextMenuCallback<'gc> {
         &self.callbacks[index]
+    }
+    pub fn build_builtin_items(&mut self, item_flags: BuiltInItemFlags, stage: Stage<'gc>) {
+        let root_mc = stage.root_clip().as_movie_clip();
+        if item_flags.play {
+            let is_playing_root_movie = root_mc.unwrap().playing();
+            self.push(
+                ContextMenuItem {
+                    enabled: true,
+                    separator_before: true,
+                    caption: "Play".to_string(),
+                    checked: is_playing_root_movie,
+                },
+                ContextMenuCallback::Play,
+            );
+        }
+        if item_flags.rewind {
+            let is_first_frame = root_mc.unwrap().current_frame() <= 1;
+            self.push(
+                ContextMenuItem {
+                    enabled: !is_first_frame,
+                    separator_before: true,
+                    caption: "Rewind".to_string(),
+                    checked: false,
+                },
+                ContextMenuCallback::Rewind,
+            );
+        }
+        if item_flags.forward_and_back {
+            let is_first_frame = root_mc.unwrap().current_frame() <= 1;
+            self.push(
+                ContextMenuItem {
+                    enabled: true,
+                    separator_before: false,
+                    caption: "Forward".to_string(),
+                    checked: false,
+                },
+                ContextMenuCallback::Forward,
+            );
+            self.push(
+                ContextMenuItem {
+                    enabled: !is_first_frame,
+                    separator_before: false,
+                    caption: "Back".to_string(),
+                    checked: false,
+                },
+                ContextMenuCallback::Back,
+            );
+        }
     }
 }
 
@@ -56,4 +107,50 @@ pub enum ContextMenuCallback<'gc> {
         item: avm1::Object<'gc>,
         callback: avm1::Object<'gc>,
     },
+    Avm2 {
+        item: avm2::Object<'gc>,
+    },
+}
+
+pub struct BuiltInItemFlags {
+    pub forward_and_back: bool,
+    pub loop_: bool,
+    pub play: bool,
+    pub print: bool,
+    pub quality: bool,
+    pub rewind: bool,
+    pub save: bool,
+    pub zoom: bool,
+}
+
+impl BuiltInItemFlags {
+    pub fn for_stage(stage: Stage<'_>) -> Self {
+        let root_mc = stage.root_clip().as_movie_clip();
+        let is_multiframe_movie = root_mc.map(|mc| mc.total_frames() > 1).unwrap_or(false);
+        if is_multiframe_movie {
+            Self {
+                forward_and_back: true,
+                loop_: true,
+                play: true,
+                print: true,
+                quality: true,
+                rewind: true,
+                zoom: true,
+
+                save: false,
+            }
+        } else {
+            Self {
+                print: true,
+                quality: true,
+                zoom: true,
+
+                forward_and_back: false,
+                rewind: false,
+                loop_: false,
+                play: false,
+                save: false,
+            }
+        }
+    }
 }


### PR DESCRIPTION
The context menu logic is a bit more of a spaghetti because I tried to deduplicate and keep decent separation of concerns, but parts of it flip between being avm-dependent and universal.
It goes like this:

- get list of enabled builtin items (avm-dependent)
- build builtin items (universal)
- build custom items (avm-dependent)

I don't really know if there's an easier way to write this.

I left dispatching the actual 
menuSelect, menuItemSelect events unimplemented for now. Actually, what do you think about making all the custom items `enabled=false` to make it explicit for now?


Result: 
![image](https://user-images.githubusercontent.com/4729533/190261022-f3a2eb23-334e-4118-8673-c43e510d3844.png)

