### PR TITLE
web: Cleanup `build` script in `package.json`

### DIFF
--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -10,7 +10,7 @@
         "dist/"
     ],
     "scripts": {
-        "build": "npm run build:wasm-vanilla && npm run build:wasm-extensions && npm run build:ts",
+        "prebuild": "npm run build:wasm-vanilla && npm run build:wasm-extensions",
 
         "//1": "# Setting ENABLE_WASM_EXTENSIONS=true causes a second module to be built as well, that utilizes WebAssembly extensions, instead of it just being a 'fake' - a copy of the 'vanilla' one.",
         "//2": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
@@ -29,7 +29,9 @@
         "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" $WASM_OPT_FLAGS || npm run build:wasm-opt-failed",
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
 
-        "build:ts": "tsc --build && node tools/set_version.js",
+        "build": "tsc --build",
+        "postbuild": "node tools/set_version.js",
+
         "docs": "typedoc",
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha"
     },

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -10,21 +10,20 @@
         "dist/"
     ],
     "scripts": {
-        "build": "npm run build:ruffle_web && npm run build:ruffle_web-wasm_extensions && npm run build:ts",
+        "build": "npm run build:wasm-vanilla && npm run build:wasm-extensions && npm run build:ts",
 
         "//1": "# Setting ENABLE_WASM_EXTENSIONS=true causes a second module to be built as well, that utilizes WebAssembly extensions, instead of it just being a 'fake' - a copy of the 'vanilla' one.",
         "//2": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
         "//3": "# Enabling 'build-std' would also be great, but it's not stable yet.",
-
-        "build:ruffle_web": "cross-env OUT_NAME=ruffle_web CARGO_PROFILE=web-vanilla-wasm RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints\" npm run build:cargo_bindgen_opt",
+        "build:wasm-vanilla": "cross-env OUT_NAME=ruffle_web CARGO_PROFILE=web-vanilla-wasm RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints\" npm run build:wasm",
 
         "//4": "# Dispatches to either building the real, or copying the fake (stand-in), 'with-extensions' module.",
-        "build:ruffle_web-wasm_extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:ruffle_web-wasm_extensions-real || npm run build:ruffle_web-wasm_extensions-fake",
-        "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" WASM_BINDGEN_FLAGS=\"--reference-types\" WASM_OPT_FLAGS=\"--enable-reference-types\" npm run build:cargo_bindgen_opt",
-        "build:ruffle_web-wasm_extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp dist/ruffle_web_bg.wasm dist/ruffle_web-wasm_extensions_bg.wasm && shx cp dist/ruffle_web_bg.wasm.d.ts dist/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp dist/ruffle_web.js dist/ruffle_web-wasm_extensions.js && shx cp dist/ruffle_web.d.ts dist/ruffle_web-wasm_extensions.d.ts",
+        "build:wasm-extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:wasm-extensions-real || npm run build:wasm-extensions-fake",
+        "build:wasm-extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" WASM_BINDGEN_FLAGS=\"--reference-types\" WASM_OPT_FLAGS=\"--enable-reference-types\" npm run build:wasm",
+        "build:wasm-extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp dist/ruffle_web_bg.wasm dist/ruffle_web-wasm_extensions_bg.wasm && shx cp dist/ruffle_web_bg.wasm.d.ts dist/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp dist/ruffle_web.js dist/ruffle_web-wasm_extensions.js && shx cp dist/ruffle_web.d.ts dist/ruffle_web-wasm_extensions.d.ts",
 
         "//5": "# This just chains together the three commands after it.",
-        "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
+        "build:wasm": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
         "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\" $CARGO_FLAGS",
         "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir dist --out-name \"$OUT_NAME\" $WASM_BINDGEN_FLAGS",
         "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" $WASM_OPT_FLAGS || npm run build:wasm-opt-failed",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -20,22 +20,14 @@
 
         "//4": "# Dispatches to either building the real, or copying the fake (stand-in), 'with-extensions' module.",
         "build:ruffle_web-wasm_extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:ruffle_web-wasm_extensions-real || npm run build:ruffle_web-wasm_extensions-fake",
-        "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" npm run build:cargo_bindgen_opt-wasm_extensions",
+        "build:ruffle_web-wasm_extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" WASM_BINDGEN_FLAGS=\"--reference-types\" WASM_OPT_FLAGS=\"--enable-reference-types\" npm run build:cargo_bindgen_opt",
         "build:ruffle_web-wasm_extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp dist/ruffle_web_bg.wasm dist/ruffle_web-wasm_extensions_bg.wasm && shx cp dist/ruffle_web_bg.wasm.d.ts dist/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp dist/ruffle_web.js dist/ruffle_web-wasm_extensions.js && shx cp dist/ruffle_web.d.ts dist/ruffle_web-wasm_extensions.d.ts",
 
-        "//5": "# These just chain together three commands after them, one for the vanilla case, and the other with extensions.",
+        "//5": "# This just chains together the three commands after it.",
         "build:cargo_bindgen_opt": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
-        "build:cargo_bindgen_opt-wasm_extensions": "npm run build:cargo && npm run build:wasm-bindgen-wasm_extensions && npm run build:wasm-opt-wasm_extensions",
-
         "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\" $CARGO_FLAGS",
-
-        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir dist --out-name \"$OUT_NAME\"",
-        "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
-
-        "//6": "# The only difference of these compared to the ones above is the single flag to enable reference-types.",
-        "build:wasm-bindgen-wasm_extensions": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --reference-types --target web --out-dir dist --out-name \"$OUT_NAME\"",
-        "build:wasm-opt-wasm_extensions": "cross-env-shell wasm-opt --enable-reference-types -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" || npm run build:wasm-opt-failed",
-
+        "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir dist --out-name \"$OUT_NAME\" $WASM_BINDGEN_FLAGS",
+        "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" $WASM_OPT_FLAGS || npm run build:wasm-opt-failed",
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
 
         "build:ts": "tsc --build && node tools/set_version.js",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -10,19 +10,24 @@
         "dist/"
     ],
     "scripts": {
+        "//0": "# Setting ENABLE_WASM_EXTENSIONS=true causes a second module to be built as well,",
+        "//1": "# that utilizes WebAssembly extensions, instead of it just being a 'fake' - a copy",
+        "//2": "# of the 'vanilla' one.",
+        "//3": "# Unfortunately, we have to set `$RUSTFLAGS` here, instead of in `.cargo/config.toml`",
+        "//4": "# (for example), because it's not yet possible to specify them per-profile:",
+        "//5": "# https://github.com/rust-lang/cargo/issues/10271",
+        "//6": "# Enabling `build-std` would also be great, but it's not stable yet.",
         "prebuild": "npm run build:wasm-vanilla && npm run build:wasm-extensions",
 
-        "//1": "# Setting ENABLE_WASM_EXTENSIONS=true causes a second module to be built as well, that utilizes WebAssembly extensions, instead of it just being a 'fake' - a copy of the 'vanilla' one.",
-        "//2": "# Unfortunately, we have to set $RUSTFLAGS here, instead of in .cargo/config.toml (for example), because it's not possible to specify them per-profile; see cargo issue #7878.",
-        "//3": "# Enabling 'build-std' would also be great, but it's not stable yet.",
         "build:wasm-vanilla": "cross-env OUT_NAME=ruffle_web CARGO_PROFILE=web-vanilla-wasm RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints\" npm run build:wasm",
 
-        "//4": "# Dispatches to either building the real, or copying the fake (stand-in), 'with-extensions' module.",
+        "//7": "# Dispatches to either building the real, or copying the fake (stand-in),",
+        "//8": "# 'with-extensions' module.",
         "build:wasm-extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:wasm-extensions-real || npm run build:wasm-extensions-fake",
         "build:wasm-extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"--cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" WASM_BINDGEN_FLAGS=\"--reference-types\" WASM_OPT_FLAGS=\"--enable-reference-types\" npm run build:wasm",
         "build:wasm-extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp dist/ruffle_web_bg.wasm dist/ruffle_web-wasm_extensions_bg.wasm && shx cp dist/ruffle_web_bg.wasm.d.ts dist/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp dist/ruffle_web.js dist/ruffle_web-wasm_extensions.js && shx cp dist/ruffle_web.d.ts dist/ruffle_web-wasm_extensions.d.ts",
 
-        "//5": "# This just chains together the three commands after it.",
+        "//9": "# This just chains together the three commands after it.",
         "build:wasm": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
         "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\" $CARGO_FLAGS",
         "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir dist --out-name \"$OUT_NAME\" $WASM_BINDGEN_FLAGS",


### PR DESCRIPTION
* Wrap comments to maximum 100 characters per line.
* Take advantage of npm pre & post scripts to logically separate between WebAssembly (pre)build, TypeScript build, and `set_version.js` postbuild. More info at: https://docs.npmjs.com/cli/v9/using-npm/scripts#pre--post-scripts
* Rename some scripts to improve clarity:
    * `build:ruffle_web` -> `build:wasm-vanilla`
    * `build:ruffle_web-wasm_extensions*` -> `build:wasm-extensions*`
    * `build:cargo_bindgen_opt` -> `build:wasm`
* Reduce script duplication by introducing the `$WASM_BINDGEN_FLAGS` and `$WASM_OPT_FLAGS` environment variables.