### PR TITLE
wgpu: Remove `width` and `height` fields from our `Texture` wrapper struct

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -410,8 +410,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
         let handle = self.next_bitmap_handle;
         self.next_bitmap_handle = BitmapHandle(self.next_bitmap_handle.0 + 1);
-        let width = bitmap.width();
-        let height = bitmap.height();
 
         if self
             .bitmap_registry
@@ -420,8 +418,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                 RegistryData {
                     bitmap,
                     texture_wrapper: Texture {
-                        width,
-                        height,
                         texture,
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),

--- a/render/wgpu/src/commands.rs
+++ b/render/wgpu/src/commands.rs
@@ -47,8 +47,8 @@ impl<'a, 'b> CommandHandler for CommandRenderer<'a, 'b> {
             self.frame.apply_transform(
                 &(transform.matrix
                     * ruffle_render::matrix::Matrix {
-                        a: texture.width as f32,
-                        d: texture.height as f32,
+                        a: entry.bitmap.width() as f32,
+                        d: entry.bitmap.height() as f32,
                         ..Default::default()
                     }),
                 ColorAdjustments::from(transform.color_transform),

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -188,8 +188,6 @@ impl From<TessGradient> for GradientStorage {
 
 #[derive(Debug)]
 struct Texture {
-    width: u32,
-    height: u32,
     texture: wgpu::Texture,
     bind_linear: OnceCell<BitmapBinds>,
     bind_nearest: OnceCell<BitmapBinds>,


### PR DESCRIPTION
These are duplicates of fields in `Bitmap`