### PR TITLE
Remove & disallow unwraps in various crates

### DIFF
--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -307,8 +307,9 @@ impl Iterator for StreamTagReader {
                             // RESEARCHME: How does Flash Player actually determine when there is an audio gap or not?
                             // If an MP3 audio track has gaps, Flash Player will often play it out of sync (too early).
                             // Seems closely related to `stream_info.num_samples_per_block`.
-                            let num_samples =
-                                u16::from_le_bytes(audio_block[..2].try_into().unwrap());
+                            let num_samples = u16::from_le_bytes(
+                                audio_block[..2].try_into().expect("2 bytes fit into a u16"),
+                            );
                             self.mp3_samples_buffered += i32::from(num_samples);
                             audio_block = &audio_block[4..];
                         }

--- a/core/src/backend/audio/decoders/adpcm.rs
+++ b/core/src/backend/audio/decoders/adpcm.rs
@@ -172,6 +172,7 @@ impl<R: AsRef<[u8]> + Default + Send + Sync> SeekableDecoder for AdpcmDecoder<Cu
         let bit_stream = std::mem::replace(&mut self.inner, BitReader::new(Default::default()));
         let mut cursor = bit_stream.into_reader();
         cursor.set_position(0);
-        *self = AdpcmDecoder::new(cursor, self.num_channels() == 2, self.sample_rate()).unwrap();
+        *self = AdpcmDecoder::new(cursor, self.num_channels() == 2, self.sample_rate())
+            .expect("Existing valid decoder should be valid when recreated");
     }
 }

--- a/core/src/backend/audio/decoders/mp3.rs
+++ b/core/src/backend/audio/decoders/mp3.rs
@@ -67,7 +67,7 @@ impl Mp3Decoder {
     ) -> Result<Self, Error> {
         let source = Box::new(reader) as Box<dyn io::MediaSource>;
         let source = io::MediaSourceStream::new(source, Default::default());
-        let reader = SymphoniaMp3Reader::try_new(source, &Default::default()).unwrap();
+        let reader = SymphoniaMp3Reader::try_new(source, &Default::default())?;
         let track = reader.default_track().ok_or(Error::NoDefaultTrack)?;
         let codec_params = track.codec_params.clone();
         let decoder = symphonia::default::get_codecs().make(&codec_params, &Default::default())?;

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -249,11 +249,11 @@ impl NullNavigatorBackend {
         }
     }
 
-    pub fn with_base_path(path: &Path, executor: &NullExecutor) -> Self {
-        Self {
+    pub fn with_base_path(path: &Path, executor: &NullExecutor) -> Result<Self, std::io::Error> {
+        Ok(Self {
             spawner: executor.spawner(),
-            relative_base_path: path.canonicalize().unwrap(),
-        }
+            relative_base_path: path.canonicalize()?,
+        })
     }
 
     #[cfg(any(unix, windows, target_os = "redox"))]

--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -24,12 +24,14 @@ fn main() {
         println!("cargo:rustc-cfg=nightly");
     }
 
-    let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
+    let out_dir: PathBuf = env::var_os("OUT_DIR")
+        .expect("OUT_DIR environment variable must be set and valid")
+        .into();
 
     File::create(out_dir.join("version-info.txt"))
-        .unwrap()
+        .expect("Must be able to create a file in OUT_DIR")
         .write_all(commit_info().as_bytes())
-        .unwrap();
+        .expect("Must be able to write to OUT_DIR");
 }
 
 // Try to get hash and date of the last commit on a best effort basis. If anything goes wrong

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -274,7 +274,7 @@ impl App {
             .with_navigator(navigator)
             .with_renderer(renderer)
             .with_storage(storage::DiskStorageBackend::new()?)
-            .with_ui(ui::DesktopUiBackend::new(window.clone()))
+            .with_ui(ui::DesktopUiBackend::new(window.clone())?)
             .with_autoplay(true)
             .with_letterbox(Letterbox::On)
             .with_warn_on_unsupported_content(!opt.dont_warn_on_unsupported_content)

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -273,7 +273,7 @@ impl App {
         builder = builder
             .with_navigator(navigator)
             .with_renderer(renderer)
-            .with_storage(storage::DiskStorageBackend::new())
+            .with_storage(storage::DiskStorageBackend::new()?)
             .with_ui(ui::DesktopUiBackend::new(window.clone()))
             .with_autoplay(true)
             .with_letterbox(Letterbox::On)

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 // By default, Windows creates an additional console window for our program.
 //
 //

--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -51,12 +51,9 @@ impl ExternalNavigatorBackend {
 
         // Force replace the last segment with empty. //
 
-        base_url
-            .path_segments_mut()
-            .unwrap()
-            .pop_if_empty()
-            .pop()
-            .push("");
+        if let Ok(mut base_url) = base_url.path_segments_mut() {
+            base_url.pop_if_empty().pop().push("");
+        }
 
         Self {
             channel,
@@ -143,7 +140,7 @@ impl NavigatorBackend for ExternalNavigatorBackend {
                         if e.kind() == ErrorKind::PermissionDenied {
                             let attempt_sandbox_open = MessageDialog::new()
                                 .set_level(MessageLevel::Warning)
-                                .set_description(&format!("The current movie is attempting to read files stored in {}.\n\nTo allow it to do so, click Yes, and then Open to grant read access to that directory.\n\nOtherwise, click No to deny access.", path.parent().unwrap().to_string_lossy()))
+                                .set_description(&format!("The current movie is attempting to read files stored in {}.\n\nTo allow it to do so, click Yes, and then Open to grant read access to that directory.\n\nOtherwise, click No to deny access.", path.parent().unwrap_or(&path).to_string_lossy()))
                                 .set_buttons(MessageButtons::YesNo)
                                 .show();
 

--- a/desktop/src/storage.rs
+++ b/desktop/src/storage.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Error};
 use ruffle_core::backend::storage::StorageBackend;
 use std::fs;
 use std::fs::File;
@@ -10,8 +11,10 @@ pub struct DiskStorageBackend {
 }
 
 impl DiskStorageBackend {
-    pub fn new() -> Self {
-        let base_path = dirs::data_local_dir().unwrap().join("ruffle");
+    pub fn new() -> Result<Self, Error> {
+        let base_path = dirs::data_local_dir()
+            .context("Couldn't find a valid data_local dir")?
+            .join("ruffle");
         let shared_objects_path = base_path.join("SharedObjects");
 
         // Create a base dir if one doesn't exist yet
@@ -22,10 +25,10 @@ impl DiskStorageBackend {
             }
         }
 
-        DiskStorageBackend {
+        Ok(DiskStorageBackend {
             base_path,
             shared_objects_path,
-        }
+        })
     }
 
     /// Verifies that the path contains no `..` components to prevent accessing files outside of the Ruffle directory.

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+
 use gc_arena::MutationContext;
 use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -146,7 +146,7 @@ impl BitmapHandleImpl for BitmapData {}
 
 fn as_bitmap_data(handle: &BitmapHandle) -> &BitmapData {
     <dyn BitmapHandleImpl>::downcast_ref(&*handle.0)
-        .expect("Bitmap handle must be BitmapHandleImpl")
+        .expect("Bitmap handle must be a Canvas BitmapData")
 }
 
 impl BitmapData {

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+
 pub mod backend;
 pub mod bitmap;
 pub mod bounding_box;

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -178,14 +178,14 @@ impl PathSegment {
         self.points.len() <= 1
     }
 
-    fn start(&self) -> (Twips, Twips) {
-        let pt = &self.points.first().unwrap();
-        (pt.x, pt.y)
+    fn start(&self) -> Option<(Twips, Twips)> {
+        let pt = &self.points.first()?;
+        Some((pt.x, pt.y))
     }
 
-    fn end(&self) -> (Twips, Twips) {
-        let pt = &self.points.last().unwrap();
-        (pt.x, pt.y)
+    fn end(&self) -> Option<(Twips, Twips)> {
+        let pt = &self.points.last()?;
+        Some((pt.x, pt.y))
     }
 
     fn is_closed(&self) -> bool {

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -195,7 +195,7 @@ impl PathSegment {
     fn to_draw_commands(&self) -> impl '_ + Iterator<Item = DrawCommand> {
         assert!(!self.is_empty());
         let mut i = self.points.iter();
-        let first = i.next().unwrap();
+        let first = i.next().expect("Points isn't empty");
         std::iter::once(DrawCommand::MoveTo {
             x: first.x,
             y: first.y,

--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -195,7 +195,7 @@ impl PathSegment {
     fn to_draw_commands(&self) -> impl '_ + Iterator<Item = DrawCommand> {
         assert!(!self.is_empty());
         let mut i = self.points.iter();
-        let first = i.next().expect("Points isn't empty");
+        let first = i.next().expect("Points should not be empty");
         std::iter::once(DrawCommand::MoveTo {
             x: first.x,
             y: first.y,

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -167,7 +167,7 @@ impl BitmapHandleImpl for RegistryData {}
 
 fn as_registry_data(handle: &BitmapHandle) -> &RegistryData {
     <dyn BitmapHandleImpl>::downcast_ref(&*handle.0)
-        .expect("Bitmap handle must be BitmapHandleImpl")
+        .expect("Bitmap handle must be webgl RegistryData")
 }
 
 const MAX_GRADIENT_COLORS: usize = 15;

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::bool_to_int_with_if)]
+#![deny(clippy::unwrap_used)]
 
 use bytemuck::{Pod, Zeroable};
 use std::borrow::Cow;

--- a/scanner/src/execute.rs
+++ b/scanner/src/execute.rs
@@ -21,7 +21,7 @@ fn execute_swf(file: &Path) {
     let frame_time = 1000.0 / movie.frame_rate().to_f64();
     let player = PlayerBuilder::new()
         .with_log(ScanLogBackend::new())
-        .with_navigator(NullNavigatorBackend::with_base_path(base_path, &executor))
+        .with_navigator(NullNavigatorBackend::with_base_path(base_path, &executor).unwrap())
         .with_max_execution_duration(Duration::from_secs(300))
         .with_movie(movie)
         .build();

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -1444,7 +1444,7 @@ fn run_swf(
 
     let player = builder
         .with_log(TestLogBackend::new(trace_output.clone()))
-        .with_navigator(NullNavigatorBackend::with_base_path(base_path, &executor))
+        .with_navigator(NullNavigatorBackend::with_base_path(base_path, &executor)?)
         .with_max_execution_duration(Duration::from_secs(300))
         .with_viewport_dimensions(
             movie.width().to_pixels() as u32,

--- a/video/src/lib.rs
+++ b/video/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+
 use generational_arena::Index;
 
 pub mod backend;

--- a/web/packages/extension/safari/src/main.rs
+++ b/web/packages/extension/safari/src/main.rs
@@ -5,9 +5,13 @@ mod macos {
     use objc::runtime::Protocol;
 
     pub fn extension_class() {
-        let mut ruffle = ClassDecl::new("RuffleWebExtension", class!(NSObject)).unwrap();
+        let mut ruffle = ClassDecl::new("RuffleWebExtension", class!(NSObject))
+            .expect("Couldn't allocate new ClassDecl");
 
-        ruffle.add_protocol(Protocol::get("NSExtensionRequestHandling").unwrap());
+        ruffle.add_protocol(
+            Protocol::get("NSExtensionRequestHandling")
+                .expect("Couldn't find NSExtensionRequestHandling"),
+        );
 
         ruffle.register();
     }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+
 //! Ruffle web frontend.
 mod audio;
 mod log_adapter;

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -110,9 +110,9 @@ impl NavigatorBackend for WebNavigatorBackend {
 
                 let form = document
                     .create_element("form")
-                    .unwrap()
+                    .expect("create_element() must succeed")
                     .dyn_into::<web_sys::HtmlFormElement>()
-                    .unwrap();
+                    .expect("create_element('form') didn't give us a form");
 
                 let _ = form.set_attribute(
                     "method",
@@ -129,7 +129,9 @@ impl NavigatorBackend for WebNavigatorBackend {
                 }
 
                 for (k, v) in formvars.iter() {
-                    let hidden = document.create_element("input").unwrap();
+                    let hidden = document
+                        .create_element("input")
+                        .expect("create_element() must succeed");
 
                     let _ = hidden.set_attribute("type", "hidden");
                     let _ = hidden.set_attribute("name", k);
@@ -178,9 +180,9 @@ impl NavigatorBackend for WebNavigatorBackend {
 
                 let datablob =
                     Blob::new_with_buffer_source_sequence_and_options(&blobparts, &blobprops)
-                        .unwrap()
+                        .map_err(|_| Error::FetchError("Got JS error".to_string()))?
                         .dyn_into()
-                        .unwrap();
+                        .map_err(|_| Error::FetchError("Got JS error".to_string()))?;
 
                 init.body(Some(&datablob));
             }
@@ -193,7 +195,9 @@ impl NavigatorBackend for WebNavigatorBackend {
                 .await
                 .map_err(|_| Error::FetchError("Got JS error".to_string()))?;
 
-            let response: WebResponse = fetchval.dyn_into().unwrap();
+            let response: WebResponse = fetchval
+                .dyn_into()
+                .map_err(|_| Error::FetchError("Fetch result wasn't a WebResponse".to_string()))?;
             if !response.ok() {
                 return Err(Error::FetchError(format!(
                     "HTTP status is not ok, got {}",
@@ -203,13 +207,19 @@ impl NavigatorBackend for WebNavigatorBackend {
 
             let url = response.url();
 
-            let body: ArrayBuffer = JsFuture::from(response.array_buffer().unwrap())
-                .await
-                .map_err(|_| {
-                    Error::FetchError("Could not allocate array buffer for response".to_string())
-                })?
-                .dyn_into()
-                .unwrap();
+            let body: ArrayBuffer = JsFuture::from(
+                response
+                    .array_buffer()
+                    .map_err(|_| Error::FetchError("Got JS error".to_string()))?,
+            )
+            .await
+            .map_err(|_| {
+                Error::FetchError("Could not allocate array buffer for response".to_string())
+            })?
+            .dyn_into()
+            .map_err(|_| {
+                Error::FetchError("array_buffer result wasn't an ArrayBuffer".to_string())
+            })?;
             let body = Uint8Array::new(&body).to_vec();
 
             Ok(Response { url, body })


### PR DESCRIPTION
Part of the "let's stop panicking" effort. Absolutely not exhaustive for the whole codebase, but this removes all use of unwraps and disallows them going forwards, in the following crates:
- render
- render/webgl
- render/canvas
- web
- desktop
- video