### PR TITLE
avm2: QName and RegExp fixes

### DIFF
--- a/core/src/avm2/globals/QName.as
+++ b/core/src/avm2/globals/QName.as
@@ -1,6 +1,8 @@
 package {
     [Ruffle(InstanceAllocator)]
     public final class QName {
+        public static const length = 2;
+        
         public function QName(uri:* = undefined, localName:*=undefined) {
             this.init(uri, localName)
         }
@@ -19,12 +21,7 @@ package {
             var self:QName = this;
             return self.AS3::toString();
         }
-        prototype.valueOf = function():QName {
-            var self:QName = this;
-            return self.AS3::valueOf();
-        }
 
         prototype.setPropertyIsEnumerable("toString", false);
-        prototype.setPropertyIsEnumerable("valueOf", false);
     }
 }

--- a/core/src/avm2/globals/RegExp.as
+++ b/core/src/avm2/globals/RegExp.as
@@ -29,23 +29,7 @@ package {
         }
 
         prototype.toString = function():String {
-            var res:String = "/" + this.source + "/";
-            if (this.ignoreCase) {
-               res += "i";
-            }
-            if (this.global) {
-               res += "g";
-            }
-            if (this.multiline) {
-               res += "m";
-            }
-            if (this.dotall) {
-               res += "s";
-            }
-            if (this.extended) {
-               res += "x";
-            }
-            return res;
+            return this.valueOf();
         }
         
         prototype.setPropertyIsEnumerable("exec", false);

--- a/core/src/avm2/globals/RegExp.as
+++ b/core/src/avm2/globals/RegExp.as
@@ -27,5 +27,8 @@ package {
         prototype.test = function(str:String = ""):Boolean {
             return this.AS3::test(str);
         }
+        
+        prototype.setPropertyIsEnumerable("exec", false);
+        prototype.setPropertyIsEnumerable("test", false);
     }
 }

--- a/core/src/avm2/globals/RegExp.as
+++ b/core/src/avm2/globals/RegExp.as
@@ -27,8 +27,29 @@ package {
         prototype.test = function(str:String = ""):Boolean {
             return this.AS3::test(str);
         }
+
+        prototype.toString = function():String {
+            var res:String = "/" + this.source + "/";
+            if (this.ignoreCase) {
+               res += "i";
+            }
+            if (this.global) {
+               res += "g";
+            }
+            if (this.multiline) {
+               res += "m";
+            }
+            if (this.dotall) {
+               res += "s";
+            }
+            if (this.extended) {
+               res += "x";
+            }
+            return res;
+        }
         
         prototype.setPropertyIsEnumerable("exec", false);
         prototype.setPropertyIsEnumerable("test", false);
+        prototype.setPropertyIsEnumerable("toString", false);
     }
 }


### PR DESCRIPTION
1. `QName` does not define `valueOf` on its prototype.
2. `RegExp`'s prototype should not be enumerable, and it should have a `toString` defined on its prototype (but _not_ as an `AS3` one).