### PR TITLE
desktop+web: Add missing key codes

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -777,6 +777,7 @@ fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<ch
         (VirtualKeyCode::NumpadSubtract, _) => '-',
         (VirtualKeyCode::NumpadDecimal, _) => '.',
         (VirtualKeyCode::NumpadDivide, _) => '/',
+
         (VirtualKeyCode::Numpad0, false) => '0',
         (VirtualKeyCode::Numpad1, false) => '1',
         (VirtualKeyCode::Numpad2, false) => '2',
@@ -787,6 +788,8 @@ fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<ch
         (VirtualKeyCode::Numpad7, false) => '7',
         (VirtualKeyCode::Numpad8, false) => '8',
         (VirtualKeyCode::Numpad9, false) => '9',
+        (VirtualKeyCode::NumpadEnter, _) => '\r',
+
         (VirtualKeyCode::Tab, _) => '\t',
         (VirtualKeyCode::Return, _) => '\r',
         (VirtualKeyCode::Back, _) => '\u{0008}',

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -777,7 +777,6 @@ fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<ch
         (VirtualKeyCode::NumpadSubtract, _) => '-',
         (VirtualKeyCode::NumpadDecimal, _) => '.',
         (VirtualKeyCode::NumpadDivide, _) => '/',
-
         (VirtualKeyCode::Numpad0, false) => '0',
         (VirtualKeyCode::Numpad1, false) => '1',
         (VirtualKeyCode::Numpad2, false) => '2',
@@ -788,6 +787,9 @@ fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<ch
         (VirtualKeyCode::Numpad7, false) => '7',
         (VirtualKeyCode::Numpad8, false) => '8',
         (VirtualKeyCode::Numpad9, false) => '9',
+        (VirtualKeyCode::Tab, _) => '\t',
+        (VirtualKeyCode::Return, _) => '\r',
+        (VirtualKeyCode::Back, _) => '\u{0008}',
 
         _ => return None,
     })

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1503,6 +1503,7 @@ fn web_to_ruffle_key_code(key_code: &str) -> KeyCode {
         "NumpadSubtract" => KeyCode::NumpadMinus,
         "NumpadDecimal" => KeyCode::NumpadPeriod,
         "NumpadDivide" => KeyCode::NumpadSlash,
+        "NumpadEnter" => KeyCode::Return,
         "PageUp" => KeyCode::PgUp,
         "PageDown" => KeyCode::PgDown,
         "End" => KeyCode::End,


### PR DESCRIPTION
Add key codes for Tab, Enter, Backspace and Numpad Enter
This fixes #8492 and #3696