### PR TITLE
web: add mobile virtual keyboard using prompt()

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -810,6 +810,25 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
+    private async openVirtualKeyboard(): Promise<void> {
+        // Use simple prompt for now. Ideally the system keyboard would come up,
+        // possibly with a library for fallback (e.g. simple-keyboard)
+        const string = prompt("String to type:") ?? "";
+
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+        for (const char of string) {
+            for (const type of ["keydown", "keyup"]) {
+                const event = new KeyboardEvent(type, {
+                    key: char,
+                    bubbles: true,
+                });
+                this.dispatchEvent(event);
+                await sleep(16);
+            }
+        }
+    }
+
     private contextMenuItems(): Array<ContextMenuItem | null> {
         const CHECKMARK = String.fromCharCode(0x2713);
         const items = [];
@@ -879,6 +898,10 @@ export class RufflePlayer extends HTMLElement {
             items.push({
                 text: "Hide this menu",
                 onClick: () => (this.contextMenuForceDisabled = true),
+            });
+            items.push({
+                text: "Virtual keyboard (experimental)",
+                onClick: () => this.openVirtualKeyboard(),
             });
         }
         return items;


### PR DESCRIPTION
Adds a simple virtual keyboard for mobile using `prompt()`.
Does not use the system keyboard, nor third party libraries.

Usage instructions:
Long press where you wish to type, then choose `Virtual keyboard (experimental)` in the context menu. Fill in the prompt and press OK. Whatever was typed in the prompt will be passed to the flash application.

Tested in [Adventure Quest](https://aq.battleon.com/game/web?launchtype=medium) in Chrome (Android & Windows) and Kiwi Browser (Android, as extension).
Tested in [Typing of the Living Dead](https://www.quickflashgames.com/games/typing-of-the-living-dead/) in Chrome (Android & Windows).

Some screenshots of it working on Android in Kiwi Browser using the extension:
![Screenshot_20230205_173445_Kiwi Browser](https://user-images.githubusercontent.com/1624180/216832485-d6de840c-360b-41a9-a3be-7386bdff852e.jpg)
![Screenshot_20230205_173528_Kiwi Browser](https://user-images.githubusercontent.com/1624180/216832486-e9672b95-4911-400f-a807-c121584c51d5.jpg)
