### PR TITLE
desktop: Add `.spl` to file dialog filter

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -160,7 +160,8 @@ fn parse_parameters(opt: &Opt) -> impl '_ + Iterator<Item = (String, String)> {
 
 fn pick_file() -> Option<PathBuf> {
     FileDialog::new()
-        .add_filter(".swf", &["swf"])
+        .add_filter("Flash Files", &["swf", "spl"])
+        .add_filter("All Files", &["*"])
         .set_title("Load a Flash File")
         .pick_file()
 }


### PR DESCRIPTION
Fixes #9172.

Tested on Windows. If anyone can check whether this works as expected on Linux and Mac, that would be great!