### PR TITLE
Remove interior mutability for Player's GcArena

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,7 +50,7 @@ pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;
 pub use indexmap;
 pub use loader::LoadBehavior;
-pub use player::{Player, PlayerBuilder, StaticCallstack};
+pub use player::{Player, PlayerBuilder};
 pub use ruffle_render::backend::ViewportDimensions;
 pub use swf;
 pub use swf::Color;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -47,10 +47,9 @@ use ruffle_render::backend::{null::NullRenderer, RenderBackend, ViewportDimensio
 use ruffle_render::commands::CommandList;
 use ruffle_render::transform::TransformStack;
 use ruffle_video::backend::VideoBackend;
-use std::cell::RefCell;
+use ruffle_wstr::WString;
 use std::collections::{HashMap, VecDeque};
 use std::ops::DerefMut;
-use std::rc::{Rc, Weak as RcWeak};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
@@ -71,25 +70,6 @@ struct GcRoot<'gc> {
 #[collect(no_drop)]
 struct GcCallstack<'gc> {
     avm2: Option<GcCell<'gc, CallStack<'gc>>>,
-}
-
-#[derive(Clone)]
-pub struct StaticCallstack {
-    arena: RcWeak<RefCell<GcArena>>,
-}
-
-impl StaticCallstack {
-    pub fn avm2(&self, f: impl for<'gc> FnOnce(&CallStack<'gc>)) {
-        if let Some(arena) = self.arena.upgrade() {
-            if let Ok(arena) = arena.try_borrow() {
-                arena.mutate(|_, root| {
-                    if let Some(callstack) = root.callstack.avm2 {
-                        f(&callstack.read())
-                    }
-                })
-            }
-        }
-    }
 }
 
 #[derive(Collect)]
@@ -229,7 +209,7 @@ pub struct Player {
 
     rng: SmallRng,
 
-    gc_arena: Rc<RefCell<GcArena>>,
+    gc_arena: GcArena,
 
     frame_rate: f64,
     actions_since_timeout_check: u16,
@@ -609,7 +589,7 @@ impl Player {
     }
 
     pub fn clear_custom_menu_items(&mut self) {
-        self.gc_arena.borrow_mut().mutate_root(|_, gc_root| {
+        self.gc_arena.mutate_root(|_, gc_root| {
             gc_root.data.current_context_menu = None;
         });
     }
@@ -1470,7 +1450,7 @@ impl Player {
             (&mut self.renderer, &mut self.ui, &mut self.transform_stack);
         let mut background_color = Color::WHITE;
 
-        let commands = self.gc_arena.borrow().mutate(|gc_context, gc_root| {
+        let commands = self.gc_arena.mutate(|gc_context, gc_root| {
             let stage = gc_root.data.stage;
 
             let mut render_context = RenderContext {
@@ -1671,101 +1651,99 @@ impl Player {
     where
         F: for<'a, 'gc> FnOnce(&mut UpdateContext<'a, 'gc>) -> R,
     {
-        self.gc_arena
-            .borrow_mut()
-            .mutate_root(|gc_context, gc_root| {
-                let root_data = &mut gc_root.data;
-                let mouse_hovered_object = root_data.mouse_hovered_object;
-                let mouse_pressed_object = root_data.mouse_pressed_object;
-                let focus_tracker = root_data.focus_tracker;
-                let (
-                    stage,
-                    library,
-                    action_queue,
-                    avm1,
-                    avm2,
-                    drag_object,
-                    load_manager,
-                    avm1_shared_objects,
-                    avm2_shared_objects,
-                    unbound_text_fields,
-                    timers,
-                    current_context_menu,
-                    external_interface,
-                    audio_manager,
-                ) = root_data.update_context_params();
+        self.gc_arena.mutate_root(|gc_context, gc_root| {
+            let root_data = &mut gc_root.data;
+            let mouse_hovered_object = root_data.mouse_hovered_object;
+            let mouse_pressed_object = root_data.mouse_pressed_object;
+            let focus_tracker = root_data.focus_tracker;
+            let (
+                stage,
+                library,
+                action_queue,
+                avm1,
+                avm2,
+                drag_object,
+                load_manager,
+                avm1_shared_objects,
+                avm2_shared_objects,
+                unbound_text_fields,
+                timers,
+                current_context_menu,
+                external_interface,
+                audio_manager,
+            ) = root_data.update_context_params();
 
-                let mut update_context = UpdateContext {
-                    player_version: self.player_version,
-                    swf: &self.swf,
-                    library,
-                    rng: &mut self.rng,
-                    renderer: self.renderer.deref_mut(),
-                    audio: self.audio.deref_mut(),
-                    navigator: self.navigator.deref_mut(),
-                    ui: self.ui.deref_mut(),
-                    action_queue,
-                    gc_context,
-                    stage,
-                    mouse_over_object: mouse_hovered_object,
-                    mouse_down_object: mouse_pressed_object,
-                    input: &self.input,
-                    mouse_position: &self.mouse_pos,
-                    drag_object,
-                    player: self.self_reference.clone(),
-                    load_manager,
-                    system: &mut self.system,
-                    instance_counter: &mut self.instance_counter,
-                    storage: self.storage.deref_mut(),
-                    log: self.log.deref_mut(),
-                    video: self.video.deref_mut(),
-                    avm1_shared_objects,
-                    avm2_shared_objects,
-                    unbound_text_fields,
-                    timers,
-                    current_context_menu,
-                    needs_render: &mut self.needs_render,
-                    avm1,
-                    avm2,
-                    external_interface,
-                    start_time: self.start_time,
-                    update_start: Instant::now(),
-                    max_execution_duration: self.max_execution_duration,
-                    focus_tracker,
-                    times_get_time_called: 0,
-                    time_offset: &mut self.time_offset,
-                    audio_manager,
-                    frame_rate: &mut self.frame_rate,
-                    actions_since_timeout_check: &mut self.actions_since_timeout_check,
-                    frame_phase: &mut self.frame_phase,
-                };
+            let mut update_context = UpdateContext {
+                player_version: self.player_version,
+                swf: &self.swf,
+                library,
+                rng: &mut self.rng,
+                renderer: self.renderer.deref_mut(),
+                audio: self.audio.deref_mut(),
+                navigator: self.navigator.deref_mut(),
+                ui: self.ui.deref_mut(),
+                action_queue,
+                gc_context,
+                stage,
+                mouse_over_object: mouse_hovered_object,
+                mouse_down_object: mouse_pressed_object,
+                input: &self.input,
+                mouse_position: &self.mouse_pos,
+                drag_object,
+                player: self.self_reference.clone(),
+                load_manager,
+                system: &mut self.system,
+                instance_counter: &mut self.instance_counter,
+                storage: self.storage.deref_mut(),
+                log: self.log.deref_mut(),
+                video: self.video.deref_mut(),
+                avm1_shared_objects,
+                avm2_shared_objects,
+                unbound_text_fields,
+                timers,
+                current_context_menu,
+                needs_render: &mut self.needs_render,
+                avm1,
+                avm2,
+                external_interface,
+                start_time: self.start_time,
+                update_start: Instant::now(),
+                max_execution_duration: self.max_execution_duration,
+                focus_tracker,
+                times_get_time_called: 0,
+                time_offset: &mut self.time_offset,
+                audio_manager,
+                frame_rate: &mut self.frame_rate,
+                actions_since_timeout_check: &mut self.actions_since_timeout_check,
+                frame_phase: &mut self.frame_phase,
+            };
 
-                let old_frame_rate = *update_context.frame_rate;
+            let old_frame_rate = *update_context.frame_rate;
 
-                let ret = f(&mut update_context);
+            let ret = f(&mut update_context);
 
-                let new_frame_rate = *update_context.frame_rate;
+            let new_frame_rate = *update_context.frame_rate;
 
-                // If we changed the framerate, let the audio handler now.
-                #[allow(clippy::float_cmp)]
-                if old_frame_rate != new_frame_rate {
-                    update_context.audio.set_frame_rate(new_frame_rate);
-                }
+            // If we changed the framerate, let the audio handler now.
+            #[allow(clippy::float_cmp)]
+            if old_frame_rate != new_frame_rate {
+                update_context.audio.set_frame_rate(new_frame_rate);
+            }
 
-                self.current_frame = update_context
-                    .stage
-                    .root_clip()
-                    .as_movie_clip()
-                    .map(|clip| clip.current_frame());
+            self.current_frame = update_context
+                .stage
+                .root_clip()
+                .as_movie_clip()
+                .map(|clip| clip.current_frame());
 
-                // Hovered object may have been updated; copy it back to the GC root.
-                let mouse_hovered_object = update_context.mouse_over_object;
-                let mouse_pressed_object = update_context.mouse_down_object;
-                root_data.mouse_hovered_object = mouse_hovered_object;
-                root_data.mouse_pressed_object = mouse_pressed_object;
+            // Hovered object may have been updated; copy it back to the GC root.
+            let mouse_hovered_object = update_context.mouse_over_object;
+            let mouse_pressed_object = update_context.mouse_down_object;
+            root_data.mouse_hovered_object = mouse_hovered_object;
+            root_data.mouse_pressed_object = mouse_pressed_object;
 
-                ret
-            })
+            ret
+        })
     }
 
     pub fn load_device_font<'gc>(
@@ -1811,7 +1789,7 @@ impl Player {
         self.update_mouse_state(false, false);
 
         // GC
-        self.gc_arena.borrow_mut().collect_debt();
+        self.gc_arena.collect_debt();
 
         rval
     }
@@ -1889,10 +1867,16 @@ impl Player {
         self.max_execution_duration = max_execution_duration
     }
 
-    pub fn callstack(&self) -> StaticCallstack {
-        StaticCallstack {
-            arena: Rc::downgrade(&self.gc_arena),
-        }
+    pub fn avm2_callstack(&self) -> Option<WString> {
+        self.gc_arena.mutate(|_, root| {
+            root.callstack.avm2.and_then(|callstack| {
+                callstack.try_read().ok().map(|cs| {
+                    let mut out = WString::new();
+                    cs.display(&mut out);
+                    out
+                })
+            })
+        })
     }
 }
 
@@ -2163,31 +2147,28 @@ impl PlayerBuilder {
                 spoofed_url: self.spoofed_url.clone(),
 
                 // GC data
-                gc_arena: Rc::new(RefCell::new(GcArena::new(
-                    ArenaParameters::default(),
-                    |gc_context| GcRoot {
-                        callstack: GcCallstack::default(),
-                        data: GcRootData {
-                            audio_manager: AudioManager::new(),
-                            action_queue: ActionQueue::new(),
-                            avm1: Avm1::new(gc_context, player_version),
-                            avm2: Avm2::new(gc_context),
-                            current_context_menu: None,
-                            drag_object: None,
-                            external_interface: ExternalInterface::new(),
-                            focus_tracker: FocusTracker::new(gc_context),
-                            library: Library::empty(),
-                            load_manager: LoadManager::new(),
-                            mouse_hovered_object: None,
-                            mouse_pressed_object: None,
-                            avm1_shared_objects: HashMap::new(),
-                            avm2_shared_objects: HashMap::new(),
-                            stage: Stage::empty(gc_context, self.fullscreen, fake_movie.clone()),
-                            timers: Timers::new(),
-                            unbound_text_fields: Vec::new(),
-                        },
+                gc_arena: GcArena::new(ArenaParameters::default(), |gc_context| GcRoot {
+                    callstack: GcCallstack::default(),
+                    data: GcRootData {
+                        audio_manager: AudioManager::new(),
+                        action_queue: ActionQueue::new(),
+                        avm1: Avm1::new(gc_context, player_version),
+                        avm2: Avm2::new(gc_context),
+                        current_context_menu: None,
+                        drag_object: None,
+                        external_interface: ExternalInterface::new(),
+                        focus_tracker: FocusTracker::new(gc_context),
+                        library: Library::empty(),
+                        load_manager: LoadManager::new(),
+                        mouse_hovered_object: None,
+                        mouse_pressed_object: None,
+                        avm1_shared_objects: HashMap::new(),
+                        avm2_shared_objects: HashMap::new(),
+                        stage: Stage::empty(gc_context, self.fullscreen, fake_movie.clone()),
+                        timers: Timers::new(),
+                        unbound_text_fields: Vec::new(),
                     },
-                ))),
+                }),
             })
         });
 
@@ -2203,7 +2184,7 @@ impl PlayerBuilder {
             stage.post_instantiation(context, None, Instantiator::Movie, false);
             stage.build_matrices(context);
         });
-        player_lock.gc_arena.borrow_mut().mutate_root(|_, root| {
+        player_lock.gc_arena.mutate_root(|_, root| {
             let call_stack = root.data.avm2.call_stack();
             root.callstack.avm2 = Some(call_stack);
         });


### PR DESCRIPTION
Replace `StaticCallback` by the `Player::avm2_callstack` method, to remove the need for interior mutability `GcArena` and `GcRoot`.