### PR TITLE
core: Support `maxlength` attribute in EditText

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -282,7 +282,7 @@ impl<'gc> EditText<'gc> {
                 hscroll: 0.0,
                 line_data,
                 scroll: 1,
-                max_chars: 0,
+                max_chars: swf_tag.max_length().unwrap_or_default() as i32,
             },
         ));
 


### PR DESCRIPTION
This is not a big change since the relevant parts are already in place:

https://github.com/ruffle-rs/ruffle/blob/c6298047d9815046541194d169d54881edc0dbf1/core/src/display_object/edit_text.rs#L138-L140

https://github.com/ruffle-rs/ruffle/blob/c6298047d9815046541194d169d54881edc0dbf1/core/src/display_object/edit_text.rs#L336-L343

https://github.com/ruffle-rs/ruffle/blob/c6298047d9815046541194d169d54881edc0dbf1/core/src/display_object/edit_text.rs#L1231-L1242

Fixes #9234.