### PR TITLE
ci: Cancel existing actions for PRs when new commits come in

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Paths filter

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Paths filter


### PR DESCRIPTION
This should help ease the action queue when rebasing or making changes to PRs. Basically, whenever a PR changes, the existing actions are cancelled as they're no longer relevant for the new changes.


Untested but taken straight from the github docs. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow