### PR TITLE
avm2: Fire soundComplete events immediately

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -191,17 +191,6 @@ pub struct UpdateContext<'a, 'gc> {
 
 /// Convenience methods for controlling audio.
 impl<'a, 'gc> UpdateContext<'a, 'gc> {
-    pub fn update_sounds(&mut self) {
-        if let Some(root_clip) = self.stage.root_clip() {
-            self.audio_manager.update_sounds(
-                self.audio,
-                self.gc_context,
-                self.action_queue,
-                root_clip,
-            );
-        }
-    }
-
     pub fn global_sound_transform(&self) -> &SoundTransform {
         self.audio_manager.global_sound_transform()
     }
@@ -497,13 +486,6 @@ pub enum ActionType<'gc> {
         reciever: Option<Avm2Object<'gc>>,
         args: Vec<Avm2Value<'gc>>,
     },
-
-    /// An AVM2 event to be dispatched. This translates to an Event class instance.
-    /// Creating an Event subclass via this dispatch is TODO.
-    Event2 {
-        event_type: &'static str,
-        target: Avm2Object<'gc>,
-    },
 }
 
 impl ActionType<'_> {
@@ -560,11 +542,6 @@ impl fmt::Debug for ActionType<'_> {
                 .field("callable", callable)
                 .field("reciever", reciever)
                 .field("args", args)
-                .finish(),
-            ActionType::Event2 { event_type, target } => f
-                .debug_struct("ActionType::Event2")
-                .field("event_type", event_type)
-                .field("target", target)
                 .finish(),
         }
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -8,7 +8,7 @@ use crate::avm1::{Activation, ActivationIdentifier};
 use crate::avm1::{ScriptObject, TObject, Value};
 use crate::avm2::{
     object::LoaderInfoObject, object::TObject as _, Activation as Avm2Activation, Avm2, CallStack,
-    Domain as Avm2Domain, EventObject as Avm2EventObject, Object as Avm2Object,
+    Domain as Avm2Domain, Object as Avm2Object,
 };
 use crate::backend::{
     audio::{AudioBackend, AudioManager},
@@ -1495,7 +1495,7 @@ impl Player {
             } else {
                 Avm1::run_frame(context);
             }
-            context.update_sounds();
+            AudioManager::update_sounds(context);
         });
 
         self.needs_render = true;
@@ -1695,13 +1695,6 @@ impl Player {
                     if let Err(e) =
                         Avm2::run_stack_frame_for_callable(callable, reciever, &args[..], context)
                     {
-                        tracing::error!("Unhandled AVM2 exception in event handler: {}", e);
-                    }
-                }
-
-                ActionType::Event2 { event_type, target } => {
-                    let event = Avm2EventObject::bare_default_event(context, event_type);
-                    if let Err(e) = Avm2::dispatch_event(context, event, target) {
                         tracing::error!("Unhandled AVM2 exception in event handler: {}", e);
                     }
                 }


### PR DESCRIPTION
Instead of queueing up these events in the `Activation`, we can fire them immediately by making `AudioManager::update_sounds` a freestanding method that takes in an `UpdateContext`