### PR TITLE
core: Add frame rate config option

### DIFF
--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -236,8 +236,10 @@ pub fn set_frame_rate<'gc>(
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let new_frame_rate = args.get_f64(activation, 0)?;
-    *activation.context.frame_rate = new_frame_rate;
+    if !activation.context.forced_frame_rate {
+        let new_frame_rate = args.get_f64(activation, 0)?;
+        *activation.context.frame_rate = new_frame_rate;
+    }
 
     Ok(Value::Undefined)
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -177,6 +177,9 @@ pub struct UpdateContext<'a, 'gc> {
     /// The current stage frame rate.
     pub frame_rate: &'a mut f64,
 
+    /// Whether movies are prevented from changing the stage frame rate.
+    pub forced_frame_rate: bool,
+
     /// Amount of actions performed since the last timeout check
     pub actions_since_timeout_check: &'a mut u16,
 
@@ -338,6 +341,7 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
             times_get_time_called: self.times_get_time_called,
             time_offset: self.time_offset,
             frame_rate: self.frame_rate,
+            forced_frame_rate: self.forced_frame_rate,
             actions_since_timeout_check: self.actions_since_timeout_check,
             frame_phase: self.frame_phase,
             stream_manager: self.stream_manager,

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -150,6 +150,10 @@ struct Opt {
     /// The version of the player to emulate
     #[clap(long)]
     player_version: Option<u8>,
+
+    /// Set and lock the player's frame rate, overriding the movie's frame rate.
+    #[clap(long)]
+    frame_rate: Option<f64>,
 }
 
 #[cfg(feature = "render_trace")]
@@ -356,7 +360,8 @@ impl App {
             .with_fullscreen(opt.fullscreen)
             .with_load_behavior(opt.load_behavior)
             .with_spoofed_url(opt.spoof_url.clone().map(|url| url.to_string()))
-            .with_player_version(opt.player_version);
+            .with_player_version(opt.player_version)
+            .with_frame_rate(opt.frame_rate);
 
         let player = builder.build();
 

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -30,6 +30,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     quality: "high",
     scale: "showAll",
     forceScale: false,
+    frameRate: null,
     wmode: WindowMode.Opaque,
     publicPath: null,
     polyfills: true,

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -301,6 +301,13 @@ export interface BaseLoadOptions {
     forceScale?: boolean;
 
     /**
+     * Sets and locks the player's frame rate, overriding the movie's frame rate.
+     *
+     * @default null
+     */
+    frameRate?: number | null;
+
+    /**
      * The window mode of the Ruffle player.
      *
      * This setting controls how the Ruffle container is layered and rendered with other content on the page.

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -158,6 +158,8 @@ struct Config {
 
     force_scale: bool,
 
+    frame_rate: Option<f64>,
+
     wmode: Option<String>,
 
     warn_on_unsupported_content: bool,
@@ -565,6 +567,7 @@ impl Ruffle {
                     .unwrap_or(StageScaleMode::ShowAll),
                 config.force_scale,
             )
+            .with_frame_rate(config.frame_rate)
             // FIXME - should this be configurable?
             .with_sandbox_type(SandboxType::Remote)
             .build();


### PR DESCRIPTION
Implements the feature described in and closes #3276.
Provides an easy workaround for #9325.