### PR TITLE
Derive `Clone` and `Copy` in `PlayerEvent`

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -1,7 +1,7 @@
 use crate::display_object::InteractiveObject;
 use swf::ClipEventFlag;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum PlayerEvent {
     KeyDown {
         key_code: KeyCode,


### PR DESCRIPTION
I've been implementing a [custom frontend for Ruffle](https://github.com/JesseTG/ruffle_libretro), and due to how I queue up input events I needed `PlayerEvent` to implement the `Clone` and `Copy` traits. This PR does so.