### PR TITLE
render: Compile a different version of 'bitmap.wgsl' for Stage3D

### DIFF
--- a/render/wgpu/shaders/bitmap.wgsl
+++ b/render/wgpu/shaders/bitmap.wgsl
@@ -42,14 +42,13 @@ fn main_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     if( color.a > 0.0 ) {
         color = vec4<f32>(color.rgb / color.a, color.a);
         color = color * colorTransforms.mult_color + colorTransforms.add_color;
-        // Apply 'saturate' *after* we re-multiply. If we get a non-premultiplied
-        // color like (1.0, 1.0. 1.0, 0.5) from a Stage3D texture, we want
-        // this shader to have no effect if we're applying a no-op colorTransforms.
-        // By applying the saturation after dividing and multiply by the alpha,
-        // we avoid saturing if the intermediate 'unmultiplied' color is temporarily
-        // out of range.
-        let alpha = saturate(color.a);
-        color = vec4<f32>(saturate(color.rgb * alpha), alpha);
+        #if early_saturate == true
+            color = saturate(color);
+        #endif
+        color = vec4<f32>(color.rgb * color.a, color.a);
+        #if early_saturate == false
+            color = saturate(color);
+        #endif
     }
     return color;
 }

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -218,8 +218,8 @@ impl Pipelines {
 
         let bitmap_opaque = device.create_render_pipeline(&create_pipeline_descriptor(
             create_debug_label!("Bitmap opaque copy").as_deref(),
-            &shaders.bitmap_shader,
-            &shaders.bitmap_shader,
+            &shaders.bitmap_late_saturate_shader,
+            &shaders.bitmap_late_saturate_shader,
             &bitmap_opaque_pipeline_layout,
             None,
             &[Some(wgpu::ColorTargetState {


### PR DESCRIPTION
When using the bitmap.wgsl shader for normal rendering, we need to saturate immediately after applying the color transformation to reproduce Flash Player's behavior. This makes the (possibly transformed) alpha value get multiplied by a in-range color, instead of a potentially out-of-range color.

However, Stage3D just applies a no-op color transformation, and should only saturate at the very end
(not after the intermediate division by the original alpha value).

To support both of these requirements, I've added in a new `early_saturate` ifdef that controls when we apply 'saturate'. We then compile the shader twice (once with early_saturate=true and once with early_saturate=false), and use the two versions in the right pipelines.

We could use a simpler shader for Stage3D - however, it can't just be a plain copy, as we need to apply the viewport transformation. For now, I'm re-using the shader code to keep things simple. If this becomes a performance issue in stage3d, we could revisit this.