### PR TITLE
Load behaviors / preload skip option

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod external;
 pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;
 pub use indexmap;
+pub use loader::LoadBehavior;
 pub use player::{Player, PlayerBuilder, StaticCallstack};
 pub use ruffle_render::backend::ViewportDimensions;
 pub use swf;

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -30,6 +30,7 @@ use gc_arena::{Collect, CollectionContext};
 use generational_arena::{Arena, Index};
 use ruffle_render::utils::{determine_jpeg_tag_format, JpegTagFormat};
 use std::fmt;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use swf::read::{extract_swz, read_compression_type};
@@ -39,6 +40,7 @@ use url::form_urlencoded;
 pub type Handle = Index;
 
 /// How Ruffle should load movies.
+#[derive(Debug, Clone, Copy)]
 pub enum LoadBehavior {
     /// Allow movies to execute before they have finished loading.
     ///
@@ -59,6 +61,22 @@ pub enum LoadBehavior {
     /// done synchronously. Complex movies will visibly block the player from
     /// accepting user input and the application will appear to freeze.
     Blocking,
+}
+
+impl FromStr for LoadBehavior {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "streaming" {
+            Ok(LoadBehavior::Streaming)
+        } else if s == "delayed" {
+            Ok(LoadBehavior::Delayed)
+        } else if s == "blocking" {
+            Ok(LoadBehavior::Blocking)
+        } else {
+            Err("Not a valid load behavior")
+        }
+    }
 }
 
 /// Enumeration of all content types that `Loader` can handle.

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -38,6 +38,29 @@ use url::form_urlencoded;
 
 pub type Handle = Index;
 
+/// How Ruffle should load movies.
+pub enum LoadBehavior {
+    /// Allow movies to execute before they have finished loading.
+    ///
+    /// Frames/bytes loaded values will tick up normally and progress events
+    /// will be fired at regular intervals. Movie preload animations will play
+    /// normally.
+    Streaming,
+
+    /// Delay execution of loaded movies until they have finished loading.
+    ///
+    /// Movies will see themselves load immediately. Preload animations will be
+    /// skipped. This may break movies that depend on loading during execution.
+    Delayed,
+
+    /// Block Ruffle until movies have finished loading.
+    ///
+    /// This has the same implications as `Delay`, but tag processing will be
+    /// done synchronously. Complex movies will visibly block the player from
+    /// accepting user input and the application will appear to freeze.
+    Blocking,
+}
+
 /// Enumeration of all content types that `Loader` can handle.
 ///
 /// This is a superset of `JpegTagFormat`.

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -20,8 +20,8 @@ use clap::Parser;
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use rfd::FileDialog;
 use ruffle_core::{
-    config::Letterbox, events::KeyCode, tag_utils::SwfMovie, Player, PlayerBuilder, PlayerEvent,
-    StageDisplayState, StaticCallstack, ViewportDimensions,
+    config::Letterbox, events::KeyCode, tag_utils::SwfMovie, LoadBehavior, Player, PlayerBuilder,
+    PlayerEvent, StageDisplayState, StaticCallstack, ViewportDimensions,
 };
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
@@ -100,6 +100,9 @@ struct Opt {
 
     #[clap(long, action)]
     dont_warn_on_unsupported_content: bool,
+
+    #[clap(long, default_value = "streaming")]
+    load_behavior: LoadBehavior,
 }
 
 #[cfg(feature = "render_trace")]
@@ -267,7 +270,8 @@ impl App {
             .with_autoplay(true)
             .with_letterbox(Letterbox::On)
             .with_warn_on_unsupported_content(!opt.dont_warn_on_unsupported_content)
-            .with_fullscreen(opt.fullscreen);
+            .with_fullscreen(opt.fullscreen)
+            .with_load_behavior(opt.load_behavior);
 
         let player = builder.build();
 


### PR DESCRIPTION
This adds a setting to Ruffle that allows disabling streaming playback.

This comes in three layers:

 * `streaming` is the current behavior - tags are processed asynchronously and all movies run concurrently with loading. Preloaders work as intended.
 * `delayed` - tags are processed asynchronously, but movies do not run until tag processing completes. Preloaders are skipped but the UI is not locked while movies load.
 * `blocking` is the old behavior - tags are processed synchronously and movies start fully loaded. The UI locks until the movie finishes loading.

You can configure this on desktop with the `--load-behavior=xyz` flag and, on web, with the `loadBehavior` parameter on `RufflePlayer.load`.

The reason for this is a handful of movies that work, but have broken preloaders in Ruffle. Notably, Red Ball's preloader relies on some unspoken assumptions about Flash Player's streaming download that Ruffle violates. Switching to `delayed` loading fixes the game.

Note that we will not be defaulting to `delayed` as some other movies (such as some z0r loops) actually break if they load immediately. The primary purpose of this option is to debug regressions from chunked loading, and to allow people to play games with broken preloaders until we can fix them in Ruffle.