### PR TITLE
chore: Always rebuild TypeScript

### DIFF
--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -34,7 +34,7 @@
         "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" $WASM_OPT_FLAGS || npm run build:wasm-opt-failed",
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
 
-        "build": "tsc --build",
+        "build": "tsc --build --force",
         "postbuild": "node tools/set_version.js",
 
         "docs": "typedoc",


### PR DESCRIPTION
Pass `--force` to tsc to always force a recompile of the TypeScript on build.

`tsc` won't rebuild the output JS if the source hasn't changed, but this would cause the version info in `build-info.js` to never get updated after an initial build. `tsc` only takes a second to run, so force a full rebuild.

Also, `tsc` won't even rebuild the output if you delete the output JS files. I hit this after wiping out the `dist` folder in an attempt to solve the above, only to be way more confused about all the errors when none of the JS rebuilt!