### PR TITLE
avm2: Shrink `Op` enum by using a `Box<[i32]>` in `LookupSwitch`

### DIFF
--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -751,7 +751,7 @@ impl<'a> Reader<'a> {
                     for _ in 0..num_cases {
                         case_offsets.push(self.read_i24()?);
                     }
-                    case_offsets
+                    case_offsets.into()
                 },
             },
             OpCode::LShift => Op::LShift,

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -472,7 +472,7 @@ pub enum Op {
     Li8,
     LookupSwitch {
         default_offset: i32,
-        case_offsets: Vec<i32>,
+        case_offsets: Box<[i32]>,
     },
     LShift,
     Modulo,

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -915,7 +915,7 @@ impl<W: Write> Writer<W> {
                 self.write_opcode(OpCode::LookupSwitch)?;
                 self.write_i24(default_offset)?;
                 self.write_u30(case_offsets.len() as u32 - 1)?;
-                for offset in case_offsets {
+                for offset in case_offsets.iter() {
                     self.write_i24(*offset)?;
                 }
             }


### PR DESCRIPTION
This shaves off one `usize` from the size of `Op`.