### PR TITLE
core: Implement XMLSocket

### DIFF
--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -61,6 +61,7 @@ mod transform;
 mod video;
 mod xml;
 mod xml_node;
+mod xml_socket;
 
 const GLOBAL_DECLS: &[Declaration] = declare_properties! {
     "trace" => method(trace; DONT_ENUM);
@@ -477,6 +478,7 @@ pub struct SystemPrototypes<'gc> {
     pub array_constructor: Object<'gc>,
     pub xml_node: Object<'gc>,
     pub xml_constructor: Object<'gc>,
+    pub xml_socket: Object<'gc>,
     pub string: Object<'gc>,
     pub number: Object<'gc>,
     pub boolean: Object<'gc>,
@@ -555,6 +557,8 @@ pub fn create_globals<'gc>(
     let xmlnode_proto = xml_node::create_proto(gc_context, object_proto, function_proto);
 
     let xml_proto = xml::create_proto(gc_context, xmlnode_proto, function_proto);
+
+    let xml_socket_proto = xml_socket::create_proto(gc_context, object_proto, function_proto);
 
     let string_proto = string::create_proto(gc_context, object_proto, function_proto);
     let number_proto = number::create_proto(gc_context, object_proto, function_proto);
@@ -685,6 +689,13 @@ pub fn create_globals<'gc>(
         constructor_to_fn!(xml::constructor),
         Some(function_proto),
         xml_proto,
+    );
+    let xmlsocket = FunctionObject::constructor(
+        gc_context,
+        Executable::Native(xml_socket::constructor),
+        constructor_to_fn!(xml_socket::constructor),
+        Some(function_proto),
+        xml_socket_proto,
     );
     let string = string::create_string_object(gc_context, string_proto, function_proto);
     let number = number::create_number_object(gc_context, number_proto, function_proto);
@@ -992,6 +1003,12 @@ pub fn create_globals<'gc>(
     );
     globals.define_value(gc_context, "XMLNode", xmlnode.into(), Attribute::DONT_ENUM);
     globals.define_value(gc_context, "XML", xml.into(), Attribute::DONT_ENUM);
+    globals.define_value(
+        gc_context,
+        "XMLSocket",
+        xmlsocket.into(),
+        Attribute::DONT_ENUM,
+    );
     globals.define_value(gc_context, "String", string.into(), Attribute::DONT_ENUM);
     globals.define_value(gc_context, "Number", number.into(), Attribute::DONT_ENUM);
     globals.define_value(gc_context, "Boolean", boolean.into(), Attribute::DONT_ENUM);
@@ -1140,6 +1157,7 @@ pub fn create_globals<'gc>(
             array_constructor: array,
             xml_node: xmlnode_proto,
             xml_constructor: xml,
+            xml_socket: xml_socket_proto,
             string: string_proto,
             number: number_proto,
             boolean: boolean_proto,

--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -1,0 +1,96 @@
+use crate::avm1::property_decl::{define_properties_on, Declaration};
+use crate::avm1::{Activation, Error, Object, ScriptObject, Value};
+use crate::avm_warn;
+use gc_arena::MutationContext;
+
+const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "connect" => method(connect);
+    "close" => method(close);
+    "send" => method(send);
+    "onConnect" => method(on_connect; DONT_ENUM | DONT_DELETE);
+    "onClose" => method(on_close; DONT_ENUM | DONT_DELETE);
+    "onData" => method(on_data; DONT_ENUM | DONT_DELETE);
+    "onXML" => method(on_xml; DONT_ENUM | DONT_DELETE);
+};
+
+/// XMLSocket constructor
+pub fn constructor<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(this.into())
+}
+
+fn connect<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm_warn!(activation, "XMLSocket.connect() not implemented");
+    Ok(false.into())
+}
+
+fn close<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm_warn!(activation, "XMLSocket.close() not implemented");
+    Ok(Value::Undefined)
+}
+
+fn send<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm_warn!(activation, "XMLSocket.send() not implemented");
+    Ok(Value::Undefined)
+}
+
+fn on_connect<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(Value::Undefined)
+}
+
+fn on_close<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // No-op by default
+    Ok(Value::Undefined)
+}
+
+fn on_data<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm_warn!(activation, "XMLSocket.onData() not implemented");
+    Ok(Value::Undefined)
+}
+
+fn on_xml<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // No-op by default
+    Ok(Value::Undefined)
+}
+
+/// Construct the prototype for `XMLSocket`.
+pub fn create_proto<'gc>(
+    gc_context: MutationContext<'gc, '_>,
+    proto: Object<'gc>,
+    fn_proto: Object<'gc>,
+) -> Object<'gc> {
+    let object = ScriptObject::new(gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    object.into()
+}

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -20,6 +20,7 @@ use crate::avm1::object::transform_object::TransformObject;
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::object::xml_node_object::XmlNodeObject;
 use crate::avm1::object::xml_object::XmlObject;
+use crate::avm1::object::xml_socket_object::XmlSocketObject;
 use crate::avm1::{Activation, Attribute, Error, ScriptObject, SoundObject, StageObject, Value};
 use crate::display_object::DisplayObject;
 use crate::html::TextFormat;
@@ -51,6 +52,7 @@ pub mod transform_object;
 pub mod value_object;
 pub mod xml_node_object;
 pub mod xml_object;
+pub mod xml_socket_object;
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
@@ -74,6 +76,7 @@ pub enum NativeObject<'gc> {
         SuperObject(SuperObject<'gc>),
         XmlObject(XmlObject<'gc>),
         XmlNodeObject(XmlNodeObject<'gc>),
+        XmlSocketObject(XmlSocketObject<'gc>),
         ValueObject(ValueObject<'gc>),
         FunctionObject(FunctionObject<'gc>),
         SharedObject(SharedObject<'gc>),
@@ -540,6 +543,11 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
     /// Get the underlying XML node for this object, if it exists.
     fn as_xml_node(&self) -> Option<XmlNode<'gc>> {
+        None
+    }
+
+    /// Get the underlying XMLSocket for this object, if it exists.
+    fn as_xml_socket(&self) -> Option<XmlSocketObject<'gc>> {
         None
     }
 

--- a/core/src/avm1/object/xml_socket_object.rs
+++ b/core/src/avm1/object/xml_socket_object.rs
@@ -1,0 +1,81 @@
+use core::fmt;
+
+use gc_arena::{Collect, GcCell, MutationContext};
+
+use crate::{
+    avm1::{Activation, Error, ScriptObject},
+    impl_custom_object,
+    socket::XmlSocketHandle,
+};
+
+use super::{Object, TObject};
+
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+pub struct XmlSocketObject<'gc>(GcCell<'gc, XmlSocketObjectData<'gc>>);
+
+#[derive(Clone, Collect)]
+#[collect(no_drop)]
+pub struct XmlSocketObjectData<'gc> {
+    base: ScriptObject<'gc>,
+    #[collect(require_static)]
+    handle: Option<XmlSocketHandle>,
+}
+
+impl<'gc> XmlSocketObject<'gc> {
+    pub fn empty(gc_context: MutationContext<'gc, '_>, proto: Option<Object<'gc>>) -> Object<'gc> {
+        Self(GcCell::allocate(
+            gc_context,
+            XmlSocketObjectData {
+                base: ScriptObject::new(gc_context, proto),
+                handle: None,
+            },
+        ))
+        .into()
+    }
+
+    pub fn handle(&self) -> Option<XmlSocketHandle> {
+        self.0.read().handle
+    }
+
+    pub fn set_handle(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+        handle: XmlSocketHandle,
+    ) -> Option<XmlSocketHandle> {
+        std::mem::replace(&mut self.0.write(gc_context).handle, Some(handle))
+    }
+}
+
+impl fmt::Debug for XmlSocketObject<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let this = self.0.read();
+        f.debug_struct("XmlSocketObject")
+            .field("base", &this.base)
+            .field("handle", &this.handle)
+            .finish()
+    }
+}
+
+impl<'gc> TObject<'gc> for XmlSocketObject<'gc> {
+    impl_custom_object!(base);
+
+    fn create_bare_object(
+        &self,
+        activation: &mut Activation<'_, 'gc, '_>,
+        this: Object<'gc>,
+    ) -> Result<Object<'gc>, Error<'gc>> {
+        Ok(Self(GcCell::allocate(
+            activation.context.gc_context,
+            XmlSocketObjectData {
+                base: ScriptObject::new(activation.context.gc_context, Some(this)),
+                handle: None,
+            },
+        ))
+        .into())
+    }
+
+    fn as_xml_socket(&self) -> Option<XmlSocketObject<'gc>> {
+        Some(*self)
+    }
+}

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -1,6 +1,7 @@
 //! Browser-related platform functions
 
 use crate::loader::Error;
+use crate::socket::XmlSocketConnection;
 use crate::string::WStr;
 use indexmap::IndexMap;
 use std::future::Future;
@@ -158,6 +159,15 @@ pub trait NavigatorBackend {
     /// Changing http -> https for example. This function may alter any part of the
     /// URL (generally only if configured to do so by the user).
     fn pre_process_url(&self, url: Url) -> Url;
+
+    /// Handle any XMLSocket connection request
+    ///
+    /// Returning `None` makes `XMLSocket.connect()` returns `false`,
+    /// as if network access was disabled.
+    ///
+    /// See [XmlSocketConnection] for more details about implementation.
+    fn connect_xml_socket(&mut self, host: &str, port: u16)
+        -> Option<Box<dyn XmlSocketConnection>>;
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -303,5 +313,13 @@ impl NavigatorBackend for NullNavigatorBackend {
 
     fn pre_process_url(&self, url: Url) -> Url {
         url
+    }
+
+    fn connect_xml_socket(
+        &mut self,
+        _host: &str,
+        _port: u16,
+    ) -> Option<Box<dyn XmlSocketConnection>> {
+        None
     }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -20,6 +20,7 @@ use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::player::Player;
 use crate::prelude::*;
+use crate::socket::XmlSockets;
 use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::timer::Timers;
 use core::fmt;
@@ -138,6 +139,9 @@ pub struct UpdateContext<'a, 'gc, 'gc_context> {
 
     /// Timed callbacks created with `setInterval`/`setTimeout`.
     pub timers: &'a mut Timers<'gc>,
+
+    /// Handle `XMLSocket` connections lifecycle
+    pub xml_sockets: &'a mut XmlSockets<'gc>,
 
     pub current_context_menu: &'a mut Option<ContextMenuState<'gc>>,
 
@@ -327,6 +331,7 @@ impl<'a, 'gc, 'gc_context> UpdateContext<'a, 'gc, 'gc_context> {
             avm2_shared_objects: self.avm2_shared_objects,
             unbound_text_fields: self.unbound_text_fields,
             timers: self.timers,
+            xml_sockets: self.xml_sockets,
             current_context_menu: self.current_context_menu,
             avm1: self.avm1,
             avm2: self.avm2,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 mod display_object;
+
 pub use display_object::StageDisplayState;
 
 #[macro_use]
@@ -35,6 +36,7 @@ pub mod loader;
 mod locale;
 mod player;
 mod prelude;
+pub mod socket;
 pub mod string;
 pub mod tag_utils;
 pub mod timer;

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -1,0 +1,243 @@
+use crate::{
+    avm1::{Activation, ActivationIdentifier, ExecutionReason, Object, TObject},
+    backend::navigator::NavigatorBackend,
+    context::UpdateContext,
+    string::AvmString,
+};
+use encoding_rs::UTF_8;
+use gc_arena::{Collect, CollectionContext};
+use generational_arena::{Arena, Index};
+use std::collections::VecDeque;
+
+/// XMLSocket backend implementation
+///
+/// When `XMLSocket.connect()` is called, the backend may provide a
+/// [XmlSocketConnection] instance, that will be polled every tick.
+/// Methods must not block.
+///
+/// For performances reasons, only 1 message will be polled per tick per connection
+/// and at most 1 message will be sent per tick per connection.
+///
+/// When the XMLSocket gets closed, the underlying [XmlSocketConnection]
+/// ise dropped, so simply implement [Drop] to handle cleanup stuff.
+///
+/// See [XmlSocketConnection::is_connected] for details about how
+/// Ruffle infer connection state, [XmlSocketConnection::send] for details
+/// about forwarding messages, [XmlSocketConnection::poll] for details
+/// about polling incoming messages.
+pub trait XmlSocketConnection {
+    /// Return socket connection state
+    ///
+    /// Possibles values:
+    ///  * `None`: connecting ([XmlSocketConnection::send] and
+    ///            [XmlSocketConnection::poll] not yet called)
+    ///  * `Some(true)`: connected ([XmlSocketConnection::send] and
+    ///                 [XmlSocketConnection::poll] got called)
+    ///  * `Some(false)`: disconnected, or connection refused socket wasn't connected
+    ///                   (called only after [XmlSocketConnection::poll] return `None`;
+    ///                    [XmlSocketConnection::send] and [XmlSocketConnection::poll]
+    ///                    won't be called after `Some(false)` is returned)
+    ///
+    /// Returning `None` after `Some(true)` was returned
+    /// will be considered as `Some(false)` (i.e. connection closed).
+    fn is_connected(&self) -> Option<bool>;
+
+    /// Send a message to the remote side
+    ///
+    /// `buf` contains all bytes for the message to send, it's up to the backend to
+    /// decide how to encode and transport them.
+    ///
+    /// Only called if there is at least 1 pending message to send.
+    fn send(&mut self, buf: Vec<u8>);
+
+    /// Poll the next available message, if any
+    ///
+    /// Called every ticks, so can be used to try to
+    /// flush message not sent yet for instance.
+    fn poll(&mut self) -> Option<Vec<u8>>;
+}
+
+pub type XmlSocketHandle = Index;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+struct Socket<'gc> {
+    target: Object<'gc>,
+    #[collect(require_static)]
+    internal: Box<dyn XmlSocketConnection>,
+    send_buffer: VecDeque<Vec<u8>>,
+    pending_connect: bool,
+}
+
+impl<'gc> Socket<'gc> {
+    fn new(target: Object<'gc>, internal: Box<dyn XmlSocketConnection>) -> Self {
+        Self {
+            target,
+            internal,
+            pending_connect: true,
+            send_buffer: Default::default(),
+        }
+    }
+}
+
+/// Manages the collection of active XmlSockets connections
+pub struct XmlSockets<'gc>(Arena<Socket<'gc>>);
+
+unsafe impl<'gc> Collect for XmlSockets<'gc> {
+    fn trace(&self, cc: CollectionContext) {
+        for (_, socket) in self.0.iter() {
+            socket.trace(cc)
+        }
+    }
+}
+
+impl<'gc> XmlSockets<'gc> {
+    pub fn empty() -> Self {
+        Self(Arena::new())
+    }
+
+    pub fn connect(
+        &mut self,
+        backend: &mut dyn NavigatorBackend,
+        target: Object<'gc>,
+        host: &str,
+        port: u16,
+    ) -> Option<XmlSocketHandle> {
+        if let Some(internal) = backend.connect_xml_socket(host, port) {
+            let socket = Socket::new(target, internal);
+            let handle = self.0.insert(socket);
+            Some(handle)
+        } else {
+            None
+        }
+    }
+
+    pub fn send(&mut self, handle: XmlSocketHandle, data: Vec<u8>) {
+        if let Some(Socket { send_buffer, .. }) = self.0.get_mut(handle) {
+            send_buffer.push_back(data);
+        }
+    }
+
+    pub fn close(&mut self, handle: XmlSocketHandle) {
+        if let Some(Socket { internal, .. }) = self.0.remove(handle) {
+            drop(internal); // explicitly close connections via `Drop::drop`
+        }
+    }
+
+    pub fn update_sockets(uc: &mut UpdateContext<'_, 'gc, '_>) {
+        #[derive(Debug)]
+        enum SocketAction {
+            Connect(XmlSocketHandle, bool),
+            Data(XmlSocketHandle, Vec<u8>),
+            Close(XmlSocketHandle),
+        }
+
+        let mut actions = vec![];
+
+        for (handle, socket) in uc.xml_sockets.0.iter_mut() {
+            let Socket {
+                pending_connect: is_connecting,
+                internal,
+                send_buffer,
+                ..
+            } = socket;
+
+            let is_connected = internal.is_connected();
+
+            match is_connected {
+                Some(success) if *is_connecting => {
+                    *is_connecting = false;
+                    actions.push(SocketAction::Connect(handle, success));
+                    if !success {
+                        continue;
+                    }
+                }
+                None => continue,
+
+                _ => {}
+            }
+
+            if let Some(received) = internal.poll() {
+                actions.push(SocketAction::Data(handle, received));
+            } else if matches!(is_connected, Some(false) | None) {
+                actions.push(SocketAction::Close(handle));
+                continue;
+            }
+
+            if let Some(to_send) = send_buffer.pop_front() {
+                internal.send(to_send);
+            }
+        }
+
+        if actions.is_empty() {
+            return;
+        }
+
+        let mut activation =
+            Activation::from_stub(uc.reborrow(), ActivationIdentifier::root("[XMLSocket]"));
+
+        for action in actions {
+            match action {
+                SocketAction::Connect(handle, success) => {
+                    let arena = &mut activation.context.xml_sockets.0;
+                    let target = if success {
+                        arena
+                            .get(handle)
+                            .expect("only valid handles in SocketAction")
+                            .target
+                    } else {
+                        arena
+                            .remove(handle)
+                            .expect("only valid handles in SocketAction")
+                            .target
+                    };
+
+                    let _ = TObject::call_method(
+                        &target,
+                        "onConnect".into(),
+                        &[success.into()],
+                        &mut activation,
+                        ExecutionReason::FunctionCall,
+                    );
+                }
+                SocketAction::Close(handle) => {
+                    let target = activation
+                        .context
+                        .xml_sockets
+                        .0
+                        .remove(handle)
+                        .expect("only valid handles in SocketAction")
+                        .target;
+
+                    let _ = TObject::call_method(
+                        &target,
+                        "onClose".into(),
+                        &[],
+                        &mut activation,
+                        ExecutionReason::FunctionCall,
+                    );
+                }
+                SocketAction::Data(handle, data) => {
+                    let target = activation
+                        .context
+                        .xml_sockets
+                        .0
+                        .get(handle)
+                        .expect("only valid handles in SocketAction")
+                        .target;
+
+                    let data =
+                        AvmString::new_utf8(activation.context.gc_context, UTF_8.decode(&data).0);
+
+                    let _ = TObject::call_method(
+                        &target,
+                        "onData".into(),
+                        &[data.into()],
+                        &mut activation,
+                        ExecutionReason::FunctionCall,
+                    );
+                }
+            };
+        }
+    }
+}

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -9,6 +9,7 @@ use ruffle_core::backend::navigator::{
 };
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
+use ruffle_core::socket::XmlSocketConnection;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
 use url::Url;
@@ -208,5 +209,13 @@ impl NavigatorBackend for ExternalNavigatorBackend {
             log::error!("Url::set_scheme failed on: {}", url);
         }
         url
+    }
+
+    fn connect_xml_socket(
+        &mut self,
+        _host: &str,
+        _port: u16,
+    ) -> Option<Box<dyn XmlSocketConnection>> {
+        None
     }
 }

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -10,10 +10,30 @@ use ruffle_core::backend::navigator::{
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
 use ruffle_core::socket::XmlSocketConnection;
+use std::collections::{HashSet, VecDeque};
+use std::io::{ErrorKind, Read, Write};
+use std::net::TcpStream;
 use std::rc::Rc;
 use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex};
 use url::Url;
 use winit::event_loop::EventLoopProxy;
+
+#[derive(clap::ArgEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum XmlSocketBehavior {
+    /// No `XMLSocket` support (i.e. `XMLSocket.connect()` always return `false`)
+    Disabled,
+
+    /// Allows movies to connect to any host using `XMLSocket`.
+    Unrestricted,
+
+    /// Refuse all `XMLSocket` connection requests
+    /// (i.e. `XMLSocket.onConnect(success)`always called with `success` = `false`)
+    Deny,
+
+    /// Ask the user every time a `XMLSocket` connection is requested
+    Ask,
+}
 
 /// Implementation of `NavigatorBackend` for non-web environments that can call
 /// out to a web browser.
@@ -30,6 +50,10 @@ pub struct ExternalNavigatorBackend {
     // Client to use for network requests
     client: Option<Rc<HttpClient>>,
 
+    xml_socket_allowed: HashSet<String>,
+
+    xml_sockets_behavior: XmlSocketBehavior,
+
     upgrade_to_https: bool,
 }
 
@@ -41,6 +65,8 @@ impl ExternalNavigatorBackend {
         event_loop: EventLoopProxy<RuffleEvent>,
         proxy: Option<Url>,
         upgrade_to_https: bool,
+        xml_socket_allowed: HashSet<String>,
+        xml_sockets_behavior: XmlSocketBehavior,
     ) -> Self {
         let proxy = proxy.and_then(|url| url.as_str().parse().ok());
         let builder = HttpClient::builder()
@@ -55,6 +81,8 @@ impl ExternalNavigatorBackend {
             client,
             movie_url,
             upgrade_to_https,
+            xml_socket_allowed,
+            xml_sockets_behavior,
         }
     }
 }
@@ -129,7 +157,6 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                 let body = std::fs::read(&path).or_else(|e| {
                     if cfg!(feature = "sandbox") {
                         use rfd::{FileDialog, MessageButtons, MessageDialog, MessageLevel};
-                        use std::io::ErrorKind;
 
                         if e.kind() == ErrorKind::PermissionDenied {
                             let attempt_sandbox_open = MessageDialog::new()
@@ -213,9 +240,176 @@ impl NavigatorBackend for ExternalNavigatorBackend {
 
     fn connect_xml_socket(
         &mut self,
-        _host: &str,
-        _port: u16,
+        host: &str,
+        port: u16,
     ) -> Option<Box<dyn XmlSocketConnection>> {
+        let addr = format!("{}:{}", host, port);
+        let is_allowed = self.xml_socket_allowed.contains(&addr);
+
+        match (is_allowed, self.xml_sockets_behavior) {
+            (false, XmlSocketBehavior::Unrestricted) | (true, _) => {
+                Some(Box::new(TcpXmlSocket::connect(host, port)))
+            }
+            (false, XmlSocketBehavior::Disabled) => None,
+            (false, XmlSocketBehavior::Deny) => Some(Box::new(DenySocket)),
+            (false, XmlSocketBehavior::Ask) => {
+                let mutex = Arc::new(Mutex::new(None));
+
+                {
+                    let host = host.to_string();
+                    let mutex: Arc<Mutex<Option<Box<dyn XmlSocketConnection>>>> = mutex.clone();
+
+                    self.spawn_future(Box::pin(async move {
+                        use rfd::{MessageButtons, AsyncMessageDialog, MessageLevel};
+
+                        let attempt_sandbox_connect = AsyncMessageDialog::new()
+                            .set_level(MessageLevel::Warning)
+                            .set_description(&format!("The current movie is attempting to connect to {:?} (port {}).\n\nTo allow it to do so, click Yes to grant network access to that host.\n\nOtherwise, click No to deny access.", host, port))
+                            .set_buttons(MessageButtons::YesNo)
+                            .show()
+                            .await;
+
+                        if let Ok(mut lock) = mutex.try_lock() {
+                            if !attempt_sandbox_connect {
+                                *lock = Some(Box::new(DenySocket));
+                            } else {
+                                *lock = Some(Box::new(TcpXmlSocket::connect(host.as_str(), port)));
+                            }
+                        }
+
+                        Ok(())
+                    }));
+                }
+
+                Some(Box::new(PendingConnectSocket(mutex)))
+            }
+        }
+    }
+}
+
+struct PendingConnectSocket(Arc<Mutex<Option<Box<dyn XmlSocketConnection>>>>);
+
+impl XmlSocketConnection for PendingConnectSocket {
+    fn is_connected(&self) -> Option<bool> {
+        self.0
+            .try_lock()
+            .ok()
+            .map(|lock| lock.as_ref().and_then(|s| s.is_connected()))
+            .unwrap_or_else(|| Some(false))
+    }
+
+    fn send(&mut self, buf: Vec<u8>) {
+        if let Ok(mut lock) = self.0.try_lock() {
+            if let Some(ref mut socket) = *lock {
+                socket.send(buf);
+            }
+        }
+    }
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        if let Ok(mut lock) = self.0.try_lock() {
+            if let Some(ref mut socket) = *lock {
+                return socket.poll();
+            }
+        }
+        None
+    }
+}
+
+struct DenySocket;
+
+impl XmlSocketConnection for DenySocket {
+    fn is_connected(&self) -> Option<bool> {
+        Some(false)
+    }
+
+    fn send(&mut self, _buf: Vec<u8>) {}
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+struct TcpXmlSocket {
+    stream: Option<TcpStream>,
+    pending_write: Vec<u8>,
+    pending_read: VecDeque<u8>,
+}
+
+impl TcpXmlSocket {
+    fn connect(host: &str, port: u16) -> Self {
+        // FIXME: make connect asynchronous
+        Self {
+            stream: TcpStream::connect((host, port)).ok().and_then(|socket| {
+                if socket.set_nonblocking(true).is_ok() {
+                    Some(socket)
+                } else {
+                    None
+                }
+            }),
+            pending_write: Default::default(),
+            pending_read: Default::default(),
+        }
+    }
+}
+
+impl XmlSocketConnection for TcpXmlSocket {
+    fn is_connected(&self) -> Option<bool> {
+        Some(self.stream.is_some())
+    }
+
+    fn send(&mut self, buf: Vec<u8>) {
+        if self.stream.is_some() {
+            self.pending_write.extend(buf);
+            self.pending_write.push(0);
+        }
+    }
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        if let Some(stream) = &mut self.stream {
+            if !self.pending_write.is_empty() {
+                match stream.write(&self.pending_write) {
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {} // just try later
+                    Err(_) | Ok(0) => {
+                        self.stream = None;
+                        return None;
+                    }
+                    Ok(written) => {
+                        let _ = self.pending_write.drain(..written);
+                    }
+                }
+            }
+
+            match process_next_message(&mut self.pending_read) {
+                Some(msg) => Some(msg),
+                None => {
+                    let mut buffer = [0; 2048];
+
+                    match stream.read(&mut buffer) {
+                        Err(e) if e.kind() == ErrorKind::WouldBlock => None, // just try later
+                        Err(_) | Ok(0) => {
+                            self.stream = None;
+                            None
+                        }
+                        Ok(read) => {
+                            self.pending_read.extend(buffer.into_iter().take(read));
+                            process_next_message(&mut self.pending_read)
+                        }
+                    }
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+fn process_next_message(pending_read: &mut VecDeque<u8>) -> Option<Vec<u8>> {
+    if let Some((index, _)) = pending_read.iter().enumerate().find(|(_, &b)| b == 0) {
+        let buffer = pending_read.drain(..index).collect::<Vec<_>>();
+        let _ = pending_read.pop_front(); // remove the separator
+        Some(buffer)
+    } else {
         None
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -78,6 +78,24 @@ extern "C" {
     fn new(message: &str) -> JsError;
 }
 
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    type JsSocket;
+
+    #[wasm_bindgen(method, js_name = "isOnline")]
+    fn is_connected(this: &JsSocket) -> bool;
+
+    #[wasm_bindgen(method)]
+    fn send(this: &JsSocket, buf: Vec<u8>);
+
+    #[wasm_bindgen(method)]
+    fn poll(this: &JsSocket) -> Option<Vec<u8>>;
+
+    #[wasm_bindgen(method)]
+    fn close(this: &JsSocket);
+}
+
 #[wasm_bindgen(module = "/packages/core/src/ruffle-player.ts")]
 extern "C" {
     #[wasm_bindgen(extends = EventTarget)]
@@ -107,6 +125,9 @@ extern "C" {
 
     #[wasm_bindgen(catch, method, js_name = "setFullscreen")]
     fn set_fullscreen(this: &JavascriptPlayer, is_full: bool) -> Result<(), JsValue>;
+
+    #[wasm_bindgen(method, js_name = "connectXmlSocket")]
+    fn connect_xml_socket(this: &JavascriptPlayer, host: &str, port: u16) -> Option<Promise>;
 
     #[wasm_bindgen(method, js_name = "setMetadata")]
     fn set_metadata(this: &JavascriptPlayer, metadata: JsValue);
@@ -475,6 +496,7 @@ impl Ruffle {
             log::error!("Unable to create audio backend. No audio will be played.");
         }
         builder = builder.with_navigator(navigator::WebNavigatorBackend::new(
+            js_player.clone(),
             allow_script_access,
             config.upgrade_to_https,
             config.base_url,

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -7,6 +7,8 @@ use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
 use ruffle_core::socket::XmlSocketConnection;
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::rc::Rc;
 use url::Url;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
@@ -14,7 +16,10 @@ use web_sys::{
     window, Blob, BlobPropertyBag, Request as WebRequest, RequestInit, Response as WebResponse,
 };
 
+use crate::{JavascriptPlayer, JsSocket};
+
 pub struct WebNavigatorBackend {
+    js_player: JavascriptPlayer,
     allow_script_access: bool,
     upgrade_to_https: bool,
     base_url: Option<Url>,
@@ -22,6 +27,7 @@ pub struct WebNavigatorBackend {
 
 impl WebNavigatorBackend {
     pub fn new(
+        js_player: JavascriptPlayer,
         allow_script_access: bool,
         upgrade_to_https: bool,
         base_url: Option<String>,
@@ -60,6 +66,7 @@ impl WebNavigatorBackend {
         }
 
         Self {
+            js_player,
             allow_script_access,
             upgrade_to_https,
             base_url,
@@ -234,9 +241,98 @@ impl NavigatorBackend for WebNavigatorBackend {
 
     fn connect_xml_socket(
         &mut self,
-        _host: &str,
-        _port: u16,
+        host: &str,
+        port: u16,
     ) -> Option<Box<dyn XmlSocketConnection>> {
+        if let Some(promise) = self.js_player.connect_xml_socket(host, port) {
+            let mutex: Box<dyn XmlSocketConnection> = Box::new(PendingConnectionSocket);
+            let mutex = Rc::from(RefCell::from(mutex));
+
+            {
+                let mutex = mutex.clone();
+
+                self.spawn_future(Box::pin(async move {
+                    let socket = JsFuture::from(promise)
+                        .await
+                        .ok()
+                        .and_then(|v| v.dyn_into::<JsSocket>().ok());
+
+                    *mutex.borrow_mut() = if let Some(socket) = socket {
+                        Box::new(socket)
+                    } else {
+                        Box::new(DenySocket)
+                    };
+
+                    Ok(())
+                }));
+            }
+
+            return Some(Box::new(DelegatedSocketConnection(mutex)));
+        }
         None
+    }
+}
+
+struct DelegatedSocketConnection(Rc<RefCell<Box<dyn XmlSocketConnection>>>);
+
+impl XmlSocketConnection for DelegatedSocketConnection {
+    fn is_connected(&self) -> Option<bool> {
+        self.0
+            .borrow()
+            .is_connected()
+    }
+
+    fn send(&mut self, buf: Vec<u8>) {
+        self.0
+            .borrow_mut()
+            .send(buf);
+    }
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        self.0
+            .borrow_mut()
+            .poll()
+    }
+}
+
+struct PendingConnectionSocket;
+
+impl XmlSocketConnection for PendingConnectionSocket {
+    fn is_connected(&self) -> Option<bool> {
+        None
+    }
+
+    fn send(&mut self, _buf: Vec<u8>) {}
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+struct DenySocket;
+
+impl XmlSocketConnection for DenySocket {
+    fn is_connected(&self) -> Option<bool> {
+        Some(false)
+    }
+
+    fn send(&mut self, _buf: Vec<u8>) {}
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        None
+    }
+}
+
+impl XmlSocketConnection for JsSocket {
+    fn is_connected(&self) -> Option<bool> {
+        Some(JsSocket::is_connected(self))
+    }
+
+    fn send(&mut self, buf: Vec<u8>) {
+        JsSocket::send(&*self, buf);
+    }
+
+    fn poll(&mut self) -> Option<Vec<u8>> {
+        JsSocket::poll(&*self)
     }
 }

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -5,6 +5,7 @@ use ruffle_core::backend::navigator::{
 };
 use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
+use ruffle_core::socket::XmlSocketConnection;
 use std::borrow::Cow;
 use url::Url;
 use wasm_bindgen::JsCast;
@@ -229,5 +230,13 @@ impl NavigatorBackend for WebNavigatorBackend {
             log::error!("Url::set_scheme failed on: {}", url);
         }
         url
+    }
+
+    fn connect_xml_socket(
+        &mut self,
+        _host: &str,
+        _port: u16,
+    ) -> Option<Box<dyn XmlSocketConnection>> {
+        None
     }
 }


### PR DESCRIPTION
Fixes #905
Fixes #1016
Linked #288
Linked #5134
Relates to #3042
Rewrites #5160

Add `XMLSocket` class.
The default behavior is unchanged: without explicit user opt-in, XMLSocket always rejects connections.

* [X] `XMLSocket` class
* [X] sockets management and integration with backends
* [X] Desktop implementation
* [ ] Web implementation¹
* [ ] Tests

¹ Since web environments doesn't allows native TCP connections, the web implementation will let the user (the one instantiating the Ruffle player) provide its own XMLSocket transport, just like with the External Interface API (over websocket for instance).