### PR TITLE
Fix DO render tree display and add info to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,11 @@ The hotkey <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>V</kbd> dumps every variable insi
 This can be very useful to inspect the internal state of games and see, for example, if a coordinate is NaN, your lives
 are negative, or maybe an important object just didn't get initialized.
 
+### Render Tree Dumping
+
+The hotkey <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd> dumps the DisplayObject render tree at the moment you press it. 
+This allows you to see Ruffle's representation of the objects on the Stage.
+
 ## Reporting Bugs
 
 [Issue reports and feature requests](https://github.com/ruffle-rs/ruffle/issues) are encouraged, and are a great way to measure our progress!

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1416,9 +1416,10 @@ pub trait TDisplayObject<'gc>:
 
     #[cfg(feature = "avm_debug")]
     fn display_render_tree(&self, depth: usize) {
-        let self_str = format!("{self:?}");
-        let paren = self_str.find('(').unwrap();
-        let self_str = &self_str[..paren];
+        let mut self_str = &*format!("{self:?}");
+        if let Some(end_char) = self_str.find(|c: char| !c.is_ascii_alphanumeric()) {
+            self_str = &self_str[..end_char];
+        }
 
         let bounds = self.world_bounds();
 


### PR DESCRIPTION
#8964 changed the format of debug strings of display objects from this:
`Stage(GcCell(Gc { ptr: 0x19c9ab557c8 }))`
To this:
`Stage { ptr: 0x205a1342bb0 }`
The change caused Ruffle's DO tree dumping code to crash, so I fixed it to handle the new format. And also added info about the keyboard shortcut to CONTRIBUTING.md since it wasn't there already.

Thanks to @Bale001 for suggesting a more resilient approach.