### PR TITLE
avm2: Use Value::Undefined for out-of-range Vector enumerant index

### DIFF
--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -236,7 +236,7 @@ impl<'gc> TObject<'gc> for VectorObject<'gc> {
                 .map(|index| index.into())
                 .unwrap_or(Value::Undefined))
         } else {
-            Ok("".into())
+            Ok(Value::Undefined)
         }
     }
 


### PR DESCRIPTION
This makes Vector consistenht with the other implementations of `get_enumerant_name`. This also fixes a bug where AMF object serialization would loop all te way to `u32::MAX` when serializing a vector, because it would never see `Value::Undefined` and break.