### PR TITLE
desktop: Handle errors before detaching from console on Windows cli

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1006,7 +1006,7 @@ fn shutdown() {
     }
 }
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), Error> {
     init();
     let opt = Opt::parse();
     let result = if opt.timedemo {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1006,7 +1006,7 @@ fn shutdown() {
     }
 }
 
-fn main() {
+fn main() -> Result<(), anyhow::Error> {
     init();
     let opt = Opt::parse();
     let result = if opt.timedemo {
@@ -1014,10 +1014,11 @@ fn main() {
     } else {
         App::new(opt).map(|app| app.run())
     };
-    if let Err(ref error) = result {
-        eprintln!("\n\n{:?}", error);
-        shutdown();
-        std::process::exit(1);
+    if cfg!(windows) {
+        if let Err(error) = &result {
+            eprintln!("{:?}", error)
+        }
     }
     shutdown();
+    result
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1006,7 +1006,7 @@ fn shutdown() {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn main() {
     init();
     let opt = Opt::parse();
     let result = if opt.timedemo {
@@ -1014,6 +1014,10 @@ fn main() -> Result<(), Error> {
     } else {
         App::new(opt).map(|app| app.run())
     };
+    if let Err(ref error) = result {
+        eprintln!("\n\n{:?}", error);
+        shutdown();
+        std::process::exit(1);
+    }
     shutdown();
-    result
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1014,10 +1014,9 @@ fn main() -> Result<(), Error> {
     } else {
         App::new(opt).map(|app| app.run())
     };
-    if cfg!(windows) {
-        if let Err(error) = &result {
-            eprintln!("{:?}", error)
-        }
+    #[cfg(windows)]
+    if let Err(error) = &result {
+        eprintln!("{:?}", error)
     }
     shutdown();
     result


### PR DESCRIPTION
When running ruffle through cmd.exe or Powershell on Windows, ruffle desktop detaches from console before printing any errors encountered during initialization:
![image](https://user-images.githubusercontent.com/86800190/221745196-040fce10-9069-411e-9c5d-04eb2687101d.png)

This PR changes error handling on main so the error is printed on cli before the console detaches:
![image](https://user-images.githubusercontent.com/86800190/221745216-f8252ab5-f584-4f45-99a7-43acefc1b866.png)

Tested on Windows (cmd.exe and powershell) as well as MacOS.