### PR TITLE
core/avm2: Use an actual FFT library in `computeSpectrum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6b8e8f0c6d2234aa58048d7290c60bf92cd36fd2888cd8331c66ad4f2e1d2"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,9 +3315,11 @@ dependencies = [
  "nellymoser-rs",
  "num-derive",
  "num-traits",
+ "once_cell",
  "percent-encoding",
  "quick-xml",
  "rand",
+ "realfft",
  "regress",
  "ruffle_macros",
  "ruffle_render",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,8 @@ static_assertions = "1.1.0"
 rustversion = "1.0.12"
 bytemuck = "1.13.1"
 clap = { version = "4.1.8", features = ["derive"], optional=true }
+realfft = "3.2.0"
+once_cell = "1.8.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.26"


### PR DESCRIPTION
This should make it _even faster_ than #9657.
Now I'm really glad for #9561!
Benchmarking to be done.
Thanks to https://github.com/ejmahler/rust_dct/issues/13#issuecomment-1465340496!