### PR TITLE
Delay reading image back from render backend using `SyncHandle`

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -159,6 +159,10 @@ pub fn get_pixel<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let (Some(x_val), Some(y_val)) = (args.get(0), args.get(1)) {
                 let x = x_val.coerce_to_i32(activation)?;
                 let y = y_val.coerce_to_i32(activation)?;
@@ -177,6 +181,10 @@ pub fn get_pixel32<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let (Some(x_val), Some(y_val)) = (args.get(0), args.get(1)) {
                 let x = x_val.coerce_to_i32(activation)?;
                 let y = y_val.coerce_to_i32(activation)?;
@@ -196,6 +204,10 @@ pub fn set_pixel<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let (Some(x_val), Some(y_val), Some(color_val)) =
                 (args.get(0), args.get(1), args.get(2))
             {
@@ -223,6 +235,10 @@ pub fn set_pixel32<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let (Some(x_val), Some(y_val), Some(color_val)) =
                 (args.get(0), args.get(1), args.get(2))
             {
@@ -276,6 +292,15 @@ pub fn copy_channel<'gc>(
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
             if let Some(source_bitmap) = source_bitmap.as_bitmap_data_object() {
+                bitmap_data
+                    .bitmap_data()
+                    .write(activation.context.gc_context)
+                    .ensure_updated(activation.context.renderer);
+                source_bitmap
+                    .bitmap_data()
+                    .write(activation.context.gc_context)
+                    .ensure_updated(activation.context.renderer);
+
                 //TODO: what if source is disposed
                 let min_x = dest_point
                     .get("x", activation)?
@@ -348,6 +373,10 @@ pub fn fill_rect<'gc>(
 
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let Some(color_val) = args.get(1) {
                 let color = color_val.coerce_to_i32(activation)?;
 
@@ -379,6 +408,10 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let new_bitmap_data = BitmapDataObject::empty_object(
                 activation.context.gc_context,
                 activation.context.avm1.prototypes().bitmap_data,
@@ -425,6 +458,10 @@ pub fn flood_fill<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let (Some(x_val), Some(y_val), Some(color_val)) =
                 (args.get(0), args.get(1), args.get(2))
             {
@@ -473,6 +510,10 @@ pub fn noise<'gc>(
 
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let Some(random_seed_val) = args.get(0) {
                 let random_seed = random_seed_val.coerce_to_i32(activation)?;
                 bitmap_data
@@ -598,6 +639,10 @@ pub fn color_transform<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             if let [rectangle, color_transform, ..] = args {
                 // TODO: Re-use `object_to_rectangle` in `movie_clip.rs`.
                 let rectangle = rectangle.coerce_to_object(activation);
@@ -638,6 +683,10 @@ pub fn get_color_bounds_rect<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let find_color = args
                 .get(2)
                 .unwrap_or(&true.into())
@@ -670,6 +719,10 @@ pub fn perlin_noise<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let base_x = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
@@ -762,6 +815,10 @@ pub fn copy_pixels<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let source_bitmap = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
@@ -795,6 +852,10 @@ pub fn copy_pixels<'gc>(
 
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
+                    src_bitmap
+                        .bitmap_data()
+                        .write(activation.context.gc_context)
+                        .ensure_updated(activation.context.renderer);
                     let merge_alpha = if args.len() >= 6 {
                         Some(
                             args.get(5)
@@ -897,6 +958,10 @@ pub fn merge<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let source_bitmap = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
@@ -950,6 +1015,10 @@ pub fn merge<'gc>(
 
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
+                    src_bitmap
+                        .bitmap_data()
+                        .write(activation.context.gc_context)
+                        .ensure_updated(activation.context.renderer);
                     // dealing with object aliasing...
                     let src_bitmap_clone: BitmapData; // only initialized if source is the same object as self
                     let src_bitmap_data_cell = src_bitmap.bitmap_data();
@@ -989,6 +1058,10 @@ pub fn palette_map<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let source_bitmap = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
@@ -1043,6 +1116,10 @@ pub fn palette_map<'gc>(
 
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
+                    src_bitmap
+                        .bitmap_data()
+                        .write(activation.context.gc_context)
+                        .ensure_updated(activation.context.renderer);
                     // dealing with object aliasing...
                     let src_bitmap_data_cell = src_bitmap.bitmap_data();
                     let read;
@@ -1054,6 +1131,10 @@ pub fn palette_map<'gc>(
                             Some(&read)
                         };
 
+                    bitmap_data
+                        .bitmap_data()
+                        .write(activation.context.gc_context)
+                        .ensure_updated(activation.context.renderer);
                     bitmap_data
                         .bitmap_data()
                         .write(activation.context.gc_context)
@@ -1095,6 +1176,10 @@ pub fn scroll<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
+            bitmap_data
+                .bitmap_data()
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let x = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)
@@ -1255,8 +1340,14 @@ pub fn compare<'gc>(
     }
 
     let this_bitmap_data = this_bitmap_data.bitmap_data();
+    this_bitmap_data
+        .write(activation.context.gc_context)
+        .ensure_updated(activation.context.renderer);
     let this_bitmap_data = this_bitmap_data.read();
     let other_bitmap_data = other_bitmap_data.bitmap_data();
+    other_bitmap_data
+        .write(activation.context.gc_context)
+        .ensure_updated(activation.context.renderer);
     let other_bitmap_data = other_bitmap_data.read();
 
     if this_bitmap_data.width() != other_bitmap_data.width() {

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -179,6 +179,9 @@ pub fn scroll<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.read().check_valid(activation)?;
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -204,6 +207,9 @@ pub fn copy_pixels<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.read().check_valid(activation)?;
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let source_bitmap = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -241,6 +247,9 @@ pub fn copy_pixels<'gc>(
 
         if let Some(src_bitmap) = source_bitmap.as_bitmap_data() {
             src_bitmap.read().check_valid(activation)?;
+            src_bitmap
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             // dealing with object aliasing...
             let src_bitmap_clone: BitmapData; // only initialized if source is the same object as self
             let src_bitmap_data_cell = src_bitmap;
@@ -324,6 +333,9 @@ pub fn get_pixel<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.read().check_valid(activation)?;
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -345,6 +357,9 @@ pub fn get_pixel32<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -367,6 +382,9 @@ pub fn set_pixel<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -394,6 +412,9 @@ pub fn set_pixel32<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -430,6 +451,9 @@ pub fn set_pixels<'gc>(
         .unwrap_or(&Value::Undefined)
         .coerce_to_object(activation)?;
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = rectangle
             .get_property(&Multiname::public("x"), activation)?
             .coerce_to_u32(activation)?;
@@ -478,6 +502,9 @@ pub fn copy_channel<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.read().check_valid(activation)?;
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let source_bitmap = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -511,6 +538,9 @@ pub fn copy_channel<'gc>(
             .coerce_to_i32(activation)?;
 
         if let Some(source_bitmap) = source_bitmap.as_bitmap_data() {
+            source_bitmap
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             //TODO: what if source is disposed
             let src_min_x = source_rect
                 .get_property(&Multiname::public("x"), activation)?
@@ -558,6 +588,9 @@ pub fn flood_fill<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let mut bitmap_data = bitmap_data.write(activation.context.gc_context);
         if !bitmap_data.disposed() {
             if let (Some(x_val), Some(y_val), Some(color_val)) =
@@ -599,6 +632,9 @@ pub fn noise<'gc>(
     let gray_scale = args.get(4).unwrap_or(&false.into()).coerce_to_boolean();
 
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let mut bitmap_data = bitmap_data.write(activation.context.gc_context);
         if !bitmap_data.disposed() {
             if let Some(random_seed_val) = args.get(0) {
@@ -616,6 +652,9 @@ pub fn color_transform<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let mut bitmap_data = bitmap_data.write(activation.context.gc_context);
         if !bitmap_data.disposed() {
             if let [rectangle, color_transform, ..] = args {
@@ -659,6 +698,9 @@ pub fn get_color_bounds_rect<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let bitmap_data = bitmap_data.read();
         if !bitmap_data.disposed() {
             let find_color = args.get(2).unwrap_or(&true.into()).coerce_to_boolean();
@@ -787,6 +829,9 @@ pub fn fill_rect<'gc>(
         .coerce_to_u32(activation)? as i32;
 
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
+        bitmap_data
+            .write(activation.context.gc_context)
+            .ensure_updated(activation.context.renderer);
         let x = rectangle
             .get_property(&Multiname::public("x"), activation)?
             .coerce_to_u32(activation)?;
@@ -864,6 +909,9 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         if !bitmap_data.read().disposed() {
+            bitmap_data
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let new_bitmap_data =
                 GcCell::allocate(activation.context.gc_context, BitmapData::default());
             new_bitmap_data
@@ -893,6 +941,9 @@ pub fn perlin_noise<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         if !bitmap_data.read().disposed() {
+            bitmap_data
+                .write(activation.context.gc_context)
+                .ensure_updated(activation.context.renderer);
             let base_x = args
                 .get(0)
                 .unwrap_or(&Value::Undefined)


### PR DESCRIPTION
This allows us to avoid blocking immediately after a `BitmapData.draw` call. Instead, we only attempt to use the `SyncHandle` when performing an operation that requires the CPU-side pixels (e.g. BitmapData.getPixel or BitmapData.setPixel).

In the best case, the SWF will never explicitly access the pixels of the target BitmapData, removing the need to ever copy back the render backend image to our BitmapData. If the SWF doesn't require access to the pixels immediately, we can delay copying the pixels until they're actually needed, hopefully allowing the render backend to finish processing the BitmapData.draw operation in the backenground before we need the result.

Now that the CPU and GPU pixels can be intentionally out of sync with each other, we need to ensure that we don't accidentally expose 'stale' CPU-side pixels to ActionScript (which needs to remain unaware of our internal laziness). To help enforce this, all access to the CPU-side pixels now goes through the new `PixelsWrapper` type. This type has a `Deref` impl which panics if a `SyncHandle` is present (e.g. `ensure_updated` has now been called).

This will prevent execution from continuing if we forget to call `ensure_updated` in one of the many places that require it, rather than reeturning incorrect data to ActionScript.