### PR TITLE
avm2: Show stack traces in error messages when log level is `Info`

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -452,7 +452,7 @@ impl<'gc> Avm2<'gc> {
     }
 
     /// Pushes an executable on the call stack
-    pub fn push_call(&self, mc: MutationContext<'gc, '_>, calling: Executable<'gc>) {
+    pub fn push_call(&self, mc: MutationContext<'gc, '_>, calling: &Executable<'gc>) {
         self.call_stack.write(mc).push(calling)
     }
 

--- a/core/src/avm2/globals/error.rs
+++ b/core/src/avm2/globals/error.rs
@@ -3,25 +3,15 @@ pub use crate::avm2::object::error_allocator;
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::TObject;
 
-#[cfg(feature = "avm_debug")]
 pub fn get_stack_trace<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    use crate::avm2::TObject;
     if let Some(error) = this.and_then(|this| this.as_error_object()) {
         return Ok(error.display_full(activation)?.into());
     }
     Ok(Value::Undefined)
-}
-
-#[cfg(not(feature = "avm_debug"))]
-pub fn get_stack_trace<'gc>(
-    _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
-    _args: &[Value<'gc>],
-) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(Value::Null)
 }


### PR DESCRIPTION
This PR actually does 2 things:
1. Reduces the size of `CallNode` from 56 bytes to 24 bytes. This was done to keep call stacks as small as possible for the next change. (this was done in the first commit)
2. Store the call stack in every error message when log level is set to `Info`, rather than when the `avm_debug` feature is enabled. However, if `avm_debug` is enabled, we store the call stack regardless of the log level. (this was done in the second commit)

I think this way is better because it allows people who do not want to build their own version of Ruffle to retrieve stack traces from error messages. Keep in mind that displaying a stack trace is slow, and storing it will also use a lot of extra memory, which is why it's important we only do this when the user manually sets the log level to `Info`.