### PR TITLE
web: Don't polyfill with self-hosted Ruffle while extension is loading

### DIFF
--- a/web/packages/core/src/plugin-polyfill.ts
+++ b/web/packages/core/src/plugin-polyfill.ts
@@ -150,6 +150,15 @@ export const FLASH_PLUGIN = new RufflePlugin(
     "ruffle.js"
 );
 
+/**
+ * A fake plugin designed to allow early detection of if the Ruffle extension is in use.
+ */
+export const RUFFLE_EXTENSION = new RufflePlugin(
+    "Ruffle Extension",
+    "Ruffle Extension",
+    "ruffle.js"
+);
+
 FLASH_PLUGIN.install({
     type: FUTURESPLASH_MIMETYPE,
     description: "Shockwave Flash",

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -199,7 +199,12 @@ export function pluginPolyfill(): void {
  */
 export function polyfill(isExt: boolean): void {
     isExtension = isExt;
-    polyfillFlashInstances();
-    polyfillFrames();
-    initMutationObserver();
+    const usingExtension =
+        navigator.plugins.namedItem("Ruffle Extension")?.filename ===
+        "ruffle.js";
+    if (isExtension || !usingExtension) {
+        polyfillFlashInstances();
+        polyfillFrames();
+        initMutationObserver();
+    }
 }

--- a/web/packages/extension/src/plugin-polyfill.ts
+++ b/web/packages/extension/src/plugin-polyfill.ts
@@ -3,6 +3,8 @@
 import {
     installPlugin,
     FLASH_PLUGIN,
+    RUFFLE_EXTENSION,
 } from "ruffle-core/dist/plugin-polyfill.js";
 
 installPlugin(FLASH_PLUGIN);
+installPlugin(RUFFLE_EXTENSION);


### PR DESCRIPTION
Finally found a way to make this work.