### PR TITLE
avm2: BitmapData.perlinNoise and DisplacementMapFilter

### DIFF
--- a/core/src/avm2/globals/flash/filters/DisplacementMapFilter.as
+++ b/core/src/avm2/globals/flash/filters/DisplacementMapFilter.as
@@ -1,0 +1,40 @@
+﻿package flash.filters {
+	import flash.display.BitmapData;
+	import flash.geom.Point;
+
+	public final class DisplacementMapFilter extends BitmapFilter {
+		public var alpha: Number;
+		public var color: uint;
+		public var componentX: uint;
+		public var componentY: uint;
+		public var mapBitmap: BitmapData;
+		public var mapPoint: Point;
+		public var mode: String;
+		public var scaleX: Number;
+		public var scaleY: Number;
+
+		public function DisplacementMapFilter(mapBitmap:BitmapData = null,
+											  mapPoint:Point = null,
+											  componentX:uint = 0,
+											  componentY:uint = 0,
+											  scaleX:Number = 0.0,
+											  scaleY:Number = 0.0,
+											  mode:String = "wrap",
+											  color:uint = 0,
+											  alpha:Number = 0.0) {
+			this.mapBitmap = mapBitmap;
+			this.mapPoint = mapPoint;
+			this.componentX = componentX;
+			this.componentY = componentY;
+			this.scaleX = scaleX;
+			this.scaleY = scaleY;
+			this.mode = mode;
+			this.color = color;
+			this.alpha = alpha;
+		}
+
+		override public function clone(): BitmapFilter {
+			return new DisplacementMapFilter(this.mapBitmap.clone(), this.mapPoint.clone(), this.componentX, this.componentY, this.scaleX, this.scaleY, this.mode, this.color, this.alpha);
+		}
+	}
+}

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -127,6 +127,7 @@ include "flash/filters/BitmapFilterQuality.as"
 include "flash/filters/BitmapFilterType.as"
 include "flash/filters/BlurFilter.as"
 include "flash/filters/ColorMatrixFilter.as"
+include "flash/filters/DisplacementMapFilter.as"
 include "flash/filters/DisplacementMapFilterMode.as"
 include "flash/filters/GlowFilter.as"
 


### PR DESCRIPTION
Both were missing in #8163. Still not working completely though due to applyFilter not implemented and what I think are transparency issues.