### PR TITLE
avm2: Add missing imports

### DIFF
--- a/core/src/avm2/globals/flash/events/TimerEvent.as
+++ b/core/src/avm2/globals/flash/events/TimerEvent.as
@@ -1,4 +1,5 @@
 package flash.events {
+	import __ruffle__.stub_method;
 	public class TimerEvent extends Event{
 		public static const TIMER:String = "timer";
 		public static const TIMER_COMPLETE:String = "timerComplete";

--- a/core/src/avm2/globals/flash/events/TouchEvent.as
+++ b/core/src/avm2/globals/flash/events/TouchEvent.as
@@ -6,6 +6,7 @@ package flash.events {
 
 import flash.utils.ByteArray;
 import flash.display.InteractiveObject;
+import __ruffle__.stub_method;
 
 public class TouchEvent extends Event {
     public static const PROXIMITY_BEGIN: String = "proximityBegin"; // [static] Defines the value of the type property of a PROXIMITY_BEGIN touch event object.


### PR DESCRIPTION
They were missed in https://github.com/ruffle-rs/ruffle/pull/9279 .