### PR TITLE
extension: Manifest v3 first draft - works minimally on FF, not Chrome

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -1,18 +1,19 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Ruffle",
     "version": null, // Filled by Webpack.
     "default_locale": "en",
     "description": "__MSG_description__",
     "homepage_url": "https://ruffle.rs/",
 
-    "browser_action": {
+    "action": {
         "default_popup": "popup.html",
         "browser_style": true,
     },
     "background": {
         "scripts": ["dist/background.js"],
-        "persistent": true,
+        //"service_worker": "dist/background.js",
+        //"persistent": true,
     },
     "content_scripts": [
         {
@@ -29,7 +30,10 @@
     ],
 
     // 'wasm-eval' added by Webpack for Chrome extension.
-    "content_security_policy": "default-src 'self'; script-src 'self'; style-src 'unsafe-inline'; connect-src *; img-src data:;",
+    "content_security_policy": {
+      "extension_pages": "default-src 'self'; script-src 'self'; style-src 'unsafe-inline'; connect-src *; img-src data:;",
+    },
+    "host_permissions": ["<all_urls>"],
 
     "icons": {
         "16": "images/icon16.png",
@@ -38,15 +42,19 @@
         "128": "images/icon128.png",
         "180": "images/icon180.png",
     },
+	"minimum_chrome_version": "93",
     "options_ui": {
         "page": "options.html",
         "open_in_tab": true,
     },
     "permissions": [
         "storage",
-        "<all_urls>",
         "webRequest",
+        //"declarativeNetRequest",
         "webRequestBlocking",
     ],
-    "web_accessible_resources": ["*"],
+    "web_accessible_resources": [{
+        "resources": ["*"],
+        "matches": ["<all_urls>"],
+    }],
 }

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -34,12 +34,12 @@ function transformManifest(content, env) {
         // Add `wasm-eval` to the `script-src` directive in the Content Security Policy.
         // This setting is required by Chrome to allow Wasm in the extension.
         // Eventually this may change to `wasm-unsafe-eval`, and we may need this for all browsers.
-        manifest.content_security_policy =
-            manifest.content_security_policy.replace(
+        /*manifest.content_security_policy.extension_pages =
+            manifest.content_security_policy.extension_pages.replace(
                 /(script-src\s+[^;]*)(;|$)/i,
                 "$1 'wasm-eval'$2"
             );
-
+        */
         // Chrome runs the extension in a single shared process by default,
         // which prevents extension pages from loading in Incognito tabs
         manifest.incognito = "split";


### PR DESCRIPTION
Will close immediately, since this does not work. Meant to help exemplify what is needed for Manifest V3.

Issues on Firefox: Extension does not activate until Ruffle symbol is clicked (maybe just because it's an unsigned add-on though); opening an SWF in a new tab does not work.

Issues on Chrome: Does not work. Chrome should use `declarativeNetRequest` instead of `webRequestBlocking` (does not work on Firefox). Chrome should use `"service_worker": "dist/background.js"` instead of `"scripts": ["dist/background.js"]`. With those two changes, I still run into https://stackoverflow.com/questions/70474845/inject-javascript-from-content-script-with-a-chrome-extension-v3 and failure of dist/background.js to register as a service worker.