### PR TITLE
BitmapData optimisations: faster copies (including draws that are copies)

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -948,7 +948,7 @@ pub fn copy_pixels<'gc>(
                         }
                     } else {
                         operations::copy_pixels(
-                            activation.context.gc_context,
+                            &mut activation.context,
                             bitmap_data.bitmap_data(),
                             src_bitmap.bitmap_data(),
                             (src_min_x, src_min_y, src_width, src_height),

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -289,27 +289,21 @@ pub fn copy_channel<'gc>(
         if !bitmap_data.disposed() {
             if let Some(source_bitmap) = source_bitmap.as_bitmap_data_object() {
                 //TODO: what if source is disposed
-                let min_x = dest_point
-                    .get("x", activation)?
-                    .coerce_to_u32(activation)?
-                    .min(bitmap_data.bitmap_data().width());
-                let min_y = dest_point
-                    .get("y", activation)?
-                    .coerce_to_u32(activation)?
-                    .min(bitmap_data.bitmap_data().height());
+                let min_x = dest_point.get("x", activation)?.coerce_to_i32(activation)?;
+                let min_y = dest_point.get("y", activation)?.coerce_to_i32(activation)?;
 
                 let src_min_x = source_rect
                     .get("x", activation)?
-                    .coerce_to_u32(activation)?;
+                    .coerce_to_i32(activation)?;
                 let src_min_y = source_rect
                     .get("y", activation)?
-                    .coerce_to_u32(activation)?;
+                    .coerce_to_i32(activation)?;
                 let src_width = source_rect
                     .get("width", activation)?
-                    .coerce_to_u32(activation)?;
+                    .coerce_to_i32(activation)?;
                 let src_height = source_rect
                     .get("height", activation)?
-                    .coerce_to_u32(activation)?;
+                    .coerce_to_i32(activation)?;
 
                 operations::copy_channel(
                     activation.context.gc_context,

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -936,7 +936,7 @@ pub fn copy_pixels<'gc>(
                                 as i32;
 
                             operations::copy_pixels_with_alpha_source(
-                                activation.context.gc_context,
+                                &mut activation.context,
                                 bitmap_data.bitmap_data(),
                                 src_bitmap.bitmap_data(),
                                 (src_min_x, src_min_y, src_width, src_height),

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -472,10 +472,10 @@ pub fn copy_channel<'gc>(
 
         let dest_x = dest_point
             .get_public_property("x", activation)?
-            .coerce_to_u32(activation)?;
+            .coerce_to_i32(activation)?;
         let dest_y = dest_point
             .get_public_property("y", activation)?
-            .coerce_to_u32(activation)?;
+            .coerce_to_i32(activation)?;
 
         let source_channel = args.get_i32(activation, 3)?;
 
@@ -485,16 +485,16 @@ pub fn copy_channel<'gc>(
             //TODO: what if source is disposed
             let src_min_x = source_rect
                 .get_public_property("x", activation)?
-                .coerce_to_u32(activation)?;
+                .coerce_to_i32(activation)?;
             let src_min_y = source_rect
                 .get_public_property("y", activation)?
-                .coerce_to_u32(activation)?;
+                .coerce_to_i32(activation)?;
             let src_width = source_rect
                 .get_public_property("width", activation)?
-                .coerce_to_u32(activation)?;
+                .coerce_to_i32(activation)?;
             let src_height = source_rect
                 .get_public_property("height", activation)?
-                .coerce_to_u32(activation)?;
+                .coerce_to_i32(activation)?;
 
             operations::copy_channel(
                 activation.context.gc_context,

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -256,7 +256,7 @@ pub fn copy_pixels<'gc>(
                 );
             } else {
                 operations::copy_pixels(
-                    activation.context.gc_context,
+                    &mut activation.context,
                     bitmap_data,
                     src_bitmap,
                     (src_min_x, src_min_y, src_width, src_height),

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -245,7 +245,7 @@ pub fn copy_pixels<'gc>(
 
             if let Some((alpha_bitmap, alpha_point)) = alpha_source {
                 operations::copy_pixels_with_alpha_source(
-                    activation.context.gc_context,
+                    &mut activation.context,
                     bitmap_data,
                     src_bitmap,
                     (src_min_x, src_min_y, src_width, src_height),

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -438,6 +438,14 @@ mod wrapper {
                 .render_bitmap(handle, context.transform_stack.transform(), smoothing);
         }
 
+        pub fn can_read(&self, read_area: PixelRegion) -> bool {
+            if let DirtyState::GpuModified(_, area) = self.0.read().dirty_state {
+                !area.intersects(read_area)
+            } else {
+                true
+            }
+        }
+
         pub fn is_point_in_bounds(&self, x: i32, y: i32) -> bool {
             x >= 0 && x < self.width() as i32 && y >= 0 && y < self.height() as i32
         }
@@ -594,6 +602,14 @@ impl<'gc> BitmapData<'gc> {
     #[inline]
     pub fn get_pixel32_raw(&self, x: u32, y: u32) -> Color {
         self.pixels[(x + y * self.width()) as usize]
+    }
+
+    pub fn raw_pixels_mut(&mut self) -> &mut Vec<Color> {
+        &mut self.pixels
+    }
+
+    pub fn raw_pixels(&self) -> &Vec<Color> {
+        &self.pixels
     }
 
     // Updates the data stored with our `BitmapHandle` if this `BitmapData`

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -608,7 +608,7 @@ impl<'gc> BitmapData<'gc> {
         &mut self.pixels
     }
 
-    pub fn raw_pixels(&self) -> &Vec<Color> {
+    pub fn raw_pixels(&self) -> &[Color] {
         &self.pixels
     }
 

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1259,7 +1259,9 @@ fn copy_on_cpu<'gc>(
                 && dest_region.height() == source_read.height()
             {
                 // Copying an entire texture that's the same size and type? Just replace the whole thing
-                *dest_write.raw_pixels_mut() = source_read.raw_pixels().to_owned();
+                dest_write
+                    .raw_pixels_mut()
+                    .copy_from_slice(source_read.raw_pixels());
             } else {
                 for y in 0..dest_region.height() {
                     for x in 0..dest_region.width() {

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -1248,7 +1248,7 @@ fn copy_on_cpu<'gc>(
         let source_read = source.read_area(source_region);
 
         if !blend && (dest_write.transparency() || !source_read.transparency()) {
-            // Copying anything to a transparent texture,
+            // Copying (not blending) anything to a transparent texture,
             // or copying an opaque texture to an opaque texture,
             // means we can skip alpha premultiplication
 
@@ -1274,7 +1274,8 @@ fn copy_on_cpu<'gc>(
                 }
             }
         } else {
-            // Copying a transparent texture to an opaque texture, or blending
+            // Copying (not blending) a transparent texture to an opaque texture,
+            // or blending anything to anything
 
             let opaque = !dest_write.transparency();
 

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -53,6 +53,10 @@ pub trait RenderBackend: Downcast {
         None
     }
 
+    fn is_filter_supported(&self, _filter: &Filter) -> bool {
+        false
+    }
+
     fn submit_frame(&mut self, clear: swf::Color, commands: CommandList);
 
     fn register_bitmap(&mut self, bitmap: Bitmap) -> Result<BitmapHandle, Error>;

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -653,6 +653,10 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         }
     }
 
+    fn is_filter_supported(&self, filter: &Filter) -> bool {
+        matches!(filter, Filter::BlurFilter(_) | Filter::ColorMatrixFilter(_))
+    }
+
     fn apply_filter(
         &mut self,
         source: BitmapHandle,


### PR DESCRIPTION
Main optimizations:
- Removed in-loop checks for "is pixel inside bitmapdata" for most methods, only iterate pixels that are valid to begin with
- `BitmapData.copyPixels()` will do its best to find the fastest way to copy a region on the cpu, including just sometimes straight up replacing the entire `Vec<Color>` if it needs to
- `BitmapData.draw(anotherBitmapData)` will recognizes cases that are trivial copies and act like `copyPixels()`, and do those on the CPU efficiently too. This means we don't need to sync those draws back, so it can be really fast for games that just use BitmapData as a kind of staging texture.

A side effect of this is that **some** `BitmapData.draw()` will work on backends that don't current support it, as the renderer isn't involved.

I was originally trying to get a `copy_on_gpu` method in here but I hit some walls with that, so this has that stripped out.