### PR TITLE
extension: Disable minification

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -82,6 +82,9 @@ module.exports = (env, _argv) => {
             assetFilter: (assetFilename) =>
                 !/\.(map|wasm)$/i.test(assetFilename),
         },
+        optimization: {
+            minimize: false,
+        },
         plugins: [
             new CopyPlugin({
                 patterns: [


### PR DESCRIPTION
Extension marketplaces recommend avoiding minifying JS code, as it does not provide benefit for local files and inhibits the review process.