### PR TITLE
render: Don't remove entry from bitmap_register for offscreen rendering

### DIFF
--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -14,6 +14,7 @@ use once_cell::sync::OnceCell;
 use ruffle_render::bitmap::{Bitmap, BitmapHandle};
 use ruffle_render::color_transform::ColorTransform;
 use ruffle_render::tessellator::{Gradient as TessGradient, GradientType, Vertex as TessVertex};
+use std::sync::Arc;
 pub use wgpu;
 
 type Error = Box<dyn std::error::Error>;
@@ -190,7 +191,7 @@ impl From<TessGradient> for GradientStorage {
 struct Texture {
     width: u32,
     height: u32,
-    texture: wgpu::Texture,
+    texture: Arc<wgpu::Texture>,
     bind_linear: OnceCell<BitmapBinds>,
     bind_nearest: OnceCell<BitmapBinds>,
     texture_offscreen: Option<TextureOffscreen>,
@@ -225,7 +226,7 @@ impl Texture {
 
 #[derive(Debug)]
 struct TextureOffscreen {
-    buffer: wgpu::Buffer,
+    buffer: Arc<wgpu::Buffer>,
     buffer_dimensions: BufferDimensions,
     surface: Surface,
 }

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -2,6 +2,7 @@ use crate::utils::BufferDimensions;
 use crate::Error;
 use ruffle_render::utils::unmultiply_alpha_rgba;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 pub trait RenderTargetFrame: Debug {
     fn view(&self) -> &wgpu::TextureView;
@@ -111,9 +112,9 @@ impl RenderTarget for SwapChainTarget {
 #[derive(Debug)]
 pub struct TextureTarget {
     pub size: wgpu::Extent3d,
-    pub texture: wgpu::Texture,
+    pub texture: Arc<wgpu::Texture>,
     pub format: wgpu::TextureFormat,
-    pub buffer: wgpu::Buffer,
+    pub buffer: Arc<wgpu::Buffer>,
     pub buffer_dimensions: BufferDimensions,
 }
 
@@ -168,9 +169,9 @@ impl TextureTarget {
         });
         Ok(Self {
             size,
-            texture,
+            texture: Arc::new(texture),
             format,
-            buffer,
+            buffer: Arc::new(buffer),
             buffer_dimensions,
         })
     }

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -88,7 +88,7 @@ pub fn create_buffer_with_data(
 }
 
 // Based off wgpu example 'capture'
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BufferDimensions {
     pub width: usize,
     pub height: usize,


### PR DESCRIPTION
It turns out that Flash supports 'recursive' BitmapData rendering (calling BitampData.draw with a source that requires rendering a Bitmap that shares the target BitmapData).

This is a first step towards supporting this case. We now need to wrap the `Texture` and `Buffer` fields in an `Arc`, in order to construct the new `TextureTarget`.