### PR TITLE
Clears the AVM1 stack after executing bytecode

### DIFF
--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -314,6 +314,10 @@ impl<'gc> Avm1<'gc> {
         self.stack.len()
     }
 
+    pub fn clear_stack(&mut self) {
+        self.stack.clear()
+    }
+
     pub fn push(&mut self, value: Value<'gc>) {
         avm_debug!(self, "Stack push {}: {value:?}", self.stack.len());
         self.stack.push(value);

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1661,6 +1661,10 @@ impl Player {
                     }
                 }
             }
+
+            // AVM1 bytecode may leave the stack unbalanced, so do not let garbage values accumulate
+            // across multiple executions and/or frames.
+            context.avm1.clear_stack();
         }
     }
 


### PR DESCRIPTION
AVM1 bytecode may leave the operand stack unbalanced, and this will cause a slow memory leak if the stack is never cleared.