### PR TITLE
avm1: Avoid cloning `NativeObject`

### DIFF
--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -449,8 +449,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native() {
-        NativeObject::BevelFilter(bevel_filter) => bevel_filter,
+    let this = match this.native().as_deref() {
+        Some(NativeObject::BevelFilter(bevel_filter)) => *bevel_filter,
         _ => return Ok(Value::Undefined),
     };
 

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -5,7 +5,8 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
 use crate::string::{AvmString, WStr};
-use gc_arena::{Collect, GcCell, MutationContext};
+use gc_arena::{Collect, MutationContext};
+use std::cell::RefCell;
 use swf::Color;
 
 #[derive(Copy, Clone, Debug, Collect)]
@@ -38,9 +39,8 @@ impl From<BevelFilterType> for &'static WStr {
     }
 }
 
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
-pub struct BevelFilterObject {
+#[derive(Clone, Debug)]
+struct BevelFilterData {
     distance: f64,
     // TODO: Introduce `Angle<Radians>` struct.
     angle: f64,
@@ -55,29 +55,7 @@ pub struct BevelFilterObject {
     type_: BevelFilterType,
 }
 
-impl BevelFilterObject {
-    fn new<'gc>(
-        activation: &mut Activation<'_, 'gc>,
-        args: &[Value<'gc>],
-    ) -> Result<GcCell<'gc, Self>, Error<'gc>> {
-        let bevel_filter = GcCell::allocate(activation.context.gc_context, Default::default());
-        bevel_filter.set_distance(activation, args.get(0))?;
-        bevel_filter.set_angle(activation, args.get(1))?;
-        bevel_filter.set_highlight_color(activation, args.get(2))?;
-        bevel_filter.set_highlight_alpha(activation, args.get(3))?;
-        bevel_filter.set_shadow_color(activation, args.get(4))?;
-        bevel_filter.set_shadow_alpha(activation, args.get(5))?;
-        bevel_filter.set_blur_x(activation, args.get(6))?;
-        bevel_filter.set_blur_y(activation, args.get(7))?;
-        bevel_filter.set_strength(activation, args.get(8))?;
-        bevel_filter.set_quality(activation, args.get(9))?;
-        bevel_filter.set_type(activation, args.get(10))?;
-        bevel_filter.set_knockout(activation, args.get(11))?;
-        Ok(bevel_filter)
-    }
-}
-
-impl Default for BevelFilterObject {
+impl Default for BevelFilterData {
     #[allow(clippy::approx_constant)]
     fn default() -> Self {
         Self {
@@ -95,293 +73,217 @@ impl Default for BevelFilterObject {
     }
 }
 
-trait BevelFilterExt<'gc> {
-    fn distance(self) -> f64;
+#[derive(Clone, Debug, Default, Collect)]
+#[collect(require_static)]
+#[repr(transparent)]
+pub struct BevelFilter(Box<RefCell<BevelFilterData>>);
 
-    fn set_distance(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
+impl<'gc> BevelFilter {
+    fn new(activation: &mut Activation<'_, 'gc>, args: &[Value<'gc>]) -> Result<Self, Error<'gc>> {
+        let bevel_filter = Self::default();
+        bevel_filter.set_distance(activation, args.get(0))?;
+        bevel_filter.set_angle(activation, args.get(1))?;
+        bevel_filter.set_highlight_color(activation, args.get(2))?;
+        bevel_filter.set_highlight_alpha(activation, args.get(3))?;
+        bevel_filter.set_shadow_color(activation, args.get(4))?;
+        bevel_filter.set_shadow_alpha(activation, args.get(5))?;
+        bevel_filter.set_blur_x(activation, args.get(6))?;
+        bevel_filter.set_blur_y(activation, args.get(7))?;
+        bevel_filter.set_strength(activation, args.get(8))?;
+        bevel_filter.set_quality(activation, args.get(9))?;
+        bevel_filter.set_type(activation, args.get(10))?;
+        bevel_filter.set_knockout(activation, args.get(11))?;
+        Ok(bevel_filter)
+    }
 
-    fn angle(self) -> f64;
-
-    fn set_angle(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn highlight_color(self) -> i32;
-
-    fn set_highlight_color(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn highlight_alpha(self) -> f64;
-
-    fn set_highlight_alpha(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn shadow_color(self) -> i32;
-
-    fn set_shadow_color(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn shadow_alpha(self) -> f64;
-
-    fn set_shadow_alpha(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn quality(self) -> i32;
-
-    fn set_quality(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn strength(self) -> f64;
-
-    fn set_strength(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn knockout(self) -> bool;
-
-    fn set_knockout(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn blur_x(self) -> f64;
-
-    fn set_blur_x(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn blur_y(self) -> f64;
-
-    fn set_blur_y(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-
-    fn type_(self) -> BevelFilterType;
-
-    fn set_type(
-        self,
-        activation: &mut Activation<'_, 'gc>,
-        value: Option<&Value<'gc>>,
-    ) -> Result<(), Error<'gc>>;
-}
-
-impl<'gc> BevelFilterExt<'gc> for GcCell<'gc, BevelFilterObject> {
-    fn distance(self) -> f64 {
-        self.read().distance
+    fn distance(&self) -> f64 {
+        self.0.borrow().distance
     }
 
     fn set_distance(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let distance = value.coerce_to_f64(activation)?;
-            self.write(activation.context.gc_context).distance = distance;
+            self.0.borrow_mut().distance = distance;
         }
         Ok(())
     }
 
-    fn angle(self) -> f64 {
-        self.read().angle.to_degrees()
+    fn angle(&self) -> f64 {
+        self.0.borrow().angle.to_degrees()
     }
 
     fn set_angle(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let angle = (value.coerce_to_f64(activation)? % 360.0).to_radians();
-            self.write(activation.context.gc_context).angle = angle;
+            self.0.borrow_mut().angle = angle;
         }
         Ok(())
     }
 
-    fn highlight_color(self) -> i32 {
-        self.read().highlight.to_rgb() as i32
+    fn highlight_color(&self) -> i32 {
+        self.0.borrow().highlight.to_rgb() as i32
     }
 
     fn set_highlight_color(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let color = Color::from_rgb(value.coerce_to_u32(activation)?, 0);
-            self.write(activation.context.gc_context).highlight = color;
+            self.0.borrow_mut().highlight = color;
         }
         Ok(())
     }
 
-    fn highlight_alpha(self) -> f64 {
-        f64::from(self.read().highlight.a) / 255.0
+    fn highlight_alpha(&self) -> f64 {
+        f64::from(self.0.borrow().highlight.a) / 255.0
     }
 
     fn set_highlight_alpha(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.write(activation.context.gc_context).highlight.a = alpha;
+            self.0.borrow_mut().highlight.a = alpha;
         }
         Ok(())
     }
 
-    fn shadow_color(self) -> i32 {
-        self.read().shadow.to_rgb() as i32
+    fn shadow_color(&self) -> i32 {
+        self.0.borrow().shadow.to_rgb() as i32
     }
 
     fn set_shadow_color(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let color = Color::from_rgb(value.coerce_to_u32(activation)?, 0);
-            self.write(activation.context.gc_context).shadow = color;
+            self.0.borrow_mut().shadow = color;
         }
         Ok(())
     }
 
-    fn shadow_alpha(self) -> f64 {
-        f64::from(self.read().shadow.a) / 255.0
+    fn shadow_alpha(&self) -> f64 {
+        f64::from(self.0.borrow().shadow.a) / 255.0
     }
 
     fn set_shadow_alpha(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let alpha = (value.coerce_to_f64(activation)? * 255.0) as u8;
-            self.write(activation.context.gc_context).shadow.a = alpha;
+            self.0.borrow_mut().shadow.a = alpha;
         }
         Ok(())
     }
 
-    fn quality(self) -> i32 {
-        self.read().quality
+    fn quality(&self) -> i32 {
+        self.0.borrow().quality
     }
 
     fn set_quality(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let quality = value.coerce_to_i32(activation)?.clamp(0, 15);
-            self.write(activation.context.gc_context).quality = quality;
+            self.0.borrow_mut().quality = quality;
         }
         Ok(())
     }
 
-    fn strength(self) -> f64 {
-        f64::from(self.read().strength) / 256.0
+    fn strength(&self) -> f64 {
+        f64::from(self.0.borrow().strength) / 256.0
     }
 
     fn set_strength(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let strength = ((value.coerce_to_f64(activation)? * 256.0) as u16).clamp(0, 0xFF00);
-            self.write(activation.context.gc_context).strength = strength;
+            self.0.borrow_mut().strength = strength;
         }
         Ok(())
     }
 
-    fn knockout(self) -> bool {
-        self.read().knockout
+    fn knockout(&self) -> bool {
+        self.0.borrow().knockout
     }
 
     fn set_knockout(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let knockout = value.as_bool(activation.swf_version());
-            self.write(activation.context.gc_context).knockout = knockout;
+            self.0.borrow_mut().knockout = knockout;
         }
         Ok(())
     }
 
-    fn blur_x(self) -> f64 {
-        self.read().blur_x
+    fn blur_x(&self) -> f64 {
+        self.0.borrow().blur_x
     }
 
     fn set_blur_x(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_x = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.write(activation.context.gc_context).blur_x = blur_x;
+            self.0.borrow_mut().blur_x = blur_x;
         }
         Ok(())
     }
 
-    fn blur_y(self) -> f64 {
-        self.read().blur_y
+    fn blur_y(&self) -> f64 {
+        self.0.borrow().blur_y
     }
 
     fn set_blur_y(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let blur_y = value.coerce_to_f64(activation)?.clamp(0.0, 255.0);
-            self.write(activation.context.gc_context).blur_y = blur_y;
+            self.0.borrow_mut().blur_y = blur_y;
         }
         Ok(())
     }
 
-    fn type_(self) -> BevelFilterType {
-        self.read().type_
+    fn type_(&self) -> BevelFilterType {
+        self.0.borrow().type_
     }
 
     fn set_type(
-        self,
+        &self,
         activation: &mut Activation<'_, 'gc>,
         value: Option<&Value<'gc>>,
     ) -> Result<(), Error<'gc>> {
         if let Some(value) = value {
             let type_ = value.coerce_to_string(activation)?.as_wstr().into();
-            self.write(activation.context.gc_context).type_ = type_;
+            self.0.borrow_mut().type_ = type_;
         }
         Ok(())
     }
@@ -441,7 +343,7 @@ fn method<'gc>(
     const SET_TYPE: u8 = 24;
 
     if index == CONSTRUCTOR {
-        let bevel_filter = BevelFilterObject::new(activation, args)?;
+        let bevel_filter = BevelFilter::new(activation, args)?;
         this.set_native(
             activation.context.gc_context,
             NativeObject::BevelFilter(bevel_filter),
@@ -449,8 +351,9 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let this = match this.native().as_deref() {
-        Some(NativeObject::BevelFilter(bevel_filter)) => *bevel_filter,
+    let native = this.native();
+    let this = match native.as_deref() {
+        Some(NativeObject::BevelFilter(bevel_filter)) => bevel_filter,
         _ => return Ok(Value::Undefined),
     };
 

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -496,7 +496,7 @@ pub fn draw<'gc>(
             let color_transform = args
                 .get(2)
                 .and_then(|v| ColorTransformObject::cast(*v))
-                .map(|color_transform| color_transform.read().clone().into())
+                .map(|color_transform| color_transform.into())
                 .unwrap_or_default();
 
             let mut blend_mode = BlendMode::Normal;
@@ -619,7 +619,7 @@ pub fn color_transform<'gc>(
                 let y_max = (y + height) as u32;
 
                 let color_transform = match ColorTransformObject::cast(*color_transform) {
-                    Some(color_transform) => color_transform.read().clone(),
+                    Some(color_transform) => color_transform,
                     None => return Ok((-3).into()),
                 };
 

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -24,18 +24,16 @@ pub fn clone<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let native = match this.native() {
-        NativeObject::BlurFilter(blur_filter) => NativeObject::BlurFilter(GcCell::allocate(
-            activation.context.gc_context,
-            blur_filter.read().clone(),
+    let native = match this.native().as_deref() {
+        Some(NativeObject::BlurFilter(blur_filter)) => Some(NativeObject::BlurFilter(
+            GcCell::allocate(activation.context.gc_context, blur_filter.read().clone()),
         )),
-        NativeObject::BevelFilter(bevel_filter) => NativeObject::BevelFilter(GcCell::allocate(
-            activation.context.gc_context,
-            bevel_filter.read().clone(),
+        Some(NativeObject::BevelFilter(bevel_filter)) => Some(NativeObject::BevelFilter(
+            GcCell::allocate(activation.context.gc_context, bevel_filter.read().clone()),
         )),
-        _ => NativeObject::None,
+        _ => None,
     };
-    if !matches!(native, NativeObject::None) {
+    if let Some(native) = native {
         let proto = this.get_local_stored("__proto__", activation);
         let cloned = ScriptObject::new(activation.context.gc_context, None);
         // Set `__proto__` manually since `ScriptObject::new()` doesn't support primitive prototypes.

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Attribute, Object, ScriptObject, TObject, Value};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "clone" => method(clone);
@@ -25,10 +25,9 @@ pub fn clone<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let native = match this.native().as_deref() {
-        Some(native @ NativeObject::BlurFilter(_)) => Some(native.clone()),
-        Some(NativeObject::BevelFilter(bevel_filter)) => Some(NativeObject::BevelFilter(
-            GcCell::allocate(activation.context.gc_context, bevel_filter.read().clone()),
-        )),
+        Some(native @ (NativeObject::BlurFilter(_) | NativeObject::BevelFilter(_))) => {
+            Some(native.clone())
+        }
         _ => None,
     };
     if let Some(native) = native {

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -25,9 +25,7 @@ pub fn clone<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let native = match this.native().as_deref() {
-        Some(NativeObject::BlurFilter(blur_filter)) => Some(NativeObject::BlurFilter(
-            GcCell::allocate(activation.context.gc_context, blur_filter.read().clone()),
-        )),
+        Some(native @ NativeObject::BlurFilter(_)) => Some(native.clone()),
         Some(NativeObject::BevelFilter(bevel_filter)) => Some(NativeObject::BevelFilter(
             GcCell::allocate(activation.context.gc_context, bevel_filter.read().clone()),
         )),

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -59,8 +59,8 @@ fn method<'gc>(
         return Ok(this.into());
     }
 
-    let blur_filter = match this.native() {
-        NativeObject::BlurFilter(blur_filter) => blur_filter,
+    let blur_filter = match this.native().as_deref() {
+        Some(NativeObject::BlurFilter(blur_filter)) => *blur_filter,
         _ => return Ok(Value::Undefined),
     };
 

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -56,8 +56,9 @@ impl<'gc> ColorTransformObject {
 
     pub fn cast(value: Value<'gc>) -> Option<GcCell<'gc, Self>> {
         if let Value::Object(object) = value {
-            if let NativeObject::ColorTransform(color_transform) = object.native() {
-                return Some(color_transform);
+            if let Some(NativeObject::ColorTransform(color_transform)) = object.native().as_deref()
+            {
+                return Some(*color_transform);
             }
         }
         None

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -450,8 +450,8 @@ fn method<'gc>(
         _ => {}
     }
 
-    let date = match this.native() {
-        NativeObject::Date(date) => date,
+    let date = match this.native().as_deref() {
+        Some(NativeObject::Date(date)) => *date,
         _ => return Ok(Value::Undefined),
     };
     let mut date_ref = date.write(activation.context.gc_context);

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -31,7 +31,7 @@ fn get_bytes_loaded<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let NativeObject::NetStream(ns) = this.native() {
+    if let Some(NativeObject::NetStream(ns)) = this.native().as_deref() {
         return Ok(ns.bytes_loaded().into());
     }
 
@@ -43,7 +43,7 @@ fn get_bytes_total<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let NativeObject::NetStream(ns) = this.native() {
+    if let Some(NativeObject::NetStream(ns)) = this.native().as_deref() {
         return Ok(ns.bytes_loaded().into());
     }
 
@@ -55,7 +55,7 @@ fn play<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let NativeObject::NetStream(ns) = this.native() {
+    if let Some(NativeObject::NetStream(ns)) = this.native().as_deref() {
         let name = args
             .get(0)
             .cloned()
@@ -73,7 +73,7 @@ fn pause<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let NativeObject::NetStream(ns) = this.native() {
+    if let Some(NativeObject::NetStream(ns)) = this.native().as_deref() {
         let action = args.get(0).cloned().unwrap_or(Value::Undefined);
         let is_pause = action.as_bool(activation.swf_version());
 

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -84,7 +84,7 @@ fn serialize_value<'gc>(
                 let string = xml_node.into_string(activation).unwrap();
                 Some(AmfValue::XML(string.to_utf8_lossy().into_owned(), true))
             } else if let Some(NativeObject::Date(date)) = o.native().as_deref() {
-                Some(AmfValue::Date(date.read().time(), None))
+                Some(AmfValue::Date(date.borrow().time(), None))
             } else {
                 let mut object_body = Vec::new();
                 recursive_serialize(activation, o, &mut object_body);

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -83,7 +83,7 @@ fn serialize_value<'gc>(
                 // TODO: What happens if an exception is thrown here?
                 let string = xml_node.into_string(activation).unwrap();
                 Some(AmfValue::XML(string.to_utf8_lossy().into_owned(), true))
-            } else if let NativeObject::Date(date) = o.native() {
+            } else if let Some(NativeObject::Date(date)) = o.native().as_deref() {
                 Some(AmfValue::Date(date.read().time(), None))
             } else {
                 let mut object_body = Vec::new();

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -7,7 +7,7 @@ use crate::display_object::{AutoSizeMode, EditText, TDisplayObject, TextSelectio
 use crate::font::round_down_to_pixel;
 use crate::html::TextFormat;
 use crate::string::{AvmString, WStr};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::MutationContext;
 use swf::Color;
 
 macro_rules! tf_method {
@@ -134,7 +134,7 @@ fn new_text_format<'gc>(
     let object = ScriptObject::new(activation.context.gc_context, Some(proto));
     object.set_native(
         activation.context.gc_context,
-        NativeObject::TextFormat(GcCell::allocate(activation.context.gc_context, text_format)),
+        NativeObject::TextFormat(Box::new(text_format.into())),
     );
     object
 }
@@ -155,7 +155,7 @@ fn set_new_text_format<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let [Value::Object(text_format), ..] = args {
         if let Some(NativeObject::TextFormat(text_format)) = text_format.native().as_deref() {
-            text_field.set_new_text_format(text_format.read().clone(), &mut activation.context);
+            text_field.set_new_text_format(text_format.borrow().clone(), &mut activation.context);
         }
     }
 
@@ -218,7 +218,7 @@ fn set_text_format<'gc>(
             text_field.set_text_format(
                 begin_index,
                 end_index,
-                text_format.read().clone(),
+                text_format.borrow().clone(),
                 &mut activation.context,
             );
         }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -154,7 +154,7 @@ fn set_new_text_format<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let [Value::Object(text_format), ..] = args {
-        if let NativeObject::TextFormat(text_format) = text_format.native() {
+        if let Some(NativeObject::TextFormat(text_format)) = text_format.native().as_deref() {
             text_field.set_new_text_format(text_format.read().clone(), &mut activation.context);
         }
     }
@@ -214,7 +214,7 @@ fn set_text_format<'gc>(
     };
 
     if let Value::Object(text_format) = text_format {
-        if let NativeObject::TextFormat(text_format) = text_format.native() {
+        if let Some(NativeObject::TextFormat(text_format)) = text_format.native().as_deref() {
             text_field.set_text_format(
                 begin_index,
                 end_index,

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -13,7 +13,7 @@ use gc_arena::{GcCell, MutationContext};
 macro_rules! getter {
     ($name:ident) => {
         |activation, this, _args| {
-            if let NativeObject::TextFormat(text_format) = this.native() {
+            if let Some(NativeObject::TextFormat(text_format)) = this.native().as_deref() {
                 return Ok($name(activation, &text_format.read()));
             }
             Ok(Value::Undefined)
@@ -24,7 +24,7 @@ macro_rules! getter {
 macro_rules! setter {
     ($name:ident) => {
         |activation, this, args| {
-            if let NativeObject::TextFormat(text_format) = this.native() {
+            if let Some(NativeObject::TextFormat(text_format)) = this.native().as_deref() {
                 let value = args.get(0).unwrap_or(&Value::Undefined);
                 $name(
                     activation,
@@ -40,7 +40,7 @@ macro_rules! setter {
 macro_rules! method {
     ($name:ident) => {
         |activation, this, args| {
-            if let NativeObject::TextFormat(text_format) = this.native() {
+            if let Some(NativeObject::TextFormat(text_format)) = this.native().as_deref() {
                 return $name(activation, &text_format.read(), args);
             }
             Ok(Value::Undefined)

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -126,10 +126,7 @@ fn set_color_transform<'gc>(
 ) -> Result<(), Error<'gc>> {
     // Set only occurs for an object with actual ColorTransform data.
     if let Some(color_transform) = ColorTransformObject::cast(value) {
-        clip.set_color_transform(
-            activation.context.gc_context,
-            color_transform.read().clone().into(),
-        );
+        clip.set_color_transform(activation.context.gc_context, color_transform.into());
         clip.set_transformed_by_script(activation.context.gc_context, true);
     }
 

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -46,8 +46,8 @@ pub fn attach_video<'gc>(
         .unwrap_or(Value::Undefined)
         .coerce_to_object(activation);
 
-    if let NativeObject::NetStream(ns) = source.native() {
-        video.attach_netstream(&mut activation.context, ns);
+    if let Some(NativeObject::NetStream(ns)) = source.native().as_deref() {
+        video.attach_netstream(&mut activation.context, *ns);
     } else {
         tracing::warn!("Cannot use object of type {:?} as video source", source);
     }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -29,7 +29,7 @@ use crate::string::AvmString;
 use crate::xml::XmlNode;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_macros::enum_trait_object;
-use std::cell::Ref;
+use std::cell::{Ref, RefCell};
 use std::fmt::Debug;
 
 pub mod array_object;
@@ -55,7 +55,7 @@ pub mod xml_object;
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum NativeObject<'gc> {
-    Date(GcCell<'gc, Date>),
+    Date(Box<RefCell<Date>>),
     BlurFilter(GcCell<'gc, BlurFilterObject>),
     BevelFilter(GcCell<'gc, BevelFilterObject>),
     ColorTransform(GcCell<'gc, ColorTransformObject>),

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -1,7 +1,7 @@
 //! Object trait to expose objects to AVM
 
 use crate::avm1::function::{Executable, ExecutionName, ExecutionReason, FunctionObject};
-use crate::avm1::globals::bevel_filter::BevelFilterObject;
+use crate::avm1::globals::bevel_filter::BevelFilter;
 use crate::avm1::globals::blur_filter::BlurFilter;
 use crate::avm1::globals::color_transform::ColorTransformObject;
 use crate::avm1::globals::date::Date;
@@ -27,7 +27,7 @@ use crate::html::TextFormat;
 use crate::streams::NetStream;
 use crate::string::AvmString;
 use crate::xml::XmlNode;
-use gc_arena::{Collect, GcCell, MutationContext};
+use gc_arena::{Collect, MutationContext};
 use ruffle_macros::enum_trait_object;
 use std::cell::{Ref, RefCell};
 use std::fmt::Debug;
@@ -57,7 +57,7 @@ pub mod xml_object;
 pub enum NativeObject<'gc> {
     Date(Box<RefCell<Date>>),
     BlurFilter(BlurFilter),
-    BevelFilter(GcCell<'gc, BevelFilterObject>),
+    BevelFilter(BevelFilter),
     ColorTransform(Box<RefCell<ColorTransformObject>>),
     TextFormat(Box<RefCell<TextFormat>>),
     NetStream(NetStream<'gc>),

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -2,7 +2,7 @@
 
 use crate::avm1::function::{Executable, ExecutionName, ExecutionReason, FunctionObject};
 use crate::avm1::globals::bevel_filter::BevelFilterObject;
-use crate::avm1::globals::blur_filter::BlurFilterObject;
+use crate::avm1::globals::blur_filter::BlurFilter;
 use crate::avm1::globals::color_transform::ColorTransformObject;
 use crate::avm1::globals::date::Date;
 use crate::avm1::object::array_object::ArrayObject;
@@ -56,7 +56,7 @@ pub mod xml_object;
 #[collect(no_drop)]
 pub enum NativeObject<'gc> {
     Date(Box<RefCell<Date>>),
-    BlurFilter(GcCell<'gc, BlurFilterObject>),
+    BlurFilter(BlurFilter),
     BevelFilter(GcCell<'gc, BevelFilterObject>),
     ColorTransform(Box<RefCell<ColorTransformObject>>),
     TextFormat(Box<RefCell<TextFormat>>),

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -58,7 +58,7 @@ pub enum NativeObject<'gc> {
     Date(Box<RefCell<Date>>),
     BlurFilter(GcCell<'gc, BlurFilterObject>),
     BevelFilter(GcCell<'gc, BevelFilterObject>),
-    ColorTransform(GcCell<'gc, ColorTransformObject>),
+    ColorTransform(Box<RefCell<ColorTransformObject>>),
     TextFormat(Box<RefCell<TextFormat>>),
     NetStream(NetStream<'gc>),
 }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -59,7 +59,7 @@ pub enum NativeObject<'gc> {
     BlurFilter(GcCell<'gc, BlurFilterObject>),
     BevelFilter(GcCell<'gc, BevelFilterObject>),
     ColorTransform(GcCell<'gc, ColorTransformObject>),
-    TextFormat(GcCell<'gc, TextFormat>),
+    TextFormat(Box<RefCell<TextFormat>>),
     NetStream(NetStream<'gc>),
 }
 

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -29,6 +29,7 @@ use crate::string::AvmString;
 use crate::xml::XmlNode;
 use gc_arena::{Collect, GcCell, MutationContext};
 use ruffle_macros::enum_trait_object;
+use std::cell::Ref;
 use std::fmt::Debug;
 
 pub mod array_object;
@@ -54,7 +55,6 @@ pub mod xml_object;
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
 pub enum NativeObject<'gc> {
-    None,
     Date(GcCell<'gc, Date>),
     BlurFilter(GcCell<'gc, BlurFilterObject>),
     BevelFilter(GcCell<'gc, BevelFilterObject>),
@@ -549,8 +549,8 @@ pub trait TObject<'gc>: 'gc + Collect + Into<Object<'gc>> + Clone + Copy {
         Ok(false)
     }
 
-    fn native(&self) -> NativeObject<'gc> {
-        NativeObject::None
+    fn native(&self) -> Option<Ref<NativeObject<'gc>>> {
+        None
     }
 
     fn set_native(&self, _gc_context: MutationContext<'gc, '_>, _native: NativeObject<'gc>) {}

--- a/core/src/avm1/object/script_object.rs
+++ b/core/src/avm1/object/script_object.rs
@@ -8,6 +8,7 @@ use crate::avm1::{Object, ObjectPtr, TObject, Value};
 use crate::string::AvmString;
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
+use std::cell::Ref;
 
 #[derive(Clone, Collect)]
 #[collect(no_drop)]
@@ -53,7 +54,7 @@ pub struct ScriptObject<'gc>(GcCell<'gc, ScriptObjectData<'gc>>);
 #[derive(Collect)]
 #[collect(no_drop)]
 pub struct ScriptObjectData<'gc> {
-    native: NativeObject<'gc>,
+    native: Option<NativeObject<'gc>>,
     properties: PropertyMap<'gc, Property<'gc>>,
     interfaces: Vec<Object<'gc>>,
     watchers: PropertyMap<'gc, Watcher<'gc>>,
@@ -72,7 +73,7 @@ impl<'gc> ScriptObject<'gc> {
         let object = Self(GcCell::allocate(
             gc_context,
             ScriptObjectData {
-                native: NativeObject::None,
+                native: None,
                 properties: PropertyMap::new(),
                 interfaces: vec![],
                 watchers: PropertyMap::new(),
@@ -479,18 +480,14 @@ impl<'gc> TObject<'gc> for ScriptObject<'gc> {
         self.0.write(gc_context).interfaces = iface_list;
     }
 
-    fn native(&self) -> NativeObject<'gc> {
-        self.0.read().native.clone()
+    fn native(&self) -> Option<Ref<NativeObject<'gc>>> {
+        Ref::filter_map(self.0.read(), |o| o.native.as_ref()).ok()
     }
 
     fn set_native(&self, gc_context: MutationContext<'gc, '_>, native: NativeObject<'gc>) {
         // Native object should be introduced at most once.
-        debug_assert!(matches!(self.0.read().native, NativeObject::None));
-
-        // Native object must not be `None`.
-        debug_assert!(!matches!(native, NativeObject::None));
-
-        self.0.write(gc_context).native = native;
+        debug_assert!(self.0.read().native.is_none());
+        self.0.write(gc_context).native = Some(native);
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -210,7 +210,7 @@ impl<'gc> Value<'gc> {
     ) -> Result<Value<'gc>, Error<'gc>> {
         let result = match self {
             Value::Object(object) => {
-                let is_date = matches!(object.native(), NativeObject::Date(_));
+                let is_date = matches!(object.native().as_deref(), Some(NativeObject::Date(_)));
                 let val = if activation.swf_version() > 5 && is_date {
                     // In SWFv6 and higher, Date objects call `toString`.
                     object.call_method(


### PR DESCRIPTION
Previously `TObject::native` used to clone the underlying `NativeObject` each time, which prevented it from being mutated. This was worked-around by wrapping the various `NativeObject` variants with an extra `GcCell`, which provides an additional layer of 
 interior mutability.

To avoid this unnecessary complexity, make `TObject::native` return an `Option<Ref<NativeObject<'gc>>>`, without cloning the 
 underlying `NativeObject`. This allows replacing said `GcCell`s with `Box<RefCell<T>>`.