### PR TITLE
web: Update Node.js versions

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["16", "18"]
+        node_version: ["18", "19"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 
@@ -100,7 +100,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["16", "18"]
+        node_version: ["18", "19"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 

--- a/web/README.md
+++ b/web/README.md
@@ -50,7 +50,7 @@ For the compiler to be able to output WebAssembly, an additional target has to b
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.
 
-We recommend using the currently active LTS 16, but we do also run tests with current Node.js 18.
+We recommend using the currently active LTS 18, but we do also run tests with current Node.js 19.
 
 Note that npm 7 or newer is required. It should come bundled with Node.js 15 or newer, but can be upgraded with older Node.js versions using `npm install -g npm` as root/Administrator.
 


### PR DESCRIPTION
Per https://nodejs.org/en/about/releases/:
* Node.js 16 became "maintenance" and Node.js 19 became "current" on October 18.
* Node.js 18 will become "active LTS" on October 25.

In order prepare for potentially breaking changes, update the tested Node.js versions from 16 and 18 to 18 and 19.