### PR TITLE
chore: Update renovate to only group rust patch dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,13 @@
   "packageRules": [
     {
       "matchLanguages": ["rust"],
-      "groupName": "Rust dependencies",
+      "matchUpdateTypes": "patch",
+      "excludePackageNames": ["wasm-bindgen"],
+      "groupName": "Rust dependency patches",
+      "extends": ["schedule:weekly"]
+    },
+    {
+      "matchLanguages": ["rust"],
       "extends": ["schedule:weekly"]
     },
     {


### PR DESCRIPTION
Leaves any minor/major dependency updates (and any wasm-bindgen) to their own PR, as those are very likely to have some deprecated methods or breaking changes that need attention