### PR TITLE
core: Use unnamed field in `Character::Bitmap`

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1309,19 +1309,16 @@ pub fn load_bitmap<'gc>(
         .library_for_movie(movie)
         .and_then(|l| l.character_by_export_name(name));
 
-    if let Some(Character::Bitmap {
-        bitmap: bitmap_object,
-    }) = character
-    {
+    if let Some(Character::Bitmap(bitmap)) = character {
         let new_bitmap_data = BitmapDataObject::empty_object(
             activation.context.gc_context,
             activation.context.avm1.prototypes().bitmap_data,
         );
 
-        let width = bitmap_object.width() as u32;
-        let height = bitmap_object.height() as u32;
+        let width = bitmap.width() as u32;
+        let height = bitmap.height() as u32;
 
-        let pixels: Vec<_> = bitmap_object.bitmap_data().read().pixels().to_vec();
+        let pixels: Vec<_> = bitmap.bitmap_data().read().pixels().to_vec();
 
         new_bitmap_data
             .as_bitmap_data_object()

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -62,7 +62,7 @@ pub fn instance_init<'gc>(
                     .avm2_class_registry()
                     .class_symbol(b_class)
                 {
-                    if let Some(Character::Bitmap { bitmap }) = activation
+                    if let Some(Character::Bitmap(bitmap)) = activation
                         .context
                         .library
                         .library_for_movie_mut(movie)

--- a/core/src/avm2/globals/flash/display/bitmapdata.rs
+++ b/core/src/avm2/globals/flash/display/bitmapdata.rs
@@ -74,7 +74,7 @@ pub fn instance_init<'gc>(
             let new_bitmap_data =
                 GcCell::allocate(activation.context.gc_context, BitmapData::default());
 
-            if let Some(Character::Bitmap { bitmap }) = character {
+            if let Some(Character::Bitmap(bitmap)) = character {
                 // Instantiating BitmapData from an Animate-style bitmap asset
                 fill_bitmap_data_from_symbol(activation, bitmap, new_bitmap_data);
             } else {

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -12,7 +12,7 @@ pub enum Character<'gc> {
     EditText(EditText<'gc>),
     Graphic(Graphic<'gc>),
     MovieClip(MovieClip<'gc>),
-    Bitmap { bitmap: Bitmap<'gc> },
+    Bitmap(Bitmap<'gc>),
     Avm1Button(Avm1Button<'gc>),
     Avm2Button(Avm2Button<'gc>),
     Font(Font<'gc>),

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -811,7 +811,7 @@ impl<'gc> MovieClip<'gc> {
                             Some(Character::BinaryData(_)) => {}
                             Some(Character::Font(_)) => {}
                             Some(Character::Sound(_)) => {}
-                            Some(Character::Bitmap { bitmap, .. }) => {
+                            Some(Character::Bitmap(bitmap)) => {
                                 bitmap.set_avm2_bitmapdata_class(
                                     &mut activation.context,
                                     class_object,
@@ -3015,7 +3015,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(define_bits_lossless.id, Character::Bitmap { bitmap });
+            .register_character(define_bits_lossless.id, Character::Bitmap(bitmap));
         Ok(())
     }
 
@@ -3132,7 +3132,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::Bitmap { bitmap });
+            .register_character(id, Character::Bitmap(bitmap));
         Ok(())
     }
 
@@ -3149,7 +3149,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::Bitmap { bitmap });
+            .register_character(id, Character::Bitmap(bitmap));
         Ok(())
     }
 
@@ -3172,7 +3172,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         context
             .library
             .library_for_movie_mut(self.movie())
-            .register_character(id, Character::Bitmap { bitmap });
+            .register_character(id, Character::Bitmap(bitmap));
         Ok(())
     }
 

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -204,7 +204,7 @@ impl<'gc> MovieLibrary<'gc> {
         gc_context: MutationContext<'gc, '_>,
     ) -> Result<DisplayObject<'gc>, &'static str> {
         match character {
-            Character::Bitmap { bitmap } => Ok(bitmap.instantiate(gc_context)),
+            Character::Bitmap(bitmap) => Ok(bitmap.instantiate(gc_context)),
             Character::EditText(edit_text) => Ok(edit_text.instantiate(gc_context)),
             Character::Graphic(graphic) => Ok(graphic.instantiate(gc_context)),
             Character::MorphShape(morph_shape) => Ok(morph_shape.instantiate(gc_context)),
@@ -218,7 +218,7 @@ impl<'gc> MovieLibrary<'gc> {
     }
 
     pub fn get_bitmap(&self, id: CharacterId) -> Option<Bitmap<'gc>> {
-        if let Some(&Character::Bitmap { bitmap, .. }) = self.characters.get(&id) {
+        if let Some(&Character::Bitmap(bitmap)) = self.characters.get(&id) {
             Some(bitmap)
         } else {
             None


### PR DESCRIPTION
Since `initial_data` was removed from `Character::Bitmap` in #9143, it now holds a single field. Move back to an unnamed field, which aligns with the other `Character` enum variants.