### PR TITLE
avm1: Fix `ExternalInterface.call` with blank strings in SWFv8

### DIFF
--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -156,6 +156,11 @@ impl Value {
             Value::Bool(value) => Avm1Value::Bool(value),
             Value::Number(value) => Avm1Value::Number(value),
             Value::String(value) => {
+                let value = if activation.swf_version() < 9 && value.trim().is_empty() {
+                    "null"
+                } else {
+                    &value
+                };
                 Avm1Value::String(AvmString::new_utf8(activation.context.gc_context, value))
             }
             Value::Object(values) => {


### PR DESCRIPTION
For some reason, Flash Player returns "null" (as a string) in this situation.
Fixes the default text not being displayed on the city sign on [miniville.fr](https://web.archive.org/web/20070628203054/http://miniville.fr/).

---

JS:
`function getVal() { return "        "; }`

AS2:
```
var text = flash.external.ExternalInterface.call("getVal");
var r = "|";
r = r + text + "|";
r = r + typeof text + "|";
trace(r);
getURL("javascript:console.log(\'" + r + "\')","");
```

[Sample (SWF)](https://github.com/ruffle-rs/ruffle/files/10071100/externali.zip)
