### PR TITLE
Fix BitmapHandle downcasting in webgl and canvas backends

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -2,13 +2,12 @@
 
 use std::sync::Arc;
 
-use downcast_rs::Downcast;
 use gc_arena::MutationContext;
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{
     Context3D, Context3DCommand, RenderBackend, ShapeHandle, ViewportDimensions,
 };
-use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapSource};
+use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapHandleImpl, BitmapSource};
 use ruffle_render::color_transform::ColorTransform;
 use ruffle_render::commands::{CommandHandler, CommandList};
 use ruffle_render::error::Error;
@@ -143,10 +142,10 @@ struct BitmapData {
     context: CanvasRenderingContext2d,
 }
 
-impl ruffle_render::bitmap::BitmapHandleImpl for BitmapData {}
+impl BitmapHandleImpl for BitmapData {}
 
 fn as_bitmap_data(handle: &BitmapHandle) -> &BitmapData {
-    handle.as_any().downcast_ref::<BitmapData>().unwrap()
+    <dyn BitmapHandleImpl>::downcast_ref(&*handle.0).unwrap()
 }
 
 impl BitmapData {

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -3,7 +3,6 @@
 
 use bytemuck::{Pod, Zeroable};
 
-use downcast_rs::Downcast;
 use gc_arena::MutationContext;
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{
@@ -163,7 +162,7 @@ impl Drop for RegistryData {
 impl BitmapHandleImpl for RegistryData {}
 
 fn as_registry_data(handle: &BitmapHandle) -> &RegistryData {
-    handle.as_any().downcast_ref::<RegistryData>().unwrap()
+    <dyn BitmapHandleImpl>::downcast_ref(&*handle.0).unwrap()
 }
 
 const MAX_GRADIENT_COLORS: usize = 15;

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -46,7 +46,7 @@ mod surface;
 impl BitmapHandleImpl for Texture {}
 
 pub fn as_texture(handle: &BitmapHandle) -> &Texture {
-    handle.0.as_any().downcast_ref().unwrap()
+    <dyn BitmapHandleImpl>::downcast_ref(&*handle.0).unwrap()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum)]


### PR DESCRIPTION
There were two issues:
1. We were accidentally calling `as_any` on `handle,` rather than `handle.0`
2. Calling `as_any` can invoke the wrong implementation, depending on what traits are in scope. We want the method implemented on the underlying type (`RegistryData`) to be used, but if `Downcast` is explicitly imported, then we appear to invoke it on the trait object `dyn BitmapHandleImpl` itself (using the fact that trait objects themselves implement `Any`). We now explicitly call the generated method on the trait object, which avoids this issue.