### PR TITLE
fix ChildContainer.depth_list child removal when child's depth changed

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -607,8 +607,7 @@ impl<'gc> ChildContainer<'gc> {
             return self.depth_list.remove(&depth).is_some();
         }
 
-            false
-        }
+        false
     }
 
     /// Remove a child from the render list.

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -594,9 +594,19 @@ impl<'gc> ChildContainer<'gc> {
     /// if no list alterations were made.
     fn remove_child_from_depth_list(&mut self, child: DisplayObject<'gc>) -> bool {
         if let Some(other_child) = self.depth_list.get(&child.depth()) {
-            DisplayObject::ptr_eq(*other_child, child)
-                && self.depth_list.remove(&child.depth()).is_some()
-        } else {
+            return DisplayObject::ptr_eq(*other_child, child)
+                && self.depth_list.remove(&child.depth()).is_some();
+        }
+
+        // Hack to remove child from depth list by value if previous fast lookup didn't work.
+        if let Some((&depth, _)) = self
+            .depth_list
+            .iter()
+            .find(|(_, obj)| DisplayObject::ptr_eq(**obj, child))
+        {
+            return self.depth_list.remove(&depth).is_some();
+        }
+
             false
         }
     }


### PR DESCRIPTION
This is a follow up on https://github.com/ruffle-rs/ruffle/pull/10362

I don't think this should actually be merged as is, just wanted to describe somewhere what's going on.

Ruffle has some sort of a leak in delayed DisplayObject child removing. When a child removing is delayed, that child object (and all of its children recursively) is assigned a negative depth and queued for removing in `ChildContainer::queue_removal()` func. Though there's a logic for updating that child element's position in depth_list (removing old ones, inserting new ones), it's not recursive, so nested children objects are having negative depths while being stored in depth_list with their previous positive depths as a keys. And this is the reason why we have lookup errors with that depth_list a bit later.

An easy and obvious fix for that would be implementing a recursive `ChildContainer::remove_child_from_depth_list()` and `ChildContainer::insert_child_into_depth_list()`. And yes, I did it, and everything just became worse when playing that slimy yellow sponge game.

I believe someone smarter than me could actually fix it the right way.