### PR TITLE
AVM2: Implement System.setClipboard

### DIFF
--- a/core/src/avm2/globals/flash/system.rs
+++ b/core/src/avm2/globals/flash/system.rs
@@ -3,3 +3,4 @@
 
 pub mod application_domain;
 pub mod security;
+pub mod system;

--- a/core/src/avm2/globals/flash/system/System.as
+++ b/core/src/avm2/globals/flash/system/System.as
@@ -3,5 +3,7 @@ package flash.system {
         public static function gc(): void {
 
         }
+
+        public static native function setClipboard(string:String): void;
     }
 }

--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -1,0 +1,25 @@
+//! `flash.system.System` native methods
+
+use crate::avm2::activation::Activation;
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+
+/// Implements `flash.system.System.setClipboard` method
+pub fn set_clipboard<'gc>(
+    activation: &mut Activation<'_, 'gc, '_>,
+    _this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    //TODO: in FP9+ this function only works when called from a button handler in the Plugin due to
+    // sandbox restrictions
+    let new_content = args
+        .get(0)
+        .unwrap_or(&Value::Undefined)
+        .coerce_to_string(activation)?
+        .to_string();
+
+    activation.context.ui.set_clipboard_content(new_content);
+
+    Ok(Value::Undefined)
+}

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -56,6 +56,8 @@ impl UiBackend for WebUiBackend {
     }
 
     fn set_clipboard_content(&mut self, _content: String) {
+        //TODO: in AVM2 FP9+ this only works when called from a button handler due to sandbox
+        // restrictions
         log::warn!("set clipboard not implemented");
     }
 


### PR DESCRIPTION
Implements [System.setClipboard()](https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/system/System.html#setClipboard())

Fixes #8435 