### PR TITLE
chore: Update avm2 compatibility warning to be less severe

### DIFF
--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -24,8 +24,8 @@ impl DesktopUiBackend {
 
 // TODO: Move link to https://ruffle.rs/faq or similar
 const UNSUPPORTED_CONTENT_MESSAGE: &str = "\
-The Ruffle emulator does not yet support ActionScript 3, required by this content.
-If you choose to run it anyway, interactivity will be missing or limited.
+The Ruffle emulator may not yet fully support all of ActionScript 3 used by this content.
+Some parts of the content may not work as expected.
 
 See the following link for more info:
 https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users";

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1635,8 +1635,8 @@ export class RufflePlayer extends HTMLElement {
         // TODO: Change link to https://ruffle.rs/faq or similar
         // TODO: Pause content until message is dismissed
         div.innerHTML = `<div class="message">
-            <p>The Ruffle emulator does not yet support ActionScript 3, required by this content.</p>
-            <p>If you choose to run it anyway, interactivity will be missing or limited.</p>
+            <p>The Ruffle emulator may not yet fully support all of ActionScript 3 used by this content.</p>
+            <p>Some parts of the content may not work as expected.</p>
             <div>
                 <a target="_blank" class="more-info-link" href="https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users">More info</a>
                 <button id="run-anyway-btn">Run anyway</button>


### PR DESCRIPTION
I think we're very close to the point of removing it entirely, but until then let's be a little more confident in our support.