### PR TITLE
web: Split Firefox extension upload into a separate process

### DIFF
--- a/.github/workflows/release_amo.yml
+++ b/.github/workflows/release_amo.yml
@@ -1,0 +1,60 @@
+name: Release to addons.mozilla.org
+
+on:
+  #Run weekly every Friday
+  schedule:
+   - cron: "0 0 * * 5"
+  
+  #Allow for manual releases if needed
+  workflow_dispatch:
+
+jobs:
+  submit-amo:
+    name: Submit to addons.mozilla.org
+    runs-on: ubuntu-22.04
+  
+  if: github.repository == 'ruffle-rs/ruffle'
+
+  steps:
+    - name: Get latest release name
+      uses: mathiasvr/command-output@v2.0.0
+      id: release_tag
+      with:
+        run: gh release list -L1 | awk '{print $4}'
+    
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{steps.release_tag.outputs.stdout}}
+
+    - name: Compute release date
+      uses: mathiasvr/command-output@v2.0.0
+      id: release_date
+      with:
+        run: gh release list -L1 | awk '{print $2}' | sed 's/-/_/g'
+    
+    - name: Download latest release assets
+      run: |
+        mkdir release_assets
+        gh release download ${{ steps.release_tag.outputs.stdout }} --pattern "*.xpi" --pattern "*.zip" --dir release_assets
+
+        mv release_assets/ruffle-nightly-${{steps.release_date.outputs.stdout}}-reproducible-source.zip reproducible-source.zip
+
+        cd release_assets
+        unzip ruffle-nightly-${{steps.release_date.outputs.stdout}}-firefox_unsigned.xpi
+        mv manifest.json ../web/packages/extension/assets/manifest.json
+        cd ..
+
+        mkdir web/packages/extension/dist
+        mv release_assets/ruffle-nightly-${{steps.release_date.outputs.stdout}}-firefox_unsigned.xpi web/packages/extension/dist/reproducible-source.xpi
+    
+    - name: Publish Firefox extension
+      id: sign-firefox
+      continue-on-error: true
+      env:
+        FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+        MOZILLA_API_KEY: ${{ secrets.MOZILLA_API_KEY }}
+        MOZILLA_API_SECRET: ${{ secrets.MOZILLA_API_SECRET }}
+        SOURCE_TAG: ${{ steps.release_tag.outputs.stdout }}
+      working-directory: web/packages/extension
+      shell: bash -l {0}
+      run: npm run sign-firefox

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -352,18 +352,6 @@ jobs:
           npm run build:repro
           npm run docs
 
-      - name: Publish Firefox extension
-        if: env.FIREFOX_EXTENSION_ID != '' && !matrix.demo
-        id: sign-firefox
-        continue-on-error: true
-        env:
-          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
-          MOZILLA_API_KEY: ${{ secrets.MOZILLA_API_KEY }}
-          MOZILLA_API_SECRET: ${{ secrets.MOZILLA_API_SECRET }}
-        working-directory: web/packages/extension
-        shell: bash -l {0}
-        run: npm run sign-firefox
-
       - name: Publish npm package
         if: ${{ !matrix.demo }}
         # npm scoped packages are private by default, explicitly make public
@@ -407,7 +395,7 @@ jobs:
           path: ./web/packages/extension/dist/ruffle_extension.zip
 
       - name: Upload Firefox extension (unsigned)
-        if: steps.sign-firefox.outcome != 'success' && !matrix.demo
+        if: !matrix.demo
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -12,7 +12,8 @@ async function sign(
     unsignedPath,
     version,
     destination,
-    sourcePath
+    sourcePath,
+    sourceTag
 ) {
     const result = await signAddon({
         xpiPath: unsignedPath,
@@ -43,17 +44,12 @@ async function sign(
         },
     });
 
-    const build_date = new Date().toISOString();
-
     var notesUpload = client.patch({
         url: `/addons/addon/${encodeURIComponent(
             extensionId
         )}/versions/${encodeURIComponent(version)}/`,
         json: {
-            approval_notes: `This version was derived from the source code available at https://github.com/ruffle-rs/ruffle/releases/tag/nightly-${build_date.substr(
-                0,
-                10
-            )} - a ZIP file from this Git tag has been attached. If you download it yourself instead of using the ZIP file provided, make sure to grab the reproducible version of the ZIP, as it contains versioning information that will not be present on the main source download.\n\
+            approval_notes: `This version was derived from the source code available at https://github.com/ruffle-rs/ruffle/releases/tag/${sourceTag} - a ZIP file from this Git tag has been attached. If you download it yourself instead of using the ZIP file provided, make sure to grab the reproducible version of the ZIP, as it contains versioning information that will not be present on the main source download.\n\
 \n\
 We highly recommend using the Docker build workflow. You can invoke it using the following three commands:\n\
 \n\
@@ -102,7 +98,8 @@ try {
     if (
         process.env.MOZILLA_API_KEY &&
         process.env.MOZILLA_API_SECRET &&
-        process.env.FIREFOX_EXTENSION_ID
+        process.env.FIREFOX_EXTENSION_ID &&
+        process.env.SOURCE_TAG
     ) {
         // TODO: Import as a JSON module once it becomes stable.
         const require = createRequire(import.meta.url);
@@ -114,11 +111,12 @@ try {
             process.argv[2],
             version,
             process.argv[3],
-            process.argv[4]
+            process.argv[4],
+            process.env.SOURCE_TAG
         );
     } else {
         console.log(
-            "Skipping signing of Firefox extension. To enable this, please provide MOZILLA_API_KEY, MOZILLA_API_SECRET and FIREFOX_EXTENSION_ID environment variables"
+            "Skipping signing of Firefox extension. To enable this, please provide MOZILLA_API_KEY, MOZILLA_API_SECRET, FIREFOX_EXTENSION_ID, and SOURCE_TAG environment variables"
         );
     }
 } catch (error) {


### PR DESCRIPTION
This removes all extension upload related processes from nightlies - specifically addons.mozilla.org uploads. Unsigned nightlies will still be compiled and provided as normal.

A new weekly upload workflow has been added for actually submitting the latest nightly to Mozilla for addons.mozilla.org. Since we have automated source code submission, this should Just Work™ in one click, and I no longer need to add and remove the extension ID secret every time I want to turn extension upload off and on. The weekly upload process can also be triggered manually at any time if something should fail - it does not create any Git tags.