### PR TITLE
Don't leak Shape meshes in renderer

### DIFF
--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -190,7 +190,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
 
         if let Some(drawing) = &self.0.read().drawing {
             drawing.render(context);
-        } else if let Some(render_handle) = self.0.read().static_data.render_handle {
+        } else if let Some(render_handle) = self.0.read().static_data.render_handle.clone() {
             context
                 .commands
                 .render_shape(render_handle, context.transform_stack.transform())

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -194,7 +194,7 @@ impl MorphShapeStatic {
         ratio: u16,
     ) -> ShapeHandle {
         let mut frame = self.get_frame(ratio);
-        if let Some(handle) = frame.shape_handle {
+        if let Some(handle) = frame.shape_handle.clone() {
             handle
         } else {
             let library = library.library_for_movie(self.movie.clone()).unwrap();
@@ -205,7 +205,7 @@ impl MorphShapeStatic {
                     gc_context: context.gc_context,
                 },
             );
-            frame.shape_handle = Some(handle);
+            frame.shape_handle = Some(handle.clone());
             handle
         }
     }

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -304,12 +304,8 @@ impl Drawing {
                 edge_bounds: self.edge_bounds.clone(),
                 id: 0,
             };
-            if let Some(handle) = self.render_handle.get() {
-                context.renderer.replace_shape(shape, self, handle);
-            } else {
-                self.render_handle
-                    .set(Some(context.renderer.register_shape(shape, self)));
-            }
+            self.render_handle
+                .set(Some(context.renderer.register_shape(shape, self)));
         }
 
         if let Some(handle) = self.render_handle.get() {

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -4,13 +4,13 @@ use ruffle_render::backend::{RenderBackend, ShapeHandle};
 use ruffle_render::bitmap::{BitmapHandle, BitmapInfo, BitmapSize, BitmapSource};
 use ruffle_render::commands::CommandHandler;
 use ruffle_render::shape_utils::{DistilledShape, DrawCommand, DrawPath, FillRule};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use swf::{FillStyle, LineStyle, Rectangle, Twips};
 
 #[derive(Clone, Debug, Collect)]
 #[collect(require_static)]
 pub struct Drawing {
-    render_handle: Cell<Option<ShapeHandle>>,
+    render_handle: RefCell<Option<ShapeHandle>>,
     shape_bounds: Rectangle<Twips>,
     edge_bounds: Rectangle<Twips>,
     dirty: Cell<bool>,
@@ -33,7 +33,7 @@ impl Default for Drawing {
 impl Drawing {
     pub fn new() -> Self {
         Self {
-            render_handle: Cell::new(None),
+            render_handle: RefCell::new(None),
             shape_bounds: Default::default(),
             edge_bounds: Default::default(),
             dirty: Cell::new(false),
@@ -50,7 +50,7 @@ impl Drawing {
 
     pub fn from_swf_shape(shape: &swf::Shape) -> Self {
         let mut this = Self {
-            render_handle: Cell::new(None),
+            render_handle: RefCell::new(None),
             shape_bounds: shape.shape_bounds.clone(),
             edge_bounds: shape.edge_bounds.clone(),
             dirty: Cell::new(true),
@@ -305,10 +305,10 @@ impl Drawing {
                 id: 0,
             };
             self.render_handle
-                .set(Some(context.renderer.register_shape(shape, self)));
+                .replace(Some(context.renderer.register_shape(shape, self)));
         }
 
-        if let Some(handle) = self.render_handle.get() {
+        if let Some(handle) = self.render_handle.borrow().to_owned() {
             context
                 .commands
                 .render_shape(handle, context.transform_stack.transform());

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -445,16 +445,6 @@ impl RenderBackend for WebCanvasRenderBackend {
         handle
     }
 
-    fn replace_shape(
-        &mut self,
-        shape: DistilledShape,
-        bitmap_source: &dyn BitmapSource,
-        handle: ShapeHandle,
-    ) {
-        let data = swf_shape_to_canvas_commands(&shape, bitmap_source, self);
-        self.shapes[handle.0] = data;
-    }
-
     fn register_glyph_shape(&mut self, glyph: &swf::Glyph) -> ShapeHandle {
         let shape = ruffle_render::shape_utils::swf_glyph_to_shape(glyph);
         self.register_shape((&shape).into(), &NullBitmapSource)

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -24,12 +24,6 @@ pub trait RenderBackend: Downcast {
         shape: DistilledShape,
         bitmap_source: &dyn BitmapSource,
     ) -> ShapeHandle;
-    fn replace_shape(
-        &mut self,
-        shape: DistilledShape,
-        bitmap_source: &dyn BitmapSource,
-        handle: ShapeHandle,
-    );
     fn register_glyph_shape(&mut self, shape: &swf::Glyph) -> ShapeHandle;
 
     /// Creates a new `RenderBackend` which renders directly

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -11,7 +11,9 @@ use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_wstr::WStr;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::fmt::Debug;
 use std::rc::Rc;
+use std::sync::Arc;
 use swf;
 
 pub trait RenderBackend: Downcast {
@@ -376,8 +378,12 @@ pub enum Context3DCommand<'gc> {
     },
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct ShapeHandle(pub usize);
+#[derive(Clone, Debug, Collect)]
+#[collect(require_static)]
+pub struct ShapeHandle(pub Arc<dyn ShapeHandleImpl>);
+
+pub trait ShapeHandleImpl: Downcast + Debug {}
+impl_downcast!(ShapeHandleImpl);
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use crate::backend::{RenderBackend, ShapeHandle, ViewportDimensions};
+use crate::backend::{RenderBackend, ShapeHandle, ShapeHandleImpl, ViewportDimensions};
 use crate::bitmap::{Bitmap, BitmapHandle, BitmapHandleImpl, BitmapSize, BitmapSource, SyncHandle};
 use crate::commands::CommandList;
 use crate::error::Error;
@@ -32,9 +32,14 @@ impl NullRenderer {
         Self { dimensions }
     }
 }
+
 #[derive(Clone, Debug)]
 struct NullBitmapHandle;
 impl BitmapHandleImpl for NullBitmapHandle {}
+
+#[derive(Clone, Debug)]
+struct NullShapeHandle;
+impl ShapeHandleImpl for NullShapeHandle {}
 
 impl RenderBackend for NullRenderer {
     fn viewport_dimensions(&self) -> ViewportDimensions {
@@ -48,10 +53,10 @@ impl RenderBackend for NullRenderer {
         _shape: DistilledShape,
         _bitmap_source: &dyn BitmapSource,
     ) -> ShapeHandle {
-        ShapeHandle(0)
+        ShapeHandle(Arc::new(NullShapeHandle))
     }
     fn register_glyph_shape(&mut self, _shape: &swf::Glyph) -> ShapeHandle {
-        ShapeHandle(0)
+        ShapeHandle(Arc::new(NullShapeHandle))
     }
 
     fn render_offscreen(

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -50,13 +50,6 @@ impl RenderBackend for NullRenderer {
     ) -> ShapeHandle {
         ShapeHandle(0)
     }
-    fn replace_shape(
-        &mut self,
-        _shape: DistilledShape,
-        _bitmap_source: &dyn BitmapSource,
-        _handle: ShapeHandle,
-    ) {
-    }
     fn register_glyph_shape(&mut self, _shape: &swf::Glyph) -> ShapeHandle {
         ShapeHandle(0)
     }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -734,6 +734,7 @@ impl WebGlRenderBackend {
         };
     }
 
+    #[allow(dead_code)]
     fn delete_mesh(&self, mesh: &Mesh) {
         if let Some(gl2) = &self.gl2 {
             for draw in &mesh.draws {
@@ -994,19 +995,6 @@ impl RenderBackend for WebGlRenderBackend {
             Err(e) => log::error!("Couldn't register shape: {:?}", e),
         }
         handle
-    }
-
-    fn replace_shape(
-        &mut self,
-        shape: DistilledShape,
-        bitmap_source: &dyn BitmapSource,
-        handle: ShapeHandle,
-    ) {
-        self.delete_mesh(&self.meshes[handle.0]);
-        match self.register_shape_internal(shape, bitmap_source) {
-            Ok(mesh) => self.meshes[handle.0] = mesh,
-            Err(e) => log::error!("Couldn't replace shape: {:?}", e),
-        }
     }
 
     fn register_glyph_shape(&mut self, glyph: &swf::Glyph) -> ShapeHandle {

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -431,17 +431,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     }
 
     #[instrument(level = "debug", skip_all)]
-    fn replace_shape(
-        &mut self,
-        shape: DistilledShape,
-        bitmap_source: &dyn BitmapSource,
-        handle: ShapeHandle,
-    ) {
-        let mesh = self.register_shape_internal(shape, bitmap_source);
-        self.meshes[handle.0] = mesh;
-    }
-
-    #[instrument(level = "debug", skip_all)]
     fn register_glyph_shape(&mut self, glyph: &swf::Glyph) -> ShapeHandle {
         let shape = ruffle_render::shape_utils::swf_glyph_to_shape(glyph);
         let handle = ShapeHandle(self.meshes.len());

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -424,22 +424,18 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         shape: DistilledShape,
         bitmap_source: &dyn BitmapSource,
     ) -> ShapeHandle {
-        let handle = ShapeHandle(self.meshes.len());
         let mesh = self.register_shape_internal(shape, bitmap_source);
-        self.meshes.push(mesh);
-        handle
+        ShapeHandle(Arc::new(mesh))
     }
 
     #[instrument(level = "debug", skip_all)]
     fn register_glyph_shape(&mut self, glyph: &swf::Glyph) -> ShapeHandle {
         let shape = ruffle_render::shape_utils::swf_glyph_to_shape(glyph);
-        let handle = ShapeHandle(self.meshes.len());
         let mesh = self.register_shape_internal(
             (&shape).into(),
             &ruffle_render::backend::null::NullBitmapSource,
         );
-        self.meshes.push(mesh);
-        handle
+        ShapeHandle(Arc::new(mesh))
     }
 
     #[instrument(level = "debug", skip_all)]

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 use wgpu::util::DeviceExt;
 
 use crate::buffer_builder::BufferBuilder;
-use ruffle_render::backend::RenderBackend;
+use ruffle_render::backend::{RenderBackend, ShapeHandle, ShapeHandleImpl};
 use ruffle_render::bitmap::BitmapSource;
 use ruffle_render::tessellator::{Bitmap, Draw as LyonDraw, DrawType as TessDrawType, Gradient};
 use swf::{CharacterId, GradientInterpolation};
@@ -20,6 +20,12 @@ pub struct Mesh {
     pub draws: Vec<Draw>,
     pub vertex_buffer: wgpu::Buffer,
     pub index_buffer: wgpu::Buffer,
+}
+
+impl ShapeHandleImpl for Mesh {}
+
+pub fn as_mesh(handle: &ShapeHandle) -> &Mesh {
+    <dyn ShapeHandleImpl>::downcast_ref(&*handle.0).expect("Shape handle must be a WGPU ShapeData")
 }
 
 #[derive(Debug)]

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -209,7 +209,6 @@ impl Surface {
                     render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
                     let mut renderer = CommandRenderer::new(
                         &self.pipelines,
-                        meshes,
                         descriptors,
                         uniform_buffers,
                         color_buffers,


### PR DESCRIPTION
I realized that our current way of doing vector meshes will leak if the Drawing/Shape gets dropped, which can happen with movies that use the drawing API a lot.

This replaces ShapeHandle with the same system that BitmapHandle uses, and adds a custom Drop for WebGL to use (not needed on wgpu or canvas)