### PR TITLE
avm2: Implement LocalConnection.domain getter

### DIFF
--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -3,6 +3,7 @@
 use crate::avm2::object::TObject;
 use crate::avm2::{Activation, Error, Object, Value};
 
+pub mod local_connection;
 pub mod object_encoding;
 pub mod shared_object;
 pub mod url_loader;

--- a/core/src/avm2/globals/flash/net/LocalConnection.as
+++ b/core/src/avm2/globals/flash/net/LocalConnection.as
@@ -13,11 +13,7 @@ package flash.net {
             this.client = this;
         }
 
-        public function get domain():String {
-            // FIXME - implement this - this is unrelated to the messaging functionality.
-            stub_getter("flash.net.LocalConnection", "domain");
-            return "localhost";
-        }
+        public native function get domain():String;
 
         public function close(): void {
             stub_method("flash.net.LocalConnection", "close");

--- a/core/src/avm2/globals/flash/net/local_connection.rs
+++ b/core/src/avm2/globals/flash/net/local_connection.rs
@@ -1,0 +1,27 @@
+use crate::avm2::{Activation, Error, Object, Value};
+use crate::string::AvmString;
+
+/// Implements `domain` getter
+pub fn get_domain<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let movie = activation.context.swf;
+
+    let domain = if let Ok(url) = url::Url::parse(movie.url()) {
+        if url.scheme() == "file" {
+            "localhost".into()
+        } else if let Some(domain) = url.domain() {
+            AvmString::new_utf8(activation.context.gc_context, domain)
+        } else {
+            // no domain?
+            "localhost".into()
+        }
+    } else {
+        tracing::error!("LocalConnection::domain: Unable to parse movie URL");
+        return Ok(Value::Null);
+    };
+
+    Ok(Value::String(domain))
+}


### PR DESCRIPTION
We don't really have a way to test this right now, sadly. Implementation is the same as AVM1.

This fixes many site locks, like https://www.newgrounds.com/portal/view/546416