### PR TITLE
avm2: Implement Sprite.hitArea getter & setter

### DIFF
--- a/core/src/avm2/globals/flash/display/Sprite.as
+++ b/core/src/avm2/globals/flash/display/Sprite.as
@@ -1,5 +1,6 @@
 package flash.display {
 
+    import flash.display.Sprite;
     import flash.geom.Rectangle;
     import flash.media.SoundTransform;
 
@@ -24,5 +25,8 @@ package flash.display {
 
         public native function startDrag(lockCenter:Boolean = false, bounds:Rectangle = null):void;
         public native function stopDrag():void;
+
+        public native function get hitArea():Sprite;
+        public native function set hitArea(hitArea:Sprite):void;
     }
 }

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -282,3 +282,41 @@ pub fn set_use_hand_cursor<'gc>(
 
     Ok(Value::Undefined)
 }
+
+/// Implements `hitArea`'s getter
+pub fn get_hit_area<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(mc) = this
+        .and_then(|o| o.as_display_object())
+        .and_then(|o| o.as_movie_clip())
+        .and_then(|o| o.hit_area())
+    {
+        return Ok(mc.object2());
+    }
+
+    Ok(Value::Null)
+}
+
+/// Implements `hitArea`'s setter
+pub fn set_hit_area<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let Some(mc) = this
+        .and_then(|this| this.as_display_object())
+        .and_then(|this| this.as_movie_clip())
+    {
+        mc.set_hit_area(
+            &mut activation.context,
+            args.get(0)
+                .and_then(|hit_area| hit_area.as_object())
+                .and_then(|hit_area| hit_area.as_display_object()),
+        );
+    }
+
+    Ok(Value::Undefined)
+}

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -102,6 +102,9 @@ pub struct MovieClipData<'gc> {
     /// Show a hand cursor when the clip is in button mode.
     use_hand_cursor: bool,
 
+    /// A DisplayObject (doesn't need to be visible) to use for hit tests instead of this clip.
+    hit_area: Option<DisplayObject<'gc>>,
+
     /// Force enable button mode, which causes all mouse-related events to
     /// trigger on this clip rather than any input-eligible children.
     button_mode: bool,
@@ -145,6 +148,7 @@ impl<'gc> MovieClip<'gc> {
                 queued_script_frame: None,
                 queued_goto_frame: None,
                 drop_target: None,
+                hit_area: None,
 
                 #[cfg(feature = "timeline_debug")]
                 tag_frame_boundaries: Default::default(),
@@ -184,6 +188,7 @@ impl<'gc> MovieClip<'gc> {
                 queued_script_frame: None,
                 queued_goto_frame: None,
                 drop_target: None,
+                hit_area: None,
 
                 #[cfg(feature = "timeline_debug")]
                 tag_frame_boundaries: Default::default(),
@@ -227,6 +232,7 @@ impl<'gc> MovieClip<'gc> {
                 queued_script_frame: None,
                 queued_goto_frame: None,
                 drop_target: None,
+                hit_area: None,
 
                 #[cfg(feature = "timeline_debug")]
                 tag_frame_boundaries: Default::default(),
@@ -288,6 +294,7 @@ impl<'gc> MovieClip<'gc> {
                 queued_script_frame: None,
                 queued_goto_frame: None,
                 drop_target: None,
+                hit_area: None,
 
                 #[cfg(feature = "timeline_debug")]
                 tag_frame_boundaries: Default::default(),
@@ -2171,6 +2178,18 @@ impl<'gc> MovieClip<'gc> {
 
     pub fn set_use_hand_cursor(self, context: &mut UpdateContext<'_, 'gc>, use_hand_cursor: bool) {
         self.0.write(context.gc_context).use_hand_cursor = use_hand_cursor;
+    }
+
+    pub fn hit_area(self) -> Option<DisplayObject<'gc>> {
+        self.0.read().hit_area
+    }
+
+    pub fn set_hit_area(
+        self,
+        context: &mut UpdateContext<'_, 'gc>,
+        hit_area: Option<DisplayObject<'gc>>,
+    ) {
+        self.0.write(context.gc_context).hit_area = hit_area;
     }
 
     pub fn tag_stream_len(&self) -> usize {


### PR DESCRIPTION
Stores it on the DisplayObject, but we don't actually use it for anything yet.

This progresses Kingdom Rush.