### PR TITLE
extension: Give precedence to toggles over default options (fixes #5825)

### DIFF
--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -12,7 +12,10 @@ declare global {
          * [[PublicAPI]] instance itself.
          */
         RufflePlayer?:
-            | { config?: DataLoadOptions | URLLoadOptions | object }
+            | {
+                  config?: DataLoadOptions | URLLoadOptions | object;
+                  conflict?: Record<string, unknown> | null;
+              }
             | PublicAPI;
     }
 }
@@ -33,11 +36,11 @@ export class PublicAPI {
      * The configuration object used when Ruffle is instantiated.
      */
     config: DataLoadOptions | URLLoadOptions | object;
+    conflict: Record<string, unknown> | null;
 
     private sources: Record<string, typeof SourceAPI>;
     private invoked: boolean;
     private newestName: string | null;
-    private conflict: Record<string, unknown> | null;
 
     /**
      * Construct the Ruffle public API.

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -666,6 +666,13 @@ export class RufflePlayer extends HTMLElement {
         try {
             this.loadedConfig = {
                 ...DEFAULT_CONFIG,
+                ...(window.RufflePlayer?.conflict &&
+                window.RufflePlayer?.conflict["newestName"] === "extension"
+                    ? (window.RufflePlayer?.conflict["config"] as Record<
+                          string,
+                          unknown
+                      >)
+                    : {}),
                 ...(window.RufflePlayer?.config ?? {}),
                 ...this.config,
                 ...options,

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -16,8 +16,8 @@ function handleMessage(message: Message) {
         case "load": {
             const api = window.RufflePlayer ?? {};
             api.config = {
-                ...api.config,
                 ...message.config,
+                ...api.config,
             };
             window.RufflePlayer = PublicAPI.negotiate(api, "extension");
             return {};


### PR DESCRIPTION
Also fixes #5696

Edit: This only works when the extension is the version of Ruffle that winds up taking precedence. If the self-hosted build takes precedence, the extension is not loaded until after RufflePlayer.load, and therefore the extension configuration is not available until then , so I can't take the toggles into account before loading content. The best way to ensure the extension loads early enough to take precedence in order to properly test this PR is to simulate a slow network connection using network throttling, as described in https://developer.chrome.com/docs/devtools/network/reference/#throttling and https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/throttling/index.html.