### PR TITLE
chore: Inherit cargo metadata from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ members = [
 resolver = "2"
 
 [workspace.package]
+authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition = "2021"
+homepage = "https://ruffle.rs"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/ruffle-rs/ruffle"
+version = "0.1.0"
 
 # Don't optimize build scripts and macros.
 [profile.release.build-override]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_core"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 byteorder = "1.4"

--- a/core/build_playerglobal/Cargo.toml
+++ b/core/build_playerglobal/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "build_playerglobal"
-version = "0.1.0"
+authors.workspace = true
 edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 convert_case = "0.6.0"

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "ruffle_macros"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [lib]
 proc-macro = true

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_desktop"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 clap = { version = "4.0.27", features = ["derive"] }

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "exporter"
-version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 clap = { version = "4.0.27", features = ["derive"] }

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_render"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 swf = { path = "../swf"}

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_render_canvas"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 js-sys = "0.3.60"

--- a/render/naga-agal/Cargo.toml
+++ b/render/naga-agal/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "naga-agal"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 bitflags = "1.3.2"

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_render_webgl"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 js-sys = "0.3.60"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_render_wgpu"
-version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 wgpu = { version = "0.14.2", features = ["naga"] }

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_scanner"
-version = "0.1.0"
 authors = ["Nathan Adams <dinnerbone@dinnerbone.com>"]
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 clap = { version = "4.0.27", features = ["derive"] }

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "swf"
 version = "0.2.0"
-edition.workspace = true
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
-repository = "https://github.com/ruffle-rs/ruffle"
-homepage = "https://github.com/ruffle-rs/ruffle"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
 description = "Read and write the Adobe Flash SWF file format."
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 bitflags = "1.3.2"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "tests"
-version = "0.1.0"
 authors = ["Aaron Hill <aa1ronham@gmail.com>"]
 edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 futures = "0.3.25"

--- a/tests/input-format/Cargo.toml
+++ b/tests/input-format/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "ruffle_input_format"
-version = "0.1.0"
+authors.workspace = true
 edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 serde = { version = "1.0.150", features = ["derive"] }

--- a/video/Cargo.toml
+++ b/video/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_video"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 swf = { path = "../swf" }

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_video_software"
-version = "0.1.0"
-authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
+authors.workspace = true
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 ruffle_render = { path = "../../render" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "ruffle_web"
-version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
-edition.workspace = true
-license = "MIT OR Apache-2.0"
 description = "Web (WASM) bindings to the Ruffle flash player"
-readme = "README.md"
-homepage = "https://ruffle.rs"
-repository = "https://github.com/ruffle-rs/ruffle/"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 publish = false # This crate is useless alone, people should use the npm package
 
 [lib]

--- a/web/packages/extension/safari/Cargo.toml
+++ b/web/packages/extension/safari/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "ruffle_web_safari"
-version = "0.1.0"
-authors = ["Mike Welsh <mwelsh@gmail.com>"]
-edition.workspace = true
-license = "MIT OR Apache-2.0"
 description = "Native binary for the Safari Web Extension"
-readme = "README.md"
-homepage = "https://ruffle.rs"
-repository = "https://github.com/ruffle-rs/ruffle/"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 publish = false # This crate is useless unless packaged into an appex bundle
 
 [dependencies]

--- a/wstr/Cargo.toml
+++ b/wstr/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "ruffle_wstr"
-version = "0.1.0"
-edition.workspace = true
 authors = ["Arthur Heuillard <arthur.heuillard<orange.fr>"]
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 static_assertions = "1.1.0"


### PR DESCRIPTION
Use workspace inheritance added in Rust 1.64 to de-duplicate various settings across all packages.

Settings like `version`, `homepage`, etc. are shared among the entire workspace, so we can specify these once and inherit them.
 * Most of these packages are meant to only be used by Ruffle, so we should use one `version` # for the entire workspace. 
   * `swf` being an exception that is meant to be usable on its own.
 * I kept any unique `authors` field.
