### PR TITLE
chore: Tell renovate to maintain lock files

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,5 +33,8 @@
             "groupName": "Github Actions dependencies",
             "extends": ["schedule:monthly"],
         },
-    ]
+    ],
+    "lockFileMaintenance": {
+        "enabled": true
+    }
 }


### PR DESCRIPTION
Renovate only updates the version range in dependencies, but when they're things like `^1.2.3` then it's only going to update it with a major release, not any patches or minor fixes. That's supposed to be the job of the package manager (cargo, npm) and lock files.

This makes Renovate update our lock file every week to allow the package managers to keep us up to date with any fixes, rather than them happening arbitrarily whenever someone happens to run `cargo update` or `npm install` locally and PRs that.

See also #9876