### PR TITLE
desktop: Improve --help messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,6 +3471,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "chrono",
+ "clap",
  "dasp",
  "downcast-rs",
  "encoding_rs",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,6 +48,7 @@ enumset = "1.0.12"
 static_assertions = "1.1.0"
 rustversion = "1.0.11"
 bytemuck = "1.13.0"
+clap = { version = "4.1.4", features = ["derive"], optional=true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.26"

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -40,6 +40,7 @@ use url::form_urlencoded;
 pub type Handle = Index;
 
 /// How Ruffle should load movies.
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy)]
 pub enum LoadBehavior {
     /// Allow movies to execute before they have finished loading.

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 clap = { version = "4.1.4", features = ["derive"] }
 cpal = "0.15.0"
-ruffle_core = { path = "../core", features = ["audio", "mp3", "nellymoser"] }
+ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser"] }
 ruffle_render = { path = "../render" }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -63,7 +63,7 @@ static RUFFLE_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version-in
     version = RUFFLE_VERSION,
 )]
 struct Opt {
-    /// Path to a Flash movie (SWF) to play.
+    /// Path or URL of a Flash movie (SWF) to play.
     #[clap(name = "FILE")]
     input_path: Option<PathBuf>,
 


### PR DESCRIPTION
Mention that SWFs can be loaded via URL as well as file path. And add a listing of the possible values for the `--load-behavior` option.