### PR TITLE
core: Propagate events to children in the reverse order

### DIFF
--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -180,7 +180,12 @@ pub trait TInteractiveObject<'gc>:
     ) -> ClipEventResult {
         if event.propagates() {
             if let Some(container) = self.as_displayobject().as_container() {
-                for child in container.iter_render_list() {
+                let children = if event.is_button_event() {
+                    container.iter_render_list().collect::<Vec<_>>()
+                } else {
+                    container.iter_render_list().rev().collect::<Vec<_>>()
+                };
+                for child in children {
                     if let Some(interactive) = child.as_interactive() {
                         if interactive.handle_clip_event(context, event) == ClipEventResult::Handled
                         {


### PR DESCRIPTION
...when the event is not an event type used by Buttons.

Fixes #8357.
