### PR TITLE
web: Remove deprecated `indentation` Stylelint rule

### DIFF
--- a/web/.stylelintrc.yaml
+++ b/web/.stylelintrc.yaml
@@ -1,5 +1,3 @@
 extends:
   - stylelint-config-standard
   - stylelint-prettier/recommended
-rules:
-  indentation: 4


### PR DESCRIPTION
Stylelint 15.0.0 deprecated `indentation`: https://stylelint.io/migration-guide/to-15 Prettier already enforces indentation, so it can be removed from `.stylelintrc.yaml`.