### PR TITLE
Bump gc-arena to upstream's current master branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.37.1+1.3.235"
+version = "0.37.0+1.3.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911015c962d56e2e4052f40182ca5462ba60a3d2ff04e827c365a0ab3d65726d"
+checksum = "006ca68e0f2b03f22d6fa9f2860f85aed430d257fec20f8879b2145e7c7ae1a6"
 dependencies = [
  "libloading",
 ]
@@ -196,9 +196,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bindgen"
-version = "0.61.0"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -211,7 +211,6 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
 ]
 
 [[package]]
@@ -333,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe233b960f12f8007e3db2d136e3cb1c291bfd7396e384ee76025fc1a3932b4"
+checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -350,9 +349,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cache-padded"
@@ -372,12 +371,12 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.10.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf530afb40e45e14440701e5e996d7fd139e84a912a4d83a8d6a0fb3e58663"
+checksum = "a22a6a8f622f797120d452c630b0ab12e1331a1a753e2039ce7868d4ac77b4ee"
 dependencies = [
  "log",
- "nix 0.25.0",
+ "nix 0.24.2",
  "slotmap",
  "thiserror",
  "vec_map",
@@ -391,9 +390,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -713,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.11"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9444b94b8024feecc29e01a9706c69c1e26bfee480221c90764200cfd778fb"
+checksum = "3dff444d80630d7073077d38d40b4501fd518bd2b922c2a55edcc8b0f7be57e6"
 dependencies = [
  "bindgen",
 ]
@@ -795,22 +794,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -925,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -937,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -952,15 +951,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1174,9 +1173,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -1673,7 +1672,7 @@ dependencies = [
 [[package]]
 name = "gc-arena"
 version = "0.2.2"
-source = "git+https://github.com/ruffle-rs/gc-arena#24d8aea5f0fd968756d6e3c1dac4c6c2ccb7280a"
+source = "git+https://github.com/kyren/gc-arena?rev=3415c1b1e73621daf51b8cee783a5dc5e63f28fb#3415c1b1e73621daf51b8cee783a5dc5e63f28fb"
 dependencies = [
  "gc-arena-derive",
 ]
@@ -1681,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "gc-arena-derive"
 version = "0.2.2"
-source = "git+https://github.com/ruffle-rs/gc-arena#24d8aea5f0fd968756d6e3c1dac4c6c2ccb7280a"
+source = "git+https://github.com/kyren/gc-arena?rev=3415c1b1e73621daf51b8cee783a5dc5e63f28fb#3415c1b1e73621daf51b8cee783a5dc5e63f28fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2084,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
+checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
 dependencies = [
  "libc",
  "windows-sys 0.42.0",
@@ -2274,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
@@ -2284,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2439,9 +2438,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.8"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -2451,15 +2450,6 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -2593,7 +2583,7 @@ checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags",
  "jni-sys",
- "ndk-sys 0.4.1+23.1.7779620",
+ "ndk-sys 0.4.0",
  "num_enum",
  "raw-window-handle 0.5.0",
  "thiserror",
@@ -2616,7 +2606,7 @@ dependencies = [
  "ndk 0.7.0",
  "ndk-context",
  "ndk-macro",
- "ndk-sys 0.4.1+23.1.7779620",
+ "ndk-sys 0.4.0",
  "once_cell",
  "parking_lot",
 ]
@@ -2645,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.4.1+23.1.7779620"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
+checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
 dependencies = [
  "jni-sys",
 ]
@@ -2694,7 +2684,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
 ]
 
 [[package]]
@@ -2706,7 +2696,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
 ]
 
 [[package]]
@@ -2719,7 +2709,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
  "pin-utils",
 ]
 
@@ -2810,9 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
@@ -2837,6 +2827,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2921,9 +2920,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -2934,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "ouroboros"
@@ -3101,9 +3100,9 @@ checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty_assertions"
@@ -3315,9 +3314,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "regress"
@@ -3666,18 +3665,18 @@ dependencies = [
 
 [[package]]
 name = "rustdct"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
+checksum = "620247053ace0eddd3e607c66423537e45c3ae36008e6d6fac1552f51ea1a63a"
 dependencies = [
  "rustfft",
 ]
 
 [[package]]
 name = "rustfft"
-version = "6.1.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434"
+checksum = "b1d089e5c57521629a59f5f39bca7434849ff89bd6873b521afe389c1c602543"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -3685,7 +3684,6 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
- "version_check",
 ]
 
 [[package]]
@@ -3918,9 +3916,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "simple_asn1"
@@ -4091,9 +4089,9 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strength_reduce"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+checksum = "a3ff2f71c82567c565ba4b3009a9350a96a7269eaa4001ebedae926230bc2254"
 
 [[package]]
 name = "strsim"
@@ -4287,11 +4285,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa 1.0.4",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -4305,9 +4305,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
 dependencies = [
  "time-core",
 ]
@@ -4406,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "transpose"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23"
+checksum = "95f9c900aa98b6ea43aee227fd680550cdec726526aab8ac801549eadb25e39f"
 dependencies = [
  "num-integer",
  "strength_reduce",
@@ -4490,9 +4490,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+checksum = "fe88247b92c1df6b6de80ddc290f3976dbdf2f5f5d3fd049a9fb598c6dd5ca73"
 
 [[package]]
 name = "version_check"
@@ -5086,9 +5086,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x11-dl"
-version = "2.20.1"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1536d6965a5d4e573c7ef73a2c15ebcd0b2de3347bdf526c34c297c00ac40f0"
+checksum = "0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6"
 dependencies = [
  "lazy_static",
  "libc",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,8 @@ byteorder = "1.4"
 bitstream-io = "1.6.0"
 flate2 = "1.0.25"
 fnv = "1.0.7"
-gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
+
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "3415c1b1e73621daf51b8cee783a5dc5e63f28fb" }
 generational-arena = "0.2.8"
 indexmap = "1.9.2"
 log = "0.4"

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -74,7 +74,7 @@ impl<'gc> RegisterSet<'gc> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ReturnType<'gc> {
     Implicit,
     Explicit(Value<'gc>),
@@ -89,7 +89,7 @@ impl<'gc> ReturnType<'gc> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 enum FrameControl<'gc> {
     Continue,
     Return(ReturnType<'gc>),

--- a/core/src/avm1/callable_value.rs
+++ b/core/src/avm1/callable_value.rs
@@ -4,7 +4,7 @@ use crate::avm1::{Object, TObject, Value};
 use crate::string::AvmString;
 use gc_arena::Collect;
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum CallableValue<'gc> {
     UnCallable(Value<'gc>),

--- a/core/src/avm1/error.rs
+++ b/core/src/avm1/error.rs
@@ -1,7 +1,9 @@
+use std::fmt;
+
 use crate::avm1::Value;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error)]
 pub enum Error<'gc> {
     #[error("Prototype recursion limit has been exceeded")]
     PrototypeRecursionLimit,
@@ -20,4 +22,19 @@ pub enum Error<'gc> {
 
     #[error("A script has thrown a custom error.")]
     ThrownValue(Value<'gc>),
+}
+
+impl<'gc> fmt::Debug for Error<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PrototypeRecursionLimit => write!(f, "PrototypeRecursionLimit"),
+            Self::ExecutionTimeout => write!(f, "ExecutionTimeout"),
+            Self::FunctionRecursionLimit(err) => {
+                f.debug_tuple("FunctionRecursionLimit").field(err).finish()
+            }
+            Self::SpecialRecursionLimit => write!(f, "SpecialRecursionLimit"),
+            Self::InvalidSwf(err) => f.debug_tuple("InvalidSwf").field(err).finish(),
+            Self::ThrownValue(_) => write!(f, "ThrownValue(_)"),
+        }
+    }
 }

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -47,7 +47,7 @@ pub enum ExecutionReason {
 
 /// Represents a function defined in the AVM1 runtime, either through
 /// `DefineFunction` or `DefineFunction2`.
-#[derive(Debug, Clone, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Avm1Function<'gc> {
     /// The file format version of the SWF that generated this function.
@@ -272,7 +272,7 @@ impl<'gc> Avm1Function<'gc> {
     }
 }
 
-#[derive(Debug, Clone, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 struct Param<'gc> {
     /// The register the argument will be preloaded into.
@@ -316,7 +316,7 @@ impl fmt::Debug for Executable<'_> {
                 .debug_tuple("Executable::Native")
                 .field(&format!("{nf:p}"))
                 .finish(),
-            Executable::Action(af) => f.debug_tuple("Executable::Action").field(&af).finish(),
+            Executable::Action(_) => write!(f, "Executable::Action(_)"),
         }
     }
 }
@@ -476,7 +476,7 @@ impl<'gc> From<Gc<'gc, Avm1Function<'gc>>> for Executable<'gc> {
 }
 
 /// Represents an `Object` that holds executable code.
-#[derive(Debug, Clone, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct FunctionObject<'gc> {
     /// The script object base.
@@ -487,7 +487,7 @@ pub struct FunctionObject<'gc> {
     data: GcCell<'gc, FunctionObjectData<'gc>>,
 }
 
-#[derive(Debug, Clone, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 struct FunctionObjectData<'gc> {
     /// The code that will be invoked when this object is called.

--- a/core/src/avm1/globals/as_broadcaster.rs
+++ b/core/src/avm1/globals/as_broadcaster.rs
@@ -41,7 +41,7 @@ pub fn create<'gc>(
     )
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct BroadcasterFunctions<'gc> {
     pub add_listener: Object<'gc>,

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -528,8 +528,7 @@ pub fn draw<'gc>(
             } else {
                 avm_error!(
                     activation,
-                    "BitmapData.draw: Unexpected source {:?} {:?}",
-                    source,
+                    "BitmapData.draw: Unexpected source {:?}",
                     args.get(0)
                 );
                 return Ok(Value::Undefined);

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -27,7 +27,6 @@ use crate::string::AvmString;
 use crate::xml::XmlNode;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_macros::enum_trait_object;
-use std::fmt::Debug;
 
 pub mod array_object;
 pub mod bitmap_data;
@@ -64,7 +63,7 @@ pub enum NativeObject<'gc> {
 /// runtime.
 #[enum_trait_object(
     #[allow(clippy::enum_variant_names)]
-    #[derive(Clone, Collect, Debug, Copy)]
+    #[derive(Clone, Collect, Copy)]
     #[collect(no_drop)]
     pub enum Object<'gc> {
         ScriptObject(ScriptObject<'gc>),
@@ -88,7 +87,7 @@ pub enum NativeObject<'gc> {
         BitmapData(BitmapDataObject<'gc>),
     }
 )]
-pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy {
+pub trait TObject<'gc>: 'gc + Collect + Into<Object<'gc>> + Clone + Copy {
     /// Retrieve a named, non-virtual property from this object exclusively.
     ///
     /// This function should not inspect prototype chains. Instead, use

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -5,7 +5,6 @@ use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
 
 use crate::bitmap::bitmap_data::BitmapData;
-use std::fmt;
 
 /// A BitmapData
 #[derive(Clone, Copy, Collect)]
@@ -18,15 +17,6 @@ pub struct BitmapDataData<'gc> {
     /// The underlying script object.
     base: ScriptObject<'gc>,
     data: GcCell<'gc, BitmapData<'gc>>,
-}
-
-impl fmt::Debug for BitmapDataObject<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let this = self.0.read();
-        f.debug_struct("BitmapData")
-            .field("data", &this.data)
-            .finish()
-    }
 }
 
 impl<'gc> BitmapDataObject<'gc> {

--- a/core/src/avm1/object/displacement_map_filter.rs
+++ b/core/src/avm1/object/displacement_map_filter.rs
@@ -71,7 +71,7 @@ impl fmt::Debug for DisplacementMapFilterObject<'_> {
             .field("color", &this.color)
             .field("componentX", &this.component_x)
             .field("componentY", &this.component_y)
-            .field("mapBitmap", &this.map_bitmap)
+            .field("mapBitmap", &this.map_bitmap.is_some())
             .field("mapPoint", &this.map_point)
             .field("mode", &this.mode)
             .field("scaleX", &this.scale_x)

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -6,10 +6,9 @@ use crate::avm1::property::{Attribute, Property};
 use crate::avm1::property_map::{Entry, PropertyMap};
 use crate::avm1::{Object, ObjectPtr, TObject, Value};
 use crate::string::AvmString;
-use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
 
-#[derive(Debug, Clone, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Watcher<'gc> {
     callback: Object<'gc>,
@@ -46,7 +45,7 @@ impl<'gc> Watcher<'gc> {
     }
 }
 
-#[derive(Debug, Copy, Clone, Collect)]
+#[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub struct ScriptObject<'gc>(GcCell<'gc, ScriptObjectData<'gc>>);
 
@@ -57,15 +56,6 @@ pub struct ScriptObjectData<'gc> {
     properties: PropertyMap<'gc, Property<'gc>>,
     interfaces: Vec<Object<'gc>>,
     watchers: PropertyMap<'gc, Watcher<'gc>>,
-}
-
-impl fmt::Debug for ScriptObjectData<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Object")
-            .field("properties", &self.properties)
-            .field("watchers", &self.watchers)
-            .finish()
-    }
 }
 
 impl<'gc> ScriptObject<'gc> {

--- a/core/src/avm1/object/sound_object.rs
+++ b/core/src/avm1/object/sound_object.rs
@@ -5,7 +5,6 @@ use crate::backend::audio::{SoundHandle, SoundInstanceHandle};
 use crate::display_object::DisplayObject;
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
-use std::fmt;
 
 /// A SoundObject that is tied to a sound from the AudioBackend.
 #[derive(Clone, Copy, Collect)]
@@ -42,17 +41,6 @@ pub struct SoundObjectData<'gc> {
     /// This will be true if `Sound.loadSound` was called with `isStreaming` of `true`.
     /// A streaming sound can only have a single active instance.
     is_streaming: bool,
-}
-
-impl fmt::Debug for SoundObject<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let this = self.0.read();
-        f.debug_struct("SoundObject")
-            .field("sound", &this.sound)
-            .field("sound_instance", &this.sound_instance)
-            .field("owner", &this.owner)
-            .finish()
-    }
 }
 
 impl<'gc> SoundObject<'gc> {

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -13,7 +13,6 @@ use crate::display_object::{
 use crate::string::{AvmString, WStr};
 use crate::types::Percent;
 use gc_arena::{Collect, GcCell, MutationContext};
-use std::fmt;
 
 /// A ScriptObject that is inherently tied to a display node.
 #[derive(Clone, Copy, Collect)]
@@ -166,16 +165,6 @@ impl<'gc> StageObject<'gc> {
 struct TextFieldBinding<'gc> {
     text_field: EditText<'gc>,
     variable_name: AvmString<'gc>,
-}
-
-impl fmt::Debug for StageObject<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let o = self.0.read();
-        f.debug_struct("StageObject")
-            .field("base", &o.base)
-            .field("display_object", &o.display_object)
-            .finish()
-    }
 }
 
 impl<'gc> TObject<'gc> for StageObject<'gc> {

--- a/core/src/avm1/object/super_object.rs
+++ b/core/src/avm1/object/super_object.rs
@@ -15,11 +15,11 @@ use gc_arena::{Collect, GcCell, MutationContext};
 /// A `SuperObject` references all data from another object, but with one layer
 /// of prototyping removed. It's as if the given object had been constructed
 /// with its parent class.
-#[derive(Copy, Clone, Collect, Debug)]
+#[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub struct SuperObject<'gc>(GcCell<'gc, SuperObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct SuperObjectData<'gc> {
     /// The object present as `this` throughout the superchain.

--- a/core/src/avm1/object/transform_object.rs
+++ b/core/src/avm1/object/transform_object.rs
@@ -2,7 +2,6 @@ use crate::avm1::{Object, ScriptObject, TObject};
 use crate::display_object::MovieClip;
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
-use std::fmt;
 
 /// A flash.geom.Transform object
 #[derive(Clone, Copy, Collect)]
@@ -15,15 +14,6 @@ pub struct TransformData<'gc> {
     /// The underlying script object.
     base: ScriptObject<'gc>,
     clip: Option<MovieClip<'gc>>,
-}
-
-impl fmt::Debug for TransformObject<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let this = self.0.read();
-        f.debug_struct("Transform")
-            .field("clip", &this.clip)
-            .finish()
-    }
 }
 
 impl<'gc> TransformObject<'gc> {

--- a/core/src/avm1/object/value_object.rs
+++ b/core/src/avm1/object/value_object.rs
@@ -5,7 +5,6 @@ use crate::avm1::object::TObject;
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::impl_custom_object;
 use gc_arena::{Collect, GcCell, MutationContext};
-use std::fmt;
 
 /// An Object that serves as a box for a primitive value.
 #[derive(Clone, Copy, Collect)]
@@ -98,16 +97,6 @@ impl<'gc> ValueObject<'gc> {
     /// Change the value in the box.
     pub fn replace_value(&mut self, gc_context: MutationContext<'gc, '_>, value: Value<'gc>) {
         self.0.write(gc_context).value = value;
-    }
-}
-
-impl fmt::Debug for ValueObject<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let this = self.0.read();
-        f.debug_struct("ValueObject")
-            .field("base", &this.base)
-            .field("value", &this.value)
-            .finish()
     }
 }
 

--- a/core/src/avm1/object/xml_node_object.rs
+++ b/core/src/avm1/object/xml_node_object.rs
@@ -44,7 +44,6 @@ impl fmt::Debug for XmlNodeObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let this = self.0.read();
         f.debug_struct("XmlNodeObject")
-            .field("base", &this.base)
             .field("node", &this.node)
             .finish()
     }

--- a/core/src/avm1/object/xml_object.rs
+++ b/core/src/avm1/object/xml_object.rs
@@ -219,9 +219,7 @@ impl<'gc> XmlObject<'gc> {
 
 impl fmt::Debug for XmlObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let this = self.0.read();
         f.debug_struct("XmlObject")
-            .field("base", &this.base)
             .field("root", &self.0.read().root)
             .finish()
     }

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -2,7 +2,6 @@
 
 use crate::avm1::{Object, Value};
 use bitflags::bitflags;
-use core::fmt;
 use gc_arena::Collect;
 
 bitflags! {
@@ -138,16 +137,5 @@ impl<'gc> Property<'gc> {
             .copied()
             .unwrap_or_default();
         (self.attributes.bits() & mask) == 0
-    }
-}
-
-impl fmt::Debug for Property<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Property")
-            .field("data", &self.data)
-            .field("getter", &self.getter)
-            .field("setter", &self.setter)
-            .field("attributes", &self.attributes)
-            .finish()
     }
 }

--- a/core/src/avm1/property_map.rs
+++ b/core/src/avm1/property_map.rs
@@ -13,7 +13,7 @@ use std::hash::{Hash, Hasher};
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
 /// A map from property names to values.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone)]
 pub struct PropertyMap<'gc, V>(FnvIndexMap<PropertyName<'gc>, V>);
 
 impl<'gc, V> PropertyMap<'gc, V> {
@@ -193,7 +193,7 @@ impl<'gc, 'a> Equivalent<PropertyName<'gc>> for CaseSensitive<&'a WStr> {
 /// SWFv6, which is case insensitive. The equality check is handled by the `Equivalent`
 /// impls above, which allow it to be either case-sensitive or insensitive.
 /// Note that the property of if key1 == key2 -> hash(key1) == hash(key2) still holds.
-#[derive(Debug, Clone, PartialEq, Eq, Collect)]
+#[derive(Clone, PartialEq, Eq, Collect)]
 #[collect(require_static)]
 struct PropertyName<'gc>(AvmString<'gc>);
 

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -29,7 +29,7 @@ pub enum ScopeClass {
 }
 
 /// Represents a scope chain for an AVM1 activation.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Scope<'gc> {
     parent: Option<Gc<'gc, Scope<'gc>>>,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -11,9 +11,9 @@ use crate::ecma_conversions::{
 };
 use crate::string::{AvmString, Integer, WStr};
 use gc_arena::Collect;
-use std::{borrow::Cow, io::Write, num::Wrapping};
+use std::{borrow::Cow, fmt, io::Write, num::Wrapping};
 
-#[derive(Debug, Clone, Copy, Collect)]
+#[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
 #[allow(dead_code)]
 pub enum Value<'gc> {
@@ -23,6 +23,19 @@ pub enum Value<'gc> {
     Number(f64),
     String(AvmString<'gc>),
     Object(Object<'gc>),
+}
+
+impl<'gc> fmt::Debug for Value<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "Undefined"),
+            Self::Null => write!(f, "Null"),
+            Self::Bool(b) => f.debug_tuple("Bool").field(b).finish(),
+            Self::Number(n) => f.debug_tuple("Number").field(n).finish(),
+            Self::String(s) => f.debug_tuple("String").field(s).finish(),
+            Self::Object(_) => write!(f, "Object(_)"),
+        }
+    }
 }
 
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -78,10 +78,7 @@ pub fn serialize_value<'gc>(
                         }),
                     ))
                 } else {
-                    log::warn!(
-                        "Serialization is not implemented for class other than Object: {:?}",
-                        o
-                    );
+                    log::warn!("Serialization is not implemented for class other than Object");
                     None
                 }
             }

--- a/core/src/avm2/array.rs
+++ b/core/src/avm2/array.rs
@@ -9,7 +9,7 @@ use std::ops::RangeBounds;
 /// Array values may consist of either standard `Value`s or "holes": values
 /// which are not properties of the associated object and must be resolved in
 /// the prototype.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ArrayStorage<'gc> {
     storage: Vec<Option<Value<'gc>>>,

--- a/core/src/avm2/call_stack.rs
+++ b/core/src/avm2/call_stack.rs
@@ -2,14 +2,14 @@ use crate::avm2::function::Executable;
 use crate::string::WString;
 use gc_arena::Collect;
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub enum CallNode<'gc> {
     GlobalInit,
     Method(Executable<'gc>),
 }
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct CallStack<'gc> {
     stack: Vec<CallNode<'gc>>,

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -136,7 +136,7 @@ impl fmt::Debug for Allocator {
 }
 
 /// A loaded ABC Class which can be used to construct objects with.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Class<'gc> {
     /// The name of the class.

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -12,11 +12,11 @@ use gc_arena::{Collect, GcCell, MutationContext};
 
 /// Represents a set of scripts and movies that share traits across different
 /// script-global scopes.
-#[derive(Copy, Clone, Debug, Collect)]
+#[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub struct Domain<'gc>(GcCell<'gc, DomainData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 struct DomainData<'gc> {
     /// A list of all exported definitions and the script that exported them.

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
 /// Which phase of event dispatch is currently occurring.
-#[derive(Copy, Clone, Collect, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Collect, PartialEq, Eq)]
 #[collect(require_static)]
 pub enum EventPhase {
     /// The event has yet to be fired on the target and is descending the
@@ -30,7 +30,7 @@ pub enum EventPhase {
 }
 
 /// How this event is allowed to propagate.
-#[derive(Copy, Clone, Collect, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Collect, PartialEq, Eq)]
 #[collect(require_static)]
 pub enum PropagationMode {
     /// Propagate events normally.
@@ -45,7 +45,7 @@ pub enum PropagationMode {
 
 /// Represents data fields of an event that can be fired on an object that
 /// implements `IEventDispatcher`.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Event<'gc> {
     /// Whether or not the event "bubbles" - fires on it's parents after it
@@ -174,7 +174,7 @@ impl<'gc> Event<'gc> {
 }
 
 /// A set of handlers organized by event type, priority, and order added.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct DispatchList<'gc>(FnvHashMap<AvmString<'gc>, BTreeMap<i32, Vec<EventHandler<'gc>>>>);
 
@@ -306,7 +306,7 @@ impl<'gc> Default for DispatchList<'gc> {
 }
 
 /// A single instance of an event handler.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 struct EventHandler<'gc> {
     /// The event handler to call.
@@ -375,9 +375,8 @@ pub fn dispatch_event_to_target<'gc>(
 ) -> Result<(), Error<'gc>> {
     avm_debug!(
         activation.context.avm2,
-        "Event dispatch: {} to {:?}",
+        "Event dispatch: {}",
         event.as_event().unwrap().event_type(),
-        target
     );
     let dispatch_list = target
         .get_property(
@@ -419,12 +418,7 @@ pub fn dispatch_event_to_target<'gc>(
         let object = activation.global_scope();
 
         if let Err(err) = handler.call(object, &[event.into()], activation) {
-            log::error!(
-                "Error dispatching event {:?} to handler {:?} : {:?}",
-                event,
-                handler,
-                err
-            );
+            log::error!("Error dispatching event: {:?}", err);
         }
     }
 

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -9,7 +9,6 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::WString;
 use gc_arena::{Collect, Gc};
-use std::fmt;
 
 /// Represents code written in AVM2 bytecode that can be executed by some
 /// means.
@@ -279,24 +278,6 @@ impl<'gc> Executable<'gc> {
         match self {
             Executable::Native(NativeExecutable { method, .. }) => method.signature.len(),
             Executable::Action(BytecodeExecutable { method, .. }) => method.signature.len(),
-        }
-    }
-}
-
-impl<'gc> fmt::Debug for Executable<'gc> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Action(be) => fmt
-                .debug_struct("Executable::Action")
-                .field("method", &be.method)
-                .field("scope", &be.scope)
-                .field("receiver", &be.receiver)
-                .finish(),
-            Self::Native(bm) => fmt
-                .debug_struct("Executable::Native")
-                .field("method", &bm.method)
-                .field("bound_receiver", &bm.bound_receiver)
-                .finish(),
         }
     }
 }

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -754,7 +754,7 @@ pub fn draw<'gc>(
         } else if let Some(source_bitmap) = source.as_bitmap_data() {
             IBitmapDrawable::BitmapData(source_bitmap)
         } else {
-            return Err(format!("BitmapData.draw: unexpected source {source:?}").into());
+            return Err("BitmapData.draw: unexpected source".into());
         };
 
         bitmap_data.draw(

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -8,7 +8,6 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::string::AvmString;
 use gc_arena::{Collect, CollectionContext, Gc, MutationContext};
-use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
 use swf::avm2::types::{
@@ -37,7 +36,7 @@ pub type NativeMethodImpl = for<'gc> fn(
 ) -> Result<Value<'gc>, Error<'gc>>;
 
 /// Configuration of a single parameter of a method.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ParamConfig<'gc> {
     /// The name of the parameter.
@@ -101,7 +100,7 @@ impl<'gc> ParamConfig<'gc> {
 }
 
 /// Represents a reference to an AVM2 method and body.
-#[derive(Collect, Clone, Debug)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct BytecodeMethod<'gc> {
     /// The translation unit this function was defined in.
@@ -278,20 +277,9 @@ unsafe impl<'gc> Collect for NativeMethod<'gc> {
     }
 }
 
-impl<'gc> fmt::Debug for NativeMethod<'gc> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NativeMethod")
-            .field("method", &format!("{:p}", &self.method))
-            .field("name", &self.name)
-            .field("signature", &self.signature)
-            .field("is_variadic", &self.is_variadic)
-            .finish()
-    }
-}
-
 /// An uninstantiated method that can either be natively implemented or sourced
 /// from an ABC file.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum Method<'gc> {
     /// A native method.

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -7,7 +7,6 @@ use crate::string::{AvmString, WStr, WString};
 use bitflags::bitflags;
 use gc_arena::Gc;
 use gc_arena::{Collect, MutationContext};
-use std::fmt::Debug;
 use std::ops::Deref;
 use swf::avm2::types::{
     AbcFile, Index, Multiname as AbcMultiname, NamespaceSet as AbcNamespaceSet,

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -2,7 +2,6 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::Error;
 use crate::string::AvmString;
 use gc_arena::{Collect, MutationContext};
-use std::fmt::Debug;
 use swf::avm2::types::{Index, Namespace as AbcNamespace};
 
 /// Represents the name of a namespace.

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -24,7 +24,6 @@ use crate::string::AvmString;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_macros::enum_trait_object;
 use std::cell::{Ref, RefMut};
-use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
 mod array_object;
@@ -93,7 +92,7 @@ pub use crate::avm2::object::xml_object::{xml_allocator, XmlObject};
 /// runtime.
 #[enum_trait_object(
     #[allow(clippy::enum_variant_names)]
-    #[derive(Clone, Collect, Debug, Copy)]
+    #[derive(Clone, Collect, Copy)]
     #[collect(no_drop)]
     pub enum Object<'gc> {
         ScriptObject(ScriptObject<'gc>),
@@ -127,7 +126,7 @@ pub use crate::avm2::object::xml_object::{xml_allocator, XmlObject};
         Program3DObject(Program3DObject<'gc>),
     }
 )]
-pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy {
+pub trait TObject<'gc>: 'gc + Collect + Into<Object<'gc>> + Clone + Copy {
     /// Get the base of this object.
     /// Any trait method implementations that were not overrided will forward the call to this instead.
     fn base(&self) -> Ref<ScriptObjectData<'gc>>;

--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -29,11 +29,11 @@ pub fn array_allocator<'gc>(
 }
 
 /// An Object which stores numerical properties in an array.
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct ArrayObject<'gc>(GcCell<'gc, ArrayObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct ArrayObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -26,11 +26,11 @@ pub fn bitmapdata_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct BitmapDataObject<'gc>(GcCell<'gc, BitmapDataObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct BitmapDataObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/bytearray_object.rs
+++ b/core/src/avm2/object/bytearray_object.rs
@@ -25,11 +25,11 @@ pub fn byte_array_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct ByteArrayObject<'gc>(GcCell<'gc, ByteArrayObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ByteArrayObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -27,7 +27,7 @@ use std::hash::{Hash, Hasher};
 #[collect(no_drop)]
 pub struct ClassObject<'gc>(GcCell<'gc, ClassObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct ClassObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -23,7 +23,7 @@ pub fn date_allocator<'gc>(
     ))
     .into())
 }
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct DateObject<'gc>(GcCell<'gc, DateObjectData<'gc>>);
 
@@ -41,7 +41,7 @@ impl<'gc> DateObject<'gc> {
     }
 }
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct DateObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -32,11 +32,11 @@ pub fn dictionary_allocator<'gc>(
 /// This is implemented by way of "object space", parallel to the property
 /// space that ordinary properties live in. This space has no namespaces, and
 /// keys are objects instead of strings.
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct DictionaryObject<'gc>(GcCell<'gc, DictionaryObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct DictionaryObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/dispatch_object.rs
+++ b/core/src/avm2/object/dispatch_object.rs
@@ -34,11 +34,11 @@ use std::cell::{Ref, RefMut};
 ///    `EventDispatcher` classes. This would require adding `DispatchList` to
 ///    other object representations that need to dispatch events, such as
 ///    `StageObject`.
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct DispatchObject<'gc>(GcCell<'gc, DispatchObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct DispatchObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/domain_object.rs
+++ b/core/src/avm2/object/domain_object.rs
@@ -24,11 +24,11 @@ pub fn appdomain_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct DomainObject<'gc>(GcCell<'gc, DomainObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct DomainObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -31,11 +31,11 @@ pub fn error_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct ErrorObject<'gc>(GcCell<'gc, ErrorObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ErrorObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -36,7 +36,7 @@ pub fn event_allocator<'gc>(
 #[collect(no_drop)]
 pub struct EventObject<'gc>(GcCell<'gc, EventObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct EventObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -51,11 +51,11 @@ pub fn function_allocator<'gc>(
 }
 
 /// An Object which can be called to execute its function code.
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct FunctionObject<'gc>(GcCell<'gc, FunctionObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct FunctionObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -47,7 +47,7 @@ pub fn loaderinfo_allocator<'gc>(
 }
 
 /// Represents a thing which can be loaded by a loader.
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub enum LoaderStream<'gc> {
     /// An SWF movie that has not yet loaded.
@@ -74,11 +74,11 @@ pub enum LoaderStream<'gc> {
 
 /// An Object which represents a loadable object, such as a SWF movie or image
 /// resource.
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct LoaderInfoObject<'gc>(GcCell<'gc, LoaderInfoObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct LoaderInfoObjectData<'gc> {
     /// All normal script data.

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -27,11 +27,11 @@ pub fn namespace_allocator<'gc>(
 }
 
 /// An Object which represents a boxed namespace name.
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct NamespaceObject<'gc>(GcCell<'gc, NamespaceObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct NamespaceObjectData<'gc> {
     /// All normal script data.

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -28,11 +28,11 @@ pub fn primitive_allocator<'gc>(
 }
 
 /// An Object which represents a primitive value of some other kind.
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct PrimitiveObject<'gc>(GcCell<'gc, PrimitiveObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct PrimitiveObjectData<'gc> {
     /// All normal script data.

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -26,11 +26,11 @@ pub fn proxy_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct ProxyObject<'gc>(GcCell<'gc, ProxyObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ProxyObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/qname_object.rs
+++ b/core/src/avm2/object/qname_object.rs
@@ -24,11 +24,11 @@ pub fn qname_allocator<'gc>(
 }
 
 /// An Object which represents a boxed QName.
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct QNameObject<'gc>(GcCell<'gc, QNameObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct QNameObjectData<'gc> {
     /// All normal script data.

--- a/core/src/avm2/object/regexp_object.rs
+++ b/core/src/avm2/object/regexp_object.rs
@@ -27,11 +27,11 @@ pub fn regexp_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct RegExpObject<'gc>(GcCell<'gc, RegExpObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct RegExpObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -33,7 +33,7 @@ pub struct ScriptObject<'gc>(GcCell<'gc, ScriptObjectData<'gc>>);
 /// Host implementations of `TObject` should embed `ScriptObjectData` and
 /// forward any trait method implementations it does not overwrite to this
 /// struct.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ScriptObjectData<'gc> {
     /// Values stored on this object.

--- a/core/src/avm2/object/sound_object.rs
+++ b/core/src/avm2/object/sound_object.rs
@@ -23,11 +23,11 @@ pub fn sound_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct SoundObject<'gc>(GcCell<'gc, SoundObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct SoundObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -27,11 +27,11 @@ pub fn soundchannel_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct SoundChannelObject<'gc>(GcCell<'gc, SoundChannelObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct SoundChannelObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/stage3d_object.rs
+++ b/core/src/avm2/object/stage3d_object.rs
@@ -25,7 +25,7 @@ pub fn stage_3d_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Stage3DObject<'gc>(GcCell<'gc, Stage3DObjectData<'gc>>);
 
@@ -39,7 +39,7 @@ impl<'gc> Stage3DObject<'gc> {
     }
 }
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Stage3DObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/stage_object.rs
+++ b/core/src/avm2/object/stage_object.rs
@@ -9,7 +9,6 @@ use crate::display_object::DisplayObject;
 use crate::display_object::TDisplayObject;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
-use std::fmt::Debug;
 
 /// A class instance allocator that allocates Stage objects.
 pub fn stage_allocator<'gc>(
@@ -32,7 +31,7 @@ pub fn stage_allocator<'gc>(
 #[collect(no_drop)]
 pub struct StageObject<'gc>(GcCell<'gc, StageObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct StageObjectData<'gc> {
     /// The base data common to all AVM2 objects.
@@ -132,24 +131,5 @@ impl<'gc> TObject<'gc> for StageObject<'gc> {
 
     fn value_of(&self, _mc: MutationContext<'gc, '_>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(Value::Object(Object::from(*self)))
-    }
-}
-
-impl<'gc> Debug for StageObject<'gc> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        match self.0.try_read() {
-            Ok(obj) => f
-                .debug_struct("StageObject")
-                .field("name", &obj.base.debug_class_name())
-                .field("display_object", &obj.display_object)
-                .field("ptr", &self.0.as_ptr())
-                .finish(),
-            Err(err) => f
-                .debug_struct("StageObject")
-                .field("name", &err)
-                .field("display_object", &err)
-                .field("ptr", &self.0.as_ptr())
-                .finish(),
-        }
     }
 }

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -26,11 +26,11 @@ pub fn textformat_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct TextFormatObject<'gc>(GcCell<'gc, TextFormatObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct TextFormatObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -37,11 +37,11 @@ pub fn vector_allocator<'gc>(
 }
 
 /// An Object which stores typed properties in vector storage
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct VectorObject<'gc>(GcCell<'gc, VectorObjectData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct VectorObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -22,11 +22,11 @@ pub fn xml_allocator<'gc>(
     .into())
 }
 
-#[derive(Clone, Collect, Debug, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct XmlObject<'gc>(GcCell<'gc, XmlObjectData<'gc>>);
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct XmlObjectData<'gc> {
     /// Base script object

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -9,7 +9,7 @@ use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
 use gc_arena::{Collect, Gc};
 
-#[derive(Debug, Collect, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub enum Property {
     Virtual { get: Option<u32>, set: Option<u32> },
@@ -31,7 +31,7 @@ pub enum Property {
 /// Additionally, property class resolution uses special
 /// logic, different from normal "runtime" class resolution,
 /// that allows private types to be referenced.
-#[derive(Debug, Collect, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub enum PropertyClass<'gc> {
     /// The type `*` (Multiname::is_any()). This allows

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -12,7 +12,7 @@ use crate::string::{AvmString, Units, WStrToUtf8};
 use bitflags::bitflags;
 use gc_arena::Collect;
 
-#[derive(Collect, Debug)]
+#[derive(Collect)]
 #[collect(no_drop)]
 pub struct RegExp<'gc> {
     source: AvmString<'gc>,
@@ -361,7 +361,7 @@ impl<'gc> RegExp<'gc> {
     }
 }
 
-#[derive(Collect, Debug)]
+#[derive(Collect)]
 #[collect(no_drop)]
 struct CachedText<'gc> {
     text: AvmString<'gc>,

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -10,7 +10,7 @@ use gc_arena::{Collect, Gc, MutationContext};
 use std::ops::Deref;
 
 /// Represents a Scope that can be on either a ScopeChain or local ScopeStack.
-#[derive(Debug, Collect, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct Scope<'gc> {
     /// The underlying object of this Scope
@@ -59,7 +59,7 @@ impl<'gc> Scope<'gc> {
 /// ScopeChain's are copy-on-write, meaning when we chain new scopes on top of a ScopeChain, we
 /// actually create a completely brand new ScopeChain. The Domain of the ScopeChain we are chaining
 /// on top of will be used for the new ScopeChain.
-#[derive(Debug, Collect, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct ScopeChain<'gc> {
     scopes: Option<Gc<'gc, Vec<Scope<'gc>>>>,

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -21,7 +21,7 @@ use swf::avm2::types::{
     AbcFile, Index, Method as AbcMethod, Multiname as AbcMultiname, Script as AbcScript,
 };
 
-#[derive(Copy, Clone, Debug, Collect)]
+#[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub struct TranslationUnit<'gc>(GcCell<'gc, TranslationUnitData<'gc>>);
 
@@ -37,7 +37,7 @@ pub struct TranslationUnit<'gc>(GcCell<'gc, TranslationUnitData<'gc>>);
 /// names preloaded. This roughly corresponds to the logical "loading" phase of
 /// ABC execution as documented in the AVM2 Overview. "Linking" takes place by
 /// constructing the appropriate runtime object for that item.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct TranslationUnitData<'gc> {
     /// The domain that all scripts in the translation unit export defs to.
@@ -329,11 +329,11 @@ impl<'gc> TranslationUnit<'gc> {
 }
 
 /// A loaded Script from an ABC file.
-#[derive(Copy, Clone, Debug, Collect)]
+#[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub struct Script<'gc>(GcCell<'gc, ScriptData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 struct ScriptData<'gc> {
     /// The global object for the script.

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -38,7 +38,7 @@ bitflags! {
 /// load before all other code. We instead generate an initial heap in the same
 /// manner as we do in AVM1, which means that we need to have a way to
 /// dynamically originate traits that do not come from any particular ABC file.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Trait<'gc> {
     /// The name of this trait.
@@ -63,7 +63,7 @@ fn trait_attribs_from_abc_traits(abc_trait: &AbcTrait) -> TraitAttributes {
 ///
 /// The kind of a trait also determines how it's instantiated on the object.
 /// See each individual variant for more information.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum TraitKind<'gc> {
     /// A data field on an object instance that can be read from and written

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -12,6 +12,7 @@ use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::string::{AvmString, WStr};
 use gc_arena::{Collect, MutationContext};
 use std::cell::Ref;
+use std::fmt;
 use swf::avm2::types::{DefaultValue as AbcDefaultValue, Index};
 
 /// Indicate what kind of primitive coercion would be preferred when coercing
@@ -30,7 +31,7 @@ pub enum Hint {
 /// An AVM2 value.
 ///
 /// TODO: AVM2 also needs Scope, Namespace, and XML values.
-#[derive(Clone, Copy, Collect, Debug)]
+#[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
 pub enum Value<'gc> {
     Undefined,
@@ -43,6 +44,20 @@ pub enum Value<'gc> {
     Integer(i32),
     String(AvmString<'gc>),
     Object(Object<'gc>),
+}
+
+impl<'gc> fmt::Debug for Value<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "Undefined"),
+            Self::Null => write!(f, "Null"),
+            Self::Bool(b) => f.debug_tuple("Bool").field(b).finish(),
+            Self::Number(n) => f.debug_tuple("Number").field(n).finish(),
+            Self::Integer(i) => f.debug_tuple("Integer").field(i).finish(),
+            Self::String(s) => f.debug_tuple("String").field(s).finish(),
+            Self::Object(_) => write!(f, "Object(_)"),
+        }
+    }
 }
 
 // This type is used very frequently, so make sure it doesn't unexpectedly grow.

--- a/core/src/avm2/vector.rs
+++ b/core/src/avm2/vector.rs
@@ -19,7 +19,7 @@ use std::slice::SliceIndex;
 ///
 /// A vector may also be configured to have a fixed size; when this is enabled,
 /// attempts to modify the length fail.
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct VectorStorage<'gc> {
     /// The storage for vector values.

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -14,11 +14,11 @@ use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::Ref;
 use std::ops::DerefMut;
 
-#[derive(Collect, Debug, Clone, Copy)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct VTable<'gc>(GcCell<'gc, VTableData<'gc>>);
 
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct VTableData<'gc> {
     /// should always be Some post-initialization
@@ -43,7 +43,7 @@ pub struct VTableData<'gc> {
 // TODO: it might make more sense to just bind the Method to the VTable (and this its class and scope) directly
 // would also be nice to somehow remove the Option-ness from `defining_class` and `scope` fields for this
 // to be more intuitive and cheaper
-#[derive(Collect, Debug, Clone)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct ClassBoundMethod<'gc> {
     pub class: ClassObject<'gc>,

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -156,7 +156,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Collect, Default, Debug)]
+#[derive(Clone, Collect, Default)]
 #[collect(no_drop)]
 pub struct BitmapData<'gc> {
     /// The pixels in the bitmap, stored as a array of pre-multiplied ARGB colour values

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -6,7 +6,7 @@ use crate::display_object::{
 use crate::font::Font;
 use gc_arena::Collect;
 
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum Character<'gc> {
     EditText(EditText<'gc>),

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -22,7 +22,6 @@ use crate::player::Player;
 use crate::prelude::*;
 use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::timer::Timers;
-use core::fmt;
 use gc_arena::{Collect, MutationContext};
 use instant::Instant;
 use rand::rngs::SmallRng;
@@ -506,60 +505,6 @@ impl ActionType<'_> {
             ActionType::Initialize { .. } => 2,
             ActionType::Construct { .. } => 1,
             _ => 0,
-        }
-    }
-}
-
-impl fmt::Debug for ActionType<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ActionType::Normal { bytecode } => f
-                .debug_struct("ActionType::Normal")
-                .field("bytecode", bytecode)
-                .finish(),
-            ActionType::Initialize { bytecode } => f
-                .debug_struct("ActionType::Initialize")
-                .field("bytecode", bytecode)
-                .finish(),
-            ActionType::Construct {
-                constructor,
-                events,
-            } => f
-                .debug_struct("ActionType::Construct")
-                .field("constructor", constructor)
-                .field("events", events)
-                .finish(),
-            ActionType::Method { object, name, args } => f
-                .debug_struct("ActionType::Method")
-                .field("object", object)
-                .field("name", name)
-                .field("args", args)
-                .finish(),
-            ActionType::NotifyListeners {
-                listener,
-                method,
-                args,
-            } => f
-                .debug_struct("ActionType::NotifyListeners")
-                .field("listener", listener)
-                .field("method", method)
-                .field("args", args)
-                .finish(),
-            ActionType::Callable2 {
-                callable,
-                reciever,
-                args,
-            } => f
-                .debug_struct("ActionType::Callable2")
-                .field("callable", callable)
-                .field("reciever", reciever)
-                .field("args", args)
-                .finish(),
-            ActionType::Event2 { event_type, target } => f
-                .debug_struct("ActionType::Event2")
-                .field("event_type", event_type)
-                .field("target", target)
-                .finish(),
         }
     }
 }

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -50,7 +50,7 @@ pub use stage::{Stage, StageAlign, StageDisplayState, StageQuality, StageScaleMo
 pub use text::Text;
 pub use video::Video;
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct DisplayObjectBase<'gc> {
     parent: Option<DisplayObject<'gc>>,
@@ -581,7 +581,7 @@ pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_
 }
 
 #[enum_trait_object(
-    #[derive(Clone, Collect, Debug, Copy)]
+    #[derive(Clone, Collect, Copy)]
     #[collect(no_drop)]
     pub enum DisplayObject<'gc> {
         Stage(Stage<'gc>),
@@ -597,9 +597,7 @@ pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_
         LoaderDisplay(LoaderDisplay<'gc>)
     }
 )]
-pub trait TDisplayObject<'gc>:
-    'gc + Clone + Copy + Collect + Debug + Into<DisplayObject<'gc>>
-{
+pub trait TDisplayObject<'gc>: 'gc + Clone + Copy + Collect + Into<DisplayObject<'gc>> {
     fn base<'a>(&'a self) -> Ref<'a, DisplayObjectBase<'gc>>;
     fn base_mut<'a>(&'a self, mc: MutationContext<'gc, '_>) -> RefMut<'a, DisplayObjectBase<'gc>>;
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -18,11 +18,11 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use swf::ButtonActionCondition;
 
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Avm1Button<'gc>(GcCell<'gc, Avm1ButtonData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Avm1ButtonData<'gc> {
     base: InteractiveObjectBase<'gc>,

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -20,11 +20,11 @@ use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Avm2Button<'gc>(GcCell<'gc, Avm2ButtonData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Avm2ButtonData<'gc> {
     base: InteractiveObjectBase<'gc>,

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -18,7 +18,7 @@ use std::cell::{Ref, RefMut};
 ///
 /// Bitmaps may be associated with either a `Bitmap` or a `BitmapData`
 /// subclass. Its superclass determines how the Bitmap will be constructed.
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub enum BitmapClass<'gc> {
     /// This Bitmap uses the stock Flash Player classes for itself.
@@ -47,11 +47,11 @@ pub enum BitmapClass<'gc> {
 /// but starting in AVM2, a raw `Bitmap` display object can be created
 /// with the `PlaceObject3` tag.
 /// It can also be created in ActionScript using the `Bitmap` class.
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Bitmap<'gc>(GcCell<'gc, BitmapData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct BitmapData<'gc> {
     base: DisplayObjectBase<'gc>,

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -14,7 +14,6 @@ use ruffle_render::commands::CommandHandler;
 use std::cell::{Ref, RefMut};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::fmt::Debug;
 use std::ops::{Bound, RangeBounds};
 
 /// Dispatch the `removedFromStage` event on a child and all of it's
@@ -121,7 +120,7 @@ pub fn dispatch_added_event<'gc>(
 }
 
 #[enum_trait_object(
-    #[derive(Clone, Collect, Debug, Copy)]
+    #[derive(Clone, Collect, Copy)]
     #[collect(no_drop)]
     pub enum DisplayObjectContainer<'gc> {
         Stage(Stage<'gc>),
@@ -131,7 +130,7 @@ pub fn dispatch_added_event<'gc>(
     }
 )]
 pub trait TDisplayObjectContainer<'gc>:
-    'gc + Clone + Copy + Collect + Debug + Into<DisplayObjectContainer<'gc>> + Into<DisplayObject<'gc>>
+    'gc + Clone + Copy + Collect + Into<DisplayObjectContainer<'gc>> + Into<DisplayObject<'gc>>
 {
     /// Get read-only access to the raw container.
     fn raw_container(&self) -> Ref<'_, ChildContainer<'gc>>;
@@ -463,7 +462,7 @@ impl<'gc> From<DisplayObjectContainer<'gc>> for DisplayObject<'gc> {
 /// list. The latter references display objects by their chosen depth; while
 /// the render list represents the order in which those children should be
 /// rendered. Not all children have a position on this depth.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct ChildContainer<'gc> {
     /// The list of all children in render order.

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -51,11 +51,11 @@ pub enum AutoSizeMode {
 /// In AS3, this is created with the `TextField` class. (https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/text/TextField.html)
 ///
 /// (SWF19 DefineEditText pp. 171-174)
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct EditText<'gc>(GcCell<'gc, EditTextData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct EditTextData<'gc> {
     /// DisplayObject and InteractiveObject common properties.

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -14,11 +14,11 @@ use ruffle_render::commands::CommandHandler;
 use std::cell::{Ref, RefMut};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Graphic<'gc>(GcCell<'gc, GraphicData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct GraphicData<'gc> {
     base: DisplayObjectBase<'gc>,

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -19,7 +19,7 @@ use gc_arena::{Collect, MutationContext};
 use instant::Instant;
 use ruffle_macros::enum_trait_object;
 use std::cell::{Ref, RefMut};
-use std::fmt::Debug;
+use std::fmt;
 use std::time::Duration;
 use swf::Twips;
 
@@ -75,7 +75,7 @@ bitflags! {
     }
 }
 
-#[derive(Collect, Clone, Debug)]
+#[derive(Collect, Clone)]
 #[collect(no_drop)]
 pub struct InteractiveObjectBase<'gc> {
     pub base: DisplayObjectBase<'gc>,
@@ -102,7 +102,7 @@ impl<'gc> Default for InteractiveObjectBase<'gc> {
 }
 
 #[enum_trait_object(
-    #[derive(Clone, Collect, Debug, Copy)]
+    #[derive(Clone, Collect, Copy)]
     #[collect(no_drop)]
     pub enum InteractiveObject<'gc> {
         Stage(Stage<'gc>),
@@ -114,7 +114,7 @@ impl<'gc> Default for InteractiveObjectBase<'gc> {
     }
 )]
 pub trait TInteractiveObject<'gc>:
-    'gc + Clone + Copy + Collect + Debug + Into<InteractiveObject<'gc>>
+    'gc + Clone + Copy + Collect + Into<InteractiveObject<'gc>>
 {
     fn raw_interactive(&self) -> Ref<InteractiveObjectBase<'gc>>;
 
@@ -506,3 +506,16 @@ impl<'gc> PartialEq for InteractiveObject<'gc> {
 }
 
 impl<'gc> Eq for InteractiveObject<'gc> {}
+
+impl<'gc> fmt::Debug for InteractiveObject<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stage(_) => write!(f, "Stage(_)"),
+            Self::Avm1Button(_) => write!(f, "Avm1Button(_)"),
+            Self::Avm2Button(_) => write!(f, "Avm2Button(_)"),
+            Self::MovieClip(_) => write!(f, "MovieClip(_)"),
+            Self::EditText(_) => write!(f, "EditText(_)"),
+            Self::LoaderDisplay(_) => write!(f, "LoaderDisplay(_)"),
+        }
+    }
+}

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -12,11 +12,11 @@ use crate::display_object::interactive::InteractiveObjectBase;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
 
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct LoaderDisplay<'gc>(GcCell<'gc, LoaderDisplayData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct LoaderDisplayData<'gc> {
     base: InteractiveObjectBase<'gc>,

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -10,11 +10,11 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::sync::Arc;
 use swf::{Fixed16, Fixed8, Twips};
 
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct MorphShape<'gc>(GcCell<'gc, MorphShapeData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct MorphShapeData<'gc> {
     base: DisplayObjectBase<'gc>,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -65,11 +65,11 @@ enum NextFrame {
 /// However, in AVM2, Sprite is a separate display object, and MovieClip is a subclass of Sprite.
 ///
 /// (SWF19 pp. 201-203)
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct MovieClip<'gc>(GcCell<'gc, MovieClipData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct MovieClipData<'gc> {
     base: InteractiveObjectBase<'gc>,
@@ -322,8 +322,8 @@ impl<'gc> MovieClip<'gc> {
         let is_swf = movie.is_some();
         let movie = movie.unwrap_or_else(|| Arc::new(SwfMovie::empty(mc.movie().version())));
         let total_frames = movie.num_frames();
-        assert_eq!(
-            mc.static_data.loader_info, None,
+        assert!(
+            mc.static_data.loader_info.is_none(),
             "Called replace_movie on a clip with LoaderInfo set"
         );
 
@@ -406,12 +406,8 @@ impl<'gc> MovieClip<'gc> {
                                 .cur_preload_symbol = None;
                         }
                     }
-                    Some(unk) => {
-                        log::error!(
-                            "Symbol {} changed to unexpected type {:?}",
-                            cur_preload_symbol,
-                            unk
-                        );
+                    Some(_) => {
+                        log::error!("Symbol {} changed to unexpected type", cur_preload_symbol,);
 
                         static_data
                             .preload_progress
@@ -4239,7 +4235,7 @@ impl ClipEventHandler {
 }
 
 /// An AVM2 frame script attached to a (presumably AVM2) MovieClip.
-#[derive(Debug, Clone, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct Avm2FrameScript<'gc> {
     /// The frame to invoke this frame script on.

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -31,11 +31,11 @@ use std::str::FromStr;
 
 /// The Stage is the root of the display object hierarchy. It contains all AVM1
 /// levels as well as AVM2 movies.
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Stage<'gc>(GcCell<'gc, StageData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct StageData<'gc> {
     /// Base properties for interactive display objects.

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -13,11 +13,11 @@ use ruffle_render::transform::Transform;
 use std::cell::{Ref, RefMut};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Text<'gc>(GcCell<'gc, TextData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct TextData<'gc> {
     base: DisplayObjectBase<'gc>,

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -30,11 +30,11 @@ use super::StageQuality;
 /// a host SWF, or an externally-loaded FLV or F4V file. In the latter form,
 /// video framerates are (supposedly) permitted to differ from the stage
 /// framerate.
-#[derive(Clone, Debug, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Video<'gc>(GcCell<'gc, VideoData<'gc>>);
 
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct VideoData<'gc> {
     base: DisplayObjectBase<'gc>,

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -4,7 +4,7 @@ use crate::context::UpdateContext;
 pub use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use gc_arena::{Collect, GcCell, MutationContext};
 
-#[derive(Clone, Copy, Collect, Debug)]
+#[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
 pub struct FocusTracker<'gc>(GcCell<'gc, Option<DisplayObject<'gc>>>);
 
@@ -42,7 +42,7 @@ impl<'gc> FocusTracker<'gc> {
             new.on_focus_changed(context.gc_context, true);
         }
 
-        log::info!("Focus is now on {:?}", focused_element);
+        log::info!("Focus is now on {:?}", focused_element.map(|o| o.path()));
 
         let level0 = context.stage.root_clip();
         Avm1::notify_system_listeners(

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -60,7 +60,7 @@ impl EvalParameters {
     }
 }
 
-#[derive(Debug, Clone, Collect, Copy)]
+#[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
 pub struct Font<'gc>(Gc<'gc, FontData>);
 

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -591,7 +591,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 /// `EditText`.
 ///
 /// The content of each box is determined by `LayoutContent`.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub struct LayoutBox<'gc> {
     /// The rectangle corresponding to the outer boundaries of the content box.
@@ -604,7 +604,7 @@ pub struct LayoutBox<'gc> {
 /// Represents different content modes of a given `LayoutBox`.
 ///
 /// Currently, a `LayoutBox` can contain `Text`, `Bullet`s, or a `Drawing`.
-#[derive(Clone, Debug, Collect)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum LayoutContent<'gc> {
     /// A layout box containing some part of a text span.

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -464,7 +464,7 @@ pub enum LoaderStatus {
     Failed,
 }
 
-#[derive(Collect, Clone, Copy, Debug)]
+#[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub enum MovieLoaderEventHandler<'gc> {
     Avm1Broadcast(Object<'gc>),

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -292,7 +292,7 @@ impl Ord for Timer<'_> {
 }
 
 /// A callback fired by a `setInterval`/`setTimeout` timer.
-#[derive(Clone, Collect, Debug)]
+#[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum TimerCallback<'gc> {
     Avm1Function {

--- a/core/src/vminterface.rs
+++ b/core/src/vminterface.rs
@@ -64,7 +64,7 @@ impl Instantiator {
 /// representation of the object. Objects cannot be shared across multiple VMs
 /// and attempting to do so will generate a runtime error. Dual-representation
 /// objects are prohibited.
-#[derive(Copy, Clone, Debug, Collect)]
+#[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub enum AvmObject<'gc> {
     /// An object that is exclusively represented as an AVM1 object. Attempts

--- a/core/src/xml/tree.rs
+++ b/core/src/xml/tree.rs
@@ -514,7 +514,7 @@ impl<'gc> fmt::Debug for XmlNode<'gc> {
                     .unwrap_or_else(|| "None".to_string()),
             )
             .field("node_value", &self.0.read().node_value)
-            .field("attributes", &self.0.read().attributes)
+            .field("attributes", &"_")
             .field("children", &self.0.read().children)
             .finish()
     }

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -16,7 +16,7 @@ downcast-rs = "1.2.0"
 lyon = { version = "1.0.1", optional = true }
 thiserror = "1.0"
 wasm-bindgen = { version = "=0.2.83", optional = true }
-gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "3415c1b1e73621daf51b8cee783a5dc5e63f28fb" }
 
 [dependencies.jpeg-decoder]
 version = "0.3.0"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -12,7 +12,8 @@ ruffle_web_common = { path = "../../web/common" }
 wasm-bindgen = "=0.2.83"
 fnv = "1.0.7"
 ruffle_render = { path = "..", features = ["web"] }
-gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
+
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "3415c1b1e73621daf51b8cee783a5dc5e63f28fb" }
 swf = { path = "../../swf" }
 
 [dependencies.web-sys]

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -73,6 +73,7 @@ impl_downcast!(IndexBuffer);
 pub trait VertexBuffer: Downcast + Collect {}
 impl_downcast!(VertexBuffer);
 
+// TODO(moulins): remove Collect requirement
 pub trait ShaderModule: Downcast + Collect {}
 impl_downcast!(ShaderModule);
 

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -12,7 +12,8 @@ ruffle_web_common = { path = "../../web/common" }
 ruffle_render = { path = "..", features = ["tessellator", "web"] }
 wasm-bindgen = "=0.2.83"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
+
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "3415c1b1e73621daf51b8cee783a5dc5e63f28fb" }
 fnv = "1.0.7"
 swf = { path = "../../swf" }
 thiserror = "1.0"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -23,7 +23,8 @@ image = { version = "0.24.5", default-features = false }
 ouroboros = "0.15.5"
 typed-arena = "2.0.1"
 once_cell = "1.16.0"
-gc-arena = { git = "https://github.com/ruffle-rs/gc-arena" }
+
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "3415c1b1e73621daf51b8cee783a5dc5e63f28fb" }
 naga-agal = { path = "../naga-agal" }
 downcast-rs = "1.2.0"
 


### PR DESCRIPTION
Because `Gc<'_, T>`'s Debug impl now prints the referenced value, (almost) all #[derive(Debug)] on types containing GC'd values were removed (otherwise, Ruffle would enter an infinite recursion when trying to debug-print objects).

This is almost certainly overkill, but I didn't want to take any risks, and useful Debug impls can be re-added again where needed.