### PR TITLE
tests: Deny unknown fields when deserializing test.toml files

### DIFF
--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -207,6 +207,7 @@ pub enum Context3DCommand<'gc> {
 pub struct ShapeHandle(pub usize);
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ViewportDimensions {
     /// The dimensions of the stage's containing viewport.
     pub width: u32,

--- a/tests/tests/util/options.rs
+++ b/tests/tests/util/options.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[derive(Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TestOptions {
     pub num_frames: u32,
     pub output_path: PathBuf,
@@ -46,7 +46,7 @@ impl TestOptions {
 }
 
 #[derive(Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Approximations {
     number_patterns: Vec<String>,
     epsilon: Option<f64>,
@@ -79,7 +79,7 @@ impl Approximations {
 }
 
 #[derive(Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PlayerOptions {
     max_execution_duration: Option<Duration>,
     viewport_dimensions: Option<ViewportDimensions>,
@@ -142,7 +142,7 @@ impl PlayerOptions {
 }
 
 #[derive(Deserialize, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ImageComparison {
     tolerance: u8,
     max_outliers: usize,
@@ -226,7 +226,7 @@ impl ImageComparison {
 }
 
 #[derive(Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct RenderOptions {
     optional: bool,
     sample_count: u32,


### PR DESCRIPTION
This will catch typos and misplaced options when modifying tests.