### PR TITLE
tests: Move tests away from giant macro to individual test.toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libtest-mimic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b603516767d1ab23d0de09d023e62966c3322f7148297c35cf3d97aa8b37fa"
+dependencies = [
+ "clap",
+ "termcolor",
+ "threadpool",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3631,7 @@ dependencies = [
  "log",
  "lyon",
  "png",
+ "serde",
  "smallvec",
  "swf",
  "thiserror",
@@ -4375,11 +4387,15 @@ dependencies = [
  "env_logger",
  "futures",
  "image",
+ "libtest-mimic",
  "pretty_assertions",
  "regex",
  "ruffle_core",
  "ruffle_input_format",
  "ruffle_render_wgpu",
+ "serde",
+ "toml",
+ "walkdir",
 ]
 
 [[package]]

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "1.0"
 wasm-bindgen = { version = "=0.2.83", optional = true }
 gc-arena = { workspace = true }
 enum-map = "2.4.2"
+serde = "1.0.152"
 
 [dependencies.jpeg-decoder]
 version = "0.3.0"

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::shape_utils::DistilledShape;
 use downcast_rs::{impl_downcast, Downcast};
 use gc_arena::{Collect, GcCell, MutationContext};
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::rc::Rc;
 use swf;
@@ -205,7 +206,7 @@ pub enum Context3DCommand<'gc> {
 #[derive(Copy, Clone, Debug)]
 pub struct ShapeHandle(pub usize);
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct ViewportDimensions {
     /// The dimensions of the stage's containing viewport.
     pub width: u32,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,3 +25,12 @@ imgtests = ["ruffle_render_wgpu"]
 approx = "0.5.1"
 pretty_assertions = "1.3.0"
 env_logger = "0.10.0"
+serde = "1.0"
+toml = "0.5.10"
+libtest-mimic = "0.6.0"
+walkdir = "2.3.2"
+
+[[test]]
+name = "tests"
+harness = false
+path = "tests/regression_tests.rs"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,37 @@
+# SWF Regression Tests
+
+Inside [tests/swfs](tests/swfs) is a large collection of automated tests that are based around running a swf and seeing what happens.
+
+To create a test, make a directory that looks like the following, at minimum:
+
+- directory/
+  - test.swf
+  - test.toml
+  - output.txt
+
+As best practice, please also include any source used to make the swf - such as `test.fla` and any actionscript files.
+
+
+# Test Structure
+## test.toml
+Except for `num_frames`, every other field and section is optional.
+
+```toml
+num_frames = 1 # The amount of frames of the swf to run
+sleep_to_meet_frame_rate = false # If true, slow the tick rate to match the movies requested fps rate
+image = false # If true, capture a screenshot of the movie and compare it against a "known good" image
+ignore = false # If true, ignore this test. Please comment why, ideally link to an issue, so we know what's up
+
+# Sometimes floating point math doesn't exactly 100% match between flash and rust.
+# If you encounter this in a test, the following section will change the output testing from "exact" to "approximate"
+# (when it comes to floating point numbers, at least.)
+[approximations]
+number_patterns = [] # A list of regex patterns with capture groups to additionally treat as approximate numbers
+epsilon = 0.0 # The upper bound of any rounding errors. Default is the difference between 1.0 and the next largest representable number
+max_relative = 0.0 # The default relative tolerance for testing values that are far-apart. Default is the difference between 1.0 and the next largest representable number
+
+# Options for the player used to run this swf 
+[player_options]
+max_execution_duration = { secs = 15, nanos = 0} # How long can actionscript execute for before being forcefully stopped
+viewport_dimensions = { width = 100, height = 100, scale_factor = 1 } # The size of the player. Defaults to the swfs stage size
+```

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -18,16 +18,93 @@ use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::{Player, PlayerBuilder, PlayerEvent, ViewportDimensions};
 use ruffle_input_format::{AutomatedEvent, InputInjector, MouseButton as InputMouseButton};
 
+use libtest_mimic::{Arguments, Trial};
 #[cfg(feature = "imgtests")]
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
 #[cfg(feature = "imgtests")]
 use ruffle_render_wgpu::{target::TextureTarget, wgpu};
+use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+#[derive(Deserialize)]
+#[serde(default)]
+struct TestOptions {
+    num_frames: u32,
+    sleep_to_meet_frame_rate: bool,
+    image: bool,
+    ignore: bool,
+    approximations: Option<Approximations>,
+    player_options: Option<PlayerOptions>,
+}
+
+impl Default for TestOptions {
+    fn default() -> Self {
+        Self {
+            num_frames: 1,
+            sleep_to_meet_frame_rate: false,
+            image: false,
+            ignore: false,
+            approximations: None,
+            player_options: None,
+        }
+    }
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct Approximations {
+    number_patterns: Vec<String>,
+    epsilon: Option<f64>,
+    max_relative: Option<f64>,
+}
+
+impl Approximations {
+    pub fn compare(&self, actual: f64, expected: f64) {
+        match (self.epsilon, self.max_relative) {
+            (Some(epsilon), Some(max_relative)) => assert_relative_eq!(
+                actual,
+                expected,
+                epsilon = epsilon,
+                max_relative = max_relative
+            ),
+            (Some(epsilon), None) => assert_relative_eq!(actual, expected, epsilon = epsilon),
+            (None, Some(max_relative)) => {
+                assert_relative_eq!(actual, expected, max_relative = max_relative)
+            }
+            (None, None) => assert_relative_eq!(actual, expected),
+        }
+    }
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct PlayerOptions {
+    max_execution_duration: Option<Duration>,
+    viewport_dimensions: Option<ViewportDimensions>,
+}
+
+impl PlayerOptions {
+    pub fn setup(&self, player: Arc<Mutex<Player>>) {
+        if let Some(max_execution_duration) = self.max_execution_duration {
+            player
+                .lock()
+                .unwrap()
+                .set_max_execution_duration(max_execution_duration);
+        }
+        if let Some(viewport_dimensions) = self.viewport_dimensions {
+            player
+                .lock()
+                .unwrap()
+                .set_viewport_dimensions(viewport_dimensions);
+        }
+    }
+}
 
 const RUN_IMG_TESTS: bool = cfg!(feature = "imgtests");
 
@@ -40,912 +117,6 @@ fn set_logger() {
 
 type Error = Box<dyn std::error::Error>;
 
-macro_rules! val_or_false {
-    ($val:literal) => {
-        $val
-    };
-    () => {
-        false
-    };
-}
-
-macro_rules! val_or_empty_slice {
-    ($val:expr) => {
-        $val
-    };
-    () => {
-        &[]
-    };
-}
-
-// This macro generates test cases for a given list of SWFs.
-// If 'img' is true, then we will render an image of the final frame
-// of the SWF, and compare it against a reference image on disk.
-macro_rules! swf_tests {
-    ($($(#[$attr:meta])* ($name:ident, $path:expr, $num_frames:literal $(, img = $img:literal)? $(, frame_time_sleep = $frame_time_sleep:literal)? ),)*) => {
-        $(
-        #[test]
-        $(#[$attr])*
-        fn $name() -> Result<(), Error> {
-            set_logger();
-            test_swf(
-                concat!("tests/swfs/", $path, "/test.swf"),
-                $num_frames,
-                concat!("tests/swfs/", $path, "/input.json"),
-                concat!("tests/swfs/", $path, "/output.txt"),
-                val_or_false!($($img)?),
-                val_or_false!($($frame_time_sleep)?),
-            )
-        }
-        )*
-    };
-}
-
-// This macro generates test cases for a given list of SWFs using `test_swf_approx`.
-// If provided, `@num_patterns` must be a `&[Regex]`. Each regex in the slice is
-// tested against the expected and actual - if it matches, then each capture
-// group is treated as a floating-point value to be compared approximately.
-// The rest of the string (outside of the capture groups) is compared exactly.
-macro_rules! swf_tests_approx {
-    ($($(#[$attr:meta])* ($name:ident, $path:expr, $num_frames:literal $(, @num_patterns = $num_patterns:expr)? $(, @img = $img:literal)? $(, $opt:ident = $val:expr)*),)*) => {
-        $(
-        #[test]
-        $(#[$attr])*
-        fn $name() -> Result<(), Error> {
-            set_logger();
-            test_swf_approx(
-                concat!("tests/swfs/", $path, "/test.swf"),
-                $num_frames,
-                concat!("tests/swfs/", $path, "/input.json"),
-                concat!("tests/swfs/", $path, "/output.txt"),
-                val_or_empty_slice!($($num_patterns)?),
-                val_or_false!($($img)?),
-                |actual, expected| assert_relative_eq!(actual, expected $(, $opt = $val)*),
-            )
-        }
-        )*
-    };
-}
-
-// List of SWFs to test.
-// Format: (test_name, test_folder, number_of_frames_to_run)
-// The test folder is a relative to core/tests/swfs
-// Inside the folder is expected to be "test.swf" and "output.txt" with the correct output.
-swf_tests! {
-    (action_to_integer, "avm1/action_to_integer", 1),
-    (add_swf4, "avm1/add_swf4", 1),
-    (add_swf5, "avm1/add_swf5", 1),
-    (add, "avm1/add", 1),
-    (add2, "avm1/add2", 1),
-    (add_property, "avm1/add_property", 1),
-    (arguments, "avm1/arguments", 1),
-    (array_call_method, "avm1/array_call_method", 1),
-    (array_concat, "avm1/array_concat", 1),
-    (array_constructor, "avm1/array_constructor", 1),
-    (array_enumerate, "avm1/array_enumerate", 1),
-    (array_length, "avm1/array_length", 1),
-    (array_properties, "avm1/array_properties", 1),
-    (array_prototyping, "avm1/array_prototyping", 1),
-    (array_slice, "avm1/array_slice", 1),
-    (array_sort, "avm1/array_sort", 1),
-    (array_splice, "avm1/array_splice", 1),
-    (array_trivial, "avm1/array_trivial", 1),
-    (as_broadcaster_initialize, "avm1/as_broadcaster_initialize", 1),
-    (as_broadcaster, "avm1/as_broadcaster", 1),
-    (as_set_prop_flags, "avm1/as_set_prop_flags", 1),
-    (as_set_prop_flags_version, "avm1/as_set_prop_flags_version", 1),
-    (as_set_prop_flags_version_swf5, "avm1/as_set_prop_flags_version_swf5", 1),
-    (as_set_prop_flags_version_swf6, "avm1/as_set_prop_flags_version_swf6", 1),
-    (as_set_prop_flags_version_swf7, "avm1/as_set_prop_flags_version_swf7", 1),
-    (as_set_prop_flags_version_swf8, "avm1/as_set_prop_flags_version_swf8", 1),
-    (as_set_prop_flags_version_swf9, "avm1/as_set_prop_flags_version_swf9", 1),
-    (as_transformed_flag, "avm1/as_transformed_flag", 3),
-    (as1_constructor_v6, "avm1/as1_constructor_v6", 1),
-    (as1_constructor_v7, "avm1/as1_constructor_v7", 1),
-    (as2_bitand, "avm1/bitand", 1),
-    (as2_bitor, "avm1/bitor", 1),
-    (as2_bitxor, "avm1/bitxor", 1),
-    (as2_oop, "avm1/as2_oop", 1),
-    (as2_super_and_this_v6, "avm1/as2_super_and_this_v6", 1),
-    (as2_super_and_this_v8, "avm1/as2_super_and_this_v8", 1),
-    (as2_super_via_manual_prototype, "avm1/as2_super_via_manual_prototype", 1),
-    (as3_add, "avm2/add", 1),
-    (as3_agal_compiler, "avm2/agal_compiler", 1),
-    (as3_application_domain, "avm2/application_domain", 1),
-    (as3_array_access, "avm2/array_access", 1),
-    (as3_array_concat, "avm2/array_concat", 1),
-    (as3_array_constr, "avm2/array_constr", 1),
-    (as3_array_delete, "avm2/array_delete", 1),
-    (as3_array_enumeration_elements, "avm2/array_enumeration_elements", 1),
-    (as3_array_enumeration, "avm2/array_enumeration", 1),
-    (as3_array_every, "avm2/array_every", 1),
-    (as3_array_filter, "avm2/array_filter", 1),
-    (as3_array_foreach, "avm2/array_foreach", 1),
-    (as3_array_hasownproperty, "avm2/array_hasownproperty", 1),
-    (as3_array_holes, "avm2/array_holes", 1),
-    (as3_array_indexof, "avm2/array_indexof", 1),
-    (as3_array_join, "avm2/array_join", 1),
-    (as3_array_lastindexof, "avm2/array_lastindexof", 1),
-    (as3_array_length, "avm2/array_length", 1),
-    (as3_array_literal, "avm2/array_literal", 1),
-    (as3_array_map, "avm2/array_map", 1),
-    (as3_array_pop, "avm2/array_pop", 1),
-    (as3_array_push, "avm2/array_push", 1),
-    (as3_array_reverse, "avm2/array_reverse", 1),
-    (as3_array_shift, "avm2/array_shift", 1),
-    (as3_array_slice, "avm2/array_slice", 1),
-    (as3_array_some, "avm2/array_some", 1),
-    (as3_array_sort, "avm2/array_sort", 1),
-    (as3_array_sorton, "avm2/array_sorton", 1),
-    (as3_array_splice, "avm2/array_splice", 1),
-    (as3_array_storage, "avm2/array_storage", 1),
-    (as3_array_tolocalestring, "avm2/array_tolocalestring", 1),
-    (as3_array_tostring, "avm2/array_tostring", 1),
-    (as3_array_unshift, "avm2/array_unshift", 1),
-    (as3_array_valueof, "avm2/array_valueof", 1),
-    (as3_astype, "avm2/astype", 1),
-    (as3_astypelate, "avm2/astypelate", 1),
-    (as3_bitand, "avm2/bitand", 1),
-    (as3_bitmap_constr, "avm2/bitmap_constr", 1),
-    (as3_bitmap_data, "avm2/bitmap_data", 1),
-    (as3_bitmapdata_copypixels, "avm2/bitmapdata_copypixels", 2, img = true),
-    #[ignore] (as3_bitmap_properties, "avm2/bitmap_properties", 1),
-    (as3_bitmap_subclass, "avm2/bitmap_subclass", 1),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (as3_bitmap_subclass_properties, "avm2/bitmap_subclass_properties", 1, img = true),
-    (as3_bitmap_timeline, "avm2/bitmap_timeline", 1),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (as3_bitmapdata_clone, "avm2/bitmapdata_clone", 1, img = true),
-    (as3_bitmapdata_constr, "avm2/bitmapdata_constr", 1),
-    (as3_bitmapdata_dispose, "avm2/bitmapdata_dispose", 1),
-    // We need a render backend in order to call `BitmapData.draw`
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (as3_bitmapdata_draw, "avm2/bitmapdata_draw", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (as3_bitmapdata_opaque, "avm2/bitmapdata_opaque", 1, img = true),
-    (as3_bitmapdata_zero_size, "avm2/bitmapdata_zero_size", 1),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (as3_bitmapdata_embedded, "avm2/bitmapdata_embedded", 1, img = true),
-    (as3_bitmapdata_fillrect, "avm2/bitmapdata_fillrect", 1),
-    (as3_bitnot, "avm2/bitnot", 1),
-    (as3_bitor, "avm2/bitor", 1),
-    (as3_bitxor, "avm2/bitxor", 1),
-    (as3_boolean_constr, "avm2/boolean_constr", 1),
-    (as3_boolean_negation, "avm2/boolean_negation", 1),
-    (as3_boolean_tostring, "avm2/boolean_tostring", 1),
-    (as3_button_hittest, "avm2/button_hittest", 1),
-    (as3_bytearray_readobject_amf0, "avm2/bytearray_readobject_amf0", 1),
-    (as3_bytearray_readobject_amf3, "avm2/bytearray_readobject_amf3", 1),
-    (as3_bytearray_writeobject, "avm2/bytearray_writeobject", 1),
-    (as3_bytearray, "avm2/bytearray", 1),
-    (as3_checkfilter, "avm2/checkfilter", 1),
-    (as3_class_call, "avm2/class_call", 1),
-    (as3_class_cast_call, "avm2/class_cast_call", 1),
-    (as3_class_enumeration, "avm2/class_enumeration", 1),
-    (as3_class_is, "avm2/class_is", 1),
-    (as3_class_methods, "avm2/class_methods", 1),
-    (as3_class_object_properties, "avm2/class_object_properties", 1),
-    (as3_class_singleton, "avm2/class_singleton", 1),
-    (as3_class_supercalls_mismatched, "avm2/class_supercalls_mismatched", 1),
-    (as3_class_to_locale_string, "avm2/class_to_locale_string", 1),
-    (as3_class_to_string, "avm2/class_to_string", 1),
-    (as3_class_value_of, "avm2/class_value_of", 1),
-    (as3_closures, "avm2/closures", 1),
-    (as3_coerce_property, "avm2/coerce_property", 1),
-    (as3_coerce_string, "avm2/coerce_string", 1),
-    (as3_constructor_call, "avm2/constructor_call", 1),
-    (as3_control_flow_bool, "avm2/control_flow_bool", 1),
-    (as3_control_flow_stricteq, "avm2/control_flow_stricteq", 1),
-    (as3_convert_boolean, "avm2/convert_boolean", 1),
-    (as3_convert_integer, "avm2/convert_integer", 1),
-    (as3_convert_number, "avm2/convert_number", 1),
-    (as3_convert_uinteger, "avm2/convert_uinteger", 1),
-    (as3_date_parse, "avm2/date_parse", 1),
-    (as3_date, "avm2/date", 1),
-    (as3_declocal_i, "avm2/declocal_i", 1),
-    (as3_declocal, "avm2/declocal", 1),
-    (as3_decrement_i, "avm2/decrement_i", 1),
-    (as3_decrement, "avm2/decrement", 1),
-    (as3_default_values, "avm2/default_values", 1),
-    (as3_dictionary_access, "avm2/dictionary_access", 1),
-    (as3_dictionary_delete, "avm2/dictionary_delete", 1),
-    (as3_dictionary_foreach, "avm2/dictionary_foreach", 1),
-    (as3_dictionary_hasownproperty, "avm2/dictionary_hasownproperty", 1),
-    (as3_dictionary_in, "avm2/dictionary_in", 1),
-    (as3_dictionary_namespaces, "avm2/dictionary_namespaces", 1),
-    (as3_displayobject_alpha, "avm2/displayobject_alpha", 1),
-    (as3_displayobject_filters, "avm2/displayobject_filters", 1),
-    (as3_displayobject_blendmode, "avm2/displayobject_blendmode", 1, img = true),
-    (as3_displayobject_hittestobject, "avm2/displayobject_hittestobject", 1),
-    (as3_displayobject_hittestpoint, "avm2/displayobject_hittestpoint", 2),
-    (as3_displayobject_mask, "avm2/displayobject_mask", 1, img = true),
-    (as3_displayobject_name, "avm2/displayobject_name", 4),
-    (as3_displayobject_parent, "avm2/displayobject_parent", 4),
-    (as3_displayobject_root, "avm2/displayobject_root", 4),
-    (as3_displayobject_visible, "avm2/displayobject_visible", 4),
-    (as3_displayobject_x, "avm2/displayobject_x", 1),
-    (as3_displayobject_y, "avm2/displayobject_y", 1),
-    (as3_displayobjectcontainer_addchild_timelinepull0, "avm2/displayobjectcontainer_addchild_timelinepull0", 7),
-    (as3_displayobjectcontainer_addchild_timelinepull1, "avm2/displayobjectcontainer_addchild_timelinepull1", 7),
-    (as3_displayobjectcontainer_addchild_timelinepull2, "avm2/displayobjectcontainer_addchild_timelinepull2", 7),
-    (as3_displayobjectcontainer_addchild, "avm2/displayobjectcontainer_addchild", 1),
-    (as3_displayobjectcontainer_addchildat_timelinelock0, "avm2/displayobjectcontainer_addchildat_timelinelock0", 7),
-    (as3_displayobjectcontainer_addchildat_timelinelock1, "avm2/displayobjectcontainer_addchildat_timelinelock1", 7),
-    (as3_displayobjectcontainer_addchildat_timelinelock2, "avm2/displayobjectcontainer_addchildat_timelinelock2", 7),
-    (as3_displayobjectcontainer_addchildat, "avm2/displayobjectcontainer_addchildat", 1),
-    (as3_displayobjectcontainer_contains, "avm2/displayobjectcontainer_contains", 5),
-    (as3_displayobjectcontainer_getchildat, "avm2/displayobjectcontainer_getchildat", 1),
-    (as3_displayobjectcontainer_getchildbyname, "avm2/displayobjectcontainer_getchildbyname", 1),
-    (as3_displayobjectcontainer_getchildindex, "avm2/displayobjectcontainer_getchildindex", 5),
-    (as3_displayobjectcontainer_removechild_timelinemanip_remove1, "avm2/displayobjectcontainer_removechild_timelinemanip_remove1", 7),
-    (as3_displayobjectcontainer_removechild, "avm2/displayobjectcontainer_removechild", 1),
-    (as3_displayobjectcontainer_removechildat, "avm2/displayobjectcontainer_removechildat", 1),
-    (as3_displayobjectcontainer_removechildren, "avm2/displayobjectcontainer_removechildren", 5),
-    (as3_displayobjectcontainer_setchildindex, "avm2/displayobjectcontainer_setchildindex", 1),
-    (as3_displayobjectcontainer_stopallmovieclips, "avm2/displayobjectcontainer_stopallmovieclips", 2),
-    (as3_displayobjectcontainer_swapchildren, "avm2/displayobjectcontainer_swapchildren", 1),
-    (as3_displayobjectcontainer_swapchildrenat, "avm2/displayobjectcontainer_swapchildrenat", 1),
-    (as3_displayobjectcontainer_timelineinstance, "avm2/displayobjectcontainer_timelineinstance", 6),
-    (as3_documentclass, "avm2/documentclass", 1),
-    (as3_domain_memory, "avm2/domain_memory", 1),
-    (as3_drag_drop, "avm2/drag_drop", 14),
-    (as3_edittext_antialiastype, "avm2/edittext_antialiastype", 1),
-    (as3_edittext_default_format, "avm2/edittext_default_format", 1),
-    (as3_edittext_html_entity, "avm2/edittext_html_entity", 1),
-    (as3_edittext_html_roundtrip, "avm2/edittext_html_roundtrip", 1),
-    (as3_edittext_mouseenabled, "avm2/edittext_mouseenabled", 1),
-    (as3_edittext_newline_stripping, "avm2/edittext_newline_stripping", 1),
-    (as3_edittext_width_height, "avm2/edittext_width_height", 1),
-    (as3_equals, "avm2/equals", 1),
-    (as3_error_stack_trace, "avm2/error_stack_trace", 1),
-    (as3_error_tostring, "avm2/error_tostring", 1),
-    (as3_error_tostring_more, "avm2/error_tostring_more", 1),
-    (as3_es3_inheritance, "avm2/es3_inheritance", 1),
-    (as3_es4_inheritance, "avm2/es4_inheritance", 1),
-    (as3_es4_interfaces, "avm2/es4_interfaces", 1),
-    (as3_es4_method_binding, "avm2/es4_method_binding", 1),
-    (as3_es4_oop_prototypes, "avm2/es4_oop_prototypes", 1),
-    (as3_es4_protected_inheritance, "avm2/es4_protected_inheritance", 1),
-    (as3_event_bubbles, "avm2/event_bubbles", 1),
-    (as3_event_cancelable, "avm2/event_cancelable", 1),
-    (as3_event_clone, "avm2/event_clone", 1),
-    (as3_event_formattostring, "avm2/event_formattostring", 1),
-    (as3_event_handler_exception, "avm2/event_handler_exception", 2),
-    (as3_event_isdefaultprevented, "avm2/event_isdefaultprevented", 1),
-    (as3_event_type, "avm2/event_type", 1),
-    (as3_event_valueof_tostring, "avm2/event_valueof_tostring", 1),
-    (as3_eventdispatcher_dispatchevent_cancel, "avm2/eventdispatcher_dispatchevent_cancel", 1),
-    (as3_eventdispatcher_dispatchevent_handlerorder, "avm2/eventdispatcher_dispatchevent_handlerorder", 1),
-    (as3_eventdispatcher_dispatchevent_this, "avm2/eventdispatcher_dispatchevent_this", 1),
-    (as3_eventdispatcher_dispatchevent, "avm2/eventdispatcher_dispatchevent", 1),
-    (as3_eventdispatcher_dispatchevent_indirect, "avm2/eventdispatcher_dispatchevent_indirect", 1),
-    (as3_eventdispatcher_haseventlistener, "avm2/eventdispatcher_haseventlistener", 1),
-    (as3_eventdispatcher_tostring, "avm2/eventdispatcher_tostring", 1),
-    (as3_eventdispatcher_willtrigger, "avm2/eventdispatcher_willtrigger", 1),
-    (as3_falsiness, "avm2/falsiness", 1),
-    (as3_filefilter_properties, "avm2/filefilter_properties", 1),
-    (as3_font_embedded, "avm2/font_embedded", 1),
-    (as3_font_hasglyphs, "avm2/font_hasglyphs", 1),
-    (as3_framelabel_constr, "avm2/framelabel_constr", 5),
-    (as3_function_call_arguments, "avm2/function_call_arguments", 1),
-    (as3_function_call_coercion, "avm2/function_call_coercion", 1),
-    (as3_function_call_default, "avm2/function_call_default", 1),
-    (as3_function_call_rest, "avm2/function_call_rest", 1),
-    (as3_function_call_types, "avm2/function_call_types", 1),
-    (as3_function_call_via_apply, "avm2/function_call_via_apply", 1),
-    (as3_function_call_via_call, "avm2/function_call_via_call", 1),
-    (as3_function_call, "avm2/function_call", 1),
-    #[ignore] (as3_function_proto, "avm2/function_proto", 1),
-    (as3_function_length, "avm2/function_length", 1),
-    (as3_function_object, "avm2/function_object", 1),
-    (as3_function_to_locale_string, "avm2/function_to_locale_string", 1),
-    (as3_function_to_string, "avm2/function_to_string", 1),
-    (as3_function_type, "avm2/function_type", 1),
-    (as3_function_value_of, "avm2/function_value_of", 1),
-    (as3_generate_random_bytes, "avm2/generate_random_bytes", 1),
-    (as3_get_definition_by_name, "avm2/get_definition_by_name", 1),
-    (as3_get_qualified_class_name, "avm2/get_qualified_class_name", 1),
-    (as3_get_qualified_super_class_name, "avm2/get_qualified_super_class_name", 1),
-    (as3_get_timer, "avm2/get_timer", 1),
-    (as3_getouterscope, "avm2/getouterscope", 1),
-    (as3_goto_methods, "avm2/goto_methods", 1),
-    (as3_goto_methods_swfver10, "avm2/goto_methods_swfver10", 1),
-    (as3_greaterequals, "avm2/greaterequals", 1),
-    (as3_greaterthan, "avm2/greaterthan", 1),
-    (as3_has_own_property, "avm2/has_own_property", 1),
-    (as3_hasownproperty_namespaces, "avm2/hasownproperty_namespaces", 1),
-    (as3_hello_world, "avm2/hello_world", 1),
-    (as3_if_eq, "avm2/if_eq", 1),
-    (as3_if_gt, "avm2/if_gt", 1),
-    (as3_if_gte, "avm2/if_gte", 1),
-    (as3_if_lt, "avm2/if_lt", 1),
-    (as3_if_lte, "avm2/if_lte", 1),
-    (as3_if_ne, "avm2/if_ne", 1),
-    (as3_if_stricteq, "avm2/if_stricteq", 1),
-    (as3_if_strictne, "avm2/if_strictne", 1),
-    (as3_in, "avm2/in", 1),
-    (as3_inclocal_i, "avm2/inclocal_i", 1),
-    (as3_inclocal, "avm2/inclocal", 1),
-    (as3_increment_i, "avm2/increment_i", 1),
-    (as3_increment, "avm2/increment", 1),
-    (as3_instanceof, "avm2/instanceof", 1),
-    (as3_instantiation_on_enter_frame, "avm2/instantiation_on_enter_frame", 2),
-    (as3_instantiation_on_enterframe_gotoandstop, "avm2/instantiation_on_enterframe_gotoandstop", 2),
-    (as3_int_constr, "avm2/int_constr", 1),
-    (as3_int_edge_cases, "avm2/int_edge_cases", 1),
-    #[ignore] (as3_int_toexponential, "avm2/int_toexponential", 1), //Ignored because Flash Player has a print routine that adds extraneous zeros to things
-    (as3_int_tofixed, "avm2/int_tofixed", 1),
-    #[ignore] (as3_int_toprecision, "avm2/int_toprecision", 1), //Ignored because Flash Player has a print routine that adds extraneous zeros to things
-    (as3_int_tostring, "avm2/int_tostring", 1),
-    (as3_interactiveobject_enabled, "avm2/interactiveobject_enabled", 1),
-    (as3_interface_namespaces, "avm2/interface_namespaces", 1),
-    (as3_invalid_utf8, "avm2/invalid_utf8", 1),
-    (as3_is_finite, "avm2/is_finite", 1),
-    (as3_is_nan, "avm2/is_nan", 1),
-    (as3_is_prototype_of, "avm2/is_prototype_of", 1),
-    (as3_issue_5292, "avm2/issue_5292", 1),
-    (as3_issue_8630, "avm2/issue_8630", 1),
-    (as3_issue_8630_placeremoveplace, "avm2/issue_8630_placeremoveplace", 1),
-    #[ignore] (as3_issue_8630_placeremoveplace_scriptremove, "avm2/issue_8630_placeremoveplace_scriptremove", 1),
-    #[ignore] (as3_issue_8630_scriptremove, "avm2/issue_8630_scriptremove", 1),
-    (as3_istype, "avm2/istype", 1),
-    (as3_istypelate_coerce, "avm2/istypelate_coerce", 1),
-    (as3_istypelate, "avm2/istypelate", 1),
-    (as3_json_parse, "avm2/json_parse", 1),
-    (as3_json_stringify, "avm2/json_stringify", 1),
-    (as3_lazyinit, "avm2/lazyinit", 1),
-    (as3_lessequals, "avm2/lessequals", 1),
-    (as3_lessthan, "avm2/lessthan", 1),
-    (as3_loader_applicationdomain, "avm2/loader_applicationDomain", 2),
-    (as3_loader_events, "avm2/loader_events", 3, img = true),
-    (as3_loader_loadbytes_events, "avm2/loader_loadbytes_events", 3, img = true),
-    (as3_loaderinfo_events, "avm2/loaderinfo_events", 2),
-    (as3_loaderinfo_properties, "avm2/loaderinfo_properties", 2),
-    (as3_loaderinfo_root, "avm2/loaderinfo_root", 1),
-    (as3_loaderinfo_quine, "avm2/loaderinfo_quine", 2),
-    (as3_lshift, "avm2/lshift", 1),
-    (as3_modulo, "avm2/modulo", 1),
-    (as3_mouseevent_constr, "avm2/mouseevent_constr", 1),
-    (as3_mouseevent_stagexy, "avm2/mouseevent_stagexy", 1),
-    (as3_mouseevent_valueof_tostring, "avm2/mouseevent_valueof_tostring", 1),
-    (as3_movieclip_child_property, "avm2/movieclip_child_property", 1),
-    (as3_movieclip_constr, "avm2/movieclip_constr", 1),
-    (as3_movieclip_currentlabels, "avm2/movieclip_currentlabels", 7),
-    (as3_movieclip_currentscene, "avm2/movieclip_currentscene", 5),
-    (as3_movieclip_dispatchevent_cancel, "avm2/movieclip_dispatchevent_cancel", 1),
-    (as3_movieclip_dispatchevent_handlerorder, "avm2/movieclip_dispatchevent_handlerorder", 1),
-    (as3_movieclip_dispatchevent_selfadd, "avm2/movieclip_dispatchevent_selfadd", 1),
-    (as3_movieclip_dispatchevent_target, "avm2/movieclip_dispatchevent_target", 1),
-    (as3_movieclip_dispatchevent, "avm2/movieclip_dispatchevent", 1),
-    (as3_movieclip_displayevents_clickgoto, "avm2/movieclip_displayevents_clickgoto", 32),
-    (as3_movieclip_displayevents_clickgoto2, "avm2/movieclip_displayevents_clickgoto2", 46),
-    (as3_movieclip_displayevents_clickplay, "avm2/movieclip_displayevents_clickplay", 32),
-    (as3_movieclip_displayevents_clicksymbol, "avm2/movieclip_displayevents_clicksymbol", 32),
-    (as3_movieclip_displayevents_constructframegoto, "avm2/movieclip_displayevents_constructframegoto", 12),
-    (as3_movieclip_displayevents_constructframeplay, "avm2/movieclip_displayevents_constructframeplay", 6),
-    (as3_movieclip_displayevents_constructframesymbol, "avm2/movieclip_displayevents_constructframesymbol", 12),
-    (as3_movieclip_displayevents_dblhandler, "avm2/movieclip_displayevents_dblhandler", 4),
-    (as3_movieclip_displayevents_enterframegoto, "avm2/movieclip_displayevents_enterframegoto", 15),
-    (as3_movieclip_displayevents_enterframeplay, "avm2/movieclip_displayevents_enterframeplay", 6),
-    (as3_movieclip_displayevents_enterframesymbol, "avm2/movieclip_displayevents_enterframesymbol", 15),
-    (as3_movieclip_displayevents_exitframegoto, "avm2/movieclip_displayevents_exitframegoto", 12),
-    (as3_movieclip_displayevents_exitframeplay, "avm2/movieclip_displayevents_exitframeplay", 6),
-    (as3_movieclip_displayevents_exitframesymbol, "avm2/movieclip_displayevents_exitframesymbol", 12),
-    (as3_movieclip_displayevents_looping, "avm2/movieclip_displayevents_looping", 5),
-    (as3_movieclip_displayevents_timeline, "avm2/movieclip_displayevents_timeline", 7),
-    (as3_movieclip_displayevents_stopped, "avm2/movieclip_displayevents_stopped", 10),
-    (as3_movieclip_displayevents, "avm2/movieclip_displayevents", 9),
-    (as3_movieclip_drawrect, "avm2/movieclip_drawrect", 1),
-    (as3_movieclip_goto_during_frame_script, "avm2/movieclip_goto_during_frame_script", 1),
-    (as3_movieclip_gotoandplay, "avm2/movieclip_gotoandplay", 5),
-    (as3_movieclip_gotoandstop, "avm2/movieclip_gotoandstop", 5),
-    (as3_movieclip_gotoandstop_children, "avm2/movieclip_gotoandstop_children", 1),
-    (as3_movieclip_gotoandstop_framescripts1, "avm2/movieclip_gotoandstop_framescripts1", 1),
-    (as3_movieclip_gotoandstop_framescripts2, "avm2/movieclip_gotoandstop_framescripts2", 1),
-    (as3_movieclip_gotoandstop_framescripts_self, "avm2/movieclip_gotoandstop_framescripts_self", 1),
-    (as3_movieclip_gotoandstop_queueing, "avm2/movieclip_gotoandstop_queueing", 2),
-    (as3_movieclip_hittest, "avm2/movieclip_hittest", 1),
-    (as3_movieclip_next_frame, "avm2/movieclip_next_frame", 5),
-    (as3_movieclip_next_scene, "avm2/movieclip_next_scene", 5),
-    (as3_movieclip_play, "avm2/movieclip_play", 5),
-    (as3_movieclip_prev_frame, "avm2/movieclip_prev_frame", 5),
-    (as3_movieclip_prev_scene, "avm2/movieclip_prev_scene", 5),
-    (as3_movieclip_properties, "avm2/movieclip_properties", 4),
-    (as3_movieclip_scenes, "avm2/movieclip_scenes", 5),
-    (as3_movieclip_soundtransform, "avm2/movieclip_soundtransform", 49),
-    (as3_movieclip_stop, "avm2/movieclip_stop", 5),
-    (as3_movieclip_symbol_constr, "avm2/movieclip_symbol_constr", 1),
-    (as3_movieclip_willtrigger, "avm2/movieclip_willtrigger", 3),
-    (as3_multiply, "avm2/multiply", 1),
-    (as3_nan_scale, "avm2/nan_scale", 1),
-    (as3_negate, "avm2/negate", 1),
-    (as3_nonconflicting_declarations, "avm2/nonconflicting_declarations", 1),
-    (as3_number_constr, "avm2/number_constr", 1),
-    #[ignore] (as3_number_tostring, "avm2/number_tostring", 1), //Ignored because Flash Player adds extra x, W, and/or ° symbols randomly
-    (as3_object_enumeration, "avm2/object_enumeration", 1),
-    (as3_object_prototype, "avm2/object_prototype", 1),
-    (as3_object_to_locale_string, "avm2/object_to_locale_string", 1),
-    (as3_object_to_string, "avm2/object_to_string", 1),
-    (as3_object_value_of, "avm2/object_value_of", 1),
-    (as3_op_coerce_x, "avm2/op_coerce_x", 1),
-    (as3_op_coerce, "avm2/op_coerce", 1),
-    (as3_op_escxattr, "avm2/op_escxattr", 1),
-    (as3_op_escxelem, "avm2/op_escxelem", 1),
-    (as3_op_lookupswitch, "avm2/op_lookupswitch", 1),
-    (as3_package_namespace, "avm2/package_namespace", 1),
-    (as3_parse_int, "avm2/parse_int", 1),
-    (as3_place_multiple, "avm2/place_multiple", 1),
-    (as3_place_object_replace_2, "avm2/place_object_replace_2", 3),
-    (as3_place_object_replace, "avm2/place_object_replace", 2),
-    (as3_point, "avm2/point", 1),
-    (as3_property_is_enumerable, "avm2/property_is_enumerable", 1),
-    (as3_propertyisenumerable_namespaces, "avm2/propertyisenumerable_namespaces", 1),
-    (as3_proxy_callproperty, "avm2/proxy_callproperty", 1),
-    (as3_proxy_deleteproperty, "avm2/proxy_deleteproperty", 1),
-    (as3_proxy_enumeration, "avm2/proxy_enumeration", 1),
-    (as3_proxy_getproperty, "avm2/proxy_getproperty", 1),
-    (as3_proxy_hasproperty, "avm2/proxy_hasproperty", 1),
-    (as3_proxy_setproperty, "avm2/proxy_setproperty", 1),
-    (as3_qname_constr_namespace, "avm2/qname_constr_namespace", 1),
-    (as3_qname_constr, "avm2/qname_constr", 1),
-    (as3_qname_indexing, "avm2/qname_indexing", 1),
-    (as3_qname_tostring, "avm2/qname_tostring", 1),
-    (as3_qname_valueof, "avm2/qname_valueof", 1),
-    (as3_rectangle, "avm2/rectangle", 1),
-    (as3_vector3d, "avm2/vector3d", 1),
-    (as3_regexp_constr, "avm2/regexp_constr", 1),
-    (as3_regexp_exec, "avm2/regexp_exec", 1),
-    (as3_regexp_test, "avm2/regexp_test", 1),
-    (as3_rshift, "avm2/rshift", 1),
-    (as3_scene_constr, "avm2/scene_constr", 5),
-    (as3_set_property_is_enumerable, "avm2/set_property_is_enumerable", 1),
-    (as3_shape_drawrect, "avm2/shape_drawrect", 1),
-    (as3_simplebutton_childevents_nested, "avm2/simplebutton_childevents_nested", 2),
-    (as3_simplebutton_childevents, "avm2/simplebutton_childevents", 2),
-    (as3_simplebutton_childprops, "avm2/simplebutton_childprops", 1),
-    (as3_simplebutton_childshuffle, "avm2/simplebutton_childshuffle", 1),
-    #[ignore] (as3_simplebutton_constr_childevents, "avm2/simplebutton_constr_childevents", 2), //Broken by other accuracy fixes
-    (as3_simplebutton_constr_params, "avm2/simplebutton_constr_params", 1),
-    (as3_simplebutton_constr, "avm2/simplebutton_constr", 2),
-    (as3_simplebutton_mouseenabled, "avm2/simplebutton_mouseenabled", 1),
-    (as3_simplebutton_soundtransform, "avm2/simplebutton_soundtransform", 49),
-    (as3_simplebutton_structure, "avm2/simplebutton_structure", 2),
-    (as3_simplebutton_symbolclass, "avm2/simplebutton_symbolclass", 3),
-    (as3_sound_embeddedprops, "avm2/sound_embeddedprops", 1),
-    (as3_sound_play, "avm2/sound_play", 1),
-    (as3_sound_valueof, "avm2/sound_valueof", 1),
-    #[ignore] (as3_soundchannel_position, "avm2/soundchannel_position", 75),
-    #[ignore] (as3_soundchannel_soundcomplete, "avm2/soundchannel_soundcomplete", 25),
-    (as3_soundchannel_soundtransform, "avm2/soundchannel_soundtransform", 49),
-    (as3_soundchannel_stop, "avm2/soundchannel_stop", 4),
-    (as3_soundmixer_buffertime, "avm2/soundmixer_buffertime", 1),
-    (as3_soundmixer_soundtransform, "avm2/soundmixer_soundtransform", 49),
-    (as3_soundmixer_stopall, "avm2/soundmixer_stopall", 4),
-    (as3_soundtransform, "avm2/soundtransform", 1),
-    (as3_stage_access, "avm2/stage_access", 1),
-    (as3_stage_display_state, "avm2/stage_display_state", 1),
-    (as3_stage_displayobject_properties, "avm2/stage_displayobject_properties", 1),
-    (as3_stage_loaderinfo_properties, "avm2/stage_loaderinfo_properties", 2),
-    (as3_stage_mouseenabled, "avm2/stage_mouseenabled", 1),
-    (as3_stage_properties, "avm2/stage_properties", 1),
-    (as3_stage3d_rotating_cube, "avm2/stage3d_rotating_cube", 40, img = true),
-    (as3_stage3d_triangle, "avm2/stage3d_triangle", 1, img = true),
-    (as3_static_text, "avm2/static_text", 1),
-    (as3_stored_properties, "avm2/stored_properties", 1),
-    (as3_strict_equality, "avm2/strict_equality", 1),
-    (as3_string_case, "avm2/string_case", 1),
-    (as3_string_char_at, "avm2/string_char_at", 1),
-    (as3_string_char_code_at, "avm2/string_char_code_at", 1),
-    (as3_string_concat_fromcharcode, "avm2/string_concat_fromcharcode", 1),
-    (as3_string_constr, "avm2/string_constr", 1),
-    (as3_string_indexof_lastindexof, "avm2/string_indexof_lastindexof", 1),
-    (as3_string_length, "avm2/string_length", 1),
-    (as3_string_locale_compare, "avm2/string_locale_compare", 1),
-    (as3_string_match, "avm2/string_match", 1),
-    (as3_string_replace, "avm2/string_replace", 1),
-    (as3_string_search, "avm2/string_search", 1),
-    (as3_swz, "avm2/swz", 10),
-    (as3_try_catch, "avm2/try_catch", 1),
-    (as3_try_catch_typed, "avm2/try_catch_typed", 1),
-    (as3_string_slice_substr_substring, "avm2/string_slice_substr_substring", 1),
-    (as3_string_split, "avm2/string_split", 1),
-    (as3_subtract, "avm2/subtract", 1),
-    (as3_symbol_class_binary_data, "avm2/symbol_class_binary_data", 1),
-    (as3_textformat, "avm2/textformat", 1),
-    (as3_throw, "avm2/throw", 1),
-    (as3_timeline_scripts, "avm2/timeline_scripts", 3),
-    (as3_trace, "avm2/trace", 1),
-    (as3_truthiness, "avm2/truthiness", 1),
-    (as3_typeof, "avm2/typeof", 1),
-    (as3_uint_constr, "avm2/uint_constr", 1),
-    #[ignore] (as3_uint_toexponential, "avm2/uint_toexponential", 1), //Ignored because Flash Player has a print routine that adds extraneous zeros to things
-    (as3_uint_tofixed, "avm2/uint_tofixed", 1),
-    #[ignore] (as3_uint_toprecision, "avm2/uint_toprecision", 1), //Ignored because Flash Player has a print routine that adds extraneous zeros to things
-    (as3_uint_tostring, "avm2/uint_tostring", 1),
-    (as3_unchecked_function, "avm2/unchecked_function", 1),
-    (as3_url_loader, "avm2/url_loader", 1),
-    (as3_url_vars, "avm2/url_vars", 1),
-    (as3_urshift, "avm2/urshift", 1),
-    (as3_vector_coercion, "avm2/vector_coercion", 1),
-    (as3_vector_concat, "avm2/vector_concat", 1),
-    (as3_vector_constr, "avm2/vector_constr", 1),
-    (as3_vector_enumeration, "avm2/vector_enumeration", 1),
-    (as3_vector_every, "avm2/vector_every", 1),
-    (as3_vector_filter, "avm2/vector_filter", 1),
-    (as3_vector_holes, "avm2/vector_holes", 1),
-    (as3_vector_indexof, "avm2/vector_indexof", 1),
-    (as3_vector_insertat, "avm2/vector_insertat", 1),
-    (as3_vector_int_access, "avm2/vector_int_access", 1),
-    (as3_vector_int_delete, "avm2/vector_int_delete", 1),
-    (as3_vector_join, "avm2/vector_join", 1),
-    (as3_vector_lastindexof, "avm2/vector_lastindexof", 1),
-    (as3_vector_legacy, "avm2/vector_legacy", 1),
-    (as3_vector_map, "avm2/vector_map", 1),
-    (as3_vector_pushpop, "avm2/vector_pushpop", 1),
-    (as3_vector_removeat, "avm2/vector_removeat", 1),
-    (as3_vector_reverse, "avm2/vector_reverse", 1),
-    (as3_vector_shiftunshift, "avm2/vector_shiftunshift", 1),
-    (as3_vector_slice, "avm2/vector_slice", 1),
-    (as3_vector_sort, "avm2/vector_sort", 1),
-    (as3_vector_splice, "avm2/vector_splice", 1),
-    (as3_vector_tostring, "avm2/vector_tostring", 1),
-    (as3_virtual_properties, "avm2/virtual_properties", 1),
-    (as3_with, "avm2/with", 1),
-    (as3_escape, "avm2/escape", 1),
-    (as3_escape_multi_byte, "avm2/escape_multi_byte", 1),
-    (attach_movie, "avm1/attach_movie", 1),
-    (bad_placeobject_clipaction, "avm1/bad_placeobject_clipaction", 2),
-    (bad_swf_tag_past_eof, "avm1/bad_swf_tag_past_eof", 1),
-    (bevel_filter, "avm1/bevel_filter", 1),
-    (bitmap_data, "avm1/bitmap_data", 1),
-    (bitmap_data_compare, "avm1/bitmap_data_compare", 1),
-    (bitmap_data_copypixels, "avm1/bitmap_data_copypixels", 2, img = true),
-    (bitmap_data_max_size_swf10, "avm1/bitmap_data_max_size_swf10", 1),
-    (bitmap_data_max_size_swf9, "avm1/bitmap_data_max_size_swf9", 1),
-    (bitmap_data_noise, "avm1/bitmap_data_noise", 1),
-    (bitmap_data_threshold, "avm1/bitmap_data_threshold", 1),
-    (bitmap_filter, "avm1/bitmap_filter", 1),
-    (biturshift, "avm1/biturshift", 1),
-    (biturshift_swf8, "avm1/biturshift_swf8", 1),
-    (blur_filter, "avm1/blur_filter", 1),
-    (button_children, "avm1/button_children", 1),
-    (button_order, "avm1/button_order", 2),
-    (call_method_empty_name, "avm1/call_method_empty_name", 1),
-    (call, "avm1/call", 2),
-    (clip_events, "avm1/clip_events", 4),
-    (closure_scope, "avm1/closure_scope", 1),
-    (color_matrix_filter, "avm1/color_matrix_filter", 1),
-    (color_transform, "avm1/color_transform", 1),
-    (color, "avm1/color", 1, img = true),
-    (conflicting_instance_names, "avm1/conflicting_instance_names", 6),
-    (constructor_function, "avm1/constructor_function", 1),
-    (context_menu_item, "avm1/context_menu_item", 1),
-    (context_menu, "avm1/context_menu", 1),
-    (convolution_filter, "avm1/convolution_filter", 1),
-    (create_empty_movie_clip, "avm1/create_empty_movie_clip", 2),
-    (cross_movie_root, "avm1/cross_movie_root", 5),
-    (custom_clip_methods, "avm1/custom_clip_methods", 3),
-    (date, "avm1/date", 1),
-    (default_names, "avm1/default_names", 6),
-    (define_function_case_sensitive, "avm1/define_function_case_sensitive", 2),
-    (define_function2_preload_order, "avm1/define_function2_preload_order", 1),
-    (define_function2_preload, "avm1/define_function2_preload", 1),
-    (define_local, "avm1/define_local", 1),
-    (define_local_with_paths, "avm1/define_local_with_paths", 1),
-    (delete, "avm1/delete", 3),
-    (displacement_map_filter, "avm1/displacement_map_filter", 1),
-    (divide_swf4, "avm1/divide_swf4", 1),
-    (do_init_action, "avm1/do_init_action", 3),
-    (drag_drop, "avm1/drag_drop", 14),
-    (drop_shadow_filter, "avm1/drop_shadow_filter", 1),
-    (duplicate_movie_clip_drawing, "avm1/duplicate_movie_clip_drawing", 1),
-    (duplicate_movie_clip, "avm1/duplicate_movie_clip", 1),
-    (edittext_antialiastype, "avm1/edittext_antialiastype", 1),
-    (edittext_default_format, "avm1/edittext_default_format", 1),
-    (edittext_font_size, "avm1/edittext_font_size", 1),
-    (edittext_html_entity, "avm1/edittext_html_entity", 1),
-    (edittext_html_roundtrip, "avm1/edittext_html_roundtrip", 1),
-    (edittext_leading, "avm1/edittext_leading", 1),
-    (edittext_newline_stripping, "avm1/edittext_newline_stripping", 1),
-    #[ignore] (edittext_newlines, "avm1/edittext_newlines", 1),
-    (edittext_password, "avm1/edittext_password", 1),
-    (edittext_scroll, "avm1/edittext_scroll", 1),
-    (edittext_width_height, "avm1/edittext_width_height", 1),
-    (empty_movieclip_can_attach_movies, "avm1/empty_movieclip_can_attach_movies", 1),
-    (enumerate, "avm1/enumerate", 1),
-    (equals_swf4, "avm1/equals_swf4", 1),
-    (equals_swf4_alt, "avm1/equals_swf4_alt", 1),
-    (equals_swf5, "avm1/equals_swf5", 1),
-    (equals, "avm1/equals", 1),
-    (equals2_swf5, "avm1/equals2_swf5", 1),
-    (equals2_swf6, "avm1/equals2_swf6", 1),
-    (equals2_swf7, "avm1/equals2_swf7", 1),
-    (error, "avm1/error", 1),
-    (escape, "avm1/escape", 1),
-    (execution_order1, "avm1/execution_order1", 3),
-    (execution_order2, "avm1/execution_order2", 15),
-    (execution_order3, "avm1/execution_order3", 5),
-    (execution_order4, "avm1/execution_order4", 4),
-    (export_assets, "avm1/export_assets", 1),
-    (extends_chain, "avm1/extends_chain", 1),
-    (extends_native_type, "avm1/extends_native_type", 1),
-    (function_as_function, "avm1/function_as_function", 1),
-    (function_base_clip_removed, "avm1/function_base_clip_removed", 3),
-    (function_base_clip, "avm1/function_base_clip", 2),
-    (function_suppress_and_preload, "avm1/function_suppress_and_preload", 1),
-    (funky_function_calls, "avm1/funky_function_calls", 1),
-    (get_bytes_total, "avm1/get_bytes_total", 1),
-    (getproperty_swf4, "avm1/getproperty_swf4", 1),
-    (getproperty_swf5, "avm1/getproperty_swf5", 1),
-    (getproperty, "avm1/getproperty", 1),
-    (get_variable_in_scope, "avm1/get_variable_in_scope", 1),
-    (global_array, "avm1/global_array", 1),
-    (global_is_bare, "avm1/global_is_bare", 1),
-    (glow_filter, "avm1/glow_filter", 1),
-    (goto_advance1, "avm1/goto_advance1", 2),
-    (goto_advance2, "avm1/goto_advance2", 2),
-    (goto_both_ways1, "avm1/goto_both_ways1", 2),
-    (goto_both_ways2, "avm1/goto_both_ways2", 3),
-    (goto_execution_order, "avm1/goto_execution_order", 3),
-    (goto_execution_order2, "avm1/goto_execution_order2", 2),
-    (goto_frame_number, "avm1/goto_frame_number", 4),
-    (goto_frame, "avm1/goto_frame", 3),
-    (goto_frame2, "avm1/goto_frame2", 5),
-    (goto_label, "avm1/goto_label", 4),
-    (goto_methods, "avm1/goto_methods", 1),
-    (goto_rewind1, "avm1/goto_rewind1", 4),
-    (goto_rewind2, "avm1/goto_rewind2", 5),
-    (goto_rewind3, "avm1/goto_rewind3", 2),
-    (gradient_bevel_filter, "avm1/gradient_bevel_filter", 1),
-    (gradient_glow_filter, "avm1/gradient_glow_filter", 1),
-    (greater_swf6, "avm1/greater_swf6", 1),
-    (greater_swf7, "avm1/greater_swf7", 1),
-    (greaterthan_swf5, "avm1/greaterthan_swf5", 1),
-    (greaterthan_swf8, "avm1/greaterthan_swf8", 1),
-    (has_own_property, "avm1/has_own_property", 1),
-    (infinite_recursion_function_in_setter, "avm1/infinite_recursion_function_in_setter", 1),
-    (infinite_recursion_function, "avm1/infinite_recursion_function", 1),
-    (infinite_recursion_virtual_property, "avm1/infinite_recursion_virtual_property", 1),
-    (init_array_invalid, "avm1/init_array_invalid", 1),
-    (init_object_invalid, "avm1/init_array_invalid", 1),
-    (init_object_order, "avm1/init_object_order", 1),
-    (is_finite, "avm1/is_finite", 1),
-    (is_finite_swf6, "avm1/is_finite_swf6", 1),
-    (is_prototype_of, "avm1/is_prototype_of", 1),
-    (issue_1086, "avm1/issue_1086", 1),
-    (issue_1104, "avm1/issue_1104", 3),
-    (issue_1671, "avm1/issue_1671", 1),
-    (issue_1906, "avm1/issue_1906", 2),
-    (issue_2030, "avm1/issue_2030", 1),
-    (issue_2084, "avm1/issue_2084", 2),
-    (issue_2166, "avm1/issue_2166", 1),
-    (issue_2870, "avm1/issue_2870", 10),
-    (issue_3169, "avm1/issue_3169", 1),
-    (issue_3446, "avm1/issue_3446", 1),
-    (issue_3522, "avm1/issue_3522", 2),
-    (issue_4377, "avm1/issue_4377", 1),
-    (issue_710, "avm1/issue_710", 1),
-    (issue_768, "avm1/issue_768", 1),
-    (lessthan_swf4, "avm1/lessthan_swf4", 1),
-    (lessthan_swf4_alt, "avm1/lessthan_swf4_alt", 1),
-    (lessthan_swf5, "avm1/lessthan_swf5", 1),
-    (lessthan, "avm1/lessthan", 1),
-    (lessthan2_swf5, "avm1/lessthan2_swf5", 1),
-    (lessthan2_swf6, "avm1/lessthan2_swf6", 1),
-    (lessthan2_swf7, "avm1/lessthan2_swf7", 1),
-    (load_vars, "avm1/load_vars", 2),
-    (loadmovie_fail, "avm1/loadmovie_fail", 1),
-    (loadmovie_method, "avm1/loadmovie_method", 2),
-    (loadmovie_registerclass, "avm1/loadmovie_registerclass", 2),
-    (loadmovie_replace_root, "avm1/loadmovie_replace_root", 3),
-    (loadmovie, "avm1/loadmovie", 2),
-    (loadmovienum, "avm1/loadmovienum", 2),
-    (loadvariables_method, "avm1/loadvariables_method", 3),
-    (loadvariables, "avm1/loadvariables", 3),
-    (loadvariablesnum, "avm1/loadvariablesnum", 3),
-    (logical_ops_swf4, "avm1/logical_ops_swf4", 1),
-    (logical_ops_swf8, "avm1/logical_ops_swf8", 1),
-    (looping, "avm1/looping", 6),
-    (math_min_max, "avm1/math_min_max", 1),
-    (matrix, "avm1/matrix", 1),
-    (mcl_as_broadcaster, "avm1/mcl_as_broadcaster", 1),
-    (mcl_getprogress, "avm1/mcl_getprogress", 6),
-    (mcl_giftarget, "avm1/mcl_giftarget", 11),
-    (mcl_jpgtarget, "avm1/mcl_jpgtarget", 11),
-    (mcl_loadclip, "avm1/mcl_loadclip", 11),
-    (mcl_mislabeled_target, "avm1/mcl_mislabeled_target", 11),
-    (mcl_pngtarget, "avm1/mcl_pngtarget", 11),
-    (mcl_unloadclip, "avm1/mcl_unloadclip", 11),
-    (mouse_listeners, "avm1/mouse_listeners", 1),
-    (mouse_events, "avm1/mouse_events", 8),
-    (movieclip_depth_methods, "avm1/movieclip_depth_methods", 3),
-    (movieclip_get_instance_at_depth, "avm1/movieclip_get_instance_at_depth", 1),
-    (movieclip_hittest_shapeflag, "avm1/movieclip_hittest_shapeflag", 11),
-    (movieclip_hittest, "avm1/movieclip_hittest", 1),
-    (movieclip_init_object, "avm1/movieclip_init_object", 1),
-    (movieclip_lockroot, "avm1/movieclip_lockroot", 10),
-    (movieclip_prototype_extension, "avm1/movieclip_prototype_extension", 1),
-    (nan_scale, "avm1/nan_scale", 1),
-    (nested_textfields_in_buttons, "avm1/nested_textfields_in_buttons", 1),
-    (new_method_wrap, "avm1/new_method_wrap", 1),
-    (new_object_enumerate, "avm1/new_object_enumerate", 1),
-    (new_object_wrap, "avm1/new_object_wrap", 1),
-    (object_constructor, "avm1/object_constructor", 1),
-    (object_function, "avm1/object_function", 1),
-    (object_prototypes, "avm1/object_prototypes", 1),
-    (object_string_coerce_swf5, "avm1/object_string_coerce_swf5", 1),
-    (object_string_coerce_swf6, "avm1/object_string_coerce_swf6", 1),
-    (on_construct, "avm1/on_construct", 1),
-    (parse_float, "avm1/parse_float", 1),
-    (parse_int, "avm1/parse_int", 1),
-    (path_string, "avm1/path_string", 1),
-    (point, "avm1/point", 1),
-    (primitive_instanceof, "avm1/primitive_instanceof", 1),
-    (primitive_type_globals, "avm1/primitive_type_globals", 1),
-    (prototype_enumerate, "avm1/prototype_enumerate", 1),
-    (prototype_properties, "avm1/prototype_properties", 1),
-    (rectangle, "avm1/rectangle", 1),
-    (recursive_prototypes, "avm1/recursive_prototypes", 2),
-    (register_and_init_order, "avm1/register_and_init_order", 1),
-    (register_class_return_value, "avm1/register_class_return_value", 1),
-    (register_class_swf6, "avm1/register_class_swf6", 3),
-    (register_class, "avm1/register_class", 3),
-    (register_underflow, "avm1/register_underflow", 1),
-    (remove_movie_clip, "avm1/remove_movie_clip", 2),
-    (removed_base_clip_tell_target, "avm1/removed_base_clip_tell_target", 2),
-    (removed_clip_halts_script, "avm1/removed_clip_halts_script", 13),
-    (root_global_parent, "avm1/root_global_parent", 3),
-    (selection, "avm1/selection", 1),
-    (set_interval, "avm1/set_interval", 40),
-    (set_variable_scope, "avm1/set_variable_scope", 1),
-    (single_frame, "avm1/single_frame", 2),
-    (slash_syntax, "avm1/slash_syntax", 2),
-    (sound, "avm1/sound", 1),
-    (stage_display_state, "avm1/stage_display_state", 1),
-    (stage_object_children, "avm1/stage_object_children", 2),
-    (stage_object_enumerate, "avm1/stage_object_enumerate", 1),
-    (stage_object_properties_get_var, "avm1/stage_object_properties_get_var", 1),
-    (stage_property_representation, "avm1/stage_property_representation", 1),
-    (strictequals_swf6, "avm1/strictequals_swf6", 1),
-    (strictly_equals, "avm1/strictly_equals", 1),
-    (string_coercion, "avm1/string_coercion", 1),
-    (string_methods_negative_args, "avm1/string_methods_negative_args", 1),
-    (string_methods, "avm1/string_methods", 1),
-    (string_ops_swf6, "avm1/string_ops_swf6", 1),
-    (swf4_actions_bool, "avm1/swf4_actions_bool", 1),
-    (swf4_bool, "avm1/swf4_bool", 1),
-    (swf4_function_calls, "avm1/swf4_function_calls", 1),
-    (swf5_encoding, "avm1/swf5_encoding", 1),
-    (swf5_no_closure, "avm1/swf5_no_closure", 1),
-    (swf5_to_6_cross_call, "avm1/swf5_to_6_cross_call", 2),
-    (swf6_string_as_bool, "avm1/swf6_string_as_bool", 1),
-    (swf6_case_insensitive, "avm1/swf6_case_insensitive", 1),
-    (swf6_to_5_cross_call, "avm1/swf6_to_5_cross_call", 2),
-    (swf7_case_sensitive, "avm1/swf7_case_sensitive", 1),
-    (target_clip_removed, "avm1/target_clip_removed", 1),
-    (target_clip_swf5, "avm1/target_clip_swf5", 2),
-    (target_clip_swf6, "avm1/target_clip_swf6", 2),
-    (target_path, "avm1/target_path", 1),
-    (tell_target_invalid, "avm1/tell_target_invalid", 1),
-    (tell_target, "avm1/tell_target", 3),
-    (text_format, "avm1/text_format", 1),
-    (textfield_background_color, "avm1/textfield_background_color", 1),
-    (textfield_border_color, "avm1/textfield_border_color", 1),
-    (textfield_properties, "avm1/textfield_properties", 1),
-    #[ignore] (textfield_text, "avm1/textfield_text", 1),
-    (textfield_variable, "avm1/textfield_variable", 8),
-    (this_scoping, "avm1/this_scoping", 1),
-    (timeline_function_def, "avm1/timeline_function_def", 3),
-    (avm2_timer, "avm2/timer", 280, frame_time_sleep = true),
-    (timer_run_actions, "avm1/timer_run_actions", 1),
-    (trace, "avm1/trace", 1),
-    (transform, "avm1/transform", 1),
-    (try_catch_finally, "avm1/try_catch_finally", 1),
-    (try_finally_simple, "avm1/try_finally_simple", 1),
-    (typeof_globals, "avm1/typeof_globals", 1),
-    (typeofs, "avm1/typeof", 1),
-    (uncaught_exception_bubbled, "avm1/uncaught_exception_bubbled", 1),
-    (uncaught_exception, "avm1/uncaught_exception", 1),
-    (undefined_to_string_swf6, "avm1/undefined_to_string_swf6", 1),
-    (unescape, "avm1/unescape", 1),
-    (unload_clip_event, "avm1/unload_clip_event", 2),
-    (unloadmovie_method, "avm1/unloadmovie_method", 11),
-    (unloadmovie, "avm1/unloadmovie", 11),
-    (unloadmovienum, "avm1/unloadmovienum", 11),
-    (use_hand_cursor, "avm1/use_hand_cursor", 1),
-    (variable_args, "avm1/variable_args", 1),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_add, "visual/blend_modes/add", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_darken, "visual/blend_modes/darken", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_difference, "visual/blend_modes/difference", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_hardlight, "visual/blend_modes/hardlight", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_invert, "visual/blend_modes/invert", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_layer_alpha, "visual/blend_modes/layer_alpha", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_layer_erase, "visual/blend_modes/layer_erase", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_lighten, "visual/blend_modes/lighten", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_multiply, "visual/blend_modes/multiply", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_overlay, "visual/blend_modes/overlay", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_screen, "visual/blend_modes/screen", 1, img = true),
-    #[cfg_attr(not(feature = "imgtests"), ignore)] (visual_blendmodes_subtract, "visual/blend_modes/subtract", 1, img = true),
-    (waitforframe, "avm1/waitforframe", 1),
-    (watch_textfield, "avm1/watch_textfield", 1),
-    (watch_virtual_property_proto, "avm1/watch_virtual_property_proto", 1),
-    #[ignore] (watch_virtual_property, "avm1/watch_virtual_property", 1),
-    (watch, "avm1/watch", 1),
-    (with_return, "avm1/with_return", 1),
-    (with, "avm1/with", 1),
-    (with_variable_scopes, "avm1/with_variable_scopes", 1),
-    (xml_append_child_with_parent, "avm1/xml_append_child_with_parent", 1),
-    (xml_append_child, "avm1/xml_append_child", 1),
-    (xml_attributes_read, "avm1/xml_attributes_read", 1),
-    (xml_cdata, "avm1/xml_cdata", 1),
-    (xml_clone_expandos, "avm1/xml_clone_expandos", 1),
-    (xml_first_last_child, "avm1/xml_first_last_child", 1),
-    (xml_has_child_nodes, "avm1/xml_has_child_nodes", 1),
-    (xml_idmap, "avm1/xml_idmap", 1),
-    (xml_ignore_comments, "avm1/xml_ignore_comments", 1),
-    (xml_ignore_white, "avm1/xml_ignore_white", 1),
-    (xml_insert_before, "avm1/xml_insert_before", 1),
-    (xml_inspect_createmethods, "avm1/xml_inspect_createmethods", 1),
-    (xml_inspect_doctype, "avm1/xml_inspect_doctype", 1),
-    (xml_inspect_parsexml, "avm1/xml_inspect_parsexml", 1),
-    (xml_inspect_xmldecl, "avm1/xml_inspect_xmldecl", 1),
-    (xml_load, "avm1/xml_load", 1),
-    (xml_namespaces, "avm1/xml_namespaces", 1),
-    (xml_parent_and_child, "avm1/xml_parent_and_child", 1),
-    (xml_remove_node, "avm1/xml_remove_node", 1),
-    (xml_reparenting, "avm1/xml_reparenting", 1),
-    (xml_siblings, "avm1/xml_siblings", 1),
-    (xml_to_string_comment, "avm1/xml_to_string_comment", 1),
-    (xml_to_string, "avm1/xml_to_string", 1),
-    (xml_unescaping, "avm1/xml_unescaping", 1),
-    (xml, "avm1/xml", 1),
-}
-
-// TODO: These tests have some inaccuracies currently, so we use approx_eq to test that numeric values are close enough.
-// Eventually we can hopefully make some of these match exactly (see #193).
-// Some will probably always need to be approx. (if they rely on trig functions, etc.)
-swf_tests_approx! {
-    (as3_coerce_string_precision, "avm2/coerce_string_precision", 1, max_relative = 30.0 * f64::EPSILON),
-    (as3_displayobject_height, "avm2/displayobject_height", 7, epsilon = 0.06), // TODO: height/width appears to be off by 1 twip sometimes
-    (as3_displayobject_rotation, "avm2/displayobject_rotation", 1, epsilon = 0.0000000001),
-    (as3_displayobject_scrollrect, "avm2/displayobject_scrollrect", 100, @num_patterns = &[
-        Regex::new(r"\(a=(.+), b=(.+), c=(.+), d=(.+), tx=(.+), ty=(.+)\)").unwrap()
-    ], @img = true, max_relative = f32::EPSILON as f64),
-    (as3_displayobject_width, "avm2/displayobject_width", 7, epsilon = 0.06),
-    (as3_displayobject_transform, "avm2/displayobject_transform", 1, @num_patterns = &[
-        Regex::new(r"\(a=(.+), b=(.+), c=(.+), d=(.+), tx=(.+), ty=(.+)\)").unwrap()
-    ], max_relative = f32::EPSILON as f64),
-    (as3_divide, "avm2/divide", 1, epsilon = 0.0), // TODO: Discrepancy in float formatting.
-    (as3_edittext_align, "avm2/edittext_align", 1, epsilon = 3.0),
-    (as3_edittext_autosize, "avm2/edittext_autosize", 1, epsilon = 0.1),
-    (as3_edittext_bullet, "avm2/edittext_bullet", 1, epsilon = 3.0),
-    (as3_edittext_font_size, "avm2/edittext_font_size", 1, epsilon = 0.1),
-    (as3_edittext_getlinemetrics, "avm2/edittext_getlinemetrics", 1, epsilon = 0.85),
-    (as3_edittext_leading, "avm2/edittext_leading", 1, epsilon = 0.3),
-    (as3_edittext_letter_spacing, "avm2/edittext_letter_spacing", 1, epsilon = 15.0), // TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
-    (as3_edittext_margins, "avm2/edittext_margins", 1, epsilon = 5.0), // TODO: Discrepancy in wrapping.
-    (as3_edittext_tab_stops, "avm2/edittext_tab_stops", 1, epsilon = 5.0),
-    (as3_edittext_underline, "avm2/edittext_underline", 1, epsilon = 4.0),
-    (as3_math, "avm2/math", 1, max_relative = 30.0 * f64::EPSILON),
-    (as3_matrix, "avm2/matrix", 1, @num_patterns = &[
-        Regex::new(r"\(a=(.+?), b=(.+?), c=(.+?), d=(.+?), tx=(.+?), ty=(.+?)\)").unwrap()
-    ], max_relative = f32::EPSILON as f64),
-    (as3_number_toexponential, "avm2/number_toexponential", 1, max_relative = 0.001),
-    (as3_number_tofixed, "avm2/number_tofixed", 1, max_relative = 0.001),
-    (as3_number_toprecision, "avm2/number_toprecision", 1, max_relative = 0.001),
-    (as3_parse_float, "avm2/parse_float", 1, max_relative = 5.0 * f64::EPSILON),
-    (as3_parse_float_swf10, "avm2/parse_float_swf10", 1, max_relative = 5.0 * f64::EPSILON),
-    (edittext_align, "avm1/edittext_align", 1, epsilon = 3.0),
-    (edittext_autosize, "avm1/edittext_autosize", 1, epsilon = 0.1),
-    (edittext_bullet, "avm1/edittext_bullet", 1, epsilon = 3.0),
-    (edittext_hscroll, "avm1/edittext_hscroll", 1, epsilon = 3.0),
-    (edittext_letter_spacing, "avm1/edittext_letter_spacing", 1, epsilon = 15.0), // TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
-    (edittext_margins, "avm1/edittext_margins", 1, epsilon = 5.0), // TODO: Discrepancy in wrapping.
-    (edittext_tab_stops, "avm1/edittext_tab_stops", 1, epsilon = 5.0),
-    (edittext_underline, "avm1/edittext_underline", 1, epsilon = 4.0),
-    (gettextextent, "avm1/gettextextent", 1, epsilon = 30.0), // TODO: Flash Player breaks single words that are longer than the line, but we don't.
-    (local_to_global, "avm1/local_to_global", 1, epsilon = 0.051),
-    (movieclip_getbounds, "avm1/movieclip_getbounds", 1, epsilon = 0.051),
-    (stage_object_properties_swf6, "avm1/stage_object_properties_swf6", 4, epsilon = 0.051),
-    (stage_object_properties, "avm1/stage_object_properties", 6, epsilon = 0.051),
-}
-
-#[test]
 fn external_interface_avm1() -> Result<(), Error> {
     set_logger();
     test_swf_with_hooks(
@@ -1000,7 +171,6 @@ fn external_interface_avm1() -> Result<(), Error> {
     )
 }
 
-#[test]
 fn external_interface_avm2() -> Result<(), Error> {
     set_logger();
     test_swf_with_hooks(
@@ -1046,7 +216,6 @@ fn external_interface_avm2() -> Result<(), Error> {
     )
 }
 
-#[test]
 fn shared_object_avm1() -> Result<(), Error> {
     set_logger();
     // Test SharedObject persistence. Run an SWF that saves data
@@ -1100,7 +269,6 @@ fn shared_object_avm1() -> Result<(), Error> {
     Ok(())
 }
 
-#[test]
 fn shared_object_avm2() -> Result<(), Error> {
     set_logger();
     // Test SharedObject persistence. Run an SWF that saves data
@@ -1154,53 +322,6 @@ fn shared_object_avm2() -> Result<(), Error> {
     Ok(())
 }
 
-#[test]
-fn timeout_avm1() -> Result<(), Error> {
-    set_logger();
-    test_swf_with_hooks(
-        "tests/swfs/avm1/timeout/test.swf",
-        1,
-        "tests/swfs/avm1/timeout/input.json",
-        "tests/swfs/avm1/timeout/output.txt",
-        |player| {
-            player
-                .lock()
-                .unwrap()
-                .set_max_execution_duration(Duration::from_secs(5));
-            Ok(())
-        },
-        |_| Ok(()),
-        false,
-        false,
-    )
-}
-
-#[test]
-fn stage_scale_mode() -> Result<(), Error> {
-    set_logger();
-    test_swf_with_hooks(
-        "tests/swfs/avm1/stage_scale_mode/test.swf",
-        1,
-        "tests/swfs/avm1/stage_scale_mode/input.json",
-        "tests/swfs/avm1/stage_scale_mode/output.txt",
-        |player| {
-            // Simulate a large viewport to test stage size.
-            player
-                .lock()
-                .unwrap()
-                .set_viewport_dimensions(ViewportDimensions {
-                    width: 900,
-                    height: 900,
-                    scale_factor: 1.0,
-                });
-            Ok(())
-        },
-        |_| Ok(()),
-        false,
-        false,
-    )
-}
-
 /// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
 /// Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
 /// test failures to show nice diffs.
@@ -1227,28 +348,6 @@ macro_rules! assert_eq {
             $message
         );
     };
-}
-
-/// Loads an SWF and runs it through the Ruffle core for a number of frames.
-/// Tests that the trace output matches the given expected output.
-fn test_swf(
-    swf_path: &str,
-    num_frames: u32,
-    simulated_input_path: &str,
-    expected_output_path: &str,
-    check_img: bool,
-    frame_time_sleep: bool,
-) -> Result<(), Error> {
-    test_swf_with_hooks(
-        swf_path,
-        num_frames,
-        simulated_input_path,
-        expected_output_path,
-        |_| Ok(()),
-        |_| Ok(()),
-        check_img,
-        frame_time_sleep,
-    )
 }
 
 /// Loads an SWF and runs it through the Ruffle core for a number of frames.
@@ -1630,4 +729,88 @@ impl ExternalInterfaceProvider for ExternalInterfaceTestProvider {
     fn on_fs_command(&self, _command: &str, _args: &str) -> bool {
         false
     }
+}
+
+fn run_test(options: TestOptions, root: &Path) -> Result<(), libtest_mimic::Failed> {
+    set_logger();
+
+    if let Some(approximations) = &options.approximations {
+        let num_patterns: Vec<Regex> = approximations
+            .number_patterns
+            .iter()
+            .map(|p| Regex::new(&p).unwrap())
+            .collect();
+        test_swf_approx(
+            root.join("test.swf").to_str().unwrap(),
+            options.num_frames,
+            root.join("input.json").to_str().unwrap(),
+            root.join("output.txt").to_str().unwrap(),
+            &num_patterns,
+            options.image,
+            |actual, expected| approximations.compare(actual, expected),
+        )
+        .map_err(|e| e.to_string().into())
+    } else {
+        test_swf_with_hooks(
+            root.join("test.swf").to_str().unwrap(),
+            options.num_frames,
+            root.join("input.json").to_str().unwrap(),
+            root.join("output.txt").to_str().unwrap(),
+            |player| {
+                if let Some(player_options) = &options.player_options {
+                    player_options.setup(player);
+                }
+                Ok(())
+            },
+            |_| Ok(()),
+            options.image,
+            options.sleep_to_meet_frame_rate,
+        )
+        .map_err(|e| e.to_string().into())
+    }
+}
+
+fn main() {
+    let args = Arguments::from_args();
+
+    let root = Path::new("tests/swfs");
+    let mut tests: Vec<Trial> = walkdir::WalkDir::new(root)
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|entry| entry.file_type().is_file() && entry.file_name() == "test.toml")
+        .map(|file| {
+            let options: TestOptions =
+                toml::from_str(&fs::read_to_string(&file.path()).unwrap()).unwrap();
+            let test_dir = file.path().parent().unwrap().to_owned();
+            let name = test_dir
+                .strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .replace('\\', "/");
+            let ignore = options.ignore || (options.image && !RUN_IMG_TESTS);
+            let mut test = Trial::test(name, move || run_test(options, &test_dir));
+            if ignore {
+                test = test.with_ignored_flag(true);
+            }
+            test
+        })
+        .collect();
+
+    // Manual tests here, since #[test] doesn't work once we use our own test harness
+    tests.push(Trial::test("shared_object_avm1", || {
+        shared_object_avm1().map_err(|e| e.to_string().into())
+    }));
+    tests.push(Trial::test("shared_object_avm2", || {
+        shared_object_avm2().map_err(|e| e.to_string().into())
+    }));
+    tests.push(Trial::test("external_interface_avm1", || {
+        external_interface_avm1().map_err(|e| e.to_string().into())
+    }));
+    tests.push(Trial::test("external_interface_avm2", || {
+        external_interface_avm2().map_err(|e| e.to_string().into())
+    }));
+
+    tests.sort_unstable_by(|a, b| a.name().cmp(b.name()));
+
+    libtest_mimic::run(&args, tests).exit()
 }

--- a/tests/tests/swfs/avm1/action_to_integer/test.toml
+++ b/tests/tests/swfs/avm1/action_to_integer/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/add/test.toml
+++ b/tests/tests/swfs/avm1/add/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/add2/test.toml
+++ b/tests/tests/swfs/avm1/add2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/add_property/test.toml
+++ b/tests/tests/swfs/avm1/add_property/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/add_swf4/test.toml
+++ b/tests/tests/swfs/avm1/add_swf4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/add_swf5/test.toml
+++ b/tests/tests/swfs/avm1/add_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/arguments/test.toml
+++ b/tests/tests/swfs/avm1/arguments/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_call_method/test.toml
+++ b/tests/tests/swfs/avm1/array_call_method/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_concat/test.toml
+++ b/tests/tests/swfs/avm1/array_concat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_constructor/test.toml
+++ b/tests/tests/swfs/avm1/array_constructor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_enumerate/test.toml
+++ b/tests/tests/swfs/avm1/array_enumerate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_length/test.toml
+++ b/tests/tests/swfs/avm1/array_length/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_properties/test.toml
+++ b/tests/tests/swfs/avm1/array_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_prototyping/test.toml
+++ b/tests/tests/swfs/avm1/array_prototyping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_slice/test.toml
+++ b/tests/tests/swfs/avm1/array_slice/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_sort/test.toml
+++ b/tests/tests/swfs/avm1/array_sort/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_splice/test.toml
+++ b/tests/tests/swfs/avm1/array_splice/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/array_trivial/test.toml
+++ b/tests/tests/swfs/avm1/array_trivial/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as1_constructor_v6/test.toml
+++ b/tests/tests/swfs/avm1/as1_constructor_v6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as1_constructor_v7/test.toml
+++ b/tests/tests/swfs/avm1/as1_constructor_v7/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as2_oop/test.toml
+++ b/tests/tests/swfs/avm1/as2_oop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as2_super_and_this_v6/test.toml
+++ b/tests/tests/swfs/avm1/as2_super_and_this_v6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as2_super_and_this_v8/test.toml
+++ b/tests/tests/swfs/avm1/as2_super_and_this_v8/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as2_super_via_manual_prototype/test.toml
+++ b/tests/tests/swfs/avm1/as2_super_via_manual_prototype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_broadcaster/test.toml
+++ b/tests/tests/swfs/avm1/as_broadcaster/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_broadcaster_initialize/test.toml
+++ b/tests/tests/swfs/avm1/as_broadcaster_initialize/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags_version/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags_version/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags_version_swf5/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags_version_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags_version_swf6/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags_version_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags_version_swf7/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags_version_swf7/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags_version_swf8/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags_version_swf8/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_set_prop_flags_version_swf9/test.toml
+++ b/tests/tests/swfs/avm1/as_set_prop_flags_version_swf9/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/as_transformed_flag/test.toml
+++ b/tests/tests/swfs/avm1/as_transformed_flag/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/attach_movie/test.toml
+++ b/tests/tests/swfs/avm1/attach_movie/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bad_placeobject_clipaction/test.toml
+++ b/tests/tests/swfs/avm1/bad_placeobject_clipaction/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/bad_swf_tag_past_eof/test.toml
+++ b/tests/tests/swfs/avm1/bad_swf_tag_past_eof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bevel_filter/test.toml
+++ b/tests/tests/swfs/avm1/bevel_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitand/test.toml
+++ b/tests/tests/swfs/avm1/bitand/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_data/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_data_compare/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_compare/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_data_copypixels/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_copypixels/test.toml
@@ -1,0 +1,2 @@
+num_frames = 2
+image = true

--- a/tests/tests/swfs/avm1/bitmap_data_max_size_swf10/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_max_size_swf10/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_data_max_size_swf9/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_max_size_swf9/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_data_noise/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_noise/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_data_threshold/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_threshold/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitmap_filter/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitor/test.toml
+++ b/tests/tests/swfs/avm1/bitor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/biturshift/test.toml
+++ b/tests/tests/swfs/avm1/biturshift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/biturshift_swf8/test.toml
+++ b/tests/tests/swfs/avm1/biturshift_swf8/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/bitxor/test.toml
+++ b/tests/tests/swfs/avm1/bitxor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/blur_filter/test.toml
+++ b/tests/tests/swfs/avm1/blur_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/button_children/test.toml
+++ b/tests/tests/swfs/avm1/button_children/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/button_order/test.toml
+++ b/tests/tests/swfs/avm1/button_order/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/call/test.toml
+++ b/tests/tests/swfs/avm1/call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/call_method_empty_name/test.toml
+++ b/tests/tests/swfs/avm1/call_method_empty_name/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/clip_events/test.toml
+++ b/tests/tests/swfs/avm1/clip_events/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm1/closure_scope/test.toml
+++ b/tests/tests/swfs/avm1/closure_scope/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/color/test.toml
+++ b/tests/tests/swfs/avm1/color/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm1/color_matrix_filter/test.toml
+++ b/tests/tests/swfs/avm1/color_matrix_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/color_transform/test.toml
+++ b/tests/tests/swfs/avm1/color_transform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/conflicting_instance_names/test.toml
+++ b/tests/tests/swfs/avm1/conflicting_instance_names/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm1/constructor_function/test.toml
+++ b/tests/tests/swfs/avm1/constructor_function/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/context_menu/test.toml
+++ b/tests/tests/swfs/avm1/context_menu/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/context_menu_item/test.toml
+++ b/tests/tests/swfs/avm1/context_menu_item/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/convolution_filter/test.toml
+++ b/tests/tests/swfs/avm1/convolution_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/create_empty_movie_clip/test.toml
+++ b/tests/tests/swfs/avm1/create_empty_movie_clip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/cross_movie_root/test.toml
+++ b/tests/tests/swfs/avm1/cross_movie_root/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm1/custom_clip_methods/test.toml
+++ b/tests/tests/swfs/avm1/custom_clip_methods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/date/test.toml
+++ b/tests/tests/swfs/avm1/date/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/default_names/test.toml
+++ b/tests/tests/swfs/avm1/default_names/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm1/define_function2_preload/test.toml
+++ b/tests/tests/swfs/avm1/define_function2_preload/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/define_function2_preload_order/test.toml
+++ b/tests/tests/swfs/avm1/define_function2_preload_order/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/define_function_case_sensitive/test.toml
+++ b/tests/tests/swfs/avm1/define_function_case_sensitive/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/define_local/test.toml
+++ b/tests/tests/swfs/avm1/define_local/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/define_local_with_paths/test.toml
+++ b/tests/tests/swfs/avm1/define_local_with_paths/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/delete/test.toml
+++ b/tests/tests/swfs/avm1/delete/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/displacement_map_filter/test.toml
+++ b/tests/tests/swfs/avm1/displacement_map_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/divide_swf4/test.toml
+++ b/tests/tests/swfs/avm1/divide_swf4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/do_init_action/test.toml
+++ b/tests/tests/swfs/avm1/do_init_action/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/drag_drop/test.toml
+++ b/tests/tests/swfs/avm1/drag_drop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 14

--- a/tests/tests/swfs/avm1/drop_shadow_filter/test.toml
+++ b/tests/tests/swfs/avm1/drop_shadow_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/duplicate_movie_clip/test.toml
+++ b/tests/tests/swfs/avm1/duplicate_movie_clip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/duplicate_movie_clip_drawing/test.toml
+++ b/tests/tests/swfs/avm1/duplicate_movie_clip_drawing/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_align/test.toml
+++ b/tests/tests/swfs/avm1/edittext_align/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 3.0

--- a/tests/tests/swfs/avm1/edittext_antialiastype/test.toml
+++ b/tests/tests/swfs/avm1/edittext_antialiastype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_autosize/test.toml
+++ b/tests/tests/swfs/avm1/edittext_autosize/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.1

--- a/tests/tests/swfs/avm1/edittext_bullet/test.toml
+++ b/tests/tests/swfs/avm1/edittext_bullet/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 3.0

--- a/tests/tests/swfs/avm1/edittext_default_format/test.toml
+++ b/tests/tests/swfs/avm1/edittext_default_format/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_font_size/test.toml
+++ b/tests/tests/swfs/avm1/edittext_font_size/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_hscroll/test.toml
+++ b/tests/tests/swfs/avm1/edittext_hscroll/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 3.0

--- a/tests/tests/swfs/avm1/edittext_html_entity/test.toml
+++ b/tests/tests/swfs/avm1/edittext_html_entity/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_html_roundtrip/test.toml
+++ b/tests/tests/swfs/avm1/edittext_html_roundtrip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_leading/test.toml
+++ b/tests/tests/swfs/avm1/edittext_leading/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_letter_spacing/test.toml
+++ b/tests/tests/swfs/avm1/edittext_letter_spacing/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+# TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
+epsilon = 15.0

--- a/tests/tests/swfs/avm1/edittext_margins/test.toml
+++ b/tests/tests/swfs/avm1/edittext_margins/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+# TODO: Discrepancy in wrapping.
+epsilon = 5.0

--- a/tests/tests/swfs/avm1/edittext_newline_stripping/test.toml
+++ b/tests/tests/swfs/avm1/edittext_newline_stripping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_newlines/test.toml
+++ b/tests/tests/swfs/avm1/edittext_newlines/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm1/edittext_password/test.toml
+++ b/tests/tests/swfs/avm1/edittext_password/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_scroll/test.toml
+++ b/tests/tests/swfs/avm1/edittext_scroll/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/edittext_tab_stops/test.toml
+++ b/tests/tests/swfs/avm1/edittext_tab_stops/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 5.0

--- a/tests/tests/swfs/avm1/edittext_underline/test.toml
+++ b/tests/tests/swfs/avm1/edittext_underline/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 4.0

--- a/tests/tests/swfs/avm1/edittext_width_height/test.toml
+++ b/tests/tests/swfs/avm1/edittext_width_height/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/empty_movieclip_can_attach_movies/test.toml
+++ b/tests/tests/swfs/avm1/empty_movieclip_can_attach_movies/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/enumerate/test.toml
+++ b/tests/tests/swfs/avm1/enumerate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals/test.toml
+++ b/tests/tests/swfs/avm1/equals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals2_swf5/test.toml
+++ b/tests/tests/swfs/avm1/equals2_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals2_swf6/test.toml
+++ b/tests/tests/swfs/avm1/equals2_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals2_swf7/test.toml
+++ b/tests/tests/swfs/avm1/equals2_swf7/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals_swf4/test.toml
+++ b/tests/tests/swfs/avm1/equals_swf4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals_swf4_alt/test.toml
+++ b/tests/tests/swfs/avm1/equals_swf4_alt/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/equals_swf5/test.toml
+++ b/tests/tests/swfs/avm1/equals_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/error/test.toml
+++ b/tests/tests/swfs/avm1/error/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/escape/test.toml
+++ b/tests/tests/swfs/avm1/escape/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/execution_order1/test.toml
+++ b/tests/tests/swfs/avm1/execution_order1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/execution_order2/test.toml
+++ b/tests/tests/swfs/avm1/execution_order2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 15

--- a/tests/tests/swfs/avm1/execution_order3/test.toml
+++ b/tests/tests/swfs/avm1/execution_order3/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm1/execution_order4/test.toml
+++ b/tests/tests/swfs/avm1/execution_order4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm1/export_assets/test.toml
+++ b/tests/tests/swfs/avm1/export_assets/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/extends_chain/test.toml
+++ b/tests/tests/swfs/avm1/extends_chain/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/extends_native_type/test.toml
+++ b/tests/tests/swfs/avm1/extends_native_type/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/function_as_function/test.toml
+++ b/tests/tests/swfs/avm1/function_as_function/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/function_base_clip/test.toml
+++ b/tests/tests/swfs/avm1/function_base_clip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/function_base_clip_removed/test.toml
+++ b/tests/tests/swfs/avm1/function_base_clip_removed/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/function_suppress_and_preload/test.toml
+++ b/tests/tests/swfs/avm1/function_suppress_and_preload/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/funky_function_calls/test.toml
+++ b/tests/tests/swfs/avm1/funky_function_calls/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/get_bytes_total/test.toml
+++ b/tests/tests/swfs/avm1/get_bytes_total/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/get_variable_in_scope/test.toml
+++ b/tests/tests/swfs/avm1/get_variable_in_scope/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/getproperty/test.toml
+++ b/tests/tests/swfs/avm1/getproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/getproperty_swf4/test.toml
+++ b/tests/tests/swfs/avm1/getproperty_swf4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/getproperty_swf5/test.toml
+++ b/tests/tests/swfs/avm1/getproperty_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/gettextextent/test.toml
+++ b/tests/tests/swfs/avm1/gettextextent/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+# TODO: Flash Player breaks single words that are longer than the line, but we don't.
+epsilon = 30.0

--- a/tests/tests/swfs/avm1/global_array/test.toml
+++ b/tests/tests/swfs/avm1/global_array/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/global_is_bare/test.toml
+++ b/tests/tests/swfs/avm1/global_is_bare/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/glow_filter/test.toml
+++ b/tests/tests/swfs/avm1/glow_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/goto_advance1/test.toml
+++ b/tests/tests/swfs/avm1/goto_advance1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/goto_advance2/test.toml
+++ b/tests/tests/swfs/avm1/goto_advance2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/goto_both_ways1/test.toml
+++ b/tests/tests/swfs/avm1/goto_both_ways1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/goto_both_ways2/test.toml
+++ b/tests/tests/swfs/avm1/goto_both_ways2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/goto_execution_order/test.toml
+++ b/tests/tests/swfs/avm1/goto_execution_order/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/goto_execution_order2/test.toml
+++ b/tests/tests/swfs/avm1/goto_execution_order2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/goto_frame/test.toml
+++ b/tests/tests/swfs/avm1/goto_frame/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/goto_frame2/test.toml
+++ b/tests/tests/swfs/avm1/goto_frame2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm1/goto_frame_number/test.toml
+++ b/tests/tests/swfs/avm1/goto_frame_number/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm1/goto_label/test.toml
+++ b/tests/tests/swfs/avm1/goto_label/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm1/goto_methods/test.toml
+++ b/tests/tests/swfs/avm1/goto_methods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/goto_rewind1/test.toml
+++ b/tests/tests/swfs/avm1/goto_rewind1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm1/goto_rewind2/test.toml
+++ b/tests/tests/swfs/avm1/goto_rewind2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm1/goto_rewind3/test.toml
+++ b/tests/tests/swfs/avm1/goto_rewind3/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/gradient_bevel_filter/test.toml
+++ b/tests/tests/swfs/avm1/gradient_bevel_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/gradient_glow_filter/test.toml
+++ b/tests/tests/swfs/avm1/gradient_glow_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/greater_swf6/test.toml
+++ b/tests/tests/swfs/avm1/greater_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/greater_swf7/test.toml
+++ b/tests/tests/swfs/avm1/greater_swf7/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/greaterthan_swf5/test.toml
+++ b/tests/tests/swfs/avm1/greaterthan_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/greaterthan_swf8/test.toml
+++ b/tests/tests/swfs/avm1/greaterthan_swf8/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/has_own_property/test.toml
+++ b/tests/tests/swfs/avm1/has_own_property/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/infinite_recursion_function/test.toml
+++ b/tests/tests/swfs/avm1/infinite_recursion_function/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/infinite_recursion_function_in_setter/test.toml
+++ b/tests/tests/swfs/avm1/infinite_recursion_function_in_setter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/infinite_recursion_virtual_property/test.toml
+++ b/tests/tests/swfs/avm1/infinite_recursion_virtual_property/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/init_array_invalid/test.toml
+++ b/tests/tests/swfs/avm1/init_array_invalid/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/init_object_order/test.toml
+++ b/tests/tests/swfs/avm1/init_object_order/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/is_finite/test.toml
+++ b/tests/tests/swfs/avm1/is_finite/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/is_finite_swf6/test.toml
+++ b/tests/tests/swfs/avm1/is_finite_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/is_prototype_of/test.toml
+++ b/tests/tests/swfs/avm1/is_prototype_of/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_1086/test.toml
+++ b/tests/tests/swfs/avm1/issue_1086/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_1104/test.toml
+++ b/tests/tests/swfs/avm1/issue_1104/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/issue_1671/test.toml
+++ b/tests/tests/swfs/avm1/issue_1671/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_1906/test.toml
+++ b/tests/tests/swfs/avm1/issue_1906/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/issue_2030/test.toml
+++ b/tests/tests/swfs/avm1/issue_2030/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_2084/test.toml
+++ b/tests/tests/swfs/avm1/issue_2084/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/issue_2166/test.toml
+++ b/tests/tests/swfs/avm1/issue_2166/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_2870/test.toml
+++ b/tests/tests/swfs/avm1/issue_2870/test.toml
@@ -1,0 +1,1 @@
+num_frames = 10

--- a/tests/tests/swfs/avm1/issue_3169/test.toml
+++ b/tests/tests/swfs/avm1/issue_3169/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_3446/test.toml
+++ b/tests/tests/swfs/avm1/issue_3446/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_3522/test.toml
+++ b/tests/tests/swfs/avm1/issue_3522/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/issue_4377/test.toml
+++ b/tests/tests/swfs/avm1/issue_4377/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_710/test.toml
+++ b/tests/tests/swfs/avm1/issue_710/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/issue_768/test.toml
+++ b/tests/tests/swfs/avm1/issue_768/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan/test.toml
+++ b/tests/tests/swfs/avm1/lessthan/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan2_swf5/test.toml
+++ b/tests/tests/swfs/avm1/lessthan2_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan2_swf6/test.toml
+++ b/tests/tests/swfs/avm1/lessthan2_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan2_swf7/test.toml
+++ b/tests/tests/swfs/avm1/lessthan2_swf7/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan_swf4/test.toml
+++ b/tests/tests/swfs/avm1/lessthan_swf4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan_swf4_alt/test.toml
+++ b/tests/tests/swfs/avm1/lessthan_swf4_alt/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/lessthan_swf5/test.toml
+++ b/tests/tests/swfs/avm1/lessthan_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/load_vars/test.toml
+++ b/tests/tests/swfs/avm1/load_vars/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/loadmovie/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/loadmovie_fail/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_fail/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/loadmovie_method/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_method/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/loadmovie_registerclass/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_registerclass/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/loadmovie_replace_root/test.toml
+++ b/tests/tests/swfs/avm1/loadmovie_replace_root/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/loadmovienum/test.toml
+++ b/tests/tests/swfs/avm1/loadmovienum/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/loadvariables/test.toml
+++ b/tests/tests/swfs/avm1/loadvariables/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/loadvariables_method/test.toml
+++ b/tests/tests/swfs/avm1/loadvariables_method/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/loadvariablesnum/test.toml
+++ b/tests/tests/swfs/avm1/loadvariablesnum/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/local_to_global/test.toml
+++ b/tests/tests/swfs/avm1/local_to_global/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.051

--- a/tests/tests/swfs/avm1/logical_ops_swf4/test.toml
+++ b/tests/tests/swfs/avm1/logical_ops_swf4/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/logical_ops_swf8/test.toml
+++ b/tests/tests/swfs/avm1/logical_ops_swf8/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/looping/test.toml
+++ b/tests/tests/swfs/avm1/looping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm1/math_min_max/test.toml
+++ b/tests/tests/swfs/avm1/math_min_max/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/matrix/test.toml
+++ b/tests/tests/swfs/avm1/matrix/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/mcl_as_broadcaster/test.toml
+++ b/tests/tests/swfs/avm1/mcl_as_broadcaster/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/mcl_getprogress/test.toml
+++ b/tests/tests/swfs/avm1/mcl_getprogress/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm1/mcl_giftarget/test.toml
+++ b/tests/tests/swfs/avm1/mcl_giftarget/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/mcl_jpgtarget/test.toml
+++ b/tests/tests/swfs/avm1/mcl_jpgtarget/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/mcl_loadclip/test.toml
+++ b/tests/tests/swfs/avm1/mcl_loadclip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/mcl_mislabeled_target/test.toml
+++ b/tests/tests/swfs/avm1/mcl_mislabeled_target/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/mcl_pngtarget/test.toml
+++ b/tests/tests/swfs/avm1/mcl_pngtarget/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/mcl_unloadclip/test.toml
+++ b/tests/tests/swfs/avm1/mcl_unloadclip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/mouse_events/test.toml
+++ b/tests/tests/swfs/avm1/mouse_events/test.toml
@@ -1,0 +1,1 @@
+num_frames = 8

--- a/tests/tests/swfs/avm1/mouse_listeners/test.toml
+++ b/tests/tests/swfs/avm1/mouse_listeners/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/movieclip_depth_methods/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_depth_methods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/movieclip_get_instance_at_depth/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_get_instance_at_depth/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/movieclip_getbounds/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_getbounds/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.051

--- a/tests/tests/swfs/avm1/movieclip_hittest/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_hittest/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/movieclip_hittest_shapeflag/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_hittest_shapeflag/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/movieclip_init_object/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_init_object/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/movieclip_lockroot/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_lockroot/test.toml
@@ -1,0 +1,1 @@
+num_frames = 10

--- a/tests/tests/swfs/avm1/movieclip_prototype_extension/test.toml
+++ b/tests/tests/swfs/avm1/movieclip_prototype_extension/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/nan_scale/test.toml
+++ b/tests/tests/swfs/avm1/nan_scale/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/nested_textfields_in_buttons/test.toml
+++ b/tests/tests/swfs/avm1/nested_textfields_in_buttons/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/new_method_wrap/test.toml
+++ b/tests/tests/swfs/avm1/new_method_wrap/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/new_object_enumerate/test.toml
+++ b/tests/tests/swfs/avm1/new_object_enumerate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/new_object_wrap/test.toml
+++ b/tests/tests/swfs/avm1/new_object_wrap/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/object_constructor/test.toml
+++ b/tests/tests/swfs/avm1/object_constructor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/object_function/test.toml
+++ b/tests/tests/swfs/avm1/object_function/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/object_prototypes/test.toml
+++ b/tests/tests/swfs/avm1/object_prototypes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/object_string_coerce_swf5/test.toml
+++ b/tests/tests/swfs/avm1/object_string_coerce_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/object_string_coerce_swf6/test.toml
+++ b/tests/tests/swfs/avm1/object_string_coerce_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/on_construct/test.toml
+++ b/tests/tests/swfs/avm1/on_construct/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/parse_float/test.toml
+++ b/tests/tests/swfs/avm1/parse_float/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/parse_int/test.toml
+++ b/tests/tests/swfs/avm1/parse_int/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/path_string/test.toml
+++ b/tests/tests/swfs/avm1/path_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/point/test.toml
+++ b/tests/tests/swfs/avm1/point/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/primitive_instanceof/test.toml
+++ b/tests/tests/swfs/avm1/primitive_instanceof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/primitive_type_globals/test.toml
+++ b/tests/tests/swfs/avm1/primitive_type_globals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/prototype_enumerate/test.toml
+++ b/tests/tests/swfs/avm1/prototype_enumerate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/prototype_properties/test.toml
+++ b/tests/tests/swfs/avm1/prototype_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/rectangle/test.toml
+++ b/tests/tests/swfs/avm1/rectangle/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/recursive_prototypes/test.toml
+++ b/tests/tests/swfs/avm1/recursive_prototypes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/register_and_init_order/test.toml
+++ b/tests/tests/swfs/avm1/register_and_init_order/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/register_class/test.toml
+++ b/tests/tests/swfs/avm1/register_class/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/register_class_return_value/test.toml
+++ b/tests/tests/swfs/avm1/register_class_return_value/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/register_class_swf6/test.toml
+++ b/tests/tests/swfs/avm1/register_class_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/register_underflow/test.toml
+++ b/tests/tests/swfs/avm1/register_underflow/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/remove_movie_clip/test.toml
+++ b/tests/tests/swfs/avm1/remove_movie_clip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/removed_base_clip_tell_target/test.toml
+++ b/tests/tests/swfs/avm1/removed_base_clip_tell_target/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/removed_clip_halts_script/test.toml
+++ b/tests/tests/swfs/avm1/removed_clip_halts_script/test.toml
@@ -1,0 +1,1 @@
+num_frames = 13

--- a/tests/tests/swfs/avm1/root_global_parent/test.toml
+++ b/tests/tests/swfs/avm1/root_global_parent/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/selection/test.toml
+++ b/tests/tests/swfs/avm1/selection/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/set_interval/test.toml
+++ b/tests/tests/swfs/avm1/set_interval/test.toml
@@ -1,0 +1,1 @@
+num_frames = 40

--- a/tests/tests/swfs/avm1/set_variable_scope/test.toml
+++ b/tests/tests/swfs/avm1/set_variable_scope/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/single_frame/test.toml
+++ b/tests/tests/swfs/avm1/single_frame/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/slash_syntax/test.toml
+++ b/tests/tests/swfs/avm1/slash_syntax/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/sound/test.toml
+++ b/tests/tests/swfs/avm1/sound/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/stage_display_state/test.toml
+++ b/tests/tests/swfs/avm1/stage_display_state/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/stage_object_children/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_children/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/stage_object_enumerate/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_enumerate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/stage_object_properties/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_properties/test.toml
@@ -1,0 +1,4 @@
+num_frames = 6
+
+[approximations]
+epsilon = 0.051

--- a/tests/tests/swfs/avm1/stage_object_properties_get_var/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_properties_get_var/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/stage_object_properties_swf6/test.toml
+++ b/tests/tests/swfs/avm1/stage_object_properties_swf6/test.toml
@@ -1,0 +1,4 @@
+num_frames = 4
+
+[approximations]
+epsilon = 0.051

--- a/tests/tests/swfs/avm1/stage_property_representation/test.toml
+++ b/tests/tests/swfs/avm1/stage_property_representation/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/stage_scale_mode/test.toml
+++ b/tests/tests/swfs/avm1/stage_scale_mode/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[player_options]
+viewport_dimensions = { width = 900, height = 900, scale_factor = 1 }

--- a/tests/tests/swfs/avm1/strictequals_swf6/test.toml
+++ b/tests/tests/swfs/avm1/strictequals_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/strictly_equals/test.toml
+++ b/tests/tests/swfs/avm1/strictly_equals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/string_coercion/test.toml
+++ b/tests/tests/swfs/avm1/string_coercion/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/string_methods/test.toml
+++ b/tests/tests/swfs/avm1/string_methods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/string_methods_negative_args/test.toml
+++ b/tests/tests/swfs/avm1/string_methods_negative_args/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/string_ops_swf6/test.toml
+++ b/tests/tests/swfs/avm1/string_ops_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf4_actions_bool/test.toml
+++ b/tests/tests/swfs/avm1/swf4_actions_bool/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf4_bool/test.toml
+++ b/tests/tests/swfs/avm1/swf4_bool/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf4_function_calls/test.toml
+++ b/tests/tests/swfs/avm1/swf4_function_calls/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf5_encoding/test.toml
+++ b/tests/tests/swfs/avm1/swf5_encoding/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf5_no_closure/test.toml
+++ b/tests/tests/swfs/avm1/swf5_no_closure/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf5_to_6_cross_call/test.toml
+++ b/tests/tests/swfs/avm1/swf5_to_6_cross_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/swf6_case_insensitive/test.toml
+++ b/tests/tests/swfs/avm1/swf6_case_insensitive/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf6_string_as_bool/test.toml
+++ b/tests/tests/swfs/avm1/swf6_string_as_bool/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/swf6_to_5_cross_call/test.toml
+++ b/tests/tests/swfs/avm1/swf6_to_5_cross_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/swf7_case_sensitive/test.toml
+++ b/tests/tests/swfs/avm1/swf7_case_sensitive/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/target_clip_removed/test.toml
+++ b/tests/tests/swfs/avm1/target_clip_removed/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/target_clip_swf5/test.toml
+++ b/tests/tests/swfs/avm1/target_clip_swf5/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/target_clip_swf6/test.toml
+++ b/tests/tests/swfs/avm1/target_clip_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/target_path/test.toml
+++ b/tests/tests/swfs/avm1/target_path/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/tell_target/test.toml
+++ b/tests/tests/swfs/avm1/tell_target/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/tell_target_invalid/test.toml
+++ b/tests/tests/swfs/avm1/tell_target_invalid/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/text_format/test.toml
+++ b/tests/tests/swfs/avm1/text_format/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/textfield_background_color/test.toml
+++ b/tests/tests/swfs/avm1/textfield_background_color/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/textfield_border_color/test.toml
+++ b/tests/tests/swfs/avm1/textfield_border_color/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/textfield_properties/test.toml
+++ b/tests/tests/swfs/avm1/textfield_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/textfield_text/test.toml
+++ b/tests/tests/swfs/avm1/textfield_text/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm1/textfield_variable/test.toml
+++ b/tests/tests/swfs/avm1/textfield_variable/test.toml
@@ -1,0 +1,1 @@
+num_frames = 8

--- a/tests/tests/swfs/avm1/this_scoping/test.toml
+++ b/tests/tests/swfs/avm1/this_scoping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/timeline_function_def/test.toml
+++ b/tests/tests/swfs/avm1/timeline_function_def/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm1/timeout/test.toml
+++ b/tests/tests/swfs/avm1/timeout/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[player_options]
+max_execution_duration = { secs = 5, nanos = 0 }

--- a/tests/tests/swfs/avm1/timer_run_actions/test.toml
+++ b/tests/tests/swfs/avm1/timer_run_actions/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/trace/test.toml
+++ b/tests/tests/swfs/avm1/trace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/transform/test.toml
+++ b/tests/tests/swfs/avm1/transform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/try_catch_finally/test.toml
+++ b/tests/tests/swfs/avm1/try_catch_finally/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/try_finally_simple/test.toml
+++ b/tests/tests/swfs/avm1/try_finally_simple/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/typeof/test.toml
+++ b/tests/tests/swfs/avm1/typeof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/typeof_globals/test.toml
+++ b/tests/tests/swfs/avm1/typeof_globals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/uncaught_exception/test.toml
+++ b/tests/tests/swfs/avm1/uncaught_exception/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/uncaught_exception_bubbled/test.toml
+++ b/tests/tests/swfs/avm1/uncaught_exception_bubbled/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/undefined_to_string_swf6/test.toml
+++ b/tests/tests/swfs/avm1/undefined_to_string_swf6/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/unescape/test.toml
+++ b/tests/tests/swfs/avm1/unescape/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/unload_clip_event/test.toml
+++ b/tests/tests/swfs/avm1/unload_clip_event/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm1/unloadmovie/test.toml
+++ b/tests/tests/swfs/avm1/unloadmovie/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/unloadmovie_method/test.toml
+++ b/tests/tests/swfs/avm1/unloadmovie_method/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/unloadmovienum/test.toml
+++ b/tests/tests/swfs/avm1/unloadmovienum/test.toml
@@ -1,0 +1,1 @@
+num_frames = 11

--- a/tests/tests/swfs/avm1/use_hand_cursor/test.toml
+++ b/tests/tests/swfs/avm1/use_hand_cursor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/variable_args/test.toml
+++ b/tests/tests/swfs/avm1/variable_args/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/waitforframe/test.toml
+++ b/tests/tests/swfs/avm1/waitforframe/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/watch/test.toml
+++ b/tests/tests/swfs/avm1/watch/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/watch_textfield/test.toml
+++ b/tests/tests/swfs/avm1/watch_textfield/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/watch_virtual_property/test.toml
+++ b/tests/tests/swfs/avm1/watch_virtual_property/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm1/watch_virtual_property_proto/test.toml
+++ b/tests/tests/swfs/avm1/watch_virtual_property_proto/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/with/test.toml
+++ b/tests/tests/swfs/avm1/with/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/with_return/test.toml
+++ b/tests/tests/swfs/avm1/with_return/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/with_variable_scopes/test.toml
+++ b/tests/tests/swfs/avm1/with_variable_scopes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml/test.toml
+++ b/tests/tests/swfs/avm1/xml/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_append_child/test.toml
+++ b/tests/tests/swfs/avm1/xml_append_child/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_append_child_with_parent/test.toml
+++ b/tests/tests/swfs/avm1/xml_append_child_with_parent/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_attributes_read/test.toml
+++ b/tests/tests/swfs/avm1/xml_attributes_read/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_cdata/test.toml
+++ b/tests/tests/swfs/avm1/xml_cdata/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_clone_expandos/test.toml
+++ b/tests/tests/swfs/avm1/xml_clone_expandos/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_first_last_child/test.toml
+++ b/tests/tests/swfs/avm1/xml_first_last_child/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_has_child_nodes/test.toml
+++ b/tests/tests/swfs/avm1/xml_has_child_nodes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_idmap/test.toml
+++ b/tests/tests/swfs/avm1/xml_idmap/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_ignore_comments/test.toml
+++ b/tests/tests/swfs/avm1/xml_ignore_comments/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_ignore_white/test.toml
+++ b/tests/tests/swfs/avm1/xml_ignore_white/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_insert_before/test.toml
+++ b/tests/tests/swfs/avm1/xml_insert_before/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_inspect_createmethods/test.toml
+++ b/tests/tests/swfs/avm1/xml_inspect_createmethods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_inspect_doctype/test.toml
+++ b/tests/tests/swfs/avm1/xml_inspect_doctype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_inspect_parsexml/test.toml
+++ b/tests/tests/swfs/avm1/xml_inspect_parsexml/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_inspect_xmldecl/test.toml
+++ b/tests/tests/swfs/avm1/xml_inspect_xmldecl/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_load/test.toml
+++ b/tests/tests/swfs/avm1/xml_load/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_namespaces/test.toml
+++ b/tests/tests/swfs/avm1/xml_namespaces/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_parent_and_child/test.toml
+++ b/tests/tests/swfs/avm1/xml_parent_and_child/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_remove_node/test.toml
+++ b/tests/tests/swfs/avm1/xml_remove_node/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_reparenting/test.toml
+++ b/tests/tests/swfs/avm1/xml_reparenting/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_siblings/test.toml
+++ b/tests/tests/swfs/avm1/xml_siblings/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_to_string/test.toml
+++ b/tests/tests/swfs/avm1/xml_to_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_to_string_comment/test.toml
+++ b/tests/tests/swfs/avm1/xml_to_string_comment/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm1/xml_unescaping/test.toml
+++ b/tests/tests/swfs/avm1/xml_unescaping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/add/test.toml
+++ b/tests/tests/swfs/avm2/add/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/agal_compiler/test.toml
+++ b/tests/tests/swfs/avm2/agal_compiler/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/application_domain/test.toml
+++ b/tests/tests/swfs/avm2/application_domain/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_access/test.toml
+++ b/tests/tests/swfs/avm2/array_access/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_concat/test.toml
+++ b/tests/tests/swfs/avm2/array_concat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_constr/test.toml
+++ b/tests/tests/swfs/avm2/array_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_delete/test.toml
+++ b/tests/tests/swfs/avm2/array_delete/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_enumeration/test.toml
+++ b/tests/tests/swfs/avm2/array_enumeration/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_enumeration_elements/test.toml
+++ b/tests/tests/swfs/avm2/array_enumeration_elements/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_every/test.toml
+++ b/tests/tests/swfs/avm2/array_every/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_filter/test.toml
+++ b/tests/tests/swfs/avm2/array_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_foreach/test.toml
+++ b/tests/tests/swfs/avm2/array_foreach/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_hasownproperty/test.toml
+++ b/tests/tests/swfs/avm2/array_hasownproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_holes/test.toml
+++ b/tests/tests/swfs/avm2/array_holes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_indexof/test.toml
+++ b/tests/tests/swfs/avm2/array_indexof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_join/test.toml
+++ b/tests/tests/swfs/avm2/array_join/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_lastindexof/test.toml
+++ b/tests/tests/swfs/avm2/array_lastindexof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_length/test.toml
+++ b/tests/tests/swfs/avm2/array_length/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_literal/test.toml
+++ b/tests/tests/swfs/avm2/array_literal/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_map/test.toml
+++ b/tests/tests/swfs/avm2/array_map/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_pop/test.toml
+++ b/tests/tests/swfs/avm2/array_pop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_push/test.toml
+++ b/tests/tests/swfs/avm2/array_push/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_reverse/test.toml
+++ b/tests/tests/swfs/avm2/array_reverse/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_shift/test.toml
+++ b/tests/tests/swfs/avm2/array_shift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_slice/test.toml
+++ b/tests/tests/swfs/avm2/array_slice/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_some/test.toml
+++ b/tests/tests/swfs/avm2/array_some/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_sort/test.toml
+++ b/tests/tests/swfs/avm2/array_sort/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_sorton/test.toml
+++ b/tests/tests/swfs/avm2/array_sorton/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_splice/test.toml
+++ b/tests/tests/swfs/avm2/array_splice/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_storage/test.toml
+++ b/tests/tests/swfs/avm2/array_storage/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_tolocalestring/test.toml
+++ b/tests/tests/swfs/avm2/array_tolocalestring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_tostring/test.toml
+++ b/tests/tests/swfs/avm2/array_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_unshift/test.toml
+++ b/tests/tests/swfs/avm2/array_unshift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/array_valueof/test.toml
+++ b/tests/tests/swfs/avm2/array_valueof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/astype/test.toml
+++ b/tests/tests/swfs/avm2/astype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/astypelate/test.toml
+++ b/tests/tests/swfs/avm2/astypelate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitand/test.toml
+++ b/tests/tests/swfs/avm2/bitand/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmap_constr/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmap_data/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_data/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmap_properties/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_properties/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm2/bitmap_subclass/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_subclass/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmap_subclass_properties/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_subclass_properties/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/bitmap_timeline/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_timeline/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmapdata_clone/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_clone/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/bitmapdata_constr/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmapdata_copypixels/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_copypixels/test.toml
@@ -1,0 +1,2 @@
+num_frames = 2
+image = true

--- a/tests/tests/swfs/avm2/bitmapdata_dispose/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_dispose/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmapdata_draw/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_draw/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/bitmapdata_embedded/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_embedded/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/bitmapdata_fillrect/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_fillrect/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitmapdata_opaque/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_opaque/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/bitmapdata_zero_size/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_zero_size/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitnot/test.toml
+++ b/tests/tests/swfs/avm2/bitnot/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitor/test.toml
+++ b/tests/tests/swfs/avm2/bitor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bitxor/test.toml
+++ b/tests/tests/swfs/avm2/bitxor/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/boolean_constr/test.toml
+++ b/tests/tests/swfs/avm2/boolean_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/boolean_negation/test.toml
+++ b/tests/tests/swfs/avm2/boolean_negation/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/boolean_tostring/test.toml
+++ b/tests/tests/swfs/avm2/boolean_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/button_hittest/test.toml
+++ b/tests/tests/swfs/avm2/button_hittest/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bytearray/test.toml
+++ b/tests/tests/swfs/avm2/bytearray/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bytearray_readobject_amf0/test.toml
+++ b/tests/tests/swfs/avm2/bytearray_readobject_amf0/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bytearray_readobject_amf3/test.toml
+++ b/tests/tests/swfs/avm2/bytearray_readobject_amf3/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/bytearray_writeobject/test.toml
+++ b/tests/tests/swfs/avm2/bytearray_writeobject/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/checkfilter/test.toml
+++ b/tests/tests/swfs/avm2/checkfilter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_call/test.toml
+++ b/tests/tests/swfs/avm2/class_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_cast_call/test.toml
+++ b/tests/tests/swfs/avm2/class_cast_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_enumeration/test.toml
+++ b/tests/tests/swfs/avm2/class_enumeration/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_is/test.toml
+++ b/tests/tests/swfs/avm2/class_is/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_methods/test.toml
+++ b/tests/tests/swfs/avm2/class_methods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_object_properties/test.toml
+++ b/tests/tests/swfs/avm2/class_object_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_singleton/test.toml
+++ b/tests/tests/swfs/avm2/class_singleton/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_supercalls_mismatched/test.toml
+++ b/tests/tests/swfs/avm2/class_supercalls_mismatched/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_to_locale_string/test.toml
+++ b/tests/tests/swfs/avm2/class_to_locale_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_to_string/test.toml
+++ b/tests/tests/swfs/avm2/class_to_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/class_value_of/test.toml
+++ b/tests/tests/swfs/avm2/class_value_of/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/closures/test.toml
+++ b/tests/tests/swfs/avm2/closures/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/coerce_property/test.toml
+++ b/tests/tests/swfs/avm2/coerce_property/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/coerce_string/test.toml
+++ b/tests/tests/swfs/avm2/coerce_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/coerce_string_precision/test.toml
+++ b/tests/tests/swfs/avm2/coerce_string_precision/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.000000000000006661338147750939

--- a/tests/tests/swfs/avm2/constructor_call/test.toml
+++ b/tests/tests/swfs/avm2/constructor_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/control_flow_bool/test.toml
+++ b/tests/tests/swfs/avm2/control_flow_bool/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/control_flow_stricteq/test.toml
+++ b/tests/tests/swfs/avm2/control_flow_stricteq/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/convert_boolean/test.toml
+++ b/tests/tests/swfs/avm2/convert_boolean/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/convert_integer/test.toml
+++ b/tests/tests/swfs/avm2/convert_integer/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/convert_number/test.toml
+++ b/tests/tests/swfs/avm2/convert_number/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/convert_uinteger/test.toml
+++ b/tests/tests/swfs/avm2/convert_uinteger/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/date/test.toml
+++ b/tests/tests/swfs/avm2/date/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/date_parse/test.toml
+++ b/tests/tests/swfs/avm2/date_parse/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/declocal/test.toml
+++ b/tests/tests/swfs/avm2/declocal/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/declocal_i/test.toml
+++ b/tests/tests/swfs/avm2/declocal_i/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/decrement/test.toml
+++ b/tests/tests/swfs/avm2/decrement/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/decrement_i/test.toml
+++ b/tests/tests/swfs/avm2/decrement_i/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/default_values/test.toml
+++ b/tests/tests/swfs/avm2/default_values/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/dictionary_access/test.toml
+++ b/tests/tests/swfs/avm2/dictionary_access/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/dictionary_delete/test.toml
+++ b/tests/tests/swfs/avm2/dictionary_delete/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/dictionary_foreach/test.toml
+++ b/tests/tests/swfs/avm2/dictionary_foreach/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/dictionary_hasownproperty/test.toml
+++ b/tests/tests/swfs/avm2/dictionary_hasownproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/dictionary_in/test.toml
+++ b/tests/tests/swfs/avm2/dictionary_in/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/dictionary_namespaces/test.toml
+++ b/tests/tests/swfs/avm2/dictionary_namespaces/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobject_alpha/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_alpha/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobject_blendmode/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_blendmode/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/displayobject_filters/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_filters/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobject_height/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_height/test.toml
@@ -1,0 +1,5 @@
+num_frames = 7
+
+[approximations]
+# TODO: height/width appears to be off by 1 twip sometimes
+epsilon = 0.06

--- a/tests/tests/swfs/avm2/displayobject_hittestobject/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_hittestobject/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobject_hittestpoint/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_hittestpoint/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/displayobject_mask/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_mask/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/displayobject_name/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_name/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/displayobject_parent/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_parent/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/displayobject_root/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_root/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/displayobject_rotation/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_rotation/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.0000000001

--- a/tests/tests/swfs/avm2/displayobject_scrollrect/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_scrollrect/test.toml
@@ -1,0 +1,6 @@
+num_frames = 100
+image = true
+
+[approximations]
+number_patterns = ["\\(a=(.+), b=(.+), c=(.+), d=(.+), tx=(.+), ty=(.+)\\)"]
+max_relative = 0.00000011920928955078125

--- a/tests/tests/swfs/avm2/displayobject_transform/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_transform/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+number_patterns = ["\\(a=(.+), b=(.+), c=(.+), d=(.+), tx=(.+), ty=(.+)\\)"]
+max_relative = 0.00000011920928955078125

--- a/tests/tests/swfs/avm2/displayobject_visible/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_visible/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/displayobject_width/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_width/test.toml
@@ -1,0 +1,4 @@
+num_frames = 7
+
+[approximations]
+epsilon = 0.06

--- a/tests/tests/swfs/avm2/displayobject_x/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_x/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobject_y/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_y/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchild/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchild/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchild_timelinepull0/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchild_timelinepull0/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchild_timelinepull1/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchild_timelinepull1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchild_timelinepull2/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchild_timelinepull2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchildat/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchildat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchildat_timelinelock0/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchildat_timelinelock0/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchildat_timelinelock1/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchildat_timelinelock1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_addchildat_timelinelock2/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_addchildat_timelinelock2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_contains/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_contains/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/displayobjectcontainer_getchildat/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_getchildat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_getchildbyname/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_getchildbyname/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_getchildindex/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_getchildindex/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/displayobjectcontainer_removechild/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_removechild/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_removechild_timelinemanip_remove1/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_removechild_timelinemanip_remove1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/displayobjectcontainer_removechildat/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_removechildat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_removechildren/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_removechildren/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/displayobjectcontainer_setchildindex/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_setchildindex/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_stopallmovieclips/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_stopallmovieclips/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/displayobjectcontainer_swapchildren/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_swapchildren/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_swapchildrenat/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_swapchildrenat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/displayobjectcontainer_timelineinstance/test.toml
+++ b/tests/tests/swfs/avm2/displayobjectcontainer_timelineinstance/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm2/divide/test.toml
+++ b/tests/tests/swfs/avm2/divide/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+# TODO: Discrepancy in float formatting.
+epsilon = 0.0

--- a/tests/tests/swfs/avm2/documentclass/test.toml
+++ b/tests/tests/swfs/avm2/documentclass/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/domain_memory/test.toml
+++ b/tests/tests/swfs/avm2/domain_memory/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/drag_drop/test.toml
+++ b/tests/tests/swfs/avm2/drag_drop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 14

--- a/tests/tests/swfs/avm2/edittext_align/test.toml
+++ b/tests/tests/swfs/avm2/edittext_align/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 3.0

--- a/tests/tests/swfs/avm2/edittext_antialiastype/test.toml
+++ b/tests/tests/swfs/avm2/edittext_antialiastype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/edittext_autosize/test.toml
+++ b/tests/tests/swfs/avm2/edittext_autosize/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.1

--- a/tests/tests/swfs/avm2/edittext_bullet/test.toml
+++ b/tests/tests/swfs/avm2/edittext_bullet/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 3.0

--- a/tests/tests/swfs/avm2/edittext_default_format/test.toml
+++ b/tests/tests/swfs/avm2/edittext_default_format/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/edittext_font_size/test.toml
+++ b/tests/tests/swfs/avm2/edittext_font_size/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.1

--- a/tests/tests/swfs/avm2/edittext_getlinemetrics/test.toml
+++ b/tests/tests/swfs/avm2/edittext_getlinemetrics/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.85

--- a/tests/tests/swfs/avm2/edittext_html_entity/test.toml
+++ b/tests/tests/swfs/avm2/edittext_html_entity/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/edittext_html_roundtrip/test.toml
+++ b/tests/tests/swfs/avm2/edittext_html_roundtrip/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/edittext_leading/test.toml
+++ b/tests/tests/swfs/avm2/edittext_leading/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 0.3

--- a/tests/tests/swfs/avm2/edittext_letter_spacing/test.toml
+++ b/tests/tests/swfs/avm2/edittext_letter_spacing/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+# TODO: Discrepancy in wrapping in letterSpacing = 0.1 test.
+epsilon = 15.0

--- a/tests/tests/swfs/avm2/edittext_margins/test.toml
+++ b/tests/tests/swfs/avm2/edittext_margins/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+# TODO: Discrepancy in wrapping.
+epsilon = 5.0

--- a/tests/tests/swfs/avm2/edittext_mouseenabled/test.toml
+++ b/tests/tests/swfs/avm2/edittext_mouseenabled/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/edittext_newline_stripping/test.toml
+++ b/tests/tests/swfs/avm2/edittext_newline_stripping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/edittext_tab_stops/test.toml
+++ b/tests/tests/swfs/avm2/edittext_tab_stops/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 5.0

--- a/tests/tests/swfs/avm2/edittext_underline/test.toml
+++ b/tests/tests/swfs/avm2/edittext_underline/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+epsilon = 4.0

--- a/tests/tests/swfs/avm2/edittext_width_height/test.toml
+++ b/tests/tests/swfs/avm2/edittext_width_height/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/equals/test.toml
+++ b/tests/tests/swfs/avm2/equals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/error_stack_trace/test.toml
+++ b/tests/tests/swfs/avm2/error_stack_trace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/error_tostring/test.toml
+++ b/tests/tests/swfs/avm2/error_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/error_tostring_more/test.toml
+++ b/tests/tests/swfs/avm2/error_tostring_more/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/es3_inheritance/test.toml
+++ b/tests/tests/swfs/avm2/es3_inheritance/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/es4_inheritance/test.toml
+++ b/tests/tests/swfs/avm2/es4_inheritance/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/es4_interfaces/test.toml
+++ b/tests/tests/swfs/avm2/es4_interfaces/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/es4_method_binding/test.toml
+++ b/tests/tests/swfs/avm2/es4_method_binding/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/es4_oop_prototypes/test.toml
+++ b/tests/tests/swfs/avm2/es4_oop_prototypes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/es4_protected_inheritance/test.toml
+++ b/tests/tests/swfs/avm2/es4_protected_inheritance/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/escape/test.toml
+++ b/tests/tests/swfs/avm2/escape/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/escape_multi_byte/test.toml
+++ b/tests/tests/swfs/avm2/escape_multi_byte/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_bubbles/test.toml
+++ b/tests/tests/swfs/avm2/event_bubbles/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_cancelable/test.toml
+++ b/tests/tests/swfs/avm2/event_cancelable/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_clone/test.toml
+++ b/tests/tests/swfs/avm2/event_clone/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_formattostring/test.toml
+++ b/tests/tests/swfs/avm2/event_formattostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_handler_exception/test.toml
+++ b/tests/tests/swfs/avm2/event_handler_exception/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/event_isdefaultprevented/test.toml
+++ b/tests/tests/swfs/avm2/event_isdefaultprevented/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_type/test.toml
+++ b/tests/tests/swfs/avm2/event_type/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/event_valueof_tostring/test.toml
+++ b/tests/tests/swfs/avm2/event_valueof_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_dispatchevent/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_dispatchevent/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_cancel/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_cancel/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_handlerorder/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_handlerorder/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_indirect/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_indirect/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_this/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_dispatchevent_this/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_haseventlistener/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_haseventlistener/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_tostring/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/eventdispatcher_willtrigger/test.toml
+++ b/tests/tests/swfs/avm2/eventdispatcher_willtrigger/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/falsiness/test.toml
+++ b/tests/tests/swfs/avm2/falsiness/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/filefilter_properties/test.toml
+++ b/tests/tests/swfs/avm2/filefilter_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/font_embedded/test.toml
+++ b/tests/tests/swfs/avm2/font_embedded/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/font_hasglyphs/test.toml
+++ b/tests/tests/swfs/avm2/font_hasglyphs/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/framelabel_constr/test.toml
+++ b/tests/tests/swfs/avm2/framelabel_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/function_call/test.toml
+++ b/tests/tests/swfs/avm2/function_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_arguments/test.toml
+++ b/tests/tests/swfs/avm2/function_call_arguments/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_coercion/test.toml
+++ b/tests/tests/swfs/avm2/function_call_coercion/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_default/test.toml
+++ b/tests/tests/swfs/avm2/function_call_default/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_rest/test.toml
+++ b/tests/tests/swfs/avm2/function_call_rest/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_types/test.toml
+++ b/tests/tests/swfs/avm2/function_call_types/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_via_apply/test.toml
+++ b/tests/tests/swfs/avm2/function_call_via_apply/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_call_via_call/test.toml
+++ b/tests/tests/swfs/avm2/function_call_via_call/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_length/test.toml
+++ b/tests/tests/swfs/avm2/function_length/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_object/test.toml
+++ b/tests/tests/swfs/avm2/function_object/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_proto/test.toml
+++ b/tests/tests/swfs/avm2/function_proto/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm2/function_to_locale_string/test.toml
+++ b/tests/tests/swfs/avm2/function_to_locale_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_to_string/test.toml
+++ b/tests/tests/swfs/avm2/function_to_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_type/test.toml
+++ b/tests/tests/swfs/avm2/function_type/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/function_value_of/test.toml
+++ b/tests/tests/swfs/avm2/function_value_of/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/generate_random_bytes/test.toml
+++ b/tests/tests/swfs/avm2/generate_random_bytes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/get_definition_by_name/test.toml
+++ b/tests/tests/swfs/avm2/get_definition_by_name/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/get_qualified_class_name/test.toml
+++ b/tests/tests/swfs/avm2/get_qualified_class_name/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/get_qualified_super_class_name/test.toml
+++ b/tests/tests/swfs/avm2/get_qualified_super_class_name/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/get_timer/test.toml
+++ b/tests/tests/swfs/avm2/get_timer/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/getouterscope/test.toml
+++ b/tests/tests/swfs/avm2/getouterscope/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/goto_methods/test.toml
+++ b/tests/tests/swfs/avm2/goto_methods/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/goto_methods_swfver10/test.toml
+++ b/tests/tests/swfs/avm2/goto_methods_swfver10/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/greaterequals/test.toml
+++ b/tests/tests/swfs/avm2/greaterequals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/greaterthan/test.toml
+++ b/tests/tests/swfs/avm2/greaterthan/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/has_own_property/test.toml
+++ b/tests/tests/swfs/avm2/has_own_property/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/hasownproperty_namespaces/test.toml
+++ b/tests/tests/swfs/avm2/hasownproperty_namespaces/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/hello_world/test.toml
+++ b/tests/tests/swfs/avm2/hello_world/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_eq/test.toml
+++ b/tests/tests/swfs/avm2/if_eq/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_gt/test.toml
+++ b/tests/tests/swfs/avm2/if_gt/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_gte/test.toml
+++ b/tests/tests/swfs/avm2/if_gte/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_lt/test.toml
+++ b/tests/tests/swfs/avm2/if_lt/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_lte/test.toml
+++ b/tests/tests/swfs/avm2/if_lte/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_ne/test.toml
+++ b/tests/tests/swfs/avm2/if_ne/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_stricteq/test.toml
+++ b/tests/tests/swfs/avm2/if_stricteq/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/if_strictne/test.toml
+++ b/tests/tests/swfs/avm2/if_strictne/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/in/test.toml
+++ b/tests/tests/swfs/avm2/in/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/inclocal/test.toml
+++ b/tests/tests/swfs/avm2/inclocal/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/inclocal_i/test.toml
+++ b/tests/tests/swfs/avm2/inclocal_i/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/increment/test.toml
+++ b/tests/tests/swfs/avm2/increment/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/increment_i/test.toml
+++ b/tests/tests/swfs/avm2/increment_i/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/instanceof/test.toml
+++ b/tests/tests/swfs/avm2/instanceof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/instantiation_on_enter_frame/test.toml
+++ b/tests/tests/swfs/avm2/instantiation_on_enter_frame/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/instantiation_on_enterframe_gotoandstop/test.toml
+++ b/tests/tests/swfs/avm2/instantiation_on_enterframe_gotoandstop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/int_constr/test.toml
+++ b/tests/tests/swfs/avm2/int_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/int_edge_cases/test.toml
+++ b/tests/tests/swfs/avm2/int_edge_cases/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/int_toexponential/test.toml
+++ b/tests/tests/swfs/avm2/int_toexponential/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true # Ignored because Flash Player has a print routine that adds extraneous zeros to things

--- a/tests/tests/swfs/avm2/int_tofixed/test.toml
+++ b/tests/tests/swfs/avm2/int_tofixed/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/int_toprecision/test.toml
+++ b/tests/tests/swfs/avm2/int_toprecision/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true # Ignored because Flash Player has a print routine that adds extraneous zeros to things

--- a/tests/tests/swfs/avm2/int_tostring/test.toml
+++ b/tests/tests/swfs/avm2/int_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/interactiveobject_enabled/test.toml
+++ b/tests/tests/swfs/avm2/interactiveobject_enabled/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/interface_namespaces/test.toml
+++ b/tests/tests/swfs/avm2/interface_namespaces/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/invalid_utf8/test.toml
+++ b/tests/tests/swfs/avm2/invalid_utf8/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/is_finite/test.toml
+++ b/tests/tests/swfs/avm2/is_finite/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/is_nan/test.toml
+++ b/tests/tests/swfs/avm2/is_nan/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/is_prototype_of/test.toml
+++ b/tests/tests/swfs/avm2/is_prototype_of/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/issue_5292/test.toml
+++ b/tests/tests/swfs/avm2/issue_5292/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/issue_8630/test.toml
+++ b/tests/tests/swfs/avm2/issue_8630/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/issue_8630_placeremoveplace/test.toml
+++ b/tests/tests/swfs/avm2/issue_8630_placeremoveplace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/issue_8630_placeremoveplace_scriptremove/test.toml
+++ b/tests/tests/swfs/avm2/issue_8630_placeremoveplace_scriptremove/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm2/issue_8630_scriptremove/test.toml
+++ b/tests/tests/swfs/avm2/issue_8630_scriptremove/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true

--- a/tests/tests/swfs/avm2/istype/test.toml
+++ b/tests/tests/swfs/avm2/istype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/istypelate/test.toml
+++ b/tests/tests/swfs/avm2/istypelate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/istypelate_coerce/test.toml
+++ b/tests/tests/swfs/avm2/istypelate_coerce/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/json_parse/test.toml
+++ b/tests/tests/swfs/avm2/json_parse/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/json_stringify/test.toml
+++ b/tests/tests/swfs/avm2/json_stringify/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/lazyinit/test.toml
+++ b/tests/tests/swfs/avm2/lazyinit/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/lessequals/test.toml
+++ b/tests/tests/swfs/avm2/lessequals/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/lessthan/test.toml
+++ b/tests/tests/swfs/avm2/lessthan/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/loader_applicationDomain/test.toml
+++ b/tests/tests/swfs/avm2/loader_applicationDomain/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/loader_events/test.toml
+++ b/tests/tests/swfs/avm2/loader_events/test.toml
@@ -1,0 +1,2 @@
+num_frames = 3
+image = true

--- a/tests/tests/swfs/avm2/loader_loadbytes_events/test.toml
+++ b/tests/tests/swfs/avm2/loader_loadbytes_events/test.toml
@@ -1,0 +1,2 @@
+num_frames = 3
+image = true

--- a/tests/tests/swfs/avm2/loaderinfo_events/test.toml
+++ b/tests/tests/swfs/avm2/loaderinfo_events/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/loaderinfo_properties/test.toml
+++ b/tests/tests/swfs/avm2/loaderinfo_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/loaderinfo_quine/test.toml
+++ b/tests/tests/swfs/avm2/loaderinfo_quine/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/loaderinfo_root/test.toml
+++ b/tests/tests/swfs/avm2/loaderinfo_root/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/lshift/test.toml
+++ b/tests/tests/swfs/avm2/lshift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/math/test.toml
+++ b/tests/tests/swfs/avm2/math/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.000000000000006661338147750939

--- a/tests/tests/swfs/avm2/matrix/test.toml
+++ b/tests/tests/swfs/avm2/matrix/test.toml
@@ -1,0 +1,5 @@
+num_frames = 1
+
+[approximations]
+number_patterns = ["\\(a=(.+?), b=(.+?), c=(.+?), d=(.+?), tx=(.+?), ty=(.+?)\\)"]
+max_relative = 0.00000011920928955078125

--- a/tests/tests/swfs/avm2/modulo/test.toml
+++ b/tests/tests/swfs/avm2/modulo/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/mouseevent_constr/test.toml
+++ b/tests/tests/swfs/avm2/mouseevent_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/mouseevent_stagexy/test.toml
+++ b/tests/tests/swfs/avm2/mouseevent_stagexy/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/mouseevent_valueof_tostring/test.toml
+++ b/tests/tests/swfs/avm2/mouseevent_valueof_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_child_property/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_child_property/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_constr/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_currentlabels/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_currentlabels/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/movieclip_currentscene/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_currentscene/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_dispatchevent/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_dispatchevent/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_dispatchevent_cancel/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_dispatchevent_cancel/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_dispatchevent_handlerorder/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_dispatchevent_handlerorder/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_dispatchevent_selfadd/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_dispatchevent_selfadd/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_dispatchevent_target/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_dispatchevent_target/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_displayevents/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents/test.toml
@@ -1,0 +1,1 @@
+num_frames = 9

--- a/tests/tests/swfs/avm2/movieclip_displayevents_clickgoto/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_clickgoto/test.toml
@@ -1,0 +1,1 @@
+num_frames = 32

--- a/tests/tests/swfs/avm2/movieclip_displayevents_clickgoto2/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_clickgoto2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 46

--- a/tests/tests/swfs/avm2/movieclip_displayevents_clickplay/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_clickplay/test.toml
@@ -1,0 +1,1 @@
+num_frames = 32

--- a/tests/tests/swfs/avm2/movieclip_displayevents_clicksymbol/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_clicksymbol/test.toml
@@ -1,0 +1,1 @@
+num_frames = 32

--- a/tests/tests/swfs/avm2/movieclip_displayevents_constructframegoto/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_constructframegoto/test.toml
@@ -1,0 +1,1 @@
+num_frames = 12

--- a/tests/tests/swfs/avm2/movieclip_displayevents_constructframeplay/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_constructframeplay/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm2/movieclip_displayevents_constructframesymbol/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_constructframesymbol/test.toml
@@ -1,0 +1,1 @@
+num_frames = 12

--- a/tests/tests/swfs/avm2/movieclip_displayevents_dblhandler/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_dblhandler/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/movieclip_displayevents_enterframegoto/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_enterframegoto/test.toml
@@ -1,0 +1,1 @@
+num_frames = 15

--- a/tests/tests/swfs/avm2/movieclip_displayevents_enterframeplay/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_enterframeplay/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm2/movieclip_displayevents_enterframesymbol/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_enterframesymbol/test.toml
@@ -1,0 +1,1 @@
+num_frames = 15

--- a/tests/tests/swfs/avm2/movieclip_displayevents_exitframegoto/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_exitframegoto/test.toml
@@ -1,0 +1,1 @@
+num_frames = 12

--- a/tests/tests/swfs/avm2/movieclip_displayevents_exitframeplay/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_exitframeplay/test.toml
@@ -1,0 +1,1 @@
+num_frames = 6

--- a/tests/tests/swfs/avm2/movieclip_displayevents_exitframesymbol/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_exitframesymbol/test.toml
@@ -1,0 +1,1 @@
+num_frames = 12

--- a/tests/tests/swfs/avm2/movieclip_displayevents_looping/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_looping/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_displayevents_stopped/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_stopped/test.toml
@@ -1,0 +1,1 @@
+num_frames = 10

--- a/tests/tests/swfs/avm2/movieclip_displayevents_timeline/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_displayevents_timeline/test.toml
@@ -1,0 +1,1 @@
+num_frames = 7

--- a/tests/tests/swfs/avm2/movieclip_drawrect/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_drawrect/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_goto_during_frame_script/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_goto_during_frame_script/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_gotoandplay/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandplay/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_gotoandstop/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandstop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_gotoandstop_children/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandstop_children/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_gotoandstop_framescripts1/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandstop_framescripts1/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_gotoandstop_framescripts2/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandstop_framescripts2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_gotoandstop_framescripts_self/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandstop_framescripts_self/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_gotoandstop_queueing/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_gotoandstop_queueing/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/movieclip_hittest/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_hittest/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_next_frame/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_next_frame/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_next_scene/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_next_scene/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_play/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_play/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_prev_frame/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_prev_frame/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_prev_scene/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_prev_scene/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_properties/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/movieclip_scenes/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_scenes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_soundtransform/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_soundtransform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 49

--- a/tests/tests/swfs/avm2/movieclip_stop/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_stop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/movieclip_symbol_constr/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_symbol_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/movieclip_willtrigger/test.toml
+++ b/tests/tests/swfs/avm2/movieclip_willtrigger/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm2/multiply/test.toml
+++ b/tests/tests/swfs/avm2/multiply/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/nan_scale/test.toml
+++ b/tests/tests/swfs/avm2/nan_scale/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/negate/test.toml
+++ b/tests/tests/swfs/avm2/negate/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/nonconflicting_declarations/test.toml
+++ b/tests/tests/swfs/avm2/nonconflicting_declarations/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/number_constr/test.toml
+++ b/tests/tests/swfs/avm2/number_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/number_toexponential/test.toml
+++ b/tests/tests/swfs/avm2/number_toexponential/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.001

--- a/tests/tests/swfs/avm2/number_tofixed/test.toml
+++ b/tests/tests/swfs/avm2/number_tofixed/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.001

--- a/tests/tests/swfs/avm2/number_toprecision/test.toml
+++ b/tests/tests/swfs/avm2/number_toprecision/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.001

--- a/tests/tests/swfs/avm2/number_tostring/test.toml
+++ b/tests/tests/swfs/avm2/number_tostring/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true # Ignored because Flash Player adds extra x, W, and/or ° symbols randomly

--- a/tests/tests/swfs/avm2/object_enumeration/test.toml
+++ b/tests/tests/swfs/avm2/object_enumeration/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/object_prototype/test.toml
+++ b/tests/tests/swfs/avm2/object_prototype/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/object_to_locale_string/test.toml
+++ b/tests/tests/swfs/avm2/object_to_locale_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/object_to_string/test.toml
+++ b/tests/tests/swfs/avm2/object_to_string/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/object_value_of/test.toml
+++ b/tests/tests/swfs/avm2/object_value_of/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/op_coerce/test.toml
+++ b/tests/tests/swfs/avm2/op_coerce/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/op_coerce_x/test.toml
+++ b/tests/tests/swfs/avm2/op_coerce_x/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/op_escxattr/test.toml
+++ b/tests/tests/swfs/avm2/op_escxattr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/op_escxelem/test.toml
+++ b/tests/tests/swfs/avm2/op_escxelem/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/op_lookupswitch/test.toml
+++ b/tests/tests/swfs/avm2/op_lookupswitch/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/package_namespace/test.toml
+++ b/tests/tests/swfs/avm2/package_namespace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/parse_float/test.toml
+++ b/tests/tests/swfs/avm2/parse_float/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.0000000000000011102230246251565

--- a/tests/tests/swfs/avm2/parse_float_swf10/test.toml
+++ b/tests/tests/swfs/avm2/parse_float_swf10/test.toml
@@ -1,0 +1,4 @@
+num_frames = 1
+
+[approximations]
+max_relative = 0.0000000000000011102230246251565

--- a/tests/tests/swfs/avm2/parse_int/test.toml
+++ b/tests/tests/swfs/avm2/parse_int/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/place_multiple/test.toml
+++ b/tests/tests/swfs/avm2/place_multiple/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/place_object_replace/test.toml
+++ b/tests/tests/swfs/avm2/place_object_replace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/place_object_replace_2/test.toml
+++ b/tests/tests/swfs/avm2/place_object_replace_2/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm2/point/test.toml
+++ b/tests/tests/swfs/avm2/point/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/property_is_enumerable/test.toml
+++ b/tests/tests/swfs/avm2/property_is_enumerable/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/propertyisenumerable_namespaces/test.toml
+++ b/tests/tests/swfs/avm2/propertyisenumerable_namespaces/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/proxy_callproperty/test.toml
+++ b/tests/tests/swfs/avm2/proxy_callproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/proxy_deleteproperty/test.toml
+++ b/tests/tests/swfs/avm2/proxy_deleteproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/proxy_enumeration/test.toml
+++ b/tests/tests/swfs/avm2/proxy_enumeration/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/proxy_getproperty/test.toml
+++ b/tests/tests/swfs/avm2/proxy_getproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/proxy_hasproperty/test.toml
+++ b/tests/tests/swfs/avm2/proxy_hasproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/proxy_setproperty/test.toml
+++ b/tests/tests/swfs/avm2/proxy_setproperty/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/qname_constr/test.toml
+++ b/tests/tests/swfs/avm2/qname_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/qname_constr_namespace/test.toml
+++ b/tests/tests/swfs/avm2/qname_constr_namespace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/qname_indexing/test.toml
+++ b/tests/tests/swfs/avm2/qname_indexing/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/qname_tostring/test.toml
+++ b/tests/tests/swfs/avm2/qname_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/qname_valueof/test.toml
+++ b/tests/tests/swfs/avm2/qname_valueof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/rectangle/test.toml
+++ b/tests/tests/swfs/avm2/rectangle/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/regexp_constr/test.toml
+++ b/tests/tests/swfs/avm2/regexp_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/regexp_exec/test.toml
+++ b/tests/tests/swfs/avm2/regexp_exec/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/regexp_test/test.toml
+++ b/tests/tests/swfs/avm2/regexp_test/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/rshift/test.toml
+++ b/tests/tests/swfs/avm2/rshift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/scene_constr/test.toml
+++ b/tests/tests/swfs/avm2/scene_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 5

--- a/tests/tests/swfs/avm2/set_property_is_enumerable/test.toml
+++ b/tests/tests/swfs/avm2/set_property_is_enumerable/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/shape_drawrect/test.toml
+++ b/tests/tests/swfs/avm2/shape_drawrect/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/simplebutton_childevents/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_childevents/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/simplebutton_childevents_nested/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_childevents_nested/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/simplebutton_childprops/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_childprops/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/simplebutton_childshuffle/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_childshuffle/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/simplebutton_constr/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/simplebutton_constr_childevents/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_constr_childevents/test.toml
@@ -1,0 +1,2 @@
+num_frames = 2
+ignore = true # Broken by other accuracy fixes

--- a/tests/tests/swfs/avm2/simplebutton_constr_params/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_constr_params/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/simplebutton_mouseenabled/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_mouseenabled/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/simplebutton_soundtransform/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_soundtransform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 49

--- a/tests/tests/swfs/avm2/simplebutton_structure/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_structure/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/simplebutton_symbolclass/test.toml
+++ b/tests/tests/swfs/avm2/simplebutton_symbolclass/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm2/sound_embeddedprops/test.toml
+++ b/tests/tests/swfs/avm2/sound_embeddedprops/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/sound_play/test.toml
+++ b/tests/tests/swfs/avm2/sound_play/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/sound_valueof/test.toml
+++ b/tests/tests/swfs/avm2/sound_valueof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/soundchannel_position/test.toml
+++ b/tests/tests/swfs/avm2/soundchannel_position/test.toml
@@ -1,0 +1,2 @@
+num_frames = 75
+ignore = true

--- a/tests/tests/swfs/avm2/soundchannel_soundcomplete/test.toml
+++ b/tests/tests/swfs/avm2/soundchannel_soundcomplete/test.toml
@@ -1,0 +1,2 @@
+num_frames = 25
+ignore = true

--- a/tests/tests/swfs/avm2/soundchannel_soundtransform/test.toml
+++ b/tests/tests/swfs/avm2/soundchannel_soundtransform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 49

--- a/tests/tests/swfs/avm2/soundchannel_stop/test.toml
+++ b/tests/tests/swfs/avm2/soundchannel_stop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/soundmixer_buffertime/test.toml
+++ b/tests/tests/swfs/avm2/soundmixer_buffertime/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/soundmixer_soundtransform/test.toml
+++ b/tests/tests/swfs/avm2/soundmixer_soundtransform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 49

--- a/tests/tests/swfs/avm2/soundmixer_stopall/test.toml
+++ b/tests/tests/swfs/avm2/soundmixer_stopall/test.toml
@@ -1,0 +1,1 @@
+num_frames = 4

--- a/tests/tests/swfs/avm2/soundtransform/test.toml
+++ b/tests/tests/swfs/avm2/soundtransform/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
@@ -1,0 +1,2 @@
+num_frames = 40
+image = true

--- a/tests/tests/swfs/avm2/stage3d_triangle/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/avm2/stage_access/test.toml
+++ b/tests/tests/swfs/avm2/stage_access/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/stage_display_state/test.toml
+++ b/tests/tests/swfs/avm2/stage_display_state/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/stage_displayobject_properties/test.toml
+++ b/tests/tests/swfs/avm2/stage_displayobject_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/stage_loaderinfo_properties/test.toml
+++ b/tests/tests/swfs/avm2/stage_loaderinfo_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 2

--- a/tests/tests/swfs/avm2/stage_mouseenabled/test.toml
+++ b/tests/tests/swfs/avm2/stage_mouseenabled/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/stage_properties/test.toml
+++ b/tests/tests/swfs/avm2/stage_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/static_text/test.toml
+++ b/tests/tests/swfs/avm2/static_text/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/stored_properties/test.toml
+++ b/tests/tests/swfs/avm2/stored_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/strict_equality/test.toml
+++ b/tests/tests/swfs/avm2/strict_equality/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_case/test.toml
+++ b/tests/tests/swfs/avm2/string_case/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_char_at/test.toml
+++ b/tests/tests/swfs/avm2/string_char_at/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_char_code_at/test.toml
+++ b/tests/tests/swfs/avm2/string_char_code_at/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_concat_fromcharcode/test.toml
+++ b/tests/tests/swfs/avm2/string_concat_fromcharcode/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_constr/test.toml
+++ b/tests/tests/swfs/avm2/string_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_indexof_lastindexof/test.toml
+++ b/tests/tests/swfs/avm2/string_indexof_lastindexof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_length/test.toml
+++ b/tests/tests/swfs/avm2/string_length/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_locale_compare/test.toml
+++ b/tests/tests/swfs/avm2/string_locale_compare/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_match/test.toml
+++ b/tests/tests/swfs/avm2/string_match/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_replace/test.toml
+++ b/tests/tests/swfs/avm2/string_replace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_search/test.toml
+++ b/tests/tests/swfs/avm2/string_search/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_slice_substr_substring/test.toml
+++ b/tests/tests/swfs/avm2/string_slice_substr_substring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/string_split/test.toml
+++ b/tests/tests/swfs/avm2/string_split/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/subtract/test.toml
+++ b/tests/tests/swfs/avm2/subtract/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/swz/test.toml
+++ b/tests/tests/swfs/avm2/swz/test.toml
@@ -1,0 +1,1 @@
+num_frames = 10

--- a/tests/tests/swfs/avm2/symbol_class_binary_data/test.toml
+++ b/tests/tests/swfs/avm2/symbol_class_binary_data/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/textformat/test.toml
+++ b/tests/tests/swfs/avm2/textformat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/throw/test.toml
+++ b/tests/tests/swfs/avm2/throw/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/timeline_scripts/test.toml
+++ b/tests/tests/swfs/avm2/timeline_scripts/test.toml
@@ -1,0 +1,1 @@
+num_frames = 3

--- a/tests/tests/swfs/avm2/timer/test.toml
+++ b/tests/tests/swfs/avm2/timer/test.toml
@@ -1,0 +1,2 @@
+num_frames = 280
+sleep_to_meet_frame_rate = true

--- a/tests/tests/swfs/avm2/trace/test.toml
+++ b/tests/tests/swfs/avm2/trace/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/truthiness/test.toml
+++ b/tests/tests/swfs/avm2/truthiness/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/try_catch/test.toml
+++ b/tests/tests/swfs/avm2/try_catch/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/try_catch_typed/test.toml
+++ b/tests/tests/swfs/avm2/try_catch_typed/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/typeof/test.toml
+++ b/tests/tests/swfs/avm2/typeof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/uint_constr/test.toml
+++ b/tests/tests/swfs/avm2/uint_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/uint_toexponential/test.toml
+++ b/tests/tests/swfs/avm2/uint_toexponential/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true # Ignored because Flash Player has a print routine that adds extraneous zeros to things

--- a/tests/tests/swfs/avm2/uint_tofixed/test.toml
+++ b/tests/tests/swfs/avm2/uint_tofixed/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/uint_toprecision/test.toml
+++ b/tests/tests/swfs/avm2/uint_toprecision/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+ignore = true # Ignored because Flash Player has a print routine that adds extraneous zeros to things

--- a/tests/tests/swfs/avm2/uint_tostring/test.toml
+++ b/tests/tests/swfs/avm2/uint_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/unchecked_function/test.toml
+++ b/tests/tests/swfs/avm2/unchecked_function/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/url_loader/test.toml
+++ b/tests/tests/swfs/avm2/url_loader/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/url_vars/test.toml
+++ b/tests/tests/swfs/avm2/url_vars/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/urshift/test.toml
+++ b/tests/tests/swfs/avm2/urshift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector3d/test.toml
+++ b/tests/tests/swfs/avm2/vector3d/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_coercion/test.toml
+++ b/tests/tests/swfs/avm2/vector_coercion/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_concat/test.toml
+++ b/tests/tests/swfs/avm2/vector_concat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_constr/test.toml
+++ b/tests/tests/swfs/avm2/vector_constr/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_enumeration/test.toml
+++ b/tests/tests/swfs/avm2/vector_enumeration/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_every/test.toml
+++ b/tests/tests/swfs/avm2/vector_every/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_filter/test.toml
+++ b/tests/tests/swfs/avm2/vector_filter/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_holes/test.toml
+++ b/tests/tests/swfs/avm2/vector_holes/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_indexof/test.toml
+++ b/tests/tests/swfs/avm2/vector_indexof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_insertat/test.toml
+++ b/tests/tests/swfs/avm2/vector_insertat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_int_access/test.toml
+++ b/tests/tests/swfs/avm2/vector_int_access/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_int_delete/test.toml
+++ b/tests/tests/swfs/avm2/vector_int_delete/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_join/test.toml
+++ b/tests/tests/swfs/avm2/vector_join/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_lastindexof/test.toml
+++ b/tests/tests/swfs/avm2/vector_lastindexof/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_legacy/test.toml
+++ b/tests/tests/swfs/avm2/vector_legacy/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_map/test.toml
+++ b/tests/tests/swfs/avm2/vector_map/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_pushpop/test.toml
+++ b/tests/tests/swfs/avm2/vector_pushpop/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_removeat/test.toml
+++ b/tests/tests/swfs/avm2/vector_removeat/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_reverse/test.toml
+++ b/tests/tests/swfs/avm2/vector_reverse/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_shiftunshift/test.toml
+++ b/tests/tests/swfs/avm2/vector_shiftunshift/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_slice/test.toml
+++ b/tests/tests/swfs/avm2/vector_slice/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_sort/test.toml
+++ b/tests/tests/swfs/avm2/vector_sort/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_splice/test.toml
+++ b/tests/tests/swfs/avm2/vector_splice/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/vector_tostring/test.toml
+++ b/tests/tests/swfs/avm2/vector_tostring/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/virtual_properties/test.toml
+++ b/tests/tests/swfs/avm2/virtual_properties/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/avm2/with/test.toml
+++ b/tests/tests/swfs/avm2/with/test.toml
@@ -1,0 +1,1 @@
+num_frames = 1

--- a/tests/tests/swfs/visual/blend_modes/add/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/add/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/darken/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/darken/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/difference/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/difference/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/hardlight/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/hardlight/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/invert/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/invert/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/layer_alpha/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/layer_alpha/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/layer_erase/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/layer_erase/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/lighten/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/lighten/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/multiply/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/multiply/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/overlay/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/overlay/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/screen/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/screen/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true

--- a/tests/tests/swfs/visual/blend_modes/subtract/test.toml
+++ b/tests/tests/swfs/visual/blend_modes/subtract/test.toml
@@ -1,0 +1,2 @@
+num_frames = 1
+image = true


### PR DESCRIPTION
The hopeful goal of this is to be able to expand the test capabilities going forwards, such as adding allowed variations to image tests, providing more options for how the player is set up, emulating different environments, etc. The biggest goal, though, is to increase maintainability and ease of writing new tests - the giant macro that this removes is a scary beast. It was okay when we had 20 tests that pretty much worked the same, but we're at >850 tests now with different options and ways of working.


## test.toml
Except for `num_frames`, every other field and section is optional.

```toml
num_frames = 1 # The amount of frames of the swf to run
sleep_to_meet_frame_rate = false # If true, slow the tick rate to match the movies requested fps rate
image = false # If true, capture a screenshot of the movie and compare it against a "known good" image
ignore = false # If true, ignore this test. Please comment why, ideally link to an issue, so we know what's up

# Sometimes floating point math doesn't exactly 100% match between flash and rust.
# If you encounter this in a test, the following section will change the output testing from "exact" to "approximate"
# (when it comes to floating point numbers, at least.)
[approximations]
number_patterns = [] # A list of regex patterns with capture groups to additionally treat as approximate numbers
epsilon = 0.0 # The upper bound of any rounding errors. Default is the difference between 1.0 and the next largest representable number
max_relative = 0.0 # The default relative tolerance for testing values that are far-apart. Default is the difference between 1.0 and the next largest representable number

# Options for the player used to run this swf 
[player_options]
max_execution_duration = { secs = 15, nanos = 0} # How long can actionscript execute for before being forcefully stopped
viewport_dimensions = { width = 100, height = 100, scale_factor = 1 } # The size of the player. Defaults to the swfs stage size
```