### PR TITLE
tests: Enable tests that no longer need to be ignored

### DIFF
--- a/tests/tests/swfs/avm1/textfield_text/test.toml
+++ b/tests/tests/swfs/avm1/textfield_text/test.toml
@@ -1,2 +1,1 @@
 num_frames = 1
-ignore = true

--- a/tests/tests/swfs/avm2/bitmap_properties/test.toml
+++ b/tests/tests/swfs/avm2/bitmap_properties/test.toml
@@ -1,2 +1,1 @@
 num_frames = 1
-ignore = true


### PR DESCRIPTION
textfield_text was made before the .text property learn how to deal with html. It works now.

bitmap_properties was made before bitmapdata could persist any data. That's solved now.