### PR TITLE
core: Store data in `BitmapData` instead of `Bitmap`

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -253,10 +253,6 @@ fn attach_bitmap<'gc>(
                     .coerce_to_i32(activation)?
                     .wrapping_add(AVM_DEPTH_BIAS);
 
-                let bitmap_handle = bitmap_data
-                    .write(activation.context.gc_context)
-                    .bitmap_handle(activation.context.renderer);
-
                 // TODO: Implement pixel snapping
                 let _pixel_snapping = args
                     .get(2)
@@ -268,29 +264,20 @@ fn attach_bitmap<'gc>(
                     .unwrap_or(&Value::Undefined)
                     .as_bool(activation.swf_version());
 
-                if let Some(bitmap_handle) = bitmap_handle {
-                    //TODO: do attached BitmapDatas have character ids?
-                    let display_object = Bitmap::new_with_bitmap_data(
-                        &mut activation.context,
-                        0,
-                        Some(bitmap_handle),
-                        bitmap_data.read().width() as u16,
-                        bitmap_data.read().height() as u16,
-                        Some(bitmap_data),
-                        smoothing,
-                    );
-                    movie_clip.replace_at_depth(
-                        &mut activation.context,
-                        display_object.into(),
-                        depth,
-                    );
-                    display_object.post_instantiation(
-                        &mut activation.context,
-                        None,
-                        Instantiator::Avm1,
-                        true,
-                    );
-                }
+                //TODO: do attached BitmapDatas have character ids?
+                let display_object = Bitmap::new_with_bitmap_data(
+                    &mut activation.context,
+                    0,
+                    bitmap_data,
+                    smoothing,
+                );
+                movie_clip.replace_at_depth(&mut activation.context, display_object.into(), depth);
+                display_object.post_instantiation(
+                    &mut activation.context,
+                    None,
+                    Instantiator::Avm1,
+                    true,
+                );
             }
         }
     }

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -10,6 +10,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::character::Character;
 use crate::display_object::{Bitmap, TDisplayObject};
@@ -43,96 +44,80 @@ pub fn instance_init<'gc>(
             .coerce_to_boolean();
 
         if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
-            if bitmap.bitmap_data().is_none() {
-                //We are being initialized by the movie. This means that we
-                //need to create bitmap data right away, since all AVM2 bitmaps
-                //hold bitmap data.
+            //We are being initialized by the movie. This means that we
+            //need to create bitmap data right away, since all AVM2 bitmaps
+            //hold bitmap data.
 
-                let bd_object = if let Some(bd_class) = bitmap.avm2_bitmapdata_class() {
-                    bd_class.construct(activation, &[])?
-                } else if let Some(b_class) = bitmap.avm2_bitmap_class() {
-                    // Instantiating Bitmap from a Flex-style bitmap asset.
-                    // Contrary to the above comment, this code path DOES
-                    // trigger from AVM2, since the DisplayObject instantiation
-                    // logic does its job in this case.
-                    if let Some((movie, symbol_id)) = activation
+            let bd_object = if let Some(bd_class) = bitmap.avm2_bitmapdata_class() {
+                bd_class.construct(activation, &[])?
+            } else if let Some(b_class) = bitmap.avm2_bitmap_class() {
+                // Instantiating Bitmap from a Flex-style bitmap asset.
+                // Contrary to the above comment, this code path DOES
+                // trigger from AVM2, since the DisplayObject instantiation
+                // logic does its job in this case.
+                if let Some((movie, symbol_id)) = activation
+                    .context
+                    .library
+                    .avm2_class_registry()
+                    .class_symbol(b_class)
+                {
+                    if let Some(Character::Bitmap {
+                        bitmap,
+                        initial_data,
+                    }) = activation
                         .context
                         .library
-                        .avm2_class_registry()
-                        .class_symbol(b_class)
+                        .library_for_movie_mut(movie)
+                        .character_by_id(symbol_id)
+                        .cloned()
                     {
-                        if let Some(Character::Bitmap {
-                            bitmap,
-                            initial_data,
-                        }) = activation
-                            .context
-                            .library
-                            .library_for_movie_mut(movie)
-                            .character_by_id(symbol_id)
-                            .cloned()
-                        {
-                            let new_bitmap_data = GcCell::allocate(
-                                activation.context.gc_context,
-                                BitmapData::default(),
-                            );
+                        let new_bitmap_data =
+                            GcCell::allocate(activation.context.gc_context, BitmapData::default());
 
-                            fill_bitmap_data_from_symbol(
-                                activation,
-                                bitmap,
-                                new_bitmap_data,
-                                initial_data,
-                            );
-                            BitmapDataObject::from_bitmap_data(
-                                activation,
-                                new_bitmap_data,
-                                activation.context.avm2.classes().bitmapdata,
-                            )?
-                        } else {
-                            //Class association not to a Bitmap
-                            return Err("Attempted to instantiate Bitmap from timeline with symbol class associated to non-Bitmap!".into());
-                        }
+                        fill_bitmap_data_from_symbol(
+                            activation,
+                            bitmap,
+                            new_bitmap_data,
+                            initial_data,
+                        );
+                        BitmapDataObject::from_bitmap_data(
+                            activation,
+                            new_bitmap_data,
+                            activation.context.avm2.classes().bitmapdata,
+                        )?
                     } else {
-                        //Class association not bidirectional
-                        return Err("Cannot instantiate Bitmap from timeline without bidirectional symbol class association".into());
+                        //Class association not to a Bitmap
+                        return Err("Attempted to instantiate Bitmap from timeline with symbol class associated to non-Bitmap!".into());
                     }
                 } else {
-                    // No class association
-                    return Err(
-                        "Cannot instantiate Bitmap from timeline without associated symbol class"
-                            .into(),
-                    );
-                };
+                    //Class association not bidirectional
+                    return Err("Cannot instantiate Bitmap from timeline without bidirectional symbol class association".into());
+                }
+            } else {
+                // No class association
+                return Err(
+                    "Cannot instantiate Bitmap from timeline without associated symbol class"
+                        .into(),
+                );
+            };
 
-                this.set_property(
-                    &Multiname::public("bitmapData"),
-                    bd_object.into(),
-                    activation,
-                )?;
-            }
+            this.set_property(
+                &Multiname::public("bitmapData"),
+                bd_object.into(),
+                activation,
+            )?;
 
             bitmap.set_smoothing(activation.context.gc_context, smoothing);
         } else {
             //We are being initialized by AVM2 (and aren't associated with a
             //Bitmap subclass).
-            let bitmap_handle = if let Some(bd) = bitmap_data {
-                bd.write(activation.context.gc_context)
-                    .bitmap_handle(activation.context.renderer)
-            } else {
-                None
-            };
 
-            let width = bitmap_data.map(|bd| bd.read().width()).unwrap_or(0) as u16;
-            let height = bitmap_data.map(|bd| bd.read().height()).unwrap_or(0) as u16;
+            let bitmap_data = bitmap_data.unwrap_or_else(|| {
+                GcCell::allocate(activation.context.gc_context, BitmapData::dummy())
+            });
 
-            let bitmap = Bitmap::new_with_bitmap_data(
-                &mut activation.context,
-                0,
-                bitmap_handle,
-                width,
-                height,
-                bitmap_data,
-                smoothing,
-            );
+            let bitmap =
+                Bitmap::new_with_bitmap_data(&mut activation.context, 0, bitmap_data, smoothing);
 
             this.init_display_object(activation.context.gc_context, bitmap.into());
         }
@@ -160,10 +145,13 @@ pub fn bitmap_data<'gc>(
         .and_then(|this| this.as_display_object())
         .and_then(|dobj| dobj.as_bitmap())
     {
-        return Ok(bitmap
-            .bitmap_data()
-            .map(|bd| bd.read().object2())
-            .unwrap_or(Value::Null));
+        let mut value = bitmap.bitmap_data().read().object2();
+
+        // AS3 expects an unset BitmapData to be null, not 'undefined'
+        if matches!(value, Value::Undefined) {
+            value = Value::Null;
+        }
+        return Ok(value);
     }
 
     Ok(Value::Undefined)
@@ -179,13 +167,15 @@ pub fn set_bitmap_data<'gc>(
         .and_then(|this| this.as_display_object())
         .and_then(|dobj| dobj.as_bitmap())
     {
-        let bitmap_data = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Null)
-            .as_object()
-            .and_then(|bd| bd.as_bitmap_data());
-
+        let bitmap_data = args.get(0).unwrap_or(&Value::Null);
+        let bitmap_data = if matches!(bitmap_data, Value::Null) {
+            GcCell::allocate(activation.context.gc_context, BitmapData::dummy())
+        } else {
+            bitmap_data
+                .coerce_to_object(activation)?
+                .as_bitmap_data()
+                .ok_or_else(|| Error::RustError("Argument was not a BitmapData".into()))?
+        };
         bitmap.set_bitmap_data(&mut activation.context, bitmap_data);
     }
 

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -200,6 +200,23 @@ impl fmt::Debug for BitmapData<'_> {
 }
 
 impl<'gc> BitmapData<'gc> {
+    // Creates a dummy BitmapData with no pixels or handle, marked as disposed.
+    // This is used for AS3 `Bitmap` instances without a corresponding AS3 `BitmapData` instance.
+    // Marking it as disposed skips rendering, and the unset `avm2_object` will cause this to
+    // be inaccessible to AS3 code.
+    pub fn dummy() -> Self {
+        BitmapData {
+            pixels: Vec::new(),
+            dirty: false,
+            width: 0,
+            height: 0,
+            transparency: false,
+            disposed: true,
+            bitmap_handle: None,
+            avm2_object: None,
+        }
+    }
+
     pub fn init_pixels(&mut self, width: u32, height: u32, transparency: bool, fill_color: i32) {
         self.width = width;
         self.height = height;

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -5,6 +5,7 @@ use crate::avm2::{
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, DisplayObjectPtr, TDisplayObject};
 use crate::drawing::Drawing;
+use crate::library::MovieLibrarySource;
 use crate::prelude::*;
 use crate::tag_utils::SwfMovie;
 use crate::vminterface::Instantiator;
@@ -47,11 +48,13 @@ impl<'gc> Graphic<'gc> {
         let static_data = GraphicStatic {
             id: swf_shape.id,
             bounds: (&swf_shape.shape_bounds).into(),
-            render_handle: Some(
-                context
-                    .renderer
-                    .register_shape((&swf_shape).into(), library),
-            ),
+            render_handle: Some(context.renderer.register_shape(
+                (&swf_shape).into(),
+                &MovieLibrarySource {
+                    library,
+                    gc_context: context.gc_context,
+                },
+            )),
             shape: swf_shape,
             movie: Some(movie),
         };

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2979,7 +2979,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> Result<(), Error> {
         let define_bits_lossless = reader.read_define_bits_lossless(version)?;
         let bitmap = ruffle_render::utils::decode_define_bits_lossless(&define_bits_lossless)?;
-        let initial_data: Vec<i32> = bitmap.clone().into();
+        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, define_bits_lossless.id, bitmap)?;
         context
             .library
@@ -3103,7 +3103,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .jpeg_tables();
         let jpeg_data = ruffle_render::utils::glue_tables_to_jpeg(jpeg_data, jpeg_tables);
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(&jpeg_data, None)?;
-        let initial_data: Vec<i32> = bitmap.clone().into();
+        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
@@ -3127,7 +3127,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let id = reader.read_u16()?;
         let jpeg_data = reader.read_slice_to_end();
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(jpeg_data, None)?;
-        let initial_data: Vec<i32> = bitmap.clone().into();
+        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
@@ -3157,7 +3157,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let jpeg_data = reader.read_slice(jpeg_len)?;
         let alpha_data = reader.read_slice_to_end();
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))?;
-        let initial_data: Vec<i32> = bitmap.clone().into();
+        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -102,33 +102,19 @@ impl Bitmap {
     pub fn data_mut(&mut self) -> &mut [u8] {
         &mut self.data
     }
-}
 
-impl From<Bitmap> for Vec<i32> {
-    fn from(bitmap: Bitmap) -> Self {
-        match bitmap.format {
-            BitmapFormat::Rgb => bitmap
-                .data
-                .chunks_exact(3)
-                .map(|chunk| {
-                    let red = chunk[0];
-                    let green = chunk[1];
-                    let blue = chunk[2];
-                    i32::from_le_bytes([blue, green, red, 0xFF])
-                })
-                .collect(),
-            BitmapFormat::Rgba => bitmap
-                .data
-                .chunks_exact(4)
-                .map(|chunk| {
-                    let red = chunk[0];
-                    let green = chunk[1];
-                    let blue = chunk[2];
-                    let alpha = chunk[3];
-                    i32::from_le_bytes([blue, green, red, alpha])
-                })
-                .collect(),
-        }
+    pub fn as_colors(&self) -> impl Iterator<Item = i32> + '_ {
+        let chunks = match self.format {
+            BitmapFormat::Rgb => self.data.chunks_exact(3),
+            BitmapFormat::Rgba => self.data.chunks_exact(4),
+        };
+        chunks.map(|chunk| {
+            let red = chunk[0];
+            let green = chunk[1];
+            let blue = chunk[2];
+            let alpha = chunk.get(3).copied().unwrap_or(0xFF);
+            i32::from_le_bytes([blue, green, red, alpha])
+        })
     }
 }
 


### PR DESCRIPTION
This makes `Bitmap` delegate to `BitmapData` for
all of the bitmap-related information (handle, width, and height). As a result, we now unconditionally store a `BitmapData` in `Bitmap`.

As a result, swapping the underling `BitmapData` instance will automatically change the properties (and rendered image) of a `Bitmap`.

This required some refactoring in the render backends in order to get access to a `BitmapHandle` through `BitmapData`.