### PR TITLE
avm2: Fix calling setTextFormat without providing a beginIndex and endIndex

### DIFF
--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -840,11 +840,11 @@ pub fn set_text_format<'gc>(
             if let Some(tf) = tf.as_text_format() {
                 let mut begin_index = args
                     .get(1)
-                    .unwrap_or(&Value::Undefined)
+                    .unwrap_or(&(-1).into())
                     .coerce_to_i32(activation)?;
                 let mut end_index = args
                     .get(2)
-                    .unwrap_or(&Value::Undefined)
+                    .unwrap_or(&(-1).into())
                     .coerce_to_i32(activation)?;
 
                 if begin_index < 0 {


### PR DESCRIPTION
Previous behaviour defaulted to undefined and applied the format to the range [0,0). The default should be -1, which applies the format to the full length of the TextField.

This fixes the text color in the windows that pop up when you click objects in [this flash](https://mrcheeze.github.io/homestuck-ruffle-tester/#00253). (Currently the text is displaying black and unreadable, with this fix it changes to white like it's supposed to.)