### PR TITLE
avm2: Add Telemetry class

### DIFF
--- a/core/src/avm2/globals/flash/profiler/Telemetry.as
+++ b/core/src/avm2/globals/flash/profiler/Telemetry.as
@@ -1,0 +1,17 @@
+package flash.profiler {
+    public final class Telemetry {
+        public static const connected: Boolean = false;
+        public static const spanMarker: Number = 0;
+
+        public static function sendMetric(metric:String, value:*):void {}
+        public static function sendSpanMetric(metric:String, startSpanMarker:Number, value:* = null):void {}
+        	
+        public static function registerCommandHandler(commandName:String, handler:Function):Boolean {
+            return false;
+        }
+
+        public static function unregisterCommandHandler(commandName:String):Boolean {
+            return false;
+        }
+    }
+}

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -215,6 +215,7 @@ include "flash/net/URLRequestHeader.as"
 include "flash/net/URLRequestMethod.as"
 include "flash/net/URLVariables.as"
 
+include "flash/profiler/Telemetry.as"
 include "flash/printing/PrintJobOrientation.as"
 
 include "flash/profiler.as"


### PR DESCRIPTION
Adds a fake Telemetry class to fool SWF's that use it (like crossbridge generated SWF's). This implementation mimics when Telemetry is not connected to any server