### PR TITLE
swf: Don't ignore Bitmap smoothing flags in SWF <8

### DIFF
--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1635,8 +1635,7 @@ impl<'a> Reader<'a> {
             0x40..=0x43 => FillStyle::Bitmap {
                 id: self.read_u16()?,
                 matrix: self.read_matrix()?,
-                // Bitmap smoothing only occurs in SWF version 8+.
-                is_smoothed: self.version >= 8 && (fill_style_type & 0b10) == 0,
+                is_smoothed: (fill_style_type & 0b10) == 0,
                 is_repeating: (fill_style_type & 0b01) == 0,
             },
 

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -1629,8 +1629,7 @@ impl<'a> Reader<'a> {
             0x40..=0x43 => FillStyle::Bitmap {
                 id: self.read_u16()?,
                 matrix: self.read_matrix()?,
-                // Bitmap smoothing only occurs in SWF version 8+.
-                is_smoothed: self.version >= 8 && (fill_style_type & 0b10) == 0,
+                is_smoothed: (fill_style_type & 0b10) == 0,
                 is_repeating: (fill_style_type & 0b01) == 0,
             },
 

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1534,9 +1534,7 @@ impl<W: Write> Writer<W> {
                 is_smoothed,
                 is_repeating,
             } => {
-                // Bitmap smoothing only an option in SWF version 8+.
-                // Lower versions use 0x40 and 0x41 type even when unsmoothed.
-                let fill_style_type = match (is_smoothed || self.version < 8, is_repeating) {
+                let fill_style_type = match (is_smoothed, is_repeating) {
                     (true, true) => 0x40,
                     (true, false) => 0x41,
                     (false, true) => 0x42,

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -1537,9 +1537,7 @@ impl<W: Write> Writer<W> {
                 is_smoothed,
                 is_repeating,
             } => {
-                // Bitmap smoothing only an option in SWF version 8+.
-                // Lower versions use 0x40 and 0x41 type even when unsmoothed.
-                let fill_style_type = match (is_smoothed || self.version < 8, is_repeating) {
+                let fill_style_type = match (is_smoothed, is_repeating) {
                     (true, true) => 0x40,
                     (true, false) => 0x41,
                     (false, true) => 0x42,


### PR DESCRIPTION
I think this comment: `Bitmap smoothing only occurs in SWF version 8+.`
Refers to this section in the AS reference:
<img src="https://user-images.githubusercontent.com/288816/225459820-51f14ed2-0f64-48e8-a8e4-c314aec3037b.png" width="300px" />

However, the SWF spec does not mention the version-gate for this flag:
<img src="https://user-images.githubusercontent.com/288816/225460167-25350032-5e86-4ae3-b365-47145f1bd0fb.png" width="300px" />

As for `Lower versions use 0x40 and 0x41 type even when unsmoothed.` it would be great if someone could come up with a real-world example of this.
I already have a counter-example: https://z0r.de/L/z0r-de_56.swf
This is a V6 SWF, and the bitmaps should appear smoothed.

And at any rate, handling this at the SWF read/write level might not be the best idea - I think it would be in a better place near rendering.