### PR TITLE
extension: Disallow content script to import `ruffle-core`

### DIFF
--- a/web/packages/extension/src/.eslintrc.yaml
+++ b/web/packages/extension/src/.eslintrc.yaml
@@ -1,3 +1,15 @@
 env:
   browser: true
   webextensions: true
+overrides:
+  - files:
+      - content.ts
+      - utils.ts
+      - common.ts
+    rules:
+      '@typescript-eslint/no-restricted-imports':
+        - error
+        - paths:
+          - name: ruffle-core
+            message: Content script must not include ruffle-core.
+            allowTypeImports: true


### PR DESCRIPTION
Use the `@typescript-eslint/no-restricted-imports` rule in order to prevent #10422 from regressing. Ideally we wouldn't need to specify each dependency of `content.ts` (i.e. `utils.ts` and `common.ts`), but I haven't found any better way.