### PR TITLE
chore: Port to bitflags 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,9 +1744,9 @@ dependencies = [
 [[package]]
 name = "h263-rs"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=8c00d0e13892ee349f76eb4f2651cb2b921d3766#8c00d0e13892ee349f76eb4f2651cb2b921d3766"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=efee5be819c4b40817a4da82f80783320cdd0e32#efee5be819c4b40817a4da82f80783320cdd0e32"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.0.0",
  "lazy_static",
  "num-traits",
  "thiserror",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "h263-rs-yuv"
 version = "0.1.0"
-source = "git+https://github.com/ruffle-rs/h263-rs?rev=8c00d0e13892ee349f76eb4f2651cb2b921d3766#8c00d0e13892ee349f76eb4f2651cb2b921d3766"
+source = "git+https://github.com/ruffle-rs/h263-rs?rev=efee5be819c4b40817a4da82f80783320cdd0e32#efee5be819c4b40817a4da82f80783320cdd0e32"
 dependencies = [
  "bytemuck",
  "wide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8512c9117059663fb5606788fbca3619e2a91dac0e3fe516242eab1fa6be5e44"
 dependencies = [
  "alsa-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "nix 0.24.3",
 ]
@@ -111,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c77a0045eda8b888c76ea473c2b0515ba6f471d318f8927c5c72240937035a6"
 dependencies = [
  "android-properties",
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "jni-sys",
  "libc",
@@ -269,7 +269,7 @@ version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -303,6 +303,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f6e5df9abedba5099a01a6567c6086a6fbcff57af07c360d356737f9e0c644"
 
 [[package]]
 name = "bitstream-io"
@@ -509,7 +515,7 @@ version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -669,7 +675,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -682,7 +688,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "foreign-types",
  "libc",
@@ -694,7 +700,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb17e2d1795b1996419648915df94bc7103c28f7b48062d7acf4652fc371b2ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation-sys 0.6.2",
  "coreaudio-sys",
 ]
@@ -932,7 +938,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libloading",
  "winapi",
 ]
@@ -1671,7 +1677,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-alloc-types",
 ]
 
@@ -1681,7 +1687,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1703,7 +1709,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-descriptor-types",
  "hashbrown 0.12.3",
 ]
@@ -1714,7 +1720,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1740,7 +1746,7 @@ name = "h263-rs"
 version = "0.1.0"
 source = "git+https://github.com/ruffle-rs/h263-rs?rev=8c00d0e13892ee349f76eb4f2651cb2b921d3766#8c00d0e13892ee349f76eb4f2651cb2b921d3766"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "num-traits",
  "thiserror",
@@ -1779,7 +1785,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90601c6189668c7345fc53842cb3f3a3d872203d523be1b3cb44a36a3e62fb85"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "com-rs",
  "libc",
  "libloading",
@@ -2356,7 +2362,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -2404,7 +2410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eafe22a23b797c9bc227c6c896419b26b5bb88fa903417a3adaed08778850d5"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -2423,7 +2429,7 @@ dependencies = [
 name = "naga-agal"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "insta",
  "naga",
  "num-derive",
@@ -2454,7 +2460,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -2515,7 +2521,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
@@ -2528,7 +2534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
@@ -2953,7 +2959,7 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
  "miniz_oxide",
@@ -2966,7 +2972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
@@ -3167,7 +3173,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3176,7 +3182,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb02a9aee8e8c7ad8d86890f1e16b49e0bbbffc9961ff3788c31d57c98bcbf03"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3268,7 +3274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -3276,7 +3282,7 @@ dependencies = [
 name = "ruffle_core"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "bitstream-io",
  "build_playerglobal",
  "bytemuck",
@@ -3354,7 +3360,7 @@ dependencies = [
 name = "ruffle_input_format"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "serde",
  "serde_json",
 ]
@@ -3602,7 +3608,7 @@ version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -3826,7 +3832,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "calloop",
  "dlib",
  "lazy_static",
@@ -3855,7 +3861,7 @@ version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "num-traits",
 ]
 
@@ -3893,7 +3899,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 name = "swf"
 version = "0.2.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "bitstream-io",
  "byteorder",
  "encoding_rs",
@@ -3925,7 +3931,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a0846e7a2c9a8081ff799fc83a975170417ad2a143f644a77ec2e3e82a2b73"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "log",
  "symphonia-core",
@@ -3939,7 +3945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b9567e2d8a5f866b2f94f5d366d811e0c6826babcff6d37de9e1a6690d38869"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "lazy_static",
  "log",
@@ -4506,7 +4512,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "libc",
  "nix 0.24.3",
@@ -4545,7 +4551,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "wayland-client",
  "wayland-commons",
  "wayland-scanner",
@@ -4645,7 +4651,7 @@ checksum = "7131408d940e335792645a98f03639573b0480e9e2e7cddbbab74f7c6d9f3fff"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "fxhash",
  "log",
@@ -4672,7 +4678,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
  "d3d12",
@@ -4710,7 +4716,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32444e121b0bd00cb02c0de32fde457a9491bd44e03e7a5db6df9b1da2f6f110"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "js-sys",
  "serde",
  "web-sys",
@@ -4869,7 +4875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d38e7dc904dda347b54dbec3b2d4bf534794f4fb4e6df0be91a264f4f2ed1cf"
 dependencies = [
  "android-activity",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg_aliases",
  "core-foundation",
  "core-graphics",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ ruffle_video = { path = "../video" }
 ruffle_macros = { path = "macros" }
 ruffle_wstr = { path = "../wstr" }
 swf = { path = "../swf" }
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 smallvec = { version = "1.10.0", features = ["union"] }
 num-traits = "0.2"
 num-derive = "0.3"

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -14,6 +14,7 @@ use std::cmp::Ordering;
 
 bitflags! {
     /// Options used by `Array.sort` and `Array.sortOn`.
+    #[derive(Clone, Copy)]
     struct SortOptions: i32 {
         const CASE_INSENSITIVE     = 1 << 0;
         const DESCENDING           = 1 << 1;

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -269,10 +269,10 @@ pub fn as_set_prop_flags<'gc>(
     };
 
     let set_flags = args.get(2).unwrap_or(&0.into()).coerce_to_f64(activation)? as u16;
-    let set_attributes = Attribute::from_bits_truncate(set_flags);
+    let set_attributes = Attribute::from_bits_retain(set_flags);
 
     let clear_flags = args.get(3).unwrap_or(&0.into()).coerce_to_f64(activation)? as u16;
-    let clear_attributes = Attribute::from_bits_truncate(clear_flags);
+    let clear_attributes = Attribute::from_bits_retain(clear_flags);
 
     if set_attributes.bits() != set_flags || clear_attributes.bits() != clear_flags {
         avm_warn!(

--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -8,7 +8,7 @@ use gc_arena::Collect;
 bitflags! {
     /// Attributes of properties in the AVM runtime.
     /// The values are significant and should match the order used by `object::as_set_prop_flags`.
-    #[derive(Collect)]
+    #[derive(Clone, Collect, Copy, Debug)]
     #[collect(require_static)]
     pub struct Attribute: u16 {
         const DONT_ENUM     = 1 << 0;

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -24,6 +24,7 @@ use super::string::AvmString;
 
 bitflags! {
     /// All possible attributes for a given class.
+    #[derive(Clone, Copy)]
     pub struct ClassAttributes: u8 {
         /// Class is sealed, attempts to set or init dynamic properties on an
         /// object will generate a runtime error.

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -803,6 +803,7 @@ bitflags! {
     /// The array options that a given sort operation may use.
     ///
     /// These are provided as a number by the VM and converted into bitflags.
+    #[derive(Clone, Copy)]
     pub struct SortOptions: u8 {
         /// Request case-insensitive string value sort.
         const CASE_INSENSITIVE     = 1 << 0;

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -49,7 +49,7 @@ impl<'gc> NamespaceSet<'gc> {
 }
 
 bitflags! {
-    #[derive(Default, Collect)]
+    #[derive(Clone, Copy, Debug, Default, Collect)]
     #[collect(require_static)]
     pub struct MultinameFlags: u8 {
         /// Whether the namespace needs to be read at runtime before use.

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -37,7 +37,7 @@ impl<'gc> Clone for RegExp<'gc> {
 }
 
 bitflags! {
-    #[derive(Collect)]
+    #[derive(Clone, Copy, Collect, Debug)]
     #[collect(require_static)]
     pub struct RegExpFlags: u8 {
         const GLOBAL       = 1 << 0;

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -17,7 +17,8 @@ use swf::avm2::types::{
 
 bitflags! {
     /// All attributes a trait can have.
-    pub struct  TraitAttributes: u8 {
+    #[derive(Clone, Copy)]
+    pub struct TraitAttributes: u8 {
         /// Whether or not traits in downstream classes are allowed to override
         /// this trait.
         const FINAL    = 1 << 0;

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -1101,8 +1101,8 @@ impl<'gc> BitmapData<'gc> {
                         // because of the saturating conversion to u8
                         *noise_c = if c == 3 { 1.0 } else { -1.0 };
 
-                        // SAFETY: `c` is always in 0..4, so `1 << c` is a valid `ChannelOptions`.
-                        let c = unsafe { ChannelOptions::from_bits_unchecked(1 << c) };
+                        // `c` is always in 0..4, so `1 << c` is never actually truncated here
+                        let c = ChannelOptions::from_bits_truncate(1 << c);
                         if channel_options.contains(c) {
                             *noise_c = turb.turbulence(
                                 channel,

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -194,7 +194,7 @@ bitflags! {
         const GREEN = 1 << 1;
         const BLUE = 1 << 2;
         const ALPHA = 1 << 3;
-        const RGB = Self::RED.bits | Self::GREEN.bits | Self::BLUE.bits;
+        const RGB = Self::RED.bits() | Self::GREEN.bits() | Self::BLUE.bits();
     }
 }
 

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1786,8 +1786,8 @@ impl<'gc> DisplayObject<'gc> {
 
 bitflags! {
     /// Bit flags used by `DisplayObject`.
-    #[derive(Collect)]
-    #[collect(no_drop)]
+    #[derive(Clone, Collect, Copy)]
+    #[collect(require_static)]
     struct DisplayObjectFlags: u16 {
         /// Whether this object has been removed from the display list.
         /// Necessary in AVM1 to throw away queued actions from removed movie clips.
@@ -1840,6 +1840,7 @@ bitflags! {
 bitflags! {
     /// Defines how hit testing should be performed.
     /// Used for mouse picking and ActionScript's hitTestClip functions.
+    #[derive(Clone, Copy)]
     pub struct HitTestOptions: u8 {
         /// Ignore objects used as masks (setMask / clipDepth).
         const SKIP_MASK = 1 << 0;

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1849,10 +1849,10 @@ bitflags! {
         const SKIP_INVISIBLE = 1 << 1;
 
         /// The options used for `hitTest` calls in ActionScript.
-        const AVM_HIT_TEST = Self::SKIP_MASK.bits;
+        const AVM_HIT_TEST = Self::SKIP_MASK.bits();
 
         /// The options used for mouse picking, such as clicking on buttons.
-        const MOUSE_PICK = Self::SKIP_MASK.bits | Self::SKIP_INVISIBLE.bits;
+        const MOUSE_PICK = Self::SKIP_MASK.bits() | Self::SKIP_INVISIBLE.bits();
     }
 }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1879,7 +1879,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
 }
 
 bitflags::bitflags! {
-    #[derive(Collect)]
+    #[derive(Clone, Copy, Collect)]
     #[collect(require_static)]
     struct EditTextFlag: u16 {
         const FIRING_VARIABLE_BINDING = 1 << 0;

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1896,8 +1896,8 @@ bitflags::bitflags! {
         const WAS_STATIC = 1 << 10;
         const BORDER = 1 << 11;
         const NO_SELECT = 1 << 12;
-        const SWF_FLAGS = Self::READ_ONLY.bits | Self::PASSWORD.bits | Self::MULTILINE.bits | Self::WORD_WRAP.bits | Self::USE_OUTLINES.bits |
-                          Self::HTML.bits | Self::WAS_STATIC.bits | Self::BORDER.bits | Self::NO_SELECT.bits;
+        const SWF_FLAGS = Self::READ_ONLY.bits() | Self::PASSWORD.bits() | Self::MULTILINE.bits() | Self::WORD_WRAP.bits() | Self::USE_OUTLINES.bits() |
+                          Self::HTML.bits() | Self::WAS_STATIC.bits() | Self::BORDER.bits() | Self::NO_SELECT.bits();
     }
 }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -65,7 +65,7 @@ fn lowest_common_ancestor<'gc>(
 
 bitflags! {
     /// Boolean state flags used by `InteractiveObject`.
-    #[derive(Collect)]
+    #[derive(Clone, Copy, Collect)]
     #[collect(require_static)]
     struct InteractiveObjectFlags: u8 {
         /// Whether this `InteractiveObject` accepts mouse and other user

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -4401,7 +4401,7 @@ pub enum QueuedTagAction {
 
 bitflags! {
     /// Boolean state flags used by `MovieClip`.
-    #[derive(Collect)]
+    #[derive(Clone, Copy, Collect)]
     #[collect(require_static)]
     struct MovieClipFlags: u8 {
         /// Whether this `MovieClip` has run its initial frame.

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -1038,7 +1038,7 @@ bitflags! {
     ///
     /// This is a bitflags instead of an enum to mimic Flash Player behavior.
     /// You can theoretically have both TOP and BOTTOM bits set, for example.
-    #[derive(Default, Collect)]
+    #[derive(Clone, Copy, Default, Collect)]
     #[collect(require_static)]
     pub struct StageAlign: u8 {
         /// Align to the top of the viewport.

--- a/render/naga-agal/Cargo.toml
+++ b/render/naga-agal/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 naga = "0.11.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"

--- a/render/naga-agal/src/types.rs
+++ b/render/naga-agal/src/types.rs
@@ -96,6 +96,7 @@ pub struct SourceField {
 }
 
 bitflags::bitflags! {
+    #[derive(Clone, Copy, Debug)]
     pub struct Mask: u8 {
         const X = 0b0001;
         const Y = 0b0010;

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 bitstream-io = "1.6.0"
 byteorder = "1.4"
 encoding_rs = "0.8.32"

--- a/swf/src/avm1/types.rs
+++ b/swf/src/avm1/types.rs
@@ -156,6 +156,7 @@ pub struct FunctionParam<'a> {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct FunctionFlags: u16 {
         const PRELOAD_THIS = 1 << 0;
         const SUPPRESS_THIS = 1 << 1;
@@ -236,6 +237,7 @@ impl GetUrl2 {
 
 bitflags! {
     // NOTE: The GetURL2 flag layout is listed backwards in the SWF19 specs.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub(crate) struct GetUrlFlags: u8 {
         const METHOD_NONE = 0;
         const METHOD_GET = 1;

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -101,6 +101,7 @@ pub struct Method {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq)]
     pub struct MethodFlags: u8 {
         const NEED_ARGUMENTS  = 1 << 0;
         const NEED_ACTIVATION = 1 << 1;

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1342,7 +1342,7 @@ impl<'a> Reader<'a> {
             ))
         } else {
             // MorphLineStyle2 in DefineMorphShape2.
-            let mut flags = LineStyleFlag::from_bits_truncate(self.read_u16()?);
+            let mut flags = LineStyleFlag::from_bits_retain(self.read_u16()?);
             // Verify valid cap and join styles.
             if flags.contains(LineStyleFlag::JOIN_STYLE) {
                 log::warn!("Invalid line join style");
@@ -1657,7 +1657,7 @@ impl<'a> Reader<'a> {
             Ok(LineStyle::new().with_width(width).with_color(color))
         } else {
             // LineStyle2 in DefineShape4
-            let mut flags = LineStyleFlag::from_bits_truncate(self.read_u16()?);
+            let mut flags = LineStyleFlag::from_bits_retain(self.read_u16()?);
             // Verify valid cap and join styles.
             if flags.contains(LineStyleFlag::JOIN_STYLE) {
                 log::warn!("Invalid line join style");
@@ -2074,7 +2074,7 @@ impl<'a> Reader<'a> {
             angle: self.read_fixed16()?,
             distance: self.read_fixed16()?,
             strength: self.read_fixed8()?,
-            flags: DropShadowFilterFlags::from_bits_truncate(self.read_u8()?),
+            flags: DropShadowFilterFlags::from_bits_retain(self.read_u8()?),
         })
     }
 
@@ -2082,7 +2082,7 @@ impl<'a> Reader<'a> {
         Ok(BlurFilter {
             blur_x: self.read_fixed16()?,
             blur_y: self.read_fixed16()?,
-            flags: BlurFilterFlags::from_bits_truncate(self.read_u8()?),
+            flags: BlurFilterFlags::from_bits_retain(self.read_u8()?),
         })
     }
 
@@ -2092,7 +2092,7 @@ impl<'a> Reader<'a> {
             blur_x: self.read_fixed16()?,
             blur_y: self.read_fixed16()?,
             strength: self.read_fixed8()?,
-            flags: GlowFilterFlags::from_bits_truncate(self.read_u8()?),
+            flags: GlowFilterFlags::from_bits_retain(self.read_u8()?),
         })
     }
 
@@ -2106,7 +2106,7 @@ impl<'a> Reader<'a> {
             angle: self.read_fixed16()?,
             distance: self.read_fixed16()?,
             strength: self.read_fixed8()?,
-            flags: BevelFilterFlags::from_bits_truncate(self.read_u8()?),
+            flags: BevelFilterFlags::from_bits_retain(self.read_u8()?),
         })
     }
 
@@ -2130,7 +2130,7 @@ impl<'a> Reader<'a> {
             angle: self.read_fixed16()?,
             distance: self.read_fixed16()?,
             strength: self.read_fixed8()?,
-            flags: GradientFilterFlags::from_bits_truncate(self.read_u8()?),
+            flags: GradientFilterFlags::from_bits_retain(self.read_u8()?),
         })
     }
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -871,7 +871,7 @@ impl LineStyle {
     #[inline]
     pub fn with_start_cap(mut self, val: LineCapStyle) -> Self {
         self.flags -= LineStyleFlag::START_CAP_STYLE;
-        self.flags |= LineStyleFlag::from_bits_truncate((val as u16) << 6);
+        self.flags |= LineStyleFlag::from_bits_retain((val as u16) << 6);
         self
     }
 
@@ -884,7 +884,7 @@ impl LineStyle {
     #[inline]
     pub fn with_end_cap(mut self, val: LineCapStyle) -> Self {
         self.flags -= LineStyleFlag::END_CAP_STYLE;
-        self.flags |= LineStyleFlag::from_bits_truncate((val as u16) << 8);
+        self.flags |= LineStyleFlag::from_bits_retain((val as u16) << 8);
         self
     }
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -261,6 +261,7 @@ bitflags! {
     /// Flags that define various characteristic of an SWF file.
     ///
     /// [SWF19 pp.57-58 ClipEvent](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=47)
+    #[derive(Clone, Copy, Debug, PartialEq)]
     pub struct FileAttributes: u8 {
         /// Whether this SWF requests hardware acceleration to blit to the screen.
         const USE_DIRECT_BLIT = 1 << 6;
@@ -462,6 +463,7 @@ bitflags! {
     /// An event that can be attached to a MovieClip instance using an `onClipEvent` or `on` block.
     ///
     /// [SWF19 pp.48-50 ClipEvent](https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf#page=50)
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct ClipEventFlag: u32 {
         const LOAD            = 1 << 0;
         const ENTER_FRAME     = 1 << 1;
@@ -643,6 +645,7 @@ pub struct Shape {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct ShapeFlag: u8 {
         const HAS_SCALING_STROKES     = 1 << 0;
         const HAS_NON_SCALING_STROKES = 1 << 1;
@@ -955,6 +958,7 @@ impl Default for LineStyle {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct LineStyleFlag: u16 {
         // First byte.
         const PIXEL_HINTING = 1 << 0;
@@ -1061,6 +1065,7 @@ pub struct ButtonRecord {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct ButtonState: u8 {
         const UP       = 1 << 0;
         const OVER     = 1 << 1;
@@ -1094,6 +1099,7 @@ pub struct ButtonAction<'a> {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct ButtonActionCondition: u16 {
         const IDLE_TO_OVER_UP       = 1 << 0;
         const OVER_UP_TO_IDLE       = 1 << 1;
@@ -1118,6 +1124,7 @@ pub struct DefineMorphShape {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct DefineMorphShapeFlag: u8 {
         const HAS_SCALING_STROKES     = 1 << 0;
         const HAS_NON_SCALING_STROKES = 1 << 1;
@@ -1151,6 +1158,7 @@ pub struct Font<'a> {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct FontFlag: u8 {
         const IS_BOLD = 1 << 0;
         const IS_ITALIC = 1 << 1;
@@ -1206,6 +1214,7 @@ pub struct FontInfo<'a> {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct FontInfoFlag: u8 {
         const HAS_WIDE_CODES = 1 << 0;
         const IS_BOLD = 1 << 1;
@@ -1559,6 +1568,7 @@ impl<'a> Default for EditText<'a> {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct EditTextFlag: u16 {
         const HAS_FONT = 1 << 0;
         const HAS_MAX_LENGTH = 1 << 1;
@@ -1731,6 +1741,7 @@ pub struct DoAbc2<'a> {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct DoAbc2Flag: u32 {
         const LAZY_INITIALIZE = 1 << 0;
     }

--- a/swf/src/types/bevel_filter.rs
+++ b/swf/src/types/bevel_filter.rs
@@ -49,7 +49,7 @@ bitflags! {
 impl BevelFilterFlags {
     #[inline]
     pub fn from_passes(num_passes: u8) -> Self {
-        let flags = Self::from_bits_truncate(num_passes);
+        let flags = Self::from_bits_retain(num_passes);
         debug_assert_eq!(flags & Self::PASSES, flags);
         flags
     }

--- a/swf/src/types/bevel_filter.rs
+++ b/swf/src/types/bevel_filter.rs
@@ -36,6 +36,7 @@ impl BevelFilter {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct BevelFilterFlags: u8 {
         const INNER_SHADOW     = 1 << 7;
         const KNOCKOUT         = 1 << 6;

--- a/swf/src/types/blur_filter.rs
+++ b/swf/src/types/blur_filter.rs
@@ -25,7 +25,7 @@ bitflags! {
 impl BlurFilterFlags {
     #[inline]
     pub fn from_passes(num_passes: u8) -> Self {
-        let flags = Self::from_bits_truncate(num_passes << 3);
+        let flags = Self::from_bits_retain(num_passes << 3);
         debug_assert_eq!(flags & Self::PASSES, flags);
         flags
     }

--- a/swf/src/types/blur_filter.rs
+++ b/swf/src/types/blur_filter.rs
@@ -16,6 +16,7 @@ impl BlurFilter {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct BlurFilterFlags: u8 {
         const PASSES = 0b11111 << 3;
     }

--- a/swf/src/types/convolution_filter.rs
+++ b/swf/src/types/convolution_filter.rs
@@ -25,6 +25,7 @@ impl ConvolutionFilter {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct ConvolutionFilterFlags: u8 {
         const CLAMP          = 1 << 1;
         const PRESERVE_ALPHA = 1 << 0;

--- a/swf/src/types/drop_shadow_filter.rs
+++ b/swf/src/types/drop_shadow_filter.rs
@@ -47,7 +47,7 @@ bitflags! {
 impl DropShadowFilterFlags {
     #[inline]
     pub fn from_passes(num_passes: u8) -> Self {
-        let flags = Self::from_bits_truncate(num_passes);
+        let flags = Self::from_bits_retain(num_passes);
         debug_assert_eq!(flags & Self::PASSES, flags);
         flags
     }

--- a/swf/src/types/drop_shadow_filter.rs
+++ b/swf/src/types/drop_shadow_filter.rs
@@ -35,6 +35,7 @@ impl DropShadowFilter {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct DropShadowFilterFlags: u8 {
         const INNER_SHADOW     = 1 << 7;
         const KNOCKOUT         = 1 << 6;

--- a/swf/src/types/glow_filter.rs
+++ b/swf/src/types/glow_filter.rs
@@ -28,6 +28,7 @@ impl GlowFilter {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct GlowFilterFlags: u8 {
         const INNER_GLOW       = 1 << 7;
         const KNOCKOUT         = 1 << 6;

--- a/swf/src/types/glow_filter.rs
+++ b/swf/src/types/glow_filter.rs
@@ -40,7 +40,7 @@ bitflags! {
 impl GlowFilterFlags {
     #[inline]
     pub fn from_passes(num_passes: u8) -> Self {
-        let flags = Self::from_bits_truncate(num_passes);
+        let flags = Self::from_bits_retain(num_passes);
         debug_assert_eq!(flags & Self::PASSES, flags);
         flags
     }

--- a/swf/src/types/gradient_filter.rs
+++ b/swf/src/types/gradient_filter.rs
@@ -48,7 +48,7 @@ bitflags! {
 impl GradientFilterFlags {
     #[inline]
     pub fn from_passes(num_passes: u8) -> Self {
-        let flags = Self::from_bits_truncate(num_passes);
+        let flags = Self::from_bits_retain(num_passes);
         debug_assert_eq!(flags & Self::PASSES, flags);
         flags
     }

--- a/swf/src/types/gradient_filter.rs
+++ b/swf/src/types/gradient_filter.rs
@@ -35,6 +35,7 @@ impl GradientFilter {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub struct GradientFilterFlags: u8 {
         const INNER_SHADOW     = 1 << 7;
         const KNOCKOUT         = 1 << 6;

--- a/tests/input-format/Cargo.toml
+++ b/tests/input-format/Cargo.toml
@@ -10,4 +10,4 @@ version.workspace = true
 [dependencies]
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
-bitflags = "1.3.2"
+bitflags = "2.0.0"

--- a/tests/input-format/src/injector.rs
+++ b/tests/input-format/src/injector.rs
@@ -12,6 +12,7 @@ bitflags! {
     ///
     /// Convertable from `MouseButton`, which is intended to represent ONE
     /// button being held or released.
+    #[derive(Clone, Copy)]
     pub struct MouseButtons: u8 {
         const LEFT = 0b00000001;
         const MIDDLE = 0b00000010;

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -16,8 +16,8 @@ thiserror = "1.0"
 flate2 = "1.0.25"
 log = "0.4"
 
-h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "8c00d0e13892ee349f76eb4f2651cb2b921d3766", optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "8c00d0e13892ee349f76eb4f2651cb2b921d3766", optional = true }
+h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "efee5be819c4b40817a4da82f80783320cdd0e32", optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "efee5be819c4b40817a4da82f80783320cdd0e32", optional = true }
 nihav_core = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_codec_support = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_duck = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }


### PR DESCRIPTION
Since Renovate won't be able to deal with this on its own, I did it for it.
I don't actually know if there is a less painful way though (through a macro option or something).