### PR TITLE
[DRAFT] Make `RufflePlayer.load` not resolve until the movie's first frame loads

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -285,6 +285,9 @@ pub struct Player {
     /// The root SWF URL provided to ActionScript. If None,
     /// the actual loaded url will be used
     spoofed_url: Option<String>,
+
+    /// Function to be called when the root movie loads enough to start playing.
+    on_movie_playing: Option<Box<dyn FnOnce()>>,
 }
 
 impl Player {
@@ -297,7 +300,9 @@ impl Player {
         movie_url: String,
         parameters: Vec<(String, String)>,
         on_metadata: Box<dyn FnOnce(&swf::HeaderExt)>,
+        on_movie_playing: Box<dyn FnOnce()>,
     ) {
+        self.on_movie_playing = Some(on_movie_playing);
         self.mutate_with_update_context(|context| {
             let future = context.load_manager.load_root_movie(
                 context.player.clone(),
@@ -1342,12 +1347,15 @@ impl Player {
     /// simulate a particular load condition or stress chunked loading may use
     /// this in lieu of an unlimited execution limit.
     pub fn preload(&mut self, limit: &mut ExecutionLimit) -> bool {
-        self.mutate_with_update_context(|context| {
-            let mut did_finish = true;
+        let mut did_finish = true;
+        let mut root_movie_playing = false;
 
+        self.mutate_with_update_context(|context| {
             if let Some(root) = context.stage.root_clip().as_movie_clip() {
                 let was_root_movie_loaded = root.loaded_bytes() == root.total_bytes();
                 did_finish = root.preload(context, limit);
+
+                root_movie_playing = root.frames_loaded() >= 1;
 
                 if !was_root_movie_loaded {
                     if let Some(loader_info) = root.loader_info() {
@@ -1387,9 +1395,15 @@ impl Player {
             if did_finish {
                 did_finish = LoadManager::preload_tick(context, limit);
             }
+        });
 
-            did_finish
-        })
+        if root_movie_playing {
+            if let Some(movie_playing) = self.on_movie_playing.take() {
+                movie_playing();
+            }
+        }
+
+        did_finish
     }
 
     pub fn run_frame(&mut self) {
@@ -2106,6 +2120,7 @@ impl PlayerBuilder {
                 self_reference: self_ref.clone(),
                 load_behavior: self.load_behavior,
                 spoofed_url: self.spoofed_url.clone(),
+                on_movie_playing: None,
 
                 // GC data
                 gc_arena: Rc::new(RefCell::new(GcArena::new(

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -285,11 +285,13 @@ impl App {
             let on_metadata = move |swf_header: &ruffle_core::swf::HeaderExt| {
                 let _ = event_loop_proxy.send_event(RuffleEvent::OnMetadata(swf_header.clone()));
             };
+            let on_movie_playing = || {};
 
             player.lock().unwrap().fetch_root_movie(
                 movie_url.to_string(),
                 parse_parameters(&opt).collect(),
                 Box::new(on_metadata),
+                Box::new(on_movie_playing),
             );
 
             CALLSTACK.with(|callstack| {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -149,6 +149,11 @@ export class RufflePlayer extends HTMLElement {
     private isExtension = false;
 
     /**
+     * List of resolve functions for onMoviePlaying event promises
+     */
+    private onMoviePlayingPromises: Array<() => void> = [];
+
+    /**
      * Triggered when a movie metadata has been loaded (such as movie width and height).
      *
      * @event RufflePlayer#loadedmetadata
@@ -639,6 +644,8 @@ export class RufflePlayer extends HTMLElement {
                     sanitizeParameters(options.parameters)
                 );
             }
+
+            await this.waitForMovieToPlay();
         } catch (err) {
             console.error(`Serious error occurred loading SWF file: ${err}`);
             throw err;
@@ -1539,6 +1546,20 @@ export class RufflePlayer extends HTMLElement {
         this.dispatchEvent(new Event(RufflePlayer.LOADED_METADATA));
         // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
         this.dispatchEvent(new Event(RufflePlayer.LOADED_DATA));
+    }
+
+    private onMoviePlaying() {
+        for (let i = 0; i < this.onMoviePlayingPromises.length; i += 1) {
+            this.onMoviePlayingPromises[i]();
+        }
+
+        this.onMoviePlayingPromises = [];
+    }
+
+    private waitForMovieToPlay(): Promise<void> {
+        return new Promise((resolve, _reject) => {
+            this.onMoviePlayingPromises.push(resolve);
+        });
     }
 
     setIsExtension(isExtension: boolean): void {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -110,6 +110,9 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = "setMetadata")]
     fn set_metadata(this: &JavascriptPlayer, metadata: JsValue);
+
+    #[wasm_bindgen(method, js_name = "onMoviePlaying")]
+    fn on_movie_playing(this: &JavascriptPlayer);
 }
 
 struct JavascriptInterface {
@@ -213,8 +216,18 @@ impl Ruffle {
             let on_metadata = move |swf_header: &ruffle_core::swf::HeaderExt| {
                 ruffle.on_metadata(swf_header);
             };
+            let on_movie_playing = move || {
+                let _ = ruffle.with_instance(|instance| {
+                    instance.js_player.on_movie_playing();
+                });
+            };
 
-            core.fetch_root_movie(movie_url, parameters_to_load, Box::new(on_metadata));
+            core.fetch_root_movie(
+                movie_url,
+                parameters_to_load,
+                Box::new(on_metadata),
+                Box::new(on_movie_playing),
+            );
         });
         Ok(())
     }


### PR DESCRIPTION
Intended to resolve #4091 and allow writing JS-side preloaders.

`load_root_movie` now accepts a second event handler for when the first frame of the root finishes loading.