### PR TITLE
Convert normal Rust errors into AVM2 errors

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1370,7 +1370,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
 
         let receiver = receiver.coerce_to_object(self)?;
-        
+
         let function = receiver.get_property(&multiname, self)?.as_callable(
             self,
             Some(&multiname),
@@ -1520,7 +1520,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             }
 
             let object = object.coerce_to_object(self)?;
-            
+
             let value = object.get_property(&multiname, self)?;
             self.push_stack(value);
             return Ok(FrameControl::Continue);
@@ -1551,7 +1551,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 }
 
                 let object = object.coerce_to_object(self)?;
-                
+
                 if let Some(dictionary) = object.as_dictionary_object() {
                     let _ = self.pop_stack();
                     let _ = self.pop_stack();
@@ -1583,7 +1583,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
 
         let object = object.coerce_to_object(self)?;
-        
+
         let value = object.get_property(&multiname, self)?;
         self.push_stack(value);
 
@@ -1616,7 +1616,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             let object = self.context.avm2.peek(1);
             if !name_value.is_primitive() {
                 let object = object.coerce_to_receiver(self, None)?;
-                
+
                 if let Some(dictionary) = object.as_dictionary_object() {
                     let _ = self.pop_stack();
                     let _ = self.pop_stack();

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1332,9 +1332,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let args = self.pop_stack_args(arg_count);
         let multiname = self.pool_multiname_and_initialize(method, index)?;
-        let receiver = self
-            .pop_stack()
-            .coerce_to_receiver(self, Some(&multiname))?;
+        let receiver = self.pop_stack();
+
+        if matches!(receiver, Value::Null) || matches!(receiver, Value::Undefined) {
+            return Err(Error::AvmError(type_error(
+                self,
+                "Error #1006: Call attempted on an object that is not a function.",
+                1006,
+            )?));
+        }
+
+        let receiver = receiver.coerce_to_object(self)?;
 
         let value = receiver.call_property(&multiname, &args, self)?;
 
@@ -1351,9 +1359,18 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let args = self.pop_stack_args(arg_count);
         let multiname = self.pool_multiname_and_initialize(method, index)?;
-        let receiver = self
-            .pop_stack()
-            .coerce_to_receiver(self, Some(&multiname))?;
+        let receiver = self.pop_stack();
+
+        if matches!(receiver, Value::Null) || matches!(receiver, Value::Undefined) {
+            return Err(Error::AvmError(type_error(
+                self,
+                "Error #1006: Call attempted on an object that is not a function.",
+                1006,
+            )?));
+        }
+
+        let receiver = receiver.coerce_to_object(self)?;
+        
         let function = receiver.get_property(&multiname, self)?.as_callable(
             self,
             Some(&multiname),
@@ -1374,9 +1391,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let args = self.pop_stack_args(arg_count);
         let multiname = self.pool_multiname_and_initialize(method, index)?;
-        let receiver = self
-            .pop_stack()
-            .coerce_to_receiver(self, Some(&multiname))?;
+        let receiver = self.pop_stack();
+
+        if matches!(receiver, Value::Null) || matches!(receiver, Value::Undefined) {
+            return Err(Error::AvmError(type_error(
+                self,
+                "Error #1006: Call attempted on an object that is not a function.",
+                1006,
+            )?));
+        }
+
+        let receiver = receiver.coerce_to_object(self)?;
 
         receiver.call_property(&multiname, &args, self)?;
 
@@ -1410,9 +1435,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         let args = self.pop_stack_args(arg_count);
         let multiname = self.pool_multiname_and_initialize(method, index)?;
-        let receiver = self
-            .pop_stack()
-            .coerce_to_receiver(self, Some(&multiname))?;
+        let receiver = self.pop_stack();
+
+        if matches!(receiver, Value::Null) || matches!(receiver, Value::Undefined) {
+            return Err(Error::AvmError(type_error(
+                self,
+                "Error #1006: Call attempted on an object that is not a function.", // TODO: confirm that this is error 1006
+                1006,
+            )?));
+        }
+
+        let receiver = receiver.coerce_to_object(self)?;
 
         let superclass_object = self.superclass_object(&multiname)?;
 

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -1,7 +1,7 @@
 //! Default AVM2 object impl
 
 use crate::avm2::activation::Activation;
-use crate::avm2::error::reference_error;
+use crate::avm2::error::type_error;
 use crate::avm2::object::{ClassObject, FunctionObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::vtable::VTable;
@@ -148,7 +148,7 @@ impl<'gc> ScriptObjectData<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if !multiname.contains_public_namespace() {
-            return Err(Error::AvmError(reference_error(
+            return Err(Error::AvmError(type_error( // TODO: Determine correct error message, code, and type
                 activation,
                 &format!(
                     "Error #2000: Non-public property {} not found on Object",
@@ -160,7 +160,7 @@ impl<'gc> ScriptObjectData<'gc> {
 
         let local_name = match multiname.local_name() {
             None => {
-                return Err(Error::AvmError(reference_error(
+                return Err(Error::AvmError(type_error( // TODO: Determine correct error message, code, and type
                     activation,
                     &format!(
                         "Error #2000: Unnamed property {} not found on Object",
@@ -206,7 +206,7 @@ impl<'gc> ScriptObjectData<'gc> {
                 })
                 .unwrap_or_else(|| AvmString::from("<UNKNOWN>"));
 
-            Err(Error::AvmError(reference_error(
+            Err(Error::AvmError(type_error(
                 activation,
                 &format!(
                     "Error #1069: Property {local_name} not found on {class_name} and there is no default value.",
@@ -229,7 +229,7 @@ impl<'gc> ScriptObjectData<'gc> {
             .map(|cls| cls.inner_class_definition().read().is_sealed())
             .unwrap_or(false)
         {
-            return Err(Error::AvmError(reference_error(
+            return Err(Error::AvmError(type_error( // TODO: Determine correct error message, code, and type
                 activation,
                 &format!(
                     "Error #2000: Cannot set undefined property {} on {:?}",
@@ -242,7 +242,7 @@ impl<'gc> ScriptObjectData<'gc> {
         }
 
         if !multiname.contains_public_namespace() {
-            return Err(Error::AvmError(reference_error(
+            return Err(Error::AvmError(type_error( // TODO: Determine correct error message, code, and type
                 activation,
                 &format!(
                     "Error #2000: Non-public property {} not found on Object.",
@@ -254,7 +254,7 @@ impl<'gc> ScriptObjectData<'gc> {
 
         let local_name = match multiname.local_name() {
             None => {
-                return Err(Error::AvmError(reference_error(
+                return Err(Error::AvmError(type_error( // TODO: Determine correct error message, code, and type
                     activation,
                     &format!(
                         "Error #2000: Unnamed property {} not found on Object",

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -147,20 +147,36 @@ impl<'gc> ScriptObjectData<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if !multiname.contains_public_namespace() {
-            return Err(format!(
-                "Non-public property {} not found on Object",
+            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
+                "Error #2000: Non-public property {} not found on Object.",
                 multiname.to_qualified_name(activation.context.gc_context)
-            )
-            .into());
+            ));
+            
+            return Err(Error::AvmError(
+                activation
+                    .avm2()
+                    .classes()
+                    .referenceerror
+                    .construct(activation, &[message.into(), 2000.into()])?
+                    .into(),
+            ));
         }
 
         let local_name = match multiname.local_name() {
             None => {
-                return Err(format!(
-                    "Unnamed property {} not found on Object",
+                let message = AvmString::new_utf8(activation.context.gc_context, &format!(
+                    "Error #2000: Unnamed property {} not found on Object",
                     multiname.to_qualified_name(activation.context.gc_context)
-                )
-                .into())
+                ));
+                
+                return Err(Error::AvmError(
+                    activation
+                        .avm2()
+                        .classes()
+                        .referenceerror
+                        .construct(activation, &[message.into(), 2000.into()])?
+                        .into(),
+                ));
             }
             Some(name) => name,
         };
@@ -226,30 +242,54 @@ impl<'gc> ScriptObjectData<'gc> {
             .map(|cls| cls.inner_class_definition().read().is_sealed())
             .unwrap_or(false)
         {
-            return Err(format!(
-                "Cannot set undefined property {} on {:?}",
+            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
+                "Error #2000: Cannot set undefined property {} on {:?}",
                 multiname.to_qualified_name(activation.context.gc_context),
                 self.instance_of()
                     .map(|cls| cls.inner_class_definition().read().name()),
-            )
-            .into());
+            ));
+            
+            return Err(Error::AvmError(
+                activation
+                    .avm2()
+                    .classes()
+                    .referenceerror
+                    .construct(activation, &[message.into(), 2000.into()])?
+                    .into(),
+            ));
         }
 
         if !multiname.contains_public_namespace() {
-            return Err(format!(
-                "Non-public property {} not found on Object",
+            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
+                "Error #2000: Non-public property {} not found on Object.",
                 multiname.to_qualified_name(activation.context.gc_context)
-            )
-            .into());
+            ));
+            
+            return Err(Error::AvmError(
+                activation
+                    .avm2()
+                    .classes()
+                    .referenceerror
+                    .construct(activation, &[message.into(), 2000.into()])?
+                    .into(),
+            ));
         }
 
         let local_name = match multiname.local_name() {
             None => {
-                return Err(format!(
-                    "Unnamed property {} not found on Object",
+                let message = AvmString::new_utf8(activation.context.gc_context, &format!(
+                    "Error #2000: Unnamed property {} not found on Object",
                     multiname.to_qualified_name(activation.context.gc_context)
-                )
-                .into())
+                ));
+                
+                return Err(Error::AvmError(
+                    activation
+                        .avm2()
+                        .classes()
+                        .referenceerror
+                        .construct(activation, &[message.into(), 2000.into()])?
+                        .into(),
+                ));
             }
             Some(name) => name,
         };

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -147,11 +147,14 @@ impl<'gc> ScriptObjectData<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if !multiname.contains_public_namespace() {
-            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
-                "Error #2000: Non-public property {} not found on Object.",
-                multiname.to_qualified_name(activation.context.gc_context)
-            ));
-            
+            let message = AvmString::new_utf8(
+                activation.context.gc_context,
+                &format!(
+                    "Error #2000: Non-public property {} not found on Object.",
+                    multiname.to_qualified_name(activation.context.gc_context)
+                ),
+            );
+
             return Err(Error::AvmError(
                 activation
                     .avm2()
@@ -164,11 +167,14 @@ impl<'gc> ScriptObjectData<'gc> {
 
         let local_name = match multiname.local_name() {
             None => {
-                let message = AvmString::new_utf8(activation.context.gc_context, &format!(
-                    "Error #2000: Unnamed property {} not found on Object",
-                    multiname.to_qualified_name(activation.context.gc_context)
-                ));
-                
+                let message = AvmString::new_utf8(
+                    activation.context.gc_context,
+                    &format!(
+                        "Error #2000: Unnamed property {} not found on Object",
+                        multiname.to_qualified_name(activation.context.gc_context)
+                    ),
+                );
+
                 return Err(Error::AvmError(
                     activation
                         .avm2()
@@ -242,13 +248,16 @@ impl<'gc> ScriptObjectData<'gc> {
             .map(|cls| cls.inner_class_definition().read().is_sealed())
             .unwrap_or(false)
         {
-            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
-                "Error #2000: Cannot set undefined property {} on {:?}",
-                multiname.to_qualified_name(activation.context.gc_context),
-                self.instance_of()
-                    .map(|cls| cls.inner_class_definition().read().name()),
-            ));
-            
+            let message = AvmString::new_utf8(
+                activation.context.gc_context,
+                &format!(
+                    "Error #2000: Cannot set undefined property {} on {:?}",
+                    multiname.to_qualified_name(activation.context.gc_context),
+                    self.instance_of()
+                        .map(|cls| cls.inner_class_definition().read().name()),
+                ),
+            );
+
             return Err(Error::AvmError(
                 activation
                     .avm2()
@@ -260,11 +269,14 @@ impl<'gc> ScriptObjectData<'gc> {
         }
 
         if !multiname.contains_public_namespace() {
-            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
-                "Error #2000: Non-public property {} not found on Object.",
-                multiname.to_qualified_name(activation.context.gc_context)
-            ));
-            
+            let message = AvmString::new_utf8(
+                activation.context.gc_context,
+                &format!(
+                    "Error #2000: Non-public property {} not found on Object.",
+                    multiname.to_qualified_name(activation.context.gc_context)
+                ),
+            );
+
             return Err(Error::AvmError(
                 activation
                     .avm2()
@@ -277,11 +289,14 @@ impl<'gc> ScriptObjectData<'gc> {
 
         let local_name = match multiname.local_name() {
             None => {
-                let message = AvmString::new_utf8(activation.context.gc_context, &format!(
-                    "Error #2000: Unnamed property {} not found on Object",
-                    multiname.to_qualified_name(activation.context.gc_context)
-                ));
-                
+                let message = AvmString::new_utf8(
+                    activation.context.gc_context,
+                    &format!(
+                        "Error #2000: Unnamed property {} not found on Object",
+                        multiname.to_qualified_name(activation.context.gc_context)
+                    ),
+                );
+
                 return Err(Error::AvmError(
                     activation
                         .avm2()

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -1,6 +1,7 @@
 //! Default AVM2 object impl
 
 use crate::avm2::activation::Activation;
+use crate::avm2::error::reference_error;
 use crate::avm2::object::{ClassObject, FunctionObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::vtable::VTable;
@@ -147,42 +148,26 @@ impl<'gc> ScriptObjectData<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         if !multiname.contains_public_namespace() {
-            let message = AvmString::new_utf8(
-                activation.context.gc_context,
+            return Err(Error::AvmError(reference_error(
+                activation,
                 &format!(
-                    "Error #2000: Non-public property {} not found on Object.",
+                    "Error #2000: Non-public property {} not found on Object",
                     multiname.to_qualified_name(activation.context.gc_context)
                 ),
-            );
-
-            return Err(Error::AvmError(
-                activation
-                    .avm2()
-                    .classes()
-                    .referenceerror
-                    .construct(activation, &[message.into(), 2000.into()])?
-                    .into(),
-            ));
+                2000,
+            )?));
         }
 
         let local_name = match multiname.local_name() {
             None => {
-                let message = AvmString::new_utf8(
-                    activation.context.gc_context,
+                return Err(Error::AvmError(reference_error(
+                    activation,
                     &format!(
                         "Error #2000: Unnamed property {} not found on Object",
                         multiname.to_qualified_name(activation.context.gc_context)
                     ),
-                );
-
-                return Err(Error::AvmError(
-                    activation
-                        .avm2()
-                        .classes()
-                        .referenceerror
-                        .construct(activation, &[message.into(), 2000.into()])?
-                        .into(),
-                ));
+                    2000,
+                )?));
             }
             Some(name) => name,
         };
@@ -221,17 +206,13 @@ impl<'gc> ScriptObjectData<'gc> {
                 })
                 .unwrap_or_else(|| AvmString::from("<UNKNOWN>"));
 
-            let message = AvmString::new_utf8(activation.context.gc_context, &format!(
-                "Error #1069: Property {local_name} not found on {class_name} and there is no default value.",
-            ));
-            Err(Error::AvmError(
-                activation
-                    .avm2()
-                    .classes()
-                    .referenceerror
-                    .construct(activation, &[message.into(), 1069.into()])?
-                    .into(),
-            ))
+            Err(Error::AvmError(reference_error(
+                activation,
+                &format!(
+                    "Error #1069: Property {local_name} not found on {class_name} and there is no default value.",
+                ),
+                1069,
+            )?))
         } else {
             Ok(Value::Undefined)
         }
@@ -248,63 +229,39 @@ impl<'gc> ScriptObjectData<'gc> {
             .map(|cls| cls.inner_class_definition().read().is_sealed())
             .unwrap_or(false)
         {
-            let message = AvmString::new_utf8(
-                activation.context.gc_context,
+            return Err(Error::AvmError(reference_error(
+                activation,
                 &format!(
                     "Error #2000: Cannot set undefined property {} on {:?}",
                     multiname.to_qualified_name(activation.context.gc_context),
                     self.instance_of()
                         .map(|cls| cls.inner_class_definition().read().name()),
                 ),
-            );
-
-            return Err(Error::AvmError(
-                activation
-                    .avm2()
-                    .classes()
-                    .referenceerror
-                    .construct(activation, &[message.into(), 2000.into()])?
-                    .into(),
-            ));
+                2000,
+            )?));
         }
 
         if !multiname.contains_public_namespace() {
-            let message = AvmString::new_utf8(
-                activation.context.gc_context,
+            return Err(Error::AvmError(reference_error(
+                activation,
                 &format!(
                     "Error #2000: Non-public property {} not found on Object.",
                     multiname.to_qualified_name(activation.context.gc_context)
                 ),
-            );
-
-            return Err(Error::AvmError(
-                activation
-                    .avm2()
-                    .classes()
-                    .referenceerror
-                    .construct(activation, &[message.into(), 2000.into()])?
-                    .into(),
-            ));
+                2000,
+            )?));
         }
 
         let local_name = match multiname.local_name() {
             None => {
-                let message = AvmString::new_utf8(
-                    activation.context.gc_context,
+                return Err(Error::AvmError(reference_error(
+                    activation,
                     &format!(
                         "Error #2000: Unnamed property {} not found on Object",
                         multiname.to_qualified_name(activation.context.gc_context)
                     ),
-                );
-
-                return Err(Error::AvmError(
-                    activation
-                        .avm2()
-                        .classes()
-                        .referenceerror
-                        .construct(activation, &[message.into(), 2000.into()])?
-                        .into(),
-                ));
+                    2000,
+                )?));
             }
             Some(name) => name,
         };


### PR DESCRIPTION
...in script_object.rs. The placeholder error code for AVM errors is 2000, and the message is the same as the Rust message.

I need help determining the correct code and the message. @adrian17 stated that it should be the same as error 1069, but I currently have no way to test that.