### PR TITLE
avm2: Add missing set_object2 impl to Bitmap

### DIFF
--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -331,6 +331,10 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
             .unwrap_or(Avm2Value::Undefined)
     }
 
+    fn set_object2(&mut self, mc: MutationContext<'gc, '_>, to: Avm2Object<'gc>) {
+        self.0.write(mc).avm2_object = Some(to);
+    }
+
     fn as_bitmap(self) -> Option<Bitmap<'gc>> {
         Some(self)
     }


### PR DESCRIPTION
Together with the fix in https://github.com/ruffle-rs/ruffle/pull/8343 , this should fix the behavior of `var bitmap = addChild(new Bitmap())`.