### PR TITLE
avm2: Introduce ParametersExt and use it inside bitmapdata

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -39,6 +39,7 @@ mod method;
 mod multiname;
 mod namespace;
 pub mod object;
+mod parameters;
 mod property;
 mod property_map;
 mod qname;

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -184,8 +184,7 @@ pub fn copy_pixels<'gc>(
             .unwrap_or(&Value::Undefined)
             .coerce_to_object(activation)?;
 
-        let rectangle_class = activation.avm2().classes().rectangle;
-        let source_rect = args.get_object_of_class(activation, 1, "sourceRect", rectangle_class)?;
+        let source_rect = args.get_object(activation, 1, "sourceRect")?;
 
         let src_min_x = source_rect
             .get_public_property("x", activation)?
@@ -200,8 +199,7 @@ pub fn copy_pixels<'gc>(
             .get_public_property("height", activation)?
             .coerce_to_i32(activation)?;
 
-        let point_class = activation.avm2().classes().point;
-        let dest_point = args.get_object_of_class(activation, 2, "destPoint", point_class)?;
+        let dest_point = args.get_object(activation, 2, "destPoint")?;
 
         let dest_x = dest_point
             .get_public_property("x", activation)?
@@ -238,9 +236,7 @@ pub fn copy_pixels<'gc>(
                     let mut x = 0;
                     let mut y = 0;
 
-                    if let Some(alpha_point) =
-                        args.try_get_object_of_class(activation, 4, point_class)?
-                    {
+                    if let Some(alpha_point) = args.try_get_object(activation, 4) {
                         x = alpha_point
                             .get_public_property("x", activation)?
                             .coerce_to_i32(activation)?;
@@ -290,8 +286,7 @@ pub fn get_pixels<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.read().check_valid(activation)?;
-        let rectangle_class = activation.avm2().classes().rectangle;
-        let rectangle = args.get_object_of_class(activation, 0, "rect", rectangle_class)?;
+        let rectangle = args.get_object(activation, 0, "rect")?;
         let x = rectangle
             .get_public_property("x", activation)?
             .coerce_to_i32(activation)?;
@@ -321,8 +316,7 @@ pub fn get_vector<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.read().check_valid(activation)?;
-        let rectangle_class = activation.avm2().classes().rectangle;
-        let rectangle = args.get_object_of_class(activation, 0, "rect", rectangle_class)?;
+        let rectangle = args.get_object(activation, 0, "rect")?;
         let x = rectangle
             .get_public_property("x", activation)?
             .coerce_to_i32(activation)?;
@@ -421,8 +415,7 @@ pub fn set_pixels<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let rectangle_class = activation.avm2().classes().rectangle;
-    let rectangle = args.get_object_of_class(activation, 0, "rect", rectangle_class)?;
+    let rectangle = args.get_object(activation, 0, "rect")?;
 
     let bytearray = args
         .get(1)
@@ -482,11 +475,9 @@ pub fn copy_channel<'gc>(
             .unwrap_or(&Value::Undefined)
             .coerce_to_object(activation)?;
 
-        let rectangle_class = activation.avm2().classes().rectangle;
-        let source_rect = args.get_object_of_class(activation, 1, "sourceRect", rectangle_class)?;
+        let source_rect = args.get_object(activation, 1, "sourceRect")?;
 
-        let point_class = activation.avm2().classes().point;
-        let dest_point = args.get_object_of_class(activation, 2, "destPoint", point_class)?;
+        let dest_point = args.get_object(activation, 2, "destPoint")?;
 
         let dest_x = dest_point
             .get_public_property("x", activation)?
@@ -594,11 +585,8 @@ pub fn color_transform<'gc>(
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         let mut bitmap_data = bitmap_data.write(activation.context.gc_context);
         if !bitmap_data.disposed() {
-            let rectangle_class = activation.avm2().classes().rectangle;
-            let color_transform_class = activation.avm2().classes().colortransform;
-
             // TODO: Re-use `object_to_rectangle` in `movie_clip.rs`.
-            let rectangle = args.get_object_of_class(activation, 0, "rect", rectangle_class)?;
+            let rectangle = args.get_object(activation, 0, "rect")?;
             let x = rectangle
                 .get_public_property("x", activation)?
                 .coerce_to_i32(activation)?;
@@ -617,8 +605,7 @@ pub fn color_transform<'gc>(
             let y_min = y.max(0) as u32;
             let y_max = (y + height) as u32;
 
-            let color_transform =
-                args.get_object_of_class(activation, 1, "colorTransform", color_transform_class)?;
+            let color_transform = args.get_object(activation, 1, "colorTransform")?;
             let color_transform =
                 crate::avm2::globals::flash::geom::transform::object_to_color_transform(
                     color_transform,
@@ -697,16 +684,12 @@ pub fn draw<'gc>(
         let mut transform = Transform::default();
         let mut blend_mode = BlendMode::Normal;
 
-        let matrix_class = activation.avm2().classes().matrix;
-        if let Some(matrix) = args.try_get_object_of_class(activation, 1, matrix_class)? {
+        if let Some(matrix) = args.try_get_object(activation, 1) {
             transform.matrix =
                 crate::avm2::globals::flash::geom::transform::object_to_matrix(matrix, activation)?;
         }
 
-        let color_transform_class = activation.avm2().classes().colortransform;
-        if let Some(color_transform) =
-            args.try_get_object_of_class(activation, 2, color_transform_class)?
-        {
+        if let Some(color_transform) = args.try_get_object(activation, 2) {
             transform.color_transform =
                 crate::avm2::globals::flash::geom::transform::object_to_color_transform(
                     color_transform,
@@ -725,8 +708,7 @@ pub fn draw<'gc>(
 
         let mut clip_rect = None;
 
-        let rectangle_class = activation.avm2().classes().rectangle;
-        if let Some(clip_rect_obj) = args.try_get_object_of_class(activation, 4, rectangle_class)? {
+        if let Some(clip_rect_obj) = args.try_get_object(activation, 4) {
             clip_rect = Some(super::display_object::object_to_rectangle(
                 activation,
                 clip_rect_obj,
@@ -783,16 +765,12 @@ pub fn draw_with_quality<'gc>(
         let mut transform = Transform::default();
         let mut blend_mode = BlendMode::Normal;
 
-        let matrix_class = activation.avm2().classes().matrix;
-        if let Some(matrix) = args.try_get_object_of_class(activation, 1, matrix_class)? {
+        if let Some(matrix) = args.try_get_object(activation, 1) {
             transform.matrix =
                 crate::avm2::globals::flash::geom::transform::object_to_matrix(matrix, activation)?;
         }
 
-        let color_transform_class = activation.avm2().classes().colortransform;
-        if let Some(color_transform) =
-            args.try_get_object_of_class(activation, 2, color_transform_class)?
-        {
+        if let Some(color_transform) = args.try_get_object(activation, 2) {
             transform.color_transform =
                 crate::avm2::globals::flash::geom::transform::object_to_color_transform(
                     color_transform,
@@ -811,8 +789,7 @@ pub fn draw_with_quality<'gc>(
 
         let mut clip_rect = None;
 
-        let rectangle_class = activation.avm2().classes().rectangle;
-        if let Some(clip_rect_obj) = args.try_get_object_of_class(activation, 4, rectangle_class)? {
+        if let Some(clip_rect_obj) = args.try_get_object(activation, 4) {
             clip_rect = Some(super::display_object::object_to_rectangle(
                 activation,
                 clip_rect_obj,
@@ -872,8 +849,7 @@ pub fn fill_rect<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let rectangle_class = activation.avm2().classes().rectangle;
-    let rectangle = args.get_object_of_class(activation, 0, "rect", rectangle_class)?;
+    let rectangle = args.get_object(activation, 0, "rect")?;
 
     let color = args.get_i32(activation, 1)?;
 
@@ -961,8 +937,7 @@ pub fn apply_filter<'gc>(
                 return Ok(Value::Undefined);
             }
         };
-        let rectangle_class = activation.avm2().classes().rectangle;
-        let source_rect = args.get_object_of_class(activation, 1, "sourceRect", rectangle_class)?;
+        let source_rect = args.get_object(activation, 1, "sourceRect")?;
         let source_rect = super::display_object::object_to_rectangle(activation, source_rect)?;
         let source_point = (
             source_rect.x_min.to_pixels().floor() as u32,
@@ -972,8 +947,7 @@ pub fn apply_filter<'gc>(
             source_rect.width().to_pixels().ceil() as u32,
             source_rect.height().to_pixels().ceil() as u32,
         );
-        let point_class = activation.avm2().classes().point;
-        let dest_point = args.get_object_of_class(activation, 2, "dstPoint", point_class)?;
+        let dest_point = args.get_object(activation, 2, "dstPoint")?;
         let dest_point = (
             dest_point
                 .get_public_property("x", activation)?
@@ -982,8 +956,7 @@ pub fn apply_filter<'gc>(
                 .get_public_property("x", activation)?
                 .coerce_to_u32(activation)?,
         );
-        let filter_class = activation.avm2().classes().bitmapfilter;
-        let filter = args.get_object_of_class(activation, 3, "filter", filter_class)?;
+        let filter = args.get_object(activation, 3, "filter")?;
         let filter = Filter::from_avm2_object(activation, filter)?;
         let mut dest_bitmap_data = dest_bitmap_data.write(activation.context.gc_context);
         dest_bitmap_data.apply_filter(

--- a/core/src/avm2/parameters.rs
+++ b/core/src/avm2/parameters.rs
@@ -4,6 +4,10 @@ use crate::avm2::Object;
 use crate::avm2::{Activation, Error, Value};
 use crate::string::AvmString;
 
+/// Extensions over parameters that are passed into AS-defined, Rust-implemented methods.
+///
+/// It is expected that the AS signature is correct and you only operate on values defined from it.
+/// These values will be `expect()`ed to exist, and any method here will panic if they're missing.  
 pub trait ParametersExt<'gc> {
     /// Gets the value at the given index and coerces it to an Object.
     ///
@@ -88,13 +92,10 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         index: usize,
         name: &'static str,
     ) -> Result<Object<'gc>, Error<'gc>> {
-        match self
-            .get(index)
-            .expect("Value must be Some() from AS definition")
-        {
+        match self[index] {
             Value::Null | Value::Undefined => Err(null_parameter_error(activation, name)),
-            Value::Object(o) => Ok(*o),
-            primitive => Ok(PrimitiveObject::from_primitive(*primitive, activation)
+            Value::Object(o) => Ok(o),
+            primitive => Ok(PrimitiveObject::from_primitive(primitive, activation)
                 .expect("Primitive object is infallible at this point")),
         }
     }
@@ -104,14 +105,11 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Option<Object<'gc>> {
-        match self
-            .get(index)
-            .expect("Value must be Some() from AS definition")
-        {
+        match self[index] {
             Value::Null | Value::Undefined => None,
-            Value::Object(o) => Some(*o),
+            Value::Object(o) => Some(o),
             primitive => Some(
-                PrimitiveObject::from_primitive(*primitive, activation)
+                PrimitiveObject::from_primitive(primitive, activation)
                     .expect("Primitive object is infallible at this point"),
             ),
         }
@@ -122,9 +120,7 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Result<f64, Error<'gc>> {
-        self.get(index)
-            .expect("Value must be Some() from AS definition")
-            .coerce_to_number(activation)
+        self[index].coerce_to_number(activation)
     }
 
     fn get_u32(
@@ -132,9 +128,7 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Result<u32, Error<'gc>> {
-        self.get(index)
-            .expect("Value must be Some() from AS definition")
-            .coerce_to_u32(activation)
+        self[index].coerce_to_u32(activation)
     }
 
     fn get_i32(
@@ -142,15 +136,11 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Result<i32, Error<'gc>> {
-        self.get(index)
-            .expect("Value must be Some() from AS definition")
-            .coerce_to_i32(activation)
+        self[index].coerce_to_i32(activation)
     }
 
     fn get_bool(&self, index: usize) -> bool {
-        self.get(index)
-            .expect("Value must be Some() from AS definition")
-            .coerce_to_boolean()
+        self[index].coerce_to_boolean()
     }
 
     fn get_string(
@@ -158,9 +148,7 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
-        self.get(index)
-            .expect("Value must be Some() from AS definition")
-            .coerce_to_string(activation)
+        self[index].coerce_to_string(activation)
     }
 
     fn try_get_string(
@@ -168,10 +156,7 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Result<Option<AvmString<'gc>>, Error<'gc>> {
-        match self
-            .get(index)
-            .expect("Value must be Some() from AS definition")
-        {
+        match self[index] {
             Value::Null | Value::Undefined => Ok(None),
             other => Ok(Some(other.coerce_to_string(activation)?)),
         }

--- a/core/src/avm2/parameters.rs
+++ b/core/src/avm2/parameters.rs
@@ -9,6 +9,9 @@ use crate::string::AvmString;
 /// It is expected that the AS signature is correct and you only operate on values defined from it.
 /// These values will be `expect()`ed to exist, and any method here will panic if they're missing.  
 pub trait ParametersExt<'gc> {
+    /// Gets the value at the given index.
+    fn get_value(&self, index: usize) -> Value<'gc>;
+
     /// Gets the value at the given index and coerces it to an Object.
     ///
     /// If the value is null or is undefined, a TypeError 2007 is raised.
@@ -86,6 +89,11 @@ pub trait ParametersExt<'gc> {
 }
 
 impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
+    #[inline]
+    fn get_value(&self, index: usize) -> Value<'gc> {
+        self[index]
+    }
+
     fn get_object(
         &self,
         activation: &mut Activation<'_, 'gc>,

--- a/core/src/avm2/parameters.rs
+++ b/core/src/avm2/parameters.rs
@@ -1,0 +1,277 @@
+use crate::avm2::error::type_error;
+use crate::avm2::object::PrimitiveObject;
+use crate::avm2::object::TObject;
+use crate::avm2::Object;
+use crate::avm2::{Activation, ClassObject, Error, Value};
+use crate::string::AvmString;
+
+pub trait ParametersExt<'gc> {
+    /// Gets the value at the given index and coerces it to an Object.
+    ///
+    /// If the value does not exist, is null, or is undefined, a TypeError 2007 is raised.
+    fn get_object(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        name: &'static str,
+    ) -> Result<Object<'gc>, Error<'gc>>;
+
+    /// Tries to get the value at the given index and coerce it to an Object.
+    ///
+    /// If the value does not exist, is null, or is undefined, None is returned.
+    fn try_get_object(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Option<Object<'gc>>;
+
+    /// Gets the value at the given index and coerces it to an Object of the given class.
+    ///
+    /// If the value does not exist, is null, or is undefined, a TypeError 2007 is raised.
+    /// If the object cannot be coerced to the specified class, a TypeError 1034 is raised.
+    fn get_object_of_class(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        name: &'static str,
+        class: ClassObject<'gc>,
+    ) -> Result<Object<'gc>, Error<'gc>>;
+
+    /// Tries to get the value at the given index and coerce it to an Object.
+    ///
+    /// If the value does not exist, is null, or is undefined, Ok(None) is returned.
+    /// If the object cannot be coerced to the specified class, a TypeError 1034 is raised.
+    fn try_get_object_of_class(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        class: ClassObject<'gc>,
+    ) -> Result<Option<Object<'gc>>, Error<'gc>>;
+
+    /// Gets the value at the given index and coerces it to an f64.
+    ///
+    /// If the value does not exist, is null, or is undefined, 0.0 is returned.
+    /// If the object cannot be coerced to an f64, a TypeError 1050 is raised.
+    fn get_f64(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<f64, Error<'gc>>;
+
+    /// Gets the value at the given index and coerces it to a u32.
+    ///
+    /// If the value does not exist, is null, or is undefined, 0 is returned.
+    /// If the object cannot be coerced to a u32, a TypeError 1050 is raised.
+    fn get_u32(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<u32, Error<'gc>>;
+
+    /// Gets the value at the given index and coerces it to a i32.
+    ///
+    /// If the value does not exist, is null, or is undefined, 0 is returned.
+    /// If the object cannot be coerced to an i32, a TypeError 1050 is raised.
+    fn get_i32(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<i32, Error<'gc>>;
+
+    /// Gets the value at the given index and coerces it to a bool.
+    ///
+    /// If the value does not exist, is null, or is undefined, false is returned.
+    fn get_bool(&self, index: usize) -> bool;
+
+    /// Gets the value at the given index and coerces it to an AvmString.
+    ///
+    /// If the value does not exist or is undefined, "undefined" is returned.
+    /// If the value is null, "null" is returned.
+    /// If the object cannot be coerced to a string, a TypeError 1050 is raised.
+    fn get_string(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<AvmString<'gc>, Error<'gc>>;
+
+    /// Gets the value at the given index and coerces it to an AvmString.
+    ///
+    /// If the value does not exist, is null, or is undefined, Ok(None) is returned.
+    /// If the object cannot be coerced to a string, a TypeError 1050 is raised.
+    fn try_get_string(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<Option<AvmString<'gc>>, Error<'gc>>;
+}
+
+impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
+    fn get_object(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        name: &'static str,
+    ) -> Result<Object<'gc>, Error<'gc>> {
+        match self.get(index) {
+            None | Some(Value::Null) | Some(Value::Undefined) => {
+                Err(null_parameter_error(activation, name))
+            }
+            Some(Value::Object(o)) => Ok(*o),
+            Some(primitive) => Ok(PrimitiveObject::from_primitive(*primitive, activation)
+                .expect("Primitive object is infallible at this point")),
+        }
+    }
+
+    fn try_get_object(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Option<Object<'gc>> {
+        match self.get(index) {
+            None | Some(Value::Null) | Some(Value::Undefined) => None,
+            Some(Value::Object(o)) => Some(*o),
+            Some(primitive) => Some(
+                PrimitiveObject::from_primitive(*primitive, activation)
+                    .expect("Primitive object is infallible at this point"),
+            ),
+        }
+    }
+
+    fn get_object_of_class(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        name: &'static str,
+        class: ClassObject<'gc>,
+    ) -> Result<Object<'gc>, Error<'gc>> {
+        let object = self.get_object(activation, index, name)?;
+        if object.is_of_type(class, activation) {
+            Ok(object)
+        } else {
+            Err(type_coercion_error(
+                activation,
+                class
+                    .inner_class_definition()
+                    .read()
+                    .name()
+                    .to_qualified_name_err_message(activation.context.gc_context),
+                object.instance_of_class_name(activation.context.gc_context),
+            ))
+        }
+    }
+
+    fn try_get_object_of_class(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        class: ClassObject<'gc>,
+    ) -> Result<Option<Object<'gc>>, Error<'gc>> {
+        if let Some(object) = self.try_get_object(activation, index) {
+            if object.is_of_type(class, activation) {
+                Ok(Some(object))
+            } else {
+                Err(type_coercion_error(
+                    activation,
+                    class
+                        .inner_class_definition()
+                        .read()
+                        .name()
+                        .to_qualified_name_err_message(activation.context.gc_context),
+                    object.instance_of_class_name(activation.context.gc_context),
+                ))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_f64(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<f64, Error<'gc>> {
+        self.get(index)
+            .copied()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_number(activation)
+    }
+
+    fn get_u32(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<u32, Error<'gc>> {
+        self.get(index)
+            .copied()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_u32(activation)
+    }
+
+    fn get_i32(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<i32, Error<'gc>> {
+        self.get(index)
+            .copied()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)
+    }
+
+    fn get_bool(&self, index: usize) -> bool {
+        self.get(index)
+            .copied()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_boolean()
+    }
+
+    fn get_string(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<AvmString<'gc>, Error<'gc>> {
+        self.get(index)
+            .copied()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_string(activation)
+    }
+
+    fn try_get_string(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+    ) -> Result<Option<AvmString<'gc>>, Error<'gc>> {
+        match self.get(index) {
+            None | Some(Value::Null) | Some(Value::Undefined) => Ok(None),
+            Some(other) => Ok(Some(other.coerce_to_string(activation)?)),
+        }
+    }
+}
+
+fn null_parameter_error<'gc>(activation: &mut Activation<'_, 'gc>, name: &str) -> Error<'gc> {
+    let error = type_error(
+        activation,
+        &format!("Parameter {name} must be non-null."),
+        2007,
+    );
+    match error {
+        Err(e) => e,
+        Ok(e) => Error::AvmError(e),
+    }
+}
+
+fn type_coercion_error<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    expected: AvmString<'gc>,
+    actual: AvmString<'gc>,
+) -> Error<'gc> {
+    let error = type_error(
+        activation,
+        &format!("Type Coercion failed: cannot convert {actual} to {expected}."),
+        1034,
+    );
+    match error {
+        Err(e) => e,
+        Ok(e) => Error::AvmError(e),
+    }
+}

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1000,9 +1000,17 @@ impl<'gc> Value<'gc> {
             }
         }
 
-        let name = class.inner_class_definition().read().name();
+        let name = class
+            .inner_class_definition()
+            .read()
+            .name()
+            .to_qualified_name_err_message(activation.context.gc_context);
 
-        Err(format!("Cannot coerce {self:?} to an {name:?}").into())
+        Err(Error::AvmError(type_error(
+            activation,
+            &format!("Type Coercion failed: cannot convert {self:?} to {name}."),
+            1034,
+        )?))
     }
 
     /// Determine if this value is any kind of number.

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -2,6 +2,7 @@
 
 use crate::avm2::activation::Activation;
 use crate::avm2::error;
+use crate::avm2::error::type_error;
 use crate::avm2::object::{ClassObject, NamespaceObject, Object, PrimitiveObject, TObject};
 use crate::avm2::script::TranslationUnit;
 use crate::avm2::Error;
@@ -659,7 +660,14 @@ impl<'gc> Value<'gc> {
                     return Ok(prim);
                 }
 
-                Err("TypeError: cannot convert object to string".into())
+                Err(Error::AvmError(type_error(
+                    activation,
+                    &format!(
+                        "Cannot convert {} to primitive.",
+                        o.instance_of_class_name(activation.context.gc_context)
+                    ),
+                    1050,
+                )?))
             }
             Value::Object(o) if hint == Hint::Number => {
                 let mut prim = *self;
@@ -681,7 +689,14 @@ impl<'gc> Value<'gc> {
                     return Ok(prim);
                 }
 
-                Err("TypeError: cannot convert object to number".into())
+                Err(Error::AvmError(type_error(
+                    activation,
+                    &format!(
+                        "Cannot convert {} to primitive.",
+                        o.instance_of_class_name(activation.context.gc_context)
+                    ),
+                    1050,
+                )?))
             }
             _ => Ok(*self),
         }


### PR DESCRIPTION
We currently have so many different ways of pulling out parameters from the function, and almost every single one is wrong. The "correct" way to do it tends to be extremely verbose.

This introduces common methods for **correctly** getting the value of a given type from the function parameters slice, and converts BitmapData to use it as an initial proof of concept.

It's still missing more useful functions like getting native object types (DisplayObject from an arg, for example), but it's already a significant improvement.