### PR TITLE
web: Allow ExternalInterface.call to call methods of primitive types (close #9105)

### DIFF
--- a/web/packages/core/src/ruffle-imports.ts
+++ b/web/packages/core/src/ruffle-imports.ts
@@ -59,3 +59,14 @@ export function copyToAudioBufferInterleaved(
         i += 2;
     }
 }
+
+/**
+ * Gets a property of an arbitrary JavaScript value.
+ * This is necessary because Reflect.get does not work for primitive targets.
+ *
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getProperty(target: any, key: string): any {
+    return target[key];
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1174,6 +1174,12 @@ impl ExternalInterfaceMethod for JavascriptMethod {
     }
 }
 
+#[wasm_bindgen(raw_module = "./ruffle-imports")]
+extern "C" {
+    #[wasm_bindgen(catch, js_name = "getProperty")]
+    pub fn get_property(target: &JsValue, key: &JsValue) -> Result<JsValue, JsValue>;
+}
+
 impl JavascriptInterface {
     fn new(js_player: JavascriptPlayer) -> Self {
         Self { js_player }
@@ -1184,7 +1190,7 @@ impl JavascriptInterface {
         let mut value = root;
         for key in name.split('.') {
             parent = value;
-            value = js_sys::Reflect::get(&parent, &JsValue::from_str(key)).ok()?;
+            value = get_property(&parent, &JsValue::from_str(key)).ok()?;
         }
         if value.is_function() {
             Some(JavascriptMethod {


### PR DESCRIPTION
See the description of https://github.com/ruffle-rs/ruffle/issues/9105.

`ExternalInterface.call("window.location.href.toString")`, for example, is a method that is sometimes used to get the current webpage url.

This does not work in ruffle currently, because we trigger the javascript code `Reflect.get(window.location.href, "toString")` (which fails because href is a primitive and not an object) instead of `window.location.href["toString"]` (which works correctly).

The only way I could find to fix this was to expose a helper method from javascript - wasm_bindgen doesn't have anything built-in which is *actually* equivalent to target[key].