### PR TITLE
web: Fix config with `serde-wasm-bindgen`

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// When letterboxed, black bars will be rendered around the exterior
 /// margins of the content.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Collect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Collect, Serialize, Deserialize)]
 #[collect(require_static)]
 #[serde(rename = "letterbox")]
 pub enum Letterbox {
@@ -16,7 +16,6 @@ pub enum Letterbox {
 
     /// The content will only be letterboxed if the content is running fullscreen.
     #[serde(rename = "fullscreen")]
-    #[default]
     Fullscreen,
 
     /// The content will always be letterboxed.

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -1,7 +1,11 @@
-/**
- * Represents the various types of auto-play behaviours that are supported.
- */
 import type { BaseLoadOptions } from "./load-options";
+import {
+    AutoPlay,
+    UnmuteOverlay,
+    WindowMode,
+    Letterbox,
+    LogLevel,
+} from "./load-options";
 
 /**
  * The configuration object to control Ruffle's behaviour on the website
@@ -10,8 +14,10 @@ import type { BaseLoadOptions } from "./load-options";
 export interface Config extends BaseLoadOptions {
     /**
      * The URL at which Ruffle can load its extra files (i.e. `.wasm`).
+     *
+     * @default null
      */
-    publicPath?: string;
+    publicPath?: string | null;
 
     /**
      * Whether or not to enable polyfills on the page.
@@ -24,3 +30,27 @@ export interface Config extends BaseLoadOptions {
      */
     polyfills?: boolean;
 }
+
+export const DEFAULT_CONFIG: Required<Config> = {
+    allowScriptAccess: false,
+    parameters: {},
+    autoplay: AutoPlay.Auto,
+    backgroundColor: null,
+    letterbox: Letterbox.Fullscreen,
+    unmuteOverlay: UnmuteOverlay.Visible,
+    upgradeToHttps: true,
+    warnOnUnsupportedContent: true,
+    logLevel: LogLevel.Error,
+    showSwfDownload: false,
+    contextMenu: true,
+    preloader: true,
+    maxExecutionDuration: { secs: 15, nanos: 0 },
+    base: null,
+    menu: true,
+    salign: "",
+    quality: "high",
+    scale: "showAll",
+    wmode: WindowMode.Opaque,
+    publicPath: null,
+    polyfills: true,
+};

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents the various types of auto-play behaviours that are supported.
+ */
 export const enum AutoPlay {
     /**
      * The player should automatically play the movie as soon as it is loaded.
@@ -135,6 +138,8 @@ export interface BaseLoadOptions {
      * If a URL if specified when loading the movie, some parameters will
      * be extracted by the query portion of that URL and then overwritten
      * by any explicitly set here.
+     *
+     * @default {}
      */
     parameters?: URLSearchParams | string | Record<string, string>;
 
@@ -225,7 +230,7 @@ export interface BaseLoadOptions {
      * Maximum amount of time a script can take before scripting
      * is disabled.
      *
-     * @default {"secs": 15, "nanos": 0}
+     * @default { secs: 15, nanos: 0 }
      */
     maxExecutionDuration?: {
         secs: number;
@@ -250,7 +255,6 @@ export interface BaseLoadOptions {
     menu?: boolean;
 
     /**
-     *
      * This is equivalent to Stage.align.
      *
      * @default ""
@@ -258,7 +262,6 @@ export interface BaseLoadOptions {
     salign?: string;
 
     /**
-     *
      * This is equivalent to Stage.quality.
      *
      * @default "high"
@@ -266,7 +269,6 @@ export interface BaseLoadOptions {
     quality?: string;
 
     /**
-     *
      * This is equivalent to Stage.scaleMode.
      *
      * @default "showAll"

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -44,7 +44,7 @@ try {
 export function publicPath(config: Config): string {
     // Default to the directory where this script resides.
     let path = currentScriptURL;
-    if (config !== undefined && config.publicPath !== undefined) {
+    if (config.publicPath !== null && config.publicPath !== undefined) {
         path = config.publicPath;
     }
 


### PR DESCRIPTION
Since `serde-wasm-bindgen` doesn't support `#[serde(default)]` (https://github.com/cloudflare/serde-wasm-bindgen/issues/20), we no longer able to deserialize a partial `Config` object. As a solution, take care to pass a full object from the TypeScript side.