### PR TITLE
avm2: Preliminary work to remove `Error::RustError`

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -691,7 +691,7 @@ fn attach_movie<'gc>(
         .context
         .library
         .library_for_movie(movie_clip.movie().unwrap())
-        .ok_or_else(|| "Movie is missing!".into())
+        .ok_or("Movie is missing!")
         .and_then(|l| l.instantiate_by_export_name(export_name, activation.context.gc_context))
     {
         // Set name and attach to parent.
@@ -860,7 +860,7 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
             .context
             .library
             .library_for_movie(movie)
-            .ok_or_else(|| "Movie is missing!".into())
+            .ok_or("Movie is missing!")
             .and_then(|l| l.instantiate_by_id(id, activation.context.gc_context))
     } else {
         // Dynamically created clip; create a new empty movie clip.

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -132,12 +132,6 @@ impl<'gc> From<String> for Error<'gc> {
     }
 }
 
-impl<'gc> From<std::fmt::Error> for Error<'gc> {
-    fn from(val: std::fmt::Error) -> Error<'gc> {
-        Error::RustError(val.into())
-    }
-}
-
 impl<'gc> From<crate::tag_utils::Error> for Error<'gc> {
     fn from(val: crate::tag_utils::Error) -> Error<'gc> {
         Error::RustError(val.into())

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -132,12 +132,6 @@ impl<'gc> From<String> for Error<'gc> {
     }
 }
 
-impl<'gc> From<crate::tag_utils::Error> for Error<'gc> {
-    fn from(val: crate::tag_utils::Error) -> Error<'gc> {
-        Error::RustError(val.into())
-    }
-}
-
 impl<'gc> From<Box<dyn std::error::Error>> for Error<'gc> {
     fn from(val: Box<dyn std::error::Error>) -> Error<'gc> {
         Error::RustError(val)

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -86,6 +86,17 @@ pub fn verify_error<'gc>(
     error_constructor(activation, class, message, code)
 }
 
+#[inline(never)]
+#[cold]
+pub fn io_error<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    message: &str,
+    code: u32,
+) -> Result<Value<'gc>, Error<'gc>> {
+    let class = activation.avm2().classes().ioerror;
+    error_constructor(activation, class, message, code)
+}
+
 fn error_constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     class: ClassObject<'gc>,
@@ -121,12 +132,6 @@ impl<'gc> From<String> for Error<'gc> {
     }
 }
 
-impl<'gc> From<std::io::Error> for Error<'gc> {
-    fn from(val: std::io::Error) -> Error<'gc> {
-        Error::RustError(val.into())
-    }
-}
-
 impl<'gc> From<std::fmt::Error> for Error<'gc> {
     fn from(val: std::fmt::Error) -> Error<'gc> {
         Error::RustError(val.into())
@@ -142,12 +147,5 @@ impl<'gc> From<crate::tag_utils::Error> for Error<'gc> {
 impl<'gc> From<Box<dyn std::error::Error>> for Error<'gc> {
     fn from(val: Box<dyn std::error::Error>) -> Error<'gc> {
         Error::RustError(val)
-    }
-}
-
-#[cfg(feature = "lzma")]
-impl<'gc> From<lzma_rs::error::Error> for Error<'gc> {
-    fn from(val: lzma_rs::error::Error) -> Error<'gc> {
-        Error::RustError(val.into())
     }
 }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -131,9 +131,3 @@ impl<'gc> From<String> for Error<'gc> {
         Error::RustError(val.into())
     }
 }
-
-impl<'gc> From<Box<dyn std::error::Error>> for Error<'gc> {
-    fn from(val: Box<dyn std::error::Error>) -> Error<'gc> {
-        Error::RustError(val)
-    }
-}

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -75,6 +75,17 @@ pub fn reference_error<'gc>(
     error_constructor(activation, class, message, code)
 }
 
+#[inline(never)]
+#[cold]
+pub fn verify_error<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    message: &str,
+    code: u32,
+) -> Result<Value<'gc>, Error<'gc>> {
+    let class = activation.avm2().classes().verifyerror;
+    error_constructor(activation, class, message, code)
+}
+
 fn error_constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     class: ClassObject<'gc>,
@@ -118,12 +129,6 @@ impl<'gc> From<std::io::Error> for Error<'gc> {
 
 impl<'gc> From<std::fmt::Error> for Error<'gc> {
     fn from(val: std::fmt::Error) -> Error<'gc> {
-        Error::RustError(val.into())
-    }
-}
-
-impl<'gc> From<swf::error::Error> for Error<'gc> {
-    fn from(val: swf::error::Error) -> Error<'gc> {
         Error::RustError(val.into())
     }
 }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -75,7 +75,7 @@ pub fn reference_error<'gc>(
     error_constructor(activation, class, message, code)
 }
 
-pub fn error_constructor<'gc>(
+fn error_constructor<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     class: ClassObject<'gc>,
     message: &str,
@@ -130,12 +130,6 @@ impl<'gc> From<swf::error::Error> for Error<'gc> {
 
 impl<'gc> From<crate::tag_utils::Error> for Error<'gc> {
     fn from(val: crate::tag_utils::Error) -> Error<'gc> {
-        Error::RustError(val.into())
-    }
-}
-
-impl<'gc> From<serde_json::Error> for Error<'gc> {
-    fn from(val: serde_json::Error) -> Error<'gc> {
         Error::RustError(val.into())
     }
 }

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -108,6 +108,7 @@ pub struct SystemClasses<'gc> {
     pub referenceerror: ClassObject<'gc>,
     pub argumenterror: ClassObject<'gc>,
     pub typeerror: ClassObject<'gc>,
+    pub verifyerror: ClassObject<'gc>,
 }
 
 impl<'gc> SystemClasses<'gc> {
@@ -183,6 +184,7 @@ impl<'gc> SystemClasses<'gc> {
             referenceerror: object,
             argumenterror: object,
             typeerror: object,
+            verifyerror: object,
         }
     }
 }
@@ -697,6 +699,7 @@ fn load_playerglobal<'gc>(
             ("", "RangeError", rangeerror),
             ("", "ReferenceError", referenceerror),
             ("", "TypeError", typeerror),
+            ("", "VerifyError", verifyerror),
             ("", "XML", xml),
             ("", "XMLList", xml_list),
             ("flash.display", "Scene", scene),

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -656,9 +656,10 @@ fn load_playerglobal<'gc>(
     activation.avm2().native_method_table = native::NATIVE_METHOD_TABLE;
     activation.avm2().native_instance_allocator_table = native::NATIVE_INSTANCE_ALLOCATOR_TABLE;
 
-    let movie = Arc::new(SwfMovie::from_data(PLAYERGLOBAL, None, None)?);
+    let movie =
+        SwfMovie::from_data(PLAYERGLOBAL, None, None).expect("playerglobal.swf should be valid");
 
-    let slice = SwfSlice::from(movie);
+    let slice = SwfSlice::from(Arc::new(movie));
 
     let mut reader = slice.read_from(0);
 

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -109,6 +109,7 @@ pub struct SystemClasses<'gc> {
     pub argumenterror: ClassObject<'gc>,
     pub typeerror: ClassObject<'gc>,
     pub verifyerror: ClassObject<'gc>,
+    pub ioerror: ClassObject<'gc>,
 }
 
 impl<'gc> SystemClasses<'gc> {
@@ -185,6 +186,7 @@ impl<'gc> SystemClasses<'gc> {
             argumenterror: object,
             typeerror: object,
             verifyerror: object,
+            ioerror: object,
         }
     }
 }
@@ -708,6 +710,7 @@ fn load_playerglobal<'gc>(
                 "IllegalOperationError",
                 illegaloperationerror
             ),
+            ("flash.errors", "IOError", ioerror),
             ("flash.events", "Event", event),
             ("flash.events", "TextEvent", textevent),
             ("flash.events", "ErrorEvent", errorevent),

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -124,20 +124,19 @@ pub fn escape_multi_byte<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .coerce_to_string(activation)?;
-    let bs = s.as_wstr().to_utf8_lossy();
-    let mut buf = WString::new();
-    for b in bs.as_bytes() {
-        if *b == 0 {
+    let utf8 = s.as_wstr().to_utf8_lossy();
+    let mut result = WString::new();
+    for byte in utf8.as_bytes() {
+        if *byte == 0 {
             break;
         }
-        if b.is_ascii_alphanumeric() {
-            buf.push_char(*b as char);
+        if byte.is_ascii_alphanumeric() {
+            result.push_byte(*byte);
         } else {
-            write!(&mut buf, "%{b:02X}")?;
+            let _ = write!(&mut result, "%{byte:02X}");
         }
     }
-    let v = AvmString::new(activation.context.gc_context, buf);
-    Ok(v.into())
+    Ok(AvmString::new(activation.context.gc_context, result).into())
 }
 
 fn handle_percent<I>(chars: &mut I) -> Option<u8>

--- a/core/src/avm2/globals/flash/utils/ByteArray.as
+++ b/core/src/avm2/globals/flash/utils/ByteArray.as
@@ -32,10 +32,18 @@ package flash.utils {
 		private native function init():void;
 
 		public native function clear():void;
-		public native function compress(algorithm:String):void;
-		public native function deflate():void;
-		public native function inflate():void;
-		public native function uncompress(algorithm:String):void;
+
+		public function deflate(): void {
+			this.compress("deflate");
+		}
+
+		public native function compress(algorithm: String = CompressionAlgorithm.ZLIB): void;
+
+		public function inflate(): void {
+			this.uncompress("deflate");
+		}
+
+		public native function uncompress(algorithm: String = CompressionAlgorithm.ZLIB): void;
 
 		public native function toString():String;
 		public function toJSON(k:String):String {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -87,7 +87,7 @@ pub struct TranslationUnitData<'gc> {
 impl<'gc> TranslationUnit<'gc> {
     /// Construct a new `TranslationUnit` for a given ABC file intended to
     /// execute within a particular domain.
-    pub fn from_abc(abc: Rc<AbcFile>, domain: Domain<'gc>, mc: MutationContext<'gc, '_>) -> Self {
+    pub fn from_abc(abc: AbcFile, domain: Domain<'gc>, mc: MutationContext<'gc, '_>) -> Self {
         let classes = vec![None; abc.classes.len()];
         let methods = vec![None; abc.methods.len()];
         let scripts = vec![None; abc.scripts.len()];
@@ -99,7 +99,7 @@ impl<'gc> TranslationUnit<'gc> {
             mc,
             TranslationUnitData {
                 domain,
-                abc,
+                abc: Rc::new(abc),
                 classes,
                 methods,
                 scripts,

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -165,12 +165,12 @@ impl<'gc> MovieLibrary<'gc> {
         &self,
         id: CharacterId,
         gc_context: MutationContext<'gc, '_>,
-    ) -> Result<DisplayObject<'gc>, Box<dyn std::error::Error>> {
+    ) -> Result<DisplayObject<'gc>, &'static str> {
         if let Some(character) = self.characters.get(&id) {
             self.instantiate_display_object(character, gc_context)
         } else {
             log::error!("Tried to instantiate non-registered character ID {}", id);
-            Err("Character id doesn't exist".into())
+            Err("Character id doesn't exist")
         }
     }
 
@@ -180,7 +180,7 @@ impl<'gc> MovieLibrary<'gc> {
         &self,
         export_name: AvmString<'gc>,
         gc_context: MutationContext<'gc, '_>,
-    ) -> Result<DisplayObject<'gc>, Box<dyn std::error::Error>> {
+    ) -> Result<DisplayObject<'gc>, &'static str> {
         if let Some(character) = self.export_characters.get(export_name, false) {
             self.instantiate_display_object(character, gc_context)
         } else {
@@ -188,7 +188,7 @@ impl<'gc> MovieLibrary<'gc> {
                 "Tried to instantiate non-registered character {}",
                 export_name
             );
-            Err("Character id doesn't exist".into())
+            Err("Character id doesn't exist")
         }
     }
 
@@ -198,7 +198,7 @@ impl<'gc> MovieLibrary<'gc> {
         &self,
         character: &Character<'gc>,
         gc_context: MutationContext<'gc, '_>,
-    ) -> Result<DisplayObject<'gc>, Box<dyn std::error::Error>> {
+    ) -> Result<DisplayObject<'gc>, &'static str> {
         match character {
             Character::Bitmap(bitmap) => Ok(bitmap.instantiate(gc_context)),
             Character::EditText(edit_text) => Ok(edit_text.instantiate(gc_context)),
@@ -209,7 +209,7 @@ impl<'gc> MovieLibrary<'gc> {
             Character::Avm2Button(button) => Ok(button.instantiate(gc_context)),
             Character::Text(text) => Ok(text.instantiate(gc_context)),
             Character::Video(video) => Ok(video.instantiate(gc_context)),
-            _ => Err("Not a DisplayObject".into()),
+            _ => Err("Not a DisplayObject"),
         }
     }
 


### PR DESCRIPTION
This PR removes almost all `impl From<T> for Error<'gc>` (except where `T` is `&str` or `String`), by favoring to throw ordinary ActionScript exceptions.
The goal is to get rid of `Error::RustError` completely, leaving `Error<'gc>` equivalent to `Value<'gc>`.

`&str` or `String` are deferred to a future PR since they are significantly more used.