### PR TITLE
chore: Extract Cargo `edition` to `[workspace.package]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+edition = "2021"
+
 # Don't optimize build scripts and macros.
 [profile.release.build-override]
 opt-level = 0
@@ -48,7 +51,6 @@ opt-level = 3
 
 [profile.dev.package.nihav_duck]
 opt-level = 3
-
 
 # TODO: Set rustflags here instead of in web/core/package.json, when that
 # feature becomes stable. See: https://github.com/rust-lang/cargo/issues/10271

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_core"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/core/build_playerglobal/Cargo.toml
+++ b/core/build_playerglobal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "build_playerglobal"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 convert_case = "0.6.0"

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_macros"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 
 [lib]
 proc-macro = true

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -2,8 +2,7 @@
 name = "ruffle_desktop"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
-default-run = "ruffle_desktop"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "exporter"
 version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_render"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_render_canvas"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_render_webgl"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_render_wgpu"
 version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_scanner"
 version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "swf"
 version = "0.2.0"
-edition = "2021"
+edition.workspace = true
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 repository = "https://github.com/ruffle-rs/ruffle"
 homepage = "https://github.com/ruffle-rs/ruffle"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tests"
 version = "0.1.0"
 authors = ["Aaron Hill <aa1ronham@gmail.com>"]
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 futures = "0.3.24"

--- a/tests/input-format/Cargo.toml
+++ b/tests/input-format/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "ruffle_input_format"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition.workspace = true
 
 [dependencies]
 serde = { version = "1.0.145", features = ["derive"] }

--- a/video/Cargo.toml
+++ b/video/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_video"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_video_software"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_web"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Web (WASM) bindings to the Ruffle flash player"
 readme = "README.md"

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_web_common"
 version = "0.1.0"
 authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/web/packages/extension/safari/Cargo.toml
+++ b/web/packages/extension/safari/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ruffle_web_safari"
 version = "0.1.0"
 authors = ["Mike Welsh <mwelsh@gmail.com>"]
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Native binary for the Safari Web Extension"
 readme = "README.md"

--- a/wstr/Cargo.toml
+++ b/wstr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruffle_wstr"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 authors = ["Arthur Heuillard <arthur.heuillard<orange.fr>"]
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
This is possible since Rust 1.64.0: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds