### PR TITLE
desktop: Add tracy feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,6 +3227,20 @@ name = "profiling"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
+dependencies = [
+ "profiling-procmacros",
+ "tracy-client",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1e2417ef905b8ad94215f8a607bd2d0f5d13d416d18dca4a530811e8a0674c"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "quick-xml"
@@ -3586,13 +3600,14 @@ dependencies = [
  "futures",
  "gc-arena",
  "image",
- "log",
  "naga-agal",
  "once_cell",
  "ouroboros",
+ "profiling",
  "raw-window-handle 0.5.0",
  "ruffle_render",
  "swf",
+ "tracing",
  "typed-arena",
  "web-sys",
  "wgpu",
@@ -4505,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-tracy"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74513033e242c0109c2ba9cb6d94117a53dbd6511eb135f5512143136eeba311"
+checksum = "ed3ebef1f9f0d00aaa29239537effef65b82c56040c680f540fc6cedfac7b230"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -4527,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.15.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c615e58172e788a208faee61b74988cd9c4778bc782384bed540b3fa4e5d4436"
+checksum = "8b3b9ab635a5b91dd66b7a1591a89f7d52423e6a9143b230bb4c503f41296c0c"
 dependencies = [
  "loom",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266041a359dfa931b370ef684cceb84b166beb14f7f0421f4a6a3d0c446d12e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.39.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2376,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3470,6 +3496,7 @@ dependencies = [
  "ruffle_video_software",
  "tracing",
  "tracing-subscriber",
+ "tracing-tracy",
  "url",
  "webbrowser",
  "winapi",
@@ -4477,6 +4504,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tracy"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74513033e242c0109c2ba9cb6d94117a53dbd6511eb135f5512143136eeba311"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracy-client",
+]
+
+[[package]]
 name = "tracing-wasm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,6 +4523,26 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c615e58172e788a208faee61b74988cd9c4778bc782384bed540b3fa4e5d4436"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcbdba03a3cfc5f757469fd5b6d795fc461484c97e47e94b0fc7db93261d9c5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4981,6 +5039,19 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
+dependencies = [
+ "windows_aarch64_msvc 0.39.0",
+ "windows_i686_gnu 0.39.0",
+ "windows_i686_msvc 0.39.0",
+ "windows_x86_64_gnu 0.39.0",
+ "windows_x86_64_msvc 0.39.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
@@ -5042,6 +5113,12 @@ checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
@@ -5057,6 +5134,12 @@ name = "windows_i686_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5078,6 +5161,12 @@ checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
@@ -5093,6 +5182,12 @@ name = "windows_x86_64_gnu"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5117,6 +5212,12 @@ name = "windows_x86_64_msvc"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -25,6 +25,7 @@ isahc = "1.7.2"
 rfd = "0.10.0"
 anyhow = "1.0"
 bytemuck = "1.12.3"
+tracing-tracy = { version = "0.10.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"
@@ -39,6 +40,7 @@ default = ["software_video"]
 avm_debug = ["ruffle_core/avm_debug"]
 lzma = ["ruffle_core/lzma"]
 software_video = ["ruffle_video_software"]
+tracy = ["tracing-tracy"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -25,7 +25,9 @@ isahc = "1.7.2"
 rfd = "0.10.0"
 anyhow = "1.0"
 bytemuck = "1.12.3"
-tracing-tracy = { version = "0.10.1", optional = true }
+
+# Deliberately held back to match tracy client used by profiling crate
+tracing-tracy = { version = "=0.10.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"
@@ -40,7 +42,7 @@ default = ["software_video"]
 avm_debug = ["ruffle_core/avm_debug"]
 lzma = ["ruffle_core/lzma"]
 software_video = ["ruffle_video_software"]
-tracy = ["tracing-tracy"]
+tracy = ["tracing-tracy", "ruffle_render_wgpu/profile-with-tracy"]
 
 # wgpu features
 render_debug_labels = ["ruffle_render_wgpu/render_debug_labels"]

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac", features = ["naga"] }
-log = "0.4"
+tracing = "0.1.37"
 ruffle_render = { path = "..", features = ["tessellator"] }
 bytemuck = { version = "1.12.3", features = ["derive"] }
 raw-window-handle = "0.5"
@@ -24,6 +24,7 @@ once_cell = "1.17.0"
 gc-arena = { workspace = true }
 naga-agal = { path = "../naga-agal" }
 downcast-rs = "1.2.0"
+profiling = { version = "1.0", default-features = false, optional = true }
 
 # desktop
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
@@ -38,3 +39,4 @@ features = ["HtmlCanvasElement"]
 render_debug_labels = []
 render_trace = ["wgpu/trace"]
 webgl = ["wgpu/webgl"]
+profile-with-tracy = ["profiling", "profiling/profile-with-tracy"]

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -22,6 +22,7 @@ use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::Arc;
 use swf::Color;
+use tracing::instrument;
 use wgpu::Extent3d;
 
 pub struct WgpuRenderBackend<T: RenderTarget> {
@@ -72,7 +73,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
         trace_path: Option<&Path>,
     ) -> Result<Self, Error> {
         if wgpu::Backends::SECONDARY.contains(backend) {
-            log::warn!(
+            tracing::warn!(
                 "{} graphics backend support may not be fully supported.",
                 format_list(&get_backend_names(backend), "and")
             );
@@ -100,7 +101,7 @@ impl WgpuRenderBackend<crate::target::TextureTarget> {
         trace_path: Option<&Path>,
     ) -> Result<Self, Error> {
         if wgpu::Backends::SECONDARY.contains(backend) {
-            log::warn!(
+            tracing::warn!(
                 "{} graphics backend support may not be fully supported.",
                 format_list(&get_backend_names(backend), "and")
             );
@@ -298,6 +299,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         )))
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn context3d_present<'gc>(
         &mut self,
         context: &mut dyn Context3D,
@@ -346,6 +348,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn register_shape(
         &mut self,
         shape: DistilledShape,
@@ -357,6 +360,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         handle
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn replace_shape(
         &mut self,
         shape: DistilledShape,
@@ -367,6 +371,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         self.meshes[handle.0] = mesh;
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn register_glyph_shape(&mut self, glyph: &swf::Glyph) -> ShapeHandle {
         let shape = ruffle_render::shape_utils::swf_glyph_to_shape(glyph);
         let handle = ShapeHandle(self.meshes.len());
@@ -378,11 +383,12 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         handle
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn submit_frame(&mut self, clear: Color, commands: CommandList) {
         let frame_output = match self.target.get_next_texture() {
             Ok(frame) => frame,
             Err(e) => {
-                log::warn!("Couldn't begin new render frame: {}", e);
+                tracing::warn!("Couldn't begin new render frame: {}", e);
                 // Attempt to recreate the swap chain in this case.
                 self.target.resize(
                     &self.descriptors.device,
@@ -420,6 +426,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         self.offscreen_texture_pool = TexturePool::new();
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, BitmapError> {
         if bitmap.width() > self.descriptors.limits.max_texture_dimension_2d
             || bitmap.height() > self.descriptors.limits.max_texture_dimension_2d
@@ -479,6 +486,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         Ok(handle)
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
@@ -513,6 +521,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn render_offscreen(
         &mut self,
         handle: BitmapHandle,

--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -174,7 +174,7 @@ impl CurrentPipeline {
             Context3DTriangleFace::Back => Some(wgpu::Face::Back),
             Context3DTriangleFace::Front => Some(wgpu::Face::Front),
             Context3DTriangleFace::FrontAndBack => {
-                log::error!("FrontAndBack culling not supported!");
+                tracing::error!("FrontAndBack culling not supported!");
                 None
             }
             Context3DTriangleFace::None => None,

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -225,7 +225,7 @@ impl WgpuContext3D {
                     mask,
                 } => {
                     if *mask != COLOR_MASK | DEPTH_MASK | STENCIL_MASK {
-                        log::warn!(
+                        tracing::warn!(
                             "Context3D::present: Clear command with mask {:x} not implemeneted",
                             mask
                         );
@@ -253,12 +253,14 @@ impl WgpuContext3D {
                     wants_best_resolution_on_browser_zoom: _,
                 } => {
                     if *anti_alias != 1 {
-                        log::warn!(
+                        tracing::warn!(
                             "configureBackBuffer: anti_alias={anti_alias} is not yet implemented"
                         );
                     }
                     if *depth_and_stencil {
-                        log::warn!("configureBackBuffer: depth_and_stencil is not yet implemented");
+                        tracing::warn!(
+                            "configureBackBuffer: depth_and_stencil is not yet implemented"
+                        );
                     }
 
                     let texture_label = create_debug_label!("Render target texture");
@@ -358,7 +360,7 @@ impl WgpuContext3D {
                     );
 
                     if !seen_clear_command {
-                        log::warn!("Context3D::present: drawTriangles called without first calling clear()");
+                        tracing::warn!("Context3D::present: drawTriangles called without first calling clear()");
                     }
 
                     if new_pipeline.is_some() || render_pass.is_none() {

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -11,6 +11,7 @@ use crate::{ColorAdjustments, Descriptors, MaskState, Pipelines, Transforms, Uni
 use ruffle_render::commands::CommandList;
 use std::sync::Arc;
 use target::CommandTarget;
+use tracing::instrument;
 
 #[derive(Debug)]
 pub struct Surface {
@@ -47,6 +48,7 @@ impl Surface {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "debug", skip_all)]
     pub fn draw_commands_to(
         &mut self,
         frame_view: &wgpu::TextureView,
@@ -165,6 +167,7 @@ impl Surface {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[instrument(level = "debug", skip_all)]
     pub fn draw_commands<'frame, 'global: 'frame>(
         &mut self,
         clear_color: wgpu::Color,

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -3,6 +3,7 @@ use crate::Error;
 use ruffle_render::utils::unmultiply_alpha_rgba;
 use std::fmt::Debug;
 use std::sync::Arc;
+use tracing::instrument;
 
 pub trait RenderTargetFrame: Debug {
     fn into_view(self) -> wgpu::TextureView;
@@ -123,6 +124,7 @@ impl RenderTarget for SwapChainTarget {
         Ok(SwapChainTargetFrame { texture, view })
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn submit<I: IntoIterator<Item = wgpu::CommandBuffer>>(
         &self,
         _device: &wgpu::Device,
@@ -209,6 +211,7 @@ impl TextureTarget {
 
     /// Captures the current contents of our texture buffer
     /// as an `RgbaImage`
+    #[instrument(level = "debug", skip_all)]
     pub fn capture(
         &self,
         device: &wgpu::Device,
@@ -251,7 +254,7 @@ impl TextureTarget {
                 image
             }
             Err(e) => {
-                log::error!("Unknown error reading capture buffer: {:?}", e);
+                tracing::error!("Unknown error reading capture buffer: {:?}", e);
                 None
             }
         }
@@ -284,6 +287,7 @@ impl RenderTarget for TextureTarget {
         ))
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn submit<I: IntoIterator<Item = wgpu::CommandBuffer>>(
         &self,
         device: &wgpu::Device,


### PR DESCRIPTION
Screenshots of Ruffle in Tracy from my macbook where unfortunately the dpi scaling is all wonky:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/317625/210961112-2964d082-48af-41d2-a7f2-95c3aac411a6.png">
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/317625/210961902-bd38b932-8ac8-416c-9b68-a534807fa19d.png">
![image](https://user-images.githubusercontent.com/317625/211012823-229ffa13-42f1-4e5b-8d9c-c19ccf3817ab.png)


Tracy ships binaries on windows, but is buildable from source on linux and mac. You can find it over at https://github.com/wolfpld/tracy.

The more spans we add, the more info will show up in tracy. We can even add custom plots in the future if we want to track other things like network usage or GC stats (if that's possible) or whatever.
