### PR TITLE
chore: Remove `static_assertions` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,11 +3361,9 @@ dependencies = [
  "ruffle_render",
  "ruffle_video",
  "ruffle_wstr",
- "rustversion",
  "serde",
  "serde_json",
  "smallvec",
- "static_assertions",
  "swf",
  "symphonia",
  "thiserror",
@@ -3600,9 +3598,6 @@ dependencies = [
 [[package]]
 name = "ruffle_wstr"
 version = "0.1.0"
-dependencies = [
- "static_assertions",
-]
 
 [[package]]
 name = "rustc-demangle"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,8 +45,6 @@ lzma-rs = {version = "0.3.0", optional = true }
 dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.2", default-features = false, features = ["mp3"], optional = true }
 enumset = "1.0.12"
-static_assertions = "1.1.0"
-rustversion = "1.0.12"
 bytemuck = "1.13.1"
 clap = { version = "4.1.11", features = ["derive"], optional=true }
 realfft = "3.2.0"

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -3,6 +3,7 @@ use crate::avm2::Activation;
 use crate::avm2::AvmString;
 use crate::avm2::Multiname;
 use crate::avm2::Value;
+use std::mem::size_of;
 
 use super::ClassObject;
 
@@ -34,17 +35,11 @@ impl<'gc> Error<'gc> {
 }
 
 // This type is used very frequently, so make sure it doesn't unexpectedly grow.
-// For now, we only test on Nightly, since a new niche optimization was recently
-// added (https://github.com/rust-lang/rust/pull/94075) that shrinks the size
-// relative to stable.
+#[cfg(target_family = "wasm")]
+const _: () = assert!(size_of::<Result<Value<'_>, Error<'_>>>() == 24);
 
-#[rustversion::nightly]
-#[cfg(target_arch = "wasm32")]
-static_assertions::assert_eq_size!(Result<Value<'_>, Error<'_>>, [u8; 24]);
-
-#[rustversion::nightly]
 #[cfg(target_pointer_width = "64")]
-static_assertions::assert_eq_size!(Result<Value<'_>, Error<'_>>, [u8; 32]);
+const _: () = assert!(size_of::<Result<Value<'_>, Error<'_>>>() == 32);
 
 #[inline(never)]
 #[cold]

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -13,6 +13,7 @@ use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::string::{AvmString, WStr};
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::Ref;
+use std::mem::size_of;
 use swf::avm2::types::{DefaultValue as AbcDefaultValue, Index};
 
 use super::e4x::E4XNode;
@@ -49,16 +50,11 @@ pub enum Value<'gc> {
 }
 
 // This type is used very frequently, so make sure it doesn't unexpectedly grow.
-// For now, we only test on Nightly, since a new niche optimization was recently
-// added (https://github.com/rust-lang/rust/pull/94075) that shrinks the size
-// relative to stable.
+#[cfg(target_family = "wasm")]
+const _: () = assert!(size_of::<Value<'_>>() == 16);
 
-#[cfg(target_arch = "wasm32")]
-static_assertions::assert_eq_size!(Value<'_>, [u8; 16]);
-
-#[rustversion::nightly]
 #[cfg(target_pointer_width = "64")]
-static_assertions::assert_eq_size!(Value<'_>, [u8; 24]);
+const _: () = assert!(size_of::<Value<'_>>() == 24);
 
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {
     fn from(string: AvmString<'gc>) -> Self {

--- a/wstr/Cargo.toml
+++ b/wstr/Cargo.toml
@@ -6,6 +6,3 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 version.workspace = true
-
-[dependencies]
-static_assertions = "1.1.0"

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -2,10 +2,9 @@ use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
-use core::mem::{self, ManuallyDrop};
+use core::mem::{self, size_of, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
-use static_assertions::assert_eq_size;
 
 use super::utils::{encode_raw_utf16, split_ascii_prefix, split_ascii_prefix_bytes, DecodeAvmUtf8};
 use super::{ptr, Units, WStr, MAX_STRING_LEN};
@@ -17,11 +16,11 @@ pub struct WString {
     capacity: u32,
 }
 
-#[cfg(target_pointer_width = "32")]
-assert_eq_size!(WString, [u8; 12]);
+#[cfg(target_family = "wasm")]
+const _: () = assert!(size_of::<WString>() == 12);
 
 #[cfg(target_pointer_width = "64")]
-assert_eq_size!(WString, [u8; 16]);
+const _: () = assert!(size_of::<WString>() == 16);
 
 impl WString {
     /// Creates a new empty `WString`.


### PR DESCRIPTION
`static_assertions` seems unmaintained, and anyway `assert!()` is usable in `const` contexts since Rust 1.57.0:
https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts So simply use the suggested method instead.

Also the `rustversion` dependency is no longer needed because https://github.com/rust-lang/rust/pull/94075 already landed in stable.