### PR TITLE
avm1: Require `fn_proto` in `FunctionObject::bare_function`

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -883,7 +883,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let func_obj = FunctionObject::function(
             self.context.gc_context,
             Gc::allocate(self.context.gc_context, func),
-            Some(self.context.avm1.prototypes().function),
+            self.context.avm1.prototypes().function,
             prototype,
         );
         if let Some(name) = name {

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -505,12 +505,10 @@ impl<'gc> FunctionObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         function: Option<Executable<'gc>>,
         constructor: Option<Executable<'gc>>,
-        fn_proto: Option<Object<'gc>>,
+        fn_proto: Object<'gc>,
     ) -> Self {
-        let base = ScriptObject::new(gc_context, fn_proto);
-
-        FunctionObject {
-            base,
+        Self {
+            base: ScriptObject::new(gc_context, Some(fn_proto)),
             data: GcCell::allocate(
                 gc_context,
                 FunctionObjectData {
@@ -533,7 +531,7 @@ impl<'gc> FunctionObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         function: Option<Executable<'gc>>,
         constructor: Option<Executable<'gc>>,
-        fn_proto: Option<Object<'gc>>,
+        fn_proto: Object<'gc>,
         prototype: Object<'gc>,
     ) -> Object<'gc> {
         let function = Self::bare_function(gc_context, function, constructor, fn_proto).into();
@@ -558,7 +556,7 @@ impl<'gc> FunctionObject<'gc> {
     pub fn function(
         gc_context: MutationContext<'gc, '_>,
         function: impl Into<Executable<'gc>>,
-        fn_proto: Option<Object<'gc>>,
+        fn_proto: Object<'gc>,
         prototype: Object<'gc>,
     ) -> Object<'gc> {
         Self::allocate_function(gc_context, Some(function.into()), None, fn_proto, prototype)
@@ -569,7 +567,7 @@ impl<'gc> FunctionObject<'gc> {
         gc_context: MutationContext<'gc, '_>,
         constructor: impl Into<Executable<'gc>>,
         function: impl Into<Executable<'gc>>,
-        fn_proto: Option<Object<'gc>>,
+        fn_proto: Object<'gc>,
         prototype: Object<'gc>,
     ) -> Object<'gc> {
         Self::allocate_function(

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -586,7 +586,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(movie_clip_loader::constructor),
         constructor_to_fn!(movie_clip_loader::constructor),
-        Some(function_proto),
+        function_proto,
         movie_clip_loader_proto,
     );
     let date_proto = date::create_proto(gc_context, object_proto, function_proto);
@@ -604,49 +604,49 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(button::constructor),
         constructor_to_fn!(button::constructor),
-        Some(function_proto),
+        function_proto,
         button_proto,
     );
     let color = FunctionObject::constructor(
         gc_context,
         Executable::Native(color::constructor),
         constructor_to_fn!(color::constructor),
-        Some(function_proto),
+        function_proto,
         color_proto,
     );
     let error = FunctionObject::constructor(
         gc_context,
         Executable::Native(error::constructor),
         constructor_to_fn!(error::constructor),
-        Some(function_proto),
+        function_proto,
         error_proto,
     );
     let function = FunctionObject::constructor(
         gc_context,
         Executable::Native(function::constructor),
         Executable::Native(function::function),
-        Some(function_proto),
+        function_proto,
         function_proto,
     );
     let load_vars = FunctionObject::constructor(
         gc_context,
         Executable::Native(load_vars::constructor),
         constructor_to_fn!(load_vars::constructor),
-        Some(function_proto),
+        function_proto,
         load_vars_proto,
     );
     let local_connection = FunctionObject::constructor(
         gc_context,
         Executable::Native(local_connection::constructor),
         constructor_to_fn!(local_connection::constructor),
-        Some(function_proto),
+        function_proto,
         local_connection_proto,
     );
     let movie_clip = FunctionObject::constructor(
         gc_context,
         Executable::Native(movie_clip::constructor),
         constructor_to_fn!(movie_clip::constructor),
-        Some(function_proto),
+        function_proto,
         movie_clip_proto,
     );
 
@@ -654,21 +654,21 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(sound::constructor),
         constructor_to_fn!(sound::constructor),
-        Some(function_proto),
+        function_proto,
         sound_proto,
     );
     let text_field = FunctionObject::constructor(
         gc_context,
         Executable::Native(text_field::constructor),
         constructor_to_fn!(text_field::constructor),
-        Some(function_proto),
+        function_proto,
         text_field_proto,
     );
     let text_format = FunctionObject::constructor(
         gc_context,
         Executable::Native(text_format::constructor),
         constructor_to_fn!(text_format::constructor),
-        Some(function_proto),
+        function_proto,
         text_format_proto,
     );
     let array = array::create_array_object(gc_context, array_proto, function_proto);
@@ -676,19 +676,19 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(xml_node::constructor),
         constructor_to_fn!(xml_node::constructor),
-        Some(function_proto),
+        function_proto,
         xmlnode_proto,
     );
     let xml = FunctionObject::constructor(
         gc_context,
         Executable::Native(xml::constructor),
         constructor_to_fn!(xml::constructor),
-        Some(function_proto),
+        function_proto,
         xml_proto,
     );
     let string = string::create_string_object(gc_context, string_proto, function_proto);
     let number = number::create_number_object(gc_context, number_proto, function_proto);
-    let boolean = boolean::create_boolean_object(gc_context, boolean_proto, Some(function_proto));
+    let boolean = boolean::create_boolean_object(gc_context, boolean_proto, function_proto);
     let date = date::create_date_object(gc_context, date_proto, function_proto);
 
     let flash = ScriptObject::new(gc_context, Some(object_proto));
@@ -697,29 +697,28 @@ pub fn create_globals<'gc>(
     let filters = ScriptObject::new(gc_context, Some(object_proto));
     let display = ScriptObject::new(gc_context, Some(object_proto));
 
-    let matrix = matrix::create_matrix_object(gc_context, matrix_proto, Some(function_proto));
+    let matrix = matrix::create_matrix_object(gc_context, matrix_proto, function_proto);
     let point = point::create_point_object(gc_context, point_proto, function_proto);
-    let rectangle =
-        rectangle::create_rectangle_object(gc_context, rectangle_proto, Some(function_proto));
+    let rectangle = rectangle::create_rectangle_object(gc_context, rectangle_proto, function_proto);
     let color_transform = FunctionObject::constructor(
         gc_context,
         Executable::Native(color_transform::constructor),
         constructor_to_fn!(color_transform::constructor),
-        Some(function_proto),
+        function_proto,
         color_transform_proto,
     );
     let transform = FunctionObject::constructor(
         gc_context,
         Executable::Native(transform::constructor),
         constructor_to_fn!(transform::constructor),
-        Some(function_proto),
+        function_proto,
         transform_proto,
     );
     let video = FunctionObject::constructor(
         gc_context,
         Executable::Native(video::constructor),
         constructor_to_fn!(video::constructor),
-        Some(function_proto),
+        function_proto,
         video_proto,
     );
 
@@ -752,7 +751,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(bitmap_filter::constructor),
         constructor_to_fn!(bitmap_filter::constructor),
-        Some(function_proto),
+        function_proto,
         bitmap_filter_proto,
     );
 
@@ -762,7 +761,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(blur_filter::constructor),
         constructor_to_fn!(blur_filter::constructor),
-        Some(function_proto),
+        function_proto,
         blur_filter_proto,
     );
 
@@ -772,7 +771,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(bevel_filter::constructor),
         constructor_to_fn!(bevel_filter::constructor),
-        Some(function_proto),
+        function_proto,
         bevel_filter_proto,
     );
 
@@ -782,7 +781,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(glow_filter::constructor),
         constructor_to_fn!(glow_filter::constructor),
-        Some(function_proto),
+        function_proto,
         glow_filter_proto,
     );
 
@@ -792,7 +791,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(drop_shadow_filter::constructor),
         constructor_to_fn!(drop_shadow_filter::constructor),
-        Some(function_proto),
+        function_proto,
         drop_shadow_filter_proto,
     );
 
@@ -802,7 +801,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(color_matrix_filter::constructor),
         constructor_to_fn!(color_matrix_filter::constructor),
-        Some(function_proto),
+        function_proto,
         color_matrix_filter_proto,
     );
 
@@ -812,7 +811,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(displacement_map_filter::constructor),
         constructor_to_fn!(displacement_map_filter::constructor),
-        Some(function_proto),
+        function_proto,
         displacement_map_filter_proto,
     );
 
@@ -822,7 +821,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(convolution_filter::constructor),
         constructor_to_fn!(convolution_filter::constructor),
-        Some(function_proto),
+        function_proto,
         convolution_filter_proto,
     );
 
@@ -832,7 +831,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(gradient_bevel_filter::constructor),
         constructor_to_fn!(gradient_bevel_filter::constructor),
-        Some(function_proto),
+        function_proto,
         gradient_bevel_filter_proto,
     );
 
@@ -842,7 +841,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(gradient_glow_filter::constructor),
         constructor_to_fn!(gradient_glow_filter::constructor),
-        Some(function_proto),
+        function_proto,
         gradient_glow_filter_proto,
     );
 
@@ -1012,7 +1011,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(context_menu::constructor),
         constructor_to_fn!(context_menu::constructor),
-        Some(function_proto),
+        function_proto,
         context_menu_proto,
     );
     globals.define_value(
@@ -1040,7 +1039,7 @@ pub fn create_globals<'gc>(
         gc_context,
         Executable::Native(context_menu_item::constructor),
         constructor_to_fn!(context_menu_item::constructor),
-        Some(function_proto),
+        function_proto,
         context_menu_item_proto,
     );
     globals.define_value(

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -68,7 +68,7 @@ pub fn create_array_object<'gc>(
         gc_context,
         Executable::Native(constructor),
         Executable::Native(constructor),
-        Some(fn_proto),
+        fn_proto,
         array_proto,
     );
     let object = array.as_script_object().unwrap();

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1251,7 +1251,7 @@ pub fn create_bitmap_data_object<'gc>(
         gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
-        Some(fn_proto),
+        fn_proto,
         bitmap_data_proto,
     );
     let object = bitmap_data.as_script_object().unwrap();

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -48,7 +48,7 @@ pub fn boolean_function<'gc>(
 pub fn create_boolean_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     boolean_proto: Object<'gc>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
         gc_context,

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -918,7 +918,7 @@ pub fn create_date_object<'gc>(
     let date = FunctionObject::function(
         gc_context,
         Executable::Native(constructor),
-        Some(fn_proto),
+        fn_proto,
         date_proto,
     );
     let object = date.as_script_object().unwrap();

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -461,7 +461,7 @@ fn to_string<'gc>(
 pub fn create_matrix_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     matrix_proto: Object<'gc>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
         gc_context,

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -69,7 +69,7 @@ pub fn create_number_object<'gc>(
         gc_context,
         Executable::Native(number),
         Executable::Native(number_function),
-        Some(fn_proto),
+        fn_proto,
         number_proto,
     );
     let object = number.as_script_object().unwrap();

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -325,7 +325,7 @@ pub fn create_object_object<'gc>(
         gc_context,
         Executable::Native(constructor),
         Executable::Native(object_function),
-        Some(fn_proto),
+        fn_proto,
         proto,
     );
     let object = object_function.as_script_object().unwrap();

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -292,7 +292,7 @@ pub fn create_point_object<'gc>(
         gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
-        Some(fn_proto),
+        fn_proto,
         point_proto,
     );
     let object = point.as_script_object().unwrap();

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -96,7 +96,7 @@ fn to_string<'gc>(
 pub fn create_rectangle_object<'gc>(
     gc_context: MutationContext<'gc, '_>,
     rectangle_proto: Object<'gc>,
-    fn_proto: Option<Object<'gc>>,
+    fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
         gc_context,

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -433,7 +433,7 @@ pub fn create_shared_object_object<'gc>(
         gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
-        Some(fn_proto),
+        fn_proto,
         shared_object_proto,
     );
     let object = shared_obj.as_script_object().unwrap();

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -80,7 +80,7 @@ pub fn create_string_object<'gc>(
         gc_context,
         Executable::Native(string),
         Executable::Native(string_function),
-        Some(fn_proto),
+        fn_proto,
         string_proto,
     );
     let object = string.as_script_object().unwrap();

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -653,7 +653,7 @@ mod tests {
             let getter = FunctionObject::function(
                 activation.context.gc_context,
                 Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
-                None,
+                activation.context.avm1.prototypes().function,
                 activation.context.avm1.prototypes().function,
             );
 
@@ -679,7 +679,7 @@ mod tests {
             let getter = FunctionObject::function(
                 activation.context.gc_context,
                 Executable::Native(|_avm, _this, _args| Ok("Virtual!".into())),
-                None,
+                activation.context.avm1.prototypes().function,
                 activation.context.avm1.prototypes().function,
             );
 
@@ -735,7 +735,7 @@ mod tests {
             let getter = FunctionObject::function(
                 activation.context.gc_context,
                 Executable::Native(|_avm, _this, _args| Ok(Value::Null)),
-                None,
+                activation.context.avm1.prototypes().function,
                 activation.context.avm1.prototypes().function,
             );
 

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -71,33 +71,20 @@ impl Declaration {
         let attributes = Attribute::from_bits_truncate(self.attributes);
         let value = match self.kind {
             DeclKind::Property { getter, setter } => {
-                let getter = FunctionObject::function(
-                    mc,
-                    Executable::Native(getter),
-                    Some(fn_proto),
-                    fn_proto,
-                );
+                let getter =
+                    FunctionObject::function(mc, Executable::Native(getter), fn_proto, fn_proto);
                 let setter = setter.map(|setter| {
-                    FunctionObject::function(
-                        mc,
-                        Executable::Native(setter),
-                        Some(fn_proto),
-                        fn_proto,
-                    )
+                    FunctionObject::function(mc, Executable::Native(setter), fn_proto, fn_proto)
                 });
                 this.add_property(mc, self.name.into(), getter, setter, attributes);
                 return Value::Undefined;
             }
-            DeclKind::Method(func) => FunctionObject::bare_function(
-                mc,
-                Some(Executable::Native(func)),
-                None,
-                Some(fn_proto),
-            )
-            .into(),
-            DeclKind::Function(func) => {
-                FunctionObject::function(mc, Executable::Native(func), Some(fn_proto), fn_proto)
+            DeclKind::Method(func) => {
+                FunctionObject::bare_function(mc, Some(Executable::Native(func)), None, fn_proto)
                     .into()
+            }
+            DeclKind::Function(func) => {
+                FunctionObject::function(mc, Executable::Native(func), fn_proto, fn_proto).into()
             }
             DeclKind::String(s) => s.into(),
             DeclKind::Bool(b) => b.into(),

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -884,7 +884,7 @@ mod test {
             let valueof = FunctionObject::function(
                 activation.context.gc_context,
                 Executable::Native(value_of_impl),
-                Some(protos.function),
+                protos.function,
                 protos.function,
             );
 


### PR DESCRIPTION
It was never `None`, except for 3 tests in `script_object.rs`, which now use `activation.context.avm1.prototypes().function`.