### PR TITLE
AVM2: Implement basic flash.net.navigateToURL

### DIFF
--- a/core/src/avm2/globals/flash/net.as
+++ b/core/src/avm2/globals/flash/net.as
@@ -1,0 +1,6 @@
+package flash.net {
+
+    import flash.net.URLRequest;
+
+    public native function navigateToURL(request:URLRequest, window:String = null):void;
+}

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -1,5 +1,36 @@
 //! `flash.net` namespace
 
+use crate::avm2::object::TObject;
+use crate::avm2::{Activation, Error, Multiname, Object, Value};
+
 pub mod object_encoding;
 pub mod sharedobject;
 pub mod url_loader;
+
+/// Implements `flash.net.navigateToURL`
+pub fn navigate_to_url<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let request = args
+        .get(0)
+        .ok_or("navigateToURL: not enough arguments")?
+        .coerce_to_object(activation)?;
+
+    let target = args
+        .get(1)
+        .ok_or("navigateToURL: not enough arguments")?
+        .coerce_to_string(activation)?;
+
+    let url = request
+        .get_property(&Multiname::public("url"), activation)?
+        .coerce_to_string(activation)?;
+
+    activation
+        .context
+        .navigator
+        .navigate_to_url(url.to_string(), target.to_string(), None);
+
+    Ok(Value::Undefined)
+}

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -163,6 +163,7 @@ include "flash/media/StageVideoAvailabilityReason.as"
 include "flash/media/VideoCodec.as"
 include "flash/media/VideoStatus.as"
 
+include "flash/net.as"
 include "flash/net/FileFilter.as"
 include "flash/net/FileReference.as"
 include "flash/net/FileReferenceList.as"


### PR DESCRIPTION
This implements the most basic use of [flash.net.navigateToURL](https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/package.html#navigateToURL()), opening the given URL.

Fixes errors logged when clicking on links, e.g. armor games logo in HitBox loader.