### PR TITLE
core: Allow sealing build information into the source ZIP for reproducibility.

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -318,7 +318,7 @@ jobs:
         shell: bash -l {0}
         run: |
           npm ci
-          npm run build:dual-wasm
+          npm run build:repro
           npm run docs
 
       - name: Publish Firefox extension

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -307,6 +307,25 @@ jobs:
       - name: Install binaryen
         shell: bash -l {0}
         run: conda install -c conda-forge binaryen
+      
+      - name: Produce reproducible source archive
+        if: ${{ !matrix.demo }}
+        shell: bash -l {0}
+        working-directory: web
+        env:
+          ENABLE_VERSION_SEAL: "true"
+        run: node packages/core/tools/set_version.js && zip -r ../reproducible-source.zip .
+
+      - name: Upload reproducible source archive
+        if: ${{ !matrix.demo }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-nightly-release.outputs.upload_url }}
+          asset_path: ./reproducible-source.zip
+          asset_name: ${{ needs.create-nightly-release.outputs.package_prefix }}-reproducible-source.zip
+          asset_content_type: application/zip
 
       - name: Build web
         env:

--- a/web/README.md
+++ b/web/README.md
@@ -93,6 +93,7 @@ In this project, you may run the following commands to build all packages:
     -   You may also use `npm run build:debug` to disable Webpack optimizations and activate the (extremely verbose) ActionScript debugging output.
     -   There is `npm run build:dual-wasm` as well, to build a second WebAssembly module that makes use of some WebAssembly extensions,
         potentially resulting in better performance in browsers that support them, at the expense of longer build time.
+    -   `npm run build:repro` enables reproducible builds. Note that this also requires a `version_seal.json`, which is not provided in the normal Git repository - only specially-marked reproducible source archives. Running this without a version seal will generate one based on the current state of your environment.
 
 From here, you may follow the instructions to [use Ruffle on your website](packages/selfhosted/README.md),
 run a demo locally with `npm run demo`, or [install the extension in your browser](https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension).

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
         "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
+        "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_VERSION_SEAL=true npm run build",
         "demo": "npm start --workspace ruffle-demo",
         "test": "npm test --workspaces --if-present",
         "docs": "npm run docs --workspaces --if-present",

--- a/web/packages/core/tools/set_version.js
+++ b/web/packages/core/tools/set_version.js
@@ -1,6 +1,6 @@
 const replace = require("replace-in-file");
 const childProcess = require("child_process");
-const fs = require('fs');
+const fs = require("fs");
 
 let version_number = process.env.npm_package_version;
 let version_channel = process.env.CFG_RELEASE_CHANNEL || "nightly";
@@ -19,23 +19,26 @@ let version_name =
         ? `nightly ${build_date.substr(0, 10)}`
         : process.env.npm_package_version;
 
+let version_seal = {};
+
 if (process.env.ENABLE_VERSION_SEAL === "true") {
-    if (fs.existsSync("version_seal.json")) { //Using the version seal stored previously.
+    if (fs.existsSync("version_seal.json")) {
+        //Using the version seal stored previously.
         version_seal = JSON.parse(fs.readFileSync("version_seal.json"));
 
-        version_number = version_seal["version_number"];
-        version_name = version_seal["version_name"];
-        version_channel = version_seal["version_channel"];
-        build_date = version_seal["build_date"];
-        commitHash = version_seal["commitHash"];
+        version_number = version_seal.version_number;
+        version_name = version_seal.version_name;
+        version_channel = version_seal.version_channel;
+        build_date = version_seal.build_date;
+        commitHash = version_seal.commitHash;
     } else {
         version_seal = {
-            "version_number": version_number,
-            "version_name": version_name,
-            "version_channel": version_channel,
-            "build_date": build_date,
-            "commitHash": commitHash
-        }
+            version_number: version_number,
+            version_name: version_name,
+            version_channel: version_channel,
+            build_date: build_date,
+            commitHash: commitHash,
+        };
 
         fs.writeFileSync("version_seal.json", JSON.stringify(version_seal));
     }

--- a/web/packages/core/tools/set_version.js
+++ b/web/packages/core/tools/set_version.js
@@ -1,11 +1,10 @@
 const replace = require("replace-in-file");
 const childProcess = require("child_process");
+const fs = require('fs');
 
-const version_number = process.env.npm_package_version;
-
-const version_channel = process.env.CFG_RELEASE_CHANNEL || "nightly";
-
-const build_date = new Date().toISOString();
+let version_number = process.env.npm_package_version;
+let version_channel = process.env.CFG_RELEASE_CHANNEL || "nightly";
+let build_date = new Date().toISOString();
 
 let commitHash = "unknown";
 
@@ -15,10 +14,32 @@ try {
     console.log("Couldn't fetch latest git commit...");
 }
 
-const version_name =
+let version_name =
     version_channel === "nightly"
         ? `nightly ${build_date.substr(0, 10)}`
         : process.env.npm_package_version;
+
+if (process.env.ENABLE_VERSION_SEAL === "true") {
+    if (fs.existsSync("version_seal.json")) { //Using the version seal stored previously.
+        version_seal = JSON.parse(fs.readFileSync("version_seal.json"));
+
+        version_number = version_seal["version_number"];
+        version_name = version_seal["version_name"];
+        version_channel = version_seal["version_channel"];
+        build_date = version_seal["build_date"];
+        commitHash = version_seal["commitHash"];
+    } else {
+        version_seal = {
+            "version_number": version_number,
+            "version_name": version_name,
+            "version_channel": version_channel,
+            "build_date": build_date,
+            "commitHash": commitHash
+        }
+
+        fs.writeFileSync("version_seal.json", JSON.stringify(version_seal));
+    }
+}
 
 const options = {
     files: "./pkg/**",


### PR DESCRIPTION
As per #8799 we need reproducible builds before Mozilla will let us back onto addons.mozilla.org. One of the largest differences between Mozilla's build and ours (save for the lack of dual-wasm) was version information, since Mozilla's reviewers are building from a source ZIP instead of a Git clone and they are building at a different time from us.

The solution is to... calculate all that information once and store it for later use. The resulting file is called `version_seal.json`. The plan is that source code submissions to Mozilla will be special "reproducible builds" archives with the version seal in them.

The version seal is only used when you specify reproducible builds with `npm run build:repro`, which also builds dual-WASM. The standard and dual-WASM builds will not use the version seal. Any future reproducibility fixes will be gated behind `build:repro` for now.

Note that this alone won't make builds reproducible - there's another major reproducibility problem I need to look into.

Intersects with #9121 - the `Dockerfile` will need to be changed to use `build:repro` once this PR lands, since that's the only build system Mozilla is able to run right now.