### PR TITLE
Remove ^M characters from Dictionary test

### DIFF
--- a/tests/tests/swfs/avm2/dictionary_access/Test.as
+++ b/tests/tests/swfs/avm2/dictionary_access/Test.as
@@ -13,14 +13,17 @@ a["key"] = 5;
 
 trace("///a[\"key\"]");
 trace(a["key"]);
-trace("///a[\"key\"] = 6");
+
+trace("///a[\"key\"] = 6");
 a["key"] = 6;
+
 trace("///var key2 = new Test()");
 var key2 = new Test();
 
 trace("///a[key2] = 23");
 a[key2] = 23;
-trace("///var key3 = new Test()");
+
+trace("///var key3 = new Test()");
 var key3 = new Test();
 
 trace('///a[key3] = "Key3 True Value"');
@@ -62,7 +65,8 @@ a[null] = "oh YES!";
 trace('///a["null"] = "yeah sure"');
 a["null"] = "yeah sure";
 
-trace('///a[true] = "true"');a[true] = "true";
+trace('///a[true] = "true"');
+a[true] = "true";
 
 trace('///a["true"] = "stringy true"');
 a["true"] = "stringy true";
@@ -79,9 +83,11 @@ trace(a["key"]);
 trace('///a[key2]');
 trace(a[key2]);
 
-trace('///a[key3]');trace(a[key3]);
+trace('///a[key3]');
+trace(a[key3]);
 
-trace('///a["key3"]');trace(a["key3"]);
+trace('///a["key3"]');
+trace(a["key3"]);
 
 trace('///a[key4]');
 trace(a[key4]);
@@ -107,7 +113,8 @@ trace(a["undefined"]);
 trace('///a[null]');
 trace(a[null]);
 
-trace('///a["null"]');trace(a["null"]);
+trace('///a["null"]');
+trace(a["null"]);
 
 trace('///a[true]');
 trace(a[true]);
@@ -115,7 +122,8 @@ trace(a[true]);
 trace('///a["true"]');
 trace(a["true"]);
 
-trace('///a[false]');trace(a[false]);
+trace('///a[false]');
+trace(a[false]);
 
 trace('///a["false"]');
 trace(a["false"]);

--- a/tests/tests/swfs/avm2/dictionary_delete/Test.as
+++ b/tests/tests/swfs/avm2/dictionary_delete/Test.as
@@ -13,14 +13,17 @@ a["key"] = 5;
 
 trace("///a[\"key\"]");
 trace(a["key"]);
-trace("///a[\"key\"] = 6");
+
+trace("///a[\"key\"] = 6");
 a["key"] = 6;
+
 trace("///var key2 = new Test()");
 var key2 = new Test();
 
 trace("///a[key2] = 23");
 a[key2] = 23;
-trace("///var key3 = new Test()");
+
+trace("///var key3 = new Test()");
 var key3 = new Test();
 
 trace('///a[key3] = "Key3 True Value"');
@@ -62,7 +65,8 @@ a[null] = "oh YES!";
 trace('///a["null"] = "yeah sure"');
 a["null"] = "yeah sure";
 
-trace('///a[true] = "true"');a[true] = "true";
+trace('///a[true] = "true"');
+a[true] = "true";
 
 trace('///a["true"] = "stringy true"');
 a["true"] = "stringy true";
@@ -88,9 +92,11 @@ trace(a[key2]);
 trace('///delete a[key3]');
 trace(delete a[key3]);
 
-trace('///a[key3]');trace(a[key3]);
+trace('///a[key3]');
+trace(a[key3]);
 
-trace('///a["key3"]');trace(a["key3"]);
+trace('///a["key3"]');
+trace(a["key3"]);
 
 trace('///delete a[\"key3\"]');
 trace(delete a["key3"]);
@@ -149,7 +155,8 @@ trace(delete a[null]);
 trace('///a[null]');
 trace(a[null]);
 
-trace('///a["null"]');trace(a["null"]);
+trace('///a["null"]');
+trace(a["null"]);
 
 trace('///delete a[true]');
 trace(delete a[true]);
@@ -163,7 +170,8 @@ trace(a["true"]);
 trace('///delete a[false]');
 trace(delete a[false]);
 
-trace('///a[false]');trace(a[false]);
+trace('///a[false]');
+trace(a[false]);
 
 trace('///a["false"]');
 trace(a["false"]);

--- a/tests/tests/swfs/avm2/dictionary_in/Test.as
+++ b/tests/tests/swfs/avm2/dictionary_in/Test.as
@@ -13,14 +13,17 @@ a["key"] = 5;
 
 trace("///a[\"key\"]");
 trace(a["key"]);
-trace("///a[\"key\"] = 6");
+
+trace("///a[\"key\"] = 6");
 a["key"] = 6;
+
 trace("///var key2 = new Test()");
 var key2 = new Test();
 
 trace("///a[key2] = 23");
 a[key2] = 23;
-trace("///var key3 = new Test()");
+
+trace("///var key3 = new Test()");
 var key3 = new Test();
 
 trace('///a[key3] = "Key3 True Value"');
@@ -62,7 +65,8 @@ a[null] = "oh YES!";
 trace('///a["null"] = "yeah sure"');
 a["null"] = "yeah sure";
 
-trace('///a[true] = "true"');a[true] = "true";
+trace('///a[true] = "true"');
+a[true] = "true";
 
 trace('///a["true"] = "stringy true"');
 a["true"] = "stringy true";


### PR DESCRIPTION
Using Github's line ending conversion to CRLF. Github's online editor does this automatically, but it also shows the whole file as changed, even though the only manual change made was a single newline added in between two traces.