### PR TITLE
avm2: Stub TextField.alwaysShowSelection

### DIFF
--- a/core/src/avm2/globals/flash/text/TextField.as
+++ b/core/src/avm2/globals/flash/text/TextField.as
@@ -11,6 +11,9 @@ package flash.text {
 
         private native function init();
         
+        public native function get alwaysShowSelection():Boolean;
+        public native function set alwaysShowSelection(value:Boolean):void;
+
         public native function get autoSize():String;
         public native function set autoSize(value:String):void;
         

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -32,6 +32,24 @@ pub fn init<'gc>(
     Ok(Value::Undefined)
 }
 
+pub fn get_always_show_selection<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.text.TextField", "alwaysShowSelection");
+    Ok(Value::Bool(false))
+}
+
+pub fn set_always_show_selection<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.text.TextField", "alwaysShowSelection");
+    Ok(Value::Undefined)
+}
+
 pub fn get_auto_size<'gc>(
     _activation: &mut Activation<'_, 'gc>,
     this: Option<Object<'gc>>,


### PR DESCRIPTION
progresses Resort Empire https://github.com/ruffle-rs/ruffle/issues/9965
now it is blocked by unimplemented BitmapData.threshold