### PR TITLE
core: Call `overwrite_cpu_pixels_from_gpu` just before we draw

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -547,6 +547,8 @@ pub fn draw<'gc>(
                 return Ok(Value::Undefined);
             };
 
+            // Do this last, so that we only call `overwrite_cpu_pixels_from_gpu`
+            // if we're actually going to draw something.
             let bmd = bitmap_data
                 .bitmap_data_wrapper()
                 .overwrite_cpu_pixels_from_gpu(&mut activation.context);


### PR DESCRIPTION
If we bail out early, we want to preserve the current GPU -> CPU sync.