### PR TITLE
Fix build when running tests from within `tests`

### DIFF
--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -529,7 +529,7 @@ impl AudioMixer {
     }
 
     #[cfg(not(feature = "mp3"))]
-    pub fn register_mp3(&mut self, data: &[u8]) -> Result<SoundHandle, DecodeError> {
+    pub fn register_mp3(&mut self, _data: &[u8]) -> Result<SoundHandle, DecodeError> {
         Err(decoders::Error::UnhandledCompression(AudioCompression::Mp3))
     }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 futures = "0.3.25"
-ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug"] }
+ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio"] }
 ruffle_render_wgpu = { path = "../render/wgpu" }
 ruffle_render = { path = "../render" }
 ruffle_input_format = { path = "input-format" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 futures = "0.3.25"
-ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio"] }
+ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3"] }
 ruffle_render_wgpu = { path = "../render/wgpu" }
 ruffle_render = { path = "../render" }
 ruffle_input_format = { path = "input-format" }


### PR DESCRIPTION
This is an amendment to #9561.

I have no idea how this worked without this when running from the project root.
I also have no idea how it still worked without the `mp3` feature when running from within `tests`. I added that too, just to be sure.