### PR TITLE
web: Make ChromeDriver dependency optional

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,6 @@
         "@wdio/static-server-service": "^7.25.4",
         "chai": "^4.3.6",
         "chai-html": "^2.1.0",
-        "chromedriver": "^106.0.1",
         "copy-webpack-plugin": "^11.0.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.24.0",
@@ -37,6 +36,9 @@
         "wdio-chromedriver-service": "^7.3.2",
         "webpack": "^5.73.0",
         "webpack-cli": "^5.0.1"
+    },
+    "optionalDependencies": {
+        "chromedriver": "^106.0.1"
     },
     "scripts": {
         "build": "npm run build --workspaces",


### PR DESCRIPTION
Because ChromeDriver was listed in Ruffle's devDependencies, it was impossible to build Ruffle Web without either installing Google Chrome Stable or manually removing the dependency from package.json, even though Chrome is only needed for running the tests. Moving the dependency to optionalDependencies causes npm to ignore the failure of the ChromeDriver installation during `npm install`. This makes Chrome no longer required to build Ruffle Web, but if Chrome is installed, ChromeDriver will still install as normal and the tests will still pass.