### PR TITLE
swf: Don't truncate `ClipEventFlag` in SWFv5

### DIFF
--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -2057,10 +2057,10 @@ impl<'a> Reader<'a> {
         let bits = if self.version >= 6 {
             self.read_u32().unwrap_or_default()
         } else {
-            // SWF19 pp. 48-50: For SWFv5, the ClipEventFlags only had 2 bytes of flags,
-            // with the 2nd byte reserved (all 0).
-            // This was expanded to 4 bytes in SWFv6.
-            (self.read_u16().unwrap_or_default() as u8).into()
+            // SWF19 pp. 48-50: For SWFv5, ClipEventFlags only had 2 bytes of flags. This was
+            // expanded to 4 bytes in SWFv6.
+            // The 2nd byte is documented to be reserved (all 0), but it's not enforced by Flash.
+            self.read_u16().unwrap_or_default().into()
         };
 
         ClipEventFlag::from_bits_truncate(bits)

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -472,7 +472,7 @@ bitflags! {
         const KEY_DOWN        = 1 << 6;
         const KEY_UP          = 1 << 7;
 
-        // Added in SWF6.
+        // Added in SWF6, but not version-gated.
         const DATA            = 1 << 8;
         const INITIALIZE      = 1 << 9;
         const PRESS           = 1 << 10;


### PR DESCRIPTION
Although in SWFv5 the 2nd byte is documented to be reserved (all 0), Flash does read it and treats it the same as for SWFv6.

Fixes #8620 (might also #7301, and #9592).