### PR TITLE
extension: Use split incognito mode in Chrome

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -39,6 +39,10 @@ function transformManifest(content, env) {
                 /(script-src\s+[^;]*)(;|$)/i,
                 "$1 'wasm-eval'$2"
             );
+
+        // Chrome runs the extension in a single shared process by default,
+        // which prevents extension pages from loading in Incognito tabs
+        manifest.incognito = "split";
     }
 
     return JSON.stringify(manifest);


### PR DESCRIPTION
As explained in the [Chrome Developers documentation](https://developer.chrome.com/docs/extensions/mv3/manifest/incognito/), Chrome runs the extension in a single shared process by default, which prevented Ruffle's internal player page from loading in Incognito tabs. This message was shown instead:
![image](https://user-images.githubusercontent.com/71368227/193708317-7118c1db-b954-4266-98fd-0780468f5686.png)

The problem does not affect Firefox, and in fact, [Firefox does not support split incognito mode](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito) at all; it refuses to load the extension if this value is present in its manifest. So we'll only use it for the Chrome extension, not the Firefox extension.