### PR TITLE
web: Enable wgpu-webgl by default

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -13,7 +13,7 @@ publish = false # This crate is useless alone, people should use the npm package
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["canvas", "console_error_panic_hook", "webgl"]
+default = ["canvas", "console_error_panic_hook", "webgl", "wgpu-webgl"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]


### PR DESCRIPTION
Let's do it? Any objections?

Newgrounds has been running an old build pre-optimisations and as far as we've seen, it's been great and only had the buffer bug, which #9133 deals with (they'll fall back to regular webgl).