### PR TITLE
tests: Use 'warn' log level for wpgu crates in regression tests

### DIFF
--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -16,7 +16,8 @@ mod util;
 
 fn set_logger() {
     let _ = env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info,ruffle_render_wgpu=warn"),
+        env_logger::Env::default()
+            .default_filter_or("info,ruffle_render_wgpu=warn,wgpu_core=warn,wgpu_hal=warn"),
     )
     .format_timestamp(None)
     .is_test(true)


### PR DESCRIPTION
This makes the test output much less verbose.