### PR TITLE
web: Small CSS fixups for save manager

### DIFF
--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -323,7 +323,6 @@ ruffleShadowTemplate.innerHTML = `
 
         #local-saves {
             border-collapse: collapse;
-            margin-left: 0 0.5em;
         }
 
         #local-saves td {
@@ -333,6 +332,7 @@ ruffleShadowTemplate.innerHTML = `
 
         #local-saves tr td:nth-child(1) {
             padding-right: 1em;
+            word-break: break-all;
         }
 
         #local-saves tr:nth-child(even) {


### PR DESCRIPTION
Remove nonfunctional CSS style. Add word-break style to prevent the save manager table from overflowing its container (and getting a horizontal scrollbar). 

**Before**:
![image](https://user-images.githubusercontent.com/71368227/228089427-5d5a5276-a55d-4c03-b280-6a6479154e87.png)

**After**:
![image](https://user-images.githubusercontent.com/71368227/228089547-79635c96-2a86-4672-9b74-788b6cedd654.png)
