### PR TITLE
core: Update to latest quick-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,8 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
-source = "git+https://github.com/ruffle-rs/quick-xml?rev=8496365ec1412eb5ba5de350937b6bce352fa0ba#8496365ec1412eb5ba5de350937b6bce352fa0ba"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c1a97b1bc42b1d550bfb48d4262153fe400a12bab1511821736f7eac76d7e2"
 dependencies = [
  "memchr",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "2.0.2"
 smallvec = { version = "1.10.0", features = ["union"] }
 num-traits = "0.2"
 num-derive = "0.3"
-quick-xml = { git = "https://github.com/ruffle-rs/quick-xml", rev = "8496365ec1412eb5ba5de350937b6bce352fa0ba" }
+quick-xml = "0.28.1"
 downcast-rs = "1.2.0"
 url = "2.3.1"
 weak-table = "0.3.2"
@@ -59,7 +59,7 @@ version = "0.4.34"
 [features]
 default = []
 lzma = ["lzma-rs", "swf/lzma"]
-wasm-bindgen = [ "instant/wasm-bindgen" ]
+wasm-bindgen = ["instant/wasm-bindgen"]
 avm_debug = []
 deterministic = []
 timeline_debug = []

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -606,13 +606,11 @@ impl FormatSpans {
         let mut reader = Reader::from_reader(&raw_bytes[..]);
         reader.expand_empty_elements(true);
         reader.check_end_names(false);
-        let mut buf = Vec::new();
         loop {
-            buf.clear();
-            match reader.read_event(&mut buf) {
+            match reader.read_event() {
                 Ok(Event::Start(ref e)) => {
                     opened_starts.push(opened_buffer.len());
-                    opened_buffer.extend(e.name());
+                    opened_buffer.extend(e.name().into_inner());
 
                     let attributes: Result<Vec<_>, _> = e.attributes().with_checks(false).collect();
                     let attributes = match attributes {
@@ -626,12 +624,13 @@ impl FormatSpans {
                         attributes.iter().find_map(|attribute| {
                             attribute
                                 .key
+                                .into_inner()
                                 .eq_ignore_ascii_case(name)
                                 .then(|| decode_to_wstr(&attribute.value))
                         })
                     };
                     let mut format = format_stack.last().unwrap().clone();
-                    match &e.name().to_ascii_lowercase()[..] {
+                    match &e.name().into_inner().to_ascii_lowercase()[..] {
                         b"br" => {
                             if is_multiline {
                                 text.push_byte(b'\n');
@@ -762,7 +761,7 @@ impl FormatSpans {
                     format_stack.push(format);
                 }
                 Ok(Event::Text(e)) if !e.is_empty() => {
-                    let e = decode_to_wstr(e.escaped());
+                    let e = decode_to_wstr(&e.into_inner());
                     let e = process_html_entity(&e).unwrap_or(e);
                     let format = format_stack.last().unwrap().clone();
                     text.push_str(&e);
@@ -772,7 +771,7 @@ impl FormatSpans {
                     // Check for a mismatch.
                     match opened_starts.last() {
                         Some(start) => {
-                            if e.name() != &opened_buffer[*start..] {
+                            if e.name().into_inner() != &opened_buffer[*start..] {
                                 continue;
                             } else {
                                 opened_buffer.truncate(*start);
@@ -782,7 +781,7 @@ impl FormatSpans {
                         None => continue,
                     }
 
-                    match &e.name().to_ascii_lowercase()[..] {
+                    match &e.name().into_inner().to_ascii_lowercase()[..] {
                         b"br" | b"sbr" => {
                             // Skip pop from `format_stack`.
                             continue;
@@ -1422,16 +1421,17 @@ impl<'a> FormatState<'a> {
                 self.close_tags();
             }
             let encoded = text.to_utf8_lossy();
-            let escaped = escape(encoded.as_bytes());
+            let escaped = escape(&encoded);
 
             if let Cow::Borrowed(_) = &encoded {
                 // Optimization: if the utf8 conversion was a no-op, we know the text is ASCII;
                 // escaping special characters cannot insert new non-ASCII characters, so we can
                 // simply append the bytes directly without converting from UTF8.
-                self.result.push_str(WStr::from_units(&*escaped));
+                self.result.push_str(WStr::from_units(escaped.as_bytes()));
             } else {
                 // TODO: updating our quick_xml fork to upstream will allow removing this UTF8 check.
-                let escaped = std::str::from_utf8(&escaped).expect("escaped text should be utf8");
+                let escaped =
+                    std::str::from_utf8(escaped.as_bytes()).expect("escaped text should be utf8");
                 self.result.push_utf8(escaped);
             }
         }

--- a/core/src/xml.rs
+++ b/core/src/xml.rs
@@ -3,4 +3,4 @@
 mod iterators;
 mod tree;
 
-pub use tree::{XmlNode, ELEMENT_NODE, TEXT_NODE};
+pub use tree::{custom_unescape, XmlNode, ELEMENT_NODE, TEXT_NODE};


### PR DESCRIPTION
I've moved our special entity handling logic into
a `custom_unescape` function. This lets us move off of our fork of `quick-xml` back onto the crates.io release