### PR TITLE
Remove impl_display_object_container! macro

### DIFF
--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -414,11 +414,14 @@ impl<'gc> TDisplayObjectContainer<'gc> for Avm1Button<'gc> {
 }
 
 impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>> {
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>> {
         Ref::map(self.0.read(), |r| &r.base)
     }
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>> {
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>> {
         RefMut::map(self.0.write(mc), |w| &mut w.base)
     }
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -401,7 +401,16 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
 }
 
 impl<'gc> TDisplayObjectContainer<'gc> for Avm1Button<'gc> {
-    impl_display_object_container!(container);
+    fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>> {
+        Ref::map(self.0.read(), |this| &this.container)
+    }
+
+    fn raw_container_mut(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+    ) -> RefMut<'_, ChildContainer<'gc>> {
+        RefMut::map(self.0.write(gc_context), |this| &mut this.container)
+    }
 }
 
 impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -718,11 +718,14 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
 }
 
 impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>> {
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>> {
         Ref::map(self.0.read(), |r| &r.base)
     }
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>> {
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>> {
         RefMut::map(self.0.write(mc), |w| &mut w.base)
     }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1690,11 +1690,14 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
 }
 
 impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>> {
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>> {
         Ref::map(self.0.read(), |r| &r.base)
     }
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>> {
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>> {
         RefMut::map(self.0.write(mc), |w| &mut w.base)
     }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -116,46 +116,49 @@ impl<'gc> Default for InteractiveObjectBase<'gc> {
 pub trait TInteractiveObject<'gc>:
     'gc + Clone + Copy + Collect + Debug + Into<InteractiveObject<'gc>>
 {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>>;
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>>;
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>>;
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>>;
 
     fn as_displayobject(self) -> DisplayObject<'gc>;
 
     /// Check if the interactive object accepts user input.
     fn mouse_enabled(self) -> bool {
-        self.ibase()
+        self.raw_interactive()
             .flags
             .contains(InteractiveObjectFlags::MOUSE_ENABLED)
     }
 
     /// Set if the interactive object accepts user input.
     fn set_mouse_enabled(self, mc: MutationContext<'gc, '_>, value: bool) {
-        self.ibase_mut(mc)
+        self.raw_interactive_mut(mc)
             .flags
             .set(InteractiveObjectFlags::MOUSE_ENABLED, value)
     }
 
     /// Check if the interactive object accepts double-click events.
     fn double_click_enabled(self) -> bool {
-        self.ibase()
+        self.raw_interactive()
             .flags
             .contains(InteractiveObjectFlags::DOUBLE_CLICK_ENABLED)
     }
 
     // Set if the interactive object accepts double-click events.
     fn set_double_click_enabled(self, mc: MutationContext<'gc, '_>, value: bool) {
-        self.ibase_mut(mc)
+        self.raw_interactive_mut(mc)
             .flags
             .set(InteractiveObjectFlags::DOUBLE_CLICK_ENABLED, value)
     }
 
     fn context_menu(self) -> Avm2Value<'gc> {
-        self.ibase().context_menu
+        self.raw_interactive().context_menu
     }
 
     fn set_context_menu(self, mc: MutationContext<'gc, '_>, value: Avm2Value<'gc>) {
-        self.ibase_mut(mc).context_menu = value;
+        self.raw_interactive_mut(mc).context_menu = value;
     }
 
     /// Filter the incoming clip event.
@@ -254,7 +257,7 @@ pub trait TInteractiveObject<'gc>:
                 ClipEventResult::Handled
             }
             ClipEvent::Release => {
-                let read = self.ibase();
+                let read = self.raw_interactive();
                 let last_click = read.last_click;
                 let this_click = Instant::now();
 
@@ -282,7 +285,7 @@ pub trait TInteractiveObject<'gc>:
                         log::error!("Got error when dispatching {:?} to AVM2: {}", event, e);
                     }
 
-                    self.ibase_mut(context.gc_context).last_click = None;
+                    self.raw_interactive_mut(context.gc_context).last_click = None;
                 } else {
                     let avm2_event = Avm2EventObject::mouse_event(
                         &mut activation,
@@ -298,7 +301,7 @@ pub trait TInteractiveObject<'gc>:
                         log::error!("Got error when dispatching {:?} to AVM2: {}", event, e);
                     }
 
-                    self.ibase_mut(context.gc_context).last_click = Some(this_click);
+                    self.raw_interactive_mut(context.gc_context).last_click = Some(this_click);
                 }
 
                 ClipEventResult::Handled
@@ -316,7 +319,7 @@ pub trait TInteractiveObject<'gc>:
                     log::error!("Got error when dispatching {:?} to AVM2: {}", event, e);
                 }
 
-                self.ibase_mut(context.gc_context).last_click = None;
+                self.raw_interactive_mut(context.gc_context).last_click = None;
 
                 ClipEventResult::Handled
             }
@@ -359,7 +362,7 @@ pub trait TInteractiveObject<'gc>:
                     rollover_target = tgt.parent();
                 }
 
-                self.ibase_mut(context.gc_context).last_click = None;
+                self.raw_interactive_mut(context.gc_context).last_click = None;
 
                 ClipEventResult::Handled
             }

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -83,11 +83,14 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
 }
 
 impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>> {
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>> {
         Ref::map(self.0.read(), |r| &r.base)
     }
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>> {
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>> {
         RefMut::map(self.0.write(mc), |w| &mut w.base)
     }
 

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -125,5 +125,14 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
 }
 
 impl<'gc> TDisplayObjectContainer<'gc> for LoaderDisplay<'gc> {
-    impl_display_object_container!(container);
+    fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>> {
+        Ref::map(self.0.read(), |this| &this.container)
+    }
+
+    fn raw_container_mut(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+    ) -> RefMut<'_, ChildContainer<'gc>> {
+        RefMut::map(self.0.write(gc_context), |this| &mut this.container)
+    }
 }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2624,11 +2624,14 @@ impl<'gc> TDisplayObjectContainer<'gc> for MovieClip<'gc> {
 }
 
 impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>> {
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>> {
         Ref::map(self.0.read(), |r| &r.base)
     }
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>> {
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>> {
         RefMut::map(self.0.write(mc), |w| &mut w.base)
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2611,7 +2611,16 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
 }
 
 impl<'gc> TDisplayObjectContainer<'gc> for MovieClip<'gc> {
-    impl_display_object_container!(container);
+    fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>> {
+        Ref::map(self.0.read(), |this| &this.container)
+    }
+
+    fn raw_container_mut(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+    ) -> RefMut<'_, ChildContainer<'gc>> {
+        RefMut::map(self.0.write(gc_context), |this| &mut this.container)
+    }
 }
 
 impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -754,11 +754,14 @@ impl<'gc> TDisplayObjectContainer<'gc> for Stage<'gc> {
 }
 
 impl<'gc> TInteractiveObject<'gc> for Stage<'gc> {
-    fn ibase(&self) -> Ref<InteractiveObjectBase<'gc>> {
+    fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>> {
         Ref::map(self.0.read(), |r| &r.base)
     }
 
-    fn ibase_mut(&self, mc: MutationContext<'gc, '_>) -> RefMut<InteractiveObjectBase<'gc>> {
+    fn raw_interactive_mut(
+        &self,
+        mc: MutationContext<'gc, '_>,
+    ) -> RefMut<InteractiveObjectBase<'gc>> {
         RefMut::map(self.0.write(mc), |w| &mut w.base)
     }
 

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -741,7 +741,16 @@ impl<'gc> TDisplayObject<'gc> for Stage<'gc> {
 }
 
 impl<'gc> TDisplayObjectContainer<'gc> for Stage<'gc> {
-    impl_display_object_container!(child);
+    fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>> {
+        Ref::map(self.0.read(), |this| &this.child)
+    }
+
+    fn raw_container_mut(
+        &self,
+        gc_context: MutationContext<'gc, '_>,
+    ) -> RefMut<'_, ChildContainer<'gc>> {
+        RefMut::map(self.0.write(gc_context), |this| &mut this.child)
+    }
 }
 
 impl<'gc> TInteractiveObject<'gc> for Stage<'gc> {

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -3,7 +3,6 @@ pub use crate::display_object::{
     DisplayObject, DisplayObjectContainer, HitTestOptions, Lists, TDisplayObject,
     TDisplayObjectContainer,
 };
-pub use crate::impl_display_object_container;
 pub use log::{error, info, trace, warn};
 pub use ruffle_render::bounding_box::BoundingBox;
 pub use ruffle_render::color_transform::ColorTransform;


### PR DESCRIPTION
It is replaced by two accessor methods on the trait + default implementations of all other methods.