### PR TITLE
tests: Ignore stage3d_raytrace on WARP

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -34,7 +34,7 @@ max_relative = 0.0 # The default relative tolerance for testing values that are 
 [player_options]
 max_execution_duration = { secs = 15, nanos = 0} # How long can actionscript execute for before being forcefully stopped
 viewport_dimensions = { width = 100, height = 100, scale_factor = 1 } # The size of the player. Defaults to the swfs stage size
-with_renderer = { optional = false, sample_count = 4 } # If this test requires a renderer to run. Optional will enable the renderer where available.
+with_renderer = { optional = false, sample_count = 4, exclude_warp = false } # If this test requires a renderer to run. Optional will enable the renderer where available.
 with_audio = false # If this test requires an audio backend to run.
 
 # Whether or not to compare the image rendered with an expected image

--- a/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
@@ -5,12 +5,12 @@
 num_frames = 80
 
 [image_comparison]
-tolerance = 0
-# FIXME - see if we can decrease this. Ideally, it wouldn't be nearly so high
-max_outliers = 5100
+tolerance = 1
+max_outliers = 3
 
 [player_options]
 # This test runs very slowly on unoptimized `test` builds,
 # so give it plenty of time.
 max_execution_duration = { secs = 1000, nanos = 0 }
-with_renderer = { optional = false, sample_count = 1 }
+# Exclude WARP due to https://github.com/gfx-rs/wgpu/issues/3193
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }


### PR DESCRIPTION
The test seems to be flaky on warp

Also reduce the number of max outliers since the vast majority are just a delta of 1