### PR TITLE
The Great Restubbening - part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,6 +2362,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkme"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bcb06ef182e7557cf18d85bd151319d657bd8f699d381435781871f3027af8"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f2011c1121c45eb4d9639cf5dcbae9622d2978fc5e922a346bfdc6c46700b5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,6 +3483,7 @@ dependencies = [
  "generational-arena",
  "indexmap",
  "instant",
+ "linkme",
  "lzma-rs",
  "nellymoser-rs",
  "num-derive",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+linkme = { version = "0.3", optional = true }
 byteorder = "1.4"
 bitstream-io = "1.6.0"
 flate2 = "1.0.25"
@@ -64,6 +65,7 @@ timeline_debug = []
 mp3 = ["symphonia"]
 nellymoser = ["nellymoser-rs"]
 audio = ["dasp"]
+known_stubs = ["linkme"]
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -63,3 +63,31 @@ macro_rules! avm_error {
         }
     )
 }
+
+#[macro_export]
+macro_rules! avm1_stub {
+    ($activation: ident, $class: literal, $method: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm1Method {
+            class: $class,
+            method: $method,
+            specifics: None,
+        };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+    ($activation: ident, $class: literal, $method: literal, $specifics: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm1Method {
+            class: $class,
+            method: $method,
+            specifics: Some(Cow::Borrowed($specifics)),
+        };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+}

--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -86,7 +86,7 @@ macro_rules! avm1_stub {
         static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm1Method {
             class: $class,
             method: $method,
-            specifics: Some(Cow::Borrowed($specifics)),
+            specifics: Some($specifics),
         };
         $activation.context.stub_tracker.encounter(&STUB);
     };

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -4,6 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
+use crate::avm1_stub;
 use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
@@ -13,29 +14,29 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn is_active<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Accessibility.isActive: not yet implemented");
+    avm1_stub!(activation, "Accessibility", "isActive");
     Ok(Value::Bool(false))
 }
 
 pub fn send_event<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Accessibility.sendEvent: not yet implemented");
+    avm1_stub!(activation, "Accessibility", "sendEvent");
     Ok(Value::Undefined)
 }
 
 pub fn update_properties<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Accessibility.updateProperties: not yet implemented");
+    avm1_stub!(activation, "Accessibility", "updateProperties");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -6,13 +6,13 @@ use crate::avm1::globals::color_transform::ColorTransformObject;
 use crate::avm1::object::bitmap_data::BitmapDataObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, TObject, Value};
-use crate::avm_error;
 use crate::bitmap::bitmap_data::IBitmapDrawable;
 use crate::bitmap::bitmap_data::{BitmapData, ChannelOptions, Color};
 use crate::bitmap::is_size_valid;
 use crate::character::Character;
 use crate::display_object::TDisplayObject;
 use crate::swf::BlendMode;
+use crate::{avm1_stub, avm_error};
 use gc_arena::{GcCell, MutationContext};
 use ruffle_render::transform::Transform;
 use std::str::FromStr;
@@ -522,7 +522,7 @@ pub fn draw<'gc>(
             }
 
             if args.get(4).is_some() {
-                tracing::warn!("BitmapData.draw with clip rect - not implemented")
+                avm1_stub!(activation, "BitmapData", "draw", "with clip rect");
             }
             let smoothing = args
                 .get(5)
@@ -570,22 +570,22 @@ pub fn draw<'gc>(
 }
 
 pub fn apply_filter<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("BitmapData.applyFilter - not yet implemented");
+    avm1_stub!(activation, "BitmapData", "applyFilter");
     Ok((-1).into())
 }
 
 pub fn generate_filter_rect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            tracing::warn!("BitmapData.generateFilterRect - not yet implemented");
+            avm1_stub!(activation, "BitmapData", "generateFilterRect");
             return Ok(Value::Undefined);
         }
     }
@@ -743,13 +743,13 @@ pub fn perlin_noise<'gc>(
 }
 
 pub fn hit_test<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            tracing::warn!("BitmapData.hitTest - not yet implemented");
+            avm1_stub!(activation, "BitmapData", "hitTest");
             return Ok(Value::Undefined);
         }
     }
@@ -1076,13 +1076,13 @@ pub fn palette_map<'gc>(
 }
 
 pub fn pixel_dissolve<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            tracing::warn!("BitmapData.pixelDissolve - not yet implemented");
+            avm1_stub!(activation, "BitmapData", "pixelDissolve");
             return Ok(Value::Undefined);
         }
     }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -7,7 +7,7 @@ use crate::avm1::function::ExecutionReason;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::avm_warn;
+use crate::avm1_stub;
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::string::AvmString;
 use gc_arena::MutationContext;
@@ -51,7 +51,7 @@ fn add_request_header<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "LoadVars.addRequestHeader: Unimplemented");
+    avm1_stub!(activation, "LoadVars", "addRequestHeader");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use crate::avm_warn;
+use crate::avm1_stub;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 use flash_lso::types::Value as AmfValue;
@@ -41,7 +41,7 @@ pub fn delete_all<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.deleteAll() not implemented");
+    avm1_stub!(activation, "SharedObject", "deleteAll");
     Ok(Value::Undefined)
 }
 
@@ -50,7 +50,7 @@ pub fn get_disk_usage<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.getDiskUsage() not implemented");
+    avm1_stub!(activation, "SharedObject", "getDiskUsage");
     Ok(Value::Undefined)
 }
 
@@ -388,7 +388,7 @@ pub fn get_remote<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.getRemote() not implemented");
+    avm1_stub!(activation, "SharedObject", "getRemote");
     Ok(Value::Undefined)
 }
 
@@ -397,7 +397,7 @@ pub fn get_max_size<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.getMaxSize() not implemented");
+    avm1_stub!(activation, "SharedObject", "getMaxSize");
     Ok(Value::Undefined)
 }
 
@@ -406,7 +406,7 @@ pub fn add_listener<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.addListener() not implemented");
+    avm1_stub!(activation, "SharedObject", "addListener");
     Ok(Value::Undefined)
 }
 
@@ -415,7 +415,7 @@ pub fn remove_listener<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.removeListener() not implemented");
+    avm1_stub!(activation, "SharedObject", "removeListener");
     Ok(Value::Undefined)
 }
 
@@ -460,7 +460,7 @@ pub fn close<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.close() not implemented");
+    avm1_stub!(activation, "SharedObject", "close");
     Ok(Value::Undefined)
 }
 
@@ -469,7 +469,7 @@ pub fn connect<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.connect() not implemented");
+    avm1_stub!(activation, "SharedObject", "connect");
     Ok(Value::Undefined)
 }
 
@@ -505,7 +505,7 @@ pub fn get_size<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.getSize() not implemented");
+    avm1_stub!(activation, "SharedObject", "getSize");
     Ok(Value::Undefined)
 }
 
@@ -514,7 +514,7 @@ pub fn send<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.send() not implemented");
+    avm1_stub!(activation, "SharedObject", "send");
     Ok(Value::Undefined)
 }
 
@@ -523,7 +523,7 @@ pub fn set_fps<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.setFps() not implemented");
+    avm1_stub!(activation, "SharedObject", "setFps");
     Ok(Value::Undefined)
 }
 
@@ -532,7 +532,7 @@ pub fn on_status<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.onStatus() not implemented");
+    avm1_stub!(activation, "SharedObject", "onStatus");
     Ok(Value::Undefined)
 }
 
@@ -541,7 +541,7 @@ pub fn on_sync<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "SharedObject.onSync() not implemented");
+    avm1_stub!(activation, "SharedObject", "onSync");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -5,10 +5,10 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, SoundObject, TObject, Value};
-use crate::avm_warn;
 use crate::backend::navigator::Request;
 use crate::character::Character;
 use crate::display_object::{SoundTransform, TDisplayObject};
+use crate::{avm1_stub, avm_warn};
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -135,7 +135,7 @@ fn get_bytes_loaded<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.swf_version() >= 6 {
-        avm_warn!(activation, "Sound.getBytesLoaded: Unimplemented");
+        avm1_stub!(activation, "Sound", "getBytesLoaded");
         Ok(1.into())
     } else {
         Ok(Value::Undefined)
@@ -148,7 +148,7 @@ fn get_bytes_total<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.swf_version() >= 6 {
-        avm_warn!(activation, "Sound.getBytesTotal: Unimplemented");
+        avm1_stub!(activation, "Sound", "getBytesTotal");
         Ok(1.into())
     } else {
         Ok(Value::Undefined)
@@ -227,7 +227,7 @@ fn id3<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if activation.swf_version() >= 6 {
-        avm_warn!(activation, "Sound.id3: Unimplemented");
+        avm1_stub!(activation, "Sound", "id3");
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -5,7 +5,7 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::runtime::Avm1;
 use crate::avm1::{ScriptObject, TObject, Value};
-use crate::avm_warn;
+use crate::avm1_stub;
 use bitflags::bitflags;
 use core::fmt;
 use gc_arena::MutationContext;
@@ -449,13 +449,9 @@ pub fn show_settings<'gc>(
         .unwrap_or(&last_panel_pos.into())
         .coerce_to_i32(activation)?;
 
-    let panel = SettingsPanel::from_u8(panel_pos as u8).unwrap_or(SettingsPanel::Privacy);
+    let _panel = SettingsPanel::from_u8(panel_pos as u8).unwrap_or(SettingsPanel::Privacy);
 
-    avm_warn!(
-        activation,
-        "System.showSettings({:?}) not not implemented",
-        panel
-    );
+    avm1_stub!(activation, "System", "showSettings");
     Ok(Value::Undefined)
 }
 
@@ -512,7 +508,7 @@ pub fn on_status<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "System.onStatus() not implemented");
+    avm1_stub!(activation, "System", "onStatus");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use crate::avm_warn;
+use crate::avm1_stub;
 use crate::string::AvmString;
 use gc_arena::MutationContext;
 
@@ -22,7 +22,7 @@ fn allow_domain<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "System.security.allowDomain() not implemented");
+    avm1_stub!(activation, "System.security", "allowDomain");
     Ok(Value::Undefined)
 }
 
@@ -31,10 +31,7 @@ fn allow_insecure_domain<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(
-        activation,
-        "System.security.allowInsecureDomain() not implemented"
-    );
+    avm1_stub!(activation, "System.security", "allowInsecureDomain");
     Ok(Value::Undefined)
 }
 
@@ -43,10 +40,7 @@ fn load_policy_file<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(
-        activation,
-        "System.security.loadPolicyFile() not implemented"
-    );
+    avm1_stub!(activation, "System.security", "loadPolicyFile");
     Ok(Value::Undefined)
 }
 
@@ -55,7 +49,7 @@ fn escape_domain<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(activation, "System.security.escapeDomain() not implemented");
+    avm1_stub!(activation, "System.security", "escapeDomain");
     Ok(Value::Undefined)
 }
 
@@ -76,10 +70,7 @@ fn get_choose_local_swf_path<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(
-        activation,
-        "System.security.chooseLocalSwfPath() not implemented"
-    );
+    avm1_stub!(activation, "System.security", "chooseLocalSwfPath");
     Ok(Value::Undefined)
 }
 
@@ -88,10 +79,7 @@ fn policy_file_resolver<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    avm_warn!(
-        activation,
-        "System.security.chooseLocalSwfPath() not implemented"
-    );
+    avm1_stub!(activation, "System.security", "chooseLocalSwfPath");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -3,7 +3,7 @@
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
-use crate::avm_warn;
+use crate::avm1_stub;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::html::TextFormat;
@@ -414,7 +414,7 @@ fn set_bullet<'gc>(
 }
 
 fn display<'gc>(activation: &mut Activation<'_, 'gc>, _text_format: &TextFormat) -> Value<'gc> {
-    avm_warn!(activation, "TextFormat.display: Unimplemented");
+    avm1_stub!(activation, "TextFormat", "display");
     Value::Null
 }
 
@@ -423,7 +423,7 @@ fn set_display<'gc>(
     _text_format: &mut TextFormat,
     _value: &Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    avm_warn!(activation, "TextFormat.display: Unimplemented");
+    avm1_stub!(activation, "TextFormat", "display");
     Ok(())
 }
 

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -43,6 +43,7 @@ mod regexp;
 mod scope;
 mod script;
 mod string;
+mod stubs;
 mod traits;
 mod value;
 mod vector;

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -14,6 +14,7 @@ use crate::avm2::QName;
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::character::Character;
 use crate::display_object::{Bitmap, TDisplayObject};
+use crate::{avm2_stub_getter, avm2_stub_setter};
 use gc_arena::{GcCell, MutationContext};
 
 /// Implements `flash.display.Bitmap`'s instance constructor.
@@ -176,20 +177,22 @@ pub fn set_bitmap_data<'gc>(
 
 /// Stub `Bitmap.pixelSnapping`'s getter
 pub fn pixel_snapping<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.Bitmap", "pixelSnapping");
     Ok("auto".into())
 }
 
 /// Stub `Bitmap.pixelSnapping`'s setter
 pub fn set_pixel_snapping<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Bitmap.pixelSnapping is a stub".into())
+    avm2_stub_setter!(activation, "flash.display.Bitmap", "pixelSnapping");
+    Ok(Value::Undefined)
 }
 
 /// Implement `Bitmap.smoothing`'s getter

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -9,6 +9,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::IBitmapDrawable;
 use crate::bitmap::bitmap_data::{BitmapData, ChannelOptions, Color};
 use crate::bitmap::is_size_valid;
@@ -684,11 +685,11 @@ pub fn get_color_bounds_rect<'gc>(
 }
 
 pub fn lock<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("BitmapData.lock - not yet implemented");
+    avm2_stub_method!(activation, "flash.display.BitmapData", "lock");
     Ok(Value::Undefined)
 }
 
@@ -850,11 +851,11 @@ pub fn rect<'gc>(
 
 /// Implement `BitmapData.applyFilter`
 pub fn apply_filter<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("BitmapData.applyFilter: Not yet implemented");
+    avm2_stub_method!(activation, "flash.display.BitmapData", "applyFilter");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display/displayobject.rs
+++ b/core/src/avm2/globals/flash/display/displayobject.rs
@@ -17,6 +17,7 @@ use crate::prelude::*;
 use crate::string::AvmString;
 use crate::types::{Degrees, Percent};
 use crate::vminterface::Instantiator;
+use crate::{avm2_stub_getter, avm2_stub_setter};
 use gc_arena::{GcCell, MutationContext};
 use std::str::FromStr;
 use swf::Twips;
@@ -375,93 +376,93 @@ pub fn set_y<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stubs `z`'s getter.
 pub fn z<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.DisplayObject", "z");
     Ok(0.into())
 }
 
-/// Stubs `z`'s setter.
 pub fn set_z<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.DisplayObject", "z");
     Ok(Value::Undefined)
 }
 
-/// Stubs `rotationX`'s getter.
 pub fn rotation_x<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationX");
     Ok(0.into())
 }
 
-/// Stubs `rotationX`'s setter.
 pub fn set_rotation_x<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationX");
     Ok(Value::Undefined)
 }
 
-/// Stubs `rotationY`'s getter.
 pub fn rotation_y<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationY");
     Ok(0.into())
 }
 
-/// Stubs `rotationY`'s setter.
 pub fn set_rotation_y<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationY");
     Ok(Value::Undefined)
 }
 
-/// Stubs `rotationZ`'s getter.
 pub fn rotation_z<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationZ");
     Ok(0.into())
 }
 
-/// Stubs `rotationZ`'s setter.
 pub fn set_rotation_z<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationZ");
     Ok(Value::Undefined)
 }
 
-/// Stubs `scaleZ`'s getter.
 pub fn scale_z<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.DisplayObject", "scaleZ");
     Ok(1.into())
 }
 
-/// Stubs `scaleZ`'s setter.
 pub fn set_scale_z<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.DisplayObject", "scaleZ");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -11,6 +11,7 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
+use crate::{avm2_stub_getter, avm2_stub_method, avm2_stub_setter};
 use gc_arena::{GcCell, MutationContext};
 use std::cmp::min;
 
@@ -558,49 +559,82 @@ pub fn stop_all_movie_clips<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stubs `DisplayObjectContainer.getObjectsUnderPoint`
 pub fn get_objects_under_point<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("DisplayObjectContainer.getObjectsUnderPoint not yet implemented".into())
+    avm2_stub_method!(
+        activation,
+        "flash.display.DisplayObjectContainer",
+        "getObjectsUnderPoint"
+    );
+    Ok(Value::Undefined)
 }
 
-/// Stubs `DisplayObjectContainer.areInaccessibleObjectsUnderPoint`
 pub fn are_inaccessible_objects_under_point<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("DisplayObjectContainer.areInaccessibleObjectsUnderPoint not yet implemented".into())
+    avm2_stub_method!(
+        activation,
+        "flash.display.DisplayObjectContainer",
+        "areInaccessibleObjectsUnderPoint"
+    );
+    Ok(Value::Undefined)
 }
 
 pub fn mouse_children<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("DisplayObjectContainer.mouseChildren getter: not yet implemented");
+    avm2_stub_setter!(
+        activation,
+        "flash.display.DisplayObjectContainer",
+        "mouseChildren"
+    );
     Ok(Value::Undefined)
 }
 
 pub fn set_mouse_children<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("DisplayObjectContainer.mouseChildren setter: not yet implemented");
+    avm2_stub_setter!(
+        activation,
+        "flash.display.DisplayObjectContainer",
+        "mouseChildren"
+    );
     Ok(Value::Undefined)
 }
 
-/// Stub getter & setter for `tabChildren`.
 pub fn tab_children<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("DisplayObjectContainer.tabChildren is a stub");
+    avm2_stub_getter!(
+        activation,
+        "flash.display.DisplayObjectContainer",
+        "areInaccessibleObjectsUnderPoint"
+    );
+
+    Ok(true.into())
+}
+
+pub fn set_tab_children<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(
+        activation,
+        "flash.display.DisplayObjectContainer",
+        "areInaccessibleObjectsUnderPoint"
+    );
 
     Ok(true.into())
 }
@@ -644,7 +678,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(mouse_children),
             Some(set_mouse_children),
         ),
-        ("tabChildren", Some(tab_children), Some(tab_children)),
+        ("tabChildren", Some(tab_children), Some(set_tab_children)),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
+++ b/core/src/avm2/globals/flash/display/displayobjectcontainer.rs
@@ -5,10 +5,10 @@ use crate::avm2::class::Class;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2::{ArrayObject, ArrayStorage, Error};
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use crate::{avm2_stub_getter, avm2_stub_method, avm2_stub_setter};
@@ -569,7 +569,7 @@ pub fn get_objects_under_point<'gc>(
         "flash.display.DisplayObjectContainer",
         "getObjectsUnderPoint"
     );
-    Ok(Value::Undefined)
+    Ok(ArrayObject::from_storage(activation, ArrayStorage::new(0))?.into())
 }
 
 pub fn are_inaccessible_objects_under_point<'gc>(
@@ -582,7 +582,7 @@ pub fn are_inaccessible_objects_under_point<'gc>(
         "flash.display.DisplayObjectContainer",
         "areInaccessibleObjectsUnderPoint"
     );
-    Ok(Value::Undefined)
+    Ok(false.into())
 }
 
 pub fn mouse_children<'gc>(
@@ -619,7 +619,7 @@ pub fn tab_children<'gc>(
     avm2_stub_getter!(
         activation,
         "flash.display.DisplayObjectContainer",
-        "areInaccessibleObjectsUnderPoint"
+        "tabChildren"
     );
 
     Ok(true.into())
@@ -633,10 +633,10 @@ pub fn set_tab_children<'gc>(
     avm2_stub_setter!(
         activation,
         "flash.display.DisplayObjectContainer",
-        "areInaccessibleObjectsUnderPoint"
+        "tabChildren"
     );
 
-    Ok(true.into())
+    Ok(Value::Undefined)
 }
 
 /// Construct `DisplayObjectContainer`'s class.

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -9,6 +9,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2_stub_method;
 use crate::display_object::TDisplayObject;
 use crate::drawing::Drawing;
 use crate::string::WStr;
@@ -82,21 +83,21 @@ fn begin_fill<'gc>(
 
 /// Implements `Graphics.beginBitmapFill`.
 fn begin_bitmap_fill<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Graphics.beginBitmapFill: not yet implemented");
+    avm2_stub_method!(activation, "flash.display.Graphics", "beginBitmapFill");
     Ok(Value::Undefined)
 }
 
 /// Implements `Graphics.beginGradientFill`.
 fn begin_gradient_fill<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Graphics.beginGradientFill: not yet implemented");
+    avm2_stub_method!(activation, "flash.display.Graphics", "beginGradientFill");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display/interactiveobject.rs
+++ b/core/src/avm2/globals/flash/display/interactiveobject.rs
@@ -10,6 +10,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::display_object::{TDisplayObject, TInteractiveObject};
+use crate::{avm2_stub_getter, avm2_stub_setter};
 use gc_arena::{GcCell, MutationContext};
 
 /// Implements `flash.display.InteractiveObject`'s instance constructor.
@@ -156,30 +157,57 @@ fn set_context_menu<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stub getter & setter for `tabEnabled`.
 pub fn tab_enabled<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("InteractiveObject.tabEnabled is a stub");
+    avm2_stub_getter!(activation, "flash.display.InteractiveObject", "tabEnabled");
 
     Ok(false.into())
 }
 
-/// Stub getter & setter for `tabIndex`.
-pub fn tab_index<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+pub fn set_tab_enabled<'gc>(
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("InteractiveObject.tabIndex is a stub");
+    avm2_stub_setter!(activation, "flash.display.InteractiveObject", "tabIndex");
+
+    Ok(Value::Undefined)
+}
+
+pub fn tab_index<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.InteractiveObject", "tabIndex");
 
     Ok((-1).into())
 }
 
+pub fn set_tab_index<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.InteractiveObject", "tabIndex");
+
+    Ok(Value::Undefined)
+}
+
 pub fn focus_rect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.InteractiveObject", "focusRect");
+    Ok(Value::Null)
+}
+
+pub fn set_focus_rect<'gc>(
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
@@ -187,7 +215,7 @@ pub fn focus_rect<'gc>(
 
     // let's only warn on true, as games sometimes just set focusRect to false for some reason.
     if matches!(args.get(0), Some(Value::Bool(true))) {
-        tracing::warn!("InteractiveObject.focusRect is a stub");
+        avm2_stub_setter!(activation, "flash.display.InteractiveObject", "focusRect");
     }
 
     Ok(Value::Null)
@@ -230,9 +258,9 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(set_double_click_enabled),
         ),
         ("contextMenu", Some(context_menu), Some(set_context_menu)),
-        ("tabEnabled", Some(tab_enabled), Some(tab_enabled)),
-        ("tabIndex", Some(tab_index), Some(tab_index)),
-        ("focusRect", Some(focus_rect), Some(focus_rect)),
+        ("tabEnabled", Some(tab_enabled), Some(set_tab_enabled)),
+        ("tabIndex", Some(tab_index), Some(set_tab_index)),
+        ("focusRect", Some(focus_rect), Some(set_focus_rect)),
     ];
     write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
 

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -10,6 +10,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
+use crate::avm2_stub_getter;
 use crate::display_object::TDisplayObject;
 use gc_arena::{GcCell, MutationContext};
 use swf::{write_swf, Compression};
@@ -253,22 +254,23 @@ pub fn height<'gc>(
     Ok(Value::Undefined)
 }
 
-/// `isURLInaccessible` getter stub
+/// `isURLInaccessible` getter
 pub fn is_url_inaccessible<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.LoaderInfo", "isURLInaccessible");
     Ok(false.into())
 }
 
-/// `parentAllowsChild` getter stub
+/// `parentAllowsChild` getter
 pub fn parent_allows_child<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("LoaderInfo.parentAllowsChild is a stub");
+    avm2_stub_getter!(activation, "flash.display.LoaderInfo", "parentAllowsChild");
     Ok(false.into())
 }
 

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -13,6 +13,7 @@ use crate::avm2::QName;
 use crate::avm2::{ArrayObject, ArrayStorage};
 use crate::display_object::{StageDisplayState, TDisplayObject};
 use crate::string::{AvmString, WString};
+use crate::{avm2_stub_getter, avm2_stub_setter};
 use gc_arena::{GcCell, MutationContext};
 use swf::Color;
 
@@ -648,24 +649,26 @@ pub fn set_stage_height<'gc>(
 }
 
 /// Implement `allowsFullScreen`'s getter
-///
-/// TODO: This is a stub.
 pub fn allows_full_screen<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.Stage", "allowsFullScreen");
     Ok(true.into())
 }
 
 /// Implement `allowsFullScreenInteractive`'s getter
-///
-/// TODO: This is a stub.
 pub fn allows_full_screen_interactive<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(
+        activation,
+        "flash.display.Stage",
+        "allowsFullScreenInteractive"
+    );
     Ok(false.into())
 }
 
@@ -723,23 +726,23 @@ pub fn stage3ds<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stage.fullScreenSourceRect Stub
+/// Stage.fullScreenSourceRect's getter
 pub fn full_screen_source_rect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("stage.fullScreenSourceRect - not yet implemented");
+    avm2_stub_getter!(activation, "flash.display.Stage", "fullScreenSourceRect");
     Ok(Value::Undefined)
 }
 
-/// Stage.fullScreenSourceRect Stub
+/// Stage.fullScreenSourceRect's setter
 pub fn set_full_screen_source_rect<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("stage.fullScreenSourceRect - not yet implemented");
+    avm2_stub_setter!(activation, "flash.display.Stage", "fullScreenSourceRect");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/display3D/index_buffer_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/index_buffer_3d.rs
@@ -2,6 +2,7 @@ use crate::avm2::object::{ClassObject, TObject};
 use crate::avm2::Activation;
 use crate::avm2::Value;
 use crate::avm2::{Error, Object};
+use crate::avm2_stub_method;
 
 pub fn index_buffer_3d_allocator<'gc>(
     _class: ClassObject<'gc>,
@@ -11,11 +12,15 @@ pub fn index_buffer_3d_allocator<'gc>(
 }
 
 pub fn upload_from_byte_array<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("IndexBuffer3D.uploadFromByteArray - not yet implemented");
+    avm2_stub_method!(
+        activation,
+        "flash.display3D.IndexBuffer3D",
+        "uploadFromByteArray"
+    );
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::Multiname;
 use crate::avm2::{Activation, Error, Namespace, Object, TObject, Value};
+use crate::avm2_stub_getter;
 use crate::display_object::{StageQuality, TDisplayObject};
 use crate::prelude::{ColorTransform, DisplayObject, Matrix, Twips};
 use swf::Fixed8;
@@ -124,11 +125,15 @@ pub fn get_concatenated_matrix<'gc>(
 }
 
 pub fn get_concatenated_color_transform<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Transform.concatenatedColorTransform: not yet implemented");
+    avm2_stub_getter!(
+        activation,
+        "flash.geom.Transform",
+        "concatenatedColorTransform"
+    );
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/media/sound.rs
+++ b/core/src/avm2/globals/flash/media/sound.rs
@@ -12,6 +12,7 @@ use crate::avm2::QName;
 use crate::backend::navigator::Request;
 use crate::character::Character;
 use crate::display_object::SoundTransform;
+use crate::{avm2_stub_getter, avm2_stub_method};
 use gc_arena::{GcCell, MutationContext};
 use swf::{SoundEvent, SoundInfo};
 
@@ -78,20 +79,22 @@ pub fn bytes_total<'gc>(
 
 /// Implements `Sound.isBuffering`
 pub fn is_buffering<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.media.Sound", "isBuffering");
     //STUB: We do not yet support network-loaded sounds.
     Ok(false.into())
 }
 
 /// Implements `Sound.url`
 pub fn url<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.media.Sound", "url");
     //STUB: We do not yet support network-loaded sounds.
     Ok(Value::Null)
 }
@@ -172,25 +175,27 @@ pub fn play<'gc>(
     Ok(Value::Null)
 }
 
-/// Stubs `Sound.extract`
+/// `Sound.extract`
 pub fn extract<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Sound.extract is a stub.".into())
+    avm2_stub_method!(activation, "flash.media.Sound", "extract");
+    Ok(Value::Undefined)
 }
 
-/// Stubs `Sound.close`
+/// `Sound.close`
 pub fn close<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Sound.close is a stub.".into())
+    avm2_stub_method!(activation, "flash.media.Sound", "close");
+    Ok(Value::Undefined)
 }
 
-/// Stubs `Sound.load`
+/// `Sound.load`
 pub fn load<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Option<Object<'gc>>,
@@ -209,6 +214,9 @@ pub fn load<'gc>(
 
         // TODO: context parameter currently unused.
         let _sound_context = args.get(1);
+        if _sound_context.is_some() {
+            avm2_stub_method!(activation, "flash.media.Sound", "load", "with context");
+        }
 
         let future = activation.context.load_manager.load_sound_avm2(
             activation.context.player.clone(),
@@ -221,22 +229,28 @@ pub fn load<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stubs `Sound.loadCompressedDataFromByteArray`
+/// `Sound.loadCompressedDataFromByteArray`
 pub fn load_compressed_data_from_byte_array<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Sound.loadCompressedDataFromByteArray is a stub.".into())
+    avm2_stub_method!(
+        activation,
+        "flash.media.Sound",
+        "loadCompressedDataFromByteArray"
+    );
+    Ok(Value::Undefined)
 }
 
-/// Stubs `Sound.loadPCMFromByteArray`
+/// `Sound.loadPCMFromByteArray`
 pub fn load_pcm_from_byte_array<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Sound.loadPCMFromByteArray is a stub.".into())
+    avm2_stub_method!(activation, "flash.media.Sound", "loadPCMFromByteArray");
+    Ok(Value::Undefined)
 }
 
 /// Construct `Sound`'s class.

--- a/core/src/avm2/globals/flash/media/soundmixer.rs
+++ b/core/src/avm2/globals/flash/media/soundmixer.rs
@@ -125,7 +125,7 @@ pub fn are_sounds_inaccessible<'gc>(
         "flash.media.SoundMixer",
         "areSoundsInaccessible"
     );
-    Ok(Value::Undefined)
+    Ok(false.into())
 }
 
 /// Implements `SoundMixer.computeSpectrum`

--- a/core/src/avm2/globals/flash/media/soundmixer.rs
+++ b/core/src/avm2/globals/flash/media/soundmixer.rs
@@ -13,6 +13,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2_stub_getter;
 use crate::display_object::SoundTransform;
 use gc_arena::{GcCell, MutationContext};
 
@@ -113,13 +114,18 @@ pub fn set_buffer_time<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stub `SoundMixer.areSoundsInaccessible`
+/// `SoundMixer.areSoundsInaccessible`
 pub fn are_sounds_inaccessible<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("SoundMixer.areSoundsInaccessible is a stub".into())
+    avm2_stub_getter!(
+        activation,
+        "flash.media.SoundMixer",
+        "areSoundsInaccessible"
+    );
+    Ok(Value::Undefined)
 }
 
 /// Implements `SoundMixer.computeSpectrum`

--- a/core/src/avm2/globals/flash/net/object_encoding.rs
+++ b/core/src/avm2/globals/flash/net/object_encoding.rs
@@ -2,21 +2,30 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::{avm2_stub_getter, avm2_stub_setter};
 
 pub fn get_dynamic_property_writer<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("ObjectEncoding.dynamicPropertyWriter: Not yet implemented");
+    avm2_stub_getter!(
+        activation,
+        "flash.net.ObjectEncoding",
+        "dynamicPropertyWriter"
+    );
     Ok(Value::Undefined)
 }
 
 pub fn set_dynamic_property_writer<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("ObjectEncoding.dynamicPropertyWriter: Not yet implemented");
+    avm2_stub_setter!(
+        activation,
+        "flash.net.ObjectEncoding",
+        "dynamicPropertyWriter"
+    );
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -3,6 +3,7 @@
 use crate::avm2::object::TObject;
 use crate::avm2::Multiname;
 use crate::avm2::{Activation, Error, Namespace, Object, Value};
+use crate::avm2_stub_method;
 use crate::display_object::DisplayObject;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
@@ -211,19 +212,19 @@ pub fn flush<'gc>(
 }
 
 pub fn close<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("SharedObject.close - not yet implemented");
+    avm2_stub_method!(activation, "flash.net.SharedObject", "close");
     Ok(Value::Undefined)
 }
 
 pub fn clear<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("SharedObject.clear - not yet implemented");
+    avm2_stub_method!(activation, "flash.net.SharedObject", "clear");
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/system/security.rs
+++ b/core/src/avm2/globals/flash/system/security.rs
@@ -4,6 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2_stub_getter;
 use crate::string::AvmString;
 
 pub fn get_sandbox_type<'gc>(
@@ -16,37 +17,37 @@ pub fn get_sandbox_type<'gc>(
 }
 
 pub fn allow_domain<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Security.allowDomain not implemented");
+    avm2_stub_getter!(activation, "flash.system.Security", "allowDomain");
     Ok(Value::Undefined)
 }
 
 pub fn allow_insecure_domain<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Security.allowInsecureDomain not implemented");
+    avm2_stub_getter!(activation, "flash.system.Security", "allowInsecureDomain");
     Ok(Value::Undefined)
 }
 
 pub fn load_policy_file<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Security.loadPolicyFile not implemented");
+    avm2_stub_getter!(activation, "flash.system.Security", "loadPolicyFile");
     Ok(Value::Undefined)
 }
 
 pub fn show_settings<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Security.showSettings not implemented");
+    avm2_stub_getter!(activation, "flash.system.Security", "showSettings");
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/text/font.rs
+++ b/core/src/avm2/globals/flash/text/font.rs
@@ -5,10 +5,10 @@ use crate::avm2::class::{Class, ClassAttributes};
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
-use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2::{ArrayObject, ArrayStorage, Error};
 use crate::avm2_stub_getter;
 use crate::character::Character;
 use crate::string::AvmString;
@@ -163,7 +163,7 @@ pub fn enumerate_fonts<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.Font", "enumerateFonts");
-    Ok(Value::Undefined)
+    Ok(ArrayObject::from_storage(activation, ArrayStorage::new(0))?.into())
 }
 
 /// `Font.registerFont`

--- a/core/src/avm2/globals/flash/text/font.rs
+++ b/core/src/avm2/globals/flash/text/font.rs
@@ -9,6 +9,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2_stub_getter;
 use crate::character::Character;
 use crate::string::AvmString;
 use gc_arena::{GcCell, MutationContext};
@@ -155,22 +156,24 @@ pub fn has_glyphs<'gc>(
     Ok(Value::Undefined)
 }
 
-/// Stub `Font.enumerateFonts`
+/// `Font.enumerateFonts`
 pub fn enumerate_fonts<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Font.enumerateFonts is a stub".into())
+    avm2_stub_getter!(activation, "flash.text.Font", "enumerateFonts");
+    Ok(Value::Undefined)
 }
 
-/// Stub `Font.registerFont`
+/// `Font.registerFont`
 pub fn register_font<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err("Font.registerFont is a stub".into())
+    avm2_stub_getter!(activation, "flash.text.Font", "registerFont");
+    Ok(Value::Undefined)
 }
 
 /// Construct `Font`'s class.

--- a/core/src/avm2/globals/flash/text/static_text.rs
+++ b/core/src/avm2/globals/flash/text/static_text.rs
@@ -1,4 +1,5 @@
 use crate::avm2::{Activation, Error, Object, Value};
+use crate::avm2_stub_getter;
 
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -13,11 +14,10 @@ pub fn native_instance_init<'gc>(
 }
 /// Implements `StaticText.text`
 pub fn get_text<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Err(Error::RustError(
-        "StaticText.text: not yet implemented".into(),
-    ))
+    avm2_stub_getter!(activation, "flash.text.StaticText", "text");
+    Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/text/static_text.rs
+++ b/core/src/avm2/globals/flash/text/static_text.rs
@@ -19,5 +19,5 @@ pub fn get_text<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.StaticText", "text");
-    Ok(Value::Undefined)
+    Ok("".into())
 }

--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -13,6 +13,7 @@ use crate::display_object::{AutoSizeMode, EditText, TDisplayObject, TextSelectio
 use crate::html::TextFormat;
 use crate::string::AvmString;
 use crate::tag_utils::SwfMovie;
+use crate::{avm2_stub_getter, avm2_stub_setter};
 use gc_arena::{GcCell, MutationContext};
 use std::sync::Arc;
 use swf::Color;
@@ -1277,20 +1278,20 @@ pub fn set_max_chars<'gc>(
 }
 
 pub fn restrict<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("TextField.restrict - not yet implemented");
+    avm2_stub_getter!(activation, "flash.text.TextField", "restrict");
     Ok(Value::Null)
 }
 
 pub fn set_restrict<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("TextField.restrict - not yet implemented");
+    avm2_stub_setter!(activation, "flash.text.TextField", "restrict");
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/flash/ui/keyboard.rs
+++ b/core/src/avm2/globals/flash/ui/keyboard.rs
@@ -3,32 +3,33 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::value::Value;
 use crate::avm2::{Error, Object};
+use crate::avm2_stub_getter;
 use crate::string::AvmString;
 
 pub fn get_caps_lock<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Keyboard.capsLock: not yet implemented");
+    avm2_stub_getter!(activation, "flash.ui.Keyboard", "capsLock");
     Ok(false.into())
 }
 
 pub fn get_has_virtual_keyboard<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Keyboard.hasVirtualKeyboard: not yet implemented");
+    avm2_stub_getter!(activation, "flash.ui.Keyboard", "hasVirtualKeyboard");
     Ok(false.into())
 }
 
 pub fn get_num_lock<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Keyboard.numLock: not yet implemented");
+    avm2_stub_getter!(activation, "flash.ui.Keyboard", "numLock");
     Ok(false.into())
 }
 
@@ -37,15 +38,15 @@ pub fn get_physical_keyboard_type<'gc>(
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Keyboard.physicalKeyboardType: not yet implemented");
+    avm2_stub_getter!(activation, "flash.ui.Keyboard", "physicalKeyboardType");
     Ok(AvmString::new_utf8(activation.context.gc_context, "alphanumeric").into())
 }
 
 pub fn is_accessible<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    tracing::warn!("Keyboard.isAccessible: not yet implemented");
+    avm2_stub_getter!(activation, "flash.ui.Keyboard", "isAccessible");
     Ok(true.into())
 }

--- a/core/src/avm2/globals/flash/utils/proxy.rs
+++ b/core/src/avm2/globals/flash/utils/proxy.rs
@@ -13,5 +13,5 @@ pub fn is_attribute<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     // yes, this is supposed to be implemented
     avm2_stub_method!(activation, "flash.utils.Proxy", "isAttribute");
-    Ok(Value::Undefined)
+    Ok(false.into())
 }

--- a/core/src/avm2/globals/flash/utils/proxy.rs
+++ b/core/src/avm2/globals/flash/utils/proxy.rs
@@ -4,12 +4,14 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 
 pub use crate::avm2::object::proxy_allocator;
+use crate::avm2_stub_method;
 
 pub fn is_attribute<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // yes, this is supposed to be implemented
-    Err("Proxy.isAttribute is not implemented".into())
+    avm2_stub_method!(activation, "flash.utils.Proxy", "isAttribute");
+    Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -9,22 +9,25 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
+use crate::avm2_stub_constructor;
 use gc_arena::{GcCell, MutationContext};
 
 /// Implements `Namespace`'s instance initializer.
 pub fn instance_init<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_constructor!(activation, "Namespace");
     Err("Namespace constructor is a stub.".into())
 }
 
 fn class_call<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
+    activation: &mut Activation<'_, 'gc>,
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_constructor!(activation, "Namespace");
     Err("Namespace constructor is a stub.".into())
 }
 

--- a/core/src/avm2/stubs.rs
+++ b/core/src/avm2/stubs.rs
@@ -1,0 +1,57 @@
+#[macro_export]
+macro_rules! avm2_stub_method {
+    ($activation: ident, $class: literal, $method: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Method {
+            class: $class,
+            method: $method,
+            specifics: None,
+        };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+    ($activation: ident, $class: literal, $method: literal, $specifics: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Method {
+            class: $class,
+            method: $method,
+            specifics: Some($specifics),
+        };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+}
+
+#[macro_export]
+macro_rules! avm2_stub_getter {
+    ($activation: ident, $class: literal, $method: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Getter {
+            class: $class,
+            field: $method,
+        };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+}
+
+#[macro_export]
+macro_rules! avm2_stub_setter {
+    ($activation: ident, $class: literal, $method: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Setter {
+            class: $class,
+            field: $method,
+        };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+}

--- a/core/src/avm2/stubs.rs
+++ b/core/src/avm2/stubs.rs
@@ -27,15 +27,27 @@ macro_rules! avm2_stub_method {
 }
 
 #[macro_export]
+macro_rules! avm2_stub_constructor {
+    ($activation: ident, $class: literal) => {
+        #[cfg_attr(
+            feature = "known_stubs",
+            linkme::distributed_slice($crate::stub::KNOWN_STUBS)
+        )]
+        static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Constructor { class: $class };
+        $activation.context.stub_tracker.encounter(&STUB);
+    };
+}
+
+#[macro_export]
 macro_rules! avm2_stub_getter {
-    ($activation: ident, $class: literal, $method: literal) => {
+    ($activation: ident, $class: literal, $property: literal) => {
         #[cfg_attr(
             feature = "known_stubs",
             linkme::distributed_slice($crate::stub::KNOWN_STUBS)
         )]
         static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Getter {
             class: $class,
-            field: $method,
+            property: $property,
         };
         $activation.context.stub_tracker.encounter(&STUB);
     };
@@ -43,14 +55,14 @@ macro_rules! avm2_stub_getter {
 
 #[macro_export]
 macro_rules! avm2_stub_setter {
-    ($activation: ident, $class: literal, $method: literal) => {
+    ($activation: ident, $class: literal, $property: literal) => {
         #[cfg_attr(
             feature = "known_stubs",
             linkme::distributed_slice($crate::stub::KNOWN_STUBS)
         )]
         static STUB: $crate::stub::Stub = $crate::stub::Stub::Avm2Setter {
             class: $class,
-            field: $method,
+            property: $property,
         };
         $activation.context.stub_tracker.encounter(&STUB);
     };

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -20,6 +20,7 @@ use crate::library::Library;
 use crate::loader::LoadManager;
 use crate::player::Player;
 use crate::prelude::*;
+use crate::stub::StubCollection;
 use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::timer::Timers;
 use core::fmt;
@@ -44,6 +45,9 @@ pub struct UpdateContext<'a, 'gc> {
 
     /// The mutation context to allocate and mutate `GcCell` types.
     pub gc_context: MutationContext<'gc, 'a>,
+
+    /// A collection of stubs encountered during this movie.
+    pub stub_tracker: &'a mut StubCollection,
 
     /// The library containing character definitions for this SWF.
     /// Used to instantiate a `DisplayObject` of a given ID.
@@ -300,6 +304,7 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
         UpdateContext {
             action_queue: self.action_queue,
             gc_context: self.gc_context,
+            stub_tracker: self.stub_tracker,
             library: self.library,
             player_version: self.player_version,
             needs_render: self.needs_render,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,6 +45,7 @@ mod xml;
 pub mod backend;
 pub mod config;
 pub mod external;
+pub mod stub;
 
 pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -37,6 +37,7 @@ use crate::loader::{LoadBehavior, LoadManager};
 use crate::locale::get_current_date_time;
 use crate::prelude::*;
 use crate::string::AvmString;
+use crate::stub::StubCollection;
 use crate::tag_utils::SwfMovie;
 use crate::timer::Timers;
 use crate::vminterface::Instantiator;
@@ -239,6 +240,8 @@ pub struct Player {
     actions_since_timeout_check: u16,
 
     frame_phase: FramePhase,
+
+    stub_tracker: StubCollection,
 
     /// A time budget for executing frames.
     /// Gained by passage of time between host frames, spent by executing SWF frames.
@@ -1742,6 +1745,7 @@ impl Player {
                 frame_rate: &mut self.frame_rate,
                 actions_since_timeout_check: &mut self.actions_since_timeout_check,
                 frame_phase: &mut self.frame_phase,
+                stub_tracker: &mut self.stub_tracker,
             };
 
             let old_frame_rate = *update_context.frame_rate;
@@ -2165,6 +2169,7 @@ impl PlayerBuilder {
                 self_reference: self_ref.clone(),
                 load_behavior: self.load_behavior,
                 spoofed_url: self.spoofed_url.clone(),
+                stub_tracker: StubCollection::new(),
 
                 // GC data
                 gc_arena: Rc::new(RefCell::new(GcArena::new(

--- a/core/src/stub.rs
+++ b/core/src/stub.rs
@@ -3,12 +3,16 @@ use std::borrow::Cow;
 use std::collections::hash_set::Iter;
 use std::fmt::{Debug, Display, Formatter};
 
+#[cfg(feature = "known_stubs")]
+#[linkme::distributed_slice]
+pub static KNOWN_STUBS: [Stub] = [..];
+
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Clone)]
 pub enum Stub {
     Avm1Method {
         class: &'static str,
         method: &'static str,
-        specifics: Option<Cow<'static, str>>,
+        specifics: Option<&'static str>,
     },
     Other(Cow<'static, str>),
 }
@@ -45,10 +49,10 @@ impl StubCollection {
         Self::default()
     }
 
-    pub fn encounter(&mut self, stub: Stub) {
-        if !self.inner.contains(&stub) {
+    pub fn encounter(&mut self, stub: &Stub) {
+        if !self.inner.contains(stub) {
             tracing::warn!("Encountered stub: {stub}");
-            self.inner.insert(stub);
+            self.inner.insert(stub.clone());
         }
     }
 

--- a/core/src/stub.rs
+++ b/core/src/stub.rs
@@ -1,0 +1,58 @@
+use fnv::FnvHashSet;
+use std::borrow::Cow;
+use std::collections::hash_set::Iter;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Clone)]
+pub enum Stub {
+    Avm1Method {
+        class: &'static str,
+        method: &'static str,
+        specifics: Option<Cow<'static, str>>,
+    },
+    Other(Cow<'static, str>),
+}
+
+impl Display for Stub {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Stub::Avm1Method {
+                class,
+                method,
+                specifics: None,
+            } => {
+                write!(f, "AVM1 {class}.{method}")
+            }
+            Stub::Avm1Method {
+                class,
+                method,
+                specifics: Some(specifics),
+            } => {
+                write!(f, "AVM1 {class}.{method} {specifics}")
+            }
+            Stub::Other(text) => write!(f, "{text}"),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct StubCollection {
+    inner: FnvHashSet<Stub>,
+}
+
+impl StubCollection {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn encounter(&mut self, stub: Stub) {
+        if !self.inner.contains(&stub) {
+            tracing::warn!("Encountered stub: {stub}");
+            self.inner.insert(stub);
+        }
+    }
+
+    pub fn iter(&self) -> Iter<Stub> {
+        self.inner.iter()
+    }
+}

--- a/core/src/stub.rs
+++ b/core/src/stub.rs
@@ -16,11 +16,14 @@ pub enum Stub {
     },
     Avm2Getter {
         class: &'static str,
-        field: &'static str,
+        property: &'static str,
     },
     Avm2Setter {
         class: &'static str,
-        field: &'static str,
+        property: &'static str,
+    },
+    Avm2Constructor {
+        class: &'static str,
     },
     Other(Cow<'static, str>),
 }
@@ -42,11 +45,20 @@ impl Display for Stub {
             } => {
                 write!(f, "AVM1 {class}.{method}() {specifics}")
             }
-            Stub::Avm2Getter { class, field } => {
+            Stub::Avm2Getter {
+                class,
+                property: field,
+            } => {
                 write!(f, "AVM2 {class}.{field} getter")
             }
-            Stub::Avm2Setter { class, field } => {
+            Stub::Avm2Setter {
+                class,
+                property: field,
+            } => {
                 write!(f, "AVM2 {class}.{field} setter")
+            }
+            Stub::Avm2Constructor { class } => {
+                write!(f, "AVM2 {class} constructor")
             }
             Stub::Other(text) => write!(f, "{text}"),
         }

--- a/core/src/stub.rs
+++ b/core/src/stub.rs
@@ -14,6 +14,14 @@ pub enum Stub {
         method: &'static str,
         specifics: Option<&'static str>,
     },
+    Avm2Getter {
+        class: &'static str,
+        field: &'static str,
+    },
+    Avm2Setter {
+        class: &'static str,
+        field: &'static str,
+    },
     Other(Cow<'static, str>),
 }
 
@@ -25,14 +33,20 @@ impl Display for Stub {
                 method,
                 specifics: None,
             } => {
-                write!(f, "AVM1 {class}.{method}")
+                write!(f, "AVM1 {class}.{method}()")
             }
             Stub::Avm1Method {
                 class,
                 method,
                 specifics: Some(specifics),
             } => {
-                write!(f, "AVM1 {class}.{method} {specifics}")
+                write!(f, "AVM1 {class}.{method}() {specifics}")
+            }
+            Stub::Avm2Getter { class, field } => {
+                write!(f, "AVM2 {class}.{field} getter")
+            }
+            Stub::Avm2Setter { class, field } => {
+                write!(f, "AVM2 {class}.{field} setter")
             }
             Stub::Other(text) => write!(f, "{text}"),
         }

--- a/core/src/stub.rs
+++ b/core/src/stub.rs
@@ -14,6 +14,11 @@ pub enum Stub {
         method: &'static str,
         specifics: Option<&'static str>,
     },
+    Avm2Method {
+        class: &'static str,
+        method: &'static str,
+        specifics: Option<&'static str>,
+    },
     Avm2Getter {
         class: &'static str,
         property: &'static str,
@@ -44,6 +49,20 @@ impl Display for Stub {
                 specifics: Some(specifics),
             } => {
                 write!(f, "AVM1 {class}.{method}() {specifics}")
+            }
+            Stub::Avm2Method {
+                class,
+                method,
+                specifics: None,
+            } => {
+                write!(f, "AVM2 {class}.{method}()")
+            }
+            Stub::Avm2Method {
+                class,
+                method,
+                specifics: Some(specifics),
+            } => {
+                write!(f, "AVM2 {class}.{method}() {specifics}")
             }
             Stub::Avm2Getter {
                 class,


### PR DESCRIPTION
We currently have a bunch of ways to stub things:
- Have a comment saying stub, return Undefined
- Have a (warning or error or info) saying (stub or not implemented), return Undefined
- Return an error saying stub

This changes all **rust stubs within AVM1 & AVM2 classes** to a new stub system, which we should use going forwards. It prints a warning when the first time an individual stub is encountered, and keeps track of the stubs encountered for a movie. It also changes things that previously errored, to return Undefined.

Later PRs will aim to achieve:
- A way to list all stubs encountered during a movie, maybe in crash reports or its own menu?
- A way to list all stubs that Ruffle has, in a format of our choosing (maybe make github issues for remaining stubs?)
- Converting AS stubs to use the same system

Individual PRs so as not to do a "change the world" PR, and we can benefit from the system right away.