### PR TITLE
avm2: Fix VertexBuffer3D.uploadDataFromByteArray size calculation

### DIFF
--- a/core/src/avm2/globals/flash/display3D/vertex_buffer_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/vertex_buffer_3d.rs
@@ -40,7 +40,10 @@ pub fn upload_from_byte_array<'gc>(
             .coerce_to_u32(activation)?;
 
         let data = byte_array
-            .read_at(num_vertices as usize * 2, byte_offset as usize)
+            .read_at(
+                num_vertices as usize * 4 * vertex_buffer.data32_per_vertex() as usize,
+                byte_offset as usize,
+            )
             .map_err(|e| e.to_avm(activation))?
             .to_vec();
 
@@ -48,7 +51,7 @@ pub fn upload_from_byte_array<'gc>(
             vertex_buffer,
             data,
             start_vertex as usize,
-            vertex_buffer.data_per_vertex(),
+            vertex_buffer.data32_per_vertex(),
             activation,
         );
     }
@@ -82,7 +85,7 @@ pub fn upload_from_vector<'gc>(
         let data: Result<Vec<f32>, _> = vector
             .iter()
             .map(|val| val.coerce_to_number(activation).map(|val| val as f32))
-            .take(num_vertices as usize * vertex_buffer.data_per_vertex())
+            .take(num_vertices as usize * vertex_buffer.data32_per_vertex() as usize)
             .collect();
 
         let data_bytes = bytemuck::cast_slice::<f32, u8>(data?.as_slice()).to_vec();
@@ -91,7 +94,7 @@ pub fn upload_from_vector<'gc>(
             vertex_buffer,
             data_bytes,
             start_vertex as usize,
-            vertex_buffer.data_per_vertex(),
+            vertex_buffer.data32_per_vertex(),
             activation,
         );
     }

--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -141,7 +141,7 @@ impl<'gc> Context3DObject<'gc> {
             activation,
             *self,
             handle,
-            data_32_per_vertex as usize,
+            data_32_per_vertex,
         )?))
     }
 
@@ -150,7 +150,7 @@ impl<'gc> Context3DObject<'gc> {
         buffer: VertexBuffer3DObject<'gc>,
         data: Vec<u8>,
         start_vertex: usize,
-        data_per_vertex: usize,
+        data32_per_vertex: u8,
         activation: &mut Activation<'_, 'gc>,
     ) {
         self.0.write(activation.context.gc_context).commands.push(
@@ -158,7 +158,7 @@ impl<'gc> Context3DObject<'gc> {
                 buffer: buffer.handle(),
                 data,
                 start_vertex,
-                data_per_vertex,
+                data32_per_vertex,
             },
         );
     }

--- a/core/src/avm2/object/vertex_buffer_3d_object.rs
+++ b/core/src/avm2/object/vertex_buffer_3d_object.rs
@@ -21,7 +21,7 @@ impl<'gc> VertexBuffer3DObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         context3d: Context3DObject<'gc>,
         handle: Rc<dyn VertexBuffer>,
-        data_per_vertex: usize,
+        data32_per_vertex: u8,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().vertexbuffer3d;
         let base = ScriptObjectData::new(class);
@@ -32,7 +32,7 @@ impl<'gc> VertexBuffer3DObject<'gc> {
                 base,
                 context3d,
                 handle,
-                data_per_vertex,
+                data32_per_vertex,
             },
         ))
         .into();
@@ -51,8 +51,8 @@ impl<'gc> VertexBuffer3DObject<'gc> {
         self.0.read().context3d
     }
 
-    pub fn data_per_vertex(&self) -> usize {
-        self.0.read().data_per_vertex
+    pub fn data32_per_vertex(&self) -> u8 {
+        self.0.read().data32_per_vertex
     }
 }
 
@@ -66,7 +66,10 @@ pub struct VertexBuffer3DObjectData<'gc> {
 
     handle: Rc<dyn VertexBuffer>,
 
-    data_per_vertex: usize,
+    /// The 'data32PerVertex' value that this object was created with.
+    /// This is the number of 32-bit values associated with each vertex,
+    /// and is at most 64
+    data32_per_vertex: u8,
 }
 
 impl<'gc> TObject<'gc> for VertexBuffer3DObject<'gc> {

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -299,7 +299,7 @@ pub enum Context3DCommand<'gc> {
     UploadToVertexBuffer {
         buffer: Rc<dyn VertexBuffer>,
         start_vertex: usize,
-        data_per_vertex: usize,
+        data32_per_vertex: u8,
         data: Vec<u8>,
     },
 

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -252,7 +252,7 @@ impl WgpuContext3D {
                 Context3DCommand::UploadToVertexBuffer {
                     buffer,
                     start_vertex,
-                    data_per_vertex,
+                    data32_per_vertex,
                     data,
                 } => {
                     let buffer: Rc<VertexBufferWrapper> = buffer
@@ -265,7 +265,9 @@ impl WgpuContext3D {
                         .write_buffer(
                             &mut buffer_command_encoder,
                             &buffer.buffer,
-                            (*start_vertex * *data_per_vertex * std::mem::size_of::<f32>()) as u64,
+                            (*start_vertex
+                                * (*data32_per_vertex as usize)
+                                * std::mem::size_of::<f32>()) as u64,
                             NonZeroU64::new(data.len() as u64).unwrap(),
                             &self.descriptors.device,
                         )


### PR DESCRIPTION
We were ignoreing 'data32PerVertex'.
To make the code clearer, I've renamed the variable to 'data32_per_vertex', and made it a 'u8' (as it has a maximum of 64)