### PR TITLE
ci: Use `ubuntu-latest`

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-nightly-release:
     name: Create Nightly Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       activity_check: ${{ env.GHA_REPO_ALIVE }}
       date: ${{ steps.current_time_underscores.outputs.formattedTime }}
@@ -77,7 +77,7 @@ jobs:
       matrix:
         include:
           - build_name: linux-x86_64
-            os: ubuntu-22.04
+            os: ubuntu-latest
 
           # Mac does two Rust builds to make a universal binary
           - build_name: macos-x86_64
@@ -284,7 +284,7 @@ jobs:
     name: Build web${{ matrix.demo && ' demo' || '' }}
     needs: create-nightly-release
     if: needs.create-nightly-release.outputs.activity_check == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         demo: [false, true]
@@ -484,7 +484,7 @@ jobs:
   publish-aur-package:
     name: Publish AUR package
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: github.repository == 'ruffle-rs/ruffle'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   changes:
     name: Paths filter
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
@@ -32,12 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         rust_version: [stable]
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - rust_version: nightly
-            os: ubuntu-22.04
+            os: ubuntu-latest
           - rust_version: beta
-            os: ubuntu-22.04
+            os: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -97,12 +97,12 @@ jobs:
     strategy:
       matrix:
         rust_version: [stable]
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - rust_version: nightly
-            os: ubuntu-22.04
+            os: ubuntu-latest
           - rust_version: beta
-            os: ubuntu-22.04
+            os: ubuntu-latest
 
     steps:
       - name: No-op

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   changes:
     name: Paths filter
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
@@ -33,7 +33,7 @@ jobs:
       matrix:
         node_version: ["18", "19"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
       matrix:
         node_version: ["18", "19"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: No-op


### PR DESCRIPTION
Since `ubuntu-22.04` became default, we no longer need to mention it explicitly.

This basically reverts #7694.