### PR TITLE
core: Advance time by 1ms when doing catchup frames

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -488,7 +488,7 @@ impl Player {
                 let timer = Instant::now();
                 self.run_frame();
                 let elapsed = timer.elapsed().as_millis();
-                if frame > 0 && elapsed == 0 {
+                if elapsed == 0 {
                     // To make sure that `getTimer()` never returns the same value between frames,
                     // pretend that at least 1ms elapsed if we ran the frame too fast.
                     self.time_offset += 1;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -482,22 +482,30 @@ impl Player {
 
             let max_frames_per_tick = self.max_frames_per_tick();
             let mut frame = 0;
+            let mut last_time_offset = self.time_offset;
 
             while frame < max_frames_per_tick && self.frame_accumulator >= frame_time {
                 let timer = Instant::now();
                 self.run_frame();
-                let elapsed = timer.elapsed().as_millis() as f64;
+                let elapsed = timer.elapsed().as_millis();
+                if frame > 0 && elapsed == 0 {
+                    // To make sure that `getTimer()` never returns the same value between frames,
+                    // pretend that at least 1ms elapsed if we ran the frame too fast.
+                    self.time_offset += 1;
+                }
 
-                self.add_frame_timing(elapsed);
+                self.add_frame_timing(elapsed as f64);
 
                 self.frame_accumulator -= frame_time;
                 frame += 1;
-                // The script probably tried implementing an FPS limiter with a busy loop.
-                // We fooled the busy loop by pretending that more time has passed that actually did.
+
+                // We fooled the movie by pretending that more time has passed that actually did.
                 // Then we need to actually pass this time, by decreasing frame_accumulator
                 // to delay the future frame.
-                if self.time_offset > 0 {
-                    self.frame_accumulator -= self.time_offset as f64;
+                let delta_time_offset = self.time_offset - last_time_offset;
+                if delta_time_offset > 0 {
+                    self.frame_accumulator -= delta_time_offset as f64;
+                    last_time_offset = self.time_offset;
                 }
             }
 


### PR DESCRIPTION
This should fix #9325.

Basically, when we do catchup frames (actual frame rate is below target frame rate so we stop waiting and do multiple frames per tick), always pretend time advanced by 1ms to avoid games from seeing `oldTime == newTime`, preventing divide by zero bugs.