### PR TITLE
avm2: Fix panic in regexp when a wide empty string is used

### DIFF
--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -408,6 +408,8 @@ impl<'gc> CachedText<'gc> {
                 // SAFETY: because `self.utf8` is None, we know `text` contains
                 // a valid UTF8 string.
                 Units::Bytes(s) => unsafe { std::str::from_utf8_unchecked(s) },
+                // NOTES: The only case where a wide string could be valid UTF8 is if it's empty.
+                Units::Wide([]) => "",
                 _ => unreachable!(),
             })
     }


### PR DESCRIPTION
Fixes #10444