### PR TITLE
render: Make retrieve_offscreen_texture pass the raw buffer

### DIFF
--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -35,9 +35,14 @@ pub trait BitmapSource {
     fn bitmap_handle(&self, id: u16, renderer: &mut dyn RenderBackend) -> Option<BitmapHandle>;
 }
 
+pub type RgbaBufRead<'a> = Box<dyn FnOnce(&[u8], u32) + 'a>;
+
 pub trait SyncHandle: Downcast + Debug {
     /// Retrieves the rendered pixels from a previous `render_offscreen` call
-    fn retrieve_offscreen_texture(self: Box<Self>) -> Result<Bitmap, crate::error::Error>;
+    fn retrieve_offscreen_texture(
+        self: Box<Self>,
+        with_rgba: RgbaBufRead,
+    ) -> Result<(), crate::error::Error>;
 }
 impl_downcast!(SyncHandle);
 

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -652,7 +652,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         match texture_offscreen {
             Some(texture_offscreen) => Some(Box::new(QueueSyncHandle::AlreadyCopied {
                 index,
-                size: target.size,
                 buffer: texture_offscreen.buffer.clone(),
                 buffer_dimensions: texture_offscreen.buffer_dimensions.clone(),
                 descriptors: self.descriptors.clone(),
@@ -728,7 +727,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         match texture_offscreen {
             Some(texture_offscreen) => Some(Box::new(QueueSyncHandle::AlreadyCopied {
                 index,
-                size: target.size,
                 buffer: texture_offscreen.buffer.clone(),
                 buffer_dimensions: texture_offscreen.buffer_dimensions.clone(),
                 descriptors: self.descriptors.clone(),

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -187,7 +187,7 @@ impl SyncHandle for QueueSyncHandle {
         self: Box<Self>,
         with_rgba: RgbaBufRead,
     ) -> Result<(), ruffle_render::error::Error> {
-        self.capture(|buf, buf_width| with_rgba(buf, buf_width));
+        self.capture(with_rgba);
         Ok(())
     }
 }


### PR DESCRIPTION
Previously we'd turn it into a vec and then put that in a struct and then copy that over manually to Pixels.
Now we just read straight from the buffer directly.