### PR TITLE
web: Display config parse errors

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -708,7 +708,12 @@ export class RufflePlayer extends HTMLElement {
             }
         } catch (e) {
             console.error(`Serious error occurred loading SWF file: ${e}`);
-            throw e;
+            const err = new Error(e as string);
+            if (err.message.includes("Error parsing config")) {
+                err.ruffleIndexError = PanicError.JavascriptConfiguration;
+            }
+            this.panic(err);
+            throw err;
         }
     }
 


### PR DESCRIPTION
Shows the panic screen when Ruffle encounters a serious error loading the SWF file. Detects config parse errors - these are the most likely cause of Ruffle failing to load an SWF that exists. Previously, when Ruffle failed to parse the provided config, it would continue to display the loading splash screen, with no outward sign of what went wrong. This confused a user in the help channel recently.