### PR TITLE
avm2: Initialize LoaderStream and Loader child before catchup_display_object_to_frame

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -606,10 +606,6 @@ impl<'gc> Loader<'gc> {
         let mc = mc.as_movie_clip().unwrap();
 
         let did_finish = mc.preload(context, limit);
-        if did_finish {
-            mc.post_instantiation(context, None, Instantiator::Movie, false);
-            catchup_display_object_to_frame(context, mc.into());
-        }
 
         Loader::movie_loader_progress(
             handle,
@@ -657,6 +653,12 @@ impl<'gc> Loader<'gc> {
                 // clip does not yet exist.
                 loader.insert_at_index(&mut activation.context, mc.into(), 0);
             }
+
+            // We call these methods after we initialize the `LoaderInfo` and add the loaded clip
+            // as a child. This may run an 'addedToStage' handler in the loaded movie,
+            // which should be able to access 'this.stage' and 'this.parent'
+            mc.post_instantiation(context, None, Instantiator::Movie, false);
+            catchup_display_object_to_frame(context, mc.into());
 
             Loader::movie_loader_complete(handle, context)?;
         }


### PR DESCRIPTION
Depending on when loading completes, calling
`catchup_display_object_to_frame` might trigger an `addedToStageEvent` inside the loaded SWF. The event listener will expect the SWF content to have 'DisplayObject.stage' accessible, so we need to make sure that we've added our loaded content as a child of the `Loader` *before* any event handlers run.

I've been unable to come up with a self-contained test for this, but it's necessary for Bloons Tower Defense 5