### PR TITLE
web: Fix XML document detection

### DIFF
--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -1,11 +1,11 @@
 import type { Options } from "./common";
-import { LogLevel } from "ruffle-core";
+import type { LogLevel } from "ruffle-core";
 
 const DEFAULT_OPTIONS: Options = {
     ruffleEnable: true,
     ignoreOptout: false,
     warnOnUnsupportedContent: true,
-    logLevel: LogLevel.Error,
+    logLevel: "error" as LogLevel,
     showSwfDownload: false,
 };
 


### PR DESCRIPTION
This also reduces the size of `content.js` from ~170 KB to ~15 KB by removing code duplication.

Fixes #9997.