### PR TITLE
avm2: Stub DisplayObject.scale9Grid

### DIFF
--- a/core/src/avm2/globals/flash/display/DisplayObject.as
+++ b/core/src/avm2/globals/flash/display/DisplayObject.as
@@ -8,6 +8,9 @@ package flash.display {
     import flash.display.Stage;
     import flash.geom.Point;
     import flash.events.EventDispatcher;
+    
+    import __ruffle__.stub_getter;
+    import __ruffle__.stub_setter;
 
     [Ruffle(InstanceAllocator)]
     [Ruffle(NativeInstanceInit)]
@@ -58,6 +61,14 @@ package flash.display {
 
         public native function get scaleZ():Number;
         public native function set scaleZ(value:Number):void;
+        
+        public function get scale9Grid():Rectangle {
+            stub_getter("flash.display.DisplayObject", "scale9Grid");
+            return null;
+        }
+        public function set scale9Grid(value:Rectangle):void {
+            stub_setter("flash.display.DisplayObject", "scale9Grid");
+        }
 
         public native function get name():String;
         public native function set name(value:String):void;

--- a/core/src/avm2/globals/flash/display/Stage.as
+++ b/core/src/avm2/globals/flash/display/Stage.as
@@ -69,7 +69,7 @@ package flash.display {
             throw new IllegalOperationError("Error #2071: The Stage class does not implement this property or method.", 2071);
         }
 
-        public function set scale9Grid(value:Rectangle):void {
+        override public function set scale9Grid(value:Rectangle):void {
             throw new IllegalOperationError("Error #2071: The Stage class does not implement this property or method.", 2071);
         }
 


### PR DESCRIPTION
Fixes the incorrect rendering of the loading bar on #9829.