### PR TITLE
extension: Give precedence to toggles over default options (fix #5825)

### DIFF
--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -196,9 +196,17 @@ export function pluginPolyfill(): void {
  * Polyfills legacy Flash content on the page.
  *
  * @param isExt Whether or not Ruffle is running as a browser's extension.
+ * @param extensionConfig The configuration sent by the PublicAPI, stored if this is the extension.
  */
-export function polyfill(isExt: boolean): void {
+export function polyfill(
+    isExt: boolean,
+    extensionConfig: URLLoadOptions | DataLoadOptions | object
+): void {
     isExtension = isExt;
+    window.RufflePlayer ||= {};
+    if (isExtension) {
+        window.RufflePlayer.extensionConfig = extensionConfig;
+    }
     polyfillFlashInstances();
     polyfillFrames();
     initMutationObserver();

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -12,7 +12,10 @@ declare global {
          * [[PublicAPI]] instance itself.
          */
         RufflePlayer?:
-            | { config?: DataLoadOptions | URLLoadOptions | object }
+            | {
+                  config?: DataLoadOptions | URLLoadOptions | object;
+                  extensionConfig?: DataLoadOptions | URLLoadOptions | object;
+              }
             | PublicAPI;
     }
 }
@@ -33,6 +36,7 @@ export class PublicAPI {
      * The configuration object used when Ruffle is instantiated.
      */
     config: DataLoadOptions | URLLoadOptions | object;
+    extensionConfig: DataLoadOptions | URLLoadOptions | object;
 
     private sources: Record<string, typeof SourceAPI>;
     private invoked: boolean;
@@ -58,6 +62,7 @@ export class PublicAPI {
     protected constructor(prev: PublicAPI | null | Record<string, unknown>) {
         this.sources = {};
         this.config = {};
+        this.extensionConfig = {};
         this.invoked = false;
         this.newestName = null;
         this.conflict = null;
@@ -162,7 +167,8 @@ export class PublicAPI {
                 "polyfills" in this.config ? this.config.polyfills : true;
             if (polyfills !== false) {
                 this.sources[this.newestName]!.polyfill(
-                    this.newestName === "extension"
+                    this.newestName === "extension",
+                    this.config
                 );
             }
         }

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -627,7 +627,6 @@ export class RufflePlayer extends HTMLElement {
         options: string | URLLoadOptions | DataLoadOptions
     ): Promise<void> {
         options = this.checkOptions(options);
-
         if (!this.isConnected || this.isUnusedFallbackObject()) {
             console.warn(
                 "Ignoring attempt to play a disconnected or suspended Ruffle element"
@@ -643,6 +642,7 @@ export class RufflePlayer extends HTMLElement {
         try {
             this.loadedConfig = {
                 ...DEFAULT_CONFIG,
+                ...(window.RufflePlayer?.extensionConfig ?? {}),
                 ...(window.RufflePlayer?.config ?? {}),
                 ...this.config,
                 ...options,

--- a/web/packages/core/src/source-api.ts
+++ b/web/packages/core/src/source-api.ts
@@ -2,6 +2,7 @@ import { pluginPolyfill, polyfill } from "./polyfills";
 import { registerElement } from "./register-element";
 import { RufflePlayer } from "./ruffle-player";
 import { buildInfo } from "./build-info";
+import type { DataLoadOptions, URLLoadOptions } from "./load-options";
 
 /**
  * Represents this particular version of Ruffle.
@@ -23,9 +24,13 @@ export const SourceAPI = {
      * Do not run polyfills for more than one Ruffle source at a time.
      *
      * @param isExt Whether or not Ruffle is running as a browser's extension.
+     * @param extensionConfig The configuration sent by the PublicAPI, stored if this is the extension.
      */
-    polyfill(isExt: boolean): void {
-        polyfill(isExt);
+    polyfill(
+        isExt: boolean,
+        extensionConfig: URLLoadOptions | DataLoadOptions | object
+    ): void {
+        polyfill(isExt, extensionConfig);
     },
 
     /**


### PR DESCRIPTION
It is possible to give them precedence over self-hosted options as well by merely rearranging the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#spread_in_object_literals) for `loadedConfig`. But @Elementtair suggested that "I would feel it as disrepectfull to override self-host configuration for a stable release of the extension."

Edit: Also fixes #5696. Though that particular game is multi-asset, so downloading the base SWF is not very useful.

Edit 2: Note - this only works when the extension is the version of Ruffle that winds up taking precedence. If the self-hosted build takes precedence, the extension is not loaded until after RufflePlayer.load, and therefore the extension configuration is not available until then , so I can't take the toggles into account before loading content. To fix that we'd first need to fix https://github.com/ruffle-rs/ruffle/discussions/7505. But this PR is an improvement. If the extension is what's used, its toggles are respected. 