### PR TITLE
core: `Loader` must pass enter/construct frame lifecycle events down

### DIFF
--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -80,6 +80,18 @@ impl<'gc> TDisplayObject<'gc> for LoaderDisplay<'gc> {
     fn as_interactive(self) -> Option<InteractiveObject<'gc>> {
         Some(self.into())
     }
+
+    fn enter_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
+        for child in self.iter_render_list() {
+            child.enter_frame(context);
+        }
+    }
+
+    fn construct_frame(&self, context: &mut UpdateContext<'_, 'gc, '_>) {
+        for child in self.iter_render_list() {
+            child.construct_frame(context);
+        }
+    }
 }
 
 impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108736/205823219-c2db1606-e802-4b86-8e4b-8b7b5ee5abcd.png)

(Almost - this also requires a few method impls that @adrian17 also needs to PR)

Turns out our `Loader` display object was also missing `enter_frame`/`construct_frame` impls. All containers need to implement these methods or the objects put in them will freeze up.