### PR TITLE
core: Make `BitmapHandle` hold a trait object instead of an id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,6 +3489,7 @@ dependencies = [
 name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
+ "downcast-rs",
  "fnv",
  "gc-arena",
  "js-sys",
@@ -3505,6 +3506,7 @@ name = "ruffle_render_webgl"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "downcast-rs",
  "fnv",
  "gc-arena",
  "js-sys",

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -57,9 +57,7 @@ impl<'gc> BitmapDataObject<'gc> {
     }
 
     pub fn dispose(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
-        self.bitmap_data()
-            .write(context.gc_context)
-            .dispose(context.renderer);
+        self.bitmap_data().write(context.gc_context).dispose();
     }
 }
 

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -818,9 +818,7 @@ pub fn dispose<'gc>(
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         // Don't check if we've already disposed this BitmapData - 'BitmapData.dispose()' can be called
         // multiple times
-        bitmap_data
-            .write(activation.context.gc_context)
-            .dispose(activation.context.renderer);
+        bitmap_data.write(activation.context.gc_context).dispose();
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -273,7 +273,7 @@ impl<'gc> Context3DObject<'gc> {
         if context3d.should_render() {
             let handle = context3d.bitmap_handle();
             context.commands.render_bitmap(
-                handle,
+                &handle,
                 // FIXME - apply x and y translation from Stage3D
                 &Transform::default(),
                 false,

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -217,14 +217,11 @@ impl<'gc> BitmapData<'gc> {
         self.disposed
     }
 
-    pub fn dispose(&mut self, renderer: &mut dyn RenderBackend) {
+    pub fn dispose(&mut self) {
         self.width = 0;
         self.height = 0;
         self.pixels.clear();
-        if let Some(handle) = self.bitmap_handle {
-            renderer.unregister_bitmap(handle);
-            self.bitmap_handle = None;
-        }
+        self.bitmap_handle = None;
         // There's no longer a handle to update
         self.dirty = false;
         self.disposed = true;
@@ -245,7 +242,7 @@ impl<'gc> BitmapData<'gc> {
             self.bitmap_handle = bitmap_handle.ok();
         }
 
-        self.bitmap_handle
+        self.bitmap_handle.clone()
     }
 
     pub fn transparency(&self) -> bool {
@@ -914,7 +911,7 @@ impl<'gc> BitmapData<'gc> {
         let handle = self.bitmap_handle(context.renderer).unwrap();
         if self.dirty() {
             if let Err(e) = context.renderer.update_texture(
-                handle,
+                &handle,
                 self.width(),
                 self.height(),
                 self.pixels_rgba(),
@@ -1028,7 +1025,7 @@ impl<'gc> BitmapData<'gc> {
                     bitmap_data.update_dirty_texture(&mut render_context);
                     let bitmap_handle = bitmap_data.bitmap_handle(render_context.renderer).unwrap();
                     render_context.commands.render_bitmap(
-                        bitmap_handle,
+                        &bitmap_handle,
                         render_context.transform_stack.transform(),
                         smoothing,
                     );

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -140,7 +140,7 @@ impl<'gc> Bitmap<'gc> {
 
     #[allow(dead_code)]
     pub fn bitmap_handle(self) -> Option<BitmapHandle> {
-        self.0.read().bitmap_handle
+        self.0.read().bitmap_handle.clone()
     }
 
     pub fn width(self) -> u16 {
@@ -306,7 +306,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         }
 
         let bitmap_data = self.0.read();
-        if let Some(bitmap_handle) = bitmap_data.bitmap_handle {
+        if let Some(bitmap_handle) = &bitmap_data.bitmap_handle {
             if let Some(inner_bitmap_data) = bitmap_data.bitmap_data {
                 if let Ok(mut bd) = inner_bitmap_data.try_write(context.gc_context) {
                     bd.update_dirty_texture(context);
@@ -316,7 +316,7 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
             }
 
             context.commands.render_bitmap(
-                bitmap_handle,
+                &bitmap_handle,
                 context.transform_stack.transform(),
                 bitmap_data.smoothing,
             );

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -467,7 +467,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
 
             context
                 .commands
-                .render_bitmap(bitmap.handle, &transform, smoothing);
+                .render_bitmap(&bitmap.handle, &transform, smoothing);
         } else {
             log::warn!("Video has no decoded frame to render.");
         }

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -409,7 +409,7 @@ impl BitmapSource for Drawing {
         })
     }
     fn bitmap_handle(&self, id: u16, _backend: &mut dyn RenderBackend) -> Option<BitmapHandle> {
-        self.bitmaps.get(id as usize).map(|bm| bm.handle)
+        self.bitmaps.get(id as usize).map(|bm| bm.handle.clone())
     }
 }
 

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -14,6 +14,7 @@ fnv = "1.0.7"
 ruffle_render = { path = "..", features = ["web"] }
 gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
 swf = { path = "../../swf" }
+downcast-rs = "1.2.0"
 
 [dependencies.web-sys]
 version = "0.3.60"

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -47,12 +47,9 @@ pub trait RenderBackend: Downcast {
     fn submit_frame(&mut self, clear: swf::Color, commands: CommandList);
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;
-    // Frees memory used by the bitmap. After this call, `handle` can no longer
-    // be used.
-    fn unregister_bitmap(&mut self, handle: BitmapHandle);
     fn update_texture(
         &mut self,
-        bitmap: BitmapHandle,
+        bitmap: &BitmapHandle,
         width: u32,
         height: u32,
         rgba: Vec<u8>,

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use crate::backend::{RenderBackend, ShapeHandle, ViewportDimensions};
-use crate::bitmap::{Bitmap, BitmapHandle, BitmapSize, BitmapSource};
+use crate::bitmap::{Bitmap, BitmapHandle, BitmapHandleImpl, BitmapSize, BitmapSource};
 use crate::commands::CommandList;
 use crate::error::Error;
 use crate::shape_utils::DistilledShape;
@@ -28,6 +30,9 @@ impl NullRenderer {
         Self { dimensions }
     }
 }
+#[derive(Clone, Debug)]
+struct NullBitmapHandle;
+impl BitmapHandleImpl for NullBitmapHandle {}
 
 impl RenderBackend for NullRenderer {
     fn viewport_dimensions(&self) -> ViewportDimensions {
@@ -66,13 +71,12 @@ impl RenderBackend for NullRenderer {
 
     fn submit_frame(&mut self, _clear: Color, _commands: CommandList) {}
     fn register_bitmap(&mut self, _bitmap: Bitmap) -> Result<BitmapHandle, Error> {
-        Ok(BitmapHandle(0))
+        Ok(BitmapHandle(Arc::new(NullBitmapHandle)))
     }
-    fn unregister_bitmap(&mut self, _bitmap: BitmapHandle) {}
 
     fn update_texture(
         &mut self,
-        _bitmap: BitmapHandle,
+        _bitmap: &BitmapHandle,
         _width: u32,
         _height: u32,
         _rgba: Vec<u8>,

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -1,8 +1,17 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use downcast_rs::{impl_downcast, Downcast};
+
 use crate::backend::RenderBackend;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct BitmapHandle(pub usize);
+#[derive(Clone, Debug)]
+pub struct BitmapHandle(pub Arc<dyn BitmapHandleImpl>);
 
+pub trait BitmapHandleImpl: Downcast + Debug {}
+impl_downcast!(BitmapHandleImpl);
+
+/// Info returned by the `register_bitmap` methods.
 #[derive(Clone, Debug)]
 pub struct BitmapInfo {
     pub handle: BitmapHandle,

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -16,6 +16,7 @@ gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
 fnv = "1.0.7"
 swf = { path = "../../swf" }
 thiserror = "1.0"
+downcast-rs = "1.2.0"
 
 [dependencies.web-sys]
 version = "0.3.60"

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -1,10 +1,11 @@
 use crate::backend::WgpuRenderBackend;
 use crate::target::RenderTarget;
 use crate::{
-    create_buffer_with_data, Descriptors, GradientStorage, GradientUniforms, Texture,
+    as_texture, create_buffer_with_data, Descriptors, GradientStorage, GradientUniforms,
     TextureTransforms, Vertex,
 };
 
+use ruffle_render::backend::RenderBackend;
 use ruffle_render::bitmap::BitmapSource;
 use ruffle_render::tessellator::{Bitmap, Draw as LyonDraw, DrawType as TessDrawType, Gradient};
 use swf::CharacterId;
@@ -32,7 +33,7 @@ impl Draw {
         draw_id: usize,
     ) -> Self {
         let vertices: Vec<_> = draw.vertices.into_iter().map(Vertex::from).collect();
-        let descriptors = backend.descriptors();
+        let descriptors = backend.descriptors().clone();
         let vertex_buffer = create_buffer_with_data(
             &descriptors.device,
             bytemuck::cast_slice(&vertices),
@@ -63,23 +64,20 @@ impl Draw {
                 num_indices: index_count,
                 num_mask_indices: draw.mask_index_count,
             },
-            TessDrawType::Bitmap(bitmap) => {
-                let bitmap_handle = source.bitmap_handle(bitmap.bitmap_id, backend).unwrap();
-                let texture = &backend.bitmap_registry()[&bitmap_handle];
-                Draw {
-                    draw_type: DrawType::bitmap(
-                        &backend.descriptors(),
-                        bitmap,
-                        texture,
-                        shape_id,
-                        draw_id,
-                    ),
-                    vertex_buffer,
-                    index_buffer,
-                    num_indices: index_count,
-                    num_mask_indices: draw.mask_index_count,
-                }
-            }
+            TessDrawType::Bitmap(bitmap) => Draw {
+                draw_type: DrawType::bitmap(
+                    &descriptors,
+                    bitmap,
+                    shape_id,
+                    draw_id,
+                    source,
+                    backend,
+                ),
+                vertex_buffer,
+                index_buffer,
+                num_indices: index_count,
+                num_mask_indices: draw.mask_index_count,
+            },
         }
     }
 }
@@ -189,12 +187,14 @@ impl DrawType {
     pub fn bitmap(
         descriptors: &Descriptors,
         bitmap: Bitmap,
-        texture: &Texture,
         shape_id: CharacterId,
         draw_id: usize,
+        source: &dyn BitmapSource,
+        backend: &mut dyn RenderBackend,
     ) -> Self {
+        let handle = source.bitmap_handle(bitmap.bitmap_id, backend).unwrap();
+        let texture = as_texture(&handle);
         let texture_view = texture.texture.create_view(&Default::default());
-
         let texture_transforms = create_texture_transforms(
             &descriptors.device,
             &bitmap.matrix,

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -7,11 +7,10 @@ use crate::surface::Surface::{Direct, DirectSrgb, Resolve, ResolveSrgb};
 use crate::uniform_buffer::BufferStorage;
 use crate::utils::remove_srgb;
 use crate::{
-    create_buffer_with_data, ColorAdjustments, Descriptors, Globals, Pipelines, Texture,
-    TextureTransforms, Transforms, UniformBuffer,
+    create_buffer_with_data, ColorAdjustments, Descriptors, Globals, Pipelines, TextureTransforms,
+    Transforms, UniformBuffer,
 };
-use fnv::FnvHashMap;
-use ruffle_render::bitmap::BitmapHandle;
+
 use ruffle_render::commands::CommandList;
 use std::sync::Arc;
 
@@ -387,7 +386,6 @@ impl Surface {
         globals: &mut Globals,
         uniform_buffers_storage: &mut BufferStorage<Transforms>,
         meshes: &Vec<Mesh>,
-        bitmap_registry: &FnvHashMap<BitmapHandle, Texture>,
         commands: CommandList,
     ) -> Vec<wgpu::CommandBuffer> {
         let label = create_debug_label!("Draw encoder");
@@ -445,7 +443,6 @@ impl Surface {
         commands.execute(&mut CommandRenderer::new(
             &mut frame,
             meshes,
-            bitmap_registry,
             descriptors.quad.vertices.slice(..),
             descriptors.quad.indices.slice(..),
         ));

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -2,6 +2,7 @@ use crate::utils::BufferDimensions;
 use crate::Error;
 use ruffle_render::utils::unmultiply_alpha_rgba;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 pub trait RenderTargetFrame: Debug {
     fn into_view(self) -> wgpu::TextureView;
@@ -136,9 +137,9 @@ impl RenderTarget for SwapChainTarget {
 #[derive(Debug)]
 pub struct TextureTarget {
     pub size: wgpu::Extent3d,
-    pub texture: wgpu::Texture,
+    pub texture: Arc<wgpu::Texture>,
     pub format: wgpu::TextureFormat,
-    pub buffer: wgpu::Buffer,
+    pub buffer: Arc<wgpu::Buffer>,
     pub buffer_dimensions: BufferDimensions,
 }
 
@@ -197,9 +198,9 @@ impl TextureTarget {
         });
         Ok(Self {
             size,
-            texture,
+            texture: Arc::new(texture),
             format,
-            buffer,
+            buffer: Arc::new(buffer),
             buffer_dimensions,
         })
     }

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -88,7 +88,7 @@ pub fn create_buffer_with_data(
 }
 
 // Based off wgpu example 'capture'
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BufferDimensions {
     pub width: usize,
     pub height: usize,

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -78,12 +78,12 @@ impl VideoBackend for SoftwareVideoBackend {
             .ok_or(Error::VideoStreamIsNotRegistered)?;
 
         let frame = stream.decoder.decode_frame(encoded_frame)?;
-        let handle = if let Some(bitmap) = stream.bitmap {
+        let handle = if let Some(bitmap) = stream.bitmap.clone() {
             renderer.update_texture(
-                bitmap,
+                &bitmap,
                 frame.width.into(),
                 frame.height.into(),
-                frame.rgba.clone(),
+                frame.rgba,
             )?;
             bitmap
         } else {
@@ -95,7 +95,7 @@ impl VideoBackend for SoftwareVideoBackend {
             );
             renderer.register_bitmap(bitmap)?
         };
-        stream.bitmap = Some(handle);
+        stream.bitmap = Some(handle.clone());
 
         Ok(BitmapInfo {
             handle,


### PR DESCRIPTION
Depends on https://github.com/ruffle-rs/ruffle/pull/8132, since `get_bitmap_pixels` doesn't go well with this approach.

`BitmapHandle` now holds `Arc<dyn BitmapHandleImpl>`. This allows us to move all of the per-bitmap backend data into `BitmapHandle`, instead of holding an id to a backend-specific hashmap.

This fixes the memory leak issue with bitmaps. Once the AVM side of a bitmap (`Bitmap`/`BitmapData`) gets garbage-collected, the `BitmapHandle` will get dropped, freeing all of the GPU resources associated with the bitmap.