### PR TITLE
AVM1: Some Activation cleanup

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -193,7 +193,7 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     scope: GcCell<'gc, Scope<'gc>>,
 
     /// The currently in use constant pool.
-    constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
+    constant_pool: Gc<'gc, Vec<Value<'gc>>>,
 
     /// The immutable value of `this`.
     ///
@@ -255,7 +255,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         id: ActivationIdentifier<'a>,
         swf_version: u8,
         scope: GcCell<'gc, Scope<'gc>>,
-        constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
+        constant_pool: Gc<'gc, Vec<Value<'gc>>>,
         base_clip: DisplayObject<'gc>,
         this: Value<'gc>,
         callee: Option<Object<'gc>>,
@@ -315,7 +315,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             context.gc_context,
             Scope::new_local_scope(global_scope, context.gc_context),
         );
-        let empty_constant_pool = GcCell::allocate(context.gc_context, Vec::new());
+        let empty_constant_pool = Gc::allocate(context.gc_context, Vec::new());
         avm_debug!(context.avm1, "START {}", id);
 
         Self {
@@ -834,7 +834,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         &mut self,
         action: ConstantPool,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        self.context.avm1.set_constant_pool(GcCell::allocate(
+        self.context.avm1.set_constant_pool(Gc::allocate(
             self.context.gc_context,
             action
                 .strings
@@ -1744,14 +1744,14 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 }
                 SwfValue::Register(v) => self.current_register(v),
                 SwfValue::ConstantPool(i) => {
-                    if let Some(value) = self.constant_pool().read().get(i as usize) {
+                    if let Some(value) = self.constant_pool().get(i as usize) {
                         *value
                     } else {
                         avm_warn!(
                             self,
                             "ActionPush: Constant pool index {} out of range (len = {})",
                             i,
-                            self.constant_pool().read().len()
+                            self.constant_pool().len()
                         );
                         Value::Undefined
                     }
@@ -2886,11 +2886,11 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         }
     }
 
-    pub fn constant_pool(&self) -> GcCell<'gc, Vec<Value<'gc>>> {
+    pub fn constant_pool(&self) -> Gc<'gc, Vec<Value<'gc>>> {
         self.constant_pool
     }
 
-    pub fn set_constant_pool(&mut self, constant_pool: GcCell<'gc, Vec<Value<'gc>>>) {
+    pub fn set_constant_pool(&mut self, constant_pool: Gc<'gc, Vec<Value<'gc>>>) {
         self.constant_pool = constant_pool;
     }
 

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -2220,8 +2220,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             value => {
                 // Note that primitives get boxed at this point.
                 let object = value.coerce_to_object(self);
-                let with_scope =
-                    Scope::new_with_scope(self.scope(), object, self.context.gc_context);
+                let with_scope = Gc::allocate(
+                    self.context.gc_context,
+                    Scope::new_with_scope(self.scope(), object),
+                );
                 let mut new_activation = self.with_new_scope("[With]", with_scope);
                 if let ReturnType::Explicit(value) = new_activation.run_actions(code)? {
                     Ok(FrameControl::Return(ReturnType::Explicit(value)))

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -21,7 +21,6 @@ use rand::Rng;
 use ruffle_render::bounding_box::BoundingBox;
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::cell::{Ref, RefMut};
 use std::cmp::min;
 use std::fmt;
 use swf::avm1::read::Reader;
@@ -190,7 +189,7 @@ pub struct Activation<'a, 'gc: 'a, 'gc_context: 'a> {
     swf_version: u8,
 
     /// All defined local variables in this stack frame.
-    scope: GcCell<'gc, Scope<'gc>>,
+    scope: Gc<'gc, Scope<'gc>>,
 
     /// The currently in use constant pool.
     constant_pool: Gc<'gc, Vec<Value<'gc>>>,
@@ -254,7 +253,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         context: UpdateContext<'a, 'gc, 'gc_context>,
         id: ActivationIdentifier<'a>,
         swf_version: u8,
-        scope: GcCell<'gc, Scope<'gc>>,
+        scope: Gc<'gc, Scope<'gc>>,
         constant_pool: Gc<'gc, Vec<Value<'gc>>>,
         base_clip: DisplayObject<'gc>,
         this: Value<'gc>,
@@ -280,7 +279,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     pub fn with_new_scope<'b, S: Into<Cow<'static, str>>>(
         &'b mut self,
         name: S,
-        scope: GcCell<'gc, Scope<'gc>>,
+        scope: Gc<'gc, Scope<'gc>>,
     ) -> Activation<'b, 'gc, 'gc_context> {
         let id = self.id.child(name);
         avm_debug!(self.context.avm1, "START {}", id);
@@ -309,9 +308,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         globals: Object<'gc>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
-        let global_scope = GcCell::allocate(context.gc_context, Scope::from_global_object(globals));
+        let global_scope = Gc::allocate(context.gc_context, Scope::from_global_object(globals));
         let swf_version = base_clip.swf_version();
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             context.gc_context,
             Scope::new_local_scope(global_scope, context.gc_context),
         );
@@ -362,10 +361,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         let clip_obj = active_clip
             .object()
             .coerce_to_object(&mut parent_activation);
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             parent_activation.context.gc_context,
             Scope::new(
-                parent_activation.scope_cell(),
+                parent_activation.scope(),
                 scope::ScopeClass::Target,
                 clip_obj,
             ),
@@ -400,11 +399,11 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             Value::Object(o) => o,
             _ => panic!("No script object for display object"),
         };
-        let global_scope = GcCell::allocate(
+        let global_scope = Gc::allocate(
             self.context.gc_context,
             Scope::from_global_object(self.context.avm1.global_object_cell()),
         );
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             self.context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
         );
@@ -870,7 +869,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             swf_version,
             func_data,
             action,
-            self.scope_cell(),
+            self.scope(),
             constant_pool,
             self.base_clip(),
         );
@@ -921,10 +920,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             ) {
                 self.set_variable(name, Value::Undefined)?;
             }
-        } else if !self.scope_cell().read().locals().has_property(self, name) {
-            let scope = self.scope;
-            let scope = scope.write(self.context.gc_context);
-            scope.define_local(name, Value::Undefined, self)?;
+        } else if !self.scope().locals().has_property(self, name) {
+            self.scope().define_local(name, Value::Undefined, self)?;
         };
         Ok(FrameControl::Continue)
     }
@@ -951,7 +948,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
         // Fun fact: This isn't in the Adobe SWF19 spec, but this opcode returns
         // a boolean based on if the delete actually deleted something.
-        let success = self.scope_cell().read().delete(self, name);
+        let success = self.scope().delete(self, name);
         self.context.avm1.push(success.into());
 
         Ok(FrameControl::Continue)
@@ -1889,11 +1886,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             }
         };
 
-        let scope = self.scope_cell();
         let clip_obj = self.target_clip_or_root().object().coerce_to_object(self);
 
         self.set_scope(Scope::new_target_scope(
-            scope,
+            self.scope(),
             clip_obj,
             self.context.gc_context,
         ));
@@ -2234,7 +2230,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 // Note that primitives get boxed at this point.
                 let object = value.coerce_to_object(self);
                 let with_scope =
-                    Scope::new_with_scope(self.scope_cell(), object, self.context.gc_context);
+                    Scope::new_with_scope(self.scope(), object, self.context.gc_context);
                 let mut new_activation = self.with_new_scope("[With]", with_scope);
                 if let ReturnType::Explicit(value) = new_activation.run_actions(code)? {
                     Ok(FrameControl::Return(ReturnType::Explicit(value)))
@@ -2347,8 +2343,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     ///
     /// WARNING: This does not support user defined virtual properties!
     pub fn locals_into_form_values(&mut self) -> IndexMap<String, String> {
-        let scope = self.scope_cell();
-        let locals = scope.read().locals_cell();
+        let locals = self.scope().locals_cell();
         self.object_into_form_values(locals)
     }
 
@@ -2359,8 +2354,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         url: AvmString<'gc>,
         method: Option<NavigationMethod>,
     ) -> Request {
-        let scope = self.scope_cell();
-        let locals = scope.read().locals_cell();
+        let locals = self.scope().locals_cell();
         self.object_into_request(locals, url, method)
     }
 
@@ -2534,15 +2528,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             // We resolve it directly on the targeted object.
             let (path, var_name) = (&path[..separator], &path[separator + 1..]);
 
-            let mut current_scope = Some(self.scope_cell());
+            let mut current_scope = Some(self.scope());
             while let Some(scope) = current_scope {
                 let avm1_root = start.avm1_root();
                 if let Some(object) =
-                    self.resolve_target_path(avm1_root, *scope.read().locals(), path, true)?
+                    self.resolve_target_path(avm1_root, *scope.locals(), path, true)?
                 {
                     return Ok(Some((object, var_name)));
                 }
-                current_scope = scope.read().parent_cell();
+                current_scope = scope.parent();
             }
 
             return Ok(None);
@@ -2589,18 +2583,18 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             // We resolve it directly on the targeted object.
             let (path, var_name) = (&path[..separator], &path[separator + 1..]);
 
-            let mut current_scope = Some(self.scope_cell());
+            let mut current_scope = Some(self.scope());
             while let Some(scope) = current_scope {
                 let avm1_root = start.avm1_root();
                 if let Some(object) =
-                    self.resolve_target_path(avm1_root, *scope.read().locals(), path, true)?
+                    self.resolve_target_path(avm1_root, *scope.locals(), path, true)?
                 {
                     let var_name = AvmString::new(self.context.gc_context, var_name);
                     if object.has_property(self, var_name) {
                         return Ok(CallableValue::Callable(object, object.get(var_name, self)?));
                     }
                 }
-                current_scope = scope.read().parent_cell();
+                current_scope = scope.parent();
             }
 
             return Ok(CallableValue::UnCallable(Value::Undefined));
@@ -2608,15 +2602,15 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
         // If it doesn't have a trailing variable, it can still be a slash path.
         if path.contains(b'/') {
-            let mut current_scope = Some(self.scope_cell());
+            let mut current_scope = Some(self.scope());
             while let Some(scope) = current_scope {
                 let avm1_root = start.avm1_root();
                 if let Some(object) =
-                    self.resolve_target_path(avm1_root, *scope.read().locals(), &path, false)?
+                    self.resolve_target_path(avm1_root, *scope.locals(), &path, false)?
                 {
                     return Ok(CallableValue::UnCallable(object.into()));
                 }
-                current_scope = scope.read().parent_cell();
+                current_scope = scope.parent();
             }
         }
 
@@ -2669,17 +2663,17 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             // We resolve it directly on the targeted object.
             let (path, var_name) = (&path[..sep], &path[sep + 1..]);
 
-            let mut current_scope = Some(self.scope_cell());
+            let mut current_scope = Some(self.scope());
             while let Some(scope) = current_scope {
                 let avm1_root = start.avm1_root();
                 if let Some(object) =
-                    self.resolve_target_path(avm1_root, *scope.read().locals(), path, true)?
+                    self.resolve_target_path(avm1_root, *scope.locals(), path, true)?
                 {
                     let var_name = AvmString::new(self.context.gc_context, var_name);
                     object.set(var_name, value, self)?;
                     return Ok(());
                 }
-                current_scope = scope.read().parent_cell();
+                current_scope = scope.parent();
             }
 
             return Ok(());
@@ -2689,8 +2683,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         // Set using scope chain, as normal.
         // This will overwrite the value if the property exists somewhere
         // in the scope chain, otherwise it is created on the top-level object.
-        let scope = self.scope_cell();
-        scope.read().set(path, value, self)?;
+        self.scope().set(path, value, self)?;
         Ok(())
     }
 
@@ -2744,7 +2737,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
             return Ok(CallableValue::UnCallable(self.this_cell()));
         }
 
-        self.scope_cell().read().resolve(name, self)
+        self.scope().resolve(name, self)
     }
 
     /// Returns the suggested string encoding for actions.
@@ -2760,24 +2753,13 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         self.swf_version
     }
 
-    /// Returns AVM local variable scope.
-    pub fn scope(&self) -> Ref<Scope<'gc>> {
-        self.scope.read()
-    }
-
-    /// Returns AVM local variable scope for mutation.
-    #[allow(dead_code)]
-    pub fn scope_mut(&mut self, mc: MutationContext<'gc, '_>) -> RefMut<Scope<'gc>> {
-        self.scope.write(mc)
-    }
-
     /// Returns AVM local variable scope for reference.
-    pub fn scope_cell(&self) -> GcCell<'gc, Scope<'gc>> {
+    pub fn scope(&self) -> Gc<'gc, Scope<'gc>> {
         self.scope
     }
 
     /// Completely replace the current scope with a new one.
-    pub fn set_scope(&mut self, scope: GcCell<'gc, Scope<'gc>>) {
+    pub fn set_scope(&mut self, scope: Gc<'gc, Scope<'gc>>) {
         self.scope = scope;
     }
 
@@ -2785,7 +2767,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     pub fn in_local_scope(&self) -> bool {
         let mut current_scope = Some(self.scope);
         while let Some(scope) = current_scope {
-            match scope.read().class() {
+            match scope.class() {
                 scope::ScopeClass::Local => {
                     return true;
                 }
@@ -2794,7 +2776,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
                 }
                 _ => (),
             };
-            current_scope = scope.read().parent_cell();
+            current_scope = scope.parent();
         }
         false
     }
@@ -2833,9 +2815,7 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         if !self.in_local_scope() && name.find(b":.".as_ref()).is_some() {
             self.set_variable(name, value)
         } else {
-            let scope = self.scope;
-            let scope = scope.write(self.context.gc_context);
-            scope.define_local(name, value, self)
+            self.scope().define_local(name, value, self)
         }
     }
 
@@ -2845,7 +2825,6 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     /// exists, it will be forcefully overwritten. Used internally to initialize objects.
     pub fn force_define_local(&mut self, name: AvmString<'gc>, value: Value<'gc>) {
         self.scope
-            .read()
             .force_define_local(name, value, self.context.gc_context)
     }
 
@@ -2949,11 +2928,10 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
 
         self.set_target_clip(new_target_clip);
 
-        let scope = self.scope_cell();
         let clip_obj = self.target_clip_or_root().object().coerce_to_object(self);
 
         self.set_scope(Scope::new_target_scope(
-            scope,
+            self.scope(),
             clip_obj,
             self.context.gc_context,
         ));

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -305,9 +305,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
     pub fn from_nothing(
         context: UpdateContext<'a, 'gc, 'gc_context>,
         id: ActivationIdentifier<'a>,
-        globals: Object<'gc>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
+        let globals = context.avm1.global_object_cell();
         let global_scope = Gc::allocate(context.gc_context, Scope::from_global_object(globals));
         let swf_version = base_clip.swf_version();
         let child_scope = Gc::allocate(
@@ -338,10 +338,8 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         context: UpdateContext<'a, 'gc, 'gc_context>,
         id: ActivationIdentifier<'a>,
     ) -> Self {
-        let globals = context.avm1.global_object_cell();
         let level0 = context.stage.root_clip();
-
-        Self::from_nothing(context, id, globals, level0)
+        Self::from_nothing(context, id, level0)
     }
 
     /// Add a stack frame that executes code in timeline scope
@@ -351,11 +349,9 @@ impl<'a, 'gc, 'gc_context> Activation<'a, 'gc, 'gc_context> {
         active_clip: DisplayObject<'gc>,
         code: SwfSlice,
     ) -> Result<ReturnType<'gc>, Error<'gc>> {
-        let globals = self.context.avm1.global_object_cell();
         let mut parent_activation = Activation::from_nothing(
             self.context.reborrow(),
             self.id.child("[Actions Parent]"),
-            globals,
             active_clip,
         );
         let clip_obj = active_clip

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -67,7 +67,7 @@ pub struct Avm1Function<'gc> {
     params: Vec<Param<'gc>>,
 
     /// The scope the function was born into.
-    scope: GcCell<'gc, Scope<'gc>>,
+    scope: Gc<'gc, Scope<'gc>>,
 
     /// The constant pool the function executes with.
     constant_pool: Gc<'gc, Vec<Value<'gc>>>,
@@ -88,7 +88,7 @@ impl<'gc> Avm1Function<'gc> {
         swf_version: u8,
         actions: SwfSlice,
         swf_function: swf::avm1::types::DefineFunction2,
-        scope: GcCell<'gc, Scope<'gc>>,
+        scope: Gc<'gc, Scope<'gc>>,
         constant_pool: Gc<'gc, Vec<Value<'gc>>>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
@@ -137,7 +137,7 @@ impl<'gc> Avm1Function<'gc> {
         self.name
     }
 
-    pub fn scope(&self) -> GcCell<'gc, Scope<'gc>> {
+    pub fn scope(&self) -> Gc<'gc, Scope<'gc>> {
         self.scope
     }
 
@@ -387,10 +387,10 @@ impl<'gc> Executable<'gc> {
                 _ => unreachable!(),
             };
             // TODO: It would be nice to avoid these extra Scope allocs.
-            let scope = GcCell::allocate(
+            let scope = Gc::allocate(
                 activation.context.gc_context,
                 Scope::new(
-                    GcCell::allocate(
+                    Gc::allocate(
                         activation.context.gc_context,
                         Scope::from_global_object(activation.context.avm1.global_object_cell()),
                     ),
@@ -401,7 +401,7 @@ impl<'gc> Executable<'gc> {
             (swf_version, scope)
         };
 
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             activation.context.gc_context,
             Scope::new_local_scope(parent_scope, activation.context.gc_context),
         );

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -266,7 +266,7 @@ impl<'gc> Avm1Function<'gc> {
     fn load_global(&self, frame: &mut Activation<'_, 'gc, '_>, preload_r: &mut u8) {
         if self.flags.contains(FunctionFlags::PRELOAD_GLOBAL) {
             let global = frame.context.avm1.global_object();
-            frame.set_local_register(*preload_r, global);
+            frame.set_local_register(*preload_r, global.into());
             *preload_r += 1;
         }
     }
@@ -390,10 +390,7 @@ impl<'gc> Executable<'gc> {
             let scope = Gc::allocate(
                 activation.context.gc_context,
                 Scope::new(
-                    Gc::allocate(
-                        activation.context.gc_context,
-                        Scope::from_global_object(activation.context.avm1.global_object_cell()),
-                    ),
+                    activation.context.avm1.global_scope(),
                     super::scope::ScopeClass::Target,
                     base_clip_obj,
                 ),

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -70,7 +70,7 @@ pub struct Avm1Function<'gc> {
     scope: GcCell<'gc, Scope<'gc>>,
 
     /// The constant pool the function executes with.
-    constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
+    constant_pool: Gc<'gc, Vec<Value<'gc>>>,
 
     /// The base movie clip that the function was defined on.
     /// This is the movie clip that contains the bytecode.
@@ -89,7 +89,7 @@ impl<'gc> Avm1Function<'gc> {
         actions: SwfSlice,
         swf_function: swf::avm1::types::DefineFunction2,
         scope: GcCell<'gc, Scope<'gc>>,
-        constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
+        constant_pool: Gc<'gc, Vec<Value<'gc>>>,
         base_clip: DisplayObject<'gc>,
     ) -> Self {
         let encoding = SwfStr::encoding_for_version(swf_version);

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -43,7 +43,7 @@ pub fn call<'gc>(
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = match myargs.get(0).unwrap_or(&Value::Undefined) {
-        Value::Undefined | Value::Null => activation.context.avm1.global_object_cell(),
+        Value::Undefined | Value::Null => activation.context.avm1.global_object(),
         this_val => this_val.coerce_to_object(activation),
     };
     let empty = [];
@@ -74,7 +74,7 @@ pub fn apply<'gc>(
     myargs: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = match myargs.get(0).unwrap_or(&Value::Undefined) {
-        Value::Undefined | Value::Null => activation.context.avm1.global_object_cell(),
+        Value::Undefined | Value::Null => activation.context.avm1.global_object(),
         this_val => this_val.coerce_to_object(activation),
     };
     let args_object = myargs.get(1).cloned().unwrap_or(Value::Undefined);

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -116,7 +116,7 @@ impl<'gc> StageObject<'gc> {
                     .unwrap_or(Value::Undefined),
             );
         } else if name.eq_with_case(b"_global", case_sensitive) {
-            return Some(activation.context.avm1.global_object());
+            return Some(activation.context.avm1.global_object().into());
         }
 
         // Resolve level names `_levelN`.

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -115,11 +115,9 @@ impl<'gc> Avm1<'gc> {
             return;
         }
 
-        let globals = context.avm1.global_object_cell();
         let mut parent_activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root("[Actions Parent]"),
-            globals,
             active_clip,
         );
 
@@ -201,11 +199,9 @@ impl<'gc> Avm1<'gc> {
             return;
         }
 
-        let globals = context.avm1.global_object_cell();
         let mut parent_activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root("[Init Parent]"),
-            globals,
             active_clip,
         );
 
@@ -254,11 +250,9 @@ impl<'gc> Avm1<'gc> {
             return;
         }
 
-        let globals = context.avm1.global_object_cell();
         let mut activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root(name.to_string()),
-            globals,
             active_clip,
         );
 
@@ -272,16 +266,16 @@ impl<'gc> Avm1<'gc> {
         method: AvmString<'gc>,
         args: &[Value<'gc>],
     ) {
-        let global = context.avm1.global_object_cell();
-
         let mut activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root("[System Listeners]"),
-            global,
             active_clip,
         );
 
-        let broadcaster = global
+        let broadcaster = activation
+            .context
+            .avm1
+            .global_object_cell()
             .get(broadcaster_name, &mut activation)
             .unwrap()
             .coerce_to_object(&mut activation);

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 use crate::string::AvmString;
 use crate::tag_utils::SwfSlice;
 use crate::{avm1, avm_debug};
-use gc_arena::{Collect, GcCell, MutationContext, Gc};
+use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use std::borrow::Cow;
 use swf::avm1::read::Reader;
 
@@ -126,10 +126,10 @@ impl<'gc> Avm1<'gc> {
         let clip_obj = active_clip
             .object()
             .coerce_to_object(&mut parent_activation);
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             parent_activation.context.gc_context,
             Scope::new(
-                parent_activation.scope_cell(),
+                parent_activation.scope(),
                 scope::ScopeClass::Target,
                 clip_obj,
             ),
@@ -166,11 +166,11 @@ impl<'gc> Avm1<'gc> {
             Value::Object(o) => o,
             _ => panic!("No script object for display object"),
         };
-        let global_scope = GcCell::allocate(
+        let global_scope = Gc::allocate(
             action_context.gc_context,
             Scope::from_global_object(action_context.avm1.global_object_cell()),
         );
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             action_context.gc_context,
             Scope::new(global_scope, scope::ScopeClass::Target, clip_obj),
         );
@@ -212,10 +212,10 @@ impl<'gc> Avm1<'gc> {
         let clip_obj = active_clip
             .object()
             .coerce_to_object(&mut parent_activation);
-        let child_scope = GcCell::allocate(
+        let child_scope = Gc::allocate(
             parent_activation.context.gc_context,
             Scope::new(
-                parent_activation.scope_cell(),
+                parent_activation.scope(),
                 scope::ScopeClass::Target,
                 clip_obj,
             ),

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 use crate::string::AvmString;
 use crate::tag_utils::SwfSlice;
 use crate::{avm1, avm_debug};
-use gc_arena::{Collect, GcCell, MutationContext};
+use gc_arena::{Collect, GcCell, MutationContext, Gc};
 use std::borrow::Cow;
 use swf::avm1::read::Reader;
 
@@ -24,7 +24,7 @@ pub struct Avm1<'gc> {
 
     /// The constant pool to use for new activations from code sources that
     /// don't close over the constant pool they were defined with.
-    constant_pool: GcCell<'gc, Vec<Value<'gc>>>,
+    constant_pool: Gc<'gc, Vec<Value<'gc>>>,
 
     /// The global object.
     globals: Object<'gc>,
@@ -77,7 +77,7 @@ impl<'gc> Avm1<'gc> {
 
         Self {
             player_version,
-            constant_pool: GcCell::allocate(gc_context, vec![]),
+            constant_pool: Gc::allocate(gc_context, vec![]),
             globals,
             prototypes,
             broadcaster_functions,
@@ -353,13 +353,13 @@ impl<'gc> Avm1<'gc> {
 
     /// Obtains the constant pool to use for new activations from code sources that
     /// don't close over the constant pool they were defined with.
-    pub fn constant_pool(&self) -> GcCell<'gc, Vec<Value<'gc>>> {
+    pub fn constant_pool(&self) -> Gc<'gc, Vec<Value<'gc>>> {
         self.constant_pool
     }
 
     /// Sets the constant pool to use for new activations from code sources that
     /// don't close over the constant pool they were defined with.
-    pub fn set_constant_pool(&mut self, constant_pool: GcCell<'gc, Vec<Value<'gc>>>) {
+    pub fn set_constant_pool(&mut self, constant_pool: Gc<'gc, Vec<Value<'gc>>>) {
         self.constant_pool = constant_pool;
     }
 

--- a/core/src/avm1/test_utils.rs
+++ b/core/src/avm1/test_utils.rs
@@ -16,10 +16,9 @@ where
     let mut player = player.lock().unwrap();
     player.mutate_with_update_context(|context| {
         let context = context.reborrow();
-        let globals = context.avm1.global_object_cell();
         let root = context.stage.root_clip();
         let mut activation =
-            Activation::from_nothing(context, ActivationIdentifier::root("[Test]"), globals, root);
+            Activation::from_nothing(context, ActivationIdentifier::root("[Test]"), root);
         let this = root.object().coerce_to_object(&mut activation);
         let result = test(&mut activation, this);
         if let Err(e) = result {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1228,11 +1228,9 @@ impl<'gc> EditText<'gc> {
             }
 
             if changed {
-                let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(
                     context.reborrow(),
                     ActivationIdentifier::root("[Propagate Text Binding]"),
-                    globals,
                     self.into(),
                 );
                 self.propagate_text_binding(&mut activation);

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -1889,7 +1889,6 @@ impl<'gc> MovieClip<'gc> {
     ) {
         //TODO: This will break horribly when AVM2 starts touching the display list
         if self.0.read().object.is_none() {
-            let globals = context.avm1.global_object_cell();
             let avm1_constructor = self.0.read().get_registered_avm1_constructor(context);
 
             // If we are running within the AVM, this must be an immediate action.
@@ -1898,7 +1897,6 @@ impl<'gc> MovieClip<'gc> {
                 let mut activation = Avm1Activation::from_nothing(
                     context.reborrow(),
                     ActivationIdentifier::root("[Construct]"),
-                    globals,
                     self.into(),
                 );
 
@@ -1949,7 +1947,6 @@ impl<'gc> MovieClip<'gc> {
                 let mut activation = Avm1Activation::from_nothing(
                     context.reborrow(),
                     ActivationIdentifier::root("[Init]"),
-                    globals,
                     self.into(),
                 );
 

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -257,11 +257,9 @@ impl<'gc> Callback<'gc> {
         match self {
             Callback::Avm1 { this, method } => {
                 let base_clip = context.stage.root_clip();
-                let globals = context.avm1.global_object_cell();
                 let mut activation = Avm1Activation::from_nothing(
                     context.reborrow(),
                     Avm1ActivationIdentifier::root("[ExternalInterface]"),
-                    globals,
                     base_clip,
                 );
                 let this = this.coerce_to_object(&mut activation);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -640,13 +640,10 @@ impl Player {
         callback: Object<'gc>,
         context: &mut UpdateContext<'_, 'gc, '_>,
     ) {
-        let globals = context.avm1.global_object_cell();
         let root_clip = context.stage.root_clip();
-
         let mut activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root("[Context Menu Callback]"),
-            globals,
             root_clip,
         );
 
@@ -1547,12 +1544,9 @@ impl Player {
                     constructor: Some(constructor),
                     events,
                 } => {
-                    let globals = context.avm1.global_object_cell();
-
                     let mut activation = Activation::from_nothing(
                         context.reborrow(),
                         ActivationIdentifier::root("[Construct]"),
-                        globals,
                         action.clip,
                     );
                     if let Ok(prototype) = constructor.get("prototype", &mut activation) {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -841,7 +841,7 @@ impl Player {
                         dumper.print_variables(
                             "Global Variables:",
                             "_global",
-                            &activation.context.avm1.global_object_cell(),
+                            &activation.context.avm1.global_object(),
                             &mut activation,
                         );
 

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -40,13 +40,10 @@ impl<'gc> Timers<'gc> {
             return None;
         }
 
-        let globals = context.avm1.global_object_cell();
         let level0 = context.stage.root_clip();
-
         let mut activation = Activation::from_nothing(
             context.reborrow(),
             ActivationIdentifier::root("[Timer Callback]"),
-            globals,
             level0,
         );
 


### PR DESCRIPTION
- Remove unused `GcCell`s on `Activation` and `Scope`;
- Remove the `globals` parameter from `Activation::from_nothing`
- Reduce allocations in `Activation::from_nothing`:
  - Pre-allocate the global scope on the `Avm1` context so that it can be reused;
  - Reuse the global constant pool instead of allocating a new empty one; this doesn't matter as no bytecode is directly executed on a `from_nothing` activation without bringing its own constant pool.

------

`Activation::from_nothing` now does a single allocation (in `Scope::new_local_scope`), but I don't know if this can be removed.

Naïvely, an activation created with this method shouldn't be used to directly execute bytecode or to define locals, and so it should be fine to reuse directly the global scope (and indeed, the tests still pass after doing this change), but I'm not sure this reasoning is actually correct.