### PR TITLE
ci: Don't use a PPA for mesa (`lavapipe`) anymore on `ubuntu-22.04`

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -50,11 +50,7 @@ jobs:
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y
-          sudo apt-get update
-          sudo apt-get dist-upgrade
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers
+        run: sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Since this PPA was only necessary back when we used `ubuntu-20.04` for CI, where `lavapipe` wasn't yet enabled in mesa.

This may or may not has had something to do with the SIGSEGVs we've seen recently, according to: https://github.com/lutris/lutris/issues/4581#issuecomment-1304638108

I hope this doesn't make the ongoing CI mess any worse. It could at least simplify and speed up tests a bit.