### PR TITLE
web: Give proper precedence to extension config when it is used

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -632,6 +632,24 @@ export class RufflePlayer extends HTMLElement {
         );
         return options;
     }
+    /**
+     * Gets the configuration set by the Ruffle extension
+     *
+     * @returns The configuration set by the Ruffle extension
+     */
+    getExtensionConfig(): Record<string, unknown> {
+        return window.RufflePlayer &&
+            window.RufflePlayer.conflict &&
+            (window.RufflePlayer.conflict["newestName"] === "extension" ||
+                (window.RufflePlayer as Record<string, unknown>)[
+                    "newestName"
+                ] === "extension")
+            ? (window.RufflePlayer?.conflict["config"] as Record<
+                  string,
+                  unknown
+              >)
+            : {};
+    }
 
     /**
      * Loads a specified movie into this player.
@@ -664,15 +682,10 @@ export class RufflePlayer extends HTMLElement {
         }
 
         try {
+            const extensionConfig = this.getExtensionConfig();
             this.loadedConfig = {
                 ...DEFAULT_CONFIG,
-                ...(window.RufflePlayer?.conflict &&
-                window.RufflePlayer?.conflict["newestName"] === "extension"
-                    ? (window.RufflePlayer?.conflict["config"] as Record<
-                          string,
-                          unknown
-                      >)
-                    : {}),
+                ...extensionConfig,
                 ...(window.RufflePlayer?.config ?? {}),
                 ...this.config,
                 ...options,


### PR DESCRIPTION
This should work when the extension config loads after the self-hosted config too:
```ts
            (window.RufflePlayer.conflict["newestName"] === "extension" ||
                (window.RufflePlayer as Record<string, unknown>)[
                    "newestName"
                ] === "extension")
```