### PR TITLE
core: Avoid several BitmapData GPU -> CPU sync

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -246,7 +246,7 @@ fn attach_bitmap<'gc>(
         if let Some(bitmap_data) = bitmap
             .coerce_to_object(activation)
             .as_bitmap_data_object()
-            .map(|bd| bd.bitmap_data())
+            .map(|bd| bd.bitmap_data_wrapper())
         {
             if let Some(depth) = args.get(1) {
                 let depth = depth

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -7,7 +7,7 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 
 use crate::avm2::parameters::ParametersExt;
-use crate::bitmap::bitmap_data::BitmapData;
+use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
 use crate::character::Character;
 use crate::display_object::{Bitmap, TDisplayObject};
 use crate::{avm2_stub_getter, avm2_stub_setter};
@@ -24,7 +24,7 @@ pub fn init<'gc>(
 
         let bitmap_data = args
             .try_get_object(activation, 0)
-            .and_then(|o| o.as_bitmap_data());
+            .and_then(|o| o.as_bitmap_data_wrapper());
         //TODO: Pixel snapping is not supported
         let _pixel_snapping = args.get_string(activation, 1);
         let smoothing = args.get_bool(2);
@@ -87,7 +87,10 @@ pub fn init<'gc>(
             //Bitmap subclass).
 
             let bitmap_data = bitmap_data.unwrap_or_else(|| {
-                GcCell::allocate(activation.context.gc_context, BitmapData::dummy())
+                BitmapDataWrapper::new(GcCell::allocate(
+                    activation.context.gc_context,
+                    BitmapData::dummy(),
+                ))
             });
 
             let bitmap =

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -117,9 +117,9 @@ pub fn get_width<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
-        bitmap_data.read().check_valid(activation)?;
-        return Ok((bitmap_data.read().width() as i32).into());
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+        bitmap_data.check_valid(activation)?;
+        return Ok((bitmap_data.width() as i32).into());
     }
 
     Ok(Value::Undefined)
@@ -131,9 +131,9 @@ pub fn get_height<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
-        bitmap_data.read().check_valid(activation)?;
-        return Ok((bitmap_data.read().height() as i32).into());
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+        bitmap_data.check_valid(activation)?;
+        return Ok((bitmap_data.height() as i32).into());
     }
 
     Ok(Value::Undefined)
@@ -1006,10 +1006,10 @@ pub fn dispose<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
         // Don't check if we've already disposed this BitmapData - 'BitmapData.dispose()' can be called
         // multiple times
-        bitmap_data.write(activation.context.gc_context).dispose();
+        bitmap_data.dispose(activation.context.gc_context);
     }
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
@@ -10,16 +10,19 @@ pub fn upload_from_bitmap_data<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(texture) = this.and_then(|this| this.as_texture()) {
-        if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
+        if let Some(source) = args[0]
+            .coerce_to_object(activation)?
+            .as_bitmap_data_wrapper()
+        {
             let side = args[1].coerce_to_u32(activation)?;
             let mip_level = args[2].coerce_to_u32(activation)?;
             if mip_level == 0 {
                 texture.context3d().copy_bitmap_to_texture(
-                    activation,
-                    source,
+                    source.bitmap_handle(&mut activation.context),
                     texture.handle(),
                     // FIXME - is this right?
                     side,
+                    activation,
                 );
             } else {
                 avm2_stub_method!(

--- a/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
@@ -9,10 +9,16 @@ pub fn upload_from_bitmap_data<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(texture) = this.and_then(|this| this.as_texture()) {
-        if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
-            texture
-                .context3d()
-                .copy_bitmap_to_texture(activation, source, texture.handle(), 0);
+        if let Some(source) = args[0]
+            .coerce_to_object(activation)?
+            .as_bitmap_data_wrapper()
+        {
+            texture.context3d().copy_bitmap_to_texture(
+                source.bitmap_handle(&mut activation.context),
+                texture.handle(),
+                0,
+                activation,
+            );
         } else {
             panic!("Invalid source: {:?}", args[0]);
         }

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -10,12 +10,18 @@ pub fn upload_from_bitmap_data<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(texture) = this.and_then(|this| this.as_texture()) {
-        if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
+        if let Some(source) = args[0]
+            .coerce_to_object(activation)?
+            .as_bitmap_data_wrapper()
+        {
             let mip_level = args[1].coerce_to_u32(activation)?;
             if mip_level == 0 {
-                texture
-                    .context3d()
-                    .copy_bitmap_to_texture(activation, source, texture.handle(), 0);
+                texture.context3d().copy_bitmap_to_texture(
+                    source.bitmap_handle(&mut activation.context),
+                    texture.handle(),
+                    0,
+                    activation,
+                );
             } else {
                 avm2_stub_method!(
                     activation,

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -6,7 +6,6 @@ use crate::avm2::object::{Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2_stub_method;
-use crate::bitmap::bitmap_data::BitmapData;
 use crate::context::RenderContext;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_render::backend::{
@@ -14,7 +13,7 @@ use ruffle_render::backend::{
     Context3DTextureFormat, Context3DTriangleFace, Context3DVertexBufferFormat, ProgramType,
     Texture,
 };
-use ruffle_render::bitmap::{Bitmap, BitmapFormat};
+use ruffle_render::bitmap::BitmapHandle;
 use ruffle_render::commands::CommandHandler;
 use std::cell::{Ref, RefMut};
 use std::rc::Rc;
@@ -351,21 +350,14 @@ impl<'gc> Context3DObject<'gc> {
 
     pub(crate) fn copy_bitmap_to_texture(
         &self,
-        activation: &mut Activation<'_, 'gc>,
-        source: GcCell<'gc, BitmapData>,
+        source: BitmapHandle,
         dest: Rc<dyn Texture>,
         layer: u32,
+        activation: &mut Activation<'_, 'gc>,
     ) {
-        let bitmap = source.read();
-
         self.0.write(activation.context.gc_context).commands.push(
             Context3DCommand::CopyBitmapToTexture {
-                source: Bitmap::new(
-                    bitmap.width(),
-                    bitmap.height(),
-                    BitmapFormat::Rgba,
-                    bitmap.pixels_rgba(),
-                ),
+                source,
                 dest,
                 layer,
             },

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -102,21 +102,21 @@ impl<'gc> Bitmap<'gc> {
     pub fn new_with_bitmap_data(
         context: &mut UpdateContext<'_, 'gc>,
         id: CharacterId,
-        bitmap_data: GcCell<'gc, crate::bitmap::bitmap_data::BitmapData<'gc>>,
+        bitmap_data: BitmapDataWrapper<'gc>,
         smoothing: bool,
     ) -> Self {
         //NOTE: We do *not* solicit a handle from the `bitmap_data` at this
         //time due to mutable borrowing issues.
 
-        let width = bitmap_data.read().width();
-        let height = bitmap_data.read().height();
+        let width = bitmap_data.width();
+        let height = bitmap_data.height();
 
         Bitmap(GcCell::allocate(
             context.gc_context,
             BitmapData {
                 base: Default::default(),
                 id,
-                bitmap_data: BitmapDataWrapper::new(bitmap_data),
+                bitmap_data,
                 width,
                 height,
                 smoothing,
@@ -155,7 +155,7 @@ impl<'gc> Bitmap<'gc> {
         Ok(Self::new_with_bitmap_data(
             context,
             id,
-            bitmap_data,
+            BitmapDataWrapper::new(bitmap_data),
             smoothing,
         ))
     }

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -356,7 +356,7 @@ pub enum Context3DCommand<'gc> {
         face: Context3DTriangleFace,
     },
     CopyBitmapToTexture {
-        source: crate::bitmap::Bitmap,
+        source: BitmapHandle,
         dest: Rc<dyn Texture>,
         layer: u32,
     },

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -6,14 +6,16 @@ use downcast_rs::{impl_downcast, Downcast};
 
 use crate::backend::RenderBackend;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Collect)]
+#[collect(require_static)]
 pub struct BitmapHandle(pub Arc<dyn BitmapHandleImpl>);
 
 pub trait BitmapHandleImpl: Downcast + Debug {}
 impl_downcast!(BitmapHandleImpl);
 
 /// Info returned by the `register_bitmap` methods.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Collect)]
+#[collect(require_static)]
 pub struct BitmapInfo {
     pub handle: BitmapHandle,
     pub width: u16,

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -276,7 +276,7 @@ impl QueueSyncHandle {
 
 #[derive(Debug)]
 pub struct Texture {
-    texture: Arc<wgpu::Texture>,
+    pub(crate) texture: Arc<wgpu::Texture>,
     bind_linear: OnceCell<BitmapBinds>,
     bind_nearest: OnceCell<BitmapBinds>,
     texture_offscreen: OnceCell<TextureOffscreen>,


### PR DESCRIPTION
We don't need to perform a sync when getting the width/height, getting or setting the 'disposed' status, or uploading to a Context3D texture.

The Context3D change (using `copy_texture_to_texture` instead of relying on the CPU pixels) has the added advantage of avoiding a validation error when our source image row length isn't aligned to `COPY_BYTES_PER_ROW_ALIGNMENT`

This dramatically speeds up the Fancy Pants World 4 loading time (on a branch with my XML prs merged). Without this change, my machine spends around 10 seconds on a blank white screen after clicking 'Play'. With this change, the time spent on that screen is reduced to around 1-2 seconds.