### PR TITLE
web: Use `Closure::new()`

### DIFF
--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -87,7 +87,7 @@ struct Buffer {
 impl Buffer {
     fn new(audio: &WebAudioBackend) -> Result<Arc<RwLock<Self>>, JsError> {
         let sample_rate = audio.context.sample_rate();
-        let buffer = Arc::new(RwLock::new(Buffer {
+        let buffer = Arc::new(RwLock::new(Self {
             context: audio.context.clone(),
             mixer_proxy: audio.mixer.proxy(),
             audio_node: None,
@@ -106,10 +106,10 @@ impl Buffer {
         buffer
             .write()
             .expect("Cannot reenter locks")
-            .on_ended_handler = Closure::wrap(Box::new(move || {
+            .on_ended_handler = Closure::new(move || {
             // Refill and schedule the buffer for playback.
             let _ = buffer_handle.write().expect("Cannot reenter locks").play();
-        }) as Box<dyn FnMut()>);
+        });
 
         Ok(buffer)
     }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -340,8 +340,8 @@ impl Ruffle {
 
             // Clean up all event listeners.
             if let Some(mouse_move_callback) = &instance.mouse_move_callback {
-                let canvas_events: &EventTarget = instance.canvas.as_ref();
-                canvas_events
+                instance
+                    .canvas
                     .remove_event_listener_with_callback(
                         "pointermove",
                         mouse_move_callback.as_ref().unchecked_ref(),
@@ -350,8 +350,8 @@ impl Ruffle {
                 instance.mouse_move_callback = None;
             }
             if let Some(mouse_down_callback) = &instance.mouse_down_callback {
-                let canvas_events: &EventTarget = instance.canvas.as_ref();
-                canvas_events
+                instance
+                    .canvas
                     .remove_event_listener_with_callback(
                         "pointerdown",
                         mouse_down_callback.as_ref().unchecked_ref(),
@@ -360,8 +360,8 @@ impl Ruffle {
                 instance.mouse_down_callback = None;
             }
             if let Some(player_mouse_down_callback) = &instance.player_mouse_down_callback {
-                let js_player_events: &EventTarget = instance.js_player.as_ref();
-                js_player_events
+                instance
+                    .js_player
                     .remove_event_listener_with_callback(
                         "pointerdown",
                         player_mouse_down_callback.as_ref().unchecked_ref(),
@@ -381,8 +381,8 @@ impl Ruffle {
                 instance.window_mouse_down_callback = None;
             }
             if let Some(mouse_up_callback) = &instance.mouse_up_callback {
-                let canvas_events: &EventTarget = instance.canvas.as_ref();
-                canvas_events
+                instance
+                    .canvas
                     .remove_event_listener_with_callback(
                         "pointerup",
                         mouse_up_callback.as_ref().unchecked_ref(),
@@ -391,8 +391,8 @@ impl Ruffle {
                 instance.mouse_up_callback = None;
             }
             if let Some(mouse_wheel_callback) = &instance.mouse_wheel_callback {
-                let canvas_events: &EventTarget = instance.canvas.as_ref();
-                canvas_events
+                instance
+                    .canvas
                     .remove_event_listener_with_callback(
                         "wheel",
                         mouse_wheel_callback.as_ref().unchecked_ref(),
@@ -624,12 +624,12 @@ impl Ruffle {
 
         // Create the animation frame closure.
         ruffle.with_instance_mut(|instance| {
-            instance.animation_handler = Some(Closure::wrap(Box::new(move |timestamp: f64| {
+            instance.animation_handler = Some(Closure::new(move |timestamp| {
                 ruffle.tick(timestamp);
-            }) as Box<dyn FnMut(f64)>));
+            }));
 
             // Create mouse move handler.
-            let mouse_move_callback = Closure::wrap(Box::new(move |js_event: PointerEvent| {
+            let mouse_move_callback = Closure::new(move |js_event: PointerEvent| {
                 let _ = ruffle.with_instance(move |instance| {
                     let event = PlayerEvent::MouseMove {
                         x: f64::from(js_event.offset_x()) * instance.device_pixel_ratio,
@@ -642,20 +642,18 @@ impl Ruffle {
                         js_event.prevent_default();
                     }
                 });
-            }) as Box<dyn FnMut(PointerEvent)>);
+            });
 
-            let canvas_events: &EventTarget = canvas.as_ref();
-            canvas_events
+            canvas
                 .add_event_listener_with_callback(
                     "pointermove",
                     mouse_move_callback.as_ref().unchecked_ref(),
                 )
                 .warn_on_error();
-
             instance.mouse_move_callback = Some(mouse_move_callback);
 
             // Create mouse down handler.
-            let mouse_down_callback = Closure::wrap(Box::new(move |js_event: PointerEvent| {
+            let mouse_down_callback = Closure::new(move |js_event: PointerEvent| {
                 let _ = ruffle.with_instance(move |instance| {
                     if let Some(target) = js_event.current_target() {
                         let _ = target
@@ -679,10 +677,9 @@ impl Ruffle {
 
                     js_event.prevent_default();
                 });
-            }) as Box<dyn FnMut(PointerEvent)>);
+            });
 
-            let canvas_events: &EventTarget = canvas.as_ref();
-            canvas_events
+            canvas
                 .add_event_listener_with_callback(
                     "pointerdown",
                     mouse_down_callback.as_ref().unchecked_ref(),
@@ -691,18 +688,16 @@ impl Ruffle {
             instance.mouse_down_callback = Some(mouse_down_callback);
 
             // Create player mouse down handler.
-            let player_mouse_down_callback =
-                Closure::wrap(Box::new(move |_js_event: PointerEvent| {
-                    let _ = ruffle.with_instance_mut(|instance| {
-                        instance.has_focus = true;
-                        // Ensure the parent window gets focus. This is necessary for events
-                        // to be received when the player is inside a frame.
-                        instance.window.focus().warn_on_error();
-                    });
-                }) as Box<dyn FnMut(PointerEvent)>);
+            let player_mouse_down_callback = Closure::new(move |_js_event| {
+                let _ = ruffle.with_instance_mut(|instance| {
+                    instance.has_focus = true;
+                    // Ensure the parent window gets focus. This is necessary for events
+                    // to be received when the player is inside a frame.
+                    instance.window.focus().warn_on_error();
+                });
+            });
 
-            let js_player_events: &EventTarget = js_player.as_ref();
-            js_player_events
+            js_player
                 .add_event_listener_with_callback(
                     "pointerdown",
                     player_mouse_down_callback.as_ref().unchecked_ref(),
@@ -711,14 +706,13 @@ impl Ruffle {
             instance.player_mouse_down_callback = Some(player_mouse_down_callback);
 
             // Create window mouse down handler.
-            let window_mouse_down_callback =
-                Closure::wrap(Box::new(move |_js_event: PointerEvent| {
-                    let _ = ruffle.with_instance_mut(|instance| {
-                        // If we actually clicked on the player, this will be reset to true
-                        // after the event bubbles down to the player.
-                        instance.has_focus = false;
-                    });
-                }) as Box<dyn FnMut(PointerEvent)>);
+            let window_mouse_down_callback = Closure::new(move |_js_event| {
+                let _ = ruffle.with_instance_mut(|instance| {
+                    // If we actually clicked on the player, this will be reset to true
+                    // after the event bubbles down to the player.
+                    instance.has_focus = false;
+                });
+            });
 
             window
                 .add_event_listener_with_callback_and_bool(
@@ -730,7 +724,7 @@ impl Ruffle {
             instance.window_mouse_down_callback = Some(window_mouse_down_callback);
 
             // Create mouse up handler.
-            let mouse_up_callback = Closure::wrap(Box::new(move |js_event: PointerEvent| {
+            let mouse_up_callback = Closure::new(move |js_event: PointerEvent| {
                 let _ = ruffle.with_instance(|instance| {
                     if let Some(target) = js_event.current_target() {
                         let _ = target
@@ -755,10 +749,9 @@ impl Ruffle {
                         js_event.prevent_default();
                     }
                 });
-            }) as Box<dyn FnMut(PointerEvent)>);
+            });
 
-            let canvas_events: &EventTarget = canvas.as_ref();
-            canvas_events
+            canvas
                 .add_event_listener_with_callback(
                     "pointerup",
                     mouse_up_callback.as_ref().unchecked_ref(),
@@ -767,7 +760,7 @@ impl Ruffle {
             instance.mouse_up_callback = Some(mouse_up_callback);
 
             // Create mouse wheel handler.
-            let mouse_wheel_callback = Closure::wrap(Box::new(move |js_event: WheelEvent| {
+            let mouse_wheel_callback = Closure::new(move |js_event: WheelEvent| {
                 let _ = ruffle.with_instance(|instance| {
                     let delta = match js_event.delta_mode() {
                         WheelEvent::DOM_DELTA_LINE => MouseWheelDelta::Lines(-js_event.delta_y()),
@@ -781,22 +774,19 @@ impl Ruffle {
                         }
                     });
                 });
-            }) as Box<dyn FnMut(WheelEvent)>);
+            });
 
-            let canvas_events: &EventTarget = canvas.as_ref();
-            let mut options = AddEventListenerOptions::new();
-            options.passive(false);
-            canvas_events
+            canvas
                 .add_event_listener_with_callback_and_add_event_listener_options(
                     "wheel",
                     mouse_wheel_callback.as_ref().unchecked_ref(),
-                    &options,
+                    AddEventListenerOptions::new().passive(false),
                 )
                 .warn_on_error();
             instance.mouse_wheel_callback = Some(mouse_wheel_callback);
 
             // Create keydown event handler.
-            let key_down_callback = Closure::wrap(Box::new(move |js_event: KeyboardEvent| {
+            let key_down_callback = Closure::new(move |js_event: KeyboardEvent| {
                 let _ = ruffle.with_instance(|instance| {
                     if instance.has_focus {
                         let _ = instance.with_core_mut(|core| {
@@ -812,7 +802,7 @@ impl Ruffle {
                         js_event.prevent_default();
                     }
                 });
-            }) as Box<dyn FnMut(KeyboardEvent)>);
+            });
 
             window
                 .add_event_listener_with_callback(
@@ -823,7 +813,7 @@ impl Ruffle {
             instance.key_down_callback = Some(key_down_callback);
 
             // Create keyup event handler.
-            let key_up_callback = Closure::wrap(Box::new(move |js_event: KeyboardEvent| {
+            let key_up_callback = Closure::new(move |js_event: KeyboardEvent| {
                 let _ = ruffle.with_instance(|instance| {
                     if instance.has_focus {
                         let _ = instance.with_core_mut(|core| {
@@ -834,18 +824,18 @@ impl Ruffle {
                         js_event.prevent_default();
                     }
                 });
-            }) as Box<dyn FnMut(KeyboardEvent)>);
+            });
 
             window
                 .add_event_listener_with_callback("keyup", key_up_callback.as_ref().unchecked_ref())
                 .warn_on_error();
             instance.key_up_callback = Some(key_up_callback);
 
-            let unload_callback = Closure::wrap(Box::new(move |_| {
+            let unload_callback = Closure::new(move |_| {
                 let _ = ruffle.with_core_mut(|core| {
                     core.flush_shared_objects();
                 });
-            }) as Box<dyn FnMut(Event)>);
+            });
 
             window
                 .add_event_listener_with_callback(


### PR DESCRIPTION
`Closure::new()` works on stable Rust since wasm-bindgen 0.2.81 (https://github.com/rustwasm/wasm-bindgen/pull/2891). Use it in place of `Closure::wrap()` for more concise code.