### PR TITLE
Take two: Delay reading image back from render backend using `SyncHandle`

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -536,7 +536,7 @@ pub fn draw<'gc>(
             let source = if let Some(source_object) = source.as_display_object() {
                 IBitmapDrawable::DisplayObject(source_object)
             } else if let Some(source_bitmap) = source.as_bitmap_data_object() {
-                IBitmapDrawable::BitmapData(source_bitmap.bitmap_data())
+                IBitmapDrawable::BitmapData(source_bitmap.bitmap_data_wrapper())
             } else {
                 avm_error!(
                     activation,
@@ -547,7 +547,7 @@ pub fn draw<'gc>(
                 return Ok(Value::Undefined);
             };
 
-            let bmd = bitmap_data.bitmap_data();
+            let bmd = bitmap_data.bitmap_data_wrapper().overwrite_cpu_pixels();
             let mut write = bmd.write(activation.context.gc_context);
             write.draw(
                 source,

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -547,7 +547,9 @@ pub fn draw<'gc>(
                 return Ok(Value::Undefined);
             };
 
-            let bmd = bitmap_data.bitmap_data_wrapper().overwrite_cpu_pixels();
+            let bmd = bitmap_data
+                .bitmap_data_wrapper()
+                .overwrite_cpu_pixels(activation.context.gc_context);
             let mut write = bmd.write(activation.context.gc_context);
             write.draw(
                 source,

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -141,8 +141,8 @@ pub fn get_rectangle<'gc>(
                 &[
                     0.into(),
                     0.into(),
-                    bitmap_data.bitmap_data().read().width().into(),
-                    bitmap_data.bitmap_data().read().height().into(),
+                    bitmap_data.width().into(),
+                    bitmap_data.height().into(),
                 ],
             )?;
             return Ok(rect);
@@ -390,9 +390,9 @@ pub fn clone<'gc>(
                 .bitmap_data()
                 .write(activation.context.gc_context)
                 .set_pixels(
-                    bitmap_data.bitmap_data().read().width(),
-                    bitmap_data.bitmap_data().read().height(),
-                    bitmap_data.bitmap_data().read().transparency(),
+                    bitmap_data.width(),
+                    bitmap_data.height(),
+                    bitmap_data.transparency(),
                     bitmap_data.bitmap_data().read().pixels().to_vec(),
                 );
 

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -32,6 +32,10 @@ impl<'gc> BitmapDataObject<'gc> {
         self.0.read().data.sync()
     }
 
+    pub fn bitmap_data_wrapper(&self) -> BitmapDataWrapper<'gc> {
+        self.0.read().data
+    }
+
     pub fn empty_object(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Self {
         Self::with_bitmap_data(gc_context, proto, Default::default())
     }

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -137,7 +137,7 @@ pub fn bitmap_data<'gc>(
         .and_then(|this| this.as_display_object())
         .and_then(|dobj| dobj.as_bitmap())
     {
-        let mut value = bitmap.bitmap_data().read().object2();
+        let mut value = bitmap.bitmap_data_wrapper().object2();
 
         // AS3 expects an unset BitmapData to be null, not 'undefined'
         if matches!(value, Value::Undefined) {

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -698,7 +698,9 @@ pub fn draw<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+        // Drawing onto a BitmapData doesn't use any of the CPU-side pixels
+        let bitmap_data = bitmap_data.overwrite_cpu_pixels();
         bitmap_data.read().check_valid(activation)?;
         let mut transform = Transform::default();
         let mut blend_mode = BlendMode::Normal;
@@ -752,7 +754,7 @@ pub fn draw<'gc>(
 
         let source = if let Some(source_object) = source.as_display_object() {
             IBitmapDrawable::DisplayObject(source_object)
-        } else if let Some(source_bitmap) = source.as_bitmap_data() {
+        } else if let Some(source_bitmap) = source.as_bitmap_data_wrapper() {
             IBitmapDrawable::BitmapData(source_bitmap)
         } else {
             return Err(format!("BitmapData.draw: unexpected source {source:?}").into());

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -700,7 +700,7 @@ pub fn draw<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
         // Drawing onto a BitmapData doesn't use any of the CPU-side pixels
-        let bitmap_data = bitmap_data.overwrite_cpu_pixels();
+        let bitmap_data = bitmap_data.overwrite_cpu_pixels(activation.context.gc_context);
         bitmap_data.read().check_valid(activation)?;
         let mut transform = Transform::default();
         let mut blend_mode = BlendMode::Normal;

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -17,7 +17,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::backend::audio::{SoundHandle, SoundInstanceHandle};
-use crate::bitmap::bitmap_data::BitmapData;
+use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
 use crate::display_object::DisplayObject;
 use crate::html::TextFormat;
 use crate::string::AvmString;
@@ -1065,6 +1065,10 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
     /// Unwrap this object's bitmap data
     fn as_bitmap_data(&self) -> Option<GcCell<'gc, BitmapData<'gc>>> {
+        None
+    }
+
+    fn as_bitmap_data_wrapper(&self) -> Option<BitmapDataWrapper<'gc>> {
         None
     }
 

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -94,6 +94,10 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
         self.0.read().bitmap_data.map(|wrapper| wrapper.sync())
     }
 
+    fn as_bitmap_data_wrapper(&self) -> Option<BitmapDataWrapper<'gc>> {
+        self.0.read().bitmap_data
+    }
+
     /// Initialize the bitmap data in this object, if it's capable of
     /// supporting said data
     fn init_bitmap_data(

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -5,7 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::bitmap::bitmap_data::BitmapData;
+use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
@@ -45,7 +45,7 @@ pub struct BitmapDataObjectData<'gc> {
     /// Base script object
     base: ScriptObjectData<'gc>,
 
-    bitmap_data: Option<GcCell<'gc, BitmapData<'gc>>>,
+    bitmap_data: Option<BitmapDataWrapper<'gc>>,
 }
 
 impl<'gc> BitmapDataObject<'gc> {
@@ -58,7 +58,7 @@ impl<'gc> BitmapDataObject<'gc> {
             activation.context.gc_context,
             BitmapDataObjectData {
                 base: ScriptObjectData::new(class),
-                bitmap_data: Some(bitmap_data),
+                bitmap_data: Some(BitmapDataWrapper::new(bitmap_data)),
             },
         ));
 
@@ -91,7 +91,7 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
 
     /// Unwrap this object's bitmap data
     fn as_bitmap_data(&self) -> Option<GcCell<'gc, BitmapData<'gc>>> {
-        self.0.read().bitmap_data
+        self.0.read().bitmap_data.map(|wrapper| wrapper.sync())
     }
 
     /// Initialize the bitmap data in this object, if it's capable of
@@ -101,6 +101,6 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
         mc: MutationContext<'gc, '_>,
         new_bitmap: GcCell<'gc, BitmapData<'gc>>,
     ) {
-        self.0.write(mc).bitmap_data = Some(new_bitmap)
+        self.0.write(mc).bitmap_data = Some(BitmapDataWrapper::new(new_bitmap))
     }
 }

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -157,6 +157,10 @@ impl<'gc> Bitmap<'gc> {
         self.0.read().bitmap_data.height() as u16
     }
 
+    pub fn bitmap_data_wrapper(self) -> BitmapDataWrapper<'gc> {
+        self.0.read().bitmap_data
+    }
+
     /// Retrieve the bitmap data associated with this `Bitmap`.
     pub fn bitmap_data(self) -> GcCell<'gc, crate::bitmap::bitmap_data::BitmapData<'gc>> {
         self.0.read().bitmap_data.sync()

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -5,6 +5,7 @@ use crate::avm2::{
     Activation as Avm2Activation, ClassObject as Avm2ClassObject, Object as Avm2Object,
     StageObject as Avm2StageObject, Value as Avm2Value,
 };
+use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::{DisplayObjectBase, DisplayObjectPtr, TDisplayObject};
 use crate::prelude::*;
@@ -13,7 +14,6 @@ use crate::vminterface::Instantiator;
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_render::bitmap::BitmapFormat;
-use ruffle_render::commands::CommandHandler;
 use std::cell::{Ref, RefMut};
 use std::sync::Arc;
 
@@ -70,7 +70,7 @@ pub struct BitmapData<'gc> {
     movie: Arc<SwfMovie>,
 
     /// The current bitmap data object.
-    bitmap_data: GcCell<'gc, crate::bitmap::bitmap_data::BitmapData<'gc>>,
+    bitmap_data: BitmapDataWrapper<'gc>,
 
     /// Whether or not bitmap smoothing is enabled.
     smoothing: bool,
@@ -107,7 +107,7 @@ impl<'gc> Bitmap<'gc> {
             BitmapData {
                 base: Default::default(),
                 id,
-                bitmap_data,
+                bitmap_data: BitmapDataWrapper::new(bitmap_data),
                 smoothing,
                 avm2_object: None,
                 avm2_bitmap_class: BitmapClass::NoSubclass,
@@ -150,16 +150,16 @@ impl<'gc> Bitmap<'gc> {
     }
 
     pub fn width(self) -> u16 {
-        self.0.read().bitmap_data.read().width() as u16
+        self.0.read().bitmap_data.width() as u16
     }
 
     pub fn height(self) -> u16 {
-        self.0.read().bitmap_data.read().height() as u16
+        self.0.read().bitmap_data.height() as u16
     }
 
     /// Retrieve the bitmap data associated with this `Bitmap`.
     pub fn bitmap_data(self) -> GcCell<'gc, crate::bitmap::bitmap_data::BitmapData<'gc>> {
-        self.0.read().bitmap_data
+        self.0.read().bitmap_data.sync()
     }
 
     /// Associate this `Bitmap` with new `BitmapData`.
@@ -175,7 +175,7 @@ impl<'gc> Bitmap<'gc> {
         context: &mut UpdateContext<'_, 'gc>,
         bitmap_data: GcCell<'gc, crate::bitmap::bitmap_data::BitmapData<'gc>>,
     ) {
-        self.0.write(context.gc_context).bitmap_data = bitmap_data;
+        self.0.write(context.gc_context).bitmap_data = BitmapDataWrapper::new(bitmap_data);
     }
 
     pub fn avm2_bitmapdata_class(self) -> Option<Avm2ClassObject<'gc>> {
@@ -290,25 +290,9 @@ impl<'gc> TDisplayObject<'gc> for Bitmap<'gc> {
         }
 
         let bitmap_data = self.0.read();
-        let inner_bitmap_data = bitmap_data.bitmap_data.try_write(context.gc_context);
-        if let Ok(mut inner_bitmap_data) = inner_bitmap_data {
-            if inner_bitmap_data.disposed() {
-                return;
-            }
-
-            inner_bitmap_data.update_dirty_texture(context);
-            let handle = inner_bitmap_data
-                .bitmap_handle(context.renderer)
-                .expect("Missing bitmap handle");
-
-            context.commands.render_bitmap(
-                handle,
-                context.transform_stack.transform(),
-                bitmap_data.smoothing,
-            );
-        } else {
-            //this is caused by recursive render attempt. TODO: support this.
-        }
+        bitmap_data
+            .bitmap_data
+            .render(bitmap_data.smoothing, context);
     }
 
     fn object2(&self) -> Avm2Value<'gc> {

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -469,13 +469,6 @@ impl RenderBackend for WebCanvasRenderBackend {
         Err(Error::Unimplemented)
     }
 
-    fn retrieve_offscreen_texture(
-        &self,
-        _sync: Box<dyn SyncHandle>,
-    ) -> Result<Bitmap, ruffle_render::error::Error> {
-        Err(Error::Unimplemented)
-    }
-
     fn submit_frame(&mut self, clear: Color, commands: CommandList) {
         self.begin_frame(clear);
         commands.execute(self);

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -45,9 +45,6 @@ pub trait RenderBackend: Downcast {
         commands: CommandList,
     ) -> Result<Box<dyn SyncHandle>, Error>;
 
-    /// Retrieves the rendered pixels from a previous `render_offscreen` call
-    fn retrieve_offscreen_texture(&self, sync: Box<dyn SyncHandle>) -> Result<Bitmap, Error>;
-
     fn submit_frame(&mut self, clear: swf::Color, commands: CommandList);
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -70,10 +70,6 @@ impl RenderBackend for NullRenderer {
         Err(Error::Unimplemented)
     }
 
-    fn retrieve_offscreen_texture(&self, _sync: Box<dyn SyncHandle>) -> Result<Bitmap, Error> {
-        Err(Error::Unimplemented)
-    }
-
     fn submit_frame(&mut self, _clear: Color, _commands: CommandList) {}
     fn register_bitmap(&mut self, _bitmap: Bitmap) -> Result<BitmapHandle, Error> {
         Ok(BitmapHandle(Arc::new(NullBitmapHandle)))

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -34,8 +34,17 @@ pub trait BitmapSource {
     fn bitmap_handle(&self, id: u16, renderer: &mut dyn RenderBackend) -> Option<BitmapHandle>;
 }
 
-pub trait SyncHandle: Downcast + Debug {}
+pub trait SyncHandle: Downcast + Debug {
+    /// Retrieves the rendered pixels from a previous `render_offscreen` call
+    fn retrieve_offscreen_texture(self: Box<Self>) -> Result<Bitmap, crate::error::Error>;
+}
 impl_downcast!(SyncHandle);
+
+impl Clone for Box<dyn SyncHandle> {
+    fn clone(&self) -> Box<dyn SyncHandle> {
+        panic!("SyncHandle should have been consumed before clone() is called!")
+    }
+}
 
 /// Decoded bitmap data from an SWF tag.
 #[derive(Clone, Debug)]

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -947,13 +947,6 @@ impl RenderBackend for WebGlRenderBackend {
         Err(ruffle_render::error::Error::Unimplemented)
     }
 
-    fn retrieve_offscreen_texture(
-        &self,
-        _sync: Box<dyn SyncHandle>,
-    ) -> Result<Bitmap, ruffle_render::error::Error> {
-        Err(ruffle_render::error::Error::Unimplemented)
-    }
-
     fn viewport_dimensions(&self) -> ViewportDimensions {
         ViewportDimensions {
             width: self.renderbuffer_width as u32,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -597,28 +597,14 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                 size: target.size,
                 buffer: texture_offscreen.buffer.clone(),
                 buffer_dimensions: texture_offscreen.buffer_dimensions.clone(),
+                descriptors: self.descriptors.clone(),
             })),
             None => Ok(Box::new(QueueSyncHandle::NotCopied {
                 handle: handle.clone(),
                 size: target.size,
+                descriptors: self.descriptors.clone(),
             })),
         }
-    }
-
-    fn retrieve_offscreen_texture(
-        &self,
-        sync: Box<dyn SyncHandle>,
-    ) -> Result<Bitmap, ruffle_render::error::Error> {
-        let sync = sync
-            .downcast::<QueueSyncHandle>()
-            .expect("Sync handle must be a wgpu backend QueueSyncHandle");
-        let image = sync.capture(&self.descriptors.device, &self.descriptors.queue);
-        Ok(Bitmap::new(
-            image.dimensions().0,
-            image.dimensions().1,
-            ruffle_render::bitmap::BitmapFormat::Rgba,
-            image.into_raw(),
-        ))
     }
 }
 

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -6,6 +6,7 @@ use crate::{
     DEFAULT_COLOR_ADJUSTMENTS,
 };
 use fnv::FnvHashMap;
+use std::fmt::Debug;
 use std::mem;
 use std::sync::{Arc, Mutex};
 
@@ -22,6 +23,12 @@ pub struct Descriptors {
     shaders: Shaders,
     pipelines: Mutex<FnvHashMap<(u32, wgpu::TextureFormat), Arc<Pipelines>>>,
     pub default_color_bind_group: wgpu::BindGroup,
+}
+
+impl Debug for Descriptors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Descriptors")
+    }
 }
 
 impl Descriptors {


### PR DESCRIPTION
This allows us to avoid blocking immediately after a `BitmapData.draw` call. Instead, we only attempt to use the `SyncHandle` when performing an operation that requires the CPU-side pixels (e.g. BitmapData.getPixel or BitmapData.setPixel).

In the best case, the SWF will never explicitly access the pixels of the target BitmapData, removing the need to ever copy back the render backend image to our BitmapData. If the SWF doesn't require access to the pixels immediately, we can delay copying the pixels until they're actually needed, hopefully allowing the render backend to finish processing the BitmapData.draw operation in the backenground before we need the result.

Now that the CPU and GPU pixels can be intentionally out of sync with each other, we need to ensure that we don't accidentally expose 'stale' CPU-side pixels to ActionScript (which needs to remain unaware of our internal laziness). We now use a wrapper type `BitmapDataWrapper` to enforce that the `SyncHandle` is consumed before accessing the underlying `BitmapData.