### PR TITLE
ci: Add OAuth client secret to chrome-extension-upload

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -408,6 +408,7 @@ jobs:
         with:
           extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
           client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
           refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
           file-path: ./web/packages/extension/dist/ruffle_extension.zip
 


### PR DESCRIPTION
Google's OAuth flow changed and this additional client secret is now required for uploading the Chrome extension.