### PR TITLE
wgpu: Use `Depth32FloatStencil8` over `Depth24PlusStencil8`

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -591,7 +591,7 @@ async fn request_device(
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
-                features: wgpu::Features::DEPTH24PLUS_STENCIL8,
+                features: wgpu::Features::DEPTH32FLOAT_STENCIL8,
                 limits,
             },
             trace_path,

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -232,7 +232,7 @@ fn create_shape_pipeline(
             shader,
             &pipeline_layout,
             Some(wgpu::DepthStencilState {
-                format: wgpu::TextureFormat::Depth24PlusStencil8,
+                format: wgpu::TextureFormat::Depth32FloatStencil8,
                 depth_write_enabled: false,
                 depth_compare: wgpu::CompareFunction::Always,
                 stencil: wgpu::StencilState {

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -64,7 +64,7 @@ impl DepthTexture {
             mip_level_count: 1,
             sample_count: msaa_sample_count,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth24PlusStencil8,
+            format: wgpu::TextureFormat::Depth32FloatStencil8,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         });
 


### PR DESCRIPTION
Credit to @crumblingstatue.

Per `wgpu` documentation, the latter has wider support than the former.

Fixes #8295, #8296.