### PR TITLE
Clean up and expand `ruffle_wstr`'s API

### DIFF
--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -8,7 +8,7 @@ use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
 use crate::avm1::{ArrayObject, Object, ObjectPtr, ScriptObject, TObject};
 use crate::display_object::{DisplayObject, TDisplayObject};
-use crate::string::{decode_swf_str, AvmString};
+use crate::string::{AvmString, SwfStrExt as _};
 use crate::tag_utils::SwfSlice;
 use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use std::{borrow::Cow, fmt, num::NonZeroU8};
@@ -96,19 +96,18 @@ impl<'gc> Avm1Function<'gc> {
         let name = if swf_function.name.is_empty() {
             None
         } else {
-            let name = decode_swf_str(swf_function.name, encoding);
-            Some(AvmString::new(gc_context, name))
+            Some(AvmString::new(
+                gc_context,
+                swf_function.name.decode(encoding),
+            ))
         };
 
         let params = swf_function
             .params
             .iter()
-            .map(|p| {
-                let name = decode_swf_str(p.name, encoding);
-                Param {
-                    register: p.register_index,
-                    name: AvmString::new(gc_context, name),
-                }
+            .map(|p| Param {
+                register: p.register_index,
+                name: AvmString::new(gc_context, p.name.decode(encoding)),
             })
             .collect();
 

--- a/core/src/avm1/function.rs
+++ b/core/src/avm1/function.rs
@@ -8,7 +8,7 @@ use crate::avm1::scope::Scope;
 use crate::avm1::value::Value;
 use crate::avm1::{ArrayObject, Object, ObjectPtr, ScriptObject, TObject};
 use crate::display_object::{DisplayObject, TDisplayObject};
-use crate::string::AvmString;
+use crate::string::{decode_swf_str, AvmString};
 use crate::tag_utils::SwfSlice;
 use gc_arena::{Collect, Gc, GcCell, MutationContext};
 use std::{borrow::Cow, fmt, num::NonZeroU8};
@@ -96,18 +96,18 @@ impl<'gc> Avm1Function<'gc> {
         let name = if swf_function.name.is_empty() {
             None
         } else {
-            let name = swf_function.name.to_str_lossy(encoding);
-            Some(AvmString::new_utf8(gc_context, name))
+            let name = decode_swf_str(swf_function.name, encoding);
+            Some(AvmString::new(gc_context, name))
         };
 
         let params = swf_function
             .params
             .iter()
             .map(|p| {
-                let name = p.name.to_str_lossy(encoding);
+                let name = decode_swf_str(p.name, encoding);
                 Param {
                     register: p.register_index,
-                    name: AvmString::new_utf8(gc_context, name),
+                    name: AvmString::new(gc_context, name),
                 }
             })
             .collect();

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -162,21 +162,21 @@ pub fn unescape_multi_byte<'gc>(
     let chars = bs.chars().map(|c| c.unwrap_or(char::REPLACEMENT_CHARACTER));
 
     let mut chars = chars.peekable();
+    let mut utf8_bytes = Vec::new();
     while let Some(c) = chars.next() {
         if c == '\0' {
             break;
         }
         if c == '%' {
-            let mut bytes = Vec::new();
             while let Some(b) = handle_percent(&mut chars) {
-                bytes.push(b);
+                utf8_bytes.push(b);
                 if !matches!(chars.peek(), Some('%')) {
                     break;
                 }
                 chars.next();
             }
-            buf.push_str(&WString::from_utf8_bytes(bytes));
-
+            buf.push_utf8_bytes(&utf8_bytes);
+            utf8_bytes.clear();
             continue;
         }
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -21,7 +21,7 @@ use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult, KeyCode};
 use crate::font::{round_down_to_pixel, Glyph, TextRenderSettings};
 use crate::html::{BoxBounds, FormatSpans, LayoutBox, LayoutContent, LayoutMetrics, TextFormat};
 use crate::prelude::*;
-use crate::string::{decode_swf_str, utils as string_utils, AvmString, WStr, WString};
+use crate::string::{utils as string_utils, AvmString, SwfStrExt as _, WStr, WString};
 use crate::tag_utils::SwfMovie;
 use crate::vminterface::{AvmObject, Instantiator};
 use chrono::Utc;
@@ -198,10 +198,9 @@ impl<'gc> EditText<'gc> {
         swf_movie: Arc<SwfMovie>,
         swf_tag: swf::EditText,
     ) -> Self {
-        let text = swf_tag.initial_text().unwrap_or_default();
         let default_format = TextFormat::from_swf_tag(swf_tag.clone(), swf_movie.clone(), context);
         let encoding = swf_movie.encoding();
-        let text = decode_swf_str(text, encoding);
+        let text = swf_tag.initial_text().unwrap_or_default().decode(encoding);
 
         let mut text_spans = if swf_tag.is_html() {
             FormatSpans::from_html(&text, default_format, swf_tag.is_multiline())
@@ -263,7 +262,7 @@ impl<'gc> EditText<'gc> {
                         layout: swf_tag.layout().cloned(),
                         initial_text: swf_tag
                             .initial_text()
-                            .map(|s| decode_swf_str(s, encoding).into_owned()),
+                            .map(|s| s.decode(encoding).into_owned()),
                     },
                 ),
                 flags,

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -31,7 +31,7 @@ use crate::events::{ButtonKeyCode, ClipEvent, ClipEventResult};
 use crate::font::Font;
 use crate::limits::ExecutionLimit;
 use crate::prelude::*;
-use crate::string::{decode_swf_str, AvmString, WStr, WString};
+use crate::string::{AvmString, SwfStrExt as _, WStr, WString};
 use crate::tag_utils::{self, ControlFlow, DecodeResult, Error, SwfMovie, SwfSlice, SwfStream};
 use crate::vminterface::{AvmObject, Instantiator};
 use core::fmt;
@@ -771,9 +771,7 @@ impl<'gc> MovieClip<'gc> {
         if !do_abc.data.is_empty() {
             let movie = self.movie();
             let domain = context.library.library_for_movie_mut(movie).avm2_domain();
-
-            let name = decode_swf_str(do_abc.name, reader.encoding());
-            let name = AvmString::new(context.gc_context, name);
+            let name = AvmString::new(context.gc_context, do_abc.name.decode(reader.encoding()));
 
             if let Err(e) = Avm2::do_abc(context, do_abc.data, Some(name), do_abc.flags, domain) {
                 let mut activation = Avm2Activation::from_nothing(context.reborrow());
@@ -800,8 +798,10 @@ impl<'gc> MovieClip<'gc> {
 
         for _ in 0..num_symbols {
             let id = reader.read_u16()?;
-            let class_name = decode_swf_str(reader.read_str()?, reader.encoding());
-            let class_name = AvmString::new(activation.context.gc_context, class_name);
+            let class_name = AvmString::new(
+                activation.context.gc_context,
+                reader.read_str()?.decode(reader.encoding()),
+            );
 
             let name = Avm2QName::from_qualified_name(class_name, &mut activation);
             let library = activation
@@ -897,9 +897,8 @@ impl<'gc> MovieClip<'gc> {
                 .map(|fld| fld.frame_num as u16 + 1)
                 .unwrap_or_else(|| static_data.total_frames + 1);
 
-            let label = decode_swf_str(label, reader.encoding());
             let scene = Scene {
-                name: label.into_owned(),
+                name: label.decode(reader.encoding()).into_owned(),
                 start,
                 length: end - start,
             };
@@ -914,7 +913,7 @@ impl<'gc> MovieClip<'gc> {
         }
 
         for FrameLabelData { frame_num, label } in sfl_data.frame_labels {
-            let label = decode_swf_str(label, reader.encoding()).into_owned();
+            let label = label.decode(reader.encoding()).into_owned();
             static_data
                 .frame_labels
                 .push((frame_num as u16 + 1, label.clone()));
@@ -1558,9 +1557,8 @@ impl<'gc> MovieClip<'gc> {
                     child.apply_place_object(context, place_object);
                     if let Some(name) = &place_object.name {
                         let encoding = swf::SwfStr::encoding_for_version(self.swf_version());
-                        let name = decode_swf_str(name, encoding);
-                        child
-                            .set_name(context.gc_context, AvmString::new(context.gc_context, name));
+                        let name = AvmString::new(context.gc_context, name.decode(encoding));
+                        child.set_name(context.gc_context, name);
                         child.set_has_explicit_name(context.gc_context, true);
                     }
                     if let Some(clip_depth) = place_object.clip_depth {
@@ -3789,7 +3787,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
     ) -> Result<(), Error> {
         let exports = reader.read_export_assets()?;
         for export in exports {
-            let name = decode_swf_str(export.name, reader.encoding());
+            let name = export.name.decode(reader.encoding());
             let name = AvmString::new(context.gc_context, name);
             let character = context
                 .library
@@ -3823,7 +3821,7 @@ impl<'gc, 'a> MovieClipData<'gc> {
         }
 
         let frame_label = reader.read_frame_label()?;
-        let mut label = decode_swf_str(frame_label.label, reader.encoding()).into_owned();
+        let mut label = frame_label.label.decode(reader.encoding()).into_owned();
 
         // In AVM1, frame labels are case insensitive (ASCII), but in AVM2 they are case sensitive.
         if !context.is_action_script_3() {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -2,7 +2,7 @@
 
 use crate::context::UpdateContext;
 use crate::html::iterators::TextSpanIter;
-use crate::string::{Integer, Units, WStr, WString};
+use crate::string::{decode_swf_str, Integer, Units, WStr, WString};
 use crate::tag_utils::SwfMovie;
 use gc_arena::Collect;
 use quick_xml::{escape::escape, events::Event, Reader};
@@ -145,7 +145,7 @@ impl TextFormat {
         let font = et.font_id().and_then(|fid| movie_library.get_font(fid));
         let font_class = et
             .font_class()
-            .map(|s| WString::from_utf8(&s.to_string_lossy(encoding)))
+            .map(|s| decode_swf_str(s, encoding).into_owned())
             .or_else(|| font.map(|font| WString::from_utf8(font.descriptor().class())))
             .unwrap_or_else(|| WString::from_utf8("Times New Roman"));
         let align = et.layout().map(|l| l.align);

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -2,7 +2,7 @@
 
 use crate::context::UpdateContext;
 use crate::html::iterators::TextSpanIter;
-use crate::string::{decode_swf_str, Integer, Units, WStr, WString};
+use crate::string::{Integer, SwfStrExt as _, Units, WStr, WString};
 use crate::tag_utils::SwfMovie;
 use gc_arena::Collect;
 use quick_xml::{escape::escape, events::Event, Reader};
@@ -145,7 +145,7 @@ impl TextFormat {
         let font = et.font_id().and_then(|fid| movie_library.get_font(fid));
         let font_class = et
             .font_class()
-            .map(|s| decode_swf_str(s, encoding).into_owned())
+            .map(|s| s.decode(encoding).into_owned())
             .or_else(|| font.map(|font| WString::from_utf8(font.descriptor().class())))
             .unwrap_or_else(|| WString::from_utf8("Times New Roman"));
         let align = et.layout().map(|l| l.align);

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -7,16 +7,17 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
 use super::utils::{encode_raw_utf16, split_ascii_prefix, split_ascii_prefix_bytes, DecodeAvmUtf8};
-use super::{ptr, Units, WStr, MAX_STRING_LEN};
+use super::{ptr, Units, WStr, WStrMetadata};
 
 /// An owned, extensible UCS2 string, analoguous to `String`.
 pub struct WString {
     data: NonNull<()>,
-    meta: ptr::WStrMetadata,
+    meta: WStrMetadata,
+    // Always less than `WStr::MAX_LEN`
     capacity: u32,
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(target_pointer_width = "32")]
 const _: () = assert!(size_of::<WString>() == 12);
 
 #[cfg(target_pointer_width = "64")]
@@ -32,7 +33,7 @@ impl WString {
     /// Creates a new empty `WString` with the given capacity and wideness.
     #[inline]
     pub fn with_capacity(capacity: usize, wide: bool) -> Self {
-        if capacity > MAX_STRING_LEN {
+        if capacity > WStr::MAX_LEN {
             super::panic_on_invalid_length(capacity);
         }
 
@@ -51,7 +52,7 @@ impl WString {
     ///
     /// # Safety
     ///
-    /// The length and the capacity cannot be greater than `MAX_STRING_LEN`.
+    /// The length and the capacity cannot be greater than `WStr::MAX_LEN`.
     #[inline]
     pub unsafe fn from_buf_unchecked(buf: Units<Vec<u8>, Vec<u16>>) -> Self {
         // SAFETY: we take ownership of the buffer; avoid double frees
@@ -74,26 +75,26 @@ impl WString {
         // Tries to shrink the capacity below the maximum allowed WStr length.
         #[cold]
         fn shrink<T>(buf: &mut Vec<T>) {
-            assert!(buf.capacity() > MAX_STRING_LEN);
+            assert!(buf.capacity() > WStr::MAX_LEN);
 
             let len = buf.len();
-            if len > MAX_STRING_LEN {
+            if len > WStr::MAX_LEN {
                 super::panic_on_invalid_length(len);
             }
 
-            buf.shrink_to(MAX_STRING_LEN);
+            buf.shrink_to(WStr::MAX_LEN);
             let ptr = ManuallyDrop::new(mem::take(buf)).as_mut_ptr();
             // SAFETY:
             // Per its contract, `Vec::shrink_to` reallocated the buffer to have
-            // a capacity between `MAX_STRING_LEN` and `buf.capacity()`.
+            // a capacity between `WStr::MAX_LEN` and `buf.capacity()`.
             unsafe {
-                *buf = Vec::from_raw_parts(ptr, len, MAX_STRING_LEN);
+                *buf = Vec::from_raw_parts(ptr, len, WStr::MAX_LEN);
             }
         }
 
         #[inline(always)]
         fn ensure_valid_cap<T>(buf: &mut Vec<T>) {
-            if buf.capacity() > MAX_STRING_LEN {
+            if buf.capacity() > WStr::MAX_LEN {
                 shrink(buf)
             }
         }
@@ -201,7 +202,7 @@ impl WString {
     /// Converts this `WString` into a string slice.
     #[inline]
     pub fn as_wstr(&self) -> &WStr {
-        let wstr = ptr::from_raw_parts(self.data.as_ptr(), self.meta);
+        let wstr = ptr::from_raw_parts_mut(self.data.as_ptr(), self.meta);
         // SAFETY:`self` is immutably borrowed.
         unsafe { &*wstr }
     }
@@ -209,7 +210,7 @@ impl WString {
     /// Converts this `WString` into a mutable string slice.
     #[inline]
     pub fn as_wstr_mut(&mut self) -> &mut WStr {
-        let wstr = ptr::from_raw_parts(self.data.as_ptr(), self.meta);
+        let wstr = ptr::from_raw_parts_mut(self.data.as_ptr(), self.meta);
         // SAFETY:`self` is mutably borrowed.
         unsafe { &mut *wstr }
     }
@@ -249,9 +250,37 @@ impl WString {
         unsafe { ManuallyDrop::into_inner(this.steal_buf()) }
     }
 
+    /// Decomposes the `WString` into its raw components, leaking the contents.
+    ///
+    /// This returns, in order:
+    /// - the pointer to the actual buffer;
+    /// - the length (number of codepoints) and wideness;
+    /// - the total capacity, in term of codepoints (guaranteed to be less than `WStr::MAX_LEN`).
+    ///
+    /// `Self::from_raw_parts` can then be called later to rebuild the `WString` back.
+    #[inline]
+    pub fn into_raw_parts(self) -> (*mut (), WStrMetadata, u32) {
+        // Don't drop the contnts; they are managed by the caller now.
+        let this = ManuallyDrop::new(self);
+        (this.data.as_ptr(), this.meta, this.capacity)
+    }
+
+    /// Rebuilds a `WString` from its raw components.
+    ///
+    /// # Safety
+    /// The arguments must come from a previous call to `Self::into_raw_parts`.
+    #[inline]
+    pub unsafe fn from_raw_parts(ptr: *mut (), meta: WStrMetadata, capacity: u32) -> Self {
+        Self {
+            data: unsafe { NonNull::new_unchecked(ptr) },
+            meta,
+            capacity,
+        }
+    }
+
     // Modify the raw internal buffer.
     //
-    // Panics if the resulting buffer has a length greater than `MAX_STRING_LEN`.
+    // Panics if the resulting buffer has a length greater than `WStr::MAX_LEN`.
     fn with_buf<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut Units<Vec<u8>, Vec<u16>>) -> R,
@@ -314,10 +343,7 @@ impl WString {
     /// Truncates this `WString`, removing all contents.
     #[inline]
     pub fn clear(&mut self) {
-        // SAFETY: 0 is always a valid length.
-        unsafe {
-            self.meta = ptr::WStrMetadata::new(0, self.meta.is_wide());
-        }
+        self.meta = ptr::WStrMetadata::new32(0, self.meta.is_wide());
     }
 
     /// Appends a UTF-16 code unit to `self`.

--- a/wstr/src/buf.rs
+++ b/wstr/src/buf.rs
@@ -179,6 +179,7 @@ impl WString {
     }
 
     /// Converts this `WString` into a string slice.
+    #[inline]
     pub fn as_wstr(&self) -> &WStr {
         let wstr = ptr::from_raw_parts(self.data.as_ptr(), self.meta);
         // SAFETY:`self` is immutably borrowed.
@@ -186,6 +187,7 @@ impl WString {
     }
 
     /// Converts this `WString` into a mutable string slice.
+    #[inline]
     pub fn as_wstr_mut(&mut self) -> &mut WStr {
         let wstr = ptr::from_raw_parts(self.data.as_ptr(), self.meta);
         // SAFETY:`self` is mutably borrowed.
@@ -290,6 +292,7 @@ impl WString {
     }
 
     /// Truncates this `WString`, removing all contents.
+    #[inline]
     pub fn clear(&mut self) {
         // SAFETY: 0 is always a valid length.
         unsafe {
@@ -372,6 +375,7 @@ impl WString {
 }
 
 impl Drop for WString {
+    #[inline]
     fn drop(&mut self) {
         // SAFETY: `self` is gone after this line.
         unsafe {

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -329,6 +329,12 @@ impl WStr {
         super::ops::str_to_ascii_lowercase(self)
     }
 
+    /// Converts this string to its ASCII lower case equivalent in-place.
+    #[inline]
+    pub fn make_ascii_lowercase(&mut self) {
+        super::ops::str_make_ascii_lowercase(self)
+    }
+
     /// Analogue of [`str::replace`].
     #[inline]
     pub fn replace<'a, P: Pattern<'a>>(&'a self, pattern: P, with: &WStr) -> WString {

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -590,10 +590,10 @@ macro_rules! __wstr_impl_internal {
             }
         }
 
-        __wstr_impl_internal! { @eq_ord_units [$($generics)* const N: usize] for $ty, [u8; N] }
-        __wstr_impl_internal! { @eq_ord_units [$($generics)* const N: usize] for $ty, [u16; N] }
-        __wstr_impl_internal! { @eq_ord_units [$($generics)*] for $ty, [u8] }
-        __wstr_impl_internal! { @eq_ord_units [$($generics)*] for $ty, [u16] }
+        $crate::__wstr_impl_internal! { @eq_ord_units [$($generics)* const N: usize] for $ty, [u8; N] }
+        $crate::__wstr_impl_internal! { @eq_ord_units [$($generics)* const N: usize] for $ty, [u16; N] }
+        $crate::__wstr_impl_internal! { @eq_ord_units [$($generics)*] for $ty, [u8] }
+        $crate::__wstr_impl_internal! { @eq_ord_units [$($generics)*] for $ty, [u16] }
     };
 
     (@base [$($generics:tt)*] for $ty:ty) => {
@@ -667,12 +667,12 @@ macro_rules! __wstr_impl_internal {
     };
 
     (@full [$($generics:tt)*] for $ty:ty) => {
-        __wstr_impl_internal!(@base [$($generics)*] for $ty);
-        __wstr_impl_internal!(@eq_ord_self [$($generics)*] for $ty);
-        __wstr_impl_internal!(@eq_ord [$($generics)*] for $ty, $crate::WStr);
-        __wstr_impl_internal!(@eq_ord [$($generics)*] for $crate::WStr, $ty);
-        __wstr_impl_internal!(@eq_ord [$($generics)* 'a,] for $ty, &'a $crate::WStr);
-        __wstr_impl_internal!(@eq_ord [$($generics)* 'a,] for &'a $crate::WStr, $ty);
+        $crate::__wstr_impl_internal!(@base [$($generics)*] for $ty);
+        $crate::__wstr_impl_internal!(@eq_ord_self [$($generics)*] for $ty);
+        $crate::__wstr_impl_internal!(@eq_ord [$($generics)*] for $ty, $crate::WStr);
+        $crate::__wstr_impl_internal!(@eq_ord [$($generics)*] for $crate::WStr, $ty);
+        $crate::__wstr_impl_internal!(@eq_ord [$($generics)* 'a,] for $ty, &'a $crate::WStr);
+        $crate::__wstr_impl_internal!(@eq_ord [$($generics)* 'a,] for &'a $crate::WStr, $ty);
     };
 }
 
@@ -691,10 +691,10 @@ macro_rules! __wstr_impl_internal {
 #[macro_export]
 macro_rules! wstr_impl_traits {
     (impl for $ty_name:ty) => {
-        __wstr_impl_internal!(@full [] for $ty_name);
+        $crate::__wstr_impl_internal!(@full [] for $ty_name);
     };
     (impl [$($generics:tt)+] for $ty_name:ty) => {
-        __wstr_impl_internal!(@full [$($generics)*,] for $ty_name);
+        $crate::__wstr_impl_internal!(@full [$($generics)*,] for $ty_name);
     };
 }
 

--- a/wstr/src/lib.rs
+++ b/wstr/src/lib.rs
@@ -1,6 +1,6 @@
 //! Provides UCS2 string types for usage in AVM1 and AVM2.
 //!
-//! Internally, these types are represeted by a sequence of 1-byte or 2-bytes (wide) code units,
+//! Internally, these types are represented by a sequence of 1-byte or 2-bytes (wide) code units,
 //! that may contains null bytes or unpaired surrogates.
 //!
 //! To match Flash behavior, the string length is limited to 2³¹-1 code units;
@@ -18,7 +18,7 @@ mod buf;
 mod ops;
 mod parse;
 mod pattern;
-mod ptr;
+pub mod ptr;
 mod tables;
 pub mod utils;
 
@@ -26,11 +26,11 @@ pub mod utils;
 mod tests;
 
 pub use buf::WString;
-pub use common::Units;
+pub use common::{Units, WStr};
 pub use ops::{CharIndices, Chars, Iter, Split, WStrToUtf8};
 pub use parse::{FromWStr, Integer};
 pub use pattern::Pattern;
-pub use ptr::{WStr, MAX_STRING_LEN};
+pub use ptr::WStrMetadata;
 
 use alloc::borrow::Cow;
 use core::borrow::Borrow;

--- a/wstr/src/ops.rs
+++ b/wstr/src/ops.rs
@@ -202,6 +202,19 @@ pub fn str_to_ascii_lowercase(s: &WStr) -> WString {
     map_latin1_chars(s, |c| c.to_ascii_lowercase())
 }
 
+pub fn str_make_ascii_lowercase(s: &mut WStr) {
+    match s.units_mut() {
+        Units::Bytes(us) => us.make_ascii_lowercase(),
+        Units::Wide(us) => {
+            for c in us {
+                if let Ok(b) = u8::try_from(*c) {
+                    *c = b.to_ascii_lowercase().into();
+                }
+            }
+        }
+    }
+}
+
 pub fn str_is_latin1(s: &WStr) -> bool {
     match s.units() {
         Units::Bytes(_) => true,

--- a/wstr/src/ops.rs
+++ b/wstr/src/ops.rs
@@ -270,7 +270,7 @@ pub fn str_repeat(s: &WStr, count: usize) -> WString {
     }
 
     let len = s.len().saturating_mul(count);
-    if len > super::MAX_STRING_LEN {
+    if len > WStr::MAX_LEN {
         super::panic_on_invalid_length(len);
     }
 

--- a/wstr/src/ptr.rs
+++ b/wstr/src/ptr.rs
@@ -1,49 +1,46 @@
+//! Raw pointers to `WStr` slices.
+//!
+//! # Internal representation
+//!
+//! What we actually want here is a custom DST, but they don't exist so we must cheat
+//! and abuse the slice metadata field.
+//!
+//! The data pointer points to the start of the units buffer, which is either a
+//! `[u8]` (`Units::Bytes`) or a `[u16]` (`Units::Wide`).
+//!
+//! String lengths are limited to less than `2³¹` units long, and the kind of
+//! buffer is indicated by the 32nd bit of the raw slice length:
+//!  - for `Units::Bytes`, it is a zero;
+//!  - for `Units::Wide`, it is a one.
+//!
+//! Note that on 64-bits targets, this leaves the high 32 bits of the length unused.
+//!
+//! # (Un)soundness
+//!
+//! Unfortunately, this scheme is technically unsound under Stacked Borrows because of provenance:
+//! when we cast a `*mut [u8]` or `*mut [u16]` to a `*mut WStr`, we lose the provenance over the
+//! original buffer as `[()]` always occupies zero bytes (which is what allows use to mess up the slice length).
+//!
+//! As such, when we access the buffer data (e.g. in `read_at` or when converting back to raw buffer references),
+//! the read is considered out-of-bounds by Stacked Borrows and causes undefined behavior.
+//!
+//! This unsoundness doesn't seem to manifest in practice though, as Rust doesn't pass through slice
+//! length information to LLVM (yet?).
+//!
+//! One observable consequence of this is that `std::mem::size_of_val::<WStr>` won't return the actual
+//! byte length of the string contents, but will instead always return 0.
+
+use core::mem::transmute;
 use core::ops::Range;
 use core::ptr::{slice_from_raw_parts, slice_from_raw_parts_mut};
 
-use super::Units;
+use super::{Units, WStr};
 
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error!("WStr only supports 32-bits and 64-bits targets");
 
-/// The maximum string length, equals to 2³¹-1.
-pub const MAX_STRING_LEN: usize = 0x7FFF_FFFF;
-const WIDE_MASK: u32 = MAX_STRING_LEN as u32 + 1;
-
-/// A UCS2 string slice, analoguous to `&'a str`.
-#[repr(transparent)]
-pub struct WStr {
-    /// The internal `WStr` representation.
-    ///
-    /// What we actually want here is a custom DST, but they don't exist so we must cheat
-    /// and abuse the slice metadata field.
-    ///
-    /// The data pointer points to the start of the units buffer, which is either a
-    /// `[u8]` (`Units::Bytes`) or a `[u16]` (`Units::Wide`).
-    ///
-    /// String lengths are limited to less than `2³¹` units long, and the kind of
-    /// buffer is indicated by the 32nd bit of the raw slice length:
-    ///  - for `Units::Bytes`, it is a zero;
-    ///  - for `Units::Wide`, it is a one.
-    ///
-    /// Note that on 64-bits targets, this leaves the high 32 bits of the length unused.
-    ///
-    /// # (Un)soundness
-    ///
-    /// Unfortunately, this scheme is technically unsound under Stacked Borrows because of provenance:
-    /// when we cast a `*mut [u8]` or `*mut [u16]` to a `*mut WStr`, we lose the provenance over the
-    /// original buffer as `[()]` always occupies zero bytes (which is what allows use to mess up the slice length).
-    ///
-    /// As such, when we access the buffer data (e.g. in `read_at` or when converting back to raw buffer references),
-    /// the read is considered out-of-bounds by Stacked Borrows and causes undefined behavior.
-    ///
-    /// This unsoundness doesn't seem to manifest in practice though, as Rust doesn't pass through slice
-    /// length information to LLVM (yet?).
-    ///
-    /// One observable consequence of this is that `std::mem::size_of_val::<WStr>` won't return the actual
-    /// byte length of the string contents, but will instead always return 0.
-    _repr: [()],
-}
+const WIDE_MASK: u32 = 0x8000_0000;
+const _: () = assert!(WIDE_MASK as usize == WStr::MAX_LEN + 1);
 
 /// The metadata of a `WStr` pointer. This is always 4 bytes wide, even on 64-bits targets.
 ///
@@ -71,10 +68,37 @@ impl WStrMetadata {
     /// Assemble `WStr` metadata from its components.
     ///
     /// # Safety
-    /// `len` must be less than or equal to `MAX_STRING_LEN`.
+    /// `len` must be less than or equal to `WStr::MAX_LEN`.
     #[inline(always)]
     pub const unsafe fn new(len: usize, is_wide: bool) -> Self {
         Self::from_usize(len | if is_wide { WIDE_MASK as usize } else { 0 })
+    }
+
+    /// Assemble `WStr` metadata from its components.
+    ///
+    /// Unlike `Self::new`, this is safe, but passing a `len` bigger
+    /// than `WStr::MAX_LEN` will give a bogus result.
+    #[inline(always)]
+    pub const fn new32(len: u32, is_wide: bool) -> Self {
+        Self(len | if is_wide { WIDE_MASK } else { 0 })
+    }
+
+    /// Gets the metadata of the given pointer.
+    ///
+    /// # Safety
+    /// `ptr` must be non-null and its metadata must be valid.
+    #[inline(always)]
+    pub const unsafe fn of(ptr: *const WStr) -> Self {
+        Self::from_usize(raw_len(ptr as *const _ as *mut [()]))
+    }
+
+    /// Gets the metadata of the given mutable pointer.
+    ///
+    /// # Safety
+    /// `ptr` must be non-null and its metadata must be valid.
+    #[inline(always)]
+    pub const unsafe fn of_mut(ptr: *mut WStr) -> Self {
+        Self::from_usize(raw_len(ptr as *mut [()]))
     }
 
     /// Returns whether this metadata describes a wide `WStr`.
@@ -83,84 +107,89 @@ impl WStrMetadata {
         (self.0 & WIDE_MASK) != 0
     }
 
-    /// Returns the length of the described `WStr`. This is never greater than `MAX_STRING_LEN`.
+    /// Returns the length of the described `WStr`. This is never greater than `WStr::MAX_LEN`.
+    #[allow(clippy::len_without_is_empty)]
     #[inline(always)]
     pub const fn len(self) -> usize {
         (self.0 & (WIDE_MASK - 1)) as usize
     }
-}
 
-/// Convenience method to turn a `&T` into a `*mut T`.
-#[inline]
-pub(crate) fn ptr_mut<T: ?Sized>(t: &T) -> *mut T {
-    t as *const T as *mut T
+    /// Same as `Self::len`, but returns an `u32`.
+    #[inline(always)]
+    pub const fn len32(self) -> u32 {
+        self.0 & (WIDE_MASK - 1)
+    }
 }
 
 /// Replacement for unstable `<*mut [T]>::len` method.
 ///
 /// # Safety
-///  - `ptr` must point to an allocated slice of the correct type.
-#[inline]
-unsafe fn raw_len<T>(ptr: *mut [T]) -> usize {
-    let fake = ptr as *mut [()];
-    // SAFETY: `ptr` points to *some* allocated storage, so we
-    // can read a `[()]` (which takes up 0 bytes) out of it.
-    (*fake).len()
-}
-
-/// Returns an untyped pointer to the raw `WStr` buffer.
-///
-/// Depending on the value of `is_wide(ptr)`, this points to a buffer of `u8`s or `u16`s.
-#[inline]
-pub fn data(ptr: *mut WStr) -> *mut () {
-    ptr.cast::<()>()
-}
-
-/// Returns the metadata part of a a raw `WStr` pointer.
-///
-/// # Safety
-///  - `ptr` must point to some allocated storage of arbitrary size.
-///  - the pointer metadata must be valid.
-#[inline]
-pub unsafe fn metadata(ptr: *mut WStr) -> WStrMetadata {
-    let raw = raw_len(ptr as *mut [()]);
-    WStrMetadata::from_usize(raw)
+/// `ptr` must be non-null.
+#[inline(always)]
+const unsafe fn raw_len<T>(ptr: *mut [T]) -> usize {
+    core::ptr::NonNull::new_unchecked(ptr).len()
 }
 
 /// Creates a `WStr` pointer from its raw parts.
-#[inline]
-pub fn from_raw_parts(data: *mut (), metadata: WStrMetadata) -> *mut WStr {
-    let slice = slice_from_raw_parts(data, metadata.0 as usize);
-    slice as *mut WStr
+#[inline(always)]
+pub const fn from_raw_parts(data: *const (), metadata: WStrMetadata) -> *const WStr {
+    slice_from_raw_parts(data, metadata.0 as usize) as *const WStr
+}
+
+/// Creates a mutable `WStr` pointer from its raw parts.
+#[inline(always)]
+pub fn from_raw_parts_mut(data: *mut (), metadata: WStrMetadata) -> *mut WStr {
+    slice_from_raw_parts_mut(data, metadata.0 as usize) as *mut WStr
 }
 
 /// Creates a `WStr` pointer from a raw units buffer.
 ///
 /// # Safety
-///  - the buffer length must be less than or equals to `MAX_STRING_LEN`
-///  - the buffer must point to allocated storage of arbitrary size.
+///  - the buffer must be non-null.
+///  - the buffer length must be less than or equals to `WStr::MAX_LEN`.
 #[inline]
-pub unsafe fn from_units(units: Units<*mut [u8], *mut [u16]>) -> *mut WStr {
+pub const unsafe fn from_units(units: Units<*const [u8], *const [u16]>) -> *const WStr {
     let (data, len, is_wide) = match units {
-        Units::Bytes(us) => (us as *mut (), raw_len(us), false),
-        Units::Wide(us) => (us as *mut (), raw_len(us), true),
+        Units::Bytes(us) => (us as *const (), raw_len::<u8>(us as *mut _), false),
+        Units::Wide(us) => (us as *const (), raw_len::<u16>(us as *mut _), true),
     };
 
     from_raw_parts(data, WStrMetadata::new(len, is_wide))
 }
 
+/// Creates a `WStr` pointer from a mutable, raw units buffer.
+///
+/// # Safety
+///  - the buffer must be non-null.
+///  - the buffer length must be less than or equals to `WStr::MAX_LEN`.
+#[inline(always)]
+pub const unsafe fn from_units_mut(units: Units<*mut [u8], *mut [u16]>) -> *mut WStr {
+    // SAFETY: `Units` is `repr(C)` so the transmute is sound.
+    from_units(transmute(units)) as *mut WStr
+}
+
 /// Gets a pointer to the buffer designated by `ptr`.
 ///
 /// # Safety
-///  - `ptr` must point to some allocated storage of arbitrary size.
+///  - `ptr` must be non-null and its metadata must be valid.
 #[inline]
-pub unsafe fn units(ptr: *mut WStr) -> Units<*mut [u8], *mut [u16]> {
-    let (data, meta) = (data(ptr), metadata(ptr));
+pub const unsafe fn units(ptr: *const WStr) -> Units<*const [u8], *const [u16]> {
+    let (data, meta) = (ptr as *const (), WStrMetadata::of(ptr));
     if meta.is_wide() {
-        Units::Wide(slice_from_raw_parts_mut(data as *mut u16, meta.len()))
+        Units::Wide(slice_from_raw_parts(data as *const u16, meta.len()))
     } else {
-        Units::Bytes(slice_from_raw_parts_mut(data as *mut u8, meta.len()))
+        Units::Bytes(slice_from_raw_parts(data as *const u8, meta.len()))
     }
+}
+
+/// Gets a mutable pointer to the buffer designated by `ptr`.
+///
+/// # Safety
+///  - `ptr` must be non-null and its metadata must be valid.
+#[inline(always)]
+pub const unsafe fn units_mut(ptr: *mut WStr) -> Units<*mut [u8], *mut [u16]> {
+    // SAFETY: `Units` is `repr(C)` so the transmute is sound.
+    transmute(units(ptr))
 }
 
 /// Gets a pointer to the `n`th unit of this `WStr`.
@@ -169,21 +198,34 @@ pub unsafe fn units(ptr: *mut WStr) -> Units<*mut [u8], *mut [u16]> {
 ///  - `ptr` must point to a valid `WStr`;
 ///  - `i` must be less than or equals to `metadata(ptr).len()`.
 #[inline]
-pub unsafe fn offset(ptr: *mut WStr, i: usize) -> Units<*mut u8, *mut u16> {
-    if metadata(ptr).is_wide() {
+pub const unsafe fn offset(ptr: *const WStr, i: usize) -> Units<*const u8, *const u16> {
+    if WStrMetadata::of(ptr).is_wide() {
         Units::Wide((ptr as *mut u16).add(i))
     } else {
         Units::Bytes((ptr as *mut u8).add(i))
     }
 }
+
+/// Gets a mutable pointer to the `n`th unit of this `WStr`.
+///
+/// # Safety
+///  - `ptr` must point to a valid `WStr`;
+///  - `i` must be less than or equals to `metadata(ptr).len()`.
+#[inline(always)]
+pub unsafe fn offset_mut(ptr: *mut WStr, i: usize) -> Units<*mut u8, *mut u16> {
+    // SAFETY: `Units` is `repr(C)` so the transmute is sound.
+    transmute(offset(ptr, i))
+}
+
 /// Dereferences the `n`th unit of this `WStr`.
 ///
 /// # Safety
 ///  - `ptr` must point to a valid `WStr` for reading;
 ///  - `i` must be less than `metadata(ptr).len()`.
-pub unsafe fn read_at(ptr: *mut WStr, i: usize) -> u16 {
+#[inline]
+pub const unsafe fn read_at(ptr: *const WStr, i: usize) -> u16 {
     match offset(ptr, i) {
-        Units::Bytes(p) => (*p).into(),
+        Units::Bytes(p) => *p as u16,
         Units::Wide(p) => *p,
     }
 }
@@ -195,11 +237,22 @@ pub unsafe fn read_at(ptr: *mut WStr, i: usize) -> u16 {
 ///  - `range.start` must be less than or equals to `range.end`;
 ///  - `range.end` must be less than or equals to `metadata(ptr).len()`.
 #[inline]
-pub unsafe fn slice(ptr: *mut WStr, range: Range<usize>) -> *mut WStr {
+pub const unsafe fn slice(ptr: *const WStr, range: Range<usize>) -> *const WStr {
     let len = range.end - range.start;
     let (data, is_wide) = match offset(ptr, range.start) {
-        Units::Bytes(p) => (p as *mut (), false),
-        Units::Wide(p) => (p as *mut (), true),
+        Units::Bytes(p) => (p as *const (), false),
+        Units::Wide(p) => (p as *const (), true),
     };
     from_raw_parts(data, WStrMetadata::new(len, is_wide))
+}
+
+/// Returns a mutable pointer to a subslice of this `WStr`.
+///
+/// # Safety
+///  - `ptr` must point to a valid `WStr`;
+///  - `range.start` must be less than or equals to `range.end`;
+///  - `range.end` must be less than or equals to `metadata(ptr).len()`.
+#[inline(always)]
+pub unsafe fn slice_mut(ptr: *mut WStr, range: Range<usize>) -> *mut WStr {
+    slice(ptr, range) as *mut WStr
 }


### PR DESCRIPTION
Various `wstr`-related refactorings extracted from my experimental string interning branch.