### PR TITLE
core: Partially implement system.capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3758,6 +3758,7 @@ dependencies = [
  "smallvec",
  "swf",
  "symphonia",
+ "sys-locale",
  "thiserror",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "weak-table",
  "web-sys",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
+ "serde",
  "winapi",
 ]
 
@@ -3742,6 +3743,7 @@ dependencies = [
  "nellymoser-rs",
  "num-derive",
  "num-traits",
+ "os_info",
  "percent-encoding",
  "png",
  "quick-xml",
@@ -3764,6 +3766,7 @@ dependencies = [
  "url",
  "wasm-bindgen-futures",
  "weak-table",
+ "web-sys",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,12 +55,14 @@ egui = { version = "0.22.0", optional = true }
 egui_extras = { version = "0.22.0", optional = true }
 png = { version = "0.17.9", optional = true }
 sys-locale = "0.3.0"
+os_info = "3.7.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.28"
 
-[target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen-futures]
-version = "0.4.37"
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-bindgen-futures = "0.4.37"
+web-sys = "0.3.61"
 
 [features]
 default = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,6 +54,7 @@ fluent-templates = "0.8.0"
 egui = { version = "0.22.0", optional = true }
 egui_extras = { version = "0.22.0", optional = true }
 png = { version = "0.17.9", optional = true }
+sys-locale = "0.3.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.28"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -64,6 +64,9 @@ version = "0.3.28"
 wasm-bindgen-futures = "0.4.37"
 web-sys = "0.3.61"
 
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3.9"
+
 [features]
 default = []
 lzma = ["lzma-rs", "swf/lzma"]

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -966,6 +966,7 @@ pub fn create_globals<'gc>(
         array_proto,
     );
 
+    // TODO: System variable doesn't exist (=> shouldn't be accessible) for SWF version <= 4
     let system = system::create(
         context,
         object_proto,

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -126,7 +126,7 @@ pub enum Manufacturer {
 }
 
 impl Manufacturer {
-    pub fn get_manufacturer_string(&self, version: u8) -> String {
+    pub fn get_manufacturer_string(&self, swf_version: u8) -> String {
         let os_part = match self {
             Manufacturer::Windows => "Windows",
             Manufacturer::Macintosh => "Macintosh",
@@ -134,13 +134,14 @@ impl Manufacturer {
             Manufacturer::Other(name) => name.as_str(),
         };
 
-        if version <= 8 {
+        if swf_version <= 8 {
             format!("Macromedia {os_part}")
         } else {
             format!("Adobe {os_part}")
         }
     }
 
+    // Old flash player versions might return "UNIX" instead of "LNX"
     pub fn get_platform_name(&self) -> &str {
         match self {
             Manufacturer::Windows => "WIN",
@@ -260,25 +261,48 @@ impl SettingsPanel {
 
 bitflags! {
     pub struct SystemCapabilities: u32 {
+        /// Specifies whether access to camera & microphone has been allowed
         const AV_HARDWARE      = 1 << 0;
+        /// Specifies whether the system supports communication with accessibility aids
         const ACCESSIBILITY    = 1 << 1;
+        /// Specifies whether the system has audio capabilities
         const AUDIO            = 1 << 2;
+        /// Specifies whether the system can encode an audio stream
         const AUDIO_ENCODER    = 1 << 3;
+        /// Specifies whether the system supports embedded video
         const EMBEDDED_VIDEO   = 1 << 4;
+        /// Specifies whether the system has an input method editor (IME) installed
         const IME              = 1 << 5;
+        /// Specifies whether the system has an MP3 decoder
         const MP3              = 1 << 6;
+        /// Specifies whether the system supports printing
         const PRINTING         = 1 << 7;
+        /// Specifies whether the system supports the development of screen broadcast
+        /// applications to be run through flash media server
         const SCREEN_BROADCAST = 1 << 8;
+        /// Specifies whether the system supports the playback of screen broadcast
+        /// applications that are being run through flash media server
         const SCREEN_PLAYBACK  = 1 << 9;
+        /// Specifies whether the system can play streaming audio
         const STREAMING_AUDIO  = 1 << 10;
+        /// Specifies whether the system can play streaming video
         const STREAMING_VIDEO  = 1 << 11;
+        /// Specifies whether the system can encode a video stream
         const VIDEO_ENCODER    = 1 << 12;
+        /// Specifies whether the system is a special debugging version
         const DEBUGGER         = 1 << 13;
+        /// Specifies whether read access to the hard disk has been allowed
         const LOCAL_FILE_READ  = 1 << 14;
+        /// Specifies whether the system supports running 64-bit processes
         const PROCESS_64_BIT   = 1 << 15;
+        /// Specifies whether the system support running 32-bit processes
         const PROCESS_32_BIT   = 1 << 16;
+        /// Specifies whether the player is embedded in a PDF file that is
+        /// open in Acrobat 9 or higher
         const ACROBAT_EMBEDDED = 1 << 17;
+        /// Specifies whether the system supports native TLS Sockets through NetConnection
         const TLS              = 1 << 18;
+        /// Specifies whether the windowless mode is not disabled
         const WINDOW_LESS      = 1 << 19;
     }
 }
@@ -702,10 +726,13 @@ impl SystemProperties {
             64
         };
 
+        // TODO: Implement the properties currently set to a default value
         SystemProperties {
-            //TODO: default to true on fp>=7, false <= 6
+            // TODO: default to true on swf version >=7, false <= 6
+            // only after logic has been implemented
             exact_settings: true,
-            //TODO: default to false on fp>=7, true <= 6
+            // TODO: default to false on swf version >=7, true <= 6
+            // only after logic has been implemented
             use_codepage: false,
             capabilities,
             player_type,
@@ -756,7 +783,7 @@ impl SystemProperties {
         percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).to_string()
     }
 
-    pub fn get_server_string(&self, context: &UpdateContext) -> String {
+    pub fn get_server_string(&self, context: &UpdateContext, swf_version: u8) -> String {
         // The server string varies depending on the flash player version (since new
         // variables have been added in later flash player versions).
         // This is the server string returned by the last flash player version (32).
@@ -810,7 +837,7 @@ impl SystemProperties {
                 "M",
                 &self.encode_string(
                     self.manufacturer
-                        .get_manufacturer_string(context.avm1.player_version())
+                        .get_manufacturer_string(swf_version)
                         .as_str(),
                 ),
             )

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -59,6 +59,12 @@ impl fmt::Display for SandboxType {
     }
 }
 
+/// Type of the Ruffle player
+pub enum RuffleType {
+    DesktopPlayer,
+    WebPlayer,
+}
+
 /// The available host operating systems
 #[allow(dead_code)]
 pub enum OperatingSystem {
@@ -201,6 +207,7 @@ impl fmt::Display for ScreenColor {
         })
     }
 }
+
 /// The type of the player
 #[allow(dead_code)]
 pub enum PlayerType {
@@ -293,7 +300,7 @@ pub struct SystemProperties {
 }
 
 impl SystemProperties {
-    pub fn new(sandbox_type: SandboxType) -> Self {
+    pub fn new(sandbox_type: SandboxType, ruffle_type: RuffleType) -> Self {
         let mut capabilities = SystemCapabilities::empty();
 
         // TODO: Fill the bitmap correctly with the system properties
@@ -359,13 +366,18 @@ impl SystemProperties {
             capabilities.insert(SystemCapabilities::WINDOW_LESS);
         }
 
+        let player_type = match ruffle_type {
+            RuffleType::DesktopPlayer => PlayerType::StandAlone,
+            RuffleType::WebPlayer => PlayerType::PlugIn,
+        };
+
         SystemProperties {
             //TODO: default to true on fp>=7, false <= 6
             exact_settings: true,
             //TODO: default to false on fp>=7, true <= 6
             use_codepage: false,
             capabilities,
-            player_type: PlayerType::StandAlone,
+            player_type,
             screen_color: ScreenColor::Color,
             // TODO: note for fp <7 this should be the locale and the ui lang for >= 7, on windows
             language: Language::English,

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -294,12 +294,77 @@ pub struct SystemProperties {
 
 impl SystemProperties {
     pub fn new(sandbox_type: SandboxType) -> Self {
+        let mut capabilities = SystemCapabilities::empty();
+
+        // TODO: Fill the bitmap correctly with the system properties
+        // Currently, there are stubs filling the bitmap with probable entries
+        // (e.g. most systems have audio encoding)
+        // Replace the true or false with the actual properties
+
+        if false {
+            capabilities.insert(SystemCapabilities::AV_HARDWARE);
+        }
+        if false {
+            capabilities.insert(SystemCapabilities::ACCESSIBILITY);
+        }
+        // AUDIO is always true, according to specs
+        capabilities.insert(SystemCapabilities::AUDIO);
+        if true {
+            capabilities.insert(SystemCapabilities::AUDIO_ENCODER);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::EMBEDDED_VIDEO);
+        }
+        if false {
+            capabilities.insert(SystemCapabilities::IME);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::MP3);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::PRINTING);
+        }
+        if false {
+            capabilities.insert(SystemCapabilities::SCREEN_BROADCAST);
+        }
+        if false {
+            capabilities.insert(SystemCapabilities::SCREEN_PLAYBACK);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::STREAMING_AUDIO);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::STREAMING_VIDEO);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::VIDEO_ENCODER);
+        }
+        if false {
+            capabilities.insert(SystemCapabilities::DEBUGGER);
+        }
+        if false {
+            capabilities.insert(SystemCapabilities::LOCAL_FILE_READ);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::PROCESS_64_BIT);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::PROCESS_32_BIT);
+        }
+        // ACROBAT_EMBEDDED is always false
+        if true {
+            capabilities.insert(SystemCapabilities::TLS);
+        }
+        if true {
+            capabilities.insert(SystemCapabilities::WINDOW_LESS);
+        }
+
         SystemProperties {
             //TODO: default to true on fp>=7, false <= 6
             exact_settings: true,
             //TODO: default to false on fp>=7, true <= 6
             use_codepage: false,
-            capabilities: SystemCapabilities::empty(),
+            capabilities,
             player_type: PlayerType::StandAlone,
             screen_color: ScreenColor::Color,
             // TODO: note for fp <7 this should be the locale and the ui lang for >= 7, on windows

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -297,6 +297,8 @@ pub struct SystemProperties {
     pub cpu_architecture: CpuArchitecture,
     /// The highest supported h264 decoder level
     pub idc_level: String,
+    /// Whether the player is running as a 32-bit or 64-bit application
+    pub cpu_address_size: u32,
 }
 
 impl SystemProperties {
@@ -625,6 +627,12 @@ impl SystemProperties {
 
         let cpu_architecture = get_cpu_architecture();
 
+        let cpu_address_size = if 4 * std::mem::size_of::<&char>() <= 32 {
+            32
+        } else {
+            64
+        };
+
         SystemProperties {
             //TODO: default to true on fp>=7, false <= 6
             exact_settings: true,
@@ -644,6 +652,7 @@ impl SystemProperties {
             sandbox_type,
             cpu_architecture,
             idc_level: "5.1".into(),
+            cpu_address_size,
         }
     }
     pub fn get_version_string(&self, avm: &mut Avm1) -> String {

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -129,11 +129,7 @@ pub fn get_language<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(AvmString::new_utf8(
         activation.context.gc_context,
-        activation
-            .context
-            .system
-            .language
-            .get_language_code(activation.context.avm1.player_version()),
+        activation.context.system.get_language_string(),
     )
     .into())
 }

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -7,12 +7,13 @@ use crate::avm1::{ScriptObject, Value};
 use crate::context::GcContext;
 use crate::string::AvmString;
 
+// Variables have been added in later flash player versions.
+// To emulate exact flash player behaviour, properties can only be returned
+// if the flash player version is at least the one in which they were added.
+// Whether the properties are returned is independent of the SWF version.
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
-    "supports64BitProcesses" => property(get_has_64_bit_support);
-    "supports32BitProcesses" => property(get_has_32_bit_support);
-    "isEmbeddedInAcrobat" => property(get_is_acrobat_embedded);
-    "hasTLS" => property(get_has_tls);
-    "cpuArchitecture" => property(get_cpu_architecture);
+    // Properties in Specs
+    "avHardwareDisable" => property(get_is_av_hardware_disabled);
     "hasAccessibility" => property(get_has_accessibility);
     "hasAudio" => property(get_has_audio);
     "hasAudioEncoder" => property(get_has_audio_encoder);
@@ -26,10 +27,8 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "hasStreamingVideo" => property(get_has_streaming_video);
     "hasVideoEncoder" => property(get_has_video_encoder);
     "isDebugger" => property(get_is_debugger);
-    "avHardwareDisable" => property(get_is_av_hardware_disabled);
-    "localFileReadDisable" => property(get_is_local_file_read_disabled);
-    "windowlessDisable" => property(get_is_windowless_disabled);
     "language" => property(get_language);
+    "localFileReadDisable" => property(get_is_local_file_read_disabled);
     "manufacturer" => property(get_manufacturer);
     "os" => property(get_os_name);
     "pixelAspectRatio" => property(get_pixel_aspect_ratio);
@@ -40,8 +39,18 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "screenResolutionY" => property(get_screen_resolution_y);
     "serverString" => property(get_server_string);
     "version" => property(get_version);
+    "windowlessDisable" => property(get_is_windowless_disabled);
+
+    // Available in Flash player 10
+    "hasTLS" => property(get_has_tls);
+    "isEmbeddedInAcrobat" => property(get_is_acrobat_embedded);
     "maxLevelIDC" => property(get_max_idc_level);
+
+    // Not available in Flash player 10, but available in Flash player 32
     "cpuAddressSize" => property(get_cpu_address_size);
+    "cpuArchitecture" => property(get_cpu_architecture);
+    "supports32BitProcesses" => property(get_has_32_bit_support);
+    "supports64BitProcesses" => property(get_has_64_bit_support);
 };
 
 macro_rules! capabilities_func {
@@ -184,7 +193,7 @@ pub fn get_manufacturer<'gc>(
             .context
             .system
             .manufacturer
-            .get_manufacturer_string(activation.context.avm1.player_version()),
+            .get_manufacturer_string(activation.swf_version()),
     )
     .into())
 }
@@ -224,7 +233,7 @@ pub fn get_server_string<'gc>(
     let server_string = activation
         .context
         .system
-        .get_server_string(&activation.context);
+        .get_server_string(&activation.context, activation.swf_version());
     Ok(AvmString::new_utf8(activation.context.gc_context, server_string).into())
 }
 

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -41,6 +41,7 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "serverString" => property(get_server_string);
     "version" => property(get_version);
     "maxLevelIDC" => property(get_max_idc_level);
+    "cpuAddressSize" => property(get_cpu_address_size);
 };
 
 macro_rules! capabilities_func {
@@ -249,6 +250,14 @@ pub fn get_max_idc_level<'gc>(
         &activation.context.system.idc_level,
     )
     .into())
+}
+
+pub fn get_cpu_address_size<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok(activation.context.system.cpu_address_size.into())
 }
 
 pub fn create<'gc>(

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2041,9 +2041,9 @@ impl PlayerBuilder {
     #[inline]
     pub fn new() -> Self {
         let ruffle_type = if cfg!(not(target_family = "wasm")) {
-            RuffleType::DesktopPlayer
+            RuffleType::Desktop
         } else {
-            RuffleType::WebPlayer
+            RuffleType::Web
         };
 
         Self {

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2370,7 +2370,7 @@ impl PlayerBuilder {
 
                 // Misc. state
                 rng: SmallRng::seed_from_u64(get_current_date_time().timestamp_millis() as u64),
-                system: SystemProperties::new(self.sandbox_type, self.ruffle_type),
+                system: SystemProperties::new(self.sandbox_type, player_version, self.ruffle_type),
                 transform_stack: TransformStack::new(),
                 instance_counter: 0,
                 player_version,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1,4 +1,4 @@
-use crate::avm1::globals::system::SandboxType;
+use crate::avm1::globals::system::{RuffleType, SandboxType};
 use crate::avm1::Attribute;
 use crate::avm1::Avm1;
 use crate::avm1::Object;
@@ -2030,6 +2030,7 @@ pub struct PlayerBuilder {
     sandbox_type: SandboxType,
     frame_rate: Option<f64>,
     external_interface_providers: Vec<Box<dyn ExternalInterfaceProvider>>,
+    ruffle_type: RuffleType,
 }
 
 impl PlayerBuilder {
@@ -2039,6 +2040,12 @@ impl PlayerBuilder {
     /// can be changed by chaining the configuration methods.
     #[inline]
     pub fn new() -> Self {
+        let ruffle_type = if cfg!(not(target_family = "wasm")) {
+            RuffleType::DesktopPlayer
+        } else {
+            RuffleType::WebPlayer
+        };
+
         Self {
             movie: None,
 
@@ -2075,6 +2082,7 @@ impl PlayerBuilder {
             sandbox_type: SandboxType::LocalTrusted,
             frame_rate: None,
             external_interface_providers: vec![],
+            ruffle_type,
         }
     }
 
@@ -2362,7 +2370,7 @@ impl PlayerBuilder {
 
                 // Misc. state
                 rng: SmallRng::seed_from_u64(get_current_date_time().timestamp_millis() as u64),
-                system: SystemProperties::new(self.sandbox_type),
+                system: SystemProperties::new(self.sandbox_type, self.ruffle_type),
                 transform_stack: TransformStack::new(),
                 instance_counter: 0,
                 player_version,


### PR DESCRIPTION
This pull request implements system.capability attributes, and fixes and improves the stubbing.

**Additions / Implementations:**
- A ruffle_type variable, whose type is the new RuffleType enum, has been added to the Player.
- The playerType property has been implemented.
- The language property has been implemented.
- The os property has been implemented.
- The cpuArchitecture property has been implemented.
- The cpuAddressSize property has been implemented.
- The hasAudio property has been implemented.
- The isEmbeddedInAcrobat property has been implemented.

**Fixes:**
- The manufacturer string has been corrected.
- Missing properties in the serverString have been added.
- hasAccessibility was previously inverted in the serverString. This has been fixed.

**Stubbing:**
- The cpuAddressSize property, which was previously missing in Ruffle, has been added.
- Some missing os return values have been added.
- The SystemCapabilities bitmap has been stubbed out.
- The default values of the boolean properties have been improved.
- The custom language part of the language property has been stubbed.

**Other:**
- Todos and comments have been added, documenting what is not emulated yet and what needs to be implemented.
- Documentation has been improved.


This pull request should close #8309, since it implements system.capabilities.playerType.
It should also check the properties listed here in #278 as fully implemented. The other properties shouldn't be checked, since they're not actually implemented yet and need to be worked on.