### PR TITLE
web: Remove `stylelint-config-prettier` package

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,7 +29,6 @@
                 "mocha": "^10.2.0",
                 "prettier": "^2.8.1",
                 "stylelint": "^15.0.0",
-                "stylelint-config-prettier": "^9.0.4",
                 "stylelint-config-standard": "^30.0.0",
                 "stylelint-prettier": "^3.0.0",
                 "ts-loader": "^9.4.1",
@@ -10459,22 +10458,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/stylelint"
-            }
-        },
-        "node_modules/stylelint-config-prettier": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
-            "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-            "dev": true,
-            "bin": {
-                "stylelint-config-prettier": "bin/check.js",
-                "stylelint-config-prettier-check": "bin/check.js"
-            },
-            "engines": {
-                "node": ">= 12"
-            },
-            "peerDependencies": {
-                "stylelint": ">=11.0.0"
             }
         },
         "node_modules/stylelint-config-recommended": {

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,6 @@
         "mocha": "^10.2.0",
         "prettier": "^2.8.1",
         "stylelint": "^15.0.0",
-        "stylelint-config-prettier": "^9.0.4",
         "stylelint-config-standard": "^30.0.0",
         "stylelint-prettier": "^3.0.0",
         "ts-loader": "^9.4.1",


### PR DESCRIPTION
From package NPM page:

> As of Stylelint v15 all style-related rules have been deprecated. If you are using v15 or higher and are not making use of these deprecated rules, this plugin is no longer necessary.

Stylelint was upgraded to 15.0.0 on 68078dc commit
This is what caused the dependency error on my previous PR