### PR TITLE
ci: Pin node to 19.7.0

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["18", "19"]
+        node_version: ["18", "~19.7.0"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 
@@ -103,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["18", "19"]
+        node_version: ["18", "~19.7.0"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 


### PR DESCRIPTION
The newly released 19.8.0 is crashing