### PR TITLE
wgpu: Use a temporary wgpu fork that increases push constants limit on webgl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4917,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.14.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac#630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac"
+source = "git+https://github.com/Dinnerbone/wgpu?rev=f1fdd1ceb1b4518b627e70b682e6695448d625d7#f1fdd1ceb1b4518b627e70b682e6695448d625d7"
 dependencies = [
  "arrayvec 0.7.2",
  "cfg-if 1.0.0",
@@ -4940,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.14.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac#630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac"
+source = "git+https://github.com/Dinnerbone/wgpu?rev=f1fdd1ceb1b4518b627e70b682e6695448d625d7#f1fdd1ceb1b4518b627e70b682e6695448d625d7"
 dependencies = [
  "arrayvec 0.7.2",
  "bit-vec",
@@ -4964,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.14.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac#630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac"
+source = "git+https://github.com/Dinnerbone/wgpu?rev=f1fdd1ceb1b4518b627e70b682e6695448d625d7#f1fdd1ceb1b4518b627e70b682e6695448d625d7"
 dependencies = [
  "android_system_properties",
  "arrayvec 0.7.2",
@@ -5004,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.14.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac#630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac"
+source = "git+https://github.com/Dinnerbone/wgpu?rev=f1fdd1ceb1b4518b627e70b682e6695448d625d7#f1fdd1ceb1b4518b627e70b682e6695448d625d7"
 dependencies = [
  "bitflags",
  "serde",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "630c12fe47a7bc0dc9ec6217f3903ec6fd6e3fac", features = ["naga"] }
+wgpu = { git = "https://github.com/Dinnerbone/wgpu", rev = "f1fdd1ceb1b4518b627e70b682e6695448d625d7", features = ["naga"] }
 tracing = "0.1.37"
 ruffle_render = { path = "..", features = ["tessellator"] }
 bytemuck = { version = "1.12.3", features = ["derive"] }

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -210,7 +210,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
 
         let (device, queue) = request_device(&adapter, trace_path).await?;
 
-        if cfg!(target_arch = "wasm") {
+        if cfg!(target_arch = "wasm") && device.limits().max_push_constant_size == 0 {
             detect_buffer_bug(&device, &queue)?;
         }
 


### PR DESCRIPTION
This significantly decreases wgpu-webgl rendering time, and works around the buffer bug.