### PR TITLE
avm1: Fix some issues with `Selection.getFocus()` and `setFocus()`

### DIFF
--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -1,7 +1,9 @@
 use crate::avm1::Avm1;
 use crate::avm1::Value;
 use crate::context::UpdateContext;
-pub use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
+pub use crate::display_object::{
+    DisplayObject, TDisplayObject, TDisplayObjectContainer, TextSelection,
+};
 use gc_arena::{Collect, GcCell, MutationContext};
 
 #[derive(Clone, Copy, Collect)]
@@ -22,44 +24,49 @@ impl<'gc> FocusTracker<'gc> {
         focused_element: Option<DisplayObject<'gc>>,
         context: &mut UpdateContext<'_, 'gc>,
     ) {
-        if let Some(text_field) = focused_element.and_then(|e| e.as_edit_text()) {
-            if text_field.is_editable() {
-                context.ui.open_virtual_keyboard();
-            }
-        }
         let old = std::mem::replace(&mut *self.0.write(context.gc_context), focused_element);
 
         if old.is_none() && focused_element.is_none() {
             // We didn't have anything, we still don't, no change.
             return;
         }
-        if old.is_some() == focused_element.is_some()
-            && old.unwrap().as_ptr() == focused_element.unwrap().as_ptr()
+        if !(old.is_some() == focused_element.is_some()
+            && old.unwrap().as_ptr() == focused_element.unwrap().as_ptr())
         {
-            // We're setting it to the same object as before, no change.
-            return;
+            if let Some(old) = old {
+                old.on_focus_changed(context.gc_context, false);
+            }
+            if let Some(new) = focused_element {
+                new.on_focus_changed(context.gc_context, true);
+            }
+
+            tracing::info!("Focus is now on {:?}", focused_element);
+
+            if let Some(level0) = context.stage.root_clip() {
+                Avm1::notify_system_listeners(
+                    level0,
+                    context,
+                    "Selection".into(),
+                    "onSetFocus".into(),
+                    &[
+                        old.map(|v| v.object()).unwrap_or(Value::Null),
+                        focused_element.map(|v| v.object()).unwrap_or(Value::Null),
+                    ],
+                );
+            }
         }
 
-        if let Some(old) = old {
-            old.on_focus_changed(context.gc_context, false);
-        }
-        if let Some(new) = focused_element {
-            new.on_focus_changed(context.gc_context, true);
-        }
+        // This applies even if the focused element hasn't changed.
+        if let Some(text_field) = focused_element.and_then(|e| e.as_edit_text()) {
+            if text_field.is_editable() {
+                let length = text_field.text_length();
+                text_field.set_selection(
+                    Some(TextSelection::for_range(0, length)),
+                    context.gc_context,
+                );
 
-        tracing::info!("Focus is now on {:?}", focused_element);
-
-        if let Some(level0) = context.stage.root_clip() {
-            Avm1::notify_system_listeners(
-                level0,
-                context,
-                "Selection".into(),
-                "onSetFocus".into(),
-                &[
-                    old.map(|v| v.object()).unwrap_or(Value::Null),
-                    focused_element.map(|v| v.object()).unwrap_or(Value::Null),
-                ],
-            );
+                context.ui.open_virtual_keyboard();
+            }
         }
     }
 }

--- a/tests/tests/swfs/avm1/selection/output.txt
+++ b/tests/tests/swfs/avm1/selection/output.txt
@@ -26,7 +26,7 @@ _level0.a
 
 
 
-false
+true
 
 // Selection.setFocus(b)
 ! - onSetFocus
@@ -50,7 +50,7 @@ _level0.b
 
 
 
-false
+true
 
 // Selection.setSelection(0)
 undefined
@@ -133,7 +133,7 @@ _level0.b
 
 
 // Selection.setFocus(b)
-false
+true
 
 // b.focusEnabled = false;
 // Selection.getBeginIndex()
@@ -195,7 +195,7 @@ _level0.c
 
 
 
-false
+true
 
 // Selection.setFocus(d)
 false
@@ -246,7 +246,7 @@ _level0.button
 
 
 
-false
+true
 
 // Selection.setFocus(text_input
 ! - onSetFocus
@@ -270,7 +270,7 @@ _level0.text_input
 
 
 
-false
+true
 
 // Selection.setFocus(text_selectable)
 ! - onSetFocus
@@ -294,7 +294,7 @@ _level0.text_selectable
 
 
 
-false
+true
 
 // Selection.setSelection(0)
 undefined
@@ -414,7 +414,7 @@ _level0.text_non_selectable
 
 
 
-false
+true
 
 // Selection.setFocus(text_input)
 ! - onSetFocus
@@ -438,7 +438,7 @@ _level0.text_input
 
 
 
-false
+true
 
 // Selection.setSelection(1, 3)
 // text_input.text


### PR DESCRIPTION
- `Selection.getFocus()` now returns a string on success, instead of an object. Our test logs the correct values because of the string coercion when using `trace`.

- `Selection.setFocus(str)` now accepts strings like `"focus"` or `"_root.focus"`. This fixes #2789.

- `Selection.setFocus(focus)` to a text field was giving the focus internally, however it wasn't possible to type anything on the keyboard. This can also be observed in the issue mentioned above. Note that it can be difficult to notice that the field has focus because of #2189 (now also happens on desktop on my end).

- `Selection.setFocus(focus)` now returns `true` on success, `false` on failure. I updated the test output to that end. Note that it's possible for `setFocus` to fail and return `false` if the file itself doesn't have the focus (for instance on a webpage, if you click an element other than the Flash file). The onSetFocus event should also be triggered. This is not implemented by this PR.