### PR TITLE
chore: Allow `clippy::bool_to_int_with_if`

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::bool_to_int_with_if)]
 // This is a new lint with false positives, see https://github.com/rust-lang/rust-clippy/issues/10318
 #![allow(clippy::extra_unused_type_parameters)]
 

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::bool_to_int_with_if)]
 #![deny(clippy::unwrap_used)]
 // This is a new lint with false positives, see https://github.com/rust-lang/rust-clippy/issues/10318
 #![allow(clippy::extra_unused_type_parameters)]

--- a/swf/src/lib.rs
+++ b/swf/src/lib.rs
@@ -7,8 +7,6 @@
 //! This library consists of a `read` module for decoding SWF data, and a `write` library for
 //! writing SWF data.
 
-#![allow(clippy::bool_to_int_with_if)]
-
 #[cfg(feature = "flate2")]
 extern crate flate2;
 #[cfg(feature = "libflate")]


### PR DESCRIPTION
Seems like Clippy no longer complains about it.