### PR TITLE
core: debug: use ctrl+alt+f to dump DO render tree

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1336,6 +1336,36 @@ pub trait TDisplayObject<'gc>:
         render_base((*self).into(), context)
     }
 
+    #[cfg(feature = "avm_debug")]
+    fn display_render_tree(&self, depth: usize) {
+        let self_str = format!("{:?}", self);
+        let paren = self_str.find('(').unwrap();
+        let self_str = &self_str[..paren];
+
+        let bounds = self.world_bounds();
+
+        let mut classname = "".to_string();
+        if let Some(o) = self.object2().as_object() {
+            classname = format!("{:?}", o.base().debug_class_name());
+        }
+
+        println!(
+            "{} rel({},{}) abs({},{}) {} {} {}",
+            " ".repeat(depth),
+            self.x(),
+            self.y(),
+            bounds.x_min.to_pixels(),
+            bounds.y_min.to_pixels(),
+            classname,
+            self.name(),
+            self_str
+        );
+
+        if let Some(ctr) = self.as_container() {
+            ctr.recurse_render_tree(depth + 1);
+        }
+    }
+
     fn unload(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
         // Unload children.
         if let Some(ctr) = self.as_container() {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -443,6 +443,13 @@ pub trait TDisplayObjectContainer<'gc>:
             context.commands.pop_mask();
         }
     }
+
+    #[cfg(feature = "avm_debug")]
+    fn recurse_render_tree(&self, depth: usize) {
+        for child in self.iter_render_list() {
+            child.display_render_tree(depth);
+        }
+    }
 }
 
 impl<'gc> From<DisplayObjectContainer<'gc>> for DisplayObject<'gc> {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -878,6 +878,16 @@ impl Player {
                         }
                     });
                 }
+                PlayerEvent::KeyDown {
+                    key_code: KeyCode::F,
+                    ..
+                } if self.input.is_key_down(KeyCode::Control)
+                    && self.input.is_key_down(KeyCode::Alt) =>
+                {
+                    self.mutate_with_update_context(|context| {
+                        context.stage.display_render_tree(0);
+                    });
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
Only enabled with `--features=avm_debug`.

Example dump for a very simple preloader. Shows the AS class, DO name and DO type.
```
 rel(0,0) abs(0,0) flash.display::Stage  Stage
  rel(0,0) abs(0,0) Main root1 MovieClip
   rel(360,260) abs(0,0) BLOCnog_fags101_fla::preloader_1 instance17 MovieClip
    rel(-360,-260) abs(0,0) BLOCnog_fags101_fla::bg_1000_2 bg MovieClip
     rel(0,0) abs(0,0) BLOCnog_fags101_fla::bgAni_10000_3 instance2 MovieClip
      rel(0,0) abs(0,0) flash.display::Shape instance1 Graphic
    rel(0,0) abs(170,359.55) flash.display::Shape instance3 Graphic
    rel(-150,-130) abs(210,130) BLOCnog_fags101_fla::adcon_4 adBox MovieClip
     rel(0,0) abs(210,130) flash.display::Shape instance4 Graphic
    rel(0,0) abs(170,90) flash.display::Shape instance5 Graphic
    rel(10,-206) abs(0,0) flash.display::SimpleButton redirFags Avm2Button
    rel(0,0) abs(200,390) flash.display::Shape instance10 Graphic
    rel(-150,170) abs(210,420) flash.display::MovieClip loaderBar MovieClip
     rel(0,0) abs(210,420) flash.display::Shape instance11 Graphic
     rel(300,0) abs(210,420) flash.display::MovieClip bar MovieClip
      rel(0,0) abs(210,420) flash.display::Shape instance12 Graphic
    rel(0,170) abs(0,0) flash.display::SimpleButton startBUT Avm2Button
```