### PR TITLE
wstr: Revert incorrect optimization in hash calculation

### DIFF
--- a/tests/tests/swfs/avm2/json_stringify/output.txt
+++ b/tests/tests/swfs/avm2/json_stringify/output.txt
@@ -9,6 +9,6 @@ b 2 1,2,3 [object Object] undefined null i [object Object] test 5.3
 226
 16
 WARNING: The output.txt file has been hand-edited to match Ruffle's output, since we don't match Flash's serialization order
-{"prop2":true,"myGetter":"Getter value","MY_CONST":"Const val","prop1":"Hello"}
+{"prop1":"Hello","myGetter":"Getter value","prop2":true,"MY_CONST":"Const val"}
 WARNING: The output.txt file has been hand-edited to match Ruffle's output, since we don't match Flash's serialization order
-{"prop2":false,"prop1":"Dynamic","dyn1":"Dyn prop"}
+{"prop1":"Dynamic","prop2":false,"dyn1":"Dyn prop"}


### PR DESCRIPTION
Calling `Hash::write_bytes` isn't guaranteed to be equivalent to a sequence of `Hash::write_u8`.

Additionally, make sure the hash is truly prefix-free by hashing the length first.

------

Fortunately, the two methods are implemented as equivalent in the hashers used in Ruffle (the `std` default hasher and `FnvHasher`), so there was no observable bug; still, we shouldn't rely on implementation details.