### PR TITLE
avm2: Add DoAbc2 tag name to GlobalInit call stack node

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -207,7 +207,7 @@ impl<'gc> Avm2<'gc> {
                 init_activation
                     .context
                     .avm2
-                    .push_global_init(init_activation.context.gc_context);
+                    .push_global_init(init_activation.context.gc_context, script);
                 let r = (method.method)(&mut init_activation, Some(scope), &[]);
                 init_activation
                     .context
@@ -219,7 +219,7 @@ impl<'gc> Avm2<'gc> {
                 init_activation
                     .context
                     .avm2
-                    .push_global_init(init_activation.context.gc_context);
+                    .push_global_init(init_activation.context.gc_context, script);
                 let r = init_activation.run_actions(method);
                 init_activation
                     .context
@@ -408,6 +408,7 @@ impl<'gc> Avm2<'gc> {
     pub fn do_abc(
         context: &mut UpdateContext<'_, 'gc>,
         data: &[u8],
+        name: Option<AvmString<'gc>>,
         flags: DoAbc2Flag,
         domain: Domain<'gc>,
     ) -> Result<(), Error<'gc>> {
@@ -425,7 +426,7 @@ impl<'gc> Avm2<'gc> {
         };
 
         let num_scripts = abc.scripts.len();
-        let tunit = TranslationUnit::from_abc(abc, domain, context.gc_context);
+        let tunit = TranslationUnit::from_abc(abc, domain, name, context.gc_context);
         for i in 0..num_scripts {
             tunit.load_script(i as u32, context)?;
         }
@@ -450,8 +451,8 @@ impl<'gc> Avm2<'gc> {
     }
 
     /// Pushes script initializer (global init) on the call stack
-    pub fn push_global_init(&self, mc: MutationContext<'gc, '_>) {
-        self.call_stack.write(mc).push_global_init()
+    pub fn push_global_init(&self, mc: MutationContext<'gc, '_>, script: Script<'gc>) {
+        self.call_stack.write(mc).push_global_init(script)
     }
 
     /// Pops an executable off the call stack

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -592,8 +592,14 @@ fn load_playerglobal<'gc>(
             let do_abc = reader
                 .read_do_abc_2()
                 .expect("playerglobal.swf should be valid");
-            Avm2::do_abc(&mut activation.context, do_abc.data, do_abc.flags, domain)
-                .expect("playerglobal.swf should be valid");
+            Avm2::do_abc(
+                &mut activation.context,
+                do_abc.data,
+                None,
+                do_abc.flags,
+                domain,
+            )
+            .expect("playerglobal.swf should be valid");
         } else if tag_code != TagCode::End {
             panic!("playerglobal should only contain `DoAbc2` tag - found tag {tag_code:?}")
         }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -743,7 +743,13 @@ impl<'gc> MovieClip<'gc> {
             let domain = context.library.library_for_movie_mut(movie).avm2_domain();
 
             // DoAbc tag seems to be equivalent to a DoAbc2 with Lazy flag set
-            if let Err(e) = Avm2::do_abc(context, data, swf::DoAbc2Flag::LAZY_INITIALIZE, domain) {
+            if let Err(e) = Avm2::do_abc(
+                context,
+                data,
+                None,
+                swf::DoAbc2Flag::LAZY_INITIALIZE,
+                domain,
+            ) {
                 tracing::warn!("Error loading ABC file: {}", e);
             }
         }
@@ -767,7 +773,10 @@ impl<'gc> MovieClip<'gc> {
             let movie = self.movie();
             let domain = context.library.library_for_movie_mut(movie).avm2_domain();
 
-            if let Err(e) = Avm2::do_abc(context, do_abc.data, do_abc.flags, domain) {
+            let name = do_abc.name.to_str_lossy(reader.encoding());
+            let name = AvmString::new_utf8(context.gc_context, name);
+
+            if let Err(e) = Avm2::do_abc(context, do_abc.data, Some(name), do_abc.flags, domain) {
                 tracing::warn!("Error loading ABC file: {}", e);
             }
         }

--- a/tests/tests/swfs/avm2/error_stack_trace/output.txt
+++ b/tests/tests/swfs/avm2/error_stack_trace/output.txt
@@ -1,18 +1,18 @@
 Error
 	at Test$cinit()
-	at global$init()
+	at global$init() [TU=]
 	at test_fla::MainTimeline/frame1()
 Error
 	at MethodInfo-1()
 	at MethodInfo-2()
-	at global$init()
+	at global$init() [TU=]
 	at test_fla::MainTimeline/frame1()
 100
 test message
 Test
 Test: test message
 Test: test message
-	at global$init()
+	at global$init() [TU=]
 	at test_fla::MainTimeline/frame1()
 Error
 	at Test()


### PR DESCRIPTION
This can help determine which DoAbc2 file contains the script initializer that appears in a stack trace (though the name can be empty).