### PR TITLE
core: `Drawing` cleanup

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -367,13 +367,11 @@ fn line_style<'gc>(
             .with_is_pixel_hinted(is_pixel_hinted)
             .with_allow_close(false);
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_line_style(Some(line_style));
     } else {
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_line_style(None);
     }
     Ok(Value::Undefined)
@@ -394,13 +392,11 @@ fn begin_fill<'gc>(
             / 100.0
             * 255.0;
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_fill_style(Some(FillStyle::Color(Color::from_rgb(rgb, alpha as u8))));
     } else {
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_fill_style(None);
     }
     Ok(Value::Undefined)
@@ -429,8 +425,7 @@ fn begin_bitmap_fill<'gc>(
             height: bitmap_data.height() as u16,
         };
         let id = movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .add_bitmap(bitmap);
 
         let mut matrix = avm1::globals::matrix::object_to_matrix_or_default(
@@ -453,8 +448,7 @@ fn begin_bitmap_fill<'gc>(
             .unwrap_or(&false.into())
             .as_bool(activation.swf_version());
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_fill_style(Some(FillStyle::Bitmap {
                 id,
                 matrix: matrix.into(),
@@ -463,8 +457,7 @@ fn begin_bitmap_fill<'gc>(
             }));
     } else {
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_fill_style(None);
     }
     Ok(Value::Undefined)
@@ -562,13 +555,11 @@ fn begin_gradient_fill<'gc>(
             return Ok(Value::Undefined);
         };
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_fill_style(Some(style));
     } else {
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .set_fill_style(None);
     }
     Ok(Value::Undefined)
@@ -583,8 +574,7 @@ fn move_to<'gc>(
         let x = x.coerce_to_f64(activation)?;
         let y = y.coerce_to_f64(activation)?;
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .draw_command(DrawCommand::MoveTo {
                 x: Twips::from_pixels(x),
                 y: Twips::from_pixels(y),
@@ -602,8 +592,7 @@ fn line_to<'gc>(
         let x = x.coerce_to_f64(activation)?;
         let y = y.coerce_to_f64(activation)?;
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .draw_command(DrawCommand::LineTo {
                 x: Twips::from_pixels(x),
                 y: Twips::from_pixels(y),
@@ -625,8 +614,7 @@ fn curve_to<'gc>(
         let x2 = x2.coerce_to_f64(activation)?;
         let y2 = y2.coerce_to_f64(activation)?;
         movie_clip
-            .as_drawing(activation.context.gc_context)
-            .unwrap()
+            .drawing(activation.context.gc_context)
             .draw_command(DrawCommand::CurveTo {
                 x1: Twips::from_pixels(x1),
                 y1: Twips::from_pixels(y1),
@@ -643,8 +631,7 @@ fn end_fill<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     movie_clip
-        .as_drawing(activation.context.gc_context)
-        .unwrap()
+        .drawing(activation.context.gc_context)
         .set_fill_style(None);
     Ok(Value::Undefined)
 }
@@ -654,10 +641,7 @@ fn clear<'gc>(
     activation: &mut Activation<'_, 'gc, '_>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    movie_clip
-        .as_drawing(activation.context.gc_context)
-        .unwrap()
-        .clear();
+    movie_clip.drawing(activation.context.gc_context).clear();
     Ok(Value::Undefined)
 }
 
@@ -880,10 +864,8 @@ pub fn duplicate_movie_clip_with_bias<'gc>(
     let clip_actions = movie_clip.clip_actions().to_vec();
     new_clip.set_clip_event_handlers(activation.context.gc_context, clip_actions);
 
-    *new_clip.as_drawing(activation.context.gc_context).unwrap() = movie_clip
-        .as_drawing(activation.context.gc_context)
-        .unwrap()
-        .clone();
+    *new_clip.drawing(activation.context.gc_context) =
+        movie_clip.drawing(activation.context.gc_context).clone();
     // TODO: Any other properties we should copy...?
     // Definitely not ScriptObject properties.
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -93,6 +93,12 @@ impl<'gc> Graphic<'gc> {
             },
         ))
     }
+
+    pub fn drawing(&self, gc_context: MutationContext<'gc, '_>) -> RefMut<'_, Drawing> {
+        RefMut::map(self.0.write(gc_context), |w| {
+            w.drawing.get_or_insert_with(Drawing::new)
+        })
+    }
 }
 
 impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
@@ -235,12 +241,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     }
 
     fn as_drawing(&self, gc_context: MutationContext<'gc, '_>) -> Option<RefMut<'_, Drawing>> {
-        let mut write = self.0.write(gc_context);
-        if write.drawing.is_none() {
-            write.drawing = Some(Drawing::new());
-        }
-
-        Some(RefMut::map(write, |m| m.drawing.as_mut().unwrap()))
+        Some(self.drawing(gc_context))
     }
 }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2202,6 +2202,10 @@ impl<'gc> MovieClip<'gc> {
         self.0.write(context.gc_context).button_mode = button_mode;
     }
 
+    pub fn drawing(&self, gc_context: MutationContext<'gc, '_>) -> RefMut<'_, Drawing> {
+        RefMut::map(self.0.write(gc_context), |s| &mut s.drawing)
+    }
+
     pub fn is_button_mode(&self, context: &mut UpdateContext<'_, 'gc, '_>) -> bool {
         if self.forced_button_mode()
             || self
@@ -2547,7 +2551,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     }
 
     fn as_drawing(&self, gc_context: MutationContext<'gc, '_>) -> Option<RefMut<'_, Drawing>> {
-        Some(RefMut::map(self.0.write(gc_context), |s| &mut s.drawing))
+        Some(self.drawing(gc_context))
     }
 
     fn post_instantiation(


### PR DESCRIPTION
Extract `MovieClip::drawing` and `Graphic::drawing`, which return a non-`Option` `Drawing`. This avoids many `.unwrap()`s in AVM1.