### PR TITLE
core: Simplify `Bitmap` creation

### DIFF
--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -120,11 +120,22 @@ impl<'gc> Bitmap<'gc> {
     pub fn new(
         context: &mut UpdateContext<'_, 'gc, '_>,
         id: CharacterId,
-        bitmap_handle: BitmapHandle,
-        width: u16,
-        height: u16,
-    ) -> Self {
-        Self::new_with_bitmap_data(context, id, Some(bitmap_handle), width, height, None, true)
+        bitmap: ruffle_render::bitmap::Bitmap,
+    ) -> Result<Self, ruffle_render::error::Error> {
+        let width = bitmap.width() as u16;
+        let height = bitmap.height() as u16;
+        let bitmap_handle = context.renderer.register_bitmap(bitmap)?;
+        let bitmap_data = None;
+        let smoothing = true;
+        Ok(Self::new_with_bitmap_data(
+            context,
+            id,
+            Some(bitmap_handle),
+            width,
+            height,
+            bitmap_data,
+            smoothing,
+        ))
     }
 
     #[allow(dead_code)]

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1367,8 +1367,8 @@ impl<'gc> Loader<'gc> {
                         Loader::movie_loader_progress(handle, uc, 0, length)?;
                     }
 
-                    let bitmap = uc.renderer.register_bitmap_jpeg_2(&data)?;
-                    let bitmap_obj = Bitmap::new(uc, 0, bitmap.handle, bitmap.width, bitmap.height);
+                    let bitmap = ruffle_render::utils::decode_define_bits_jpeg(data, None)?;
+                    let bitmap_obj = Bitmap::new(uc, 0, bitmap)?;
 
                     if let Some(mc) = clip.as_movie_clip() {
                         mc.replace_at_depth(uc, bitmap_obj.into(), 1);


### PR DESCRIPTION
Change `Bitmap::new()` to accept a `ruffle_render::bitmap::Bitmap` directly, instead of `width`, `height` and `bitmap_handle`. As a consequence, all `RenderBackend::register_bitmap_*` methods are no longer necessary - we can use `ruffle_redner::utils::*` to obtain a `ruffle_render::bitmap::Bitmap` right before calling `Bitmap::new()`.