### PR TITLE
avm2: Correct name of rollover event

### DIFF
--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -342,9 +342,9 @@ pub trait TInteractiveObject<'gc>:
                         .unwrap_or_else(|| activation.context.stage.into()),
                 );
 
-                let mut rollover_target = Some(self.as_displayobject());
-                while let Some(tgt) = rollover_target {
-                    if DisplayObject::option_ptr_eq(rollover_target, lca) {
+                let mut rollout_target = Some(self.as_displayobject());
+                while let Some(tgt) = rollout_target {
+                    if DisplayObject::option_ptr_eq(rollout_target, lca) {
                         break;
                     }
 
@@ -363,7 +363,7 @@ pub trait TInteractiveObject<'gc>:
                         }
                     }
 
-                    rollover_target = tgt.parent();
+                    rollout_target = tgt.parent();
                 }
 
                 self.raw_interactive_mut(context.gc_context).last_click = None;
@@ -384,7 +384,7 @@ pub trait TInteractiveObject<'gc>:
                     }
 
                     let avm2_event =
-                        Avm2EventObject::mouse_event(&mut activation, "mouseOut", tgt, from, 0);
+                        Avm2EventObject::mouse_event(&mut activation, "rollOver", tgt, from, 0);
 
                     if let Avm2Value::Object(avm2_target) = tgt.object2() {
                         if let Err(e) =


### PR DESCRIPTION
Due to a typo, the rollOver event was being fired as a mouseOut event instead. Also, the variable for the target of a rollOut event was misnamed as "rollover_target".

Fixes this little issue in Pursuit of Hat:

https://user-images.githubusercontent.com/71368227/212291896-5e8a0312-88e0-4074-aed7-1674c75ec390.mp4

