### PR TITLE
chore: Bundle wasm-bindgen and wasm-bindgen-futures updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,13 +7,16 @@
     {
       "matchLanguages": ["rust"],
       "matchUpdateTypes": "patch",
-      "excludePackageNames": ["wasm-bindgen"],
       "groupName": "Rust dependency patches",
       "extends": ["schedule:weekly"]
     },
     {
       "matchLanguages": ["rust"],
       "extends": ["schedule:weekly"]
+    },
+    {
+      "matchPackageNames": ["wasm-bindgen", "wasm-bindgen-futures"],
+      "groupName": "Rust dependencies - wasm-bindgen related"
     },
     {
       "matchLanguages": ["js"],


### PR DESCRIPTION
This should fix the mess that is a wasm-bindgen update breaking every dependency PR