### PR TITLE
core: Introduce and use `F64Extension::clamp_to_i32`

### DIFF
--- a/core/src/avm1.rs
+++ b/core/src/avm1.rs
@@ -9,6 +9,7 @@ mod property_decl;
 
 mod activation;
 mod callable_value;
+mod clamp;
 mod debug;
 mod error;
 mod fscommand;

--- a/core/src/avm1/clamp.rs
+++ b/core/src/avm1/clamp.rs
@@ -1,0 +1,27 @@
+pub trait Clamp {
+    fn clamp_also_nan(self, min: Self, max: Self) -> Self;
+
+    fn clamp_to_i32(self) -> i32;
+}
+
+// Extend the f64 type.
+impl Clamp for f64 {
+    /// A value bounded by a minimum and a maximum.
+    ///
+    /// `(f64::NAN).clamp(min, max)` causes the code to propagate NaN rather
+    /// than returning either `max` or `min`. Instead this function returns
+    /// the smallest value from the numbers provided.
+    #[allow(clippy::manual_clamp)]
+    fn clamp_also_nan(self, min: Self, max: Self) -> Self {
+        self.max(min).min(max)
+    }
+
+    fn clamp_to_i32(self) -> i32 {
+        // Clamp NaN and out-of-range (including infinite) values to `i32::MIN`.
+        if self >= i32::MIN.into() && self <= i32::MAX.into() {
+            self as i32
+        } else {
+            i32::MIN
+        }
+    }
+}

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -1,13 +1,13 @@
 //! Array class
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::AvmString;
-use crate::types::F64Extension;
 use bitflags::bitflags;
 use gc_arena::MutationContext;
 use std::cmp::Ordering;

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -7,6 +7,7 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::AvmString;
+use crate::types::F64Extension;
 use bitflags::bitflags;
 use gc_arena::MutationContext;
 use std::cmp::Ordering;
@@ -87,14 +88,8 @@ pub fn constructor<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let [Value::Number(length)] = *args {
-        let length = if length.is_finite() && length >= i32::MIN.into() && length <= i32::MAX.into()
-        {
-            length as i32
-        } else {
-            i32::MIN
-        };
         let array = ArrayObject::empty(activation);
-        array.set_length(activation, length)?;
+        array.set_length(activation, length.clamp_to_i32())?;
         Ok(array.into())
     } else {
         Ok(ArrayObject::new(

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -1,11 +1,11 @@
 //! flash.filters.ConvolutionFilter object
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::object::convolution_filter::ConvolutionFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -1,10 +1,10 @@
+use crate::avm1::clamp::Clamp;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
 use crate::locale::{get_current_date_time, get_timezone};
 use crate::string::AvmString;
-use crate::types::F64Extension;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
 

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -1,12 +1,12 @@
 //! flash.filters.DisplacementMapFilter object
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::object::displacement_map_filter::DisplacementMapFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use crate::string::{AvmString, WStr};
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -1,11 +1,11 @@
 //! flash.filters.DropShadowFilter object
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::object::drop_shadow_filter::DropShadowFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -1,11 +1,11 @@
 //! flash.filters.GlowFilter object
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::object::glow_filter::GlowFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -1,13 +1,13 @@
 //! flash.filters.GradientBevelFilter object
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_bevel_filter::GradientBevelFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
 use crate::string::{AvmString, WStr};
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -1,13 +1,13 @@
 //! flash.filters.GradientGlowFilter object
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_glow_filter::GradientGlowFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
 use crate::string::{AvmString, WStr};
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -1,13 +1,13 @@
 //! `Number` class impl
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use crate::string::AvmString;
-use crate::types::F64Extension;
 use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -2,13 +2,13 @@
 //! TODO: Sound position, transform, loadSound
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, SoundObject, TObject, Value};
 use crate::backend::navigator::Request;
 use crate::character::Character;
 use crate::display_object::{SoundTransform, TDisplayObject};
-use crate::types::F64Extension;
 use crate::{avm1_stub, avm_warn};
 use gc_arena::MutationContext;
 

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -1,6 +1,7 @@
 //! AVM1 object type to represent objects on the stage.
 
 use crate::avm1::activation::Activation;
+use crate::avm1::clamp::Clamp;
 use crate::avm1::error::Error;
 use crate::avm1::property_map::PropertyMap;
 use crate::avm1::{Object, ObjectPtr, ScriptObject, TObject, Value};
@@ -10,7 +11,7 @@ use crate::display_object::{
     DisplayObject, EditText, MovieClip, TDisplayObject, TDisplayObjectContainer,
 };
 use crate::string::{AvmString, WStr};
-use crate::types::{F64Extension, Percent};
+use crate::types::Percent;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::fmt;
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -64,6 +64,8 @@ impl From<Degrees> for f64 {
 /// Extends the f64 type.
 pub trait F64Extension {
     fn clamp_also_nan(self, min: f64, max: f64) -> f64;
+
+    fn clamp_to_i32(self) -> i32;
 }
 
 impl F64Extension for f64 {
@@ -75,5 +77,14 @@ impl F64Extension for f64 {
     #[allow(clippy::manual_clamp)]
     fn clamp_also_nan(self, min: f64, max: f64) -> f64 {
         self.max(min).min(max)
+    }
+
+    fn clamp_to_i32(self) -> i32 {
+        // Clamp NaN and out-of-range (including infinite) values to `i32::MIN`.
+        if self >= i32::MIN.into() && self <= i32::MAX.into() {
+            self as i32
+        } else {
+            i32::MIN
+        }
     }
 }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -60,31 +60,3 @@ impl From<Degrees> for f64 {
         degrees.0
     }
 }
-
-/// Extends the f64 type.
-pub trait F64Extension {
-    fn clamp_also_nan(self, min: f64, max: f64) -> f64;
-
-    fn clamp_to_i32(self) -> i32;
-}
-
-impl F64Extension for f64 {
-    /// A value bounded by a minimum and a maximum.
-    ///
-    /// `(f64::NAN).clamp(min, max)` causes the code to propagate NaN rather
-    /// than returning either `max` or `min`. Instead this function returns
-    /// the smallest value from the numbers provided.
-    #[allow(clippy::manual_clamp)]
-    fn clamp_also_nan(self, min: f64, max: f64) -> f64 {
-        self.max(min).min(max)
-    }
-
-    fn clamp_to_i32(self) -> i32 {
-        // Clamp NaN and out-of-range (including infinite) values to `i32::MIN`.
-        if self >= i32::MIN.into() && self <= i32::MAX.into() {
-            self as i32
-        } else {
-            i32::MIN
-        }
-    }
-}


### PR DESCRIPTION
Previously there were multiple implementations scattered across the codebase. Unify them to a single place, in a more "Rusty" way (now it's called via dot notation, rather than as a free function).