### PR TITLE
web: Improve styling of extension pop-up, options menus

### DIFF
--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -29,11 +29,11 @@ body {
 
 .logo {
     width: 100%;
-    transition: opacity 0.5s;
+    transition: transform 0.2s;
 }
 
 .logo:hover {
-    opacity: 0.5;
+    transform: scale(104%);
 }
 
 /* Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW */

--- a/web/packages/extension/assets/css/options.css
+++ b/web/packages/extension/assets/css/options.css
@@ -5,5 +5,5 @@
 .container {
     max-width: 400px;
     margin: auto;
-    padding: 16px 32px;
+    padding: 24px 32px;
 }

--- a/web/packages/extension/assets/css/popup.css
+++ b/web/packages/extension/assets/css/popup.css
@@ -24,6 +24,9 @@ button {
 
 #version-text {
     text-align: center;
+    font-size: 12px;
+    opacity: 0.8;
+    margin: 2px 0 6px;
 }
 
 #status-container {


### PR DESCRIPTION
Nothing major but it should improve the presentation of the extension a little.

### Changes
- Made the nightly watermark smaller and slightly transparent so it doesn't look as out-of-place
- Changed the hover animation of the Ruffle logo to a snappier pop-out animation
- Slightly increased spacing between options and Ruffle logo in options menu