### PR TITLE
avm2: Loaders should not be opaque to mouse events.

### DIFF
--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -105,6 +105,23 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
     ) -> ClipEventResult {
         ClipEventResult::NotHandled
     }
+
+    fn mouse_pick(
+        &self,
+        context: &mut UpdateContext<'_, 'gc, '_>,
+        pos: (Twips, Twips),
+        require_button_mode: bool,
+    ) -> Option<InteractiveObject<'gc>> {
+        for child in self.iter_render_list().rev() {
+            if let Some(int) = child.as_interactive() {
+                if let Some(result) = int.mouse_pick(context, pos, require_button_mode) {
+                    return Some(result);
+                }
+            }
+        }
+
+        None
+    }
 }
 
 impl<'gc> TDisplayObjectContainer<'gc> for LoaderDisplay<'gc> {


### PR DESCRIPTION
While loaders themselves have no interactivity, they contain children, and thus need to implement `mouse_pick`. The default implementation of `mouse_pick` makes the entire object unpickable otherwise.