### PR TITLE
avm2: Stub Video.deblocking and Video.smoothing

### DIFF
--- a/core/src/avm2/globals/flash/media/Video.as
+++ b/core/src/avm2/globals/flash/media/Video.as
@@ -2,21 +2,39 @@ package flash.media
 {
     import flash.display.DisplayObject
     import flash.net.NetStream
-    
+
     public class Video extends DisplayObject
     {
+        private var _deblocking: int;
+        private var _smoothing: Boolean;
         private var _videoWidth: int;
         private var _videoHeight: int;
-        
+
         public function Video(width: int = 320, height: int = 240) {
             this._videoWidth = width;
             this._videoHeight = height;
         }
-        
+
+        public function get deblocking():int {
+            return this._deblocking;
+        }
+
+        public function set deblocking(value:int):void {
+            this._deblocking = value;
+        }
+
+        public function get smoothing():Boolean {
+            return this._smoothing;
+        }
+
+        public function set smoothing(value:Boolean):void {
+            this._smoothing = value;
+        }
+
         public function get videoWidth():int {
             return this._videoWidth;
         }
-        
+
         public function get videoHeight():int {
             return this._videoHeight;
         }


### PR DESCRIPTION
At least `smoothing` is used by z0r.de loops 7428 and 7876.
Relevant docs: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/media/Video.html#propertySummary