### PR TITLE
[Draft] AVM2: Implement Stage.invalidate

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -774,7 +774,7 @@ impl<'gc> ChildContainer<'gc> {
     }
 
     /// Yield children in the order they are rendered.
-    fn iter_render_list<'a>(&'a self) -> impl 'a + Iterator<Item = DisplayObject<'gc>> {
+    pub fn iter_render_list<'a>(&'a self) -> impl 'a + Iterator<Item = DisplayObject<'gc>> {
         self.render_list.iter().copied()
     }
 }

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -162,6 +162,10 @@ impl Drawing {
         self.dirty.set(true);
     }
 
+    pub fn set_dirty(&mut self, dirty: bool) {
+        self.dirty = dirty.into();
+    }
+
     pub fn draw_command(&mut self, command: DrawCommand) {
         let add_to_bounds = if let DrawCommand::MoveTo { x, y } = command {
             // Close any pending fills before moving.


### PR DESCRIPTION
Draft pull request implementing `Stage.invalidate` for AVM2 

- Tests need to be written to ensure behavior between flash player and this code is equivalent. 
  - Based on my reading of the docs, FP broadcasts a `Render` event to all child display objects to force redraws, which I am doing with the `dirty` parameter.
- Code also needs some cleaning up.