### PR TITLE
render: Make render_offscreen non blocking

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -5,7 +5,9 @@ use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{
     Context3D, Context3DCommand, RenderBackend, ShapeHandle, ViewportDimensions,
 };
-use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapHandleImpl, BitmapSource};
+use ruffle_render::bitmap::{
+    Bitmap, BitmapFormat, BitmapHandle, BitmapHandleImpl, BitmapSource, SyncHandle,
+};
 use ruffle_render::color_transform::ColorTransform;
 use ruffle_render::commands::{CommandHandler, CommandList};
 use ruffle_render::error::Error;
@@ -463,6 +465,13 @@ impl RenderBackend for WebCanvasRenderBackend {
         _width: u32,
         _height: u32,
         _commands: CommandList,
+    ) -> Result<Box<dyn SyncHandle>, ruffle_render::error::Error> {
+        Err(Error::Unimplemented)
+    }
+
+    fn retrieve_offscreen_texture(
+        &self,
+        _sync: Box<dyn SyncHandle>,
     ) -> Result<Bitmap, ruffle_render::error::Error> {
         Err(Error::Unimplemented)
     }

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -1,6 +1,6 @@
 pub mod null;
 
-use crate::bitmap::{Bitmap, BitmapHandle, BitmapSource};
+use crate::bitmap::{Bitmap, BitmapHandle, BitmapSource, SyncHandle};
 use crate::commands::CommandList;
 use crate::error::Error;
 use crate::shape_utils::DistilledShape;
@@ -43,7 +43,10 @@ pub trait RenderBackend: Downcast {
         width: u32,
         height: u32,
         commands: CommandList,
-    ) -> Result<Bitmap, Error>;
+    ) -> Result<Box<dyn SyncHandle>, Error>;
+
+    /// Retrieves the rendered pixels from a previous `render_offscreen` call
+    fn retrieve_offscreen_texture(&self, sync: Box<dyn SyncHandle>) -> Result<Bitmap, Error>;
 
     fn submit_frame(&mut self, clear: swf::Color, commands: CommandList);
 

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use crate::backend::{RenderBackend, ShapeHandle, ViewportDimensions};
-use crate::bitmap::{Bitmap, BitmapHandle, BitmapHandleImpl, BitmapSize, BitmapSource};
+use crate::bitmap::{Bitmap, BitmapHandle, BitmapHandleImpl, BitmapSize, BitmapSource, SyncHandle};
 use crate::commands::CommandList;
 use crate::error::Error;
 use crate::shape_utils::DistilledShape;
@@ -66,7 +66,11 @@ impl RenderBackend for NullRenderer {
         _width: u32,
         _height: u32,
         _commands: CommandList,
-    ) -> Result<Bitmap, Error> {
+    ) -> Result<Box<dyn SyncHandle>, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    fn retrieve_offscreen_texture(&self, _sync: Box<dyn SyncHandle>) -> Result<Bitmap, Error> {
         Err(Error::Unimplemented)
     }
 

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -34,6 +34,9 @@ pub trait BitmapSource {
     fn bitmap_handle(&self, id: u16, renderer: &mut dyn RenderBackend) -> Option<BitmapHandle>;
 }
 
+pub trait SyncHandle: Downcast + Debug {}
+impl_downcast!(SyncHandle);
+
 /// Decoded bitmap data from an SWF tag.
 #[derive(Clone, Debug)]
 pub struct Bitmap {

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -9,7 +9,9 @@ use ruffle_render::backend::null::NullBitmapSource;
 use ruffle_render::backend::{
     Context3D, Context3DCommand, RenderBackend, ShapeHandle, ViewportDimensions,
 };
-use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapHandleImpl, BitmapSource};
+use ruffle_render::bitmap::{
+    Bitmap, BitmapFormat, BitmapHandle, BitmapHandleImpl, BitmapSource, SyncHandle,
+};
 use ruffle_render::commands::{CommandHandler, CommandList};
 use ruffle_render::error::Error as BitmapError;
 use ruffle_render::shape_utils::DistilledShape;
@@ -941,6 +943,13 @@ impl RenderBackend for WebGlRenderBackend {
         _width: u32,
         _height: u32,
         _commands: CommandList,
+    ) -> Result<Box<dyn SyncHandle>, ruffle_render::error::Error> {
+        Err(ruffle_render::error::Error::Unimplemented)
+    }
+
+    fn retrieve_offscreen_texture(
+        &self,
+        _sync: Box<dyn SyncHandle>,
     ) -> Result<Bitmap, ruffle_render::error::Error> {
         Err(ruffle_render::error::Error::Unimplemented)
     }

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -6,18 +6,19 @@ use crate::target::RenderTargetFrame;
 use crate::target::TextureTarget;
 use crate::uniform_buffer::BufferStorage;
 use crate::{
-    as_texture, format_list, get_backend_names, BufferDimensions, ColorAdjustments, Descriptors,
-    Error, RenderTarget, SwapChainTarget, Texture, TextureOffscreen, Transforms,
+    as_texture, format_list, get_backend_names, ColorAdjustments, Descriptors, Error,
+    QueueSyncHandle, RenderTarget, SwapChainTarget, Texture, Transforms,
 };
 use gc_arena::MutationContext;
 use ruffle_render::backend::{Context3D, Context3DCommand};
 use ruffle_render::backend::{RenderBackend, ShapeHandle, ViewportDimensions};
-use ruffle_render::bitmap::{Bitmap, BitmapHandle, BitmapSource};
+use ruffle_render::bitmap::{Bitmap, BitmapHandle, BitmapSource, SyncHandle};
 use ruffle_render::commands::CommandList;
 use ruffle_render::error::Error as BitmapError;
 use ruffle_render::shape_utils::DistilledShape;
 use ruffle_render::tessellator::ShapeTessellator;
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::mem;
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -120,8 +121,19 @@ impl WgpuRenderBackend<crate::target::TextureTarget> {
     }
 
     pub fn capture_frame(&self, premultiplied_alpha: bool) -> Option<image::RgbaImage> {
-        self.target
-            .capture(&self.descriptors.device, premultiplied_alpha, None)
+        use crate::utils::buffer_to_image;
+        if let Some((buffer, dimensions)) = &self.target.buffer {
+            Some(buffer_to_image(
+                &self.descriptors.device,
+                buffer,
+                dimensions,
+                None,
+                self.target.size,
+                premultiplied_alpha,
+            ))
+        } else {
+            None
+        }
     }
 }
 
@@ -293,6 +305,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             texture_offscreen: Default::default(),
             width: 0,
             height: 0,
+            copy_count: Cell::new(0),
         }));
         Ok(Box::new(WgpuContext3D::new(
             self.descriptors.clone(),
@@ -482,6 +495,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             texture_offscreen: Default::default(),
             width: bitmap.width(),
             height: bitmap.height(),
+            copy_count: Cell::new(0),
         }));
 
         Ok(handle)
@@ -529,7 +543,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         width: u32,
         height: u32,
         commands: CommandList,
-    ) -> Result<Bitmap, ruffle_render::error::Error> {
+    ) -> Result<Box<dyn SyncHandle>, ruffle_render::error::Error> {
         let texture = as_texture(&handle);
 
         let extent = wgpu::Extent3d {
@@ -538,40 +552,13 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
             depth_or_array_layers: 1,
         };
 
-        // We will (presumably) never render to the majority of textures, so
-        // we lazily create the buffer and depth texture.
-        // Once created, we never destroy this data, under the assumption
-        // that the SWF will try to render to this more than once.
-        //
-        // If we end up hitting wgpu device limits due to having too
-        // many buffers / depth textures rendered at once, we could
-        // try storing this data in an LRU cache, evicting entries
-        // as needed.
-        let texture_offscreen = texture.texture_offscreen.get_or_init(|| {
-            let buffer_dimensions = BufferDimensions::new(width as usize, height as usize);
-            let buffer_label = create_debug_label!("Render target buffer");
-            let buffer = self
-                .descriptors
-                .device
-                .create_buffer(&wgpu::BufferDescriptor {
-                    label: buffer_label.as_deref(),
-                    size: (buffer_dimensions.padded_bytes_per_row.get() as u64
-                        * buffer_dimensions.height as u64),
-                    usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-                    mapped_at_creation: false,
-                });
-            TextureOffscreen {
-                buffer: Arc::new(buffer),
-                buffer_dimensions,
-            }
-        });
+        let texture_offscreen = texture.texture_offscreen.get();
 
         let mut target = TextureTarget {
             size: extent,
             texture: texture.texture.clone(),
             format: wgpu::TextureFormat::Rgba8Unorm,
-            buffer: texture_offscreen.buffer.clone(),
-            buffer_dimensions: texture_offscreen.buffer_dimensions.clone(),
+            buffer: texture_offscreen.map(|t| (t.buffer.clone(), t.buffer_dimensions.clone())),
         };
 
         let frame_output = target
@@ -604,19 +591,34 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         self.uniform_buffers_storage.recall();
         self.color_buffers_storage.recall();
 
-        // Capture with premultiplied alpha, which is what we use for all textures
-        let image = target.capture(&self.descriptors.device, true, Some(index));
+        match texture_offscreen {
+            Some(texture_offscreen) => Ok(Box::new(QueueSyncHandle::AlreadyCopied {
+                index,
+                size: target.size,
+                buffer: texture_offscreen.buffer.clone(),
+                buffer_dimensions: texture_offscreen.buffer_dimensions.clone(),
+            })),
+            None => Ok(Box::new(QueueSyncHandle::NotCopied {
+                handle: handle.clone(),
+                size: target.size,
+            })),
+        }
+    }
 
-        let image = image.map(|image| {
-            Bitmap::new(
-                image.dimensions().0,
-                image.dimensions().1,
-                ruffle_render::bitmap::BitmapFormat::Rgba,
-                image.into_raw(),
-            )
-        });
-
-        Ok(image.unwrap())
+    fn retrieve_offscreen_texture(
+        &self,
+        sync: Box<dyn SyncHandle>,
+    ) -> Result<Bitmap, ruffle_render::error::Error> {
+        let sync = sync
+            .downcast::<QueueSyncHandle>()
+            .expect("Sync handle must be a wgpu backend QueueSyncHandle");
+        let image = sync.capture(&self.descriptors.device, &self.descriptors.queue);
+        Ok(Bitmap::new(
+            image.dimensions().0,
+            image.dimensions().1,
+            ruffle_render::bitmap::BitmapFormat::Rgba,
+            image.into_raw(),
+        ))
     }
 }
 

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -3,6 +3,7 @@ use ruffle_render::backend::{
     ShaderModule, VertexBuffer,
 };
 use ruffle_render::bitmap::BitmapHandle;
+use std::cell::Cell;
 
 use wgpu::util::StagingBelt;
 use wgpu::{
@@ -295,6 +296,7 @@ impl WgpuContext3D {
                         texture_offscreen: Default::default(),
                         width: *width,
                         height: *height,
+                        copy_count: Cell::new(0),
                     }));
                 }
                 Context3DCommand::UploadToIndexBuffer {


### PR DESCRIPTION
This can significantly improve performance of games that use `BitmapData.draw()`, especially if they don't immediately read from the bitmap afterwards.

However, this PR now only includes the possibility to use it async, and actually making AVM1/2 use it async will be in a future PR.