### PR TITLE
Fix incorrect line-height being inherited on the self-hosted version

### DIFF
--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -20,9 +20,10 @@ ruffleShadowTemplate.innerHTML = `
             user-select: none;
             -webkit-user-select: none;
             -webkit-tap-highlight-color: transparent;
+            line-height: normal;
         }
 
-        /* Ruffle's width/height CSS interferes Safari fullscreen CSS. */
+        /* Ruffle's width/height CSS interferes with Safari's fullscreen CSS. */
         /* Ensure that Safari's fullscreen mode actually fills the screen. */
         :host(:-webkit-full-screen) {
             display: block;


### PR DESCRIPTION
Sets line-height to default on Ruffle's shadow-root, preventing incorrect line-height inheritance from the document.
Fixes #8977.