### PR TITLE
web: Fix XML document detection

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -209,7 +209,7 @@ export class RufflePlayer extends HTMLElement {
      */
     constructor() {
         super();
-        
+
         const ruffleShadowTemplate = document.createElement("template");
         ruffleShadowTemplate.innerHTML = ruffleShadowTemplateHTML;
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1,6 +1,6 @@
 import type { Ruffle } from "../dist/ruffle_web";
 import { loadRuffle } from "./load-ruffle";
-import { ruffleShadowTemplate } from "./shadow-template";
+import { ruffleShadowTemplateHTML } from "./shadow-template";
 import { lookupElement } from "./register-element";
 import { DEFAULT_CONFIG } from "./config";
 import {
@@ -209,6 +209,9 @@ export class RufflePlayer extends HTMLElement {
      */
     constructor() {
         super();
+        
+        const ruffleShadowTemplate = document.createElement("template");
+        ruffleShadowTemplate.innerHTML = ruffleShadowTemplateHTML;
 
         this.shadow = this.attachShadow({ mode: "open" });
         this.shadow.appendChild(ruffleShadowTemplate.content.cloneNode(true));

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -2,8 +2,7 @@
  * The shadow template which is used to fill the actual Ruffle player element
  * on the page.
  */
-export const ruffleShadowTemplate = document.createElement("template");
-ruffleShadowTemplate.innerHTML = `
+export const ruffleShadowTemplateHTML = `
     <style>
         :host {
             --ruffle-blue: #37528c;


### PR DESCRIPTION
The code in `shadow-template.ts` would error if the document was an XML document, which means the code for detecting XML documents at the end of `ruffle-player.ts` would not run.

Fixes https://github.com/ruffle-rs/ruffle/issues/9997.