### PR TITLE
chore: Bump h263-rs to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "h263-rs"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=023e14c73e565c4c778d41f66cfbac5ece6419b2#023e14c73e565c4c778d41f66cfbac5ece6419b2"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=f0083f5933f173798dd308d1678f06d181a99975#f0083f5933f173798dd308d1678f06d181a99975"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=023e14c73e565c4c778d41f66cfbac5ece6419b2#023e14c73e565c4c778d41f66cfbac5ece6419b2"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=f0083f5933f173798dd308d1678f06d181a99975#f0083f5933f173798dd308d1678f06d181a99975"
 dependencies = [
  "bytemuck",
  "wide",

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1.0"
 flate2 = "1.0.25"
 log = "0.4"
 
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "023e14c73e565c4c778d41f66cfbac5ece6419b2", optional = true }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "f0083f5933f173798dd308d1678f06d181a99975", optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "f0083f5933f173798dd308d1678f06d181a99975", optional = true }
 nihav_core = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_codec_support = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_duck = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }


### PR DESCRIPTION
To take advantage of https://github.com/ruffle-rs/h263-rs/pull/38.