### PR TITLE
web: Remove Config object; it was never a correct type for the config

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -7,31 +7,7 @@ import {
     LogLevel,
 } from "./load-options";
 
-/**
- * The configuration object to control Ruffle's behaviour on the website
- * that it is included on.
- */
-export interface Config extends BaseLoadOptions {
-    /**
-     * The URL at which Ruffle can load its extra files (i.e. `.wasm`).
-     *
-     * @default null
-     */
-    publicPath?: string | null;
-
-    /**
-     * Whether or not to enable polyfills on the page.
-     *
-     * Polyfills will look for "legacy" flash content like `<object>`
-     * and `<embed>` elements, and replace them with compatible
-     * Ruffle elements.
-     *
-     * @default true
-     */
-    polyfills?: boolean;
-}
-
-export const DEFAULT_CONFIG: Required<Config> = {
+export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     allowScriptAccess: false,
     parameters: {},
     autoplay: AutoPlay.Auto,

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -318,6 +318,24 @@ export interface BaseLoadOptions {
      * @default null
      */
     playerVersion?: number | null;
+
+    /**
+     * The URL at which Ruffle can load its extra files (i.e. `.wasm`).
+     *
+     * @default null
+     */
+    publicPath?: string | null;
+
+    /**
+     * Whether or not to enable polyfills on the page.
+     *
+     * Polyfills will look for "legacy" flash content like `<object>`
+     * and `<embed>` elements, and replace them with compatible
+     * Ruffle elements.
+     *
+     * @default true
+     */
+    polyfills?: boolean;
 }
 
 /**

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -11,7 +11,7 @@ import {
 } from "wasm-feature-detect";
 import { setPolyfillsOnLoad } from "./js-polyfills";
 import { publicPath } from "./public-path";
-import type { Config } from "./config";
+import type { DataLoadOptions, URLLoadOptions } from "./load-options";
 
 declare global {
     let __webpack_public_path__: string;
@@ -32,7 +32,7 @@ type ProgressCallback = (bytesLoaded: number, bytesTotal: number) => void;
  * instances.
  */
 async function fetchRuffle(
-    config: Config,
+    config: URLLoadOptions | DataLoadOptions | object,
     progressCallback?: ProgressCallback
 ): Promise<typeof Ruffle> {
     // Apply some pure JavaScript polyfills to prevent conflicts with external
@@ -123,7 +123,7 @@ let lastLoaded: Promise<Ruffle> | null = null;
  * instances.
  */
 export function loadRuffle(
-    config: Config,
+    config: URLLoadOptions | DataLoadOptions | object,
     progressCallback?: ProgressCallback
 ): Promise<Ruffle> {
     if (lastLoaded === null) {

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -2,10 +2,11 @@ import { RuffleObject } from "./ruffle-object";
 import { RuffleEmbed } from "./ruffle-embed";
 import { installPlugin, FLASH_PLUGIN } from "./plugin-polyfill";
 import { publicPath } from "./public-path";
-import type { Config } from "./config";
+import type { DataLoadOptions, URLLoadOptions } from "./load-options";
 
 let isExtension: boolean;
-const globalConfig: Config = window.RufflePlayer?.config ?? {};
+const globalConfig: DataLoadOptions | URLLoadOptions | object =
+    window.RufflePlayer?.config ?? {};
 const jsScriptUrl = publicPath(globalConfig) + "ruffle.js";
 
 /**

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -1,7 +1,7 @@
 import { Version } from "./version";
 import { VersionRange } from "./version-range";
 import { SourceAPI } from "./source-api";
-import type { Config } from "./config";
+import type { DataLoadOptions, URLLoadOptions } from "./load-options";
 
 declare global {
     interface Window {
@@ -11,7 +11,9 @@ declare global {
          * [[PublicAPI]] via [[PublicAPI.negotiate]], or an actual
          * [[PublicAPI]] instance itself.
          */
-        RufflePlayer?: { config?: Config } | PublicAPI;
+        RufflePlayer?:
+            | { config?: DataLoadOptions | URLLoadOptions | object }
+            | PublicAPI;
     }
 }
 
@@ -30,7 +32,7 @@ export class PublicAPI {
     /**
      * The configuration object used when Ruffle is instantiated.
      */
-    config: Config;
+    config: DataLoadOptions | URLLoadOptions | object;
 
     private sources: Record<string, typeof SourceAPI>;
     private invoked: boolean;
@@ -156,7 +158,8 @@ export class PublicAPI {
                 throw new Error("No registered Ruffle source!");
             }
 
-            const polyfills = this.config.polyfills;
+            const polyfills =
+                "polyfills" in this.config ? this.config.polyfills : true;
             if (polyfills !== false) {
                 this.sources[this.newestName]!.polyfill(
                     this.newestName === "extension"
@@ -284,7 +287,10 @@ export class PublicAPI {
             // This is necessary because scripts such as SWFObject check for the
             // Flash Player immediately when they load.
             // TODO: Maybe there's a better place for this.
-            const polyfills = publicAPI.config.polyfills;
+            const polyfills =
+                "polyfills" in publicAPI.config
+                    ? publicAPI.config.polyfills
+                    : true;
             if (polyfills !== false) {
                 SourceAPI.pluginPolyfill();
             }

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -1,4 +1,4 @@
-import type { Config } from "./config";
+import type { DataLoadOptions, URLLoadOptions } from "./load-options";
 
 // This must be in global scope because `document.currentScript`
 // works only while the script is initially being processed.
@@ -41,10 +41,16 @@ try {
  * @param config The `window.RufflePlayer.config` object.
  * @returns The public path for the given source.
  */
-export function publicPath(config: Config): string {
+export function publicPath(
+    config: URLLoadOptions | DataLoadOptions | object
+): string {
     // Default to the directory where this script resides.
     let path = currentScriptURL;
-    if (config.publicPath !== null && config.publicPath !== undefined) {
+    if (
+        "publicPath" in config &&
+        config.publicPath !== null &&
+        config.publicPath !== undefined
+    ) {
         path = config.publicPath;
     }
 

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -1,8 +1,8 @@
-import { PublicAPI, Config } from "ruffle-core";
+import { PublicAPI, BaseLoadOptions } from "ruffle-core";
 
 interface LoadMessage {
     type: "load";
-    config: Config;
+    config: BaseLoadOptions;
 }
 
 interface PingMessage {


### PR DESCRIPTION
As @n0samu noted on Discord:

> I don't think we actually have any TypeScript type definition that correctly defines the object passed to player.load
> and I guess we've been relying all this time on no one actually calling that function from TypeScript
> or finding a way to trick TypeScript into letting them do it

This lets `player.load(player.loadedConfig)` work. See https://github.com/ruffle-rs/ruffle/pull/10040/commits/ad02672890dba071ca765dde3d41c23b63392352