### PR TITLE
avm1: Add opcode 137

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1930,10 +1930,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
     
-    fn action_strict_mode(
-        &mut self,
-        _data: StrictMode,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn action_strict_mode(&mut self, _data: StrictMode) -> Result<FrameControl<'gc>, Error<'gc>> {
         // From the Open Flash documentation:
         //     "This AVM1 action only serves as a hint that the byte code was compiled using 'strict mode'. It has no runtime effect."
         Ok(FrameControl::Continue)

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -509,6 +509,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Action::SetVariable => self.action_set_variable(),
                 Action::StackSwap => self.action_stack_swap(),
                 Action::StartDrag => self.action_start_drag(),
+                Action::StrictMode(action) => self.action_strict_mode(action),
                 Action::Stop => self.action_stop(),
                 Action::StopSounds => self.action_stop_sounds(),
                 Action::StoreRegister(action) => self.action_store_register(action),
@@ -1926,6 +1927,15 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let val = self.context.avm1.pop();
         self.context.avm1.push(val);
         self.set_current_register(action.register, val);
+        Ok(FrameControl::Continue)
+    }
+    
+    fn action_strict_mode(
+        &mut self,
+        _data: StrictMode,
+    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+        // From the Open Flash documentation:
+        //     "This AVM1 action only serves as a hint that the byte code was compiled using 'strict mode'. It has no runtime effect."
         Ok(FrameControl::Continue)
     }
 

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1929,7 +1929,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.set_current_register(action.register, val);
         Ok(FrameControl::Continue)
     }
-    
+
     fn action_strict_mode(&mut self, _data: StrictMode) -> Result<FrameControl<'gc>, Error<'gc>> {
         // From the Open Flash documentation:
         //     "This AVM1 action only serves as a hint that the byte code was compiled using 'strict mode'. It has no runtime effect."

--- a/swf/src/avm1/opcode.rs
+++ b/swf/src/avm1/opcode.rs
@@ -96,6 +96,7 @@ pub enum OpCode {
 
     StoreRegister = 0x87,
     ConstantPool = 0x88,
+    StrictMode = 0x89,
 
     WaitForFrame = 0x8A,
     SetTarget = 0x8B,

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -176,6 +176,7 @@ impl<'a> Reader<'a> {
                 OpCode::StopSounds => Action::StopSounds,
                 OpCode::StoreRegister => Action::StoreRegister(self.read_store_register()?),
                 OpCode::StrictEquals => Action::StrictEquals,
+                OpCode::StrictMode => Action::StrictMode(self.read_strict_mode()?),
                 OpCode::StringAdd => Action::StringAdd,
                 OpCode::StringEquals => Action::StringEquals,
                 OpCode::StringExtract => Action::StringExtract,
@@ -346,6 +347,12 @@ impl<'a> Reader<'a> {
     fn read_store_register(&mut self) -> Result<StoreRegister> {
         Ok(StoreRegister {
             register: self.read_u8()?,
+        })
+    }
+
+    fn read_strict_mode(&mut self) -> Result<StrictMode> {
+        Ok(StrictMode {
+            data: self.read_u8()?,
         })
     }
 

--- a/swf/src/avm1/types.rs
+++ b/swf/src/avm1/types.rs
@@ -85,6 +85,7 @@ pub enum Action<'a> {
     StopSounds,
     StoreRegister(StoreRegister),
     StrictEquals,
+    StrictMode(StrictMode),
     StringAdd,
     StringEquals,
     StringExtract,
@@ -307,6 +308,11 @@ pub struct SetTarget<'a> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct StoreRegister {
     pub register: u8,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StrictMode {
+    pub data: u8,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/swf/src/avm1/write.rs
+++ b/swf/src/avm1/write.rs
@@ -159,6 +159,7 @@ impl<W: Write> Writer<W> {
             Action::StopSounds => self.write_small_action(OpCode::StopSounds),
             Action::StoreRegister(action) => self.write_store_register(action),
             Action::StrictEquals => self.write_small_action(OpCode::StrictEquals),
+            Action::StrictMode(action) => self.write_strict_mode(action),
             Action::StringAdd => self.write_small_action(OpCode::StringAdd),
             Action::StringEquals => self.write_small_action(OpCode::StringEquals),
             Action::StringExtract => self.write_small_action(OpCode::StringExtract),
@@ -385,6 +386,12 @@ impl<W: Write> Writer<W> {
     fn write_store_register(&mut self, action: &StoreRegister) -> Result<()> {
         self.write_action_header(OpCode::StoreRegister, 1)?;
         self.write_u8(action.register)?;
+        Ok(())
+    }
+
+    fn write_strict_mode(&mut self, action: &StrictMode) -> Result<()> {
+        self.write_action_header(OpCode::StrictMode, 1)?;
+        self.write_u8(action.data)?;
         Ok(())
     }
 


### PR DESCRIPTION
According to the Open Flash documentation, this was added to inform the interpreter that runtime type-checking was done. It served no actual purpose in the interpreter, though, and the person who documented this for Open Flash could not find a compiler that generated this opcode.
```
This AVM1 action only serves as a hint that the byte code was compiled using "strict mode". It has no runtime effect.
```