### PR TITLE
Dockerfile to build web

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -1,0 +1,25 @@
+# run this file from ruffle root dir (not the docker dir) like 
+# docker build --tag ruffle-web-docker -f web/docker/Dockerfile .
+# docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive 
+RUN apt-get update -y 
+RUN apt-get -y full-upgrade
+RUN apt-get install -y wget
+RUN wget 'https://deb.nodesource.com/setup_lts.x' --quiet -O- | bash
+RUN apt-get update
+RUN apt-get install -y \
+ git pkg-config openssl libssl-dev gcc \
+ default-jdk default-jre \
+  nodejs binaryen
+RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y
+# RUN source "$HOME/.cargo/env"
+# source to modify env doesn't work with docker it seems :( so add cargo to PATH manually:
+ENV PATH="/root/.cargo/bin:$PATH"
+RUN rustup update
+RUN rustup target add wasm32-unknown-unknown
+RUN cargo install wasm-bindgen-cli --version 0.2.83
+COPY . ruffle
+WORKDIR ruffle/web
+RUN npm install
+RUN npm run build

--- a/web/docker/docker_builds/.gitignore
+++ b/web/docker/docker_builds/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+


### PR DESCRIPTION
per https://github.com/ruffle-rs/ruffle/issues/8799#issuecomment-1374391215 the addons.mozilla.org team had trouble building ruffle from source,
with this docker file, Ruffle can now be built with 4 commands, with the only prerequisites being git and docker:
```
git clone https://github.com/ruffle-rs/ruffle;

cd ruffle;

docker build --tag ruffle-web-docker -f web/docker/Dockerfile .;

docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages
```
and voila, you have 
```
$ file web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi 

web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi: Zip archive data, at least v1.0 to extract, compression method=store
```
hopefully this will make the addons.mozilla.org team's life easier and get Ruffle back on addons.mozilla.org 

related issues: #9054  and #8799