### PR TITLE
web: Fix various version-seal related issues

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -315,7 +315,6 @@ jobs:
           npm ci
       
       - name: Seal version data
-        if: ${{ !matrix.demo }}
         shell: bash -l {0}
         working-directory: web
         env:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -320,7 +320,7 @@ jobs:
         env:
           BUILD_ID: ${{ github.run_number }}
           ENABLE_VERSION_SEAL: "true"
-        run: node packages/core/tools/set_version.js
+        run: npm run version-seal
       
       - name: Produce reproducible source archive
         if: ${{ !matrix.demo }}

--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
         "test": "npm test --workspaces --if-present",
         "docs": "npm run docs --workspaces --if-present",
         "lint": "eslint . && stylelint **.css",
-        "format": "eslint . --fix && stylelint --fix **.css"
+        "format": "eslint . --fix && stylelint --fix **.css",
+        "version-seal": "cross-env ENABLE_VERSION_SEAL=true node packages/core/tools/set_version.js"
     }
 }


### PR DESCRIPTION
This should fix the demo not building and the extension getting a version of `undefined`.

Turns out all the `process.env` stuff about package versioning only exists when you run under NPM - not just by being invoked by `node`.