### PR TITLE
avm2,audio: Implement `SoundChannel.leftPeak` and `SoundChannel.rightPeak`

### DIFF
--- a/core/src/avm2/globals/flash/media/soundchannel.rs
+++ b/core/src/avm2/globals/flash/media/soundchannel.rs
@@ -34,22 +34,40 @@ pub fn class_init<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stub `SoundChannel.leftPeak`
+/// Implements `SoundChannel.leftPeak`
 pub fn left_peak<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
-    _this: Option<Object<'gc>>,
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Sound.leftPeak is a stub.".into())
+    if let Some(instance) = this
+        .and_then(|this| this.as_sound_channel())
+        .and_then(|channel| channel.instance())
+    {
+        if let Some(peak) = activation.context.audio.get_sound_peak(instance) {
+            return Ok(Value::Number(peak[0].into()));
+        }
+    }
+
+    Ok(Value::Undefined)
 }
 
-/// Stub `SoundChannel.rightPeak`
+/// Implements `SoundChannel.rightPeak`
 pub fn right_peak<'gc>(
-    _activation: &mut Activation<'_, 'gc, '_>,
-    _this: Option<Object<'gc>>,
+    activation: &mut Activation<'_, 'gc, '_>,
+    this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Sound.rightPeak is a stub.".into())
+    if let Some(instance) = this
+        .and_then(|this| this.as_sound_channel())
+        .and_then(|channel| channel.instance())
+    {
+        if let Some(peak) = activation.context.audio.get_sound_peak(instance) {
+            return Ok(Value::Number(peak[1].into()));
+        }
+    }
+
+    Ok(Value::Undefined)
 }
 
 /// Impl `SoundChannel.position`

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -95,6 +95,8 @@ pub trait AudioBackend: Downcast {
     /// Set the volume transform for a sound instance.
     fn set_sound_transform(&mut self, instance: SoundInstanceHandle, transform: SoundTransform);
 
+    fn get_sound_peak(&mut self, instance: SoundInstanceHandle) -> Option<[f32; 2]>;
+
     // TODO: Eventually remove this/move it to library.
     fn is_loading_complete(&self) -> bool {
         true
@@ -239,6 +241,10 @@ impl AudioBackend for NullAudioBackend {
     }
 
     fn set_sound_transform(&mut self, _instance: SoundInstanceHandle, _transform: SoundTransform) {}
+
+    fn get_sound_peak(&mut self, _instance: SoundInstanceHandle) -> Option<[f32; 2]> {
+        None
+    }
 
     fn volume(&self) -> f32 {
         self.volume


### PR DESCRIPTION
A bit of a WIP, but works well enough.
For example, it improves the following z0r loops at least: 6268, 6411, 6565.

Unlike with #8356, I didn't make sure to decouple the window of time over which this peak is taken from the output stream of the backend, because it didn't seem as important here.