### PR TITLE
desktop: Fix loading relative URLs when movie URL ends in empty path segment

### DIFF
--- a/desktop/src/navigator.rs
+++ b/desktop/src/navigator.rs
@@ -51,7 +51,7 @@ impl ExternalNavigatorBackend {
         // Force replace the last segment with empty. //
 
         if let Ok(mut base_url) = base_url.path_segments_mut() {
-            base_url.pop_if_empty().pop().push("");
+            base_url.pop().pop_if_empty().push("");
         }
 
         Self {


### PR DESCRIPTION
On desktop, if the movie URL ended in an empty path segment (a slash), then the base URL used for loading relative URLs would be incorrect. For example, if the movie URL was `http://games.example.com/game2/`, then Ruffle would use `http://games.example.com/` as the base for relative fetches, when it should use `http://games.example.com/game2/`.