### PR TITLE
web: Use TypeScript project references

### DIFF
--- a/web/packages/core/.gitignore
+++ b/web/packages/core/.gitignore
@@ -1,2 +1,5 @@
+# TypeDoc output.
 /docs/
-/tsd/
+
+# TypeScript incremental compilation information.
+/tsconfig.tsbuildinfo

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -38,7 +38,7 @@
 
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
 
-        "build:ts": "tsc -d && node tools/set_version.js",
+        "build:ts": "tsc --build && node tools/set_version.js",
         "docs": "typedoc",
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha"
     },

--- a/web/packages/core/tsconfig.json
+++ b/web/packages/core/tsconfig.json
@@ -1,9 +1,11 @@
 {
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
+        "composite": true,
         "module": "es2020",
         "moduleResolution": "node",
         "target": "es2017",
+        "rootDir": "src",
         "outDir": "dist",
     },
     "include": ["src/**/*"],

--- a/web/packages/extension/tsconfig.json
+++ b/web/packages/extension/tsconfig.json
@@ -4,6 +4,8 @@
         "module": "es2020",
         "moduleResolution": "node",
         "target": "es2017",
+        "rootDir": "src",
     },
     "include": ["src/**/*"],
+    "references": [{ "path": "../core" }],
 }


### PR DESCRIPTION
This slightly improves TypeScript build times, and allows LSP to work across packages without building `ruffle-core`.

Official documentation at:
https://www.typescriptlang.org/docs/handbook/project-references.html