### PR TITLE
core: Make `ExternalInterface.call` support `undefined` values in browsers

### DIFF
--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -26,7 +26,7 @@ pub fn add_callback<'gc>(
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if args.len() < 3 {
+    if !activation.context.external_interface.available() || args.len() < 3 {
         return Ok(false.into());
     }
 
@@ -53,25 +53,33 @@ pub fn call<'gc>(
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if args.is_empty() {
-        return Ok(ExternalValue::check_avm1_value(Value::Undefined));
+    if !activation.context.external_interface.available() {
+        return Ok(Value::Null);
     }
 
-    let name = args.get(0).unwrap().coerce_to_string(activation)?;
+    let (name, external_args_len) = if let Some(method_name) = args.get(0) {
+        (*method_name, args.len() - 1)
+    } else {
+        (Value::Undefined, 0)
+    };
+    let name = name.coerce_to_string(activation)?;
+
     if let Some(method) = activation
         .context
         .external_interface
         .get_method_for(&name.to_utf8_lossy())
     {
-        let mut external_args = Vec::with_capacity(args.len() - 1);
-        for arg in &args[1..] {
-            external_args.push(ExternalValue::from_avm1(activation, arg.to_owned())?);
+        let mut external_args = Vec::with_capacity(external_args_len);
+        if external_args_len > 0 {
+            for arg in &args[1..] {
+                external_args.push(ExternalValue::from_avm1(activation, arg.to_owned())?);
+            }
         }
         Ok(method
             .call(&mut activation.context, &external_args)
             .into_avm1(activation))
     } else {
-        Ok(ExternalValue::check_avm1_value(Value::Undefined))
+        Ok(Value::Null)
     }
 }
 

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -54,7 +54,7 @@ pub fn call<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.is_empty() {
-        return Ok(Value::Null);
+        return Ok(ExternalValue::check_avm1_value(Value::Undefined));
     }
 
     let name = args.get(0).unwrap().coerce_to_string(activation)?;
@@ -71,7 +71,7 @@ pub fn call<'gc>(
             .call(&mut activation.context, &external_args)
             .into_avm1(activation))
     } else {
-        Ok(Value::Null)
+        Ok(ExternalValue::check_avm1_value(Value::Undefined))
     }
 }
 

--- a/core/src/avm2/globals/flash/external/external_interface.rs
+++ b/core/src/avm2/globals/flash/external/external_interface.rs
@@ -21,7 +21,7 @@ pub fn call<'gc>(
             .call(&mut activation.context, &external_args)
             .into_avm2(activation))
     } else {
-        Ok(ExternalValue::check_avm2_value(Value::Undefined))
+        Ok(Value::Null)
     }
 }
 

--- a/core/src/avm2/globals/flash/external/external_interface.rs
+++ b/core/src/avm2/globals/flash/external/external_interface.rs
@@ -21,7 +21,7 @@ pub fn call<'gc>(
             .call(&mut activation.context, &external_args)
             .into_avm2(activation))
     } else {
-        Ok(Value::Null)
+        Ok(ExternalValue::check_avm2_value(Value::Undefined))
     }
 }
 

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Null,
+    Undefined,
     Bool(bool),
     Number(f64),
     String(String),
@@ -118,12 +119,26 @@ impl From<Vec<Value>> for Value {
 }
 
 impl Value {
+    pub fn check_avm1_value(value: Avm1Value) -> Avm1Value {
+        match value {
+            Avm1Value::Undefined => {
+                if cfg!(not(target_family = "wasm")) {
+                    Avm1Value::Null
+                } else {
+                    value
+                }
+            }
+            _ => value,
+        }
+    }
+
     pub fn from_avm1<'gc>(
         activation: &mut Avm1Activation<'_, 'gc>,
         value: Avm1Value<'gc>,
     ) -> Result<Value, Avm1Error<'gc>> {
         Ok(match value {
-            Avm1Value::Undefined | Avm1Value::Null => Value::Null,
+            Avm1Value::Null => Value::Null,
+            Avm1Value::Undefined => Value::Undefined,
             Avm1Value::Bool(value) => value.into(),
             Avm1Value::Number(value) => value.into(),
             Avm1Value::String(value) => Value::String(value.to_string()),
@@ -154,6 +169,7 @@ impl Value {
     pub fn into_avm1<'gc>(self, activation: &mut Avm1Activation<'_, 'gc>) -> Avm1Value<'gc> {
         match self {
             Value::Null => Avm1Value::Null,
+            Value::Undefined => Avm1Value::Undefined,
             Value::Bool(value) => Avm1Value::Bool(value),
             Value::Number(value) => Avm1Value::Number(value),
             Value::String(value) => {
@@ -186,9 +202,23 @@ impl Value {
         }
     }
 
+    pub fn check_avm2_value(value: Avm2Value) -> Avm2Value {
+        match value {
+            Avm2Value::Undefined => {
+                if cfg!(not(target_family = "wasm")) {
+                    Avm2Value::Null
+                } else {
+                    value
+                }
+            }
+            _ => value,
+        }
+    }
+
     pub fn from_avm2(value: Avm2Value) -> Value {
         match value {
-            Avm2Value::Undefined | Avm2Value::Null => Value::Null,
+            Avm2Value::Null => Value::Null,
+            Avm2Value::Undefined => Value::Undefined,
             Avm2Value::Bool(value) => value.into(),
             Avm2Value::Number(value) => value.into(),
             Avm2Value::Integer(value) => value.into(),
@@ -215,6 +245,7 @@ impl Value {
     pub fn into_avm2<'gc>(self, activation: &mut Avm2Activation<'_, 'gc>) -> Avm2Value<'gc> {
         match self {
             Value::Null => Avm2Value::Null,
+            Value::Undefined => Avm2Value::Undefined,
             Value::Bool(value) => Avm2Value::Bool(value),
             Value::Number(value) => Avm2Value::Number(value),
             Value::String(value) => {
@@ -271,12 +302,14 @@ impl<'gc> Callback<'gc> {
                     let name = AvmString::new_utf8(activation.context.gc_context, name);
                     if let Ok(result) = method
                         .call(name, &mut activation, this.into(), &args)
-                        .and_then(|value| Value::from_avm1(&mut activation, value))
+                        .and_then(|value| {
+                            Value::from_avm1(&mut activation, Value::check_avm1_value(value))
+                        })
                     {
                         return result;
                     }
                 }
-                Value::Null
+                Value::Undefined
             }
             Callback::Avm2 { method } => {
                 let domain = context
@@ -290,13 +323,13 @@ impl<'gc> Callback<'gc> {
                     .map(|v| v.into_avm2(&mut activation))
                     .collect();
                 match method.call(None, &args, &mut activation) {
-                    Ok(result) => Value::from_avm2(result),
+                    Ok(result) => Value::from_avm2(Value::check_avm2_value(result)),
                     Err(e) => {
                         tracing::error!(
                             "Unhandled error in External Interface callback {name}: {}",
                             e.detailed_message(&mut activation)
                         );
-                        Value::Null
+                        Value::Undefined
                     }
                 }
             }

--- a/tests/tests/swfs/avm1/external_interface/output.txt
+++ b/tests/tests/swfs/avm1/external_interface/output.txt
@@ -43,7 +43,7 @@ successful reentry!
 Traced!
 
 /// callWith() end
-null
+undefined
 
 /// parrot() start
 // this
@@ -81,4 +81,4 @@ trace
 Traced!
 
 /// callWith() end
-After calling `callWith` with a complex payload: Null
+After calling `callWith` with a complex payload: Undefined

--- a/tests/tests/swfs/avm2/external_interface/output.txt
+++ b/tests/tests/swfs/avm2/external_interface/output.txt
@@ -37,7 +37,7 @@ successful reentry!
 Traced!
 
 /// callWith() end
-null
+undefined
 
 /// parrot() start
 // this
@@ -80,4 +80,4 @@ string,100,,false
 Traced!
 
 /// callWith() end
-After calling `callWith` with a complex payload: Null
+After calling `callWith` with a complex payload: Undefined

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1164,10 +1164,10 @@ impl ExternalInterfaceMethod for JavascriptMethod {
             if let Ok(result) = function.apply(&self.this, &args_array) {
                 js_to_external_value(&result)
             } else {
-                ExternalValue::Null
+                ExternalValue::Undefined
             }
         } else {
-            ExternalValue::Null
+            ExternalValue::Undefined
         };
         CURRENT_CONTEXT.with(|v| v.replace(old_context));
         result
@@ -1252,14 +1252,17 @@ fn js_to_external_value(js: &JsValue) -> ExternalValue {
             }
         }
         ExternalValue::Object(values)
-    } else {
+    } else if js.is_null() {
         ExternalValue::Null
+    } else {
+        ExternalValue::Undefined
     }
 }
 
 fn external_to_js_value(external: ExternalValue) -> JsValue {
     match external {
         Value::Null => JsValue::NULL,
+        Value::Undefined => JsValue::UNDEFINED,
         Value::Bool(value) => JsValue::from_bool(value),
         Value::Number(value) => JsValue::from_f64(value),
         Value::String(value) => JsValue::from_str(&value),

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -458,7 +458,7 @@ impl Ruffle {
         }
 
         self.with_core_mut(|core| external_to_js_value(core.call_internal_interface(name, args)))
-            .unwrap_or(JsValue::NULL)
+            .unwrap_or(JsValue::UNDEFINED)
     }
 
     pub fn set_trace_observer(&self, observer: JsValue) {
@@ -1213,7 +1213,12 @@ impl ExternalInterfaceProvider for JavascriptInterface {
                 return Some(Box::new(method));
             }
         }
-        None
+
+        // Return a dummy method, as `ExternalInterface.call` must return `undefined`, not `null`.
+        Some(Box::new(JavascriptMethod {
+            this: JsValue::UNDEFINED,
+            function: JsValue::UNDEFINED,
+        }))
     }
 
     fn on_callback_available(&self, name: &str) {
@@ -1261,8 +1266,8 @@ fn js_to_external_value(js: &JsValue) -> ExternalValue {
 
 fn external_to_js_value(external: ExternalValue) -> JsValue {
     match external {
-        Value::Null => JsValue::NULL,
         Value::Undefined => JsValue::UNDEFINED,
+        Value::Null => JsValue::NULL,
         Value::Bool(value) => JsValue::from_bool(value),
         Value::Number(value) => JsValue::from_f64(value),
         Value::String(value) => JsValue::from_str(&value),


### PR DESCRIPTION
Fixes #8621. The behavior can be verified using [this sample](https://github.com/ruffle-rs/ruffle/files/11045693/externalUndefined.zip).