### PR TITLE
Fixed a typo in messages on pressing Ctrl+Alt+D

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -858,9 +858,7 @@ impl Player {
                             context.avm1.set_show_debug_output(false);
                             context.avm2.set_show_debug_output(false);
                         } else {
-                            log::info!(
-                                "AVM Debugging turned on! Press CTRL+ALT+D to turn off."
-                            );
+                            log::info!("AVM Debugging turned on! Press CTRL+ALT+D to turn off.");
                             context.avm1.set_show_debug_output(true);
                             context.avm2.set_show_debug_output(true);
                         }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -853,13 +853,13 @@ impl Player {
                     self.mutate_with_update_context(|context| {
                         if context.avm1.show_debug_output() {
                             log::info!(
-                                "AVM Debugging turned off! Press CTRL+ALT+D to turn off again."
+                                "AVM Debugging turned off! Press CTRL+ALT+D to turn on again."
                             );
                             context.avm1.set_show_debug_output(false);
                             context.avm2.set_show_debug_output(false);
                         } else {
                             log::info!(
-                                "AVM Debugging turned on! Press CTRL+ALT+D to turn on again."
+                                "AVM Debugging turned on! Press CTRL+ALT+D to turn off."
                             );
                             context.avm1.set_show_debug_output(true);
                             context.avm2.set_show_debug_output(true);


### PR DESCRIPTION
Changed "AVM Debugging turned off! Press CTRL+ALT+D to turn off again." into "AVM Debugging turned off! Press CTRL+ALT+D to turn on again." and "AVM Debugging turned on! Press CTRL+ALT+D to turn on again." into "AVM Debugging turned on! Press CTRL+ALT+D to turn off."