### PR TITLE
avm1: Various minor fixes in filters

### DIFF
--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -5,6 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::convolution_filter::ConvolutionFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
+use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -58,7 +59,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&0.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 1.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 1.0))?;
 
     if let Some(filter) = this.as_convolution_filter_object() {
         filter.set_alpha(activation.context.gc_context, alpha);

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -6,6 +6,7 @@ use crate::avm1::object::displacement_map_filter::DisplacementMapFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use crate::string::{AvmString, WStr};
+use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -59,7 +60,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&0.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 1.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 1.0))?;
 
     if let Some(filter) = this.as_displacement_map_filter_object() {
         filter.set_alpha(activation.context.gc_context, alpha);

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -5,6 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::drop_shadow_filter::DropShadowFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
+use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -62,7 +63,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 1.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 1.0))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_alpha(activation.context.gc_context, alpha);
@@ -359,7 +360,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 255.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 255.0))?;
 
     if let Some(object) = this.as_drop_shadow_filter_object() {
         object.set_strength(activation.context.gc_context, strength);

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -5,6 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::glow_filter::GlowFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
+use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -54,7 +55,7 @@ pub fn set_alpha<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 1.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 1.0))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_alpha(activation.context.gc_context, alpha);
@@ -262,7 +263,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&2.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 255.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 255.0))?;
 
     if let Some(filter) = this.as_glow_filter_object() {
         filter.set_strength(activation.context.gc_context, strength);

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -7,6 +7,7 @@ use crate::avm1::object::gradient_bevel_filter::GradientBevelFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
 use crate::string::{AvmString, WStr};
+use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -190,14 +191,18 @@ pub fn set_alphas<'gc>(
 
     if let Value::Object(obj) = alphas {
         if let Some(filter) = this.as_gradient_bevel_filter_object() {
-            let length = (obj.length(activation)? as usize).min(filter.colors().len());
+            let length = filter.colors().len();
+            let obj_length = obj.length(activation)? as usize;
 
             let alphas: Result<Vec<_>, Error<'gc>> = (0..length)
                 .map(|i| {
-                    Ok(obj
-                        .get_element(activation, i as i32)
-                        .coerce_to_f64(activation)?
-                        .clamp(0.0, 1.0))
+                    Ok(if i >= obj_length {
+                        1.0
+                    } else {
+                        obj.get_element(activation, i as i32)
+                            .coerce_to_f64(activation)?
+                            .clamp_also_nan(0.0, 1.0)
+                    })
                 })
                 .collect();
             let alphas = alphas?;
@@ -347,7 +352,7 @@ pub fn set_strength<'gc>(
         .get(0)
         .unwrap_or(&1.into())
         .coerce_to_f64(activation)
-        .map(|x| x.clamp(0.0, 255.0))?;
+        .map(|x| x.clamp_also_nan(0.0, 255.0))?;
 
     if let Some(object) = this.as_gradient_bevel_filter_object() {
         object.set_strength(activation.context.gc_context, strength);

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -60,3 +60,20 @@ impl From<Degrees> for f64 {
         degrees.0
     }
 }
+
+/// Extends the f64 type.
+pub trait F64Extension {
+    fn clamp_also_nan(self, min: f64, max: f64) -> f64;
+}
+
+impl F64Extension for f64 {
+    /// A value bounded by a minimum and a maximum.
+    ///
+    /// `(f64::NAN).clamp(min, max)` causes the code to propagate NaN rather
+    /// than returning either `max` or `min`. Instead this function returns
+    /// the smallest value from the numbers provided.
+    #[allow(clippy::manual_clamp)]
+    fn clamp_also_nan(self, min: f64, max: f64) -> f64 {
+        self.max(min).min(max)
+    }
+}


### PR DESCRIPTION
[Here is the file (.SWF)](https://github.com/ruffle-rs/ruffle/files/10105540/filters.zip) I used for testing.

<details>
  <summary>View raw code</summary>
  
```
trace("ConvolutionFilter");
var x = new flash.filters.ConvolutionFilter();
trace(x.alpha);
x.alpha = NaN;
trace(x.alpha);

trace("");
trace("DisplacementMapFilter");
var x = new flash.filters.DisplacementMapFilter();
trace(x.alpha);
x.alpha = NaN;
trace(x.alpha);

trace("");
trace("DropShadowFilter");
var x = new flash.filters.DropShadowFilter();
trace(x.alpha);
x.alpha = NaN;
trace(x.alpha);
trace(x.strength);
x.strength = NaN;
trace(x.strength);

trace("");
trace("GlowFilter");
var x = new flash.filters.GlowFilter();
trace(x.alpha);
x.alpha = NaN;
trace(x.alpha);
trace(x.strength);
x.strength = NaN;
trace(x.strength);

trace("");
trace("GradientBevelFilter");
var x = new flash.filters.GradientBevelFilter();
x.colors = [16777215,13421772,0];
trace(x.alphas);
x.alphas = [2,NaN];
trace(x.alphas);
trace(x.strength);
x.strength = NaN;
trace(x.strength);

trace("");
trace("GradientGlowFilter");
var x = new flash.filters.GradientGlowFilter();
x.colors = [16777215,13421772,0];
trace(x.alphas);
x.alphas = [2,NaN];
trace(x.alphas);
trace(x.strength);
x.strength = NaN;
trace(x.strength);
```
</details>
