### PR TITLE
core: BitmapData cleanups + slightly less syncs

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -78,7 +78,7 @@ pub fn constructor<'gc>(
 
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         let (sync, _) = bitmap_data
-            .bitmap_data_wrapper()
+            .bitmap_data()
             .overwrite_cpu_pixels_from_gpu(&mut activation.context);
         sync.write(activation.context.gc_context).init_pixels(
             width,
@@ -98,7 +98,7 @@ pub fn height<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            return Ok(bitmap_data.bitmap_data_wrapper().height().into());
+            return Ok(bitmap_data.bitmap_data().height().into());
         }
     }
 
@@ -112,7 +112,7 @@ pub fn width<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            return Ok(bitmap_data.bitmap_data_wrapper().width().into());
+            return Ok(bitmap_data.bitmap_data().width().into());
         }
     }
 
@@ -126,7 +126,7 @@ pub fn get_transparent<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            return Ok(bitmap_data.bitmap_data_wrapper().transparency().into());
+            return Ok(bitmap_data.bitmap_data().transparency().into());
         }
     }
 
@@ -167,7 +167,7 @@ pub fn get_pixel<'gc>(
             if let (Some(x_val), Some(y_val)) = (args.get(0), args.get(1)) {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let col = operations::get_pixel(bitmap_data.bitmap_data_wrapper(), x, y);
+                let col = operations::get_pixel(bitmap_data.bitmap_data(), x, y);
                 return Ok(col.into());
             }
         }
@@ -186,7 +186,7 @@ pub fn get_pixel32<'gc>(
             if let (Some(x_val), Some(y_val)) = (args.get(0), args.get(1)) {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let col = operations::get_pixel32(bitmap_data.bitmap_data_wrapper(), x, y);
+                let col = operations::get_pixel32(bitmap_data.bitmap_data(), x, y);
                 return Ok(col.into());
             }
         }
@@ -211,7 +211,7 @@ pub fn set_pixel<'gc>(
 
                 operations::set_pixel(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     x,
                     y,
                     color.into(),
@@ -241,7 +241,7 @@ pub fn set_pixel32<'gc>(
 
                 operations::set_pixel32(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     x,
                     y,
                     color,
@@ -292,11 +292,11 @@ pub fn copy_channel<'gc>(
                 let min_x = dest_point
                     .get("x", activation)?
                     .coerce_to_u32(activation)?
-                    .min(bitmap_data.bitmap_data_wrapper().width());
+                    .min(bitmap_data.bitmap_data().width());
                 let min_y = dest_point
                     .get("y", activation)?
                     .coerce_to_u32(activation)?
-                    .min(bitmap_data.bitmap_data_wrapper().height());
+                    .min(bitmap_data.bitmap_data().height());
 
                 let src_min_x = source_rect
                     .get("x", activation)?
@@ -313,10 +313,10 @@ pub fn copy_channel<'gc>(
 
                 operations::copy_channel(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     (min_x, min_y),
                     (src_min_x, src_min_y, src_width, src_height),
-                    source_bitmap.bitmap_data_wrapper(),
+                    source_bitmap.bitmap_data(),
                     source_channel,
                     dest_channel,
                 );
@@ -355,7 +355,7 @@ pub fn fill_rect<'gc>(
 
                 operations::fill_rect(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     x,
                     y,
                     width,
@@ -377,7 +377,7 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            let new_bitmap_data = operations::clone(bitmap_data.bitmap_data_wrapper());
+            let new_bitmap_data = operations::clone(bitmap_data.bitmap_data());
             let new_bitmap_data = BitmapDataObject::with_bitmap_data(
                 activation.context.gc_context,
                 activation.context.avm1.prototypes().bitmap_data,
@@ -422,7 +422,7 @@ pub fn flood_fill<'gc>(
 
                 operations::flood_fill(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     x,
                     y,
                     color,
@@ -464,7 +464,7 @@ pub fn noise<'gc>(
                 let random_seed = random_seed_val.coerce_to_i32(activation)?;
                 operations::noise(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     random_seed,
                     low,
                     high.max(low),
@@ -528,7 +528,7 @@ pub fn draw<'gc>(
             let source = if let Some(source_object) = source.as_display_object() {
                 IBitmapDrawable::DisplayObject(source_object)
             } else if let Some(source_bitmap) = source.as_bitmap_data_object() {
-                IBitmapDrawable::BitmapData(source_bitmap.bitmap_data_wrapper())
+                IBitmapDrawable::BitmapData(source_bitmap.bitmap_data())
             } else {
                 avm_error!(
                     activation,
@@ -544,7 +544,7 @@ pub fn draw<'gc>(
             let quality = activation.context.stage.quality();
             match operations::draw(
                 &mut activation.context,
-                bitmap_data.bitmap_data_wrapper(),
+                bitmap_data.bitmap_data(),
                 source,
                 Transform {
                     matrix,
@@ -625,7 +625,7 @@ pub fn color_transform<'gc>(
 
                 operations::color_transform(
                     &mut activation.context,
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     x_min,
                     y_min,
                     x_max,
@@ -656,7 +656,7 @@ pub fn get_color_bounds_rect<'gc>(
                 let color = color_val.coerce_to_i32(activation)?;
 
                 let (x, y, w, h) = operations::color_bounds_rect(
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     find_color,
                     mask,
                     color,
@@ -733,7 +733,7 @@ pub fn perlin_noise<'gc>(
 
             operations::perlin_noise(
                 &mut activation.context,
-                bitmap_data.bitmap_data_wrapper(),
+                bitmap_data.bitmap_data(),
                 (base_x, base_y),
                 num_octaves,
                 seed,
@@ -805,10 +805,10 @@ pub fn hit_test<'gc>(
                     .coerce_to_u32(activation)?;
 
                 let result = operations::hit_test_bitmapdata(
-                    bitmap_data.bitmap_data_wrapper(),
+                    bitmap_data.bitmap_data(),
                     top_left,
                     source_threshold,
-                    other_bmd.bitmap_data_wrapper(),
+                    other_bmd.bitmap_data(),
                     second_point,
                     second_threshold,
                 );
@@ -830,7 +830,7 @@ pub fn hit_test<'gc>(
                             test_y.coerce_to_i32(activation)? - top_left.1,
                         );
                         return Ok(Value::Bool(operations::hit_test_point(
-                            bitmap_data.bitmap_data_wrapper(),
+                            bitmap_data.bitmap_data(),
                             source_threshold,
                             test_point,
                         )));
@@ -847,7 +847,7 @@ pub fn hit_test<'gc>(
                             test_height.coerce_to_i32(activation)?,
                         );
                         return Ok(Value::Bool(operations::hit_test_rectangle(
-                            bitmap_data.bitmap_data_wrapper(),
+                            bitmap_data.bitmap_data(),
                             source_threshold,
                             test_point,
                             size,
@@ -941,11 +941,11 @@ pub fn copy_pixels<'gc>(
 
                             operations::copy_pixels_with_alpha_source(
                                 &mut activation.context,
-                                bitmap_data.bitmap_data_wrapper(),
-                                src_bitmap.bitmap_data_wrapper(),
+                                bitmap_data.bitmap_data(),
+                                src_bitmap.bitmap_data(),
                                 (src_min_x, src_min_y, src_width, src_height),
                                 (dest_x, dest_y),
-                                alpha_bitmap.bitmap_data_wrapper(),
+                                alpha_bitmap.bitmap_data(),
                                 (alpha_x, alpha_y),
                                 merge_alpha.unwrap_or(true),
                             );
@@ -953,8 +953,8 @@ pub fn copy_pixels<'gc>(
                     } else {
                         operations::copy_pixels(
                             &mut activation.context,
-                            bitmap_data.bitmap_data_wrapper(),
-                            src_bitmap.bitmap_data_wrapper(),
+                            bitmap_data.bitmap_data(),
+                            src_bitmap.bitmap_data(),
                             (src_min_x, src_min_y, src_width, src_height),
                             (dest_x, dest_y),
                             // Despite what the docs claim, mergeAlpa appears to be treated as 'false'
@@ -1034,8 +1034,8 @@ pub fn merge<'gc>(
                 if !src_bitmap.disposed() {
                     operations::merge(
                         &mut activation.context,
-                        bitmap_data.bitmap_data_wrapper(),
-                        src_bitmap.bitmap_data_wrapper(),
+                        bitmap_data.bitmap_data(),
+                        src_bitmap.bitmap_data(),
                         (src_min_x, src_min_y, src_width, src_height),
                         (dest_x, dest_y),
                         (red_mult, green_mult, blue_mult, alpha_mult),
@@ -1113,8 +1113,8 @@ pub fn palette_map<'gc>(
                 if !src_bitmap.disposed() {
                     operations::palette_map(
                         &mut activation.context,
-                        bitmap_data.bitmap_data_wrapper(),
-                        src_bitmap.bitmap_data_wrapper(),
+                        bitmap_data.bitmap_data(),
+                        src_bitmap.bitmap_data(),
                         (src_min_x, src_min_y, src_width, src_height),
                         (dest_x, dest_y),
                         (red_array, green_array, blue_array, alpha_array),
@@ -1160,12 +1160,7 @@ pub fn scroll<'gc>(
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_i32(activation)?;
 
-            operations::scroll(
-                &mut activation.context,
-                bitmap_data.bitmap_data_wrapper(),
-                x,
-                y,
-            );
+            operations::scroll(&mut activation.context, bitmap_data.bitmap_data(), x, y);
 
             return Ok(Value::Undefined);
         }
@@ -1243,8 +1238,8 @@ pub fn threshold<'gc>(
                 if !src_bitmap.disposed() {
                     let modified_count = operations::threshold(
                         &mut activation.context,
-                        bitmap_data.bitmap_data_wrapper(),
-                        src_bitmap.bitmap_data_wrapper(),
+                        bitmap_data.bitmap_data(),
+                        src_bitmap.bitmap_data(),
                         (src_min_x, src_min_y, src_width, src_height),
                         (dest_x, dest_y),
                         operation,
@@ -1303,8 +1298,8 @@ pub fn compare<'gc>(
         return Ok(BITMAP_DISPOSED.into());
     }
 
-    let this_bitmap_data = this_bitmap_data.bitmap_data_wrapper();
-    let other_bitmap_data = other_bitmap_data.bitmap_data_wrapper();
+    let this_bitmap_data = this_bitmap_data.bitmap_data();
+    let other_bitmap_data = other_bitmap_data.bitmap_data();
 
     if this_bitmap_data.width() != other_bitmap_data.width() {
         return Ok(DIFFERENT_WIDTHS.into());
@@ -1367,7 +1362,7 @@ pub fn load_bitmap<'gc>(
         let (sync, _) = new_bitmap_data
             .as_bitmap_data_object()
             .unwrap()
-            .bitmap_data_wrapper()
+            .bitmap_data()
             .overwrite_cpu_pixels_from_gpu(&mut activation.context);
 
         sync.write(activation.context.gc_context)

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -98,7 +98,7 @@ pub fn height<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            return Ok(bitmap_data.bitmap_data().read().height().into());
+            return Ok(bitmap_data.bitmap_data_wrapper().height().into());
         }
     }
 
@@ -112,7 +112,7 @@ pub fn width<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         if !bitmap_data.disposed() {
-            return Ok(bitmap_data.bitmap_data().read().width().into());
+            return Ok(bitmap_data.bitmap_data_wrapper().width().into());
         }
     }
 
@@ -292,11 +292,11 @@ pub fn copy_channel<'gc>(
                 let min_x = dest_point
                     .get("x", activation)?
                     .coerce_to_u32(activation)?
-                    .min(bitmap_data.bitmap_data().read().width());
+                    .min(bitmap_data.bitmap_data_wrapper().width());
                 let min_y = dest_point
                     .get("y", activation)?
                     .coerce_to_u32(activation)?
-                    .min(bitmap_data.bitmap_data().read().height());
+                    .min(bitmap_data.bitmap_data_wrapper().height());
 
                 let src_min_x = source_rect
                     .get("x", activation)?

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -210,7 +210,7 @@ pub fn set_pixel<'gc>(
                 let color = color_val.coerce_to_i32(activation)?;
 
                 operations::set_pixel(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     x,
                     y,
@@ -240,7 +240,7 @@ pub fn set_pixel32<'gc>(
                 let color = color_val.coerce_to_i32(activation)?;
 
                 operations::set_pixel32(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     x,
                     y,
@@ -312,7 +312,7 @@ pub fn copy_channel<'gc>(
                     .coerce_to_u32(activation)?;
 
                 operations::copy_channel(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     (min_x, min_y),
                     (src_min_x, src_min_y, src_width, src_height),
@@ -354,7 +354,7 @@ pub fn fill_rect<'gc>(
                     .coerce_to_i32(activation)?;
 
                 operations::fill_rect(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     x,
                     y,
@@ -421,7 +421,7 @@ pub fn flood_fill<'gc>(
                 let color = color_val.coerce_to_i32(activation)?;
 
                 operations::flood_fill(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     x,
                     y,
@@ -463,7 +463,7 @@ pub fn noise<'gc>(
             if let Some(random_seed_val) = args.get(0) {
                 let random_seed = random_seed_val.coerce_to_i32(activation)?;
                 operations::noise(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     random_seed,
                     low,
@@ -624,7 +624,7 @@ pub fn color_transform<'gc>(
                 };
 
                 operations::color_transform(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data.bitmap_data(),
                     x_min,
                     y_min,
@@ -732,7 +732,7 @@ pub fn perlin_noise<'gc>(
             let octave_offsets = octave_offsets?;
 
             operations::perlin_noise(
-                &mut activation.context,
+                activation.context.gc_context,
                 bitmap_data.bitmap_data(),
                 (base_x, base_y),
                 num_octaves,
@@ -940,7 +940,7 @@ pub fn copy_pixels<'gc>(
                                 as i32;
 
                             operations::copy_pixels_with_alpha_source(
-                                &mut activation.context,
+                                activation.context.gc_context,
                                 bitmap_data.bitmap_data(),
                                 src_bitmap.bitmap_data(),
                                 (src_min_x, src_min_y, src_width, src_height),
@@ -952,7 +952,7 @@ pub fn copy_pixels<'gc>(
                         }
                     } else {
                         operations::copy_pixels(
-                            &mut activation.context,
+                            activation.context.gc_context,
                             bitmap_data.bitmap_data(),
                             src_bitmap.bitmap_data(),
                             (src_min_x, src_min_y, src_width, src_height),
@@ -1033,7 +1033,7 @@ pub fn merge<'gc>(
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
                     operations::merge(
-                        &mut activation.context,
+                        activation.context.gc_context,
                         bitmap_data.bitmap_data(),
                         src_bitmap.bitmap_data(),
                         (src_min_x, src_min_y, src_width, src_height),
@@ -1112,7 +1112,7 @@ pub fn palette_map<'gc>(
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
                     operations::palette_map(
-                        &mut activation.context,
+                        activation.context.gc_context,
                         bitmap_data.bitmap_data(),
                         src_bitmap.bitmap_data(),
                         (src_min_x, src_min_y, src_width, src_height),
@@ -1160,7 +1160,12 @@ pub fn scroll<'gc>(
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_i32(activation)?;
 
-            operations::scroll(&mut activation.context, bitmap_data.bitmap_data(), x, y);
+            operations::scroll(
+                activation.context.gc_context,
+                bitmap_data.bitmap_data(),
+                x,
+                y,
+            );
 
             return Ok(Value::Undefined);
         }
@@ -1237,7 +1242,7 @@ pub fn threshold<'gc>(
             if let Some(src_bitmap) = source_bitmap.as_bitmap_data_object() {
                 if !src_bitmap.disposed() {
                     let modified_count = operations::threshold(
-                        &mut activation.context,
+                        activation.context.gc_context,
                         bitmap_data.bitmap_data(),
                         src_bitmap.bitmap_data(),
                         (src_min_x, src_min_y, src_width, src_height),

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -77,10 +77,15 @@ pub fn constructor<'gc>(
     }
 
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
-        bitmap_data
-            .bitmap_data()
-            .write(activation.context.gc_context)
-            .init_pixels(width, height, transparency, fill_color);
+        let (sync, _) = bitmap_data
+            .bitmap_data_wrapper()
+            .overwrite_cpu_pixels_from_gpu(&mut activation.context);
+        sync.write(activation.context.gc_context).init_pixels(
+            width,
+            height,
+            transparency,
+            fill_color,
+        );
     }
 
     Ok(this.into())

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1364,12 +1364,13 @@ pub fn load_bitmap<'gc>(
         let height = bitmap.height() as u32;
 
         let pixels: Vec<_> = bitmap.bitmap_data().read().pixels().to_vec();
-
-        new_bitmap_data
+        let (sync, _) = new_bitmap_data
             .as_bitmap_data_object()
             .unwrap()
-            .bitmap_data()
-            .write(activation.context.gc_context)
+            .bitmap_data_wrapper()
+            .overwrite_cpu_pixels_from_gpu(&mut activation.context);
+
+        sync.write(activation.context.gc_context)
             .set_pixels(width, height, true, pixels);
 
         return Ok(new_bitmap_data.into());

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -79,7 +79,7 @@ pub fn constructor<'gc>(
     if let Some(bitmap_data) = this.as_bitmap_data_object() {
         let (sync, _) = bitmap_data
             .bitmap_data()
-            .overwrite_cpu_pixels_from_gpu(&mut activation.context);
+            .overwrite_cpu_pixels_from_gpu(activation.context.gc_context);
         sync.write(activation.context.gc_context).init_pixels(
             width,
             height,
@@ -1363,7 +1363,7 @@ pub fn load_bitmap<'gc>(
             .as_bitmap_data_object()
             .unwrap()
             .bitmap_data()
-            .overwrite_cpu_pixels_from_gpu(&mut activation.context);
+            .overwrite_cpu_pixels_from_gpu(activation.context.gc_context);
 
         sync.write(activation.context.gc_context)
             .set_pixels(width, height, true, pixels);

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -247,7 +247,7 @@ fn attach_bitmap<'gc>(
         if let Some(bitmap_data) = bitmap
             .coerce_to_object(activation)
             .as_bitmap_data_object()
-            .map(|bd| bd.bitmap_data_wrapper())
+            .map(|bd| bd.bitmap_data())
         {
             if let Some(depth) = args.get(1) {
                 let depth = depth
@@ -400,7 +400,7 @@ fn begin_bitmap_fill<'gc>(
         .and_then(|val| val.coerce_to_object(activation).as_bitmap_data_object())
     {
         // Register the bitmap data with the drawing.
-        let bitmap_data = bitmap_data.bitmap_data_wrapper();
+        let bitmap_data = bitmap_data.bitmap_data();
         let handle =
             bitmap_data.bitmap_handle(activation.context.gc_context, activation.context.renderer);
         let bitmap = ruffle_render::bitmap::BitmapInfo {

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -28,10 +28,6 @@ impl fmt::Debug for BitmapDataObject<'_> {
 }
 
 impl<'gc> BitmapDataObject<'gc> {
-    pub fn bitmap_data(&self) -> GcCell<'gc, BitmapData<'gc>> {
-        self.0.read().data.sync()
-    }
-
     pub fn bitmap_data_wrapper(&self) -> BitmapDataWrapper<'gc> {
         self.0.read().data
     }

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -71,7 +71,7 @@ impl<'gc> BitmapDataObject<'gc> {
     }
 
     pub fn dispose(&self, context: &mut UpdateContext<'_, 'gc>) {
-        self.bitmap_data().write(context.gc_context).dispose();
+        self.bitmap_data_wrapper().dispose(context.gc_context);
     }
 }
 

--- a/core/src/avm1/object/bitmap_data.rs
+++ b/core/src/avm1/object/bitmap_data.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for BitmapDataObject<'_> {
 }
 
 impl<'gc> BitmapDataObject<'gc> {
-    pub fn bitmap_data_wrapper(&self) -> BitmapDataWrapper<'gc> {
+    pub fn bitmap_data(&self) -> BitmapDataWrapper<'gc> {
         self.0.read().data
     }
 
@@ -67,7 +67,7 @@ impl<'gc> BitmapDataObject<'gc> {
     }
 
     pub fn dispose(&self, context: &mut UpdateContext<'_, 'gc>) {
-        self.bitmap_data_wrapper().dispose(context.gc_context);
+        self.bitmap_data().dispose(context.gc_context);
     }
 }
 

--- a/core/src/avm2/filters.rs
+++ b/core/src/avm2/filters.rs
@@ -414,7 +414,7 @@ fn avm2_to_displacement_map_filter<'gc>(
     let map_bitmap = if let Value::Object(bitmap) =
         object.get_public_property("mapBitmap", activation)?
     {
-        if let Some(bitmap) = bitmap.as_bitmap_data_wrapper() {
+        if let Some(bitmap) = bitmap.as_bitmap_data() {
             Some(bitmap.bitmap_handle(activation.context.gc_context, activation.context.renderer))
         } else {
             return Err(Error::AvmError(type_error(

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -139,11 +139,14 @@ pub fn set_bitmap_data<'gc>(
     {
         let bitmap_data = args.get(0).unwrap_or(&Value::Null);
         let bitmap_data = if matches!(bitmap_data, Value::Null) {
-            GcCell::allocate(activation.context.gc_context, BitmapData::dummy())
+            BitmapDataWrapper::new(GcCell::allocate(
+                activation.context.gc_context,
+                BitmapData::dummy(),
+            ))
         } else {
             bitmap_data
                 .coerce_to_object(activation)?
-                .as_bitmap_data()
+                .as_bitmap_data_wrapper()
                 .ok_or_else(|| Error::RustError("Argument was not a BitmapData".into()))?
         };
         bitmap.set_bitmap_data(&mut activation.context, bitmap_data);

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -56,13 +56,10 @@ pub fn init<'gc>(
                         .character_by_id(symbol_id)
                         .cloned()
                     {
-                        let new_bitmap_data =
-                            GcCell::allocate(activation.context.gc_context, BitmapData::default());
-
-                        fill_bitmap_data_from_symbol(activation, bitmap, new_bitmap_data);
+                        let new_bitmap_data = fill_bitmap_data_from_symbol(activation, bitmap);
                         BitmapDataObject::from_bitmap_data(
                             activation,
-                            BitmapDataWrapper::new(new_bitmap_data),
+                            new_bitmap_data,
                             activation.context.avm2.classes().bitmapdata,
                         )?
                     } else {

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -62,7 +62,7 @@ pub fn init<'gc>(
                         fill_bitmap_data_from_symbol(activation, bitmap, new_bitmap_data);
                         BitmapDataObject::from_bitmap_data(
                             activation,
-                            new_bitmap_data,
+                            BitmapDataWrapper::new(new_bitmap_data),
                             activation.context.avm2.classes().bitmapdata,
                         )?
                     } else {

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -24,7 +24,7 @@ pub fn init<'gc>(
 
         let bitmap_data = args
             .try_get_object(activation, 0)
-            .and_then(|o| o.as_bitmap_data_wrapper());
+            .and_then(|o| o.as_bitmap_data());
         //TODO: Pixel snapping is not supported
         let _pixel_snapping = args.get_string(activation, 1);
         let smoothing = args.get_bool(2);
@@ -146,7 +146,7 @@ pub fn set_bitmap_data<'gc>(
         } else {
             bitmap_data
                 .coerce_to_object(activation)?
-                .as_bitmap_data_wrapper()
+                .as_bitmap_data()
                 .ok_or_else(|| Error::RustError("Argument was not a BitmapData".into()))?
         };
         bitmap.set_bitmap_data(&mut activation.context, bitmap_data);

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -7,11 +7,10 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 
 use crate::avm2::parameters::ParametersExt;
-use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
+use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::character::Character;
 use crate::display_object::{Bitmap, TDisplayObject};
 use crate::{avm2_stub_getter, avm2_stub_setter};
-use gc_arena::GcCell;
 
 /// Implements `flash.display.Bitmap`'s `init` method, which is called from the constructor
 pub fn init<'gc>(
@@ -85,12 +84,8 @@ pub fn init<'gc>(
             //We are being initialized by AVM2 (and aren't associated with a
             //Bitmap subclass).
 
-            let bitmap_data = bitmap_data.unwrap_or_else(|| {
-                BitmapDataWrapper::new(GcCell::allocate(
-                    activation.context.gc_context,
-                    BitmapData::dummy(),
-                ))
-            });
+            let bitmap_data = bitmap_data
+                .unwrap_or_else(|| BitmapDataWrapper::dummy(activation.context.gc_context));
 
             let bitmap =
                 Bitmap::new_with_bitmap_data(&mut activation.context, 0, bitmap_data, smoothing);
@@ -136,10 +131,7 @@ pub fn set_bitmap_data<'gc>(
     {
         let bitmap_data = args.get(0).unwrap_or(&Value::Null);
         let bitmap_data = if matches!(bitmap_data, Value::Null) {
-            BitmapDataWrapper::new(GcCell::allocate(
-                activation.context.gc_context,
-                BitmapData::dummy(),
-            ))
+            BitmapDataWrapper::dummy(activation.context.gc_context)
         } else {
             bitmap_data
                 .coerce_to_object(activation)?

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -165,7 +165,7 @@ pub fn scroll<'gc>(
         let x = args.get_i32(activation, 0)?;
         let y = args.get_i32(activation, 1)?;
 
-        operations::scroll(&mut activation.context, bitmap_data, x, y);
+        operations::scroll(activation.context.gc_context, bitmap_data, x, y);
     }
 
     Ok(Value::Undefined)
@@ -241,7 +241,7 @@ pub fn copy_pixels<'gc>(
 
             if let Some((alpha_bitmap, alpha_point)) = alpha_source {
                 operations::copy_pixels_with_alpha_source(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data,
                     src_bitmap,
                     (src_min_x, src_min_y, src_width, src_height),
@@ -252,7 +252,7 @@ pub fn copy_pixels<'gc>(
                 );
             } else {
                 operations::copy_pixels(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data,
                     src_bitmap,
                     (src_min_x, src_min_y, src_width, src_height),
@@ -373,7 +373,13 @@ pub fn set_pixel<'gc>(
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
         let color = args.get_i32(activation, 2)?;
-        operations::set_pixel(&mut activation.context, bitmap_data, x, y, color.into());
+        operations::set_pixel(
+            activation.context.gc_context,
+            bitmap_data,
+            x,
+            y,
+            color.into(),
+        );
     }
 
     Ok(Value::Undefined)
@@ -392,7 +398,7 @@ pub fn set_pixel32<'gc>(
         let y = args.get_u32(activation, 1)?;
         let color = args.get_i32(activation, 2)?;
 
-        operations::set_pixel32(&mut activation.context, bitmap_data, x, y, color);
+        operations::set_pixel32(activation.context.gc_context, bitmap_data, x, y, color);
     }
 
     Ok(Value::Undefined)
@@ -429,7 +435,7 @@ pub fn set_pixels<'gc>(
             .ok_or("ArgumentError: Parameter must be a bytearray")?;
 
         operations::set_pixels_from_byte_array(
-            &mut activation.context,
+            activation.context.gc_context,
             bitmap_data,
             x,
             y,
@@ -487,7 +493,7 @@ pub fn copy_channel<'gc>(
                 .coerce_to_u32(activation)?;
 
             operations::copy_channel(
-                &mut activation.context,
+                activation.context.gc_context,
                 bitmap_data,
                 (dest_x, dest_y),
                 (src_min_x, src_min_y, src_width, src_height),
@@ -511,7 +517,7 @@ pub fn flood_fill<'gc>(
             let y = args.get_u32(activation, 1)?;
             let color = args.get_i32(activation, 2)?;
 
-            operations::flood_fill(&mut activation.context, bitmap_data, x, y, color);
+            operations::flood_fill(activation.context.gc_context, bitmap_data, x, y, color);
         }
     }
 
@@ -535,7 +541,7 @@ pub fn noise<'gc>(
         bitmap_data.check_valid(activation)?;
         let random_seed = args.get_i32(activation, 0)?;
         operations::noise(
-            &mut activation.context,
+            activation.context.gc_context,
             bitmap_data,
             random_seed,
             low,
@@ -582,7 +588,7 @@ pub fn color_transform<'gc>(
                 )?;
 
             operations::color_transform(
-                &mut activation.context,
+                activation.context.gc_context,
                 bitmap_data,
                 x_min,
                 y_min,
@@ -967,7 +973,7 @@ pub fn fill_rect<'gc>(
             .coerce_to_i32(activation)?;
 
         operations::fill_rect(
-            &mut activation.context,
+            activation.context.gc_context,
             bitmap_data,
             x,
             y,
@@ -1145,7 +1151,7 @@ pub fn palette_map<'gc>(
         let alpha_array = get_channel(6, 24)?;
 
         operations::palette_map(
-            &mut activation.context,
+            activation.context.gc_context,
             bitmap_data,
             source_bitmap,
             (source_point.0, source_point.1, source_size.0, source_size.1),
@@ -1202,7 +1208,7 @@ pub fn perlin_noise<'gc>(
             let octave_offsets = octave_offsets?;
 
             operations::perlin_noise(
-                &mut activation.context,
+                activation.context.gc_context,
                 bitmap_data,
                 (base_x, base_y),
                 num_octaves,
@@ -1276,7 +1282,7 @@ pub fn threshold<'gc>(
                 src_bitmap.check_valid(activation)?;
 
                 return Ok(operations::threshold(
-                    &mut activation.context,
+                    activation.context.gc_context,
                     bitmap_data,
                     src_bitmap,
                     (src_min_x, src_min_y, src_width, src_height),

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -50,7 +50,7 @@ pub fn init<'gc>(
     if let Some(this) = this {
         activation.super_init(this, &[])?;
 
-        if this.as_bitmap_data().is_none() {
+        if this.as_bitmap_data_wrapper().is_none() {
             let name = this.instance_of_class_definition().map(|c| c.read().name());
             let character = this
                 .instance_of()

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -1080,7 +1080,10 @@ pub fn clone<'gc>(
             let class = activation.avm2().classes().bitmapdata;
             let new_bitmap_data_object = BitmapDataObject::from_bitmap_data(
                 activation,
-                GcCell::allocate(activation.context.gc_context, new_bitmap_data),
+                BitmapDataWrapper::new(GcCell::allocate(
+                    activation.context.gc_context,
+                    new_bitmap_data,
+                )),
                 class,
             )?;
 

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -7,7 +7,9 @@ use crate::avm2::object::{BitmapDataObject, ByteArrayObject, Object, TObject, Ve
 use crate::avm2::value::Value;
 use crate::avm2::vector::VectorStorage;
 use crate::avm2::Error;
-use crate::bitmap::bitmap_data::{BitmapData, ChannelOptions, ThresholdOperation};
+use crate::bitmap::bitmap_data::{
+    BitmapData, BitmapDataWrapper, ChannelOptions, ThresholdOperation,
+};
 use crate::bitmap::bitmap_data::{BitmapDataDrawError, IBitmapDrawable};
 use crate::bitmap::{is_size_valid, operations};
 use crate::character::Character;
@@ -103,7 +105,10 @@ pub fn init<'gc>(
             new_bitmap_data
                 .write(activation.context.gc_context)
                 .init_object2(this);
-            this.init_bitmap_data(activation.context.gc_context, new_bitmap_data);
+            this.init_bitmap_data(
+                activation.context.gc_context,
+                BitmapDataWrapper::new(new_bitmap_data),
+            );
         }
     }
 

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -50,7 +50,7 @@ pub fn init<'gc>(
     if let Some(this) = this {
         activation.super_init(this, &[])?;
 
-        if this.as_bitmap_data_wrapper().is_none() {
+        if this.as_bitmap_data().is_none() {
             let name = this.instance_of_class_definition().map(|c| c.read().name());
             let character = this
                 .instance_of()
@@ -116,7 +116,7 @@ pub fn get_width<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         return Ok((bitmap_data.width() as i32).into());
     }
@@ -130,7 +130,7 @@ pub fn get_height<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         return Ok((bitmap_data.height() as i32).into());
     }
@@ -144,7 +144,7 @@ pub fn get_transparent<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         return Ok(bitmap_data.transparency().into());
     }
@@ -158,7 +158,7 @@ pub fn scroll<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let x = args.get_i32(activation, 0)?;
         let y = args.get_i32(activation, 1)?;
@@ -175,7 +175,7 @@ pub fn copy_pixels<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let source_bitmap = args
             .get(0)
@@ -206,7 +206,7 @@ pub fn copy_pixels<'gc>(
             .get_public_property("y", activation)?
             .coerce_to_i32(activation)?;
 
-        if let Some(src_bitmap) = source_bitmap.as_bitmap_data_wrapper() {
+        if let Some(src_bitmap) = source_bitmap.as_bitmap_data() {
             src_bitmap.check_valid(activation)?;
 
             let mut alpha_source = None;
@@ -215,7 +215,7 @@ pub fn copy_pixels<'gc>(
                 if let Some(alpha_bitmap) = args
                     .get(3)
                     .and_then(|o| o.as_object())
-                    .and_then(|o| o.as_bitmap_data_wrapper())
+                    .and_then(|o| o.as_bitmap_data())
                 {
                     // Testing shows that a null/undefined 'alphaPoint' parameter is treated
                     // as 'new Point(0, 0)'
@@ -270,7 +270,7 @@ pub fn get_pixels<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let rectangle = args.get_object(activation, 0, "rect")?;
         let x = rectangle
@@ -300,7 +300,7 @@ pub fn get_vector<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let rectangle = args.get_object(activation, 0, "rect")?;
         let x = rectangle
@@ -333,7 +333,7 @@ pub fn get_pixel<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
@@ -350,7 +350,7 @@ pub fn get_pixel32<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
@@ -367,7 +367,7 @@ pub fn set_pixel<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
         let color = args.get_i32(activation, 2)?;
@@ -383,7 +383,7 @@ pub fn set_pixel32<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
 
         let x = args.get_u32(activation, 0)?;
@@ -408,7 +408,7 @@ pub fn set_pixels<'gc>(
         .get(1)
         .unwrap_or(&Value::Undefined)
         .coerce_to_object(activation)?;
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         let x = rectangle
             .get_public_property("x", activation)?
             .coerce_to_i32(activation)?;
@@ -447,7 +447,7 @@ pub fn copy_channel<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let source_bitmap = args
             .get(0)
@@ -469,7 +469,7 @@ pub fn copy_channel<'gc>(
 
         let dest_channel = args.get_i32(activation, 4)?;
 
-        if let Some(source_bitmap) = source_bitmap.as_bitmap_data_wrapper() {
+        if let Some(source_bitmap) = source_bitmap.as_bitmap_data() {
             //TODO: what if source is disposed
             let src_min_x = source_rect
                 .get_public_property("x", activation)?
@@ -503,7 +503,7 @@ pub fn flood_fill<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             let x = args.get_u32(activation, 0)?;
             let y = args.get_u32(activation, 1)?;
@@ -529,7 +529,7 @@ pub fn noise<'gc>(
 
     let gray_scale = args.get_bool(4);
 
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let random_seed = args.get_i32(activation, 0)?;
         operations::noise(
@@ -550,7 +550,7 @@ pub fn color_transform<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             // TODO: Re-use `object_to_rectangle` in `movie_clip.rs`.
             let rectangle = args.get_object(activation, 0, "rect")?;
@@ -599,7 +599,7 @@ pub fn get_color_bounds_rect<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             let find_color = args.get_bool(2);
 
@@ -654,7 +654,7 @@ pub fn hit_test<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             let first_point = args.get_object(activation, 0, "firstPoint")?;
             let top_left = (
@@ -711,7 +711,7 @@ pub fn hit_test<'gc>(
                     test_point,
                     size,
                 )));
-            } else if let Some(other_bmd) = compare_object.as_bitmap_data_wrapper() {
+            } else if let Some(other_bmd) = compare_object.as_bitmap_data() {
                 other_bmd.check_valid(activation)?;
                 let second_point = args.get_object(activation, 3, "secondBitmapDataPoint")?;
                 let second_point = (
@@ -778,7 +778,7 @@ pub fn draw<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         let mut transform = Transform::default();
         let mut blend_mode = BlendMode::Normal;
 
@@ -819,7 +819,7 @@ pub fn draw<'gc>(
 
         let source = if let Some(source_object) = source.as_display_object() {
             IBitmapDrawable::DisplayObject(source_object)
-        } else if let Some(source_bitmap) = source.as_bitmap_data_wrapper() {
+        } else if let Some(source_bitmap) = source.as_bitmap_data() {
             IBitmapDrawable::BitmapData(source_bitmap)
         } else {
             return Err(format!("BitmapData.draw: unexpected source {source:?}").into());
@@ -857,7 +857,7 @@ pub fn draw_with_quality<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         let mut transform = Transform::default();
         let mut blend_mode = BlendMode::Normal;
 
@@ -898,7 +898,7 @@ pub fn draw_with_quality<'gc>(
 
         let source = if let Some(source_object) = source.as_display_object() {
             IBitmapDrawable::DisplayObject(source_object)
-        } else if let Some(source_bitmap) = source.as_bitmap_data_wrapper() {
+        } else if let Some(source_bitmap) = source.as_bitmap_data() {
             IBitmapDrawable::BitmapData(source_bitmap)
         } else {
             return Err(format!("BitmapData.drawWithQuality: unexpected source {source:?}").into());
@@ -949,7 +949,7 @@ pub fn fill_rect<'gc>(
 
     let color = args.get_i32(activation, 1)?;
 
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let x = rectangle
             .get_public_property("x", activation)?
@@ -983,7 +983,7 @@ pub fn dispose<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         // Don't check if we've already disposed this BitmapData - 'BitmapData.dispose()' can be called
         // multiple times
         bitmap_data.dispose(activation.context.gc_context);
@@ -997,7 +997,7 @@ pub fn get_rect<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         return Ok(activation
             .avm2()
             .classes()
@@ -1022,9 +1022,9 @@ pub fn apply_filter<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dest_bitmap) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(dest_bitmap) = this.and_then(|this| this.as_bitmap_data()) {
         let source_bitmap = args.get_object(activation, 0, "sourceBitmapData")?
-            .as_bitmap_data_wrapper()
+            .as_bitmap_data()
             .ok_or_else(|| {
                 Error::from(format!("TypeError: Error #1034: Type Coercion failed: cannot convert {} to flash.display.BitmapData.", args[0].coerce_to_string(activation).unwrap_or_default()))
             })?;
@@ -1068,7 +1068,7 @@ pub fn clone<'gc>(
     this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             let new_bitmap_data = operations::clone(bitmap_data);
 
@@ -1091,11 +1091,11 @@ pub fn palette_map<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
         let source_bitmap = args
             .get_object(activation, 0, "sourceBitmapData")?
-            .as_bitmap_data_wrapper()
+            .as_bitmap_data()
             .unwrap();
 
         let source_rect = args.get_object(activation, 1, "sourceRect")?;
@@ -1158,7 +1158,7 @@ pub fn perlin_noise<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             let base_x = args.get_f64(activation, 0)?;
             let base_y = args.get_f64(activation, 1)?;
@@ -1220,7 +1220,7 @@ pub fn threshold<'gc>(
     this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data_wrapper()) {
+    if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         if !bitmap_data.disposed() {
             let src_bitmap = args.get_object(activation, 0, "sourceBitmapData")?;
             let source_rect = args.get_object(activation, 1, "sourceRect")?;
@@ -1267,7 +1267,7 @@ pub fn threshold<'gc>(
                 .get_public_property("height", activation)?
                 .coerce_to_i32(activation)?;
 
-            if let Some(src_bitmap) = src_bitmap.as_bitmap_data_wrapper() {
+            if let Some(src_bitmap) = src_bitmap.as_bitmap_data() {
                 src_bitmap.check_valid(activation)?;
 
                 return Ok(operations::threshold(

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -52,7 +52,7 @@ pub fn begin_bitmap_fill<'gc>(
     if let Some(this) = this.and_then(|t| t.as_display_object()) {
         let bitmap = args
             .get_object(activation, 0, "bitmap")?
-            .as_bitmap_data_wrapper()
+            .as_bitmap_data()
             .expect("Bitmap argument is ensured to be a BitmapData from actionscript");
         let matrix = if let Some(matrix) = args.try_get_object(activation, 1) {
             Matrix::from(object_to_matrix(matrix, activation)?)
@@ -890,7 +890,7 @@ pub fn line_bitmap_style<'gc>(
     if let Some(this) = this.and_then(|t| t.as_display_object()) {
         let bitmap = args
             .get_object(activation, 0, "bitmap")?
-            .as_bitmap_data_wrapper()
+            .as_bitmap_data()
             .expect("Bitmap argument is ensured to be a BitmapData from actionscript");
         let matrix = if let Some(matrix) = args.try_get_object(activation, 1) {
             Matrix::from(object_to_matrix(matrix, activation)?)

--- a/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
@@ -10,10 +10,7 @@ pub fn upload_from_bitmap_data<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(texture) = this.and_then(|this| this.as_texture()) {
-        if let Some(source) = args[0]
-            .coerce_to_object(activation)?
-            .as_bitmap_data_wrapper()
-        {
+        if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             let side = args[1].coerce_to_u32(activation)?;
             let mip_level = args[2].coerce_to_u32(activation)?;
             if mip_level == 0 {

--- a/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
@@ -9,10 +9,7 @@ pub fn upload_from_bitmap_data<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(texture) = this.and_then(|this| this.as_texture()) {
-        if let Some(source) = args[0]
-            .coerce_to_object(activation)?
-            .as_bitmap_data_wrapper()
-        {
+        if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             texture.context3d().copy_bitmap_to_texture(
                 source.bitmap_handle(activation.context.gc_context, activation.context.renderer),
                 texture.handle(),

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -10,10 +10,7 @@ pub fn upload_from_bitmap_data<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(texture) = this.and_then(|this| this.as_texture()) {
-        if let Some(source) = args[0]
-            .coerce_to_object(activation)?
-            .as_bitmap_data_wrapper()
-        {
+        if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             let mip_level = args[1].coerce_to_u32(activation)?;
             if mip_level == 0 {
                 texture.context3d().copy_bitmap_to_texture(

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -1223,11 +1223,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         None
     }
 
-    /// Unwrap this object's bitmap data
-    fn as_bitmap_data(&self) -> Option<GcCell<'gc, BitmapData<'gc>>> {
-        None
-    }
-
     fn as_bitmap_data_wrapper(&self) -> Option<BitmapDataWrapper<'gc>> {
         None
     }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -17,7 +17,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
-use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
+use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use crate::context::UpdateContext;
 use crate::display_object::DisplayObject;
 use crate::html::TextFormat;
@@ -1233,11 +1233,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// This should only be called to initialize the association between an AVM
     /// object and it's associated bitmap data. This association should not be
     /// reinitialized later.
-    fn init_bitmap_data(
-        &self,
-        _mc: MutationContext<'gc, '_>,
-        _new_bitmap: GcCell<'gc, BitmapData<'gc>>,
-    ) {
+    fn init_bitmap_data(&self, _mc: MutationContext<'gc, '_>, _new_bitmap: BitmapDataWrapper<'gc>) {
     }
 
     /// Get this objects `DateObject`, if it has one.

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -1223,7 +1223,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         None
     }
 
-    fn as_bitmap_data_wrapper(&self) -> Option<BitmapDataWrapper<'gc>> {
+    fn as_bitmap_data(&self) -> Option<BitmapDataWrapper<'gc>> {
         None
     }
 

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -89,7 +89,7 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
         Ok(Value::Object(Object::from(*self)))
     }
 
-    fn as_bitmap_data_wrapper(&self) -> Option<BitmapDataWrapper<'gc>> {
+    fn as_bitmap_data(&self) -> Option<BitmapDataWrapper<'gc>> {
         self.0.read().bitmap_data
     }
 

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -89,11 +89,6 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
         Ok(Value::Object(Object::from(*self)))
     }
 
-    /// Unwrap this object's bitmap data
-    fn as_bitmap_data(&self) -> Option<GcCell<'gc, BitmapData<'gc>>> {
-        self.0.read().bitmap_data.map(|wrapper| wrapper.sync())
-    }
-
     fn as_bitmap_data_wrapper(&self) -> Option<BitmapDataWrapper<'gc>> {
         self.0.read().bitmap_data
     }

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -95,11 +95,7 @@ impl<'gc> TObject<'gc> for BitmapDataObject<'gc> {
 
     /// Initialize the bitmap data in this object, if it's capable of
     /// supporting said data
-    fn init_bitmap_data(
-        &self,
-        mc: MutationContext<'gc, '_>,
-        new_bitmap: GcCell<'gc, BitmapData<'gc>>,
-    ) {
-        self.0.write(mc).bitmap_data = Some(BitmapDataWrapper::new(new_bitmap))
+    fn init_bitmap_data(&self, mc: MutationContext<'gc, '_>, new_bitmap: BitmapDataWrapper<'gc>) {
+        self.0.write(mc).bitmap_data = Some(new_bitmap)
     }
 }

--- a/core/src/avm2/object/bitmapdata_object.rs
+++ b/core/src/avm2/object/bitmapdata_object.rs
@@ -5,7 +5,7 @@ use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
-use crate::bitmap::bitmap_data::{BitmapData, BitmapDataWrapper};
+use crate::bitmap::bitmap_data::BitmapDataWrapper;
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::{Ref, RefMut};
@@ -51,20 +51,18 @@ pub struct BitmapDataObjectData<'gc> {
 impl<'gc> BitmapDataObject<'gc> {
     pub fn from_bitmap_data(
         activation: &mut Activation<'_, 'gc>,
-        bitmap_data: GcCell<'gc, BitmapData<'gc>>,
+        bitmap_data: BitmapDataWrapper<'gc>,
         class: ClassObject<'gc>,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let mut instance = Self(GcCell::allocate(
             activation.context.gc_context,
             BitmapDataObjectData {
                 base: ScriptObjectData::new(class),
-                bitmap_data: Some(BitmapDataWrapper::new(bitmap_data)),
+                bitmap_data: Some(bitmap_data),
             },
         ));
 
-        bitmap_data
-            .write(activation.context.gc_context)
-            .init_object2(instance.into());
+        bitmap_data.init_object2(activation.context.gc_context, instance.into());
         instance.install_instance_slots(activation);
         class.call_native_init(Some(instance.into()), &[], activation)?;
 

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -231,8 +231,8 @@ enum DirtyState {
 }
 
 mod wrapper {
-    use crate::context::RenderContext;
-    use crate::{avm2::Value as Avm2Value, context::UpdateContext};
+    use crate::avm2::{Object as Avm2Object, Value as Avm2Value};
+    use crate::context::{RenderContext, UpdateContext};
     use gc_arena::{Collect, GcCell, MutationContext};
     use ruffle_render::backend::RenderBackend;
     use ruffle_render::bitmap::{BitmapHandle, PixelRegion};
@@ -394,6 +394,10 @@ mod wrapper {
 
         pub fn dispose(&self, mc: MutationContext<'gc, '_>) {
             self.0.write(mc).dispose();
+        }
+
+        pub fn init_object2(&self, mc: MutationContext<'gc, '_>, object: Avm2Object<'gc>) {
+            self.0.write(mc).avm2_object = Some(object)
         }
 
         pub fn render(&self, smoothing: bool, context: &mut RenderContext<'_, 'gc>) {

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -232,7 +232,7 @@ enum DirtyState {
 
 mod wrapper {
     use crate::avm2::{Object as Avm2Object, Value as Avm2Value};
-    use crate::context::{RenderContext, UpdateContext};
+    use crate::context::RenderContext;
     use gc_arena::{Collect, GcCell, MutationContext};
     use ruffle_render::backend::RenderBackend;
     use ruffle_render::bitmap::{BitmapHandle, PixelRegion};
@@ -344,9 +344,9 @@ mod wrapper {
         #[allow(clippy::type_complexity)]
         pub fn overwrite_cpu_pixels_from_gpu(
             &self,
-            context: &mut UpdateContext<'_, 'gc>,
+            mc: MutationContext<'gc, '_>,
         ) -> (GcCell<'gc, BitmapData<'gc>>, Option<PixelRegion>) {
-            let mut write = self.0.write(context.gc_context);
+            let mut write = self.0.write(mc);
             let dirty_rect = match write.dirty_state {
                 DirtyState::GpuModified(_, rect) => {
                     write.dirty_state = DirtyState::Clean;

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -279,6 +279,26 @@ mod wrapper {
             BitmapDataWrapper(data)
         }
 
+        // Creates a dummy BitmapData with no pixels or handle, marked as disposed.
+        // This is used for AS3 `Bitmap` instances without a corresponding AS3 `BitmapData` instance.
+        // Marking it as disposed skips rendering, and the unset `avm2_object` will cause this to
+        // be inaccessible to AS3 code.
+        pub fn dummy(mc: MutationContext<'gc, '_>) -> Self {
+            BitmapDataWrapper(GcCell::allocate(
+                mc,
+                BitmapData {
+                    pixels: Vec::new(),
+                    width: 0,
+                    height: 0,
+                    transparency: false,
+                    disposed: true,
+                    bitmap_handle: None,
+                    avm2_object: None,
+                    dirty_state: DirtyState::Clean,
+                },
+            ))
+        }
+
         // Provides access to the underlying `BitmapData`. If a GPU -> CPU sync
         // is in progress, waits for it to complete
         pub fn sync(&self) -> GcCell<'gc, BitmapData<'gc>> {
@@ -444,23 +464,6 @@ impl fmt::Debug for BitmapData<'_> {
 }
 
 impl<'gc> BitmapData<'gc> {
-    // Creates a dummy BitmapData with no pixels or handle, marked as disposed.
-    // This is used for AS3 `Bitmap` instances without a corresponding AS3 `BitmapData` instance.
-    // Marking it as disposed skips rendering, and the unset `avm2_object` will cause this to
-    // be inaccessible to AS3 code.
-    pub fn dummy() -> Self {
-        BitmapData {
-            pixels: Vec::new(),
-            width: 0,
-            height: 0,
-            transparency: false,
-            disposed: true,
-            bitmap_handle: None,
-            avm2_object: None,
-            dirty_state: DirtyState::Clean,
-        }
-    }
-
     pub fn init_pixels(&mut self, width: u32, height: u32, transparency: bool, fill_color: i32) {
         self.width = width;
         self.height = height;

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -40,7 +40,7 @@ pub fn fill_rect<'gc>(
 
     let target = if rect.width() == target.width() && rect.height() == target.height() {
         // If we're filling the whole region, we can discard the gpu data
-        target.overwrite_cpu_pixels_from_gpu(context).0
+        target.overwrite_cpu_pixels_from_gpu(context.gc_context).0
     } else {
         // If we're filling a partial region, finish any gpu->cpu sync
         target.sync()
@@ -177,7 +177,7 @@ pub fn noise<'gc>(
     channel_options: ChannelOptions,
     gray_scale: bool,
 ) {
-    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context);
+    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context.gc_context);
     let mut write = target.write(context.gc_context);
 
     let true_seed = if seed <= 0 {
@@ -247,7 +247,7 @@ pub fn perlin_noise<'gc>(
     grayscale: bool,
     offsets: Vec<(f64, f64)>, // must contain `num_octaves` values
 ) {
-    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context);
+    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context.gc_context);
     let mut write = target.write(context.gc_context);
 
     let turb = Turbulence::from_seed(random_seed);
@@ -1184,7 +1184,7 @@ pub fn apply_filter<'gc>(
     filter: Filter,
 ) {
     let source_handle = source.bitmap_handle(context.gc_context, context.renderer);
-    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context);
+    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context.gc_context);
     let mut write = target.write(context.gc_context);
     let dest = write.bitmap_handle(context.renderer).unwrap();
 
@@ -1293,7 +1293,7 @@ pub fn draw<'gc>(
         commands
     };
 
-    let (target, include_dirty_area) = target.overwrite_cpu_pixels_from_gpu(context);
+    let (target, include_dirty_area) = target.overwrite_cpu_pixels_from_gpu(context.gc_context);
     let mut write = target.write(context.gc_context);
     // If we have another dirty area to preserve, expand this to include it
     if let Some(old) = include_dirty_area {
@@ -1375,7 +1375,7 @@ pub fn set_pixels_from_byte_array<'gc>(
 
     let target = if region.width() == target.width() && region.height() == target.height() {
         // If we're filling the whole region, we can discard the gpu data
-        target.overwrite_cpu_pixels_from_gpu(context).0
+        target.overwrite_cpu_pixels_from_gpu(context.gc_context).0
     } else {
         // If we're filling a partial region, finish any gpu->cpu sync
         target.sync()

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -7,6 +7,7 @@ use crate::bitmap::bitmap_data::{
 use crate::bitmap::turbulence::Turbulence;
 use crate::context::{RenderContext, UpdateContext};
 use crate::display_object::TDisplayObject;
+use gc_arena::MutationContext;
 use ruffle_render::bitmap::PixelRegion;
 use ruffle_render::commands::{CommandHandler, CommandList};
 use ruffle_render::filters::Filter;
@@ -23,7 +24,7 @@ use swf::{BlendMode, ColorTransform, Fixed8, Rectangle, Twips};
 /// same code between VMs.
 
 pub fn fill_rect<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     x: i32,
     y: i32,
@@ -40,12 +41,12 @@ pub fn fill_rect<'gc>(
 
     let target = if rect.width() == target.width() && rect.height() == target.height() {
         // If we're filling the whole region, we can discard the gpu data
-        target.overwrite_cpu_pixels_from_gpu(context.gc_context).0
+        target.overwrite_cpu_pixels_from_gpu(mc).0
     } else {
         // If we're filling a partial region, finish any gpu->cpu sync
         target.sync()
     };
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
     let color = Color::from(color).to_premultiplied_alpha(write.transparency());
 
     for x in rect.x_min..rect.x_max {
@@ -57,7 +58,7 @@ pub fn fill_rect<'gc>(
 }
 
 pub fn set_pixel32<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     x: u32,
     y: u32,
@@ -67,7 +68,7 @@ pub fn set_pixel32<'gc>(
         return;
     }
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
     let transparency = write.transparency();
     write.set_pixel32_raw(
         x,
@@ -86,7 +87,7 @@ pub fn get_pixel32(target: BitmapDataWrapper, x: u32, y: u32) -> i32 {
 }
 
 pub fn set_pixel<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     x: u32,
     y: u32,
@@ -96,7 +97,7 @@ pub fn set_pixel<'gc>(
         return;
     }
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     if write.transparency() {
         let current_alpha = write.get_pixel32_raw(x, y).alpha();
@@ -127,7 +128,7 @@ pub fn clone(original: BitmapDataWrapper) -> BitmapData {
 }
 
 pub fn flood_fill<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     x: u32,
     y: u32,
@@ -137,7 +138,7 @@ pub fn flood_fill<'gc>(
         return;
     }
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
     let expected_color = write.get_pixel32_raw(x, y);
     let replace_color = Color::from(color).to_premultiplied_alpha(write.transparency());
 
@@ -169,7 +170,7 @@ pub fn flood_fill<'gc>(
 }
 
 pub fn noise<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     seed: i32,
     low: u8,
@@ -177,8 +178,8 @@ pub fn noise<'gc>(
     channel_options: ChannelOptions,
     gray_scale: bool,
 ) {
-    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context.gc_context);
-    let mut write = target.write(context.gc_context);
+    let (target, _) = target.overwrite_cpu_pixels_from_gpu(mc);
+    let mut write = target.write(mc);
 
     let true_seed = if seed <= 0 {
         (-seed + 1) as u32
@@ -236,7 +237,7 @@ pub fn noise<'gc>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn perlin_noise<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     base: (f64, f64),
     num_octaves: usize,
@@ -247,8 +248,8 @@ pub fn perlin_noise<'gc>(
     grayscale: bool,
     offsets: Vec<(f64, f64)>, // must contain `num_octaves` values
 ) {
-    let (target, _) = target.overwrite_cpu_pixels_from_gpu(context.gc_context);
-    let mut write = target.write(context.gc_context);
+    let (target, _) = target.overwrite_cpu_pixels_from_gpu(mc);
+    let mut write = target.write(mc);
 
     let turb = Turbulence::from_seed(random_seed);
 
@@ -347,7 +348,7 @@ pub fn perlin_noise<'gc>(
 }
 
 pub fn copy_channel<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     dest_point: (u32, u32),
     src_rect: (u32, u32, u32, u32),
@@ -379,7 +380,7 @@ pub fn copy_channel<'gc>(
     };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     for x in source_region.x_min..source_region.x_max {
         for y in source_region.y_min..source_region.y_max {
@@ -435,7 +436,7 @@ pub fn copy_channel<'gc>(
 }
 
 pub fn color_transform<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     x_min: u32,
     y_min: u32,
@@ -464,7 +465,7 @@ pub fn color_transform<'gc>(
     }
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
     let transparency = write.transparency();
 
     for x in x_min..x_max {
@@ -488,7 +489,7 @@ pub fn color_transform<'gc>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn threshold<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     source_bitmap: BitmapDataWrapper<'gc>,
     src_rect: (i32, i32, i32, i32),
@@ -521,7 +522,7 @@ pub fn threshold<'gc>(
     };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     // Check each pixel
     for src_y in src_min_y..(src_min_y + src_height) {
@@ -585,12 +586,7 @@ pub fn threshold<'gc>(
     modified_count
 }
 
-pub fn scroll<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
-    target: BitmapDataWrapper<'gc>,
-    x: i32,
-    y: i32,
-) {
+pub fn scroll<'gc>(mc: MutationContext<'gc, '_>, target: BitmapDataWrapper<'gc>, x: i32, y: i32) {
     let width = target.width() as i32;
     let height = target.height() as i32;
 
@@ -621,7 +617,7 @@ pub fn scroll<'gc>(
     let dx = if reverse_x { -1 } else { 1 };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     let mut src_y = y_from;
     while src_y != y_to {
@@ -639,7 +635,7 @@ pub fn scroll<'gc>(
 }
 
 pub fn palette_map<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     source_bitmap: BitmapDataWrapper<'gc>,
     src_rect: (i32, i32, i32, i32),
@@ -659,7 +655,7 @@ pub fn palette_map<'gc>(
     };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     for src_y in src_min_y..(src_min_y + src_height) {
         for src_x in src_min_x..(src_min_x + src_width) {
@@ -893,7 +889,7 @@ pub fn color_bounds_rect(
 }
 
 pub fn merge<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     source_bitmap: BitmapDataWrapper<'gc>,
     src_rect: (i32, i32, i32, i32),
@@ -914,7 +910,7 @@ pub fn merge<'gc>(
     };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     for src_y in src_min_y..(src_min_y + src_height) {
         for src_x in src_min_x..(src_min_x + src_width) {
@@ -982,7 +978,7 @@ pub fn merge<'gc>(
 }
 
 pub fn copy_pixels<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     source_bitmap: BitmapDataWrapper<'gc>,
     src_rect: (i32, i32, i32, i32),
@@ -1004,7 +1000,7 @@ pub fn copy_pixels<'gc>(
     };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     for src_y in src_min_y..(src_min_y + src_height) {
         for src_x in src_min_x..(src_min_x + src_width) {
@@ -1052,7 +1048,7 @@ pub fn copy_pixels<'gc>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn copy_pixels_with_alpha_source<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     source_bitmap: BitmapDataWrapper<'gc>,
     src_rect: (i32, i32, i32, i32),
@@ -1086,7 +1082,7 @@ pub fn copy_pixels_with_alpha_source<'gc>(
     };
 
     let target = target.sync();
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     for src_y in src_min_y..(src_min_y + src_height) {
         for src_x in src_min_x..(src_min_x + src_width) {
@@ -1361,7 +1357,7 @@ pub fn get_pixels_as_byte_array<'gc>(
 }
 
 pub fn set_pixels_from_byte_array<'gc>(
-    context: &mut UpdateContext<'_, 'gc>,
+    mc: MutationContext<'gc, '_>,
     target: BitmapDataWrapper<'gc>,
     x: i32,
     y: i32,
@@ -1375,12 +1371,12 @@ pub fn set_pixels_from_byte_array<'gc>(
 
     let target = if region.width() == target.width() && region.height() == target.height() {
         // If we're filling the whole region, we can discard the gpu data
-        target.overwrite_cpu_pixels_from_gpu(context.gc_context).0
+        target.overwrite_cpu_pixels_from_gpu(mc).0
     } else {
         // If we're filling a partial region, finish any gpu->cpu sync
         target.sync()
     };
-    let mut write = target.write(context.gc_context);
+    let mut write = target.write(mc);
 
     if region.width() > 0 && region.height() > 0 {
         for y in region.y_min..region.y_max {

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -49,8 +49,8 @@ pub fn fill_rect<'gc>(
     let mut write = target.write(mc);
     let color = Color::from(color).to_premultiplied_alpha(write.transparency());
 
-    for x in rect.x_min..rect.x_max {
-        for y in rect.y_min..rect.y_max {
+    for y in rect.y_min..rect.y_max {
+        for x in rect.x_min..rect.x_max {
             write.set_pixel32_raw(x, y, color);
         }
     }
@@ -382,8 +382,8 @@ pub fn copy_channel<'gc>(
     let target = target.sync();
     let mut write = target.write(mc);
 
-    for x in source_region.x_min..source_region.x_max {
-        for y in source_region.y_min..source_region.y_max {
+    for y in source_region.y_min..source_region.y_max {
+        for x in source_region.x_min..source_region.x_max {
             let dst_x = x as i32 + min_x as i32;
             let dst_y = y as i32 + min_y as i32;
             if write.is_point_in_bounds(dst_x, dst_y) {
@@ -468,8 +468,8 @@ pub fn color_transform<'gc>(
     let mut write = target.write(mc);
     let transparency = write.transparency();
 
-    for x in x_min..x_max {
-        for y in y_min..y_max {
+    for y in y_min..y_max {
+        for x in x_min..x_max {
             let color = write.get_pixel32_raw(x, y).to_un_multiplied_alpha();
 
             let color = color_transform * swf::Color::from(color);
@@ -780,8 +780,8 @@ pub fn hit_test_rectangle(
     region.clamp(target.width(), target.height());
     let read = target.read_area(region);
 
-    for x in region.x_min..region.x_max {
-        for y in region.y_min..region.y_max {
+    for y in region.y_min..region.y_max {
+        for x in region.x_min..region.x_max {
             if read.get_pixel32_raw(x, y).alpha() as u32 >= alpha_threshold {
                 return true;
             }

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -52,7 +52,7 @@ pub enum BitmapClass<'gc> {
 /// It can also be created in ActionScript using the `Bitmap` class.
 #[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
-pub struct Bitmap<'gc>(GcCell<'gc, BitmapData<'gc>>);
+pub struct Bitmap<'gc>(GcCell<'gc, BitmapGraphicData<'gc>>);
 
 impl fmt::Debug for Bitmap<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -64,7 +64,7 @@ impl fmt::Debug for Bitmap<'_> {
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
-pub struct BitmapData<'gc> {
+pub struct BitmapGraphicData<'gc> {
     base: DisplayObjectBase<'gc>,
     id: CharacterId,
     movie: Arc<SwfMovie>,
@@ -113,7 +113,7 @@ impl<'gc> Bitmap<'gc> {
 
         Bitmap(GcCell::allocate(
             context.gc_context,
-            BitmapData {
+            BitmapGraphicData {
                 base: Default::default(),
                 id,
                 bitmap_data,

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -191,15 +191,15 @@ impl<'gc> Bitmap<'gc> {
     pub fn set_bitmap_data(
         self,
         context: &mut UpdateContext<'_, 'gc>,
-        bitmap_data: GcCell<'gc, crate::bitmap::bitmap_data::BitmapData<'gc>>,
+        bitmap_data: BitmapDataWrapper<'gc>,
     ) {
         let mut write = self.0.write(context.gc_context);
         // Refresh our cached values, even if we're writing the same BitmapData
         // that we currently have stored. This will update them to '0' if the
         // BitmapData has been disposed since it was originally set.
-        write.width = bitmap_data.read().width();
-        write.height = bitmap_data.read().height();
-        write.bitmap_data = BitmapDataWrapper::new(bitmap_data);
+        write.width = bitmap_data.width();
+        write.height = bitmap_data.height();
+        write.bitmap_data = bitmap_data;
     }
 
     pub fn avm2_bitmapdata_class(self) -> Option<Avm2ClassObject<'gc>> {


### PR DESCRIPTION
We now exclusively use BitmapDataWrapper places and be explicit about syncing, which also shown that we were syncing in more places we didn't have to (like assigning to a Bitmap, or disposing)

Definitely more cleanups to be done but trying to take it piece by piece