### PR TITLE
web: Don't unnecessarily borrow-mut instance on mouse-down

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -663,7 +663,7 @@ impl Ruffle {
 
             // Create mouse up handler.
             let mouse_up_callback = Closure::wrap(Box::new(move |js_event: PointerEvent| {
-                let _ = ruffle.with_instance_mut(|instance| {
+                let _ = ruffle.with_instance(|instance| {
                     if let Some(target) = js_event.current_target() {
                         let _ = target
                             .unchecked_ref::<Element>()


### PR DESCRIPTION
Fixes panic screen not popping up when panicking code is triggered by mouse click.