### PR TITLE
web: Give toggleable option to reload SWFs (fix #1885)

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -19,6 +19,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
     showSwfDownload: false,
+    showReload: false,
     contextMenu: true,
     // Backwards-compatibility option
     preloader: true,

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -223,6 +223,14 @@ export interface BaseLoadOptions {
     showSwfDownload?: boolean;
 
     /**
+     * If set to true, the context menu has an option to reload
+     * the content.
+     *
+     * @default false
+     */
+    showReload?: boolean;
+
+    /**
      * Whether or not to show a context menu when right-clicking
      * a Ruffle instance.
      *

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1080,6 +1080,15 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
+     * Reloads the loaded SWF.
+     */
+    private reloadSwf(): void {
+        if (this.loadedConfig) {
+            this.load(this.loadedConfig);
+        }
+    }
+
+    /**
      * Fetches the loaded SWF and downloads it.
      */
     async downloadSwf(): Promise<void> {
@@ -1191,6 +1200,14 @@ export class RufflePlayer extends HTMLElement {
             items.push({
                 text: "Download .swf",
                 onClick: this.downloadSwf.bind(this),
+            });
+        }
+
+        if (this.loadedConfig && this.loadedConfig.showReload === true) {
+            items.push(null);
+            items.push({
+                text: "Reload content",
+                onClick: this.reloadSwf.bind(this),
             });
         }
 

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -11,6 +11,9 @@
     "settings_show_swf_download": {
         "message": "Show SWF download in context menu"
     },
+    "settings_show_reload": {
+        "message": "Show reload option in context menu"
+    },
     "settings_warn_on_unsupported_content": {
         "message": "Warn on unsupported content"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -24,12 +24,20 @@
                 <label for="ruffle_enable">Play Flash content in Ruffle</label>
             </div>
             <div class="option checkbox">
-                <input type="checkbox" id="ignore_optout" />
-                <label for="ignore_optout">Ignore website compatibility warnings</label>
+                <input type="checkbox" id="show_swf_download" />
+                <label for="show_swf_download">Show SWF download in context menu</label>
+            </div>
+            <div class="option checkbox">
+                <input type="checkbox" id="show_reload" />
+                <label for="show_reload">Show reload option in context menu</label>
             </div>
             <div class="option checkbox">
                 <input type="checkbox" id="warn_on_unsupported_content" />
                 <label for="warn_on_unsupported_content">Warn on unsupported content</label>
+            </div>
+            <div class="option checkbox">
+                <input type="checkbox" id="ignore_optout" />
+                <label for="ignore_optout">Ignore website compatibility warnings</label>
             </div>
             <div class="option select">
                 <select id="log_level">
@@ -38,10 +46,6 @@
                     <option value="error">Error</option>
                 </select>
                 <label for="log_level">Log level</label>
-            </div>
-            <div class="option checkbox">
-                <input type="checkbox" id="show_swf_download" />
-                <label for="show_swf_download">Show SWF download in context menu</label>
             </div>
         </div>
         <script src="dist/options.js"></script>

--- a/web/packages/extension/assets/popup.html
+++ b/web/packages/extension/assets/popup.html
@@ -28,12 +28,12 @@
                 <label for="ruffle_enable">Play Flash content in Ruffle</label>
             </div>
             <div class="option checkbox">
-                <input type="checkbox" id="ignore_optout" />
-                <label for="ignore_optout">Ignore website compatibility warnings</label>
-            </div>
-            <div class="option checkbox">
                 <input type="checkbox" id="show_swf_download" />
                 <label for="show_swf_download">Show SWF download in context menu</label>
+            </div>
+            <div class="option checkbox">
+                <input type="checkbox" id="show_reload" />
+                <label for="show_reload">Show reload option in context menu</label>
             </div>
         </div>
         <div id="version-text">Ruffle extension</div>

--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -7,6 +7,7 @@ export interface Options {
     warnOnUnsupportedContent: boolean;
     logLevel: LogLevel;
     showSwfDownload: boolean;
+    showReload: boolean;
 }
 
 interface OptionElement<T> {

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -173,6 +173,7 @@ function isXMLDocument(): boolean {
             warnOnUnsupportedContent: options.warnOnUnsupportedContent,
             logLevel: options.logLevel,
             showSwfDownload: options.showSwfDownload,
+            showReload: options.showReload,
         },
     });
 })();

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -7,6 +7,7 @@ const DEFAULT_OPTIONS: Options = {
     warnOnUnsupportedContent: true,
     logLevel: "error" as LogLevel,
     showSwfDownload: false,
+    showReload: false,
 };
 
 export let i18n: {


### PR DESCRIPTION
Also does the same extension option reordering as #9904. This option may be better as extension only, however, I think it would actually surprisingly be harder to not include it for self-hosted.