### PR TITLE
ci: Don't fail the build on Nightly clippy lints

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -71,7 +71,10 @@ jobs:
         run: cargo run -p build_playerglobal -- lint
 
       - name: Check clippy
-        run: cargo clippy --all --all-features --tests -- -D warnings
+        # FIXME - run Clippy on nightly again once https://github.com/clap-rs/clap/issues/4733 is fixed
+        if: matrix.rust_version != 'nightly'
+        # Don't fail the build for clippy on nightly, since we get a lot of false-positives
+        run: cargo clippy --all --all-features --tests ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
 
       - name: Check documentation
         run: cargo doc --no-deps --all-features


### PR DESCRIPTION
We consistently get false-positives from nightly changes, so don't fail the build (but still print warnings).