### PR TITLE
fix ChildContainer.replace_at_depth() panic

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -650,6 +650,7 @@ impl<'gc> ChildContainer<'gc> {
                     None
                 }
             } else {
+                tracing::error!("ChildContainer::replace_at_depth: Previous child is not in render list");
                 self.push_id(child);
                 None
             }

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -650,7 +650,9 @@ impl<'gc> ChildContainer<'gc> {
                     None
                 }
             } else {
-                tracing::error!("ChildContainer::replace_at_depth: Previous child is not in render list");
+                tracing::error!(
+                    "ChildContainer::replace_at_depth: Previous child is not in render list"
+                );
                 self.push_id(child);
                 None
             }

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -640,14 +640,18 @@ impl<'gc> ChildContainer<'gc> {
             let position = self
                 .render_list
                 .iter()
-                .position(|x| DisplayObject::ptr_eq(*x, prev_child))
-                .unwrap();
+                .position(|x| DisplayObject::ptr_eq(*x, prev_child));
 
-            if !prev_child.placed_by_script() {
-                self.replace_id(position, child);
-                Some(prev_child)
+            if let Some(position) = position {
+                if !prev_child.placed_by_script() {
+                    self.replace_id(position, child);
+                    Some(prev_child)
+                } else {
+                    self.insert_id(position + 1, child);
+                    None
+                }
             } else {
-                self.insert_id(position + 1, child);
+                self.push_id(child);
                 None
             }
         } else {

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -637,12 +637,11 @@ impl<'gc> ChildContainer<'gc> {
     ) -> Option<DisplayObject<'gc>> {
         let prev_child = self.insert_child_into_depth_list(depth, child);
         if let Some(prev_child) = prev_child {
-            let position = self
+            if let Some(position) = self
                 .render_list
                 .iter()
-                .position(|x| DisplayObject::ptr_eq(*x, prev_child));
-
-            if let Some(position) = position {
+                .position(|x| DisplayObject::ptr_eq(*x, prev_child))
+            {
                 if !prev_child.placed_by_script() {
                     self.replace_id(position, child);
                     Some(prev_child)


### PR DESCRIPTION
Right now this method panics if a previous child is not in a render list, which causes https://github.com/ruffle-rs/ruffle/issues/10314. I'm totally unsure about this one, because I don't yet understand what's going on here, but at least that Sponge Bobbity thing works now.

Anyway, it would be nice if someone could explain me why there's a references in depth array to MovieClips that are not in render list.