### PR TITLE
avm2: Stub `tabChildren`, `tabIndex`, and `tabEnabled`.

### DIFF
--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -597,6 +597,17 @@ pub fn set_mouse_children<'gc>(
     Ok(Value::Undefined)
 }
 
+/// Stub getter & setter for `tabChildren`.
+pub fn tab_children<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    log::warn!("DisplayObjectContainer.tabChildren is a stub");
+
+    Ok(true.into())
+}
+
 /// Construct `DisplayObjectContainer`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
@@ -636,6 +647,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(mouse_children),
             Some(set_mouse_children),
         ),
+        ("tabChildren", Some(tab_children), Some(tab_children)),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/interactiveobject.rs
+++ b/core/src/avm2/globals/flash/display/interactiveobject.rs
@@ -156,6 +156,28 @@ fn set_context_menu<'gc>(
     Ok(Value::Undefined)
 }
 
+/// Stub getter & setter for `tabEnabled`.
+pub fn tab_enabled<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    log::warn!("InteractiveObject.tabEnabled is a stub");
+
+    Ok(false.into())
+}
+
+/// Stub getter & setter for `tabIndex`.
+pub fn tab_index<'gc>(
+    _activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    log::warn!("InteractiveObject.tabIndex is a stub");
+
+    Ok((-1).into())
+}
+
 /// Construct `InteractiveObject`'s class.
 pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
     let class = Class::new(
@@ -193,6 +215,8 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(set_double_click_enabled),
         ),
         ("contextMenu", Some(context_menu), Some(set_context_menu)),
+        ("tabEnabled", Some(tab_enabled), Some(tab_enabled)),
+        ("tabIndex", Some(tab_index), Some(tab_index)),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 


### PR DESCRIPTION
As it says on the tin.

I've implemented these as "functional stubs": i.e. we log a warning when they are used but return reasonable default values in the hopes that the movie in question will continue working. When we get proper support for accessibility we will need to implement these properties, too.