### PR TITLE
core: Make SandboxType configurable, and set to 'remote' on web

### DIFF
--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -295,6 +295,27 @@ pub struct SystemProperties {
 }
 
 impl SystemProperties {
+    pub fn new(sandbox_type: SandboxType) -> Self {
+        SystemProperties {
+            //TODO: default to true on fp>=7, false <= 6
+            exact_settings: true,
+            //TODO: default to false on fp>=7, true <= 6
+            use_codepage: false,
+            capabilities: SystemCapabilities::empty(),
+            player_type: PlayerType::StandAlone,
+            screen_color: ScreenColor::Color,
+            // TODO: note for fp <7 this should be the locale and the ui lang for >= 7, on windows
+            language: Language::English,
+            screen_resolution: (0, 0),
+            aspect_ratio: 1_f32,
+            dpi: 1_f32,
+            manufacturer: Manufacturer::Linux,
+            os: OperatingSystem::Linux,
+            sandbox_type,
+            cpu_architecture: CpuArchitecture::X86,
+            idc_level: "5.1".into(),
+        }
+    }
     pub fn get_version_string(&self, avm: &mut Avm1) -> String {
         format!(
             "{} {},0,0,0",
@@ -393,30 +414,6 @@ impl SystemProperties {
             )
             .append_pair("DP", &self.dpi.to_string())
             .finish()
-    }
-}
-
-impl Default for SystemProperties {
-    fn default() -> Self {
-        SystemProperties {
-            //TODO: default to true on fp>=7, false <= 6
-            exact_settings: true,
-            //TODO: default to false on fp>=7, true <= 6
-            use_codepage: false,
-            capabilities: SystemCapabilities::empty(),
-            player_type: PlayerType::StandAlone,
-            screen_color: ScreenColor::Color,
-            // TODO: note for fp <7 this should be the locale and the ui lang for >= 7, on windows
-            language: Language::English,
-            screen_resolution: (0, 0),
-            aspect_ratio: 1_f32,
-            dpi: 1_f32,
-            manufacturer: Manufacturer::Linux,
-            os: OperatingSystem::Linux,
-            sandbox_type: SandboxType::LocalTrusted,
-            cpu_architecture: CpuArchitecture::X86,
-            idc_level: "5.1".into(),
-        }
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod config;
 pub mod external;
 pub mod stub;
 
+pub use avm1::globals::system::SandboxType;
 pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;
 pub use indexmap;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,3 +1,4 @@
+use crate::avm1::globals::system::SandboxType;
 use crate::avm1::Attribute;
 use crate::avm1::Avm1;
 use crate::avm1::Object;
@@ -1948,6 +1949,7 @@ pub struct PlayerBuilder {
     spoofed_url: Option<String>,
     player_version: Option<u8>,
     quality: StageQuality,
+    sandbox_type: SandboxType,
 }
 
 impl PlayerBuilder {
@@ -1985,6 +1987,7 @@ impl PlayerBuilder {
             spoofed_url: None,
             player_version: None,
             quality: StageQuality::High,
+            sandbox_type: SandboxType::LocalTrusted,
         }
     }
 
@@ -2116,6 +2119,12 @@ impl PlayerBuilder {
         self
     }
 
+    // Configured the security sandbox type (default is `SandboxType::LocalTrusted`)
+    pub fn with_sandbox_type(mut self, sandbox_type: SandboxType) -> Self {
+        self.sandbox_type = sandbox_type;
+        self
+    }
+
     /// Builds the player, wiring up the backends and configuring the specified settings.
     pub fn build(self) -> Arc<Mutex<Player>> {
         use crate::backend::*;
@@ -2185,7 +2194,7 @@ impl PlayerBuilder {
 
                 // Misc. state
                 rng: SmallRng::seed_from_u64(get_current_date_time().timestamp_millis() as u64),
-                system: SystemProperties::default(),
+                system: SystemProperties::new(self.sandbox_type),
                 transform_stack: TransformStack::new(),
                 instance_counter: 0,
                 player_version,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -16,7 +16,9 @@ use ruffle_core::external::{
     ExternalInterfaceMethod, ExternalInterfaceProvider, Value as ExternalValue, Value,
 };
 use ruffle_core::tag_utils::SwfMovie;
-use ruffle_core::{Color, Player, PlayerBuilder, PlayerEvent, StaticCallstack, ViewportDimensions};
+use ruffle_core::{
+    Color, Player, PlayerBuilder, PlayerEvent, SandboxType, StaticCallstack, ViewportDimensions,
+};
 use ruffle_render::quality::StageQuality;
 use ruffle_video_software::backend::SoftwareVideoBackend;
 use ruffle_web_common::JsResult;
@@ -552,6 +554,8 @@ impl Ruffle {
                     .and_then(|q| StageQuality::from_str(&q).ok())
                     .unwrap_or(default_quality),
             )
+            // FIXME - should this be configurable?
+            .with_sandbox_type(SandboxType::Remote)
             .build();
 
         let mut callstack = None;


### PR DESCRIPTION
The Newgrounds API checks `Security.sandboxType` to see if it should run in debug mode or not (which determines whether or not medals can actually be unlocked).

For now, desktop continues to use `localTrusted` as the default, while web now uses `remote`. We might want to make this configurable at some point, but this should be good enough for now (and better match Flash's behavior).