### PR TITLE
swf: Add some inlines

### DIFF
--- a/swf/src/types/color.rs
+++ b/swf/src/types/color.rs
@@ -37,6 +37,7 @@ impl Color {
     /// let green = Color::from_rgb(0x00FF00, 255);
     /// let blue = Color::from_rgb(0x0000FF, 255);
     /// ```
+    #[inline]
     pub const fn from_rgb(rgb: u32, alpha: u8) -> Self {
         let [b, g, r, _] = rgb.to_le_bytes();
         Self { r, g, b, a: alpha }
@@ -55,6 +56,7 @@ impl Color {
     /// let green = Color::from_rgba(0xFF00FF00);
     /// let blue = Color::from_rgba(0xFF0000FF);
     /// ```
+    #[inline]
     pub const fn from_rgba(rgba: u32) -> Self {
         let [b, g, r, a] = rgba.to_le_bytes();
         Self { r, g, b, a }
@@ -82,6 +84,7 @@ impl Color {
     /// let color2 = Color::from_rgb(0xFF00FF, 0);
     /// assert_eq!(color1.to_rgb(), color2.to_rgb());
     /// ```
+    #[inline]
     pub const fn to_rgb(&self) -> u32 {
         u32::from_le_bytes([self.b, self.g, self.r, 0])
     }
@@ -97,6 +100,7 @@ impl Color {
     /// let color = Color::from_rgb(0xFF00FF, 255);
     /// assert_eq!(color.to_rgba(), 0xFFFF00FF);
     /// ```
+    #[inline]
     pub const fn to_rgba(&self) -> u32 {
         u32::from_le_bytes([self.b, self.g, self.r, self.a])
     }

--- a/swf/src/types/point.rs
+++ b/swf/src/types/point.rs
@@ -32,6 +32,7 @@ impl Point {
     /// ```rust
     /// let point = swf::Point::new(40, 40);
     /// ```
+    #[inline]
     pub const fn new(x: i32, y: i32) -> Self {
         Self {
             x: Twips::new(x),
@@ -56,6 +57,7 @@ impl Point {
     /// assert_eq!(point.x.get(), 800);
     /// assert_eq!(point.y.get(), 400);
     /// ```
+    #[inline]
     pub fn from_pixels(x: f64, y: f64) -> Self {
         Self {
             x: Twips::from_pixels(x),
@@ -78,6 +80,7 @@ impl Point {
     /// let point = swf::Point::new(713, 200);
     /// assert_eq!(point.to_pixels(), (35.65, 10.0));
     /// ```
+    #[inline]
     pub fn to_pixels(self) -> (f64, f64) {
         (self.x.to_pixels(), self.y.to_pixels())
     }
@@ -86,6 +89,7 @@ impl Point {
 impl ops::Add for Point {
     type Output = Self;
 
+    #[inline]
     fn add(self, other: Self) -> Self {
         Self {
             x: self.x + other.x,
@@ -95,6 +99,7 @@ impl ops::Add for Point {
 }
 
 impl ops::AddAssign for Point {
+    #[inline]
     fn add_assign(&mut self, other: Self) {
         self.x += other.x;
         self.y += other.y;
@@ -103,7 +108,7 @@ impl ops::AddAssign for Point {
 
 impl ops::Sub for Point {
     type Output = Self;
-
+    #[inline]
     fn sub(self, other: Self) -> Self {
         Self {
             x: self.x - other.x,
@@ -113,6 +118,7 @@ impl ops::Sub for Point {
 }
 
 impl ops::SubAssign for Point {
+    #[inline]
     fn sub_assign(&mut self, other: Self) {
         self.x -= other.x;
         self.y -= other.y;
@@ -121,7 +127,7 @@ impl ops::SubAssign for Point {
 
 impl ops::Mul<i32> for Point {
     type Output = Self;
-
+    #[inline]
     fn mul(self, other: i32) -> Self {
         Self {
             x: self.x * other,
@@ -131,6 +137,7 @@ impl ops::Mul<i32> for Point {
 }
 
 impl ops::MulAssign<i32> for Point {
+    #[inline]
     fn mul_assign(&mut self, other: i32) {
         self.x *= other;
         self.y *= other;
@@ -139,7 +146,7 @@ impl ops::MulAssign<i32> for Point {
 
 impl ops::Div<i32> for Point {
     type Output = Self;
-
+    #[inline]
     fn div(self, other: i32) -> Self {
         Self {
             x: self.x / other,
@@ -149,6 +156,7 @@ impl ops::Div<i32> for Point {
 }
 
 impl ops::DivAssign<i32> for Point {
+    #[inline]
     fn div_assign(&mut self, other: i32) {
         self.x /= other;
         self.y /= other;
@@ -156,6 +164,7 @@ impl ops::DivAssign<i32> for Point {
 }
 
 impl fmt::Display for Point {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {})", self.x, self.y)
     }

--- a/swf/src/types/twips.rs
+++ b/swf/src/types/twips.rs
@@ -46,6 +46,7 @@ impl Twips {
     ///
     /// let twips = Twips::new(40);
     /// ```
+    #[inline]
     pub const fn new(twips: i32) -> Self {
         Self(twips)
     }
@@ -60,6 +61,7 @@ impl Twips {
     /// let twips = Twips::new(47);
     /// assert_eq!(twips.get(), 47);
     /// ```
+    #[inline]
     pub const fn get(self) -> i32 {
         self.0
     }
@@ -81,11 +83,13 @@ impl Twips {
     /// let twips = Twips::from_pixels(40.018);
     /// assert_eq!(twips.get(), 800);
     /// ```
+    #[inline]
     pub fn from_pixels(pixels: f64) -> Self {
         Self((pixels * Self::TWIPS_PER_PIXEL as f64) as i32)
     }
 
     /// Converts the given number of `pixels` into twips.
+    #[inline]
     pub const fn from_pixels_i32(pixels: i32) -> Self {
         Self(pixels * Self::TWIPS_PER_PIXEL)
     }
@@ -107,6 +111,7 @@ impl Twips {
     /// let twips = Twips::new(713);
     /// assert_eq!(twips.to_pixels(), 35.65);
     /// ```
+    #[inline]
     pub fn to_pixels(self) -> f64 {
         f64::from(self.0) / Self::TWIPS_PER_PIXEL as f64
     }
@@ -114,12 +119,14 @@ impl Twips {
 
 impl std::ops::Add for Twips {
     type Output = Self;
+    #[inline]
     fn add(self, other: Self) -> Self {
         Self(self.0 + other.0)
     }
 }
 
 impl std::ops::AddAssign for Twips {
+    #[inline]
     fn add_assign(&mut self, other: Self) {
         self.0 += other.0
     }
@@ -127,12 +134,14 @@ impl std::ops::AddAssign for Twips {
 
 impl std::ops::Sub for Twips {
     type Output = Self;
+    #[inline]
     fn sub(self, other: Self) -> Self {
         Self(self.0 - other.0)
     }
 }
 
 impl std::ops::SubAssign for Twips {
+    #[inline]
     fn sub_assign(&mut self, other: Self) {
         self.0 -= other.0
     }
@@ -140,12 +149,14 @@ impl std::ops::SubAssign for Twips {
 
 impl std::ops::Mul<i32> for Twips {
     type Output = Self;
+    #[inline]
     fn mul(self, other: i32) -> Self {
         Self(self.0 * other)
     }
 }
 
 impl std::ops::MulAssign<i32> for Twips {
+    #[inline]
     fn mul_assign(&mut self, other: i32) {
         self.0 *= other
     }
@@ -153,12 +164,14 @@ impl std::ops::MulAssign<i32> for Twips {
 
 impl std::ops::Div<i32> for Twips {
     type Output = Self;
+    #[inline]
     fn div(self, other: i32) -> Self {
         Self(self.0 / other)
     }
 }
 
 impl std::ops::DivAssign<i32> for Twips {
+    #[inline]
     fn div_assign(&mut self, other: i32) {
         self.0 /= other
     }
@@ -166,12 +179,14 @@ impl std::ops::DivAssign<i32> for Twips {
 
 impl std::ops::Neg for Twips {
     type Output = Self;
+    #[inline]
     fn neg(self) -> Self {
         Twips(-self.0)
     }
 }
 
 impl std::fmt::Display for Twips {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.to_pixels())
     }


### PR DESCRIPTION
Pointed out on Discord. Add `#[inline]` to `Twips`, `Point`, and `Color` methods.