### PR TITLE
avm2: Add non-debug version of ErrorObject::display_full

### DIFF
--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -77,6 +77,14 @@ impl<'gc> ErrorObject<'gc> {
         Ok(AvmString::new(activation.context.gc_context, output))
     }
 
+    #[cfg(not(feature = "avm_debug"))]
+    pub fn display_full(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+    ) -> Result<AvmString<'gc>, Error<'gc>> {
+        self.display(activation)
+    }
+
     #[cfg(feature = "avm_debug")]
     fn call_stack(&self) -> Ref<CallStack<'gc>> {
         Ref::map(self.0.read(), |r| &r.call_stack)


### PR DESCRIPTION
This is causing builds without the avm_debug feature to fail, because we now have code relying on this method existing even when we aren't building with avm_debug.

This needs to be merged ASAP or nightly will fail. Also, we should probably have a test without avm_debug enabled so this doesn't happen in the future.