### PR TITLE
ci: Upgrade Node 12 actions workflows

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -124,10 +124,7 @@ jobs:
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev
 
       - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
+        run: cargo build --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
@@ -165,10 +162,7 @@ jobs:
 
       - name: Build Safari Web Extension stub binary
         if: runner.os == 'macOS'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
+        run: cargo build --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
@@ -313,10 +307,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in test_web.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: wasm-bindgen-cli --version 0.2.83
+        run: cargo install wasm-bindgen-cli --version 0.2.83
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -112,11 +112,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -300,11 +299,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Ruffle repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -192,7 +192,7 @@ jobs:
       PACKAGE_FILE: ${{ needs.create-nightly-release.outputs.package_prefix }}-macos-universal.tar.gz
     steps:
       - name: Clone Ruffle repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download aarch64 binary
         uses: actions/download-artifact@v2
@@ -297,7 +297,7 @@ jobs:
         demo: [false, true]
     steps:
       - name: Clone Ruffle repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -307,7 +307,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "16"
           registry-url: https://registry.npmjs.org
@@ -424,7 +424,7 @@ jobs:
 
       - name: Clone web demo
         if: matrix.demo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ruffle-rs/demo
           path: demo
@@ -459,7 +459,7 @@ jobs:
 
       - name: Clone JS docs
         if: ${{ !matrix.demo }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ruffle-rs/js-docs
           path: js-docs
@@ -498,7 +498,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'ruffle-rs/ruffle'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get current time with dashes
         uses: 1466587594/get-current-time@v2

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -62,47 +62,29 @@ jobs:
           shared-key: "desktop"
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Lint AS3 playerglobals 
         if: runner.os == 'Linux' && matrix.rust_version == 'stable'
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p build_playerglobal -- lint
+        run: cargo run -p build_playerglobal -- lint
 
       - name: Check clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --all-features --tests -- -D warnings
+        run: cargo clippy --all --all-features --tests -- -D warnings
 
       - name: Check documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --all-features
+        run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
 
       - name: Run tests with image tests
         if: runner.os == 'Linux' || runner.os == 'Windows'
-        uses: actions-rs/cargo@v1
+        run: cargo test --locked --features imgtests
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
-        with:
-          command: test
-          args: --locked --features imgtests
 
       - name: Run tests without image tests
         if: ${{ !(runner.os == 'Linux' || runner.os == 'Windows') }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --locked
+        run: cargo test --locked
 
       - name: Upload images
         if: failure()

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -43,11 +43,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust_version }}
-          override: true
           components: rustfmt, clippy
 
       - name: Install Linux dependencies

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: dorny/paths-filter@v2
         id: filter
@@ -40,7 +40,7 @@ jobs:
             os: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -57,7 +57,7 @@ jobs:
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers
 
       - name: Cache Cargo output
-        uses: Swatinem/rust-cache@90429b3dea365e9a1b0cb82d7f98aabf3089dc63
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: "desktop"
 

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: dorny/paths-filter@v2
         id: filter
@@ -36,10 +36,10 @@ jobs:
         os: [ubuntu-22.04, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -46,11 +46,10 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust_version }}
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@90429b3dea365e9a1b0cb82d7f98aabf3089dc63

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -52,7 +52,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache Cargo output
-        uses: Swatinem/rust-cache@90429b3dea365e9a1b0cb82d7f98aabf3089dc63
+        uses: Swatinem/rust-cache@v2
         with:
           shared-key: "web"
 


### PR DESCRIPTION
Do the simple v2 ---> v3 workflow upgrades in the first commit.

The second commit has the actions-rs/toolchain ---> dtolnay/rust-toolchain replacement to move away from the seemingly unmaintained https://github.com/actions-rs/toolchain and instead use https://github.com/dtolnay/rust-toolchain.

The third commit is an attempt to move away from the seemingly unmaintained https://github.com/actions-rs/cargo.

The fourth commit switches Swatinem/rust-cache to the more generic v2 instead of a specific revision.