### PR TITLE
[DRAFT] web: Extension source upload

### DIFF
--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -8,7 +8,7 @@
         "build": "npm run build:generic && npm run build:firefox",
         "build:generic": "webpack --env generic && node tools/inject_plugin_polyfill.js && node tools/zip.js dist/ruffle_extension.zip",
         "build:firefox": "webpack --env firefox && node tools/inject_plugin_polyfill.js && node tools/zip.js dist/firefox_unsigned.xpi && npm run sign-firefox",
-        "sign-firefox": "node tools/sign_xpi.js dist/firefox_unsigned.xpi dist/firefox.xpi"
+        "sign-firefox": "node tools/sign_xpi.js dist/firefox_unsigned.xpi dist/firefox.xpi ../../../reproducible-source.zip"
     },
     "dependencies": {
         "ruffle-core": "^0.1.0"

--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import { createRequire } from "module";
 import tempDir from "temp-dir";
 import { signAddon } from "sign-addon";
+import { Client as AMOClient } from "sign-addon/lib/amo-client.js";
 
 async function sign(
     apiKey,
@@ -9,7 +10,8 @@ async function sign(
     extensionId,
     unsignedPath,
     version,
-    destination
+    destination,
+    sourcePath
 ) {
     const result = await signAddon({
         xpiPath: unsignedPath,
@@ -19,6 +21,57 @@ async function sign(
         id: extensionId,
         downloadDir: tempDir,
     });
+
+    if (result.id !== null) {
+        //Since sign-addon doesn't support source upload, let's make the request
+        //ourselves.
+        const client = new AMOClient({
+            apiKey,
+            apiSecret,
+            apiUrlPrefix: "https://addons.mozilla.org/api/v5",
+            downloadDir: tempDir,
+        });
+
+        client.post({
+            url: `/addons/addon/${encodeURIComponent(
+                extensionId
+            )}/versions/${encodeURIComponent(result.id)}`,
+            formData: {
+                source: this._fs.createReadStream(sourcePath),
+            },
+        });
+
+        const build_date = new Date().toISOString();
+
+        client.patch({
+            url: `/addons/addon/${encodeURIComponent(
+                extensionId
+            )}/versions/${encodeURIComponent(result.id)}`,
+            json: {
+                approval_notes: `This version was derived from the source code available at https://github.com/ruffle-rs/ruffle/releases/tag/nightly-${build_date.substr(
+                    0,
+                    10
+                )} - a ZIP file from this Git tag has been attached. If you download it yourself instead of using the ZIP file provided, make sure to grab the reproducible version of the ZIP, as it contains versioning information that will not be present on the main source download.\n\
+\n\
+We highly recommend using the Docker build workflow. You can invoke it using the following three commands:\n\
+\n\
+rm -rf web/docker/docker_builds/*\n\
+docker build --tag ruffle-web-docker -f web/docker/Dockerfile .\n\
+docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages\n\
+\n\
+These commands are run at the root of the project. The compiled XPI will be in web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi. Please take care to use this file (and not the surrounding packages directory) when comparing against the extension submission.\n\
+\n\
+Alternatively, you may also attempt building using npm and cargo. However, this workflow is more complicated to set up. It is documented here:\n\
+https://github.com/ruffle-rs/ruffle/blob/master/web/README.md\n\
+\n\
+Note that the commands for the npm/cargo workflow are run in the web subdirectory. If you're working with the Dockerfile you should be in the root of the project.\n\
+\n\
+The compiled version of this extension was built on Ubuntu 22.04 by our CI runner.\n\
+\n\
+As this is indeed a complicated build process, please let me know if there is anything I can do to assist.`,
+            },
+        });
+    }
 
     if (!result.success) {
         throw result;
@@ -52,7 +105,8 @@ try {
             process.env.FIREFOX_EXTENSION_ID,
             process.argv[2],
             version,
-            process.argv[3]
+            process.argv[3],
+            process.argv[4]
         );
     } else {
         console.log(


### PR DESCRIPTION
This PR attempts to add support for source upload on addons.mozilla.org, which is a necessary prerequisite to automating our extension submissions again.

The reason why this wasn't done before is that:

 * We use Mozilla's `sign-addon` tool to upload the extension, and that uses API v4
 * Source upload was only added in API v5 and `sign-addon` does not implement that API endpoint
 * Nobody at Mozilla is currently interested in updating `sign-addon` for API v5 (in lieu of a major refactor)

We hack around that by manually issuing the v5 requests using the same `Client` class that `sign-addon` provides. I'm still not 100% sure that this is correct, however; because the v5 API endpoint requires a version ID and I'm not sure the v4 (or v5) signing endpoint returns a compatible ID. In fact, [the logs from the most recent extension upload](https://github.com/ruffle-rs/ruffle/actions/runs/4237972881/jobs/7364530429) seem to imply that we DON'T get a version ID as part of the initial request at all. Hence why this is a draft - I need to do more analysis.