### PR TITLE
wgpu optimisations - vertex attributes and shared mesh buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,13 +3567,13 @@ dependencies = [
  "gc-arena",
  "gif 0.12.0",
  "jpeg-decoder",
- "log",
  "lyon",
  "png",
  "serde",
  "smallvec",
  "swf",
  "thiserror",
+ "tracing",
  "wasm-bindgen",
 ]
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -52,7 +52,7 @@ thread_local! {
 #[cfg(feature = "tracy")]
 #[global_allocator]
 static GLOBAL: tracing_tracy::client::ProfiledAllocator<std::alloc::System> =
-    tracing_tracy::client::ProfiledAllocator::new(std::alloc::System, 100);
+    tracing_tracy::client::ProfiledAllocator::new(std::alloc::System, 0);
 
 static RUFFLE_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version-info.txt"));
 

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 swf = { path = "../swf"}
-log = "0.4"
+tracing = "0.1.37"
 gif = "0.12.0"
 png = { version = "0.17.7" }
 flate2 = "1.0.25"

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -61,7 +61,7 @@ impl Bitmap {
         // If the size is incorrect, either we screwed up or the decoder screwed up.
         let expected_len = width as usize * height as usize * format.bytes_per_pixel();
         if data.len() != expected_len {
-            log::warn!(
+            tracing::warn!(
                 "Incorrect bitmap data size, expected {} bytes, got {}",
                 data.len(),
                 expected_len

--- a/render/src/tessellator.rs
+++ b/render/src/tessellator.rs
@@ -8,6 +8,7 @@ use lyon::tessellation::{
     FillTessellator, FillVertex, StrokeTessellator, StrokeVertex, StrokeVertexConstructor,
 };
 use lyon::tessellation::{FillOptions, StrokeOptions};
+use tracing::instrument;
 
 pub struct ShapeTessellator {
     fill_tess: FillTessellator,
@@ -30,6 +31,7 @@ impl ShapeTessellator {
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     pub fn tessellate_shape(
         &mut self,
         shape: DistilledShape,
@@ -182,7 +184,7 @@ impl ShapeTessellator {
                 }
                 Err(e) => {
                     // This may simply be a degenerate path.
-                    log::error!("Tessellation failure: {:?}", e);
+                    tracing::error!("Tessellation failure: {:?}", e);
                 }
             }
         }

--- a/render/src/utils.rs
+++ b/render/src/utils.rs
@@ -32,7 +32,7 @@ pub fn decode_define_bits_jpeg(data: &[u8], alpha_data: Option<&[u8]>) -> Result
     let format = determine_jpeg_tag_format(data);
     if format != JpegTagFormat::Jpeg && alpha_data.is_some() {
         // Only DefineBitsJPEG3 with true JPEG data should have separate alpha data.
-        log::warn!("DefineBitsJPEG contains non-JPEG data with alpha; probably incorrect")
+        tracing::warn!("DefineBitsJPEG contains non-JPEG data with alpha; probably incorrect")
     }
     match format {
         JpegTagFormat::Jpeg => decode_jpeg(data, alpha_data),
@@ -135,7 +135,7 @@ pub fn remove_invalid_jpeg_data(data: &[u8]) -> Cow<[u8]> {
     if data.ends_with(&[0xFF, EOI]) {
         data
     } else {
-        log::warn!("JPEG is missing EOI marker and may not decode properly");
+        tracing::warn!("JPEG is missing EOI marker and may not decode properly");
         data.to_mut().extend_from_slice(&[0xFF, EOI]);
         data
     }
@@ -171,7 +171,7 @@ fn decode_jpeg(jpeg_data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap, Er
             .collect(),
         jpeg_decoder::PixelFormat::L8 => decoded_data.iter().flat_map(|&c| [c, c, c]).collect(),
         jpeg_decoder::PixelFormat::L16 => {
-            log::warn!("Unimplemented L16 JPEG pixel format");
+            tracing::warn!("Unimplemented L16 JPEG pixel format");
             decoded_data
         }
     };
@@ -204,7 +204,7 @@ fn decode_jpeg(jpeg_data: &[u8], alpha_data: Option<&[u8]>) -> Result<Bitmap, Er
             ));
         } else {
             // Size isn't correct; fallback to RGB?
-            log::error!("Size mismatch in DefineBitsJPEG3 alpha data");
+            tracing::error!("Size mismatch in DefineBitsJPEG3 alpha data");
         }
     }
 

--- a/render/wgpu/shaders/color.wgsl
+++ b/render/wgpu/shaders/color.wgsl
@@ -2,6 +2,11 @@
 
 #import common
 
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
@@ -15,7 +20,7 @@ struct VertexOutput {
 #endif
 
 @vertex
-fn main_vertex(in: common::VertexInput) -> VertexOutput {
+fn main_vertex(in: VertexInput) -> VertexOutput {
     #if use_push_constants == true
         var transforms = pc.transforms;
     #endif

--- a/render/wgpu/shaders/common.wgsl
+++ b/render/wgpu/shaders/common.wgsl
@@ -36,13 +36,10 @@ struct PushConstants {
     colorTransforms: ColorTransforms,
 }
 
-/// The vertex format shared among all shaders.
+/// The vertex format shared among most shaders.
 struct VertexInput {
     /// The position of the vertex in object space.
     @location(0) position: vec2<f32>,
-
-    /// The color of this vertex (only used by the color shader).
-    @location(1) color: vec4<f32>,
 };
 
 /// Common uniform layout shared by all shaders.

--- a/render/wgpu/shaders/gradient/common.wgsl
+++ b/render/wgpu/shaders/gradient/common.wgsl
@@ -66,9 +66,6 @@ fn find_t(focal_point: f32, uv: vec2<f32>) -> f32 {
 struct GradientVertexInput {
     /// The position of the vertex in object space.
     @location(0) position: vec2<f32>,
-
-    /// The color of this vertex (only used by the color shader).
-    @location(1) color: vec4<f32>,
 };
 
 @vertex

--- a/render/wgpu/shaders/gradient/common.wgsl
+++ b/render/wgpu/shaders/gradient/common.wgsl
@@ -15,45 +15,24 @@ struct VertexOutput {
     @group(3) @binding(0) var<uniform> textureTransforms: common::TextureTransforms;
 #endif
 
-#if use_storage_buffers == true
-    struct Gradient {
-        colors: array<vec4<f32>,16u>,
-        ratios: array<f32,16u>,
-        gradient_type: i32,
-        num_colors: u32,
-        interpolation: i32,
-        focal_point: f32,
-    };
+struct Gradient {
+    colors: array<vec4<f32>, 16>,
+    ratios: array<vec4<f32>, 4u>, // secretly array<f32; 16> but this let's us squeeze it into alignment
+    gradient_type: i32,
+    num_colors: u32,
+    interpolation: i32,
+    focal_point: f32,
+};
 
-    #if use_push_constants == true
-        @group(1) @binding(1) var<storage> gradient: Gradient;
-    #else
-        @group(3) @binding(1) var<storage> gradient: Gradient;
-    #endif
-
-    fn ratio(i: u32) -> f32 {
-        return gradient.ratios[i];
-    }
+#if use_push_constants == true
+    @group(1) @binding(1) var<uniform> gradient: Gradient;
 #else
-    struct Gradient {
-        colors: array<vec4<f32>, 16>,
-        ratios: array<vec4<f32>, 4u>, // secretly array<f32; 16> but this let's us squeeze it into alignment
-        gradient_type: i32,
-        num_colors: u32,
-        interpolation: i32,
-        focal_point: f32,
-    };
-
-    #if use_push_constants == true
-        @group(1) @binding(1) var<uniform> gradient: Gradient;
-    #else
-        @group(3) @binding(1) var<uniform> gradient: Gradient;
-    #endif
-
-    fn ratio(i: u32) -> f32 {
-        return gradient.ratios[i / 4u][i % 4u];
-    }
+    @group(3) @binding(1) var<uniform> gradient: Gradient;
 #endif
+
+fn ratio(i: u32) -> f32 {
+    return gradient.ratios[i / 4u][i % 4u];
+}
 
 fn find_t(focal_point: f32, uv: vec2<f32>) -> f32 {
     return 0.0;

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -673,10 +673,6 @@ async fn request_device(
     limits = limits.using_resolution(adapter.limits());
     limits = limits.using_alignment(adapter.limits());
 
-    limits.max_storage_buffers_per_shader_stage =
-        adapter.limits().max_storage_buffers_per_shader_stage;
-    limits.max_storage_buffer_binding_size = adapter.limits().max_storage_buffer_binding_size;
-
     let mut features = Default::default();
     let needed_size = (mem::size_of::<Transforms>() + mem::size_of::<ColorAdjustments>()) as u32;
     if adapter.features().contains(wgpu::Features::PUSH_CONSTANTS)

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -235,7 +235,9 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
             .tessellate_shape(shape, bitmap_source);
 
         let mut draws = Vec::with_capacity(lyon_mesh.len());
-        let mut uniform_buffer = BufferBuilder::new(&self.descriptors);
+        let mut uniform_buffer = BufferBuilder::new(
+            self.descriptors.limits.min_uniform_buffer_offset_alignment as usize,
+        );
         for draw in lyon_mesh {
             let draw_id = draws.len();
             if let Some(draw) = PendingDraw::new(
@@ -253,6 +255,7 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
         let uniform_buffer = uniform_buffer.finish(
             &self.descriptors.device,
             create_debug_label!("Shape {} uniforms", shape_id),
+            wgpu::BufferUsages::UNIFORM,
         );
 
         let draws = draws

--- a/render/wgpu/src/buffer_builder.rs
+++ b/render/wgpu/src/buffer_builder.rs
@@ -1,4 +1,3 @@
-use crate::descriptors::Descriptors;
 use bytemuck::{AnyBitPattern, NoUninit};
 use wgpu::util::DeviceExt;
 
@@ -8,11 +7,10 @@ pub struct BufferBuilder {
 }
 
 impl BufferBuilder {
-    pub fn new(descriptors: &Descriptors) -> Self {
-        let align_mask = (descriptors.limits.min_uniform_buffer_offset_alignment - 1) as usize;
+    pub fn new(alignment: usize) -> Self {
         Self {
             inner: Vec::new(),
-            align_mask,
+            align_mask: alignment - 1,
         }
     }
 
@@ -29,11 +27,16 @@ impl BufferBuilder {
         address
     }
 
-    pub fn finish(self, device: &wgpu::Device, label: Option<String>) -> wgpu::Buffer {
+    pub fn finish(
+        self,
+        device: &wgpu::Device,
+        label: Option<String>,
+        usage: wgpu::BufferUsages,
+    ) -> wgpu::Buffer {
         device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: label.as_deref(),
             contents: &self.inner,
-            usage: wgpu::BufferUsages::UNIFORM,
+            usage,
         })
     }
 }

--- a/render/wgpu/src/buffer_builder.rs
+++ b/render/wgpu/src/buffer_builder.rs
@@ -1,0 +1,39 @@
+use crate::descriptors::Descriptors;
+use bytemuck::{AnyBitPattern, NoUninit};
+use wgpu::util::DeviceExt;
+
+pub struct BufferBuilder {
+    inner: Vec<u8>,
+    align_mask: usize,
+}
+
+impl BufferBuilder {
+    pub fn new(descriptors: &Descriptors) -> Self {
+        let align_mask = (descriptors.limits.min_uniform_buffer_offset_alignment - 1) as usize;
+        Self {
+            inner: Vec::new(),
+            align_mask,
+        }
+    }
+
+    pub fn add<T: NoUninit + AnyBitPattern>(&mut self, value: T) -> wgpu::BufferAddress {
+        if !self.inner.is_empty() {
+            // Pad the internal buffer to match alignment requirements
+            // Pad on creation so that we don't wastefully pad the end of the buffer
+            let length = (self.inner.len() + self.align_mask) & !self.align_mask;
+            self.inner.resize(length, 0);
+        }
+
+        let address = self.inner.len() as wgpu::BufferAddress;
+        self.inner.extend_from_slice(bytemuck::cast_slice(&[value]));
+        address
+    }
+
+    pub fn finish(self, device: &wgpu::Device, label: Option<String>) -> wgpu::Buffer {
+        device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: label.as_deref(),
+            contents: &self.inner,
+            usage: wgpu::BufferUsages::UNIFORM,
+        })
+    }
+}

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -1,9 +1,9 @@
 use crate::layouts::BindLayouts;
-use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION;
+use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION_POS;
 use crate::shaders::Shaders;
 use crate::{
-    create_buffer_with_data, BitmapSamplers, Pipelines, TextureTransforms, Transforms, Vertex,
-    DEFAULT_COLOR_ADJUSTMENTS,
+    create_buffer_with_data, BitmapSamplers, Pipelines, PosColorVertex, PosVertex,
+    TextureTransforms, Transforms, DEFAULT_COLOR_ADJUSTMENTS,
 };
 use fnv::FnvHashMap;
 use std::fmt::Debug;
@@ -109,7 +109,7 @@ impl Descriptors {
                             vertex: wgpu::VertexState {
                                 module: &self.shaders.copy_srgb_shader,
                                 entry_point: "main_vertex",
-                                buffers: &VERTEX_BUFFERS_DESCRIPTION,
+                                buffers: &VERTEX_BUFFERS_DESCRIPTION_POS,
                             },
                             fragment: Some(wgpu::FragmentState {
                                 module: &self.shaders.copy_srgb_shader,
@@ -182,7 +182,7 @@ impl Descriptors {
                             vertex: wgpu::VertexState {
                                 module: &self.shaders.copy_shader,
                                 entry_point: "main_vertex",
-                                buffers: &VERTEX_BUFFERS_DESCRIPTION,
+                                buffers: &VERTEX_BUFFERS_DESCRIPTION_POS,
                             },
                             fragment: Some(wgpu::FragmentState {
                                 module: &self.shaders.copy_shader,
@@ -236,38 +236,60 @@ impl Descriptors {
 }
 
 pub struct Quad {
-    pub vertices: wgpu::Buffer,
+    pub vertices_pos: wgpu::Buffer,
+    pub vertices_pos_color: wgpu::Buffer,
     pub indices: wgpu::Buffer,
     pub texture_transforms: wgpu::Buffer,
 }
 
 impl Quad {
     pub fn new(device: &wgpu::Device) -> Self {
-        let vertices = [
-            Vertex {
+        let vertices_pos = [
+            PosVertex {
+                position: [0.0, 0.0],
+            },
+            PosVertex {
+                position: [1.0, 0.0],
+            },
+            PosVertex {
+                position: [1.0, 1.0],
+            },
+            PosVertex {
+                position: [0.0, 1.0],
+            },
+        ];
+        let vertices_pos_color = [
+            PosColorVertex {
                 position: [0.0, 0.0],
                 color: [1.0, 1.0, 1.0, 1.0],
             },
-            Vertex {
+            PosColorVertex {
                 position: [1.0, 0.0],
                 color: [1.0, 1.0, 1.0, 1.0],
             },
-            Vertex {
+            PosColorVertex {
                 position: [1.0, 1.0],
                 color: [1.0, 1.0, 1.0, 1.0],
             },
-            Vertex {
+            PosColorVertex {
                 position: [0.0, 1.0],
                 color: [1.0, 1.0, 1.0, 1.0],
             },
         ];
         let indices: [u32; 6] = [0, 1, 2, 0, 2, 3];
 
-        let vbo = create_buffer_with_data(
+        let vbo_pos = create_buffer_with_data(
             device,
-            bytemuck::cast_slice(&vertices),
+            bytemuck::cast_slice(&vertices_pos),
             wgpu::BufferUsages::VERTEX,
-            create_debug_label!("Quad vbo"),
+            create_debug_label!("Quad vbo (pos)"),
+        );
+
+        let vbo_pos_color = create_buffer_with_data(
+            device,
+            bytemuck::cast_slice(&vertices_pos_color),
+            wgpu::BufferUsages::VERTEX,
+            create_debug_label!("Quad vbo (pos & color)"),
         );
 
         let ibo = create_buffer_with_data(
@@ -292,7 +314,8 @@ impl Quad {
         );
 
         Self {
-            vertices: vbo,
+            vertices_pos: vbo_pos,
+            vertices_pos_color: vbo_pos_color,
             indices: ibo,
             texture_transforms: tex_transforms,
         }

--- a/render/wgpu/src/layouts.rs
+++ b/render/wgpu/src/layouts.rs
@@ -1,5 +1,5 @@
 use crate::globals::GlobalsUniform;
-use crate::{ColorAdjustments, GradientStorage, GradientUniforms, TextureTransforms, Transforms};
+use crate::{ColorAdjustments, GradientUniforms, TextureTransforms, Transforms};
 
 #[derive(Debug)]
 pub struct BindLayouts {
@@ -150,18 +150,10 @@ impl BindLayouts {
                     binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
-                        ty: if device.limits().max_storage_buffers_per_shader_stage > 0 {
-                            wgpu::BufferBindingType::Storage { read_only: true }
-                        } else {
-                            wgpu::BufferBindingType::Uniform
-                        },
+                        ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         min_binding_size: wgpu::BufferSize::new(
-                            if device.limits().max_storage_buffers_per_shader_stage > 0 {
-                                std::mem::size_of::<GradientStorage>() as u64
-                            } else {
-                                std::mem::size_of::<GradientUniforms>() as u64
-                            },
+                            std::mem::size_of::<GradientUniforms>() as u64,
                         ),
                     },
                     count: None,

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -171,39 +171,6 @@ impl From<TessGradient> for GradientUniforms {
     }
 }
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Pod, Zeroable)]
-struct GradientStorage {
-    colors: [[f32; 4]; 16],
-    ratios: [f32; 16],
-    gradient_type: i32,
-    num_colors: u32,
-    interpolation: i32,
-    focal_point: f32,
-}
-
-impl From<TessGradient> for GradientStorage {
-    fn from(gradient: TessGradient) -> Self {
-        let mut ratios = [0.0; 16];
-        let mut colors = [[0.0; 4]; 16];
-        ratios[..gradient.num_colors].copy_from_slice(&gradient.ratios[..gradient.num_colors]);
-        colors[..gradient.num_colors].copy_from_slice(&gradient.colors[..gradient.num_colors]);
-
-        Self {
-            colors,
-            ratios,
-            gradient_type: match gradient.gradient_type {
-                GradientType::Linear => 0,
-                GradientType::Radial => 1,
-                GradientType::Focal => 2,
-            },
-            num_colors: gradient.num_colors as u32,
-            interpolation: (gradient.interpolation == swf::GradientInterpolation::LinearRgb) as i32,
-            focal_point: gradient.focal_point.to_f32(),
-        }
-    }
-}
-
 #[derive(Debug)]
 pub enum QueueSyncHandle {
     AlreadyCopied {

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -101,12 +101,26 @@ impl From<ColorTransform> for ColorAdjustments {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
-struct Vertex {
+struct PosVertex {
+    position: [f32; 2],
+}
+
+impl From<TessVertex> for PosVertex {
+    fn from(vertex: TessVertex) -> Self {
+        Self {
+            position: [vertex.x, vertex.y],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct PosColorVertex {
     position: [f32; 2],
     color: [f32; 4],
 }
 
-impl From<TessVertex> for Vertex {
+impl From<TessVertex> for PosColorVertex {
     fn from(vertex: TessVertex) -> Self {
         Self {
             position: [vertex.x, vertex.y],

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -32,6 +32,7 @@ mod uniform_buffer;
 
 pub mod backend;
 mod blend;
+mod buffer_builder;
 mod buffer_pool;
 #[cfg(feature = "clap")]
 pub mod clap;
@@ -349,6 +350,7 @@ impl Texture {
                 &layout,
                 samplers.get_sampler(false, smoothed),
                 &quad.texture_transforms,
+                0 as wgpu::BufferAddress,
                 self.texture.create_view(&Default::default()),
                 create_debug_label!("Bitmap {:?} bind group (smoothed: {})", handle.0, smoothed),
             )

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -2,9 +2,10 @@ use crate::backend::WgpuRenderBackend;
 use crate::target::RenderTarget;
 use crate::{
     as_texture, create_buffer_with_data, Descriptors, GradientStorage, GradientUniforms,
-    PosColorVertex, PosVertex,
+    PosColorVertex, PosVertex, TextureTransforms,
 };
 
+use crate::buffer_builder::BufferBuilder;
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::bitmap::BitmapSource;
 use ruffle_render::tessellator::{
@@ -18,6 +19,27 @@ pub struct Mesh {
 }
 
 #[derive(Debug)]
+pub struct PendingDraw {
+    pub draw_type: PendingDrawType,
+    pub vertex_buffer: wgpu::Buffer,
+    pub index_buffer: wgpu::Buffer,
+    pub num_indices: u32,
+    pub num_mask_indices: u32,
+}
+
+impl PendingDraw {
+    pub fn finish(self, descriptors: &Descriptors, uniform_buffer: &wgpu::Buffer) -> Draw {
+        Draw {
+            draw_type: self.draw_type.finish(descriptors, uniform_buffer),
+            vertex_buffer: self.vertex_buffer,
+            index_buffer: self.index_buffer,
+            num_indices: self.num_indices,
+            num_mask_indices: self.num_mask_indices,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct Draw {
     pub draw_type: DrawType,
     pub vertex_buffer: wgpu::Buffer,
@@ -26,13 +48,14 @@ pub struct Draw {
     pub num_mask_indices: u32,
 }
 
-impl Draw {
+impl PendingDraw {
     pub fn new<T: RenderTarget>(
         backend: &mut WgpuRenderBackend<T>,
         source: &dyn BitmapSource,
         draw: LyonDraw,
         shape_id: CharacterId,
         draw_id: usize,
+        uniform_buffer: &mut BufferBuilder,
     ) -> Option<Self> {
         let descriptors = backend.descriptors().clone();
 
@@ -66,59 +89,48 @@ impl Draw {
         );
 
         let index_count = draw.indices.len() as u32;
-        Some(match draw.draw_type {
-            TessDrawType::Color => Draw {
-                draw_type: DrawType::color(),
-                vertex_buffer,
-                index_buffer,
-                num_indices: index_count,
-                num_mask_indices: draw.mask_index_count,
-            },
-            TessDrawType::Gradient(gradient) => Draw {
-                draw_type: DrawType::gradient(&descriptors, gradient, shape_id, draw_id),
-                vertex_buffer,
-                index_buffer,
-                num_indices: index_count,
-                num_mask_indices: draw.mask_index_count,
-            },
-            TessDrawType::Bitmap(bitmap) => Draw {
-                draw_type: DrawType::bitmap(
-                    &descriptors,
-                    bitmap,
-                    shape_id,
-                    draw_id,
-                    source,
-                    backend,
-                )?,
-                vertex_buffer,
-                index_buffer,
-                num_indices: index_count,
-                num_mask_indices: draw.mask_index_count,
-            },
+        let draw_type = match draw.draw_type {
+            TessDrawType::Color => PendingDrawType::color(),
+            TessDrawType::Gradient(gradient) => {
+                PendingDrawType::gradient(&descriptors, gradient, shape_id, draw_id, uniform_buffer)
+            }
+            TessDrawType::Bitmap(bitmap) => {
+                PendingDrawType::bitmap(bitmap, shape_id, draw_id, source, backend, uniform_buffer)?
+            }
+        };
+        Some(PendingDraw {
+            draw_type,
+            vertex_buffer,
+            index_buffer,
+            num_indices: index_count,
+            num_mask_indices: draw.mask_index_count,
         })
     }
 }
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub enum DrawType {
+pub enum PendingDrawType {
     Color,
     Gradient {
-        texture_transforms: wgpu::Buffer,
+        texture_transforms_index: wgpu::BufferAddress,
         gradient: wgpu::Buffer,
-        bind_group: wgpu::BindGroup,
         spread: GradientSpread,
         mode: GradientType,
+        bind_group_label: Option<String>,
     },
     Bitmap {
-        texture_transforms: wgpu::Buffer,
-        binds: BitmapBinds,
+        texture_transforms_index: wgpu::BufferAddress,
+        texture_view: wgpu::TextureView,
+        is_repeating: bool,
+        is_smoothed: bool,
+        bind_group_label: Option<String>,
     },
 }
 
-impl DrawType {
+impl PendingDrawType {
     pub fn color() -> Self {
-        DrawType::Color
+        PendingDrawType::Color
     }
 
     pub fn gradient(
@@ -126,16 +138,9 @@ impl DrawType {
         gradient: Gradient,
         shape_id: CharacterId,
         draw_id: usize,
+        uniform_buffers: &mut BufferBuilder,
     ) -> Self {
-        let tex_transforms_ubo = create_texture_transforms(
-            &descriptors.device,
-            &gradient.matrix,
-            create_debug_label!(
-                "Shape {} draw {} textransforms ubo transfer buffer",
-                shape_id,
-                draw_id
-            ),
-        );
+        let tex_transforms_index = create_texture_transforms(&gradient.matrix, uniform_buffers);
 
         let spread = gradient.repeat_mode;
         let mode = gradient.gradient_type;
@@ -166,70 +171,116 @@ impl DrawType {
 
         let bind_group_label =
             create_debug_label!("Shape {} (gradient) draw {} bindgroup", shape_id, draw_id);
-        let bind_group = descriptors
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                layout: &descriptors.bind_layouts.gradient,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: tex_transforms_ubo.as_entire_binding(),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: gradient_ubo.as_entire_binding(),
-                    },
-                ],
-                label: bind_group_label.as_deref(),
-            });
-        DrawType::Gradient {
-            texture_transforms: tex_transforms_ubo,
+        PendingDrawType::Gradient {
+            texture_transforms_index: tex_transforms_index,
             gradient: gradient_ubo,
             spread,
             mode,
-            bind_group,
+            bind_group_label,
         }
     }
 
     pub fn bitmap(
-        descriptors: &Descriptors,
         bitmap: Bitmap,
         shape_id: CharacterId,
         draw_id: usize,
         source: &dyn BitmapSource,
         backend: &mut dyn RenderBackend,
+        uniform_buffers: &mut BufferBuilder,
     ) -> Option<Self> {
         let handle = source.bitmap_handle(bitmap.bitmap_id, backend)?;
         let texture = as_texture(&handle);
         let texture_view = texture.texture.create_view(&Default::default());
-        let texture_transforms = create_texture_transforms(
-            &descriptors.device,
-            &bitmap.matrix,
-            create_debug_label!(
-                "Shape {} draw {} textransforms ubo transfer buffer",
-                shape_id,
-                draw_id
-            ),
-        );
-
+        let texture_transforms_index = create_texture_transforms(&bitmap.matrix, uniform_buffers);
         let bind_group_label =
             create_debug_label!("Shape {} (bitmap) draw {} bindgroup", shape_id, draw_id);
-        let binds = BitmapBinds::new(
-            &descriptors.device,
-            &descriptors.bind_layouts.bitmap,
-            descriptors
-                .bitmap_samplers
-                .get_sampler(bitmap.is_repeating, bitmap.is_smoothed),
-            &texture_transforms,
-            texture_view,
-            bind_group_label,
-        );
 
-        Some(DrawType::Bitmap {
-            texture_transforms,
-            binds,
+        Some(PendingDrawType::Bitmap {
+            texture_transforms_index,
+            texture_view,
+            is_repeating: bitmap.is_repeating,
+            is_smoothed: bitmap.is_smoothed,
+            bind_group_label,
         })
     }
+
+    pub fn finish(self, descriptors: &Descriptors, uniform_buffer: &wgpu::Buffer) -> DrawType {
+        match self {
+            PendingDrawType::Color => DrawType::Color,
+            PendingDrawType::Gradient {
+                texture_transforms_index,
+                gradient,
+                spread,
+                mode,
+                bind_group_label,
+            } => {
+                let bind_group = descriptors
+                    .device
+                    .create_bind_group(&wgpu::BindGroupDescriptor {
+                        layout: &descriptors.bind_layouts.gradient,
+                        entries: &[
+                            wgpu::BindGroupEntry {
+                                binding: 0,
+                                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                                    buffer: &uniform_buffer,
+                                    offset: texture_transforms_index,
+                                    size: wgpu::BufferSize::new(
+                                        std::mem::size_of::<TextureTransforms>() as u64,
+                                    ),
+                                }),
+                            },
+                            wgpu::BindGroupEntry {
+                                binding: 1,
+                                resource: gradient.as_entire_binding(),
+                            },
+                        ],
+                        label: bind_group_label.as_deref(),
+                    });
+                DrawType::Gradient {
+                    gradient,
+                    bind_group,
+                    spread,
+                    mode,
+                }
+            }
+            PendingDrawType::Bitmap {
+                texture_transforms_index,
+                texture_view,
+                is_repeating,
+                is_smoothed,
+                bind_group_label,
+            } => {
+                let binds = BitmapBinds::new(
+                    &descriptors.device,
+                    &descriptors.bind_layouts.bitmap,
+                    descriptors
+                        .bitmap_samplers
+                        .get_sampler(is_repeating, is_smoothed),
+                    &uniform_buffer,
+                    texture_transforms_index,
+                    texture_view,
+                    bind_group_label,
+                );
+
+                DrawType::Bitmap { binds }
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum DrawType {
+    Color,
+    Gradient {
+        gradient: wgpu::Buffer,
+        bind_group: wgpu::BindGroup,
+        spread: GradientSpread,
+        mode: GradientType,
+    },
+    Bitmap {
+        binds: BitmapBinds,
+    },
 }
 
 #[derive(Debug)]
@@ -242,46 +293,47 @@ impl BitmapBinds {
         device: &wgpu::Device,
         layout: &wgpu::BindGroupLayout,
         sampler: &wgpu::Sampler,
-        texture_transforms: &wgpu::Buffer,
+        uniform_buffer: &wgpu::Buffer,
+        texture_transforms: wgpu::BufferAddress,
         texture_view: wgpu::TextureView,
         label: Option<String>,
     ) -> Self {
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: texture_transforms.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&texture_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::Sampler(&sampler),
-                },
-            ],
-            label: label.as_deref(),
-        });
+        let bind_group =
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: &layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: &uniform_buffer,
+                            offset: texture_transforms,
+                            size: wgpu::BufferSize::new(
+                                std::mem::size_of::<TextureTransforms>() as u64
+                            ),
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(&texture_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Sampler(&sampler),
+                    },
+                ],
+                label: label.as_deref(),
+            });
         Self { bind_group }
     }
 }
 
 fn create_texture_transforms(
-    device: &wgpu::Device,
     matrix: &[[f32; 3]; 3],
-    label: Option<String>,
-) -> wgpu::Buffer {
+    buffer: &mut BufferBuilder,
+) -> wgpu::BufferAddress {
     let mut texture_transform = [[0.0; 4]; 4];
     texture_transform[0][..3].copy_from_slice(&matrix[0]);
     texture_transform[1][..3].copy_from_slice(&matrix[1]);
     texture_transform[2][..3].copy_from_slice(&matrix[2]);
-
-    create_buffer_with_data(
-        &device,
-        bytemuck::cast_slice(&[texture_transform]),
-        wgpu::BufferUsages::UNIFORM,
-        label,
-    )
+    buffer.add(texture_transform)
 }

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -1,8 +1,8 @@
 use crate::backend::WgpuRenderBackend;
 use crate::target::RenderTarget;
 use crate::{
-    as_texture, create_buffer_with_data, Descriptors, GradientStorage, GradientUniforms,
-    PosColorVertex, PosVertex, TextureTransforms,
+    as_texture, create_buffer_with_data, Descriptors, GradientUniforms, PosColorVertex, PosVertex,
+    TextureTransforms,
 };
 use std::ops::Range;
 
@@ -136,29 +136,16 @@ impl PendingDrawType {
         let spread = gradient.repeat_mode;
         let mode = gradient.gradient_type;
 
-        let gradient_ubo = if descriptors.limits.max_storage_buffers_per_shader_stage > 0 {
-            create_buffer_with_data(
-                &descriptors.device,
-                bytemuck::cast_slice(&[GradientStorage::from(gradient)]),
-                wgpu::BufferUsages::STORAGE,
-                create_debug_label!(
-                    "Shape {} draw {} gradient ubo transfer buffer",
-                    shape_id,
-                    draw_id
-                ),
-            )
-        } else {
-            create_buffer_with_data(
-                &descriptors.device,
-                bytemuck::cast_slice(&[GradientUniforms::from(gradient)]),
-                wgpu::BufferUsages::UNIFORM,
-                create_debug_label!(
-                    "Shape {} draw {} gradient ubo transfer buffer",
-                    shape_id,
-                    draw_id
-                ),
-            )
-        };
+        let gradient_ubo = create_buffer_with_data(
+            &descriptors.device,
+            bytemuck::cast_slice(&[GradientUniforms::from(gradient)]),
+            wgpu::BufferUsages::UNIFORM,
+            create_debug_label!(
+                "Shape {} draw {} gradient ubo transfer buffer",
+                shape_id,
+                draw_id
+            ),
+        );
 
         let bind_group_label =
             create_debug_label!("Shape {} (gradient) draw {} bindgroup", shape_id, draw_id);

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -1,21 +1,31 @@
 use crate::blend::{ComplexBlend, TrivialBlend};
 use crate::layouts::BindLayouts;
 use crate::shaders::Shaders;
-use crate::{MaskState, PushConstants, Transforms, Vertex};
+use crate::{MaskState, PosColorVertex, PosVertex, PushConstants, Transforms};
 use enum_map::{enum_map, Enum, EnumMap};
 use ruffle_render::tessellator::GradientType;
 use std::mem;
 use swf::GradientSpread;
 use wgpu::vertex_attr_array;
 
-pub const VERTEX_BUFFERS_DESCRIPTION: [wgpu::VertexBufferLayout; 1] = [wgpu::VertexBufferLayout {
-    array_stride: std::mem::size_of::<Vertex>() as u64,
-    step_mode: wgpu::VertexStepMode::Vertex,
-    attributes: &vertex_attr_array![
-        0 => Float32x2,
-        1 => Float32x4,
-    ],
-}];
+pub const VERTEX_BUFFERS_DESCRIPTION_POS: [wgpu::VertexBufferLayout; 1] =
+    [wgpu::VertexBufferLayout {
+        array_stride: std::mem::size_of::<PosVertex>() as u64,
+        step_mode: wgpu::VertexStepMode::Vertex,
+        attributes: &vertex_attr_array![
+            0 => Float32x2,
+        ],
+    }];
+
+pub const VERTEX_BUFFERS_DESCRIPTION_COLOR: [wgpu::VertexBufferLayout; 1] =
+    [wgpu::VertexBufferLayout {
+        array_stride: std::mem::size_of::<PosColorVertex>() as u64,
+        step_mode: wgpu::VertexStepMode::Vertex,
+        attributes: &vertex_attr_array![
+            0 => Float32x2,
+            1 => Float32x4,
+        ],
+    }];
 
 #[derive(Debug)]
 pub struct ShapePipeline {
@@ -104,7 +114,7 @@ impl Pipelines {
             format,
             &shaders.color_shader,
             msaa_sample_count,
-            &VERTEX_BUFFERS_DESCRIPTION,
+            &VERTEX_BUFFERS_DESCRIPTION_COLOR,
             &colort_bindings,
             wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
             &full_push_constants,
@@ -129,7 +139,7 @@ impl Pipelines {
                     format,
                     &shaders.gradient_shaders[mode][spread],
                     msaa_sample_count,
-                    &VERTEX_BUFFERS_DESCRIPTION,
+                    &VERTEX_BUFFERS_DESCRIPTION_POS,
                     &gradient_bindings,
                     wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
                     &full_push_constants,
@@ -154,7 +164,7 @@ impl Pipelines {
                 format,
                 &shaders.blend_shaders[blend],
                 msaa_sample_count,
-                &VERTEX_BUFFERS_DESCRIPTION,
+                &VERTEX_BUFFERS_DESCRIPTION_POS,
                 &complex_blend_bindings,
                 wgpu::BlendState::REPLACE,
                 &partial_push_constants,
@@ -182,7 +192,7 @@ impl Pipelines {
                     format,
                     &shaders.bitmap_shader,
                     msaa_sample_count,
-                    &VERTEX_BUFFERS_DESCRIPTION,
+                    &VERTEX_BUFFERS_DESCRIPTION_POS,
                     &bitmap_blend_bindings,
                     blend.blend_state(),
                     &full_push_constants,

--- a/render/wgpu/src/shaders.rs
+++ b/render/wgpu/src/shaders.rs
@@ -26,10 +26,6 @@ impl Shaders {
             "use_push_constants".to_owned(),
             ShaderDefValue::Bool(device.limits().max_push_constant_size > 0),
         );
-        shader_defs.insert(
-            "use_storage_buffers".to_owned(),
-            ShaderDefValue::Bool(device.limits().max_storage_buffers_per_shader_stage > 0),
-        );
         let color_shader = make_shader(
             &device,
             &mut composer,

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -166,7 +166,7 @@ impl Surface {
             render_pass.set_bind_group(2, &copy_bind_group, &[]);
         }
 
-        render_pass.set_vertex_buffer(0, descriptors.quad.vertices.slice(..));
+        render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
         render_pass.set_index_buffer(
             descriptors.quad.indices.slice(..),
             wgpu::IndexFormat::Uint32,
@@ -377,7 +377,7 @@ impl Surface {
                         render_pass.set_bind_group(2, &blend_bind_group, &[]);
                     }
 
-                    render_pass.set_vertex_buffer(0, descriptors.quad.vertices.slice(..));
+                    render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
                     render_pass.set_index_buffer(
                         descriptors.quad.indices.slice(..),
                         wgpu::IndexFormat::Uint32,

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -249,7 +249,7 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
         );
 
         self.draw(
-            self.descriptors.quad.vertices.slice(..),
+            self.descriptors.quad.vertices_pos.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
@@ -271,7 +271,7 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
         self.apply_transform(&transform.matrix, &transform.color_transform);
 
         self.draw(
-            self.descriptors.quad.vertices.slice(..),
+            self.descriptors.quad.vertices_pos.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );
@@ -351,7 +351,7 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
         }
 
         self.draw(
-            self.descriptors.quad.vertices.slice(..),
+            self.descriptors.quad.vertices_pos_color.slice(..),
             self.descriptors.quad.indices.slice(..),
             6,
         );

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -319,8 +319,8 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
             self.apply_transform(&transform.matrix, &transform.color_transform);
 
             self.draw(
-                draw.vertex_buffer.slice(..),
-                draw.index_buffer.slice(..),
+                mesh.vertex_buffer.slice(draw.vertices.clone()),
+                mesh.index_buffer.slice(draw.indices.clone()),
                 num_indices,
             );
         }


### PR DESCRIPTION
In games with lots of individual meshes, like box2d demo, rendering is about 33% faster
![image](https://user-images.githubusercontent.com/317625/216400521-d60b96b8-c9c0-40fe-8c95-ceff24ca6567.png)

Registration (or replacement) of meshes is about 60% faster
![image](https://user-images.githubusercontent.com/317625/216400704-ac1bce70-e15c-42f6-8f94-ebf281df8c66.png)

Heartcore is about 8% faster, but it doesn't have that many individual meshes
![image](https://user-images.githubusercontent.com/317625/216399546-53e68426-bce1-41d1-a83a-29edc9a630d7.png)


