### PR TITLE
core,avm2,desktop: Implement `SoundMixer.computeSpectrum()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,7 @@ name = "ruffle_desktop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "clap",
  "clipboard",
  "cpal",

--- a/core/src/avm2/globals/flash/media/soundmixer.rs
+++ b/core/src/avm2/globals/flash/media/soundmixer.rs
@@ -1,9 +1,13 @@
 //! `flash.media.SoundMixer` builtin/prototype
 
+use std::cell::RefMut;
+
 use crate::avm2::activation::Activation;
+use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::Object;
+use crate::avm2::object::TObject;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
@@ -118,13 +122,93 @@ pub fn are_sounds_inaccessible<'gc>(
     Err("SoundMixer.areSoundsInaccessible is a stub".into())
 }
 
-/// Stub `SoundMixer.computeSpectrum`
+/// Implements `SoundMixer.computeSpectrum`
 pub fn compute_spectrum<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
+    activation: &mut Activation<'_, 'gc, '_>,
     _this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
+    args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("SoundMixer.computeSpectrum is a stub".into())
+    let arg0 = args[0].as_object().unwrap();
+    let mut bytearray: RefMut<ByteArrayStorage> = arg0
+        .as_bytearray_mut(activation.context.gc_context)
+        .unwrap();
+    let mut hist = activation.context.audio.get_sample_history();
+
+    let fft = args.len() > 1 && args[1].coerce_to_boolean();
+    let stretch = if args.len() > 2 {
+        args[2].coerce_to_i32(activation)?
+    } else {
+        0
+    };
+
+    // This is actually more like a DCT, but at least it's related to an FFT.
+    if fft {
+        // This function was reverse-engineered with blood and tears.
+        #[inline]
+        fn postproc(x: f32) -> f32 {
+            x.abs().ln().max(0.0) / 4.0
+        }
+
+        // Need to make a copy of the samples used by the FFT, so they aren't
+        // modified in place.
+        let mut inp = [[0.0; 2]; 512];
+        inp.copy_from_slice(&hist[..512]);
+
+        // We could stop earlier here, depending on the value of 'stretch'.
+        for (freq, h) in hist.iter_mut().take(512).enumerate() {
+            let mut sum_left = 0.0;
+            let mut sum_right = 0.0;
+
+            for (i, sample) in inp.iter().enumerate() {
+                let freq = freq as f32;
+                let i = i as f32;
+                let coeff = (std::f32::consts::PI * freq * i / 1024.0).cos();
+
+                sum_left += sample[0] * coeff;
+                sum_right += sample[1] * coeff;
+            }
+
+            *h = [postproc(sum_left), postproc(sum_right)];
+        }
+    }
+
+    // A stretch factor of 0 appears to be "special" in that it squishes the
+    // 512 used input values (both with or without FFT) of each channel into
+    // 256 by skipping every odd one.
+    if stretch == 0 {
+        for i in 0..256 {
+            hist[i] = hist[2 * i];
+        }
+    }
+
+    // Positive stretch factors simply repeat every value some number of times.
+    // Stretch factors 1 and 2 appear to be identical (again both with or
+    // without FFT). They simply use the first 256 values without repetition.
+    let repeats = (stretch - 1).max(1);
+
+    bytearray.set_length(256 * 2 * 4);
+    bytearray.set_position(0);
+    // Writing out the left channel values.
+    'outer: for sample in &hist[..256] {
+        for _ in 0..repeats {
+            bytearray.write_float(sample[0])?;
+            if bytearray.position() >= 1024 {
+                break 'outer;
+            }
+        }
+    }
+    // Writing out the right channel values.
+    'outer: for sample in &hist[..256] {
+        for _ in 0..repeats {
+            bytearray.write_float(sample[1])?;
+            if bytearray.position() >= 2048 {
+                break 'outer;
+            }
+        }
+    }
+    // The read head has to be rewound for AS.
+    bytearray.set_position(0);
+    Ok(Value::Undefined)
 }
 
 /// Construct `SoundMixer`'s class.

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -125,6 +125,9 @@ pub trait AudioBackend: Downcast {
 
     /// Sets the master volume of the audio backend.
     fn set_volume(&mut self, volume: f32);
+
+    /// Returns the last whole window of output samples.
+    fn get_sample_history(&self) -> [[f32; 2]; 1024];
 }
 
 impl_downcast!(AudioBackend);
@@ -243,6 +246,10 @@ impl AudioBackend for NullAudioBackend {
 
     fn set_volume(&mut self, volume: f32) {
         self.volume = volume;
+    }
+
+    fn get_sample_history(&self) -> [[f32; 2]; 1024] {
+        [[0.0f32; 2]; 1024]
     }
 }
 

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -7,6 +7,39 @@ use std::io::Cursor;
 use std::sync::{Arc, Mutex, RwLock};
 use swf::AudioCompression;
 
+/// Holds the last 2048 output audio frames. Frames can be written to it one by
+/// one, and the last completely filled 1024-wide window can be read from it.
+struct CircBuf {
+    pub samples: [[f32; 2]; 2048],
+    pub pos: usize,
+}
+
+impl CircBuf {
+    /// Creates an empty circular buffer.
+    pub fn new() -> Self {
+        Self {
+            samples: [[0.0; 2]; 2048],
+            pos: 0,
+        }
+    }
+
+    /// Writes a value into the buffer, pushing the write position forward.
+    pub fn push(&mut self, sample: [f32; 2]) {
+        self.samples[self.pos] = sample;
+        self.pos = (self.pos + 1) % 2048;
+    }
+
+    /// Returns one half of the inner buffer, the one that is not currently
+    /// being written to.
+    pub fn get(&self) -> &[[f32; 2]; 1024] {
+        if self.pos < 1024 {
+            self.samples[1024..2048].try_into().unwrap()
+        } else {
+            self.samples[0..1024].try_into().unwrap()
+        }
+    }
+}
+
 /// An audio mixer for a Flash movie.
 ///
 /// `AudioMixer` manages the audio state for a Flash movie. This can be used by any backend that
@@ -29,6 +62,9 @@ pub struct AudioMixer {
 
     /// The sample rate of the output stream in Hz.
     output_sample_rate: u32,
+
+    /// The last two windows of output samples.
+    output_memory: Arc<RwLock<CircBuf>>,
 }
 
 /// An audio stream.
@@ -155,6 +191,7 @@ impl AudioMixer {
             volume: Arc::new(RwLock::new(1.0)),
             num_output_channels,
             output_sample_rate,
+            output_memory: Arc::new(RwLock::new(CircBuf::new())),
         }
     }
 
@@ -164,6 +201,7 @@ impl AudioMixer {
             sound_instances: Arc::clone(&self.sound_instances),
             volume: Arc::clone(&self.volume),
             num_output_channels: self.num_output_channels,
+            output_memory: Arc::clone(&self.output_memory),
         }
     }
 
@@ -173,18 +211,22 @@ impl AudioMixer {
     /// `output_buffer` is expected to be in 2-channel interleaved format.
     pub fn mix<'a, T>(&mut self, output_buffer: &mut [T])
     where
-        T: 'a + dasp::Sample + Default,
-        T::Signed: dasp::sample::conv::FromSample<i16>,
-        T::Float: dasp::sample::conv::FromSample<f32>,
+        T: 'a
+            + Default
+            + dasp::Sample<Signed = T>
+            + dasp::sample::ToSample<f32>
+            + dasp::sample::FromSample<i16>,
     {
         let mut sound_instances = self.sound_instances.lock().unwrap();
         let volume = *self.volume.read().unwrap();
+        let mut output_memory = self.output_memory.write().unwrap();
         Self::mix_audio::<T>(
             &mut sound_instances,
             volume,
             self.num_output_channels,
             output_buffer,
-        )
+            &mut output_memory,
+        );
     }
 
     /// Instantiate a seekable decoder for audio data with the given format.
@@ -319,10 +361,13 @@ impl AudioMixer {
         volume: f32,
         num_channels: u8,
         mut output_buffer: &mut [T],
+        output_memory: &mut CircBuf,
     ) where
-        T: 'a + Default + dasp::Sample,
-        T::Signed: dasp::sample::conv::FromSample<i16>,
-        T::Float: dasp::sample::conv::FromSample<f32>,
+        T: 'a
+            + Default
+            + dasp::Sample<Signed = T>
+            + dasp::sample::ToSample<f32>
+            + dasp::sample::FromSample<i16>,
     {
         use dasp::{
             frame::{Frame, Stereo},
@@ -343,7 +388,7 @@ impl AudioMixer {
                     let sound_frame = sound.stream.next();
                     let [left_0, left_1] = sound_frame.mul_amp(sound.left_transform);
                     let [right_0, right_1] = sound_frame.mul_amp(sound.right_transform);
-                    let mut sound_frame: Stereo<T::Signed> = [
+                    let mut sound_frame: Stereo<T> = [
                         Sample::add_amp(left_0, left_1).to_sample(),
                         Sample::add_amp(right_0, right_1).to_sample(),
                     ];
@@ -354,13 +399,21 @@ impl AudioMixer {
                 }
             }
 
+            output_memory.push([output_frame[0].to_sample(), output_frame[1].to_sample()]);
+
             for (buf_sample, output_sample) in buf_frame.iter_mut().zip(output_frame.iter()) {
-                *buf_sample = output_sample.to_sample();
+                *buf_sample = *output_sample;
             }
         }
 
         // Remove all dead sounds.
         sound_instances.retain(|_, sound| sound.active);
+    }
+
+    pub fn get_sample_history(&self) -> [[f32; 2]; 1024] {
+        let output_memory = self.output_memory.read().unwrap();
+
+        *output_memory.get()
     }
 
     /// Registers an embedded SWF sound with the audio mixer.
@@ -559,6 +612,8 @@ pub struct AudioMixerProxy {
 
     /// The number of channels in the output stream. Must be 1 or 2.
     num_output_channels: u8,
+
+    output_memory: Arc<RwLock<CircBuf>>,
 }
 
 impl AudioMixerProxy {
@@ -568,17 +623,21 @@ impl AudioMixerProxy {
     /// `output_buffer` is expected to be in 2-channel interleaved format.
     pub fn mix<'a, T>(&self, output_buffer: &mut [T])
     where
-        T: 'a + dasp::Sample + Default,
-        T::Signed: dasp::sample::conv::FromSample<i16>,
-        T::Float: dasp::sample::conv::FromSample<f32>,
+        T: 'a
+            + Default
+            + dasp::Sample<Signed = T>
+            + dasp::sample::ToSample<f32>
+            + dasp::sample::FromSample<i16>,
     {
         let mut sound_instances = self.sound_instances.lock().unwrap();
         let volume = *self.volume.read().unwrap();
+        let mut output_memory = self.output_memory.write().unwrap();
         AudioMixer::mix_audio::<T>(
             &mut sound_instances,
             volume,
             self.num_output_channels,
             output_buffer,
+            &mut output_memory,
         )
     }
 }
@@ -969,6 +1028,10 @@ macro_rules! impl_audio_mixer_backend {
         #[inline]
         fn set_volume(&mut self, volume: f32) {
             self.$mixer.set_volume(volume)
+        }
+
+        fn get_sample_history(&self) -> [[f32; 2]; 1024] {
+            self.$mixer.get_sample_history()
         }
     };
 }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -22,6 +22,7 @@ dirs = "4.0"
 isahc = "1.7.2"
 rfd = "0.10.0"
 anyhow = "1.0"
+bytemuck = "1.7.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
This should help with a number of z0r.de loops, such as: 2627, 5482, 6984, 7719, 7757, 7761, 7801, 7812, 7850, 7855, 7903, 7907

Here is a test file based on https://code.tutsplus.com/articles/render-an-mp3-audio-spectrum-in-flash-with-computespectrum--active-10808: (warning, loud beeps and boops after pressing the play button!)
[spectrumvis.zip](https://github.com/ruffle-rs/ruffle/files/9845577/spectrumvis.zip)

Some hints were also taken from:
https://web.archive.org/web/20120410195615/http://blog.benstucki.net/?p=60

Unfortunately the FFT still doesn't match what FP does, but at least the idea is the same.
If anyone has any ideas about how exactly their implementation is broken, that would be very much welcome.

The code is not particularly elegant or efficient yet either, but as a PoC I think it's fine.