### PR TITLE
chore: Appease clippy

### DIFF
--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -648,6 +648,7 @@ impl<W: Write> Writer<W> {
             Tag::DefineFont2(ref font) => self.write_define_font_2(font)?,
             Tag::DefineFont4(ref font) => self.write_define_font_4(font)?,
 
+            #[allow(clippy::unusual_byte_groupings)]
             Tag::DefineFontAlignZones {
                 id,
                 thickness,


### PR DESCRIPTION
The remaining Clippy errors in `core/build_playerglobal/src/cli.rs` are caused by https://github.com/clap-rs/clap/issues/4733, and sadly cannot be silenced with `#[allow(clippy::almost_swapped)]`, because the proc-macro expands with `#[deny(clippy::correctness)]`.