### PR TITLE
avm2: Implement `updateAfterEvent`

### DIFF
--- a/core/src/avm2/globals/flash/events.rs
+++ b/core/src/avm2/globals/flash/events.rs
@@ -4,3 +4,5 @@ pub mod event;
 pub mod event_dispatcher;
 pub mod gesture_event;
 pub mod mouse_event;
+pub mod timer_event;
+pub mod touch_event;

--- a/core/src/avm2/globals/flash/events/MouseEvent.as
+++ b/core/src/avm2/globals/flash/events/MouseEvent.as
@@ -76,10 +76,7 @@ package flash.events
             return this.formatToString("MouseEvent","type","bubbles","cancelable","eventPhase","localX","localY","stageX","stageY","relatedObject","ctrlKey","altKey","shiftKey","buttonDown","delta");
         }
 
-        public function updateAfterEvent():void {
-            // TODO - determine when we should actually force a frame to be rendered.
-            stub_method("flash.events.MouseEvent", "updateAfterEvent");
-        }
+        public native function updateAfterEvent():void;
 
         public native function get stageX() : Number;
         public native function get stageY() : Number;

--- a/core/src/avm2/globals/flash/events/TimerEvent.as
+++ b/core/src/avm2/globals/flash/events/TimerEvent.as
@@ -12,9 +12,6 @@ package flash.events {
 			return new TimerEvent(this.type,this.bubbles,this.cancelable);
 		}
 
-		public function updateAfterEvent():void {
-			// TODO - determine when we should actually force a frame to be rendered.
-			stub_method("flash.events.TimerEvent", "updateAfterEvent");
-		}
+		public native function updateAfterEvent():void;
 	}
 }

--- a/core/src/avm2/globals/flash/events/TouchEvent.as
+++ b/core/src/avm2/globals/flash/events/TouchEvent.as
@@ -101,9 +101,7 @@ public class TouchEvent extends Event {
     }
 
     // Instructs Flash Player or Adobe AIR to render after processing of this event completes, if the display list has been modified.
-    public function updateAfterEvent(): void {
-        stub_method("flash.events.TouchEvent", "updateAfterEvent");
-    }
+    public native function updateAfterEvent(): void;
 
     public function get stageX(): Number {
         return this._stageX;

--- a/core/src/avm2/globals/flash/events/mouse_event.rs
+++ b/core/src/avm2/globals/flash/events/mouse_event.rs
@@ -74,3 +74,12 @@ pub fn get_stage_y<'gc>(
 
     Ok(Value::Undefined)
 }
+
+pub fn update_after_event<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    *activation.context.needs_render = true;
+    Ok(Value::Undefined)
+}

--- a/core/src/avm2/globals/flash/events/timer_event.rs
+++ b/core/src/avm2/globals/flash/events/timer_event.rs
@@ -1,0 +1,13 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+
+pub fn update_after_event<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    *activation.context.needs_render = true;
+    Ok(Value::Undefined)
+}

--- a/core/src/avm2/globals/flash/events/touch_event.rs
+++ b/core/src/avm2/globals/flash/events/touch_event.rs
@@ -1,0 +1,13 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+
+pub fn update_after_event<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    *activation.context.needs_render = true;
+    Ok(Value::Undefined)
+}


### PR DESCRIPTION
Implement `MouseEvent.updateAfterEvent` and `TimerEvent.updateAfterEvent`. Implementation is the same as AVM1, simply signaling that a render is requested. The various frontends handle as appropriate by checking `core.needs_render()`.