### PR TITLE
core: Implement Color::to_premultiplied_alpha without floats

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -69,11 +69,10 @@ impl Color {
 
         let old_alpha = if transparency { self.alpha() } else { 255 };
 
-        let a = old_alpha as f64 / 255.0;
-
-        let r = (self.red() as f64 * a).round() as u8;
-        let g = (self.green() as f64 * a).round() as u8;
-        let b = (self.blue() as f64 * a).round() as u8;
+        let a = old_alpha as u32;
+        let r = ((self.red() as u32 * a + 127) / 255) as u8;
+        let g = ((self.green() as u32 * a + 127) / 255) as u8;
+        let b = ((self.blue() as u32 * a + 127) / 255) as u8;
 
         Self::argb(old_alpha, r, g, b)
     }


### PR DESCRIPTION
I didn't test it extensively on real content, but I checked that on paper it should return exactly the same values - there are only 256*256 combinations after all.

On content heavy with `setPixels()`, on desktop I see 3-4x more fps and on web almost 2x more. Now, it's still a slow function in general (range checks on each pixel etc), but I saw it jump down from 40% of time to <20% of time in FF profiles.

Test code:

```rs
pub fn main() {
    for alpha in 0..256 {
        for color in 250..256 {
            let a = alpha as f64 / 255.0;
            let r1 = (color as f64 * a).round() as u8;
            let r2 = ((color as u32 * alpha + 127) / 255) as u8;
            if r1 != r2 {
                println!("{} {} {} {}" , alpha, color, r1, r2);
            }
        }
    }
}
```