### PR TITLE
docs: Document Java in the web version README, too

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -51,7 +51,7 @@ For the compiler to be able to output WebAssembly, an additional target has to b
 Follow the instructions [to install OpenJDK](https://openjdk.org/projects/jdk/19/) on your machine.
 
 We do not have a specific Java support policy. Any Java version that supports running the AS3 compiler
-should work.
+should work. Additionally, headless JREs should also work.
 
 #### Node.js
 

--- a/web/README.md
+++ b/web/README.md
@@ -46,6 +46,13 @@ rust using the above instructions).
 
 For the compiler to be able to output WebAssembly, an additional target has to be added to it: `rustup target add wasm32-unknown-unknown`
 
+#### Java
+
+Follow the instructions [to install OpenJDK](https://openjdk.org/projects/jdk/19/) on your machine.
+
+We do not have a specific Java support policy. Any Java version that supports running the AS3 compiler
+should work.
+
 #### Node.js
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.


### PR DESCRIPTION
Our build process has required Java for a while, but we don't document this requirement as good as we could. This is a problem for people who need to build from scratch in a container (such as, say, extension reviewers).