### PR TITLE
core: Log an error when a font is missing a glyph for a character

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -289,6 +289,12 @@ impl<'gc> Font<'gc> {
                 // Step horizontally.
                 transform.matrix.tx += twips_advance;
                 x += twips_advance;
+            } else {
+                tracing::error!(
+                    "Font {:?} is misssing glyph for character {:?}",
+                    self.0.descriptor,
+                    c
+                );
             }
         }
     }


### PR DESCRIPTION
My hope is that this never happens for real SWFS (unless Ruffle has a bug). If this does get hit intentionally in real SWFs, then it's going to be very verbose (logging each time we render), so we'll need to adjust this to log only once for a given char.