### PR TITLE
avm2: Add ctrlKey, altKey, shiftKey, controlKey properties to KeyboardEvent

### DIFF
--- a/core/src/avm2/globals/flash/events/KeyboardEvent.as
+++ b/core/src/avm2/globals/flash/events/KeyboardEvent.as
@@ -6,6 +6,10 @@ package flash.events
         public static const KEY_UP:String = "keyUp";
         private var _charCode:uint;
         private var _keyCode:uint;
+        private var _ctrlKey:Boolean;
+        private var _altKey:Boolean;
+        private var _shiftKey:Boolean;
+        private var _controlKey:Boolean;
 
         public function KeyboardEvent(type:String, 
                                       bubbles:Boolean = true, 
@@ -15,11 +19,17 @@ package flash.events
                                       keyLocationValue:uint = 0, 
                                       ctrlKeyValue:Boolean = false, 
                                       altKeyValue:Boolean = false, 
-                                      shiftKeyValue:Boolean = false)
+                                      shiftKeyValue:Boolean = false, 
+                                      controlKeyValue:Boolean = false, 
+                                      commandKeyValue:Boolean = false)
         {
             super(type,bubbles,cancelable);
             this._charCode = charCodeValue;
             this._keyCode = keyCodeValue;
+            this._ctrlKey = ctrlKeyValue;
+            this._altKey = altKeyValue;
+            this._shiftKey = shiftKeyValue;
+            this._controlKey = controlKeyValue;
         }
 
         public function get charCode():uint {
@@ -34,6 +44,34 @@ package flash.events
         }
         public function set keyCode(val:uint) {
             this._keyCode = val;
+        }
+
+        public function get ctrlKey():Boolean {
+            return this._ctrlKey;
+        }
+        public function set ctrlKey(val:Boolean) {
+            this._ctrlKey = val;
+        }
+
+        public function get altKey():Boolean {
+            return this._altKey;
+        }
+        public function set altKey(val:Boolean) {
+            this._altKey = val;
+        }
+
+        public function get shiftKey():Boolean {
+            return this._shiftKey;
+        }
+        public function set shiftKey(val:Boolean) {
+            this._shiftKey = val;
+        }
+
+        public function get controlKey():Boolean {
+            return this._controlKey;
+        }
+        public function set controlKey(val:Boolean) {
+            this._controlKey = val;
         }
 
         override public function clone() : Event

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -948,6 +948,10 @@ impl Player {
                 if let PlayerEvent::KeyDown { key_code, key_char }
                 | PlayerEvent::KeyUp { key_code, key_char } = event
                 {
+                    let ctrl_key = context.input.is_key_down(KeyCode::Control);
+                    let alt_key = context.input.is_key_down(KeyCode::Alt);
+                    let shift_key = context.input.is_key_down(KeyCode::Shift);
+
                     let mut activation = Avm2Activation::from_nothing(context.reborrow());
 
                     let event_name = match event {
@@ -959,15 +963,24 @@ impl Player {
                     let keyboardevent_class = activation.avm2().classes().keyboardevent;
                     let event_name_val: Avm2Value<'_> =
                         AvmString::new_utf8(activation.context.gc_context, event_name).into();
+
+                    // TODO: keyLocation should not be a dummy value.
+                    // ctrlKey and controlKey can be different from each other on Mac.
+                    // commandKey should be supported.
                     let keyboard_event = keyboardevent_class
                         .construct(
                             &mut activation,
                             &[
-                                event_name_val,
+                                event_name_val,                          /* type */
                                 true.into(),                             /* bubbles */
                                 false.into(),                            /* cancelable */
                                 key_char.map_or(0, |c| c as u32).into(), /* charCode */
                                 (key_code as u32).into(),                /* keyCode */
+                                0.into(),                                /* keyLocation */
+                                ctrl_key.into(),                         /* ctrlKey */
+                                alt_key.into(),                          /* altKey */
+                                shift_key.into(),                        /* shiftKey */
+                                ctrl_key.into(),                         /* controlKey */
                             ],
                         )
                         .expect("Failed to construct KeyboardEvent");


### PR DESCRIPTION
Based on [similar logic](https://github.com/ruffle-rs/ruffle/blob/664c67ea27ac98337fb7cb01b976c3b34cdd2164/core/src/avm2/object/event_object.rs#L127-L136) already existing in MouseEvent.

I also included controlKey as always having the same value, which [is not strictly correct](https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/events/KeyboardEvent.html) (there are differences on Mac), but I figured was better than leaving it out entirely. I did not include commandKey at all, though.