### PR TITLE
web: Change `ruffle-core` output directory to `dist`

### DIFF
--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -1,3 +1,2 @@
 dist/
-pkg/
 docs/

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,4 +1,3 @@
 dist/
-pkg/
 docs/
 package-lock.json

--- a/web/.stylelintignore
+++ b/web/.stylelintignore
@@ -1,3 +1,2 @@
 dist/
-pkg/
 docs/

--- a/web/packages/core/.gitignore
+++ b/web/packages/core/.gitignore
@@ -1,3 +1,2 @@
-/pkg/
 /docs/
 /tsd/

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -4,10 +4,10 @@
     "description": "Core bindings for Ruffle",
     "license": "(MIT OR Apache-2.0)",
     "private": true,
-    "main": "./pkg/index.js",
-    "types": "./pkg/index.d.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "files": [
-        "pkg/"
+        "dist/"
     ],
     "scripts": {
         "build": "npm run build:ruffle_web && npm run build:ruffle_web-wasm_extensions && npm run build:ts",
@@ -21,7 +21,7 @@
         "//4": "# Dispatches to either building the real, or copying the fake (stand-in), 'with-extensions' module.",
         "build:ruffle_web-wasm_extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:ruffle_web-wasm_extensions-real || npm run build:ruffle_web-wasm_extensions-fake",
         "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" npm run build:cargo_bindgen_opt-wasm_extensions",
-        "build:ruffle_web-wasm_extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp ./pkg/ruffle_web_bg.wasm ./pkg/ruffle_web-wasm_extensions_bg.wasm && shx cp ./pkg/ruffle_web_bg.wasm.d.ts ./pkg/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp ./pkg/ruffle_web.js ./pkg/ruffle_web-wasm_extensions.js && shx cp ./pkg/ruffle_web.d.ts ./pkg/ruffle_web-wasm_extensions.d.ts",
+        "build:ruffle_web-wasm_extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp dist/ruffle_web_bg.wasm dist/ruffle_web-wasm_extensions_bg.wasm && shx cp dist/ruffle_web_bg.wasm.d.ts dist/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp dist/ruffle_web.js dist/ruffle_web-wasm_extensions.js && shx cp dist/ruffle_web.d.ts dist/ruffle_web-wasm_extensions.d.ts",
 
         "//5": "# These just chain together three commands after them, one for the vanilla case, and the other with extensions.",
         "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
@@ -29,12 +29,12 @@
 
         "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\" $CARGO_FLAGS",
 
-        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir ./pkg --out-name \"$OUT_NAME\"",
-        "build:wasm-opt": "cross-env-shell wasm-opt -o \"./pkg/${OUT_NAME}_bg.wasm\" -O -g \"./pkg/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
+        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir dist --out-name \"$OUT_NAME\"",
+        "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
 
         "//6": "# The only difference of these compared to the ones above is the single flag to enable reference-types.",
-        "build:wasm-bindgen-wasm_extensions": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --reference-types --target web --out-dir ./pkg --out-name \"$OUT_NAME\"",
-        "build:wasm-opt-wasm_extensions": "cross-env-shell wasm-opt --enable-reference-types -o \"./pkg/${OUT_NAME}_bg.wasm\" -O -g \"./pkg/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
+        "build:wasm-bindgen-wasm_extensions": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --reference-types --target web --out-dir dist --out-name \"$OUT_NAME\"",
+        "build:wasm-opt-wasm_extensions": "cross-env-shell wasm-opt --enable-reference-types -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
 
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
 

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -61,12 +61,12 @@ async function fetchRuffle(
     // Note: The argument passed to import() has to be a simple string literal,
     // otherwise some bundler will get confused and won't include the module?
     const { default: init, Ruffle } = await (extensionsSupported
-        ? import("../pkg/ruffle_web-wasm_extensions")
-        : import("../pkg/ruffle_web"));
+        ? import("../dist/ruffle_web-wasm_extensions")
+        : import("../dist/ruffle_web"));
     let response;
     const wasmUrl = extensionsSupported
-        ? new URL("../pkg/ruffle_web-wasm_extensions_bg.wasm", import.meta.url)
-        : new URL("../pkg/ruffle_web_bg.wasm", import.meta.url);
+        ? new URL("../dist/ruffle_web-wasm_extensions_bg.wasm", import.meta.url)
+        : new URL("../dist/ruffle_web_bg.wasm", import.meta.url);
     const wasmResponse = await fetch(wasmUrl);
     if (progressCallback) {
         const contentLength = wasmResponse.headers.get("content-length") || "";
@@ -107,8 +107,8 @@ async function fetchRuffle(
 }
 
 type Ruffle =
-    | typeof import("../pkg/ruffle_web")["Ruffle"]
-    | typeof import("../pkg/ruffle_web-wasm_extensions")["Ruffle"];
+    | typeof import("../dist/ruffle_web")["Ruffle"]
+    | typeof import("../dist/ruffle_web-wasm_extensions")["Ruffle"];
 
 let lastLoaded: Promise<Ruffle> | null = null;
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1,4 +1,4 @@
-import type { Ruffle } from "../pkg/ruffle_web";
+import type { Ruffle } from "../dist/ruffle_web";
 import { loadRuffle } from "./load-ruffle";
 import { ruffleShadowTemplate } from "./shadow-template";
 import { lookupElement } from "./register-element";

--- a/web/packages/core/tools/set_version.js
+++ b/web/packages/core/tools/set_version.js
@@ -49,7 +49,7 @@ if (process.env.ENABLE_VERSION_SEAL === "true") {
 }
 
 const options = {
-    files: "./pkg/**",
+    files: "dist/**",
     from: [
         /%VERSION_NUMBER%/g,
         /%VERSION_NAME%/g,

--- a/web/packages/core/tsconfig.json
+++ b/web/packages/core/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "es2020",
         "moduleResolution": "node",
         "target": "es2017",
-        "outDir": "pkg",
+        "outDir": "dist",
     },
     "include": ["src/**/*"],
 }

--- a/web/packages/extension/src/plugin-polyfill.ts
+++ b/web/packages/extension/src/plugin-polyfill.ts
@@ -3,6 +3,6 @@
 import {
     installPlugin,
     FLASH_PLUGIN,
-} from "ruffle-core/pkg/plugin-polyfill.js";
+} from "ruffle-core/dist/plugin-polyfill.js";
 
 installPlugin(FLASH_PLUGIN);


### PR DESCRIPTION
This aligns with the other packages.