### PR TITLE
avm2: Array-related fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,7 @@ dependencies = [
  "flate2",
  "gc-arena",
  "gif",
+ "h263-rs-yuv",
  "jpeg-decoder",
  "lyon",
  "png",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,7 +3623,6 @@ dependencies = [
  "flate2",
  "generational-arena",
  "h263-rs",
- "h263-rs-yuv",
  "log",
  "nihav_codec_support",
  "nihav_core",

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -602,7 +602,16 @@ impl<'gc> BitmapData<'gc> {
         let handle = self.bitmap_handle(renderer).unwrap();
         match &self.dirty_state {
             DirtyState::CpuModified(region) => {
-                if let Err(e) = renderer.update_texture(&handle, self.pixels_rgba(), *region) {
+                if let Err(e) = renderer.update_texture(
+                    &handle,
+                    Bitmap::new(
+                        self.width(),
+                        self.height(),
+                        BitmapFormat::Rgba,
+                        self.pixels_rgba(),
+                    ),
+                    *region,
+                ) {
                     tracing::error!("Failed to update dirty bitmap {:?}: {:?}", handle, e);
                 }
                 self.dirty_state = DirtyState::Clean;

--- a/core/src/display_object/bitmap.rs
+++ b/core/src/display_object/bitmap.rs
@@ -146,6 +146,9 @@ impl<'gc> Bitmap<'gc> {
             match bitmap.format() {
                 BitmapFormat::Rgba => true,
                 BitmapFormat::Rgb => false,
+                _ => unreachable!(
+                    "Bitmap objects can only be constructed from RGB or RGBA source bitmaps"
+                ),
             },
             pixels,
         );

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1815,8 +1815,10 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
         context: &mut UpdateContext<'_, 'gc>,
         _event: ClipEvent<'gc>,
     ) -> ClipEventResult {
-        let tracker = context.focus_tracker;
-        tracker.set(Some(self.into()), context);
+        if self.is_editable() {
+            let tracker = context.focus_tracker;
+            tracker.set(Some(self.into()), context);
+        }
         if let Some(position) = self
             .screen_position_to_index(*context.mouse_position)
             .map(TextSelection::for_position)

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -23,6 +23,7 @@ gc-arena = { workspace = true }
 enum-map = "2.5.0"
 serde = { version = "1.0.159", features = ["derive"] }
 clap = { version = "4.2.1", features = ["derive"], optional = true }
+h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "d5d78eb251c1ce1f1da57c63db14f0fdc77a4b36"}
 
 [dependencies.jpeg-decoder]
 version = "0.3.0"

--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -4,7 +4,7 @@ use ruffle_render::backend::{
     Context3D, RenderBackend, ShapeHandle, ShapeHandleImpl, ViewportDimensions,
 };
 use ruffle_render::bitmap::{
-    Bitmap, BitmapFormat, BitmapHandle, BitmapHandleImpl, BitmapSource, PixelRegion, SyncHandle,
+    Bitmap, BitmapHandle, BitmapHandleImpl, BitmapSource, PixelRegion, SyncHandle,
 };
 use ruffle_render::commands::{CommandHandler, CommandList};
 use ruffle_render::error::Error;
@@ -467,17 +467,11 @@ impl RenderBackend for WebCanvasRenderBackend {
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
-        rgba: Vec<u8>,
+        bitmap: Bitmap,
         _region: PixelRegion,
     ) -> Result<(), Error> {
         let data = as_bitmap_data(handle);
-        data.update_pixels(Bitmap::new(
-            data.bitmap.width(),
-            data.bitmap.height(),
-            BitmapFormat::Rgba,
-            rgba,
-        ))
-        .map_err(Error::JavascriptError)?;
+        data.update_pixels(bitmap).map_err(Error::JavascriptError)?;
         Ok(())
     }
 

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -58,8 +58,8 @@ pub trait RenderBackend: Downcast {
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;
     fn update_texture(
         &mut self,
-        bitmap: &BitmapHandle,
-        rgba: Vec<u8>,
+        handle: &BitmapHandle,
+        bitmap: Bitmap,
         region: PixelRegion,
     ) -> Result<(), Error>;
 

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -74,8 +74,8 @@ impl RenderBackend for NullRenderer {
 
     fn update_texture(
         &mut self,
-        _bitmap: &BitmapHandle,
-        _rgba: Vec<u8>,
+        _handle: &BitmapHandle,
+        _bitmap: Bitmap,
         _region: PixelRegion,
     ) -> Result<(), Error> {
         Ok(())

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -74,8 +74,8 @@ impl Bitmap {
         if data.len() != expected_len {
             tracing::warn!(
                 "Incorrect bitmap data size, expected {} bytes, got {}",
+                expected_len,
                 data.len(),
-                expected_len
             );
             // Truncate or zero pad to the expected size.
             data.resize(expected_len, 0);

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -69,7 +69,7 @@ impl Bitmap {
     /// Ensures that `data` is the correct size for the given `width` and `height`.
     pub fn new(width: u32, height: u32, format: BitmapFormat, mut data: Vec<u8>) -> Self {
         // If the size is incorrect, either we screwed up or the decoder screwed up.
-        let expected_len = width as usize * height as usize * format.bytes_per_pixel();
+        let expected_len = format.length_for_size(width as usize, height as usize);
         if data.len() != expected_len {
             tracing::warn!(
                 "Incorrect bitmap data size, expected {} bytes, got {}",
@@ -152,10 +152,10 @@ pub enum BitmapFormat {
 
 impl BitmapFormat {
     #[inline]
-    pub fn bytes_per_pixel(self) -> usize {
+    pub fn length_for_size(self, width: usize, height: usize) -> usize {
         match self {
-            BitmapFormat::Rgb => 3,
-            BitmapFormat::Rgba => 4,
+            BitmapFormat::Rgb => width * height * 3,
+            BitmapFormat::Rgba => width * height * 4,
         }
     }
 }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -988,9 +988,11 @@ impl RenderBackend for WebGlRenderBackend {
     }
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, BitmapError> {
-        let format = match bitmap.format() {
-            BitmapFormat::Rgb => Gl::RGB,
-            BitmapFormat::Rgba => Gl::RGBA,
+        let (format, bitmap) = match bitmap.format() {
+            BitmapFormat::Rgb => (Gl::RGB, bitmap),
+            BitmapFormat::Rgba | BitmapFormat::Yuv420p | BitmapFormat::Yuva420p => {
+                (Gl::RGBA, bitmap.to_rgba())
+            }
         };
 
         let texture = self

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -989,10 +989,8 @@ impl RenderBackend for WebGlRenderBackend {
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, BitmapError> {
         let (format, bitmap) = match bitmap.format() {
-            BitmapFormat::Rgb => (Gl::RGB, bitmap),
-            BitmapFormat::Rgba | BitmapFormat::Yuv420p | BitmapFormat::Yuva420p => {
-                (Gl::RGBA, bitmap.to_rgba())
-            }
+            BitmapFormat::Rgb | BitmapFormat::Yuv420p => (Gl::RGB, bitmap.to_rgb()),
+            BitmapFormat::Rgba | BitmapFormat::Yuva420p => (Gl::RGBA, bitmap.to_rgba()),
         };
 
         let texture = self

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -515,16 +515,17 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
     fn update_texture(
         &mut self,
         handle: &BitmapHandle,
-        rgba: Vec<u8>,
+        bitmap: Bitmap,
         region: PixelRegion,
     ) -> Result<(), BitmapError> {
         let texture = as_texture(handle);
 
         let extent = wgpu::Extent3d {
-            width: region.width(),
-            height: region.height(),
+            width: bitmap.width(),
+            height: bitmap.height(),
             depth_or_array_layers: 1,
         };
+        let bitmap = bitmap.to_rgba();
 
         self.descriptors.queue.write_texture(
             wgpu::ImageCopyTexture {
@@ -537,8 +538,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                 },
                 aspect: wgpu::TextureAspect::All,
             },
-            &rgba[(region.y_min * texture.width * 4) as usize
-                ..(region.y_max * texture.width * 4) as usize],
+            bitmap.data(),
             wgpu::ImageDataLayout {
                 offset: (region.x_min * 4) as wgpu::BufferAddress,
                 bytes_per_row: NonZeroU32::new(4 * texture.width),

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -17,13 +17,12 @@ flate2 = "1.0.25"
 log = "0.4"
 
 h263-rs = { git = "https://github.com/ruffle-rs/h263-rs", rev = "d5d78eb251c1ce1f1da57c63db14f0fdc77a4b36", optional = true }
-h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "d5d78eb251c1ce1f1da57c63db14f0fdc77a4b36", optional = true }
 nihav_core = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_codec_support = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 nihav_duck = { git = "https://github.com/ruffle-rs/nihav-vp6", rev = "9416fcc9fc8aab8f4681aa9093b42922214abbd3", optional = true }
 
 [features]
 default = ["h263", "vp6", "screenvideo"]
-h263 = ["h263-rs", "h263-rs-yuv"]
-vp6 = ["nihav_core", "nihav_codec_support", "nihav_duck", "h263-rs-yuv"]
+h263 = ["h263-rs"]
+vp6 = ["nihav_core", "nihav_codec_support", "nihav_duck"]
 screenvideo = []

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -82,20 +82,20 @@ impl VideoBackend for SoftwareVideoBackend {
             renderer.update_texture(
                 &bitmap,
                 Bitmap::new(
-                    frame.width.into(),
-                    frame.height.into(),
+                    frame.width(),
+                    frame.height(),
                     BitmapFormat::Rgba,
-                    frame.rgba,
+                    frame.data().to_vec(),
                 ),
-                PixelRegion::for_whole_size(frame.width.into(), frame.height.into()),
+                PixelRegion::for_whole_size(frame.width(), frame.height()),
             )?;
             bitmap
         } else {
             let bitmap = Bitmap::new(
-                frame.width.into(),
-                frame.height.into(),
+                frame.width(),
+                frame.height(),
                 BitmapFormat::Rgba,
-                frame.rgba,
+                frame.data().to_vec(),
             );
             renderer.register_bitmap(bitmap)?
         };
@@ -103,8 +103,8 @@ impl VideoBackend for SoftwareVideoBackend {
 
         Ok(BitmapInfo {
             handle,
-            width: frame.width,
-            height: frame.height,
+            width: frame.width() as u16,
+            height: frame.height() as u16,
         })
     }
 }

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -81,7 +81,12 @@ impl VideoBackend for SoftwareVideoBackend {
         let handle = if let Some(bitmap) = stream.bitmap.clone() {
             renderer.update_texture(
                 &bitmap,
-                frame.rgba,
+                Bitmap::new(
+                    frame.width.into(),
+                    frame.height.into(),
+                    BitmapFormat::Rgba,
+                    frame.rgba,
+                ),
                 PixelRegion::for_whole_size(frame.width.into(), frame.height.into()),
             )?;
             bitmap

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -1,7 +1,7 @@
 use crate::decoder::VideoDecoder;
 use generational_arena::Arena;
 use ruffle_render::backend::RenderBackend;
-use ruffle_render::bitmap::{Bitmap, BitmapFormat, BitmapHandle, BitmapInfo, PixelRegion};
+use ruffle_render::bitmap::{BitmapHandle, BitmapInfo, PixelRegion};
 use ruffle_video::backend::VideoBackend;
 use ruffle_video::error::Error;
 use ruffle_video::frame::{EncodedFrame, FrameDependency};
@@ -78,33 +78,22 @@ impl VideoBackend for SoftwareVideoBackend {
             .ok_or(Error::VideoStreamIsNotRegistered)?;
 
         let frame = stream.decoder.decode_frame(encoded_frame)?;
+
+        let w = frame.width();
+        let h = frame.height();
+
         let handle = if let Some(bitmap) = stream.bitmap.clone() {
-            renderer.update_texture(
-                &bitmap,
-                Bitmap::new(
-                    frame.width(),
-                    frame.height(),
-                    BitmapFormat::Rgba,
-                    frame.data().to_vec(),
-                ),
-                PixelRegion::for_whole_size(frame.width(), frame.height()),
-            )?;
+            renderer.update_texture(&bitmap, frame, PixelRegion::for_whole_size(w, h))?;
             bitmap
         } else {
-            let bitmap = Bitmap::new(
-                frame.width(),
-                frame.height(),
-                BitmapFormat::Rgba,
-                frame.data().to_vec(),
-            );
-            renderer.register_bitmap(bitmap)?
+            renderer.register_bitmap(frame)?
         };
         stream.bitmap = Some(handle.clone());
 
         Ok(BitmapInfo {
             handle,
-            width: frame.width() as u16,
-            height: frame.height() as u16,
+            width: w as u16,
+            height: h as u16,
         })
     }
 }

--- a/video/software/src/decoder/h263.rs
+++ b/video/software/src/decoder/h263.rs
@@ -2,6 +2,7 @@ use crate::decoder::VideoDecoder;
 use h263_rs::parser::H263Reader;
 use h263_rs::{DecoderOption, H263State, PictureTypeCode};
 use h263_rs_yuv::bt601::yuv420_to_rgba;
+use ruffle_render::bitmap::BitmapFormat;
 use ruffle_video::error::Error;
 use ruffle_video::frame::{DecodedFrame, EncodedFrame, FrameDependency};
 
@@ -72,11 +73,12 @@ impl VideoDecoder for H263Decoder {
         debug_assert_eq!(chroma_width, (width as usize + 1) / 2);
         let (y, b, r) = picture.as_yuv();
         let rgba = yuv420_to_rgba(y, b, r, width.into());
-        Ok(DecodedFrame {
-            width,
-            height,
+        Ok(DecodedFrame::new(
+            width as u32,
+            height as u32,
+            BitmapFormat::Rgba,
             rgba,
-        })
+        ))
     }
 }
 

--- a/video/software/src/decoder/h263.rs
+++ b/video/software/src/decoder/h263.rs
@@ -1,7 +1,6 @@
 use crate::decoder::VideoDecoder;
 use h263_rs::parser::H263Reader;
 use h263_rs::{DecoderOption, H263State, PictureTypeCode};
-use h263_rs_yuv::bt601::yuv420_to_rgba;
 use ruffle_render::bitmap::BitmapFormat;
 use ruffle_video::error::Error;
 use ruffle_video::frame::{DecodedFrame, EncodedFrame, FrameDependency};
@@ -69,15 +68,17 @@ impl VideoDecoder for H263Decoder {
             .format()
             .into_width_and_height()
             .ok_or(H263Error::MissingWidthHeight)?;
-        let chroma_width = picture.chroma_samples_per_row();
-        debug_assert_eq!(chroma_width, (width as usize + 1) / 2);
         let (y, b, r) = picture.as_yuv();
-        let rgba = yuv420_to_rgba(y, b, r, width.into());
+
+        let mut data = y.to_vec();
+        data.extend(b);
+        data.extend(r);
+
         Ok(DecodedFrame::new(
             width as u32,
             height as u32,
-            BitmapFormat::Rgba,
-            rgba,
+            BitmapFormat::Yuv420p,
+            data,
         ))
     }
 }

--- a/video/software/src/decoder/screen.rs
+++ b/video/software/src/decoder/screen.rs
@@ -190,28 +190,25 @@ impl VideoDecoder for ScreenVideoDecoder {
             return Err(ScreenError::KeyframeInvalid.into());
         }
 
-        let mut rgba = vec![0u8; w * h * 4];
+        let mut rgb = vec![0u8; w * h * 3];
 
-        // convert from BGR to RGBA and flip Y
+        // convert from BGR to RGB and flip Y
         for y in 0..h {
             let data_row = &data[y * w * 3..(y + 1) * w * 3];
-            let rgba_row = &mut rgba[(h - y - 1) * w * 4..(h - y) * w * 4];
+            let rgb_row = &mut rgb[(h - y - 1) * w * 3..(h - y) * w * 3];
 
-            for (bgr, rgba) in data_row.chunks(3).zip(rgba_row.chunks_mut(4)) {
-                rgba.copy_from_slice(&[bgr[2], bgr[1], bgr[0], 255]);
+            for (bgr, rgb) in data_row.chunks(3).zip(rgb_row.chunks_mut(3)) {
+                rgb.copy_from_slice(&[bgr[2], bgr[1], bgr[0]]);
             }
         }
 
         self.last_frame = Some(data);
 
-        // NOTE: We could get away with only storing RGB data (saving some memory), as there is no
-        // alpha support in Screen V1, but since the render backends always want RGBA right now,
-        // it's better to do the pixel format conversion here, all at once.
         Ok(DecodedFrame::new(
             w as u32,
             h as u32,
-            BitmapFormat::Rgba,
-            rgba,
+            BitmapFormat::Rgb,
+            rgb,
         ))
     }
 }

--- a/video/software/src/decoder/screen.rs
+++ b/video/software/src/decoder/screen.rs
@@ -2,6 +2,7 @@
 // written by Kostya Shishkov, with permission.
 
 use crate::decoder::VideoDecoder;
+use ruffle_render::bitmap::BitmapFormat;
 use ruffle_video::error::Error;
 
 use flate2::Decompress;
@@ -203,11 +204,15 @@ impl VideoDecoder for ScreenVideoDecoder {
 
         self.last_frame = Some(data);
 
-        Ok(DecodedFrame {
-            width: w as u16,
-            height: h as u16,
+        // NOTE: We could get away with only storing RGB data (saving some memory), as there is no
+        // alpha support in Screen V1, but since the render backends always want RGBA right now,
+        // it's better to do the pixel format conversion here, all at once.
+        Ok(DecodedFrame::new(
+            w as u32,
+            h as u32,
+            BitmapFormat::Rgba,
             rgba,
-        })
+        ))
     }
 }
 

--- a/video/software/src/decoder/vp6.rs
+++ b/video/software/src/decoder/vp6.rs
@@ -2,8 +2,6 @@ use crate::decoder::VideoDecoder;
 use ruffle_render::bitmap::BitmapFormat;
 use ruffle_video::error::Error;
 
-use h263_rs_yuv::bt601::yuv420_to_rgba;
-
 use nihav_codec_support::codecs::{NABufferRef, NAVideoBuffer, NAVideoInfo};
 use nihav_codec_support::codecs::{NABufferType::Video, YUV420_FORMAT};
 use nihav_core::codecs::NADecoderSupport;
@@ -69,6 +67,31 @@ impl Vp6Decoder {
             last_frame: None,
         }
     }
+}
+
+fn crop(data: &[u8], mut width: usize, to_size: (u16, u16)) -> Vec<u8> {
+    debug_assert!(data.len() % width == 0);
+    let mut height = data.len() / width;
+    let mut data = data.to_vec();
+
+    if width > to_size.0 as usize {
+        // Removing the unwanted pixels on the right edge
+        // by squishing all the rows tightly next to each other.
+        let new_width = to_size.0 as usize;
+        let new_height = usize::min(height, to_size.1 as usize);
+        // no need to move the first row, nor any rows on the bottom that will end up being cropped entirely
+        for row in 1..new_height {
+            data.copy_within(row * width..(row * width + new_width), row * new_width);
+        }
+        width = new_width;
+        height = new_height;
+    }
+
+    // Cropping the unwanted rows on the bottom, also dropping any unused space at the end left by the squish above
+    height = usize::min(height, to_size.1 as usize);
+    data.truncate(width * height);
+
+    data
 }
 
 impl VideoDecoder for Vp6Decoder {
@@ -151,8 +174,6 @@ impl VideoDecoder for Vp6Decoder {
             frame
         };
 
-        // Converting it from YUV420 to RGBA.
-
         let yuv = frame.get_data();
 
         let (mut width, mut height) = frame.get_dimensions(0);
@@ -172,32 +193,9 @@ impl VideoDecoder for Vp6Decoder {
             frame.get_offset(2),
         );
 
-        let mut rgba = yuv420_to_rgba(
-            &yuv[offsets.0..offsets.0 + width * height],
-            &yuv[offsets.1..offsets.1 + chroma_width * chroma_height],
-            &yuv[offsets.2..offsets.2 + chroma_width * chroma_height],
-            width,
-        );
-
-        // Adding in the alpha component, if present.
-
-        if self.with_alpha {
-            debug_assert!(frame.get_stride(3) == frame.get_dimensions(3).0);
-            let alpha_offset = frame.get_offset(3);
-            let alpha = &yuv[alpha_offset..alpha_offset + width * height];
-            for (alpha, rgba) in alpha.iter().zip(rgba.chunks_mut(4)) {
-                // The SWF spec mandates the `min` to avoid any accidental "invalid"
-                // premultiplied colors, which would cause strange results after blending.
-                // And the alpha data is encoded in full range (0-255), unlike the Y
-                // component of the main color data, so no remapping is needed.
-                rgba.copy_from_slice(&[
-                    u8::min(rgba[0], *alpha),
-                    u8::min(rgba[1], *alpha),
-                    u8::min(rgba[2], *alpha),
-                    *alpha,
-                ]);
-            }
-        }
+        let y = &yuv[offsets.0..offsets.0 + width * height];
+        let u = &yuv[offsets.1..offsets.1 + chroma_width * chroma_height];
+        let v = &yuv[offsets.2..offsets.2 + chroma_width * chroma_height];
 
         // Cropping the encoded frame (containing whole macroblocks) to the
         // size requested by the the bounds attribute.
@@ -209,33 +207,46 @@ impl VideoDecoder for Vp6Decoder {
             // Flash Player just produces a black image in this case!
         }
 
-        if width > bounds.0 as usize {
-            // Removing the unwanted pixels on the right edge (most commonly: unused pieces of macroblocks)
-            // by squishing all the rows tightly next to each other.
-            // Bitmap at the moment does not allow these gaps, so we need to remove them.
-            let new_width = bounds.0 as usize;
-            let new_height = usize::min(height, bounds.1 as usize);
-            // no need to move the first row, nor any rows on the bottom that will end up being cropped entirely
-            for row in 1..new_height {
-                rgba.copy_within(
-                    row * width * 4..(row * width + new_width) * 4,
-                    row * new_width * 4,
-                );
-            }
-            width = new_width;
-            height = new_height;
+        //(most commonly: unused pieces of macroblocks)
+        // Bitmap at the moment does not allow these gaps, so we need to remove them.
+
+        let y = crop(y, width, bounds);
+        let u = crop(u, chroma_width, ((bounds.0 + 1) / 2, (bounds.1 + 1) / 2));
+        let v = crop(v, chroma_width, ((bounds.0 + 1) / 2, (bounds.1 + 1) / 2));
+
+        width = bounds.0 as usize;
+        height = bounds.1 as usize;
+
+        // Adding in the alpha component, if present.
+        if self.with_alpha {
+            debug_assert!(frame.get_stride(3) == frame.get_dimensions(3).0);
+            let alpha_offset = frame.get_offset(3);
+            let alpha = &yuv[alpha_offset..alpha_offset + width * height];
+            let a = crop(alpha, width, bounds);
+
+            let mut data = y.to_vec();
+            data.extend(u);
+            data.extend(v);
+            data.extend(a);
+
+            Ok(DecodedFrame::new(
+                width as u32,
+                height as u32,
+                BitmapFormat::Yuva420p,
+                data,
+            ))
+        } else {
+            let mut data = y.to_vec();
+            data.extend(u);
+            data.extend(v);
+
+            Ok(DecodedFrame::new(
+                width as u32,
+                height as u32,
+                BitmapFormat::Yuv420p,
+                data,
+            ))
         }
-
-        // Cropping the unwanted rows on the bottom, also dropping any unused space at the end left by the squish above
-        height = usize::min(height, bounds.1 as usize);
-        rgba.truncate(width * height * 4);
-
-        Ok(DecodedFrame::new(
-            width as u32,
-            height as u32,
-            BitmapFormat::Rgba,
-            rgba,
-        ))
     }
 }
 

--- a/video/software/src/decoder/vp6.rs
+++ b/video/software/src/decoder/vp6.rs
@@ -1,4 +1,5 @@
 use crate::decoder::VideoDecoder;
+use ruffle_render::bitmap::BitmapFormat;
 use ruffle_video::error::Error;
 
 use h263_rs_yuv::bt601::yuv420_to_rgba;
@@ -229,11 +230,12 @@ impl VideoDecoder for Vp6Decoder {
         height = usize::min(height, bounds.1 as usize);
         rgba.truncate(width * height * 4);
 
-        Ok(DecodedFrame {
-            width: width as u16,
-            height: height as u16,
+        Ok(DecodedFrame::new(
+            width as u32,
+            height as u32,
+            BitmapFormat::Rgba,
             rgba,
-        })
+        ))
     }
 }
 

--- a/video/src/frame.rs
+++ b/video/src/frame.rs
@@ -1,3 +1,4 @@
+use ruffle_render::bitmap::Bitmap;
 use swf::VideoCodec;
 
 /// An encoded video frame of some video codec.
@@ -20,12 +21,8 @@ impl<'a> EncodedFrame<'a> {
     }
 }
 
-/// A decoded frame of video in RGBA format.
-pub struct DecodedFrame {
-    pub width: u16,
-    pub height: u16,
-    pub rgba: Vec<u8>,
-}
+/// A decoded frame of video. It can be in whichever format the decoder chooses.
+pub type DecodedFrame = Bitmap;
 
 /// What dependencies a given video frame has on any previous frames.
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
1. toString and toLocaleString should only be defined on the prototype.
2. concat should only be defined as an as3 and proto property, not as an instace property.
3. Array doesn't have a valueOf defined directly on it.

Progresses #9085 a little.