### PR TITLE
web: Fix `temp-dir` upgrade

### DIFF
--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -9,7 +9,7 @@ async function sign(
     destination
 ) {
     const { signAddon } = await import("sign-addon");
-    const tempDir = require("temp-dir");
+    const tempDir = await import("temp-dir");
     const result = await signAddon({
         xpiPath: unsignedPath,
         version,


### PR DESCRIPTION
`temp-dir` 3.0.0 is now pure ESM. As such, it no longer can be `require`d. To workaround this, use `await import` instead.

In the long-term, it might be worth converting the `sign_xpi.js` script itself to ESM.