### PR TITLE
avm2: Remove dead code from MovieClip constructor

### DIFF
--- a/core/src/avm2/globals/flash/display/movieclip.rs
+++ b/core/src/avm2/globals/flash/display/movieclip.rs
@@ -12,9 +12,7 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::display_object::{MovieClip, Scene, TDisplayObject};
 use crate::string::{AvmString, WString};
-use crate::tag_utils::SwfMovie;
 use gc_arena::{GcCell, MutationContext};
-use std::sync::Arc;
 
 /// Implements `flash.display.MovieClip`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -24,17 +22,6 @@ pub fn instance_init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this {
         activation.super_init(this, &[])?;
-
-        if this.as_display_object().is_none() {
-            let class_object = this
-                .instance_of()
-                .ok_or("Attempted to construct MovieClip on a bare object")?;
-            let movie = Arc::new(SwfMovie::empty(activation.context.swf.version()));
-            let new_do =
-                MovieClip::new_with_avm2(movie, this, class_object, activation.context.gc_context);
-
-            this.init_display_object(activation.context.gc_context, new_do.into());
-        }
     }
     Ok(Value::Undefined)
 }


### PR DESCRIPTION
The call to `super_init` will initialize a `DisplayObject` (if unset) in the `Sprite` constructor, using exactly the same logic that we're attempting to use. The code in `MovieClip` is unreachable, and can be deleted.