### PR TITLE
web: Construct SwfMovie with spoofed URL when loaded from data

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -316,4 +316,11 @@ export interface DataLoadOptions extends BaseLoadOptions {
      * The data to load a movie from.
      */
     data: Iterable<number>;
+
+    /**
+     * The filename of the SWF movie to provide to ActionScript.
+     *
+     * @default "movie.swf"
+     */
+    swfFileName?: string;
 }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -640,7 +640,8 @@ export class RufflePlayer extends HTMLElement {
                 console.log("Loading SWF data");
                 this.instance!.load_data(
                     new Uint8Array(options.data),
-                    sanitizeParameters(options.parameters)
+                    sanitizeParameters(options.parameters),
+                    options.swfFileName || "movie.swf"
                 );
             }
         } catch (err) {

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -144,7 +144,7 @@ async function loadFile(file) {
     }
     hideSample();
     const data = await new Response(file).arrayBuffer();
-    load({ data, ...defaultConfig });
+    load({ data: data, swfFileName: file.name, ...defaultConfig });
 }
 
 function loadSample() {


### PR DESCRIPTION
Implements the feature described in and closes #8448.
Fixes #8130.

To prevent abuse of this feature, the spoofed URL is constructed relative to the webpage's current URL, and the user can only specify the last path segment of the URL.