### PR TITLE
core: Don't use `cur_preload_frame` directly to implement load barriers.

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1313,9 +1313,7 @@ impl<'gc> MovieClip<'gc> {
         match next_frame {
             NextFrame::Next => {
                 let mut write = self.0.write(context.gc_context);
-                if (write.current_frame + 1)
-                    >= write.static_data.preload_progress.read().cur_preload_frame
-                {
+                if (write.current_frame + 1) >= write.frames_loaded() {
                     return;
                 }
 
@@ -3923,6 +3921,10 @@ struct PreloadProgress {
     next_preload_chunk: u64,
 
     /// The current frame being preloaded.
+    ///
+    /// NOTE: This property is indexed from one. Comparing it directly to the
+    /// current frame count may break loading. If you need to know if a
+    /// particular frame is loaded, compare against frames_loaded().
     cur_preload_frame: u16,
 
     /// The SWF offset that the current frame started in.


### PR DESCRIPTION
`cur_preload_frame` is one-indexed, which is necessary for code that counts frames in `preload` but will make ineffective load barriers if used directly elsewhere. Always check `frames_loaded` instead.

Discovered after fixing other bugs in #8114. The actual movie does *not* work yet, but it at least breaks on `tabChildren` rather than broken loading.

I did a cursory review for anything else in `movie_clip.rs` that uses `cur_preload_frame`, but didn't find anything. The fix I implemented for `construct_frame` in a previous PR used `frames_loaded` correctly.