### PR TITLE
core: Small cleanups in ActionQueue

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -324,7 +324,7 @@ impl<'gc> AudioManager<'gc> {
                     object.set_position(gc_context, duration.round() as u32);
 
                     // Fire soundComplete event.
-                    action_queue.queue_actions(
+                    action_queue.queue_action(
                         root,
                         crate::context::ActionType::Method {
                             object: object.into(),
@@ -340,7 +340,7 @@ impl<'gc> AudioManager<'gc> {
 
                     //TODO: AVM2 events are usually not queued, but we can't
                     //hold the update context in the audio manager yet.
-                    action_queue.queue_actions(
+                    action_queue.queue_action(
                         root,
                         crate::context::ActionType::Event2 {
                             event_type: "soundComplete",

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -493,7 +493,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
         // (e.g., clip.onRelease = foo).
         if context.swf.version() >= 6 {
             if let Some(name) = event.method_name() {
-                context.action_queue.queue_actions(
+                context.action_queue.queue_action(
                     self_display_object,
                     ActionType::Method {
                         object: write.object.unwrap(),
@@ -579,7 +579,7 @@ impl<'gc> Avm1ButtonData<'gc> {
                 {
                     // Note that AVM1 buttons run actions relative to their parent, not themselves.
                     handled = ClipEventResult::Handled;
-                    context.action_queue.queue_actions(
+                    context.action_queue.queue_action(
                         parent,
                         ActionType::Normal {
                             bytecode: action.action_data.clone(),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2002,7 +2002,7 @@ impl<'gc> MovieClip<'gc> {
                 .iter()
             {
                 if event_handler.events.contains(ClipEventFlag::INITIALIZE) {
-                    context.action_queue.queue_actions(
+                    context.action_queue.queue_action(
                         self.into(),
                         ActionType::Initialize {
                             bytecode: event_handler.action_data.clone(),
@@ -2015,7 +2015,7 @@ impl<'gc> MovieClip<'gc> {
                 }
             }
 
-            context.action_queue.queue_actions(
+            context.action_queue.queue_action(
                 self.into(),
                 ActionType::Construct {
                     constructor: avm1_constructor,
@@ -2719,7 +2719,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                             }
                         }
 
-                        context.action_queue.queue_actions(
+                        context.action_queue.queue_action(
                             self.into(),
                             ActionType::Normal {
                                 bytecode: event_handler.action_data.clone(),
@@ -2735,7 +2735,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
                     if let Some(name) = event.method_name() {
                         // Keyboard events don't fire their methods unless the MovieClip has focus (#2120).
                         if !event.is_key_event() || read.has_focus {
-                            context.action_queue.queue_actions(
+                            context.action_queue.queue_action(
                                 self.into(),
                                 ActionType::Method {
                                     object,
@@ -3650,7 +3650,7 @@ impl<'gc, 'a> MovieClip<'gc> {
             .swf
             .resize_to_reader(reader, tag_len);
         if !slice.is_empty() {
-            context.action_queue.queue_actions(
+            context.action_queue.queue_action(
                 self.into(),
                 ActionType::Normal { bytecode: slice },
                 false,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -876,7 +876,7 @@ impl<'gc> Loader<'gc> {
                 // Fire the onData method and event.
                 if let Some(display_object) = that.as_display_object() {
                     if let Some(movie_clip) = display_object.as_movie_clip() {
-                        activation.context.action_queue.queue_actions(
+                        activation.context.action_queue.queue_action(
                             movie_clip.into(),
                             ActionType::Method {
                                 object: that,
@@ -1646,7 +1646,7 @@ impl<'gc> Loader<'gc> {
             LoaderStatus::Succeeded => {
                 // AVM2 is handled separately
                 if let Some(MovieLoaderEventHandler::Avm1Broadcast(broadcaster)) = event_handler {
-                    queue.queue_actions(
+                    queue.queue_action(
                         clip,
                         ActionType::Method {
                             object: broadcaster,


### PR DESCRIPTION
- Use a fixed-size array instead of a Vec for the queues
- Remove unwanted plurals in methods and types names