### PR TITLE
render: Remove `get_bitmap_pixels` and store data in `Character::Bitmap`

### DIFF
--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -61,7 +61,10 @@ pub fn instance_init<'gc>(
                         .avm2_class_registry()
                         .class_symbol(b_class)
                     {
-                        if let Some(Character::Bitmap(bitmap)) = activation
+                        if let Some(Character::Bitmap {
+                            bitmap,
+                            initial_data,
+                        }) = activation
                             .context
                             .library
                             .library_for_movie_mut(movie)
@@ -77,7 +80,7 @@ pub fn instance_init<'gc>(
                                 activation,
                                 bitmap,
                                 new_bitmap_data,
-                                Some(b_class.inner_class_definition().read().name()),
+                                initial_data,
                             );
                             BitmapDataObject::from_bitmap_data(
                                 activation,

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -12,7 +12,10 @@ pub enum Character<'gc> {
     EditText(EditText<'gc>),
     Graphic(Graphic<'gc>),
     MovieClip(MovieClip<'gc>),
-    Bitmap(Bitmap<'gc>),
+    Bitmap {
+        bitmap: Bitmap<'gc>,
+        initial_data: Vec<i32>,
+    },
     Avm1Button(Avm1Button<'gc>),
     Avm2Button(Avm2Button<'gc>),
     Font(Font<'gc>),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -785,7 +785,7 @@ impl<'gc> MovieClip<'gc> {
                             Some(Character::BinaryData(_)) => {}
                             Some(Character::Font(_)) => {}
                             Some(Character::Sound(_)) => {}
-                            Some(Character::Bitmap(bitmap)) => {
+                            Some(Character::Bitmap { bitmap, .. }) => {
                                 bitmap.set_avm2_bitmapdata_class(
                                     &mut activation.context,
                                     class_object,
@@ -2973,11 +2973,18 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> Result<(), Error> {
         let define_bits_lossless = reader.read_define_bits_lossless(version)?;
         let bitmap = ruffle_render::utils::decode_define_bits_lossless(&define_bits_lossless)?;
+        let initial_data: Vec<i32> = bitmap.clone().into();
         let bitmap = Bitmap::new(context, define_bits_lossless.id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(define_bits_lossless.id, Character::Bitmap(bitmap));
+            .register_character(
+                define_bits_lossless.id,
+                Character::Bitmap {
+                    bitmap,
+                    initial_data,
+                },
+            );
         Ok(())
     }
 
@@ -3090,11 +3097,18 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .jpeg_tables();
         let jpeg_data = ruffle_render::utils::glue_tables_to_jpeg(jpeg_data, jpeg_tables);
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(&jpeg_data, None)?;
+        let initial_data: Vec<i32> = bitmap.clone().into();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::Bitmap(bitmap));
+            .register_character(
+                id,
+                Character::Bitmap {
+                    bitmap,
+                    initial_data,
+                },
+            );
         Ok(())
     }
 
@@ -3107,11 +3121,18 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let id = reader.read_u16()?;
         let jpeg_data = reader.read_slice_to_end();
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(jpeg_data, None)?;
+        let initial_data: Vec<i32> = bitmap.clone().into();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::Bitmap(bitmap));
+            .register_character(
+                id,
+                Character::Bitmap {
+                    bitmap,
+                    initial_data,
+                },
+            );
         Ok(())
     }
 
@@ -3130,11 +3151,18 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let jpeg_data = reader.read_slice(jpeg_len)?;
         let alpha_data = reader.read_slice_to_end();
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))?;
+        let initial_data: Vec<i32> = bitmap.clone().into();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::Bitmap(bitmap));
+            .register_character(
+                id,
+                Character::Bitmap {
+                    bitmap,
+                    initial_data,
+                },
+            );
         Ok(())
     }
 

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -257,8 +257,8 @@ impl<'gc> Video<'gc> {
                         .decode_video_stream_frame(*stream, encframe, context.renderer)
                 }
                 None => {
-                    if let Some((_old_id, old_frame)) = read.decoded_frame {
-                        Ok(old_frame)
+                    if let Some((_old_id, old_frame)) = &read.decoded_frame {
+                        Ok(old_frame.clone())
                     } else {
                         Err(Error::SeekingBeforeDecoding(frame_id))
                     }

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -202,7 +202,10 @@ impl<'gc> MovieLibrary<'gc> {
         gc_context: MutationContext<'gc, '_>,
     ) -> Result<DisplayObject<'gc>, &'static str> {
         match character {
-            Character::Bitmap(bitmap) => Ok(bitmap.instantiate(gc_context)),
+            Character::Bitmap {
+                bitmap,
+                initial_data: _,
+            } => Ok(bitmap.instantiate(gc_context)),
             Character::EditText(edit_text) => Ok(edit_text.instantiate(gc_context)),
             Character::Graphic(graphic) => Ok(graphic.instantiate(gc_context)),
             Character::MorphShape(morph_shape) => Ok(morph_shape.instantiate(gc_context)),
@@ -216,7 +219,7 @@ impl<'gc> MovieLibrary<'gc> {
     }
 
     pub fn get_bitmap(&self, id: CharacterId) -> Option<Bitmap<'gc>> {
-        if let Some(&Character::Bitmap(bitmap)) = self.characters.get(&id) {
+        if let Some(&Character::Bitmap { bitmap, .. }) = self.characters.get(&id) {
             Some(bitmap)
         } else {
             None

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -170,30 +170,6 @@ impl BitmapData {
             context,
         })
     }
-
-    fn get_pixels(&self) -> Option<Bitmap> {
-        if let Ok(bitmap_pixels) =
-            self.context
-                .get_image_data(0.0, 0.0, self.width().into(), self.height().into())
-        {
-            Some(Bitmap::new(
-                self.width(),
-                self.height(),
-                BitmapFormat::Rgba,
-                bitmap_pixels.data().to_vec(),
-            ))
-        } else {
-            None
-        }
-    }
-
-    fn width(&self) -> u32 {
-        self.bitmap.width()
-    }
-
-    fn height(&self) -> u32 {
-        self.bitmap.height()
-    }
 }
 
 impl WebCanvasRenderBackend {
@@ -456,11 +432,6 @@ impl RenderBackend for WebCanvasRenderBackend {
     fn submit_frame(&mut self, clear: Color, commands: CommandList) {
         self.begin_frame(clear);
         commands.execute(self);
-    }
-
-    fn get_bitmap_pixels(&mut self, bitmap: BitmapHandle) -> Option<Bitmap> {
-        let bitmap = &self.bitmaps[&bitmap];
-        bitmap.get_pixels()
     }
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error> {

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -44,7 +44,6 @@ pub trait RenderBackend: Downcast {
 
     fn submit_frame(&mut self, clear: swf::Color, commands: CommandList);
 
-    fn get_bitmap_pixels(&mut self, bitmap: BitmapHandle) -> Option<Bitmap>;
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;
     // Frees memory used by the bitmap. After this call, `handle` can no longer
     // be used.

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -62,10 +62,6 @@ impl RenderBackend for NullRenderer {
     }
 
     fn submit_frame(&mut self, _clear: Color, _commands: CommandList) {}
-
-    fn get_bitmap_pixels(&mut self, _bitmap: BitmapHandle) -> Option<Bitmap> {
-        None
-    }
     fn register_bitmap(&mut self, _bitmap: Bitmap) -> Result<BitmapHandle, Error> {
         Ok(BitmapHandle(0))
     }

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -3,8 +3,7 @@ use crate::backend::RenderBackend;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct BitmapHandle(pub usize);
 
-/// Info returned by the `register_bitmap` methods.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct BitmapInfo {
     pub handle: BitmapHandle,
     pub width: u16,

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -987,10 +987,6 @@ impl RenderBackend for WebGlRenderBackend {
         self.end_frame();
     }
 
-    fn get_bitmap_pixels(&mut self, bitmap: BitmapHandle) -> Option<Bitmap> {
-        self.bitmap_registry.get(&bitmap).map(|e| e.bitmap.clone())
-    }
-
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, BitmapError> {
         let format = match bitmap.format() {
             BitmapFormat::Rgb => Gl::RGB,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -218,7 +218,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         &self.descriptors.device
     }
 
-    pub fn bitmap_registry(&self) -> &FnvHashMap<BitmapHandle, RegistryData> {
+    pub fn bitmap_registry(&self) -> &FnvHashMap<BitmapHandle, Texture> {
         &self.bitmap_registry
     }
 }

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -11,7 +11,7 @@ use bytemuck::{Pod, Zeroable};
 use descriptors::Descriptors;
 use enum_map::Enum;
 use once_cell::sync::OnceCell;
-use ruffle_render::bitmap::{Bitmap, BitmapHandle};
+use ruffle_render::bitmap::BitmapHandle;
 use ruffle_render::color_transform::ColorTransform;
 use ruffle_render::tessellator::{Gradient as TessGradient, GradientType, Vertex as TessVertex};
 pub use wgpu;
@@ -37,11 +37,6 @@ mod layouts;
 mod mesh;
 mod shaders;
 mod surface;
-
-pub struct RegistryData {
-    bitmap: Bitmap,
-    texture_wrapper: Texture,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]
 pub enum MaskState {
@@ -187,11 +182,13 @@ impl From<TessGradient> for GradientStorage {
 }
 
 #[derive(Debug)]
-struct Texture {
+pub struct Texture {
     texture: wgpu::Texture,
     bind_linear: OnceCell<BitmapBinds>,
     bind_nearest: OnceCell<BitmapBinds>,
     texture_offscreen: Option<TextureOffscreen>,
+    width: u32,
+    height: u32,
 }
 
 impl Texture {

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -7,7 +7,7 @@ use crate::surface::Surface::{Direct, DirectSrgb, Resolve, ResolveSrgb};
 use crate::uniform_buffer::BufferStorage;
 use crate::utils::remove_srgb;
 use crate::{
-    create_buffer_with_data, ColorAdjustments, Descriptors, Globals, Pipelines, RegistryData,
+    create_buffer_with_data, ColorAdjustments, Descriptors, Globals, Pipelines, Texture,
     TextureTransforms, Transforms, UniformBuffer,
 };
 use fnv::FnvHashMap;
@@ -387,7 +387,7 @@ impl Surface {
         globals: &mut Globals,
         uniform_buffers_storage: &mut BufferStorage<Transforms>,
         meshes: &Vec<Mesh>,
-        bitmap_registry: &FnvHashMap<BitmapHandle, RegistryData>,
+        bitmap_registry: &FnvHashMap<BitmapHandle, Texture>,
         commands: CommandList,
     ) -> Vec<wgpu::CommandBuffer> {
         let label = create_debug_label!("Draw encoder");

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -79,14 +79,19 @@ impl VideoBackend for SoftwareVideoBackend {
 
         let frame = stream.decoder.decode_frame(encoded_frame)?;
         let handle = if let Some(bitmap) = stream.bitmap {
-            renderer.update_texture(bitmap, frame.width.into(), frame.height.into(), frame.rgba)?;
+            renderer.update_texture(
+                bitmap,
+                frame.width.into(),
+                frame.height.into(),
+                frame.rgba.clone(),
+            )?;
             bitmap
         } else {
             let bitmap = Bitmap::new(
                 frame.width.into(),
                 frame.height.into(),
                 BitmapFormat::Rgba,
-                frame.rgba,
+                frame.rgba.clone(),
             );
             renderer.register_bitmap(bitmap)?
         };


### PR DESCRIPTION
We only called `get_bitmap_pixels` when creating a `BitmapData` for an SWF-provided `Bitmap`. We now store the initial pixels in `Character::Bitmap`, and use them to initialize a `BitmapData` when needed.

This lets us simplify the wgpu backend, which no longer needs to store a `Bitmap` object. In addition to saving space for `BitmapData` objects that lack an SWF `Bitmap`, this will make it easier to move data from `bitmap_registry` into `BitmapHandle` itself.