### PR TITLE
Avm2: Correctly support private namespaces

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -56,7 +56,7 @@ pub use crate::avm2::domain::Domain;
 pub use crate::avm2::error::Error;
 pub use crate::avm2::globals::flash::ui::context_menu::make_context_menu_state;
 pub use crate::avm2::multiname::Multiname;
-pub use crate::avm2::namespace::Namespace;
+pub use crate::avm2::namespace::{Namespace, NamespaceData};
 pub use crate::avm2::object::{
     ArrayObject, ClassObject, EventObject, Object, ScriptObject, SoundChannelObject, StageObject,
     TObject,
@@ -86,6 +86,13 @@ pub struct Avm2<'gc> {
 
     /// System classes.
     system_classes: Option<SystemClasses<'gc>>,
+
+    pub public_namespace: Namespace<'gc>,
+    pub as3_namespace: Namespace<'gc>,
+    pub vector_public_namespace: Namespace<'gc>,
+    pub vector_internal_namespace: Namespace<'gc>,
+    pub proxy_namespace: Namespace<'gc>,
+    pub ruffle_private_namespace: Namespace<'gc>,
 
     #[collect(require_static)]
     native_method_table: &'static [Option<(&'static str, NativeMethodImpl)>],
@@ -121,6 +128,17 @@ impl<'gc> Avm2<'gc> {
             call_stack: GcCell::allocate(mc, CallStack::new()),
             globals,
             system_classes: None,
+
+            public_namespace: Namespace::package("", mc),
+            as3_namespace: Namespace::package("http://adobe.com/AS3/2006/builtin", mc),
+            vector_public_namespace: Namespace::package("__AS3__.vec", mc),
+            vector_internal_namespace: Namespace::internal("__AS3__.vec", mc),
+            proxy_namespace: Namespace::package(
+                "http://www.adobe.com/2006/actionscript/flash/proxy",
+                mc,
+            ),
+            ruffle_private_namespace: Namespace::private("", mc),
+
             native_method_table: Default::default(),
             native_instance_allocator_table: Default::default(),
             native_instance_init_table: Default::default(),

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -93,6 +93,10 @@ pub struct Avm2<'gc> {
     pub vector_internal_namespace: Namespace<'gc>,
     pub proxy_namespace: Namespace<'gc>,
     pub ruffle_private_namespace: Namespace<'gc>,
+    // these are required to facilitate shared access between Rust and AS
+    pub flash_display_internal: Namespace<'gc>,
+    pub flash_utils_internal: Namespace<'gc>,
+    pub flash_geom_internal: Namespace<'gc>,
 
     #[collect(require_static)]
     native_method_table: &'static [Option<(&'static str, NativeMethodImpl)>],
@@ -138,6 +142,10 @@ impl<'gc> Avm2<'gc> {
                 mc,
             ),
             ruffle_private_namespace: Namespace::private("", mc),
+            // these are required to facilitate shared access between Rust and AS
+            flash_display_internal: Namespace::internal("flash.display", mc),
+            flash_utils_internal: Namespace::internal("flash.utils", mc),
+            flash_geom_internal: Namespace::internal("flash.geom", mc),
 
             native_method_table: Default::default(),
             native_instance_allocator_table: Default::default(),

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -2,7 +2,6 @@ use crate::avm2::bytearray::ByteArrayStorage;
 use crate::avm2::object::{ByteArrayObject, TObject};
 use crate::avm2::ArrayObject;
 use crate::avm2::ArrayStorage;
-use crate::avm2::Multiname;
 use crate::avm2::{Activation, Error, Object, Value};
 use crate::string::AvmString;
 use enumset::EnumSet;
@@ -101,7 +100,7 @@ pub fn recursive_serialize<'gc>(
         let name = obj
             .get_enumerant_name(index, activation)?
             .coerce_to_string(activation)?;
-        let value = obj.get_property(&Multiname::public(name), activation)?;
+        let value = obj.get_public_property(name, activation)?;
 
         if let Some(value) = serialize_value(activation, value, amf_version) {
             elements.push(Element::new(name.to_utf8_lossy(), value));
@@ -138,11 +137,8 @@ pub fn deserialize_value<'gc>(
             let mut array = ArrayObject::from_storage(activation, storage)?;
             // Now let's add each element as a property
             for element in elements {
-                array.set_property(
-                    &Multiname::public(AvmString::new_utf8(
-                        activation.context.gc_context,
-                        element.name(),
-                    )),
+                array.set_public_property(
+                    AvmString::new_utf8(activation.context.gc_context, element.name()),
                     deserialize_value(activation, element.value())?,
                     activation,
                 )?;
@@ -172,11 +168,8 @@ pub fn deserialize_value<'gc>(
                 .construct(activation, &[])?;
             for entry in elements {
                 let value = deserialize_value(activation, entry.value())?;
-                obj.set_property(
-                    &Multiname::public(AvmString::new_utf8(
-                        activation.context.gc_context,
-                        entry.name(),
-                    )),
+                obj.set_public_property(
+                    AvmString::new_utf8(activation.context.gc_context, entry.name()),
                     value,
                     activation,
                 )?;
@@ -227,11 +220,8 @@ pub fn deserialize_lso<'gc>(
         .construct(activation, &[])?;
 
     for child in &lso.body {
-        obj.set_property(
-            &Multiname::public(AvmString::new_utf8(
-                activation.context.gc_context,
-                &child.name,
-            )),
+        obj.set_public_property(
+            AvmString::new_utf8(activation.context.gc_context, &child.name),
             deserialize_value(activation, child.value())?,
             activation,
         )?;

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 use fnv::FnvHashMap;
@@ -342,8 +341,6 @@ impl<'gc> Hash for EventHandler<'gc> {
     }
 }
 
-pub const NS_EVENT_DISPATCHER: &str = "https://ruffle.rs/AS3/impl/EventDispatcher/";
-
 /// Retrieve the parent of a given `EventDispatcher`.
 ///
 /// `EventDispatcher` does not provide a generic way for it's subclasses to
@@ -381,7 +378,7 @@ pub fn dispatch_event_to_target<'gc>(
     );
     let dispatch_list = dispatcher
         .get_property(
-            &Multiname::new(Namespace::private(NS_EVENT_DISPATCHER), "dispatch_list"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "dispatch_list"),
             activation,
         )?
         .as_object();
@@ -438,7 +435,7 @@ pub fn dispatch_event<'gc>(
 ) -> Result<bool, Error<'gc>> {
     let target = this
         .get_property(
-            &Multiname::new(Namespace::private(NS_EVENT_DISPATCHER), "target"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "target"),
             activation,
         )?
         .as_object()

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -39,11 +39,6 @@ mod vector;
 mod xml;
 mod xml_list;
 
-pub(crate) const NS_RUFFLE_INTERNAL: &str = "https://ruffle.rs/AS3/impl/";
-pub(crate) const NS_VECTOR: &str = "__AS3__.vec";
-
-pub use flash::utils::NS_FLASH_PROXY;
-
 /// This structure represents all system builtin classes.
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
@@ -217,7 +212,10 @@ fn function<'gc>(
     let (_, mut global, mut domain) = script.init();
     let mc = activation.context.gc_context;
     let scope = activation.create_scopechain();
-    let qname = QName::new(Namespace::package(package), name);
+    let qname = QName::new(
+        Namespace::package(package, activation.context.gc_context),
+        name,
+    );
     let method = Method::from_builtin(nf, name, mc);
     let as3fn = FunctionObject::from_method(activation, method, scope, None, None).into();
     domain.export_definition(qname, script, mc)?;
@@ -250,9 +248,9 @@ fn dynamic_class<'gc>(
 /// This function returns the class object and class prototype as a class, which
 /// may be stored in `SystemClasses`
 fn class<'gc>(
-    activation: &mut Activation<'_, 'gc>,
     class_def: GcCell<'gc, Class<'gc>>,
     script: Script<'gc>,
+    activation: &mut Activation<'_, 'gc>,
 ) -> Result<ClassObject<'gc>, Error<'gc>> {
     let (_, mut global, mut domain) = script.init();
 
@@ -299,7 +297,7 @@ fn class<'gc>(
 
 macro_rules! avm2_system_class {
     ($field:ident, $activation:ident, $class:expr, $script:expr) => {
-        let class_object = class($activation, $class, $script)?;
+        let class_object = class($class, $script, $activation)?;
 
         let sc = $activation.avm2().system_classes.as_mut().unwrap();
         sc.$field = class_object;
@@ -341,20 +339,20 @@ pub fn load_player_globals<'gc>(
     //
     // Hence, this ridiculously complicated dance of classdef, type allocation,
     // and partial initialization.
-    let object_classdef = object::create_class(mc);
+    let object_classdef = object::create_class(activation);
     let object_class = ClassObject::from_class_partial(activation, object_classdef, None)?;
     let object_proto = ScriptObject::custom_object(mc, Some(object_class), None);
 
-    let fn_classdef = function::create_class(mc);
+    let fn_classdef = function::create_class(activation);
     let fn_class = ClassObject::from_class_partial(activation, fn_classdef, Some(object_class))?;
     let fn_proto = ScriptObject::custom_object(mc, Some(fn_class), Some(object_proto));
 
-    let class_classdef = class::create_class(mc);
+    let class_classdef = class::create_class(activation);
     let class_class =
         ClassObject::from_class_partial(activation, class_classdef, Some(object_class))?;
     let class_proto = ScriptObject::custom_object(mc, Some(object_class), Some(object_proto));
 
-    let global_classdef = global_scope::create_class(mc);
+    let global_classdef = global_scope::create_class(activation);
     let global_class =
         ClassObject::from_class_partial(activation, global_classdef, Some(object_class))?;
     let global_proto = ScriptObject::custom_object(mc, Some(object_class), Some(object_proto));
@@ -405,14 +403,24 @@ pub fn load_player_globals<'gc>(
     // After this point, it is safe to initialize any other classes.
     // Make sure to initialize superclasses *before* their subclasses!
 
-    avm2_system_class!(string, activation, string::create_class(mc), script);
-    avm2_system_class!(boolean, activation, boolean::create_class(mc), script);
-    avm2_system_class!(number, activation, number::create_class(mc), script);
-    avm2_system_class!(int, activation, int::create_class(mc), script);
-    avm2_system_class!(uint, activation, uint::create_class(mc), script);
-    avm2_system_class!(namespace, activation, namespace::create_class(mc), script);
-    avm2_system_class!(qname, activation, qname::create_class(mc), script);
-    avm2_system_class!(array, activation, array::create_class(mc), script);
+    avm2_system_class!(string, activation, string::create_class(activation), script);
+    avm2_system_class!(
+        boolean,
+        activation,
+        boolean::create_class(activation),
+        script
+    );
+    avm2_system_class!(number, activation, number::create_class(activation), script);
+    avm2_system_class!(int, activation, int::create_class(activation), script);
+    avm2_system_class!(uint, activation, uint::create_class(activation), script);
+    avm2_system_class!(
+        namespace,
+        activation,
+        namespace::create_class(activation),
+        script
+    );
+    avm2_system_class!(qname, activation, qname::create_class(activation), script);
+    avm2_system_class!(array, activation, array::create_class(activation), script);
 
     function(activation, "", "trace", toplevel::trace, script)?;
     function(
@@ -456,105 +464,105 @@ pub fn load_player_globals<'gc>(
     function(activation, "", "parseFloat", toplevel::parse_float, script)?;
     function(activation, "", "escape", toplevel::escape, script)?;
 
-    avm2_system_class!(regexp, activation, regexp::create_class(mc), script);
-    avm2_system_class!(vector, activation, vector::create_class(mc), script);
+    avm2_system_class!(regexp, activation, regexp::create_class(activation), script);
+    avm2_system_class!(vector, activation, vector::create_class(activation), script);
 
-    avm2_system_class!(date, activation, date::create_class(mc), script);
+    avm2_system_class!(date, activation, date::create_class(activation), script);
 
     // package `flash.system`
     avm2_system_class!(
         application_domain,
         activation,
-        flash::system::application_domain::create_class(mc),
+        flash::system::application_domain::create_class(activation),
         script
     );
 
     class(
-        activation,
-        flash::events::ieventdispatcher::create_interface(mc),
+        flash::events::ieventdispatcher::create_interface(activation),
         script,
+        activation,
     )?;
     avm2_system_class!(
         eventdispatcher,
         activation,
-        flash::events::eventdispatcher::create_class(mc),
+        flash::events::eventdispatcher::create_class(activation),
         script
     );
 
     // package `flash.display`
     class(
-        activation,
-        flash::display::ibitmapdrawable::create_interface(mc),
+        flash::display::ibitmapdrawable::create_interface(activation),
         script,
+        activation,
     )?;
     avm2_system_class!(
         display_object,
         activation,
-        flash::display::displayobject::create_class(mc),
+        flash::display::displayobject::create_class(activation),
         script
     );
     avm2_system_class!(
         shape,
         activation,
-        flash::display::shape::create_class(mc),
+        flash::display::shape::create_class(activation),
         script
     );
     class(
-        activation,
-        flash::display::interactiveobject::create_class(mc),
+        flash::display::interactiveobject::create_class(activation),
         script,
+        activation,
     )?;
     avm2_system_class!(
         simplebutton,
         activation,
-        flash::display::simplebutton::create_class(mc),
+        flash::display::simplebutton::create_class(activation),
         script
     );
     class(
-        activation,
-        flash::display::displayobjectcontainer::create_class(mc),
+        flash::display::displayobjectcontainer::create_class(activation),
         script,
+        activation,
     )?;
     avm2_system_class!(
         sprite,
         activation,
-        flash::display::sprite::create_class(mc),
+        flash::display::sprite::create_class(activation),
         script
     );
     avm2_system_class!(
         movieclip,
         activation,
-        flash::display::movieclip::create_class(mc),
+        flash::display::movieclip::create_class(activation),
         script
     );
     avm2_system_class!(
         graphics,
         activation,
-        flash::display::graphics::create_class(mc),
+        flash::display::graphics::create_class(activation),
         script
     );
     avm2_system_class!(
         loaderinfo,
         activation,
-        flash::display::loaderinfo::create_class(mc),
+        flash::display::loaderinfo::create_class(activation),
         script
     );
     avm2_system_class!(
         stage,
         activation,
-        flash::display::stage::create_class(mc),
+        flash::display::stage::create_class(activation),
         script
     );
     avm2_system_class!(
         bitmap,
         activation,
-        flash::display::bitmap::create_class(mc),
+        flash::display::bitmap::create_class(activation),
         script
     );
     avm2_system_class!(
         bitmapdata,
         activation,
-        flash::display::bitmapdata::create_class(mc),
+        flash::display::bitmapdata::create_class(activation),
         script
     );
 
@@ -564,25 +572,29 @@ pub fn load_player_globals<'gc>(
     avm2_system_class!(
         video,
         activation,
-        flash::media::video::create_class(mc),
-        script
-    );
-    class(activation, flash::media::sound::create_class(mc), script)?;
-    avm2_system_class!(
-        soundtransform,
-        activation,
-        flash::media::soundtransform::create_class(mc),
+        flash::media::video::create_class(activation),
         script
     );
     class(
-        activation,
-        flash::media::soundmixer::create_class(mc),
+        flash::media::sound::create_class(activation),
         script,
+        activation,
+    )?;
+    avm2_system_class!(
+        soundtransform,
+        activation,
+        flash::media::soundtransform::create_class(activation),
+        script
+    );
+    class(
+        flash::media::soundmixer::create_class(activation),
+        script,
+        activation,
     )?;
     avm2_system_class!(
         soundchannel,
         activation,
-        flash::media::soundchannel::create_class(mc),
+        flash::media::soundchannel::create_class(activation),
         script
     );
 
@@ -590,16 +602,20 @@ pub fn load_player_globals<'gc>(
     avm2_system_class!(
         textfield,
         activation,
-        flash::text::textfield::create_class(mc),
+        flash::text::textfield::create_class(activation),
         script
     );
     avm2_system_class!(
         textformat,
         activation,
-        flash::text::textformat::create_class(mc),
+        flash::text::textformat::create_class(activation),
         script
     );
-    class(activation, flash::text::font::create_class(mc), script)?;
+    class(
+        flash::text::font::create_class(activation),
+        script,
+        activation,
+    )?;
 
     // Inside this call, the macro `avm2_system_classes_playerglobal`
     // triggers classloading. Therefore, we run `load_playerglobal`
@@ -652,7 +668,7 @@ fn load_playerglobal<'gc>(
     macro_rules! avm2_system_classes_playerglobal {
         ($activation:expr, $script:expr, [$(($package:expr, $class_name:expr, $field:ident)),* $(,)?]) => {
             $(
-                let name = Multiname::new(Namespace::package($package), $class_name);
+                let name = Multiname::new(Namespace::package($package, activation.context.gc_context), $class_name);
                 let class_object = activation.resolve_class(&name)?;
                 let sc = $activation.avm2().system_classes.as_mut().unwrap();
                 sc.$field = class_object;

--- a/core/src/avm2/globals/flash/display/Loader.as
+++ b/core/src/avm2/globals/flash/display/Loader.as
@@ -8,7 +8,7 @@ package flash.display {
 		import flash.net.URLRequest;
    		import __ruffle__.stub_method;
 
-		private var _contentLoaderInfo: LoaderInfo;
+		internal var _contentLoaderInfo: LoaderInfo;
 
 		public function get contentLoaderInfo():LoaderInfo {
 			return this._contentLoaderInfo;

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -18,7 +18,7 @@ use crate::bitmap::is_size_valid;
 use crate::character::Character;
 use crate::display_object::Bitmap;
 use crate::swf::BlendMode;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 use ruffle_render::filters::{BlurFilter, ColorMatrixFilter, Filter};
 use ruffle_render::transform::Transform;
 use std::str::FromStr;
@@ -219,16 +219,16 @@ pub fn copy_pixels<'gc>(
             .coerce_to_object(activation)?;
 
         let src_min_x = source_rect
-            .get_property(&Multiname::public("x"), activation)?
+            .get_public_property("x", activation)?
             .coerce_to_i32(activation)?;
         let src_min_y = source_rect
-            .get_property(&Multiname::public("y"), activation)?
+            .get_public_property("y", activation)?
             .coerce_to_i32(activation)?;
         let src_width = source_rect
-            .get_property(&Multiname::public("width"), activation)?
+            .get_public_property("width", activation)?
             .coerce_to_i32(activation)?;
         let src_height = source_rect
-            .get_property(&Multiname::public("height"), activation)?
+            .get_public_property("height", activation)?
             .coerce_to_i32(activation)?;
 
         let dest_point = args
@@ -237,10 +237,10 @@ pub fn copy_pixels<'gc>(
             .coerce_to_object(activation)?;
 
         let dest_x = dest_point
-            .get_property(&Multiname::public("x"), activation)?
+            .get_public_property("x", activation)?
             .coerce_to_i32(activation)?;
         let dest_y = dest_point
-            .get_property(&Multiname::public("y"), activation)?
+            .get_public_property("y", activation)?
             .coerce_to_i32(activation)?;
 
         if let Some(src_bitmap) = source_bitmap.as_bitmap_data() {
@@ -277,10 +277,10 @@ pub fn copy_pixels<'gc>(
                         .coerce_to_object(activation)
                     {
                         x = alpha_point
-                            .get_property(&Multiname::public("x"), activation)?
+                            .get_public_property("x", activation)?
                             .coerce_to_i32(activation)?;
                         y = alpha_point
-                            .get_property(&Multiname::public("y"), activation)?
+                            .get_public_property("y", activation)?
                             .coerce_to_i32(activation)?;
                     }
 
@@ -333,16 +333,16 @@ pub fn get_pixels<'gc>(
             .unwrap_or(&Value::Undefined)
             .coerce_to_object(activation)?;
         let x = rectangle
-            .get_property(&Multiname::public("x"), activation)?
+            .get_public_property("x", activation)?
             .coerce_to_i32(activation)?;
         let y = rectangle
-            .get_property(&Multiname::public("y"), activation)?
+            .get_public_property("y", activation)?
             .coerce_to_i32(activation)?;
         let width = rectangle
-            .get_property(&Multiname::public("width"), activation)?
+            .get_public_property("width", activation)?
             .coerce_to_i32(activation)?;
         let height = rectangle
-            .get_property(&Multiname::public("height"), activation)?
+            .get_public_property("height", activation)?
             .coerce_to_i32(activation)?;
         let bytearray = ByteArrayObject::from_storage(
             activation,
@@ -469,16 +469,16 @@ pub fn set_pixels<'gc>(
         .coerce_to_object(activation)?;
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         let x = rectangle
-            .get_property(&Multiname::public("x"), activation)?
+            .get_public_property("x", activation)?
             .coerce_to_u32(activation)?;
         let y = rectangle
-            .get_property(&Multiname::public("y"), activation)?
+            .get_public_property("y", activation)?
             .coerce_to_u32(activation)?;
         let width = rectangle
-            .get_property(&Multiname::public("width"), activation)?
+            .get_public_property("width", activation)?
             .coerce_to_u32(activation)?;
         let height = rectangle
-            .get_property(&Multiname::public("height"), activation)?
+            .get_public_property("height", activation)?
             .coerce_to_u32(activation)?;
 
         let ba_read = bytearray
@@ -532,10 +532,10 @@ pub fn copy_channel<'gc>(
             .coerce_to_object(activation)?;
 
         let dest_x = dest_point
-            .get_property(&Multiname::public("x"), activation)?
+            .get_public_property("x", activation)?
             .coerce_to_u32(activation)?;
         let dest_y = dest_point
-            .get_property(&Multiname::public("y"), activation)?
+            .get_public_property("y", activation)?
             .coerce_to_u32(activation)?;
 
         let source_channel = args
@@ -551,16 +551,16 @@ pub fn copy_channel<'gc>(
         if let Some(source_bitmap) = source_bitmap.as_bitmap_data() {
             //TODO: what if source is disposed
             let src_min_x = source_rect
-                .get_property(&Multiname::public("x"), activation)?
+                .get_public_property("x", activation)?
                 .coerce_to_u32(activation)?;
             let src_min_y = source_rect
-                .get_property(&Multiname::public("y"), activation)?
+                .get_public_property("y", activation)?
                 .coerce_to_u32(activation)?;
             let src_width = source_rect
-                .get_property(&Multiname::public("width"), activation)?
+                .get_public_property("width", activation)?
                 .coerce_to_u32(activation)?;
             let src_height = source_rect
-                .get_property(&Multiname::public("height"), activation)?
+                .get_public_property("height", activation)?
                 .coerce_to_u32(activation)?;
             let src_max_x = src_min_x + src_width;
             let src_max_y = src_min_y + src_height;
@@ -660,16 +660,16 @@ pub fn color_transform<'gc>(
                 // TODO: Re-use `object_to_rectangle` in `movie_clip.rs`.
                 let rectangle = rectangle.coerce_to_object(activation)?;
                 let x = rectangle
-                    .get_property(&Multiname::public("x"), activation)?
+                    .get_public_property("x", activation)?
                     .coerce_to_i32(activation)?;
                 let y = rectangle
-                    .get_property(&Multiname::public("y"), activation)?
+                    .get_public_property("y", activation)?
                     .coerce_to_i32(activation)?;
                 let width = rectangle
-                    .get_property(&Multiname::public("width"), activation)?
+                    .get_public_property("width", activation)?
                     .coerce_to_i32(activation)?;
                 let height = rectangle
-                    .get_property(&Multiname::public("height"), activation)?
+                    .get_public_property("height", activation)?
                     .coerce_to_i32(activation)?;
 
                 let x_min = x.max(0) as u32;
@@ -828,16 +828,16 @@ pub fn fill_rect<'gc>(
 
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         let x = rectangle
-            .get_property(&Multiname::public("x"), activation)?
+            .get_public_property("x", activation)?
             .coerce_to_u32(activation)?;
         let y = rectangle
-            .get_property(&Multiname::public("y"), activation)?
+            .get_public_property("y", activation)?
             .coerce_to_u32(activation)?;
         let width = rectangle
-            .get_property(&Multiname::public("width"), activation)?
+            .get_public_property("width", activation)?
             .coerce_to_u32(activation)?;
         let height = rectangle
-            .get_property(&Multiname::public("height"), activation)?
+            .get_public_property("height", activation)?
             .coerce_to_u32(activation)?;
 
         bitmap_data.write(activation.context.gc_context).fill_rect(
@@ -942,10 +942,10 @@ pub fn apply_filter<'gc>(
             })?;
         let dest_point = (
             dest_point
-                .get_property(&Multiname::public("x"), activation)?
+                .get_public_property("x", activation)?
                 .coerce_to_u32(activation)?,
             dest_point
-                .get_property(&Multiname::public("x"), activation)?
+                .get_public_property("x", activation)?
                 .coerce_to_u32(activation)?,
         );
         let filter = args[3]
@@ -954,46 +954,27 @@ pub fn apply_filter<'gc>(
                 Error::from(format!("TypeError: Error #1034: Type Coercion failed: cannot convert {} to flash.filters.BitmapFilter.", args[1].coerce_to_string(activation).unwrap_or_default()))
             })?;
 
-        let bevel_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "BevelFilter",
-        ))?;
-        let bitmap_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "BitmapFilter",
-        ))?;
-        let blur_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "BlurFilter",
-        ))?;
-        let color_matrix_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "ColorMatrixFilter",
-        ))?;
-        let convolution_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "ConvolutionFilter",
-        ))?;
-        let displacement_map_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "DisplacementMapFilter",
-        ))?;
-        let drop_shadow_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "DropShadowFilter",
-        ))?;
-        let glow_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "GlowFilter",
-        ))?;
-        let gradient_bevel_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "GradientBevelFilter",
-        ))?;
-        let gradient_glow_filter = activation.resolve_class(&Multiname::new(
-            Namespace::package("flash.filters"),
-            "GradientGlowFilter",
-        ))?;
+        let filters_namespace = Namespace::package("flash.filters", activation.context.gc_context);
+        let bevel_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "BevelFilter"))?;
+        let bitmap_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "BitmapFilter"))?;
+        let blur_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "BlurFilter"))?;
+        let color_matrix_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "ColorMatrixFilter"))?;
+        let convolution_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "ConvolutionFilter"))?;
+        let displacement_map_filter = activation
+            .resolve_class(&Multiname::new(filters_namespace, "DisplacementMapFilter"))?;
+        let drop_shadow_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "DropShadowFilter"))?;
+        let glow_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "GlowFilter"))?;
+        let gradient_bevel_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "GradientBevelFilter"))?;
+        let gradient_glow_filter =
+            activation.resolve_class(&Multiname::new(filters_namespace, "GradientGlowFilter"))?;
         // let shader_filter = activation.resolve_class(&Multiname::new(
         //     Namespace::package("flash.filters"),
         //     "ShaderFilter",
@@ -1001,7 +982,7 @@ pub fn apply_filter<'gc>(
         let filter = if filter.is_of_type(color_matrix_filter, activation) {
             let mut matrix = [0.0; 20];
             if let Some(object) = filter
-                .get_property(&Multiname::public("matrix"), activation)?
+                .get_public_property("matrix", activation)?
                 .as_object()
             {
                 if let Some(array) = object.as_array_storage() {
@@ -1017,13 +998,13 @@ pub fn apply_filter<'gc>(
             Filter::ColorMatrixFilter(ColorMatrixFilter { matrix })
         } else if filter.is_of_type(blur_filter, activation) {
             let blur_x = filter
-                .get_property(&Multiname::public("blurX"), activation)?
+                .get_public_property("blurX", activation)?
                 .coerce_to_number(activation)?;
             let blur_y = filter
-                .get_property(&Multiname::public("blurY"), activation)?
+                .get_public_property("blurY", activation)?
                 .coerce_to_number(activation)?;
             let quality = filter
-                .get_property(&Multiname::public("quality"), activation)?
+                .get_public_property("quality", activation)?
                 .coerce_to_u32(activation)?;
             Filter::BlurFilter(BlurFilter {
                 blur_x: blur_x as f32,
@@ -1207,10 +1188,10 @@ pub fn perlin_noise<'gc>(
                         if let Some(offsets) = offsets.as_array_storage() {
                             if let Some(Value::Object(e)) = offsets.get(i) {
                                 let x = e
-                                    .get_property(&Multiname::public("x"), activation)?
+                                    .get_public_property("x", activation)?
                                     .coerce_to_number(activation)?;
                                 let y = e
-                                    .get_property(&Multiname::public("y"), activation)?
+                                    .get_public_property("y", activation)?
                                     .coerce_to_number(activation)?;
                                 Ok((x, y))
                             } else {
@@ -1245,10 +1226,11 @@ pub fn perlin_noise<'gc>(
 }
 
 /// Construct `BitmapData`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.display"), "BitmapData"),
-        Some(Multiname::new(Namespace::package(""), "Object")),
+        QName::new(Namespace::package("flash.display", mc), "BitmapData"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<BitmapData instance initializer>", mc),
         Method::from_builtin(class_init, "<BitmapData class initializer>", mc),
         mc,
@@ -1260,7 +1242,7 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_instance_allocator(bitmapdata_allocator);
 
     write.implements(Multiname::new(
-        Namespace::package("flash.display"),
+        Namespace::package("flash.display", mc),
         "IBitmapDrawable",
     ));
 
@@ -1274,7 +1256,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("rect", Some(rect), None),
         ("transparent", Some(transparent), None),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("getPixels", get_pixels),
@@ -1299,7 +1285,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("clone", clone),
         ("perlinNoise", perlin_noise),
     ];
-    write.define_public_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/display/ibitmapdrawable.rs
+++ b/core/src/avm2/globals/flash/display/ibitmapdrawable.rs
@@ -8,7 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Emulates attempts to execute bodiless methods.
 pub fn bodiless_method<'gc>(
@@ -29,9 +29,10 @@ pub fn class_init<'gc>(
 }
 
 /// Construct `IBitmapDrawable`'s class.
-pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_interface<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.display"), "IBitmapDrawable"),
+        QName::new(Namespace::package("flash.display", mc), "IBitmapDrawable"),
         None,
         Method::from_builtin(
             bodiless_method,

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -40,7 +40,7 @@ pub fn init<'gc>(
         )?;
         this.set_property(
             &Multiname::new(
-                activation.avm2().ruffle_private_namespace,
+                activation.avm2().flash_display_internal,
                 "_contentLoaderInfo",
             ),
             loader_info.into(),
@@ -75,7 +75,7 @@ pub fn load<'gc>(
         let loader_info = this
             .get_property(
                 &Multiname::new(
-                    activation.avm2().ruffle_private_namespace,
+                    activation.avm2().flash_display_internal,
                     "_contentLoaderInfo",
                 ),
                 activation,
@@ -118,7 +118,7 @@ pub fn load_bytes<'gc>(
         let loader_info = this
             .get_property(
                 &Multiname::new(
-                    activation.avm2().ruffle_private_namespace,
+                    activation.avm2().flash_display_internal,
                     "_contentLoaderInfo",
                 ),
                 activation,

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -5,7 +5,6 @@ use crate::avm2::object::LoaderInfoObject;
 use crate::avm2::object::TObject;
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::{Error, Object};
 use crate::backend::navigator::Request;
 use crate::display_object::LoaderDisplay;
@@ -40,7 +39,10 @@ pub fn init<'gc>(
             false,
         )?;
         this.set_property(
-            &Multiname::new(Namespace::private(""), "_contentLoaderInfo"),
+            &Multiname::new(
+                activation.avm2().ruffle_private_namespace,
+                "_contentLoaderInfo",
+            ),
             loader_info.into(),
             activation,
         )?;
@@ -61,7 +63,7 @@ pub fn load<'gc>(
             .and_then(|v| v.coerce_to_object(activation).ok());
 
         let url = url_request
-            .get_property(&Multiname::public("url"), activation)?
+            .get_public_property("url", activation)?
             .coerce_to_string(activation)?;
 
         // This is a dummy MovieClip, which will get overwritten in `Loader`
@@ -72,7 +74,10 @@ pub fn load<'gc>(
 
         let loader_info = this
             .get_property(
-                &Multiname::new(Namespace::private(""), "_contentLoaderInfo"),
+                &Multiname::new(
+                    activation.avm2().ruffle_private_namespace,
+                    "_contentLoaderInfo",
+                ),
                 activation,
             )?
             .as_object()
@@ -112,7 +117,10 @@ pub fn load_bytes<'gc>(
 
         let loader_info = this
             .get_property(
-                &Multiname::new(Namespace::private(""), "_contentLoaderInfo"),
+                &Multiname::new(
+                    activation.avm2().ruffle_private_namespace,
+                    "_contentLoaderInfo",
+                ),
                 activation,
             )?
             .as_object()

--- a/core/src/avm2/globals/flash/display/loaderinfo.rs
+++ b/core/src/avm2/globals/flash/display/loaderinfo.rs
@@ -12,7 +12,7 @@ use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
 use crate::avm2_stub_getter;
 use crate::display_object::TDisplayObject;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 use swf::{write_swf, Compression};
 
 // FIXME - Throw an actual 'Error' with the proper code
@@ -470,7 +470,7 @@ pub fn parameters<'gc>(
             for (k, v) in parameters.iter() {
                 let avm_k = AvmString::new_utf8(activation.context.gc_context, k);
                 let avm_v = AvmString::new_utf8(activation.context.gc_context, v);
-                params_obj.set_property(&Multiname::public(avm_k), avm_v.into(), activation)?;
+                params_obj.set_public_property(avm_k, avm_v.into(), activation)?;
             }
 
             return Ok(params_obj.into());
@@ -505,11 +505,12 @@ pub fn uncaught_error_events<'gc>(
 }
 
 /// Construct `LoaderInfo`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.display"), "LoaderInfo"),
+        QName::new(Namespace::package("flash.display", mc), "LoaderInfo"),
         Some(Multiname::new(
-            Namespace::package("flash.events"),
+            Namespace::package("flash.events", mc),
             "EventDispatcher",
         )),
         Method::from_builtin(instance_init, "<LoaderInfo instance initializer>", mc),
@@ -552,7 +553,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("sharedEvents", Some(shared_events), None),
         ("uncaughtErrorEvents", Some(uncaught_error_events), None),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -2,7 +2,6 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
-use crate::avm2::globals::NS_RUFFLE_INTERNAL;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{Object, StageObject, TObject};
 use crate::avm2::traits::Trait;
@@ -12,7 +11,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::display_object::Graphic;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `flash.display.Shape`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -52,13 +51,13 @@ pub fn graphics<'gc>(
         if let Some(dobj) = this.as_display_object() {
             // Lazily initialize the `Graphics` object in a hidden property.
             let graphics = match this.get_property(
-                &Multiname::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
+                &Multiname::new(activation.avm2().ruffle_private_namespace, "graphics"),
                 activation,
             )? {
                 Value::Undefined | Value::Null => {
                     let graphics = Value::from(StageObject::graphics(activation, dobj)?);
                     this.set_property(
-                        &Multiname::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
+                        &Multiname::new(activation.avm2().ruffle_private_namespace, "graphics"),
                         graphics,
                         activation,
                     )?;
@@ -74,11 +73,12 @@ pub fn graphics<'gc>(
 }
 
 /// Construct `Shape`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.display"), "Shape"),
+        QName::new(Namespace::package("flash.display", mc), "Shape"),
         Some(Multiname::new(
-            Namespace::package("flash.display"),
+            Namespace::package("flash.display", mc),
             "DisplayObject",
         )),
         Method::from_builtin(instance_init, "<Shape instance initializer>", mc),
@@ -93,12 +93,16 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         Option<NativeMethodImpl>,
         Option<NativeMethodImpl>,
     )] = &[("graphics", Some(graphics), None)];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     // Slot for lazy-initialized Graphics object.
     write.define_instance_trait(Trait::from_slot(
-        QName::new(Namespace::private(NS_RUFFLE_INTERNAL), "graphics"),
-        Multiname::new(Namespace::package("flash.display"), "Graphics"),
+        QName::new(activation.avm2().ruffle_private_namespace, "graphics"),
+        Multiname::new(Namespace::package("flash.display", mc), "Graphics"),
         None,
     ));
 

--- a/core/src/avm2/globals/flash/display/simplebutton.rs
+++ b/core/src/avm2/globals/flash/display/simplebutton.rs
@@ -12,7 +12,7 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::display_object::{Avm2Button, ButtonTracking, TDisplayObject};
 use crate::vminterface::Instantiator;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 use swf::ButtonState;
 
 /// Implements `flash.display.SimpleButton`'s instance constructor.
@@ -362,11 +362,12 @@ pub fn set_use_hand_cursor<'gc>(
 }
 
 /// Construct `SimpleButton`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.display"), "SimpleButton"),
+        QName::new(Namespace::package("flash.display", mc), "SimpleButton"),
         Some(Multiname::new(
-            Namespace::package("flash.display"),
+            Namespace::package("flash.display", mc),
             "InteractiveObject",
         )),
         Method::from_builtin(instance_init, "<SimpleButton instance initializer>", mc),
@@ -404,7 +405,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(set_sound_transform),
         ),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/display/stage_3d.rs
+++ b/core/src/avm2/globals/flash/display/stage_3d.rs
@@ -1,6 +1,5 @@
 use crate::avm2::object::Context3DObject;
 use crate::avm2::object::TObject;
-use crate::avm2::Multiname;
 
 use crate::avm2::{Activation, Error, Object, Value};
 
@@ -26,11 +25,7 @@ pub fn request_context3d_internal<'gc>(
 
             // FIXME - fire this at least one frame later,
             // since some seems to expect this (e.g. the adobe triangle example)
-            this.call_property(
-                &Multiname::public("dispatchEvent"),
-                &[event.into()],
-                activation,
-            )?;
+            this.call_public_property("dispatchEvent", &[event.into()], activation)?;
         }
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -4,7 +4,6 @@ use ruffle_render::backend::Context3DVertexBufferFormat;
 use ruffle_render::backend::ProgramType;
 
 use crate::avm2::Activation;
-use crate::avm2::Multiname;
 use crate::avm2::TObject;
 use crate::avm2::Value;
 use crate::avm2::{Error, Object};
@@ -255,14 +254,14 @@ pub fn set_program_constants_from_matrix<'gc>(
         // See https://github.com/openfl/openfl/blob/971a4c9e43b5472fd84d73920a2b7c1b3d8d9257/src/openfl/display3D/Context3D.hx#L1532-L1550
         if user_transposedMatrix {
             matrix = matrix
-                .call_property(&Multiname::public("clone"), &[], activation)?
+                .call_public_property("clone", &[], activation)?
                 .coerce_to_object(activation)?;
 
-            matrix.call_property(&Multiname::public("transpose"), &[], activation)?;
+            matrix.call_public_property("transpose", &[], activation)?;
         }
 
         let matrix_raw_data = matrix
-            .get_property(&Multiname::public("rawData"), activation)?
+            .get_public_property("rawData", activation)?
             .coerce_to_object(activation)?;
         let matrix_raw_data = matrix_raw_data
             .as_vector_storage()

--- a/core/src/avm2/globals/flash/events/ieventdispatcher.rs
+++ b/core/src/avm2/globals/flash/events/ieventdispatcher.rs
@@ -8,7 +8,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Emulates attempts to execute bodiless methods.
 pub fn bodiless_method<'gc>(
@@ -29,9 +29,10 @@ pub fn class_init<'gc>(
 }
 
 /// Construct `IEventDispatcher`'s class.
-pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_interface<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.events"), "IEventDispatcher"),
+        QName::new(Namespace::package("flash.events", mc), "IEventDispatcher"),
         None,
         Method::from_builtin(
             bodiless_method,
@@ -53,7 +54,11 @@ pub fn create_interface<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<
         ("removeEventListener", bodiless_method),
         ("willTrigger", bodiless_method),
     ];
-    write.define_public_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/events/mouse_event.rs
+++ b/core/src/avm2/globals/flash/events/mouse_event.rs
@@ -2,7 +2,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::avm2::Multiname;
 use crate::display_object::TDisplayObject;
 use swf::Twips;
 
@@ -15,7 +14,7 @@ pub fn get_stage_x<'gc>(
     if let Some(this) = this {
         if let Some(evt) = this.as_event() {
             let local_x = this
-                .get_property(&Multiname::public("localX"), activation)?
+                .get_public_property("localX", activation)?
                 .coerce_to_number(activation)?;
 
             if local_x.is_nan() {
@@ -43,7 +42,7 @@ pub fn get_stage_y<'gc>(
     if let Some(this) = this {
         if let Some(evt) = this.as_event() {
             let local_y = this
-                .get_property(&Multiname::public("localY"), activation)?
+                .get_public_property("localY", activation)?
                 .coerce_to_number(activation)?;
 
             if local_y.is_nan() {

--- a/core/src/avm2/globals/flash/geom/Transform.as
+++ b/core/src/avm2/globals/flash/geom/Transform.as
@@ -1,7 +1,7 @@
 package flash.geom {
 	import flash.display.DisplayObject;
 	public class Transform {
-		private var _displayObject:DisplayObject;
+		internal var _displayObject:DisplayObject;
 
 		function Transform(object: DisplayObject) {
 			this.init(object);

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -14,7 +14,7 @@ fn get_display_object<'gc>(
 ) -> Result<DisplayObject<'gc>, Error<'gc>> {
     Ok(this
         .get_property(
-            &Multiname::new(activation.avm2().ruffle_private_namespace, "_displayObject"),
+            &Multiname::new(activation.avm2().flash_geom_internal, "_displayObject"),
             activation,
         )?
         .as_object()
@@ -29,7 +29,7 @@ pub fn init<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     this.unwrap().set_property(
-        &Multiname::new(activation.avm2().ruffle_private_namespace, "_displayObject"),
+        &Multiname::new(activation.avm2().flash_geom_internal, "_displayObject"),
         args[0],
         activation,
     )?;

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::avm2::Multiname;
-use crate::avm2::{Activation, Error, Namespace, Object, TObject, Value};
+use crate::avm2::{Activation, Error, Object, TObject, Value};
 use crate::avm2_stub_getter;
 use crate::display_object::TDisplayObject;
 use crate::prelude::{ColorTransform, DisplayObject, Matrix, Twips};
@@ -14,7 +14,7 @@ fn get_display_object<'gc>(
 ) -> Result<DisplayObject<'gc>, Error<'gc>> {
     Ok(this
         .get_property(
-            &Multiname::new(Namespace::Private("".into()), "_displayObject"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "_displayObject"),
             activation,
         )?
         .as_object()
@@ -29,7 +29,7 @@ pub fn init<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     this.unwrap().set_property(
-        &Multiname::new(Namespace::Private("".into()), "_displayObject"),
+        &Multiname::new(activation.avm2().ruffle_private_namespace, "_displayObject"),
         args[0],
         activation,
     )?;
@@ -145,28 +145,28 @@ pub fn object_to_color_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<ColorTransform, Error<'gc>> {
     let red_multiplier = object
-        .get_property(&Multiname::public("redMultiplier"), activation)?
+        .get_public_property("redMultiplier", activation)?
         .coerce_to_number(activation)?;
     let green_multiplier = object
-        .get_property(&Multiname::public("greenMultiplier"), activation)?
+        .get_public_property("greenMultiplier", activation)?
         .coerce_to_number(activation)?;
     let blue_multiplier = object
-        .get_property(&Multiname::public("blueMultiplier"), activation)?
+        .get_public_property("blueMultiplier", activation)?
         .coerce_to_number(activation)?;
     let alpha_multiplier = object
-        .get_property(&Multiname::public("alphaMultiplier"), activation)?
+        .get_public_property("alphaMultiplier", activation)?
         .coerce_to_number(activation)?;
     let red_offset = object
-        .get_property(&Multiname::public("redOffset"), activation)?
+        .get_public_property("redOffset", activation)?
         .coerce_to_number(activation)?;
     let green_offset = object
-        .get_property(&Multiname::public("greenOffset"), activation)?
+        .get_public_property("greenOffset", activation)?
         .coerce_to_number(activation)?;
     let blue_offset = object
-        .get_property(&Multiname::public("blueOffset"), activation)?
+        .get_public_property("blueOffset", activation)?
         .coerce_to_number(activation)?;
     let alpha_offset = object
-        .get_property(&Multiname::public("alphaOffset"), activation)?
+        .get_public_property("alphaOffset", activation)?
         .coerce_to_number(activation)?;
     Ok(ColorTransform {
         r_mult: Fixed8::from_f64(red_multiplier),
@@ -224,25 +224,25 @@ pub fn object_to_matrix<'gc>(
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Matrix, Error<'gc>> {
     let a = object
-        .get_property(&Multiname::public("a"), activation)?
+        .get_public_property("a", activation)?
         .coerce_to_number(activation)? as f32;
     let b = object
-        .get_property(&Multiname::public("b"), activation)?
+        .get_public_property("b", activation)?
         .coerce_to_number(activation)? as f32;
     let c = object
-        .get_property(&Multiname::public("c"), activation)?
+        .get_public_property("c", activation)?
         .coerce_to_number(activation)? as f32;
     let d = object
-        .get_property(&Multiname::public("d"), activation)?
+        .get_public_property("d", activation)?
         .coerce_to_number(activation)? as f32;
     let tx = Twips::from_pixels(
         object
-            .get_property(&Multiname::public("tx"), activation)?
+            .get_public_property("tx", activation)?
             .coerce_to_number(activation)?,
     );
     let ty = Twips::from_pixels(
         object
-            .get_property(&Multiname::public("ty"), activation)?
+            .get_public_property("ty", activation)?
             .coerce_to_number(activation)?,
     );
 

--- a/core/src/avm2/globals/flash/media/soundchannel.rs
+++ b/core/src/avm2/globals/flash/media/soundchannel.rs
@@ -10,7 +10,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::display_object::SoundTransform;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `flash.media.SoundChannel`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -131,11 +131,12 @@ pub fn stop<'gc>(
 }
 
 /// Construct `SoundChannel`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.media"), "SoundChannel"),
+        QName::new(Namespace::package("flash.media", mc), "SoundChannel"),
         Some(Multiname::new(
-            Namespace::package("flash.events"),
+            Namespace::package("flash.events", mc),
             "EventDispatcher",
         )),
         Method::from_builtin(instance_init, "<SoundChannel instance initializer>", mc),
@@ -162,10 +163,18 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             Some(set_sound_transform),
         ),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[("stop", stop)];
-    write.define_public_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/media/soundmixer.rs
+++ b/core/src/avm2/globals/flash/media/soundmixer.rs
@@ -15,7 +15,7 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2_stub_getter;
 use crate::display_object::SoundTransform;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `flash.media.SoundMixer`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -218,10 +218,11 @@ pub fn compute_spectrum<'gc>(
 }
 
 /// Construct `SoundMixer`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.media"), "SoundMixer"),
-        Some(Multiname::public("Object")),
+        QName::new(Namespace::package("flash.media", mc), "SoundMixer"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<SoundMixer instance initializer>", mc),
         Method::from_builtin(class_init, "<SoundMixer class initializer>", mc),
         mc,
@@ -240,14 +241,22 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
             ),
             ("bufferTime", Some(buffer_time), Some(set_buffer_time)),
         ];
-    write.define_public_builtin_class_properties(mc, PUBLIC_CLASS_PROPERTIES);
+    write.define_builtin_class_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_CLASS_PROPERTIES,
+    );
 
     const PUBLIC_CLASS_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("stopAll", stop_all),
         ("areSoundsInaccessible", are_sounds_inaccessible),
         ("computeSpectrum", compute_spectrum),
     ];
-    write.define_public_builtin_class_methods(mc, PUBLIC_CLASS_METHODS);
+    write.define_builtin_class_methods(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_CLASS_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -9,7 +9,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `flash.media.Video`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -34,11 +34,12 @@ pub fn class_init<'gc>(
 }
 
 /// Construct `Video`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.media"), "Video"),
+        QName::new(Namespace::package("flash.media", mc), "Video"),
         Some(Multiname::new(
-            Namespace::package("flash.display"),
+            Namespace::package("flash.display", mc),
             "DisplayObject",
         )),
         Method::from_builtin(instance_init, "<Video instance initializer>", mc),

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -1,7 +1,7 @@
 //! `flash.net` namespace
 
 use crate::avm2::object::TObject;
-use crate::avm2::{Activation, Error, Multiname, Object, Value};
+use crate::avm2::{Activation, Error, Object, Value};
 
 pub mod object_encoding;
 pub mod shared_object;
@@ -24,7 +24,7 @@ pub fn navigate_to_url<'gc>(
         .coerce_to_string(activation)?;
 
     let url = request
-        .get_property(&Multiname::public("url"), activation)?
+        .get_public_property("url", activation)?
         .coerce_to_string(activation)?;
 
     activation

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -141,7 +141,10 @@ pub fn get_local<'gc>(
     let mut this = sharedobject_cls.construct(activation, &[])?;
 
     // Set the internal name
-    let ruffle_name = Multiname::new(Namespace::Namespace("__ruffle__".into()), "_ruffleName");
+    let ruffle_name = Multiname::new(
+        Namespace::package("__ruffle__", activation.context.gc_context),
+        "_ruffleName",
+    );
     this.set_property(
         &ruffle_name,
         AvmString::new_utf8(activation.context.gc_context, &full_name).into(),
@@ -167,7 +170,7 @@ pub fn get_local<'gc>(
             .into();
     }
 
-    this.set_property(&Multiname::public("data"), data, activation)?;
+    this.set_public_property("data", data, activation)?;
     activation
         .context
         .avm2_shared_objects
@@ -183,10 +186,13 @@ pub fn flush<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this {
         let data = this
-            .get_property(&Multiname::public("data"), activation)?
+            .get_public_property("data", activation)?
             .coerce_to_object(activation)?;
 
-        let ruffle_name = Multiname::new(Namespace::Namespace("__ruffle__".into()), "_ruffleName");
+        let ruffle_name = Multiname::new(
+            Namespace::package("__ruffle__", activation.context.gc_context),
+            "_ruffleName",
+        );
         let name = this
             .get_property(&ruffle_name, activation)?
             .coerce_to_string(activation)?;

--- a/core/src/avm2/globals/flash/net/url_loader.rs
+++ b/core/src/avm2/globals/flash/net/url_loader.rs
@@ -3,7 +3,6 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::object::TObject;
 use crate::avm2::value::Value;
-use crate::avm2::Multiname;
 use crate::avm2::{Error, Object};
 use crate::avm2_stub_method;
 use crate::backend::navigator::{NavigationMethod, Request};
@@ -23,7 +22,7 @@ pub fn load<'gc>(
         };
 
         let data_format = this
-            .get_property(&Multiname::public("dataFormat"), activation)?
+            .get_public_property("dataFormat", activation)?
             .coerce_to_string(activation)?;
 
         let data_format = if &data_format == b"binary" {
@@ -48,11 +47,11 @@ fn spawn_fetch<'gc>(
     data_format: DataFormat,
 ) -> Result<Value<'gc>, Error<'gc>> {
     let url = url_request
-        .get_property(&Multiname::public("url"), activation)?
+        .get_public_property("url", activation)?
         .coerce_to_string(activation)?;
 
     let method_str = url_request
-        .get_property(&Multiname::public("method"), activation)?
+        .get_public_property("method", activation)?
         .coerce_to_string(activation)?;
 
     let method = NavigationMethod::from_method_str(&method_str).unwrap_or_else(|| {
@@ -61,10 +60,10 @@ fn spawn_fetch<'gc>(
     });
 
     let content_type = url_request
-        .get_property(&Multiname::public("contentType"), activation)?
+        .get_public_property("contentType", activation)?
         .coerce_to_string(activation)?;
 
-    let data = url_request.get_property(&Multiname::public("data"), activation)?;
+    let data = url_request.get_public_property("data", activation)?;
 
     let data = if let Value::Null = data {
         None
@@ -80,7 +79,7 @@ fn spawn_fetch<'gc>(
         if data.is_of_type(activation.avm2().classes().urlvariables, activation) {
             if &*content_type == b"application/x-www-form-urlencoded" {
                 let data = data
-                    .call_property(&Multiname::public("toString"), &[], activation)?
+                    .call_public_property("toString", &[], activation)?
                     .coerce_to_string(activation)?
                     .to_string()
                     .into_bytes();

--- a/core/src/avm2/globals/flash/text/textfield.rs
+++ b/core/src/avm2/globals/flash/text/textfield.rs
@@ -14,7 +14,7 @@ use crate::html::TextFormat;
 use crate::string::AvmString;
 use crate::tag_utils::SwfMovie;
 use crate::{avm2_stub_getter, avm2_stub_setter};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 use std::sync::Arc;
 use swf::Color;
 
@@ -1296,11 +1296,12 @@ pub fn set_restrict<'gc>(
 }
 
 /// Construct `TextField`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::package("flash.text"), "TextField"),
+        QName::new(Namespace::package("flash.text", mc), "TextField"),
         Some(Multiname::new(
-            Namespace::package("flash.display"),
+            Namespace::package("flash.display", mc),
             "InteractiveObject",
         )),
         Method::from_builtin(instance_init, "<TextField instance initializer>", mc),
@@ -1364,7 +1365,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("sharpness", Some(sharpness), Some(set_sharpness)),
         ("numLines", Some(num_lines), None),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     const PUBLIC_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("appendText", append_text),
@@ -1375,7 +1380,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("setTextFormat", set_text_format),
         ("getLineMetrics", get_line_metrics),
     ];
-    write.define_public_builtin_instance_methods(mc, PUBLIC_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/flash/ui/context_menu.rs
+++ b/core/src/avm2/globals/flash/ui/context_menu.rs
@@ -1,5 +1,4 @@
 use crate::avm2::activation::Activation;
-use crate::avm2::multiname::Multiname;
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
@@ -11,26 +10,16 @@ pub fn hide_built_in_items<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this {
-        if let Value::Object(mut items) =
-            this.get_property(&Multiname::public("builtInItems"), activation)?
-        {
+        if let Value::Object(mut items) = this.get_public_property("builtInItems", activation)? {
             // items is a ContextMenuBuiltInItems
-            items.set_property(
-                &Multiname::public("forwardAndBack"),
-                Value::Bool(false),
-                activation,
-            )?;
-            items.set_property(&Multiname::public("loop"), Value::Bool(false), activation)?;
-            items.set_property(&Multiname::public("play"), Value::Bool(false), activation)?;
-            items.set_property(&Multiname::public("print"), Value::Bool(false), activation)?;
-            items.set_property(
-                &Multiname::public("quality"),
-                Value::Bool(false),
-                activation,
-            )?;
-            items.set_property(&Multiname::public("rewind"), Value::Bool(false), activation)?;
-            items.set_property(&Multiname::public("save"), Value::Bool(false), activation)?;
-            items.set_property(&Multiname::public("zoom"), Value::Bool(false), activation)?;
+            items.set_public_property("forwardAndBack", Value::Bool(false), activation)?;
+            items.set_public_property("loop", Value::Bool(false), activation)?;
+            items.set_public_property("play", Value::Bool(false), activation)?;
+            items.set_public_property("print", Value::Bool(false), activation)?;
+            items.set_public_property("quality", Value::Bool(false), activation)?;
+            items.set_public_property("rewind", Value::Bool(false), activation)?;
+            items.set_public_property("save", Value::Bool(false), activation)?;
+            items.set_public_property("zoom", Value::Bool(false), activation)?;
         }
     }
 
@@ -46,7 +35,7 @@ pub fn make_context_menu_state<'gc>(
     macro_rules! check_bool {
         ( $obj:expr, $name:expr, $value:expr ) => {
             matches!(
-                $obj.get_property(&Multiname::public($name), activation),
+                $obj.get_public_property($name, activation),
                 Ok(Value::Bool($value))
             )
         };
@@ -54,9 +43,7 @@ pub fn make_context_menu_state<'gc>(
 
     let mut builtin_items = context_menu::BuiltInItemFlags::for_stage(activation.context.stage);
     if let Some(menu) = menu {
-        if let Ok(Value::Object(builtins)) =
-            menu.get_property(&Multiname::public("builtInItems"), activation)
-        {
+        if let Ok(Value::Object(builtins)) = menu.get_public_property("builtInItems", activation) {
             if check_bool!(builtins, "zoom", false) {
                 builtin_items.zoom = false;
             }
@@ -84,8 +71,7 @@ pub fn make_context_menu_state<'gc>(
     result.build_builtin_items(builtin_items, activation.context.stage);
 
     if let Some(menu) = menu {
-        if let Ok(Value::Object(custom_items)) =
-            menu.get_property(&Multiname::public("customItems"), activation)
+        if let Ok(Value::Object(custom_items)) = menu.get_public_property("customItems", activation)
         {
             // note: this borrows the array, but it shouldn't be possible for
             // AS to get invoked here and cause BorrowMutError
@@ -94,7 +80,7 @@ pub fn make_context_menu_state<'gc>(
                     // this is a CustomMenuItem
                     if let Some(Value::Object(item)) = item {
                         let caption = if let Ok(Value::String(s)) =
-                            item.get_property(&Multiname::public("caption"), activation)
+                            item.get_public_property("caption", activation)
                         {
                             s
                         } else {

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -13,9 +13,6 @@ pub mod dictionary;
 pub mod proxy;
 pub mod timer;
 
-/// `flash.utils.flash_proxy` namespace
-pub const NS_FLASH_PROXY: &str = "http://www.adobe.com/2006/actionscript/flash/proxy";
-
 /// Implements `flash.utils.getTimer`
 pub fn get_timer<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -260,6 +257,6 @@ pub fn get_definition_by_name<'gc>(
         .get(0)
         .unwrap_or(&Value::Undefined)
         .coerce_to_string(activation)?;
-    let qname = QName::from_qualified_name(name, activation.context.gc_context);
+    let qname = QName::from_qualified_name(name, activation);
     appdomain.get_defined_value(activation, qname)
 }

--- a/core/src/avm2/globals/flash/utils/Timer.as
+++ b/core/src/avm2/globals/flash/utils/Timer.as
@@ -2,10 +2,10 @@ package flash.utils {
 	import flash.events.EventDispatcher;
 	import flash.events.TimerEvent;
 	public class Timer extends EventDispatcher {
-		private var _currentCount: int;
-		private var _delay: Number;
-		private var _repeatCount: int;
-		private var _timerId: int = -1;
+		internal var _currentCount: int;
+		internal var _delay: Number;
+		internal var _repeatCount: int;
+		internal var _timerId: int = -1;
 
 		private function checkDelay(delay:Number): void {
 			if (!isFinite(delay) || delay < 0) {
@@ -61,7 +61,7 @@ package flash.utils {
 		public native function start():void;
 
 		// Returns 'true' if we should cancel the underlying Ruffle native timer
-		private function onUpdate():Boolean {
+		internal function onUpdate():Boolean {
 			this._currentCount += 1;
 			this.dispatchEvent(new TimerEvent(TimerEvent.TIMER, false, false));
 			if (this.repeatCount != 0 && this._currentCount >= this._repeatCount) {

--- a/core/src/avm2/globals/flash/utils/timer.rs
+++ b/core/src/avm2/globals/flash/utils/timer.rs
@@ -4,7 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::TObject;
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::{Error, Object};
 use crate::timer::TimerCallback;
 
@@ -17,7 +16,7 @@ pub fn stop<'gc>(
     let mut this = this.expect("`this` should be set in native method!");
     let id = this
         .get_property(
-            &Multiname::new(Namespace::Private("".into()), "_timerId"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
             activation,
         )
         .unwrap()
@@ -26,7 +25,7 @@ pub fn stop<'gc>(
     if id != -1 {
         activation.context.timers.remove(id);
         this.set_property(
-            &Multiname::new(Namespace::Private("".into()), "_timerId"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
             (-1).into(),
             activation,
         )?;
@@ -44,7 +43,7 @@ pub fn start<'gc>(
     let mut this = this.expect("`this` should be set in native method!");
     let id = this
         .get_property(
-            &Multiname::new(Namespace::Private("".into()), "_timerId"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
             activation,
         )
         .unwrap()
@@ -52,7 +51,7 @@ pub fn start<'gc>(
 
     let delay = this
         .get_property(
-            &Multiname::new(Namespace::Private("".into()), "_delay"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "_delay"),
             activation,
         )
         .unwrap()
@@ -61,7 +60,7 @@ pub fn start<'gc>(
     if id == -1 {
         let on_update = this
             .get_property(
-                &Multiname::new(Namespace::Private("".into()), "onUpdate"),
+                &Multiname::new(activation.avm2().ruffle_private_namespace, "onUpdate"),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -74,7 +73,7 @@ pub fn start<'gc>(
             false,
         );
         this.set_property(
-            &Multiname::new(Namespace::Private("".into()), "_timerId"),
+            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
             id.into(),
             activation,
         )?;

--- a/core/src/avm2/globals/flash/utils/timer.rs
+++ b/core/src/avm2/globals/flash/utils/timer.rs
@@ -16,7 +16,7 @@ pub fn stop<'gc>(
     let mut this = this.expect("`this` should be set in native method!");
     let id = this
         .get_property(
-            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
+            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
             activation,
         )
         .unwrap()
@@ -25,7 +25,7 @@ pub fn stop<'gc>(
     if id != -1 {
         activation.context.timers.remove(id);
         this.set_property(
-            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
+            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
             (-1).into(),
             activation,
         )?;
@@ -43,7 +43,7 @@ pub fn start<'gc>(
     let mut this = this.expect("`this` should be set in native method!");
     let id = this
         .get_property(
-            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
+            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
             activation,
         )
         .unwrap()
@@ -51,7 +51,7 @@ pub fn start<'gc>(
 
     let delay = this
         .get_property(
-            &Multiname::new(activation.avm2().ruffle_private_namespace, "_delay"),
+            &Multiname::new(activation.avm2().flash_utils_internal, "_delay"),
             activation,
         )
         .unwrap()
@@ -60,7 +60,7 @@ pub fn start<'gc>(
     if id == -1 {
         let on_update = this
             .get_property(
-                &Multiname::new(activation.avm2().ruffle_private_namespace, "onUpdate"),
+                &Multiname::new(activation.avm2().flash_utils_internal, "onUpdate"),
                 activation,
             )?
             .coerce_to_object(activation)?;
@@ -73,7 +73,7 @@ pub fn start<'gc>(
             false,
         );
         this.set_property(
-            &Multiname::new(activation.avm2().ruffle_private_namespace, "_timerId"),
+            &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
             id.into(),
             activation,
         )?;

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -11,9 +11,8 @@ use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `global`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -34,10 +33,11 @@ pub fn class_init<'gc>(
 }
 
 /// Construct `global`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     Class::new(
-        QName::new(Namespace::public(), "global"),
-        Some(Multiname::public("Object")),
+        QName::new(activation.avm2().public_namespace, "global"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<global instance initializer>", mc),
         Method::from_builtin(class_init, "<global class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -7,10 +7,9 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `int`'s instance initializer.
 fn instance_init<'gc>(
@@ -59,8 +58,8 @@ fn class_init<'gc>(
         let this_class = this.as_class_object().unwrap();
         let int_proto = this_class.prototype();
 
-        int_proto.set_property_local(
-            &Multiname::public("toExponential"),
+        int_proto.set_string_property_local(
+            "toExponential",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_exponential, "toExponential", gc_context),
@@ -71,8 +70,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        int_proto.set_property_local(
-            &Multiname::public("toFixed"),
+        int_proto.set_string_property_local(
+            "toFixed",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_fixed, "toFixed", gc_context),
@@ -83,8 +82,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        int_proto.set_property_local(
-            &Multiname::public("toPrecision"),
+        int_proto.set_string_property_local(
+            "toPrecision",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_precision, "toPrecision", gc_context),
@@ -95,8 +94,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        int_proto.set_property_local(
-            &Multiname::public("toString"),
+        int_proto.set_string_property_local(
+            "toString",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_string, "toString", gc_context),
@@ -107,8 +106,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        int_proto.set_property_local(
-            &Multiname::public("valueOf"),
+        int_proto.set_string_property_local(
+            "valueOf",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(value_of, "valueOf", gc_context),
@@ -265,10 +264,11 @@ fn value_of<'gc>(
 }
 
 /// Construct `int`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::public(), "int"),
-        Some(Multiname::public("Object")),
+        QName::new(activation.avm2().public_namespace, "int"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<int instance initializer>", mc),
         Method::from_builtin(class_init, "<int class initializer>", mc),
         mc,
@@ -284,7 +284,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     ));
 
     const CLASS_CONSTANTS: &[(&str, i32)] = &[("MAX_VALUE", i32::MAX), ("MIN_VALUE", i32::MIN)];
-    write.define_public_constant_int_class_traits(CLASS_CONSTANTS);
+    write.define_constant_int_class_traits(
+        activation.avm2().public_namespace,
+        CLASS_CONSTANTS,
+        activation,
+    );
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("toExponential", to_exponential),
@@ -293,7 +297,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    write.define_as3_builtin_instance_methods(mc, AS3_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().as3_namespace,
+        AS3_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -7,10 +7,9 @@ use crate::avm2::object::{namespace_allocator, Object};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2_stub_constructor;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `Namespace`'s instance initializer.
 pub fn instance_init<'gc>(
@@ -54,10 +53,11 @@ pub fn class_init<'gc>(
 }
 
 /// Construct `Namespace`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::public(), "Namespace"),
-        Some(Multiname::public("Object")),
+        QName::new(activation.avm2().public_namespace, "Namespace"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<Namespace instance initializer>", mc),
         Method::from_builtin(class_init, "<Namespace class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/qname.rs
+++ b/core/src/avm2/globals/qname.rs
@@ -9,7 +9,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `QName`'s instance initializer.
 pub fn instance_init<'gc>(
@@ -25,8 +25,11 @@ pub fn instance_init<'gc>(
 
                 let namespace = match ns_arg {
                     Value::Object(o) if o.as_namespace().is_some() => *o.as_namespace().unwrap(),
-                    Value::Undefined | Value::Null => Namespace::Any,
-                    v => Namespace::Namespace(v.coerce_to_string(activation)?),
+                    Value::Undefined | Value::Null => Namespace::any(activation.context.gc_context),
+                    v => Namespace::package(
+                        v.coerce_to_string(activation)?,
+                        activation.context.gc_context,
+                    ),
                 };
 
                 (namespace, local_arg)
@@ -36,7 +39,7 @@ pub fn instance_init<'gc>(
                     Value::Object(o) if o.as_qname_object().is_some() => {
                         o.as_qname_object().unwrap().qname().unwrap().namespace()
                     }
-                    _ => Namespace::Namespace("".into()),
+                    _ => activation.avm2().public_namespace,
                 };
 
                 (namespace, qname_arg)
@@ -68,10 +71,10 @@ pub fn class_init<'gc>(
     let this = this.unwrap();
     let scope = activation.create_scopechain();
     let this_class = this.as_class_object().unwrap();
-    let mut qname_proto = this_class.prototype();
+    let qname_proto = this_class.prototype();
 
-    qname_proto.set_property(
-        &Multiname::public("toString"),
+    qname_proto.set_string_property_local(
+        "toString",
         FunctionObject::from_method(
             activation,
             Method::from_builtin(to_string, "toString", activation.context.gc_context),
@@ -83,8 +86,8 @@ pub fn class_init<'gc>(
         activation,
     )?;
 
-    qname_proto.set_property(
-        &Multiname::public("valueOf"),
+    qname_proto.set_string_property_local(
+        "valueOf",
         FunctionObject::from_method(
             activation,
             Method::from_builtin(value_of, "valueOf", activation.context.gc_context),
@@ -134,7 +137,7 @@ pub fn uri<'gc>(
     if let Some(this) = this.and_then(|t| t.as_qname_object()) {
         if let Some(qname) = this.qname() {
             return Ok(match qname.namespace() {
-                Namespace::Any => Value::Null,
+                ns if ns.is_any() => Value::Null,
                 ns => ns.as_uri().into(),
             });
         }
@@ -172,10 +175,11 @@ pub fn value_of<'gc>(
 }
 
 /// Construct `QName`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::public(), "QName"),
-        Some(Multiname::public("Object")),
+        QName::new(activation.avm2().public_namespace, "QName"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<QName instance initializer>", mc),
         Method::from_builtin(class_init, "<QName class initializer>", mc),
         mc,
@@ -193,11 +197,19 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("localName", Some(local_name), None),
         ("uri", Some(uri), None),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] =
         &[("toString", to_string), ("valueOf", value_of)];
-    write.define_as3_builtin_instance_methods(mc, AS3_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().as3_namespace,
+        AS3_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/regexp.rs
+++ b/core/src/avm2/globals/regexp.rs
@@ -7,11 +7,10 @@ use crate::avm2::regexp::RegExpFlags;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{activation::Activation, array::ArrayStorage};
 use crate::string::{AvmString, WString};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `RegExp`'s instance initializer.
 pub fn instance_init<'gc>(
@@ -233,13 +232,9 @@ pub fn exec<'gc>(
 
             let object = ArrayObject::from_storage(activation, storage)?;
 
-            object.set_property_local(
-                &Multiname::public("index"),
-                Value::Number(index as f64),
-                activation,
-            )?;
+            object.set_string_property_local("index", Value::Number(index as f64), activation)?;
 
-            object.set_property_local(&Multiname::public("input"), text.into(), activation)?;
+            object.set_string_property_local("input", text.into(), activation)?;
 
             return Ok(object.into());
         }
@@ -268,16 +263,25 @@ pub fn test<'gc>(
 }
 
 /// Construct `RegExp`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::public(), "RegExp"),
-        Some(Multiname::public("Object")),
+        QName::new(activation.avm2().public_namespace, "RegExp"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin_and_params(
             instance_init,
             "<RegExp instance initializer>",
             vec![
-                ParamConfig::optional("re", Multiname::public("String"), ""),
-                ParamConfig::optional("flags", Multiname::public("String"), ""),
+                ParamConfig::optional(
+                    "re",
+                    Multiname::new(activation.avm2().public_namespace, "String"),
+                    "",
+                ),
+                ParamConfig::optional(
+                    "flags",
+                    Multiname::new(activation.avm2().public_namespace, "String"),
+                    "",
+                ),
             ],
             false,
             mc,
@@ -307,10 +311,18 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("lastIndex", Some(last_index), Some(set_last_index)),
         ("source", Some(source), None),
     ];
-    write.define_public_builtin_instance_properties(mc, PUBLIC_INSTANCE_PROPERTIES);
+    write.define_builtin_instance_properties(
+        mc,
+        activation.avm2().public_namespace,
+        PUBLIC_INSTANCE_PROPERTIES,
+    );
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[("exec", exec), ("test", test)];
-    write.define_as3_builtin_instance_methods(mc, AS3_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().as3_namespace,
+        AS3_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -7,10 +7,9 @@ use crate::avm2::method::{Method, NativeMethodImpl, ParamConfig};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 /// Implements `uint`'s instance initializer.
 fn instance_init<'gc>(
@@ -59,8 +58,8 @@ fn class_init<'gc>(
         let this_class = this.as_class_object().unwrap();
         let uint_proto = this_class.prototype();
 
-        uint_proto.set_property_local(
-            &Multiname::public("toExponential"),
+        uint_proto.set_string_property_local(
+            "toExponential",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_exponential, "toExponential", gc_context),
@@ -71,8 +70,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        uint_proto.set_property_local(
-            &Multiname::public("toFixed"),
+        uint_proto.set_string_property_local(
+            "toFixed",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_fixed, "toFixed", gc_context),
@@ -83,8 +82,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        uint_proto.set_property_local(
-            &Multiname::public("toPrecision"),
+        uint_proto.set_string_property_local(
+            "toPrecision",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_precision, "toPrecision", gc_context),
@@ -95,8 +94,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        uint_proto.set_property_local(
-            &Multiname::public("toString"),
+        uint_proto.set_string_property_local(
+            "toString",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(to_string, "toString", gc_context),
@@ -107,8 +106,8 @@ fn class_init<'gc>(
             .into(),
             activation,
         )?;
-        uint_proto.set_property_local(
-            &Multiname::public("valueOf"),
+        uint_proto.set_string_property_local(
+            "valueOf",
             FunctionObject::from_method(
                 activation,
                 Method::from_builtin(value_of, "valueOf", gc_context),
@@ -264,10 +263,11 @@ fn value_of<'gc>(
 }
 
 /// Construct `uint`'s class.
-pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
     let class = Class::new(
-        QName::new(Namespace::public(), "uint"),
-        Some(Multiname::public("Object")),
+        QName::new(activation.avm2().public_namespace, "uint"),
+        Some(Multiname::new(activation.avm2().public_namespace, "Object")),
         Method::from_builtin(instance_init, "<uint instance initializer>", mc),
         Method::from_builtin(class_init, "<uint class initializer>", mc),
         mc,
@@ -279,13 +279,20 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
     write.set_native_instance_init(Method::from_builtin_and_params(
         native_instance_init,
         "<uint native instance initializer>",
-        vec![ParamConfig::of_type("num", Multiname::public("Object"))],
+        vec![ParamConfig::of_type(
+            "num",
+            Multiname::new(activation.avm2().public_namespace, "Object"),
+        )],
         false,
         mc,
     ));
 
     const CLASS_CONSTANTS: &[(&str, u32)] = &[("MAX_VALUE", u32::MAX), ("MIN_VALUE", u32::MIN)];
-    write.define_public_constant_uint_class_traits(CLASS_CONSTANTS);
+    write.define_constant_uint_class_traits(
+        activation.avm2().public_namespace,
+        CLASS_CONSTANTS,
+        activation,
+    );
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] = &[
         ("toExponential", to_exponential),
@@ -294,7 +301,11 @@ pub fn create_class<'gc>(mc: MutationContext<'gc, '_>) -> GcCell<'gc, Class<'gc>
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    write.define_as3_builtin_instance_methods(mc, AS3_INSTANCE_METHODS);
+    write.define_builtin_instance_methods(
+        mc,
+        activation.avm2().as3_namespace,
+        AS3_INSTANCE_METHODS,
+    );
 
     class
 }

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -173,7 +173,7 @@ impl<'gc> BytecodeMethod<'gc> {
             abc_method: abc_method.0,
             abc_method_body: None,
             signature,
-            return_type: Multiname::any(),
+            return_type: Multiname::any(activation.context.gc_context),
             is_function,
         })
     }

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -11,7 +11,13 @@ pub struct Namespace<'gc>(pub Gc<'gc, NamespaceData<'gc>>);
 
 impl<'gc> PartialEq for Namespace<'gc> {
     fn eq(&self, other: &Self) -> bool {
-        *self.0 == *other.0
+        if Gc::as_ptr(self.0) == Gc::as_ptr(other.0) {
+            true
+        } else if self.is_private() || other.is_private() {
+            false
+        } else {
+            *self.0 == *other.0
+        }
     }
 }
 impl<'gc> Eq for Namespace<'gc> {}

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -284,11 +284,7 @@ impl<'gc> ClassObject<'gc> {
         class_proto: Object<'gc>,
     ) -> Result<(), Error<'gc>> {
         self.0.write(activation.context.gc_context).prototype = Some(class_proto);
-        class_proto.set_property_local(
-            &Multiname::public("constructor"),
-            self.into(),
-            activation,
-        )?;
+        class_proto.set_string_property_local("constructor", self.into(), activation)?;
         class_proto.set_local_property_is_enumerable(
             activation.context.gc_context,
             "constructor".into(),
@@ -353,7 +349,10 @@ impl<'gc> ClassObject<'gc> {
 
                 for interface_trait in iface_read.instance_traits() {
                     if !interface_trait.name().namespace().is_public() {
-                        let public_name = QName::dynamic_name(interface_trait.name().local_name());
+                        let public_name = QName::new(
+                            activation.context.avm2.public_namespace,
+                            interface_trait.name().local_name(),
+                        );
                         self.instance_vtable().copy_property_for_interface(
                             activation.context.gc_context,
                             public_name,

--- a/core/src/avm2/object/dictionary_object.rs
+++ b/core/src/avm2/object/dictionary_object.rs
@@ -4,7 +4,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
-use crate::avm2::{Error, Multiname};
+use crate::avm2::Error;
 use crate::string::AvmString;
 use core::fmt;
 use fnv::FnvHashMap;
@@ -153,10 +153,7 @@ impl<'gc> TObject<'gc> for DictionaryObject<'gc> {
         if !name_value.is_primitive() {
             Ok(self.get_property_by_object(name_value.as_object().unwrap()))
         } else {
-            self.get_property(
-                &Multiname::public(name_value.coerce_to_string(activation)?),
-                activation,
-            )
+            self.get_public_property(name_value.coerce_to_string(activation)?, activation)
         }
     }
 

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -8,7 +8,6 @@ use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::avm2::Multiname;
 use crate::string::WString;
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -62,10 +61,10 @@ impl<'gc> ErrorObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         let name = self
-            .get_property(&Multiname::public("name"), activation)?
+            .get_public_property("name", activation)?
             .coerce_to_string(activation)?;
         let message = self
-            .get_property(&Multiname::public("message"), activation)?
+            .get_public_property("message", activation)?
             .coerce_to_string(activation)?;
         if message.is_empty() {
             return Ok(name);

--- a/core/src/avm2/object/namespace_object.rs
+++ b/core/src/avm2/object/namespace_object.rs
@@ -21,7 +21,7 @@ pub fn namespace_allocator<'gc>(
         activation.context.gc_context,
         NamespaceObjectData {
             base,
-            namespace: Namespace::public(),
+            namespace: activation.context.avm2.public_namespace,
         },
     ))
     .into())

--- a/core/src/avm2/object/proxy_object.rs
+++ b/core/src/avm2/object/proxy_object.rs
@@ -1,12 +1,10 @@
 //! Object representation for `Proxy`.
 
 use crate::avm2::activation::Activation;
-use crate::avm2::globals::NS_FLASH_PROXY;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, QNameObject, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
-use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
 use core::fmt;
@@ -79,7 +77,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
                         QNameObject::from_qname(activation, QName::new(*namespace, local_name))?;
 
                     return self.call_property(
-                        &Multiname::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "getProperty"),
+                        &Multiname::new(activation.avm2().proxy_namespace, "getProperty"),
                         &[qname.into()],
                         activation,
                     );
@@ -115,7 +113,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
                         QNameObject::from_qname(activation, QName::new(*namespace, local_name))?;
 
                     self.call_property(
-                        &Multiname::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "setProperty"),
+                        &Multiname::new(activation.avm2().proxy_namespace, "setProperty"),
                         &[qname.into(), value],
                         activation,
                     )?;
@@ -160,10 +158,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
                     args.extend_from_slice(arguments);
 
                     return self.call_property(
-                        &Multiname::new(
-                            Namespace::Namespace(NS_FLASH_PROXY.into()),
-                            "callProperty",
-                        ),
+                        &Multiname::new(activation.avm2().proxy_namespace, "callProperty"),
                         &args[..],
                         activation,
                     );
@@ -195,10 +190,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
 
                     return Ok(self
                         .call_property(
-                            &Multiname::new(
-                                Namespace::Namespace(NS_FLASH_PROXY.into()),
-                                "deleteProperty",
-                            ),
+                            &Multiname::new(activation.avm2().proxy_namespace, "deleteProperty"),
                             &[qname.into()],
                             activation,
                         )?
@@ -221,7 +213,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
     ) -> Result<bool, Error<'gc>> {
         Ok(self
             .call_property(
-                &Multiname::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "hasProperty"),
+                &Multiname::new(activation.avm2().proxy_namespace, "hasProperty"),
                 // this should probably pass the multiname as-is? See above
                 &[name.local_name().unwrap().into()],
                 activation,
@@ -236,7 +228,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
     ) -> Result<Option<u32>, Error<'gc>> {
         Ok(Some(
             self.call_property(
-                &Multiname::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "nextNameIndex"),
+                &Multiname::new(activation.avm2().proxy_namespace, "nextNameIndex"),
                 &[last_index.into()],
                 activation,
             )?
@@ -250,7 +242,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         self.call_property(
-            &Multiname::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "nextName"),
+            &Multiname::new(activation.avm2().proxy_namespace, "nextName"),
             &[index.into()],
             activation,
         )
@@ -262,7 +254,7 @@ impl<'gc> TObject<'gc> for ProxyObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
         self.call_property(
-            &Multiname::new(Namespace::Namespace(NS_FLASH_PROXY.into()), "nextValue"),
+            &Multiname::new(activation.avm2().proxy_namespace, "nextValue"),
             &[index.into()],
             activation,
         )

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -5,7 +5,6 @@ use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
 use crate::avm2::method::{BytecodeMethod, Method};
 use crate::avm2::object::{Object, TObject};
-use crate::avm2::property_map::PropertyMap;
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::Trait;
 use crate::avm2::value::Value;
@@ -69,23 +68,6 @@ pub struct TranslationUnitData<'gc> {
     /// Note that some of these may have a runtime (lazy) component.
     /// Make sure to check for that before using them.
     multinames: Vec<Option<Gc<'gc, Multiname<'gc>>>>,
-
-    /// A map from trait names to their defining `Scripts`.
-    /// This is very similar to `Domain.defs`, except it
-    /// only stores traits with `Namespace::Private`, which are
-    /// not exported/stored in `Domain`.
-    ///
-    /// This should only be used in very specific circumstances -
-    /// such as resolving classes for property types. All other
-    /// lookups should go through `Activation.resolve_definition`,
-    /// which takes scopes and privacy into account.
-    ///
-    /// Note that this map is 'gradually' populated over time -
-    /// each call to `script.load_traits` inserts all private
-    /// traits declared by that script. When looking up a
-    /// trait name in this map, you must ensure that its
-    /// corresponing `Script` will have already been loaded.
-    private_trait_scripts: PropertyMap<'gc, Script<'gc>>,
 }
 
 impl<'gc> TranslationUnit<'gc> {
@@ -98,7 +80,6 @@ impl<'gc> TranslationUnit<'gc> {
         let strings = vec![None; abc.constant_pool.strings.len() + 1];
         let namespaces = vec![None; abc.constant_pool.namespaces.len() + 1];
         let multinames = vec![None; abc.constant_pool.multinames.len() + 1];
-        let private_trait_scripts = PropertyMap::new();
 
         Self(GcCell::allocate(
             mc,
@@ -111,7 +92,6 @@ impl<'gc> TranslationUnit<'gc> {
                 strings,
                 namespaces,
                 multinames,
-                private_trait_scripts,
             },
         ))
     }
@@ -123,14 +103,6 @@ impl<'gc> TranslationUnit<'gc> {
     /// Retrieve the underlying `AbcFile` for this translation unit.
     pub fn abc(self) -> Rc<AbcFile> {
         self.0.read().abc.clone()
-    }
-
-    pub fn get_loaded_private_trait_script(self, name: &Multiname<'gc>) -> Option<Script<'gc>> {
-        self.0
-            .read()
-            .private_trait_scripts
-            .get_for_multiname(name)
-            .copied()
     }
 
     /// Load a method from the ABC file and return its method definition.
@@ -489,19 +461,11 @@ impl<'gc> Script<'gc> {
 
         for abc_trait in script.traits.iter() {
             let newtrait = Trait::from_abc_trait(unit, abc_trait, activation)?;
-            let name = newtrait.name();
-            if name.namespace().is_private() {
-                unit.0
-                    .write(activation.context.gc_context)
-                    .private_trait_scripts
-                    .insert(name, *self);
-            } else {
-                write.domain.export_definition(
-                    newtrait.name(),
-                    *self,
-                    activation.context.gc_context,
-                )?;
-            }
+            write.domain.export_definition(
+                newtrait.name(),
+                *self,
+                activation.context.gc_context,
+            )?;
             write.traits.push(newtrait);
         }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1319,8 +1319,9 @@ pub trait TDisplayObject<'gc>:
             if self.has_explicit_name() {
                 if let Some(Avm2Value::Object(mut p)) = self.parent().map(|p| p.object2()) {
                     if let Avm2Value::Object(c) = self.object2() {
-                        let name = Avm2Multiname::public(self.name());
                         let mut activation = Avm2Activation::from_nothing(context.reborrow());
+                        let name =
+                            Avm2Multiname::new(activation.avm2().public_namespace, self.name());
                         if let Err(e) = p.init_property(&name, c.into(), &mut activation) {
                             tracing::error!(
                                 "Got error when setting AVM2 child named \"{}\": {}",
@@ -1895,23 +1896,23 @@ impl SoundTransform {
     ) -> Result<Self, Avm2Error<'gc>> {
         Ok(SoundTransform {
             left_to_left: (as3_st
-                .get_property(&Avm2Multiname::public("leftToLeft"), activation)?
+                .get_public_property("leftToLeft", activation)?
                 .coerce_to_number(activation)?
                 * 100.0) as i32,
             left_to_right: (as3_st
-                .get_property(&Avm2Multiname::public("leftToRight"), activation)?
+                .get_public_property("leftToRight", activation)?
                 .coerce_to_number(activation)?
                 * 100.0) as i32,
             right_to_left: (as3_st
-                .get_property(&Avm2Multiname::public("rightToLeft"), activation)?
+                .get_public_property("rightToLeft", activation)?
                 .coerce_to_number(activation)?
                 * 100.0) as i32,
             right_to_right: (as3_st
-                .get_property(&Avm2Multiname::public("rightToRight"), activation)?
+                .get_public_property("rightToRight", activation)?
                 .coerce_to_number(activation)?
                 * 100.0) as i32,
             volume: (as3_st
-                .get_property(&Avm2Multiname::public("volume"), activation)?
+                .get_public_property("volume", activation)?
                 .coerce_to_number(activation)?
                 * 100.0) as i32,
         })
@@ -1927,31 +1928,27 @@ impl SoundTransform {
             .soundtransform
             .construct(activation, &[])?;
 
-        as3_st.set_property(
-            &Avm2Multiname::public("leftToLeft"),
+        as3_st.set_public_property(
+            "leftToLeft",
             (self.left_to_left as f64 / 100.0).into(),
             activation,
         )?;
-        as3_st.set_property(
-            &Avm2Multiname::public("leftToRight"),
+        as3_st.set_public_property(
+            "leftToRight",
             (self.left_to_right as f64 / 100.0).into(),
             activation,
         )?;
-        as3_st.set_property(
-            &Avm2Multiname::public("rightToLeft"),
+        as3_st.set_public_property(
+            "rightToLeft",
             (self.right_to_left as f64 / 100.0).into(),
             activation,
         )?;
-        as3_st.set_property(
-            &Avm2Multiname::public("rightToRight"),
+        as3_st.set_public_property(
+            "rightToRight",
             (self.right_to_right as f64 / 100.0).into(),
             activation,
         )?;
-        as3_st.set_property(
-            &Avm2Multiname::public("volume"),
-            (self.volume as f64 / 100.0).into(),
-            activation,
-        )?;
+        as3_st.set_public_property("volume", (self.volume as f64 / 100.0).into(), activation)?;
 
         Ok(as3_st)
     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -737,7 +737,7 @@ impl<'gc> MovieClip<'gc> {
             let class_name = reader.read_str()?.to_str_lossy(reader.encoding());
             let class_name = AvmString::new_utf8(activation.context.gc_context, class_name);
 
-            let name = Avm2QName::from_qualified_name(class_name, activation.context.gc_context);
+            let name = Avm2QName::from_qualified_name(class_name, &mut activation);
             let library = activation
                 .context
                 .library

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -10,8 +10,8 @@ use crate::avm2::object::EventObject as Avm2EventObject;
 use crate::avm2::object::LoaderStream;
 use crate::avm2::object::TObject as _;
 use crate::avm2::{
-    Activation as Avm2Activation, Avm2, Domain as Avm2Domain, Multiname as Avm2Multiname,
-    Object as Avm2Object, Value as Avm2Value,
+    Activation as Avm2Activation, Avm2, Domain as Avm2Domain, Object as Avm2Object,
+    Value as Avm2Value,
 };
 use crate::backend::navigator::{OwnedFuture, Request};
 use crate::context::{ActionQueue, ActionType, UpdateContext};
@@ -632,7 +632,7 @@ impl<'gc> Loader<'gc> {
             if let Some(MovieLoaderEventHandler::Avm2LoaderInfo(loader_info)) = event_handler {
                 let mut activation = Avm2Activation::from_nothing(context.reborrow());
                 let mut loader = loader_info
-                    .get_property(&Avm2Multiname::public("loader"), &mut activation)
+                    .get_public_property("loader", &mut activation)
                     .map_err(|e| Error::Avm2Error(e.to_string()))?
                     .as_object()
                     .unwrap()
@@ -1035,7 +1035,7 @@ impl<'gc> Loader<'gc> {
                     };
 
                     target
-                        .set_property(&Avm2Multiname::public("data"), data_object, activation)
+                        .set_public_property("data", data_object, activation)
                         .unwrap();
                 }
 
@@ -1386,11 +1386,8 @@ impl<'gc> Loader<'gc> {
                     let mut activation = Avm2Activation::from_nothing(uc.reborrow());
                     let domain = context
                         .and_then(|o| {
-                            o.get_property(
-                                &Avm2Multiname::public("applicationDomain"),
-                                &mut activation,
-                            )
-                            .ok()
+                            o.get_public_property("applicationDomain", &mut activation)
+                                .ok()
                         })
                         .and_then(|v| v.coerce_to_object(&mut activation).ok())
                         .and_then(|o| o.as_application_domain())


### PR DESCRIPTION
Problem description tldr: in FP, the following:
```
class B { private var x; } // QName("x", PrivateNamespace(""))
class C extends B { private var x; } // QName("x", PrivateNamespace(""))
```
Works without conflicts, as even though the namespaces "look" the same, they are actually two different namespace objects. This previously failed in Ruffle, as we only compared the contents.
(note: I couldn't add a test for it, as mxmlc doesn't generate such identical-looking qnames, and jpexs doesn't support precisely manipulating pool contents)

Unfortunately this required a massive refactor to propagate Activation everywhere, as now 1. creating a Namespace requires MC, 2. we want to avoid creating Namespaces on each use so I put the most common ones in `activation.context.avm2`, 3. this propagates into nearly every user of `.get_property(Multiname::public(...))`

This should hopefully fix most/all of the errors that look like:
```
Trait _p in class BG has same name as trait _p in class FlxSprite, but does not override it
```
But the only SWF I tested so far was https://www.newgrounds.com/portal/view/510303, which indeed becomes playable now.

Also removed the private_trait_scripts, as to the best of my knowledge, there's now nothing preventing us from just using the domain's definitions for everything. @Aaron1011 is this safe?

Todo:
- test more swfs?
- Do a perf comparison. (I checked that in basic content like box2d demo, we aren't creating any namespaces after init, so that's nice)

Also I'd really appreciate some feedback on the commit `avm2: Fix rust<->avm shared private fields`. I didn't really figure out a nicer way of doing this, but maybe someone else has something.
(and this commit needs to be squashed as otherwise the previous one doesn't pass tests)

Also to reviewers: in the first commit, 99% of changes in `avm2/globals` are identical, so you can skip through most of them. `avm2/object` are a bit more interesting, and top-level files are all interesting. That should still reduce the review volume by like 2-3x :)