### PR TITLE
desktop: Implement crash report dialog when a panic happens

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,50 @@
+name: "\U0001f4A5 Crash report"
+description: File a crash report.
+labels: ["bug", "panic", "desktop"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - If you have a question about Ruffle, you can ask for help on our [Discord chat][chat].
+        - Also consult the [Frequently Asked Questions][faq] for common issues and questions.
+        - Please do your best to search for duplicate issues before filing a new issue so we can keep our issue board clean.
+        - Also make sure that you are using the [latest available version of Ruffle][version].
+        - Otherwise, fill out the information below to the best of your ability. Thank you!
+
+        [chat]: https://discord.gg/ruffle
+        [faq]: https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users
+        [version]: https://github.com/ruffle-rs/ruffle/tags
+  - type: textarea
+    attributes:
+      label: Describe what you were doing
+      description: |
+        Provide a clear and concise description of what you were doing when you encountered the crash.
+        - If there are steps to reproduce, list them here.
+        - If this is an issue with a specific SWF file, please provide a link to the SWF file, or you can attach the SWF by zipping it and dragging it onto the issue box.
+    validations:
+      required: true
+  - type: textarea
+    id: panic_text
+    attributes:
+      label: What does the crash message say?
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        # Device information
+  - type: input
+    id: operating_system
+    attributes:
+      label: Operating system
+      description: Please list the OS you are using.
+      placeholder: Windows 10, macOS Catalina, Android 11, iOS 14, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: extra_info
+    attributes:
+      label: Additional information
+      description: If you have any additional information for us, such as device logs or renderer info, use the field below.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -33,6 +33,13 @@ body:
     attributes:
       value: |
         # Device information
+  - type: input
+    id: ruffle_version
+    attributes:
+      label: Ruffle Version
+      description: What version of Ruffle did this crash occur in?
+    validations:
+      required: true
   - type: dropdown
     id: platform
     attributes:

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,6 +1,6 @@
 name: "\U0001f4A5 Crash report"
 description: File a crash report.
-labels: ["bug", "panic", "desktop"]
+labels: ["bug", "panic"]
 body:
   - type: markdown
     attributes:
@@ -33,6 +33,18 @@ body:
     attributes:
       value: |
         # Device information
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Affected platform
+      description: Is the problem with the Ruffle desktop app, online demo, browser's extension, or self-hosted version?
+      options:
+        - Desktop app
+        - Online demo
+        - Browser's extension
+        - Self-hosted version
+    validations:
+      required: true
   - type: input
     id: operating_system
     attributes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4750134fb6a5d49afc80777394ad5d95b04bc12068c6abb92fae8f43817270f"
+dependencies = [
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,8 +3544,10 @@ dependencies = [
  "embed-resource",
  "generational-arena",
  "isahc",
+ "os_info",
  "rfd",
  "ruffle_core",
+ "ruffle_render",
  "ruffle_render_wgpu",
  "ruffle_video_software",
  "tracing",

--- a/core/src/avm2/call_stack.rs
+++ b/core/src/avm2/call_stack.rs
@@ -41,6 +41,10 @@ impl<'gc> CallStack<'gc> {
             }
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.stack.is_empty()
+    }
 }
 
 impl<'gc> Default for CallStack<'gc> {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -85,7 +85,10 @@ impl StaticCallstack {
                 arena.mutate(|_, root| {
                     let callstack = root.callstack.read();
                     if let Some(callstack) = callstack.avm2 {
-                        f(&callstack.read())
+                        let stack = callstack.read();
+                        if !stack.is_empty() {
+                            f(&stack)
+                        }
                     }
                 })
             }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 clap = { version = "4.0.32", features = ["derive"] }
 cpal = "0.14.2"
 ruffle_core = { path = "../core", features = ["audio", "mp3", "nellymoser"] }
+ruffle_render = { path = "../render" }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
@@ -25,6 +26,7 @@ isahc = "1.7.2"
 rfd = "0.10.0"
 anyhow = "1.0"
 bytemuck = "1.12.3"
+os_info = { version = "3", default-features = false }
 
 # Deliberately held back to match tracy client used by profiling crate
 tracing-tracy = { version = "=0.10.0", optional = true }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -920,6 +920,13 @@ fn panic_hook(info: &PanicInfo) {
                 extra_info.push(format!("SWF: {swf_name}"));
             }
         });
+        CALLSTACK.with(|callstack| {
+            if let Some(callstack) = &*callstack.borrow() {
+                callstack.avm2(|callstack| {
+                    extra_info.push(format!("AVM2 Callstack:\n```{callstack}\n```"));
+                });
+            }
+        });
         if !extra_info.is_empty() {
             params.push(("extra_info", extra_info.join("\n")));
         }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -914,22 +914,22 @@ fn panic_hook(info: &PanicInfo) {
             ("ruffle_version", RUFFLE_VERSION.to_string()),
         ];
         let mut extra_info = vec![];
+        SWF_INFO.with(|i| {
+            if let Some(swf_name) = i.take() {
+                extra_info.push(format!("Filename: {swf_name}\n"));
+                params.push(("title", format!("Crash on {swf_name}")));
+            }
+        });
         CALLSTACK.with(|callstack| {
             if let Some(callstack) = &*callstack.borrow() {
                 callstack.avm2(|callstack| {
-                    extra_info.push(format!("# AVM2 Callstack\n```{callstack}\n```\n"));
+                    extra_info.push(format!("### AVM2 Callstack\n```{callstack}\n```\n"));
                 });
             }
         });
         RENDER_INFO.with(|i| {
             if let Some(render_info) = i.take() {
-                extra_info.push(format!("# Render Info\n{render_info}\n"));
-            }
-        });
-        SWF_INFO.with(|i| {
-            if let Some(swf_name) = i.take() {
-                extra_info.push(format!("# SWF\nFilename: {swf_name}\n"));
-                params.push(("title", format!("Crash on {swf_name}")));
+                extra_info.push(format!("### Render Info\n{render_info}\n"));
             }
         });
         if !extra_info.is_empty() {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -54,11 +54,13 @@ thread_local! {
 static GLOBAL: tracing_tracy::client::ProfiledAllocator<std::alloc::System> =
     tracing_tracy::client::ProfiledAllocator::new(std::alloc::System, 100);
 
+static RUFFLE_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version-info.txt"));
+
 #[derive(Parser, Debug)]
 #[clap(
     name = "Ruffle",
     author,
-    version = include_str!(concat!(env!("OUT_DIR"), "/version-info.txt")),
+    version = RUFFLE_VERSION,
 )]
 struct Opt {
     /// Path to a Flash movie (SWF) to play.
@@ -909,6 +911,7 @@ fn panic_hook(info: &PanicInfo) {
         params.push(("panic_text", info.to_string()));
         params.push(("platform", "Desktop app".to_string()));
         params.push(("operating_system", os_info::get().to_string()));
+        params.push(("ruffle_version", RUFFLE_VERSION.to_string()));
         let mut extra_info = vec![];
         RENDER_INFO.with(|i| {
             if let Some(render_info) = i.take() {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -907,11 +907,12 @@ fn panic_hook(info: &PanicInfo) {
         .set_buttons(rfd::MessageButtons::YesNo)
         .show()
     {
-        let mut params = vec![];
-        params.push(("panic_text", info.to_string()));
-        params.push(("platform", "Desktop app".to_string()));
-        params.push(("operating_system", os_info::get().to_string()));
-        params.push(("ruffle_version", RUFFLE_VERSION.to_string()));
+        let mut params = vec![
+            ("panic_text", info.to_string()),
+            ("platform", "Desktop app".to_string()),
+            ("operating_system", os_info::get().to_string()),
+            ("ruffle_version", RUFFLE_VERSION.to_string()),
+        ];
         let mut extra_info = vec![];
         RENDER_INFO.with(|i| {
             if let Some(render_info) = i.take() {
@@ -933,7 +934,7 @@ fn panic_hook(info: &PanicInfo) {
         if !extra_info.is_empty() {
             params.push(("extra_info", extra_info.join("\n")));
         }
-        if let Ok(url) = Url::parse_with_params("https://github.com/ruffle-rs/ruffle/issues/new?assignees=&labels=bug&template=crash_report.yml", &params) {
+        if let Ok(url) = Url::parse_with_params("https://github.com/dinnerbone/ruffle/issues/new?assignees=&labels=bug&template=crash_report.yml", &params) {
             let _ = webbrowser::open(url.as_str());
         }
     }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -907,6 +907,7 @@ fn panic_hook(info: &PanicInfo) {
     {
         let mut params = vec![];
         params.push(("panic_text", info.to_string()));
+        params.push(("platform", "Desktop app".to_string()));
         params.push(("operating_system", os_info::get().to_string()));
         let mut extra_info = vec![];
         RENDER_INFO.with(|i| {


### PR DESCRIPTION
When a panic happens:

![image](https://user-images.githubusercontent.com/317625/213272613-8a68e7a8-3667-43bd-9621-19aeed454fb6.png)

Pressing Yes takes you to [this new issue template, prefilled](https://github.com/dinnerbone/ruffle/issues/new?assignees=&labels=bug&template=crash_report.yml&panic_text=panicked+at+%27wgpu+error%3A+Validation+Error%0A%0ACaused+by%3A%0A++++In+Device%3A%3Acreate_texture%0A++++Dimension+X+value+390000+exceeds+the+limit+of+16384%0A%0A%27%2C+C%3A%5CUsers%5CDinnerbone%5C.cargo%5Cgit%5Ccheckouts%5Cwgpu-e4487c3622394142%5Ca154700%5Cwgpu%5Csrc%5Cbackend%5Cdirect.rs%3A2962%3A5&operating_system=Windows+10.0.19044+%28Windows+10+Pro%29+%5B64-bit%5D&extra_info=Renderer%3A+wgpu%0AAdapter+Backend%3A+Vulkan%0AAdapter+Name%3A+%22AMD+Radeon+RX+6900+XT%22%0AAdapter+Device+Type%3A+DiscreteGpu%0AAdapter+Driver+Name%3A+%22AMD+proprietary+driver%22%0AAdapter+Driver+Info%3A+%2222.11.2%22%0AEnabled+features%3A+PUSH_CONSTANTS%0AAvailable+features%3A+DEPTH_CLIP_CONTROL+%7C+DEPTH32FLOAT_STENCIL8+%7C+TEXTURE_COMPRESSION_BC+%7C+INDIRECT_FIRST_INSTANCE+%7C+TIMESTAMP_QUERY+%7C+PIPELINE_STATISTICS_QUERY+%7C+SHADER_FLOAT16+%7C+MAPPABLE_PRIMARY_BUFFERS+%7C+TEXTURE_BINDING_ARRAY+%7C+BUFFER_BINDING_ARRAY+%7C+STORAGE_RESOURCE_BINDING_ARRAY+%7C+SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING+%7C+UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING+%7C+PARTIALLY_BOUND_BINDING_ARRAY+%7C+MULTI_DRAW_INDIRECT+%7C+MULTI_DRAW_INDIRECT_COUNT+%7C+ADDRESS_MODE_CLAMP_TO_BORDER+%7C+POLYGON_MODE_LINE+%7C+POLYGON_MODE_POINT+%7C+TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES+%7C+SHADER_FLOAT64+%7C+CONSERVATIVE_RASTERIZATION+%7C+VERTEX_WRITABLE_STORAGE+%7C+CLEAR_TEXTURE+%7C+SPIRV_SHADER_PASSTHROUGH+%7C+SHADER_PRIMITIVE_INDEX+%7C+MULTIVIEW+%7C+TEXTURE_FORMAT_16BIT_NORM+%7C+ADDRESS_MODE_CLAMP_TO_ZERO+%7C+WRITE_TIMESTAMP_INSIDE_PASSES%0ACurrent+limits%3A+Limits+%7B+max_texture_dimension_1d%3A+16384%2C+max_texture_dimension_2d%3A+16384%2C+max_texture_dimension_3d%3A+8192%2C+max_texture_array_layers%3A+256%2C+max_bind_groups%3A+4%2C+max_bindings_per_bind_group%3A+640%2C+max_dynamic_uniform_buffers_per_pipeline_layout%3A+8%2C+max_dynamic_storage_buffers_per_pipeline_layout%3A+0%2C+max_sampled_textures_per_shader_stage%3A+16%2C+max_samplers_per_shader_stage%3A+16%2C+max_storage_buffers_per_shader_stage%3A+4294967295%2C+max_storage_textures_per_shader_stage%3A+0%2C+max_uniform_buffers_per_shader_stage%3A+11%2C+max_uniform_buffer_binding_size%3A+16384%2C+max_storage_buffer_binding_size%3A+2147483648%2C+max_vertex_buffers%3A+8%2C+max_vertex_attributes%3A+16%2C+max_vertex_buffer_array_stride%3A+255%2C+max_push_constant_size%3A+96%2C+min_uniform_buffer_offset_alignment%3A+32%2C+min_storage_buffer_offset_alignment%3A+32%2C+max_inter_stage_shader_components%3A+60%2C+max_compute_workgroup_storage_size%3A+0%2C+max_compute_invocations_per_workgroup%3A+0%2C+max_compute_workgroup_size_x%3A+0%2C+max_compute_workgroup_size_y%3A+0%2C+max_compute_workgroup_size_z%3A+0%2C+max_compute_workgroups_per_dimension%3A+0%2C+max_buffer_size%3A+268435456+%7D%0ASurface+samples%3A+4%0ASurface+size%3A+Extent3d+%7B+width%3A+800%2C+height%3A+600%2C+depth_or_array_layers%3A+1+%7D%0ASWF%3A%20catburglar.swf)