### PR TITLE
web: Fix broken extensions

### DIFF
--- a/web/packages/extension/assets/_locales/zh_TW/messages.json
+++ b/web/packages/extension/assets/_locales/zh_TW/messages.json
@@ -61,5 +61,5 @@
     },
     "status_tabs_error": {
         "message": "尋找目前標籤頁時發生錯誤。"
-    },
+    }
 }


### PR DESCRIPTION
[Nightly 2023-02-27 extensions](https://github.com/ruffle-rs/ruffle/releases/tag/nightly-2023-02-27) are broken and throw this error:

>Extension is invalid
>Loading locale file _locales/zh_TW/messages.json: SyntaxError: JSON.parse: expected double-quoted property name at line 65 column 1 of the JSON data
