### PR TITLE
Include the whole project in the reproducible archive

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -314,13 +314,18 @@ jobs:
         run: |
           npm ci
       
-      - name: Produce reproducible source archive
+      - name: Seal version data
         if: ${{ !matrix.demo }}
         shell: bash -l {0}
         working-directory: web
         env:
           ENABLE_VERSION_SEAL: "true"
-        run: node packages/core/tools/set_version.js && zip -r ../reproducible-source.zip .
+        run: node packages/core/tools/set_version.js
+      
+      - name: Produce reproducible source archive
+        if: ${{ !matrix.demo }}
+        shell: bash -l {0}
+        run: zip -r reproducible-source.zip .
 
       - name: Upload reproducible source archive
         if: ${{ !matrix.demo }}


### PR DESCRIPTION
Note that this does *not* attempt to filter out `node_modules` as per @Dinnerbone 's suggestion that we keep them installed in case NPM dies.