### PR TITLE
web: Fix strings using buildInfo variables

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -865,7 +865,7 @@ export class RufflePlayer extends HTMLElement {
 
         const extensionString = this.isExtension ? "extension" : "";
         items.push({
-            text: `About Ruffle ${extensionString} (buildInfo.versionName)`,
+            text: `About Ruffle ${extensionString} (${buildInfo.versionName})`,
             onClick() {
                 window.open(RUFFLE_ORIGIN, "_blank");
             },
@@ -1155,11 +1155,11 @@ export class RufflePlayer extends HTMLElement {
         );
 
         dataArray.push("\n# Ruffle Info\n");
-        dataArray.push(`Version: buildInfo.versionNumber\n`);
-        dataArray.push(`Name: buildInfo.versionName\n`);
-        dataArray.push(`Channel: buildInfo.versionChannel\n`);
-        dataArray.push(`Built: buildInfo.buildDate\n`);
-        dataArray.push(`Commit: buildInfo.commitHash\n`);
+        dataArray.push(`Version: ${buildInfo.versionNumber}\n`);
+        dataArray.push(`Name: ${buildInfo.versionName}\n`);
+        dataArray.push(`Channel: ${buildInfo.versionChannel}\n`);
+        dataArray.push(`Built: ${buildInfo.buildDate}\n`);
+        dataArray.push(`Commit: ${buildInfo.commitHash}\n`);
         dataArray.push(`Is extension: ${this.isExtension}\n`);
         dataArray.push("\n# Metadata\n");
         if (this.metadata) {
@@ -1391,7 +1391,7 @@ export class RufflePlayer extends HTMLElement {
                     <p>If you are the server administrator, we invite you to try loading the file on a blank page.</p>
                 `;
                 if (isBuildOutdated) {
-                    errorBody += `<p>You can also try to upload a more recent version of Ruffle that may circumvent the issue (current build is outdated: buildInfo.buildDate).</p>`;
+                    errorBody += `<p>You can also try to upload a more recent version of Ruffle that may circumvent the issue (current build is outdated: ${buildInfo.buildDate}).</p>`;
                 }
                 errorFooter = `
                     <li>${actionTag}</li>
@@ -1416,7 +1416,7 @@ export class RufflePlayer extends HTMLElement {
                 if (!isBuildOutdated) {
                     errorBody += `<p>This isn't supposed to happen, so we'd really appreciate if you could file a bug!</p>`;
                 } else {
-                    errorBody += `<p>If you are the server administrator, please try to upload a more recent version of Ruffle (current build is outdated: buildInfo.buildDate).</p>`;
+                    errorBody += `<p>If you are the server administrator, please try to upload a more recent version of Ruffle (current build is outdated: ${buildInfo.buildDate}).</p>`;
                 }
                 errorFooter = `
                     <li>${actionTag}</li>


### PR DESCRIPTION
Unfortunately I didn't catch this mistake before #8728 was merged, but buildInfo variables were not correctly interpolated into the format strings:
![image](https://user-images.githubusercontent.com/71368227/207531579-c5497b8e-5f60-46b5-ab2a-4a2f5936fbff.png)

![image](https://user-images.githubusercontent.com/71368227/207531592-b34a4039-0efd-4bf9-a9dd-cb64f966f191.png)

This PR fixes the issue.