### PR TITLE
core: Use BitmapData instead of separate `initial_data` field

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1309,7 +1309,6 @@ pub fn load_bitmap<'gc>(
 
     if let Some(Character::Bitmap {
         bitmap: bitmap_object,
-        initial_data,
     }) = character
     {
         let new_bitmap_data = BitmapDataObject::empty_object(
@@ -1319,17 +1318,15 @@ pub fn load_bitmap<'gc>(
 
         let width = bitmap_object.width() as u32;
         let height = bitmap_object.height() as u32;
+
+        let pixels: Vec<_> = bitmap_object.bitmap_data().read().pixels().to_vec();
+
         new_bitmap_data
             .as_bitmap_data_object()
             .unwrap()
             .bitmap_data()
             .write(activation.context.gc_context)
-            .set_pixels(
-                width,
-                height,
-                true,
-                initial_data.iter().map(|p| (*p).into()).collect(),
-            );
+            .set_pixels(width, height, true, pixels);
 
         return Ok(new_bitmap_data.into());
     }

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -61,10 +61,7 @@ pub fn instance_init<'gc>(
                     .avm2_class_registry()
                     .class_symbol(b_class)
                 {
-                    if let Some(Character::Bitmap {
-                        bitmap,
-                        initial_data,
-                    }) = activation
+                    if let Some(Character::Bitmap { bitmap }) = activation
                         .context
                         .library
                         .library_for_movie_mut(movie)
@@ -74,12 +71,7 @@ pub fn instance_init<'gc>(
                         let new_bitmap_data =
                             GcCell::allocate(activation.context.gc_context, BitmapData::default());
 
-                        fill_bitmap_data_from_symbol(
-                            activation,
-                            bitmap,
-                            new_bitmap_data,
-                            initial_data,
-                        );
+                        fill_bitmap_data_from_symbol(activation, bitmap, new_bitmap_data);
                         BitmapDataObject::from_bitmap_data(
                             activation,
                             new_bitmap_data,

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -27,7 +27,6 @@ pub fn fill_bitmap_data_from_symbol<'gc>(
     activation: &mut Activation<'_, 'gc>,
     bd: Bitmap<'gc>,
     new_bitmap_data: GcCell<'gc, BitmapData<'gc>>,
-    pixels: Vec<i32>,
 ) {
     new_bitmap_data
         .write(activation.context.gc_context)
@@ -35,7 +34,7 @@ pub fn fill_bitmap_data_from_symbol<'gc>(
             bd.width().into(),
             bd.height().into(),
             true,
-            pixels.into_iter().map(|p| p.into()).collect(),
+            bd.bitmap_data().read().pixels().to_vec(),
         );
 }
 
@@ -71,13 +70,9 @@ pub fn instance_init<'gc>(
             let new_bitmap_data =
                 GcCell::allocate(activation.context.gc_context, BitmapData::default());
 
-            if let Some(Character::Bitmap {
-                bitmap,
-                initial_data,
-            }) = character
-            {
+            if let Some(Character::Bitmap { bitmap }) = character {
                 // Instantiating BitmapData from an Animate-style bitmap asset
-                fill_bitmap_data_from_symbol(activation, bitmap, new_bitmap_data, initial_data);
+                fill_bitmap_data_from_symbol(activation, bitmap, new_bitmap_data);
             } else {
                 if character.is_some() {
                     //TODO: Determine if mismatched symbols will still work as a

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -12,10 +12,7 @@ pub enum Character<'gc> {
     EditText(EditText<'gc>),
     Graphic(Graphic<'gc>),
     MovieClip(MovieClip<'gc>),
-    Bitmap {
-        bitmap: Bitmap<'gc>,
-        initial_data: Vec<i32>,
-    },
+    Bitmap { bitmap: Bitmap<'gc> },
     Avm1Button(Avm1Button<'gc>),
     Avm2Button(Avm2Button<'gc>),
     Font(Font<'gc>),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2969,18 +2969,11 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> Result<(), Error> {
         let define_bits_lossless = reader.read_define_bits_lossless(version)?;
         let bitmap = ruffle_render::utils::decode_define_bits_lossless(&define_bits_lossless)?;
-        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, define_bits_lossless.id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(
-                define_bits_lossless.id,
-                Character::Bitmap {
-                    bitmap,
-                    initial_data,
-                },
-            );
+            .register_character(define_bits_lossless.id, Character::Bitmap { bitmap });
         Ok(())
     }
 
@@ -3093,18 +3086,11 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .jpeg_tables();
         let jpeg_data = ruffle_render::utils::glue_tables_to_jpeg(jpeg_data, jpeg_tables);
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(&jpeg_data, None)?;
-        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(
-                id,
-                Character::Bitmap {
-                    bitmap,
-                    initial_data,
-                },
-            );
+            .register_character(id, Character::Bitmap { bitmap });
         Ok(())
     }
 
@@ -3117,18 +3103,11 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let id = reader.read_u16()?;
         let jpeg_data = reader.read_slice_to_end();
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(jpeg_data, None)?;
-        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(
-                id,
-                Character::Bitmap {
-                    bitmap,
-                    initial_data,
-                },
-            );
+            .register_character(id, Character::Bitmap { bitmap });
         Ok(())
     }
 
@@ -3147,18 +3126,11 @@ impl<'gc, 'a> MovieClipData<'gc> {
         let jpeg_data = reader.read_slice(jpeg_len)?;
         let alpha_data = reader.read_slice_to_end();
         let bitmap = ruffle_render::utils::decode_define_bits_jpeg(jpeg_data, Some(alpha_data))?;
-        let initial_data: Vec<i32> = bitmap.as_colors().collect();
         let bitmap = Bitmap::new(context, id, bitmap)?;
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(
-                id,
-                Character::Bitmap {
-                    bitmap,
-                    initial_data,
-                },
-            );
+            .register_character(id, Character::Bitmap { bitmap });
         Ok(())
     }
 

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -204,10 +204,7 @@ impl<'gc> MovieLibrary<'gc> {
         gc_context: MutationContext<'gc, '_>,
     ) -> Result<DisplayObject<'gc>, &'static str> {
         match character {
-            Character::Bitmap {
-                bitmap,
-                initial_data: _,
-            } => Ok(bitmap.instantiate(gc_context)),
+            Character::Bitmap { bitmap } => Ok(bitmap.instantiate(gc_context)),
             Character::EditText(edit_text) => Ok(edit_text.instantiate(gc_context)),
             Character::Graphic(graphic) => Ok(graphic.instantiate(gc_context)),
             Character::MorphShape(morph_shape) => Ok(morph_shape.instantiate(gc_context)),


### PR DESCRIPTION
Now that a `Bitmap` always stores a `BitmapData`, we can read the pixels directly from the `BitmapData`, instead of duplicating them in an `initial_data` field