### PR TITLE
avm2: Fix typing of add/removeChild methods

### DIFF
--- a/core/src/avm2/globals/flash/display/DisplayObjectContainer.as
+++ b/core/src/avm2/globals/flash/display/DisplayObjectContainer.as
@@ -1,11 +1,11 @@
 // This is a stub - the actual class is defined in `displayobjectcontainer.rs`
 package flash.display {
 	public class DisplayObjectContainer extends InteractiveObject {
-		public native function addChild(child:DisplayObject):void;
-		public native function addChildAt(child:DisplayObject, index:int):void;
-		public native function removeChild(child:DisplayObject, index:int):void
-		public native function removeChildAt(index:int):void
-		public native function setChildIndex(child:DisplayObject, index:int):void
+		public native function addChild(child:DisplayObject):DisplayObject;
+		public native function addChildAt(child:DisplayObject, index:int):DisplayObject;
+		public native function removeChild(child:DisplayObject, index:int):DisplayObject;
+		public native function removeChildAt(index:int):DisplayObject;
+		public native function setChildIndex(child:DisplayObject, index:int):void;
 		public native function getChildAt(index:int):DisplayObject;
 	}
 }

--- a/core/src/avm2/globals/flash/display/Loader.as
+++ b/core/src/avm2/globals/flash/display/Loader.as
@@ -30,19 +30,19 @@ package flash.display {
 
 		public native function loadBytes(data: ByteArray, context: LoaderContext = null):void;
 
-		override public function addChild(child:DisplayObject):void {
+		override public function addChild(child:DisplayObject):DisplayObject {
 			throw new IllegalOperationError("Error #2069: The Loader class does not implement this method.", 2069);
 		}
 
-		override public function addChildAt(child:DisplayObject, index:int):void {
+		override public function addChildAt(child:DisplayObject, index:int):DisplayObject {
 			throw new IllegalOperationError("Error #2069: The Loader class does not implement this method.", 2069);
 		}
 
-		override public function removeChild(child:DisplayObject, index:int):void {
+		override public function removeChild(child:DisplayObject, index:int):DisplayObject {
 			throw new IllegalOperationError("Error #2069: The Loader class does not implement this method.", 2069);
 		}
 
-		override public function removeChildAt(index:int):void {
+		override public function removeChildAt(index:int):DisplayObject {
 			throw new IllegalOperationError("Error #2069: The Loader class does not implement this method.", 2069);
 		}
 


### PR DESCRIPTION
This doesn't actually change any behavior right now, but still is objectively a correct thing to do.