### PR TITLE
wgpu: Fix buffer bug detection

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -5,7 +5,6 @@ use crate::surface::Surface;
 use crate::target::RenderTargetFrame;
 use crate::target::TextureTarget;
 use crate::uniform_buffer::BufferStorage;
-use crate::utils::detect_buffer_bug;
 use crate::{
     as_texture, format_list, get_backend_names, ColorAdjustments, Descriptors, Error,
     QueueSyncHandle, RenderTarget, SwapChainTarget, Texture, Transforms,
@@ -210,9 +209,8 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
 
         let (device, queue) = request_device(&adapter, trace_path).await?;
 
-        if cfg!(target_arch = "wasm") && device.limits().max_push_constant_size == 0 {
-            detect_buffer_bug(&device, &queue)?;
-        }
+        #[cfg(target_family = "wasm")]
+        crate::utils::detect_buffer_bug(&device, &queue)?;
 
         Ok(Descriptors::new(adapter, device, queue))
     }


### PR DESCRIPTION
This makes 8 passes of the test just to be safe, but from testing it appears that it always fails on pass 0. We can reduce the passes down to 4 or 2 or 1 later if we find it impacts performance, but let's be safe for now.