### PR TITLE
avm1: onData fails if the loaded data is an empty string

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -938,13 +938,19 @@ impl<'gc> Loader<'gc> {
                         );
 
                         // Fire the onData method with the loaded string.
-                        let string_data = AvmString::new_utf8(
-                            activation.context.gc_context,
-                            UTF_8.decode(&response.body).0,
-                        );
+                        // If the loaded data is an empty string, the load is considered unsuccessful.
+                        let value_data = if response.body.is_empty() {
+                            Value::Undefined
+                        } else {
+                            AvmString::new_utf8(
+                                activation.context.gc_context,
+                                UTF_8.decode(&response.body).0,
+                            )
+                            .into()
+                        };
                         let _ = that.call_method(
                             "onData".into(),
-                            &[string_data.into()],
+                            &[value_data],
                             &mut activation,
                             ExecutionReason::Special,
                         );


### PR DESCRIPTION
```
var lv = new LoadVars();

lv.onData = function(src) {
   if(src == undefined) {
      trace("ERROR: " + src);
      return undefined;
   }
   trace("OK: " + src);
};

lv.load("params.txt");
```

If params.txt exists but doesn't contain anything, `ERROR: undefined` is now traced. This matches Flash's behavior.
In master, `OK: ` was traced.