### PR TITLE
Update to chrono 0.4.23 and fix deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/core/src/locale.rs
+++ b/core/src/locale.rs
@@ -7,7 +7,11 @@ const MOCK_TIME: bool = cfg!(any(test, feature = "deterministic"));
 
 pub fn get_current_date_time() -> DateTime<Utc> {
     if MOCK_TIME {
-        get_timezone().ymd(2001, 2, 3).and_hms(4, 5, 6).into()
+        get_timezone()
+            .with_ymd_and_hms(2001, 2, 3, 4, 5, 6)
+            .single()
+            .expect("Unambiguous mock time")
+            .into()
     } else {
         Utc::now()
     }
@@ -15,7 +19,7 @@ pub fn get_current_date_time() -> DateTime<Utc> {
 
 pub fn get_timezone() -> FixedOffset {
     if MOCK_TIME {
-        FixedOffset::east(20700)
+        FixedOffset::east_opt(20700).expect("Unambiguous mock timezone")
     } else {
         Local::now().offset().fix()
     }


### PR DESCRIPTION
Obsoletes #8550.

This *looks* like it introduces a lot of new unwrap points, but those were already there in the deprecated function calls I removed.