### PR TITLE
core: Add root movie URL spoofing (desktop only).

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -697,7 +697,15 @@ impl<'gc> Loader<'gc> {
                 error
             })?;
 
-            let mut movie = SwfMovie::from_data(&response.body, Some(response.url), None)?;
+            // The spoofed root movie URL takes precedence over the actual URL.
+            let url = player
+                .lock()
+                .unwrap()
+                .spoofed_url()
+                .map(|u| u.to_string())
+                .unwrap_or(response.url);
+
+            let mut movie = SwfMovie::from_data(&response.body, Some(url), None)?;
             on_metadata(movie.header());
             movie.append_parameters(parameters);
             player.lock().unwrap().set_root_movie(movie);

--- a/core/src/tag_utils.rs
+++ b/core/src/tag_utils.rs
@@ -148,6 +148,10 @@ impl SwfMovie {
         self.url.as_deref()
     }
 
+    pub fn set_url(&mut self, url: Option<String>) {
+        self.url = url;
+    }
+
     /// Get the URL that triggered the fetch of this SWF.
     pub fn loader_url(&self) -> Option<&str> {
         self.loader_url.as_deref()

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -103,6 +103,10 @@ struct Opt {
 
     #[clap(long, default_value = "streaming")]
     load_behavior: LoadBehavior,
+
+    /// Spoofs the root SWF URL provided to ActionScript.
+    #[clap(long, value_parser)]
+    spoof_url: Option<Url>,
 }
 
 #[cfg(feature = "render_trace")]
@@ -271,7 +275,8 @@ impl App {
             .with_letterbox(Letterbox::On)
             .with_warn_on_unsupported_content(!opt.dont_warn_on_unsupported_content)
             .with_fullscreen(opt.fullscreen)
-            .with_load_behavior(opt.load_behavior);
+            .with_load_behavior(opt.load_behavior)
+            .with_spoofed_url(opt.spoof_url.clone().map(|url| url.to_string()));
 
         let player = builder.build();
 


### PR DESCRIPTION
The desktop player now takes a `--spoof-url` argument, which overrides the movie URL provided to ActionScript. This does not affect non-root movies loaded through `Loader`.