### PR TITLE
avm2: Explicitly delay frame construction until the first frame is loaded.

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2320,7 +2320,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 
         // AVM1 code expects to execute in line with timeline instructions, so
         // it's exempted from frame construction.
-        if context.is_action_script_3() {
+        if context.is_action_script_3() && self.frames_loaded() >= 1 {
             let needs_construction = if matches!(self.object2(), Avm2Value::Undefined) {
                 self.allocate_as_avm2_object(context, (*self).into());
                 true


### PR DESCRIPTION
Here's an oversight from the chunked preloading PR: the root movie exists before the movie loads, and so it can get events before certain pieces of information are known. Such as its `SymbolClass`. `run_frame_internal` has a check to make sure the next frame has been processed before we try to run it, which gates off *almost* everything in the movie from happening, but not this one specific thing.

So we just make sure to check `frames_loaded` in `construct_frame` too.