### PR TITLE
render: Support more Context3D texture formats

### DIFF
--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -351,11 +351,11 @@ pub fn create_texture<'gc>(
         let format = args[2].coerce_to_string(activation)?;
         let optimize_for_render_to_texture = args[3].coerce_to_boolean();
         let streaming_levels = args[4].as_integer(activation.context.gc_context)? as u32;
-        let format = if &*format == b"bgra" {
-            Context3DTextureFormat::Bgra
-        } else {
-            panic!("Unsupported texture format in createTexture: {:?}", format);
-        };
+        let format = Context3DTextureFormat::from_wstr(&format).ok_or_else(|| {
+            Error::RustError(
+                format!("Unsupported texture format in createTexture: {:?}", format).into(),
+            )
+        })?;
 
         let class = activation.avm2().classes().texture;
 
@@ -383,14 +383,15 @@ pub fn create_rectangle_texture<'gc>(
         let height = args[1].as_integer(activation.context.gc_context)? as u32;
         let format = args[2].coerce_to_string(activation)?;
         let optimize_for_render_to_texture = args[3].coerce_to_boolean();
-        let format = if &*format == b"bgra" {
-            Context3DTextureFormat::Bgra
-        } else {
-            panic!(
-                "Unsupported texture format in createRectangleTexture: {:?}",
-                format
-            );
-        };
+        let format = Context3DTextureFormat::from_wstr(&format).ok_or_else(|| {
+            Error::RustError(
+                format!(
+                    "Unsupported texture format in createRectangleTexture: {:?}",
+                    format
+                )
+                .into(),
+            )
+        })?;
 
         let class = activation.avm2().classes().rectangletexture;
 
@@ -418,14 +419,15 @@ pub fn create_cube_texture<'gc>(
         let format = args[1].coerce_to_string(activation)?;
         let optimize_for_render_to_texture = args[2].coerce_to_boolean();
         let streaming_levels = args[3].as_integer(activation.context.gc_context)? as u32;
-        let format = if &*format == b"bgra" {
-            Context3DTextureFormat::Bgra
-        } else {
-            panic!(
-                "Unsupported texture format in createCubeTexture: {:?}",
-                format
-            );
-        };
+        let format = Context3DTextureFormat::from_wstr(&format).ok_or_else(|| {
+            Error::RustError(
+                format!(
+                    "Unsupported texture format in createCubeTexture: {:?}",
+                    format
+                )
+                .into(),
+            )
+        })?;
 
         return context.create_cube_texture(
             size,

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -5,6 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2_stub_method;
 use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::RenderContext;
 use gc_arena::{Collect, GcCell, MutationContext};
@@ -104,6 +105,7 @@ impl<'gc> Context3DObject<'gc> {
         class: ClassObject<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
+        check_texture_stub(activation, format);
         let texture = self
             .0
             .write(activation.context.gc_context)
@@ -410,6 +412,7 @@ impl<'gc> Context3DObject<'gc> {
         streaming_levels: u32,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
+        check_texture_stub(activation, format);
         let texture = self
             .0
             .write(activation.context.gc_context)
@@ -468,5 +471,29 @@ impl<'gc> TObject<'gc> for Context3DObject<'gc> {
 impl std::fmt::Debug for Context3DObject<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Context3D")
+    }
+}
+
+// This would ideally be placed closer to the actual usage, but
+// we don't have stub support in 'render' crates
+fn check_texture_stub(activation: &mut Activation<'_, '_>, format: Context3DTextureFormat) {
+    match format {
+        Context3DTextureFormat::BgrPacked => {
+            avm2_stub_method!(
+                activation,
+                "flash.display3D.Context3D",
+                "createTexture",
+                "with BgrPacked"
+            );
+        }
+        Context3DTextureFormat::Compressed => {
+            avm2_stub_method!(
+                activation,
+                "flash.display3D.Context3D",
+                "createTexture",
+                "with Compressed"
+            );
+        }
+        _ => {}
     }
 }

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -104,7 +104,7 @@ impl_downcast!(ShaderModule);
 pub trait Texture: Downcast + Collect {}
 impl_downcast!(Texture);
 
-#[derive(Collect, Debug)]
+#[derive(Collect, Debug, Copy, Clone)]
 #[collect(require_static)]
 pub enum Context3DTextureFormat {
     Bgra,
@@ -113,6 +113,26 @@ pub enum Context3DTextureFormat {
     Compressed,
     CompressedAlpha,
     RgbaHalfFloat,
+}
+
+impl Context3DTextureFormat {
+    pub fn from_wstr(wstr: &WStr) -> Option<Context3DTextureFormat> {
+        if wstr == b"bgra" {
+            Some(Context3DTextureFormat::Bgra)
+        } else if wstr == b"bgraPacked4444" {
+            Some(Context3DTextureFormat::BgraPacked)
+        } else if wstr == b"bgrPacked565" {
+            Some(Context3DTextureFormat::BgrPacked)
+        } else if wstr == b"compressed" {
+            Some(Context3DTextureFormat::Compressed)
+        } else if wstr == b"compressedAlpha" {
+            Some(Context3DTextureFormat::CompressedAlpha)
+        } else if wstr == b"rgbaHalfFloat" {
+            Some(Context3DTextureFormat::RgbaHalfFloat)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Collect, Debug, Copy, Clone)]


### PR DESCRIPTION
None of these formats can currently be implemented correctly with wgpu, so we just use Rgba8Unorm instead.

The handling of opaque compressed textures is a little sketchy - it should work for 'normal' SWFs that upload an opaque BitmapData, but we might need to manually adjust the alpha values if