### PR TITLE
String interning MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,15 +1611,16 @@ dependencies = [
 [[package]]
 name = "gc-arena"
 version = "0.2.2"
-source = "git+https://github.com/kyren/gc-arena?rev=1a6310c0d5c98836fa9efb1c4773038ecfd5a92e#1a6310c0d5c98836fa9efb1c4773038ecfd5a92e"
+source = "git+https://github.com/kyren/gc-arena?rev=fcc8764362d25f8724912dd7f09f2405779ec053#fcc8764362d25f8724912dd7f09f2405779ec053"
 dependencies = [
  "gc-arena-derive",
+ "sptr",
 ]
 
 [[package]]
 name = "gc-arena-derive"
 version = "0.2.2"
-source = "git+https://github.com/kyren/gc-arena?rev=1a6310c0d5c98836fa9efb1c4773038ecfd5a92e#1a6310c0d5c98836fa9efb1c4773038ecfd5a92e"
+source = "git+https://github.com/kyren/gc-arena?rev=fcc8764362d25f8724912dd7f09f2405779ec053#fcc8764362d25f8724912dd7f09f2405779ec053"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3458,6 +3459,7 @@ dependencies = [
  "futures",
  "gc-arena",
  "generational-arena",
+ "hashbrown 0.13.2",
  "indexmap",
  "instant",
  "linkme",
@@ -3475,6 +3477,7 @@ dependencies = [
  "ruffle_render",
  "ruffle_video",
  "ruffle_wstr",
+ "scopeguard",
  "serde",
  "serde_json",
  "smallvec",
@@ -4035,6 +4038,12 @@ dependencies = [
  "bitflags 1.3.2",
  "num-traits",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ repository = "https://github.com/ruffle-rs/ruffle"
 version = "0.1.0"
 
 [workspace.dependencies]
-gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "1a6310c0d5c98836fa9efb1c4773038ecfd5a92e" }
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "fcc8764362d25f8724912dd7f09f2405779ec053" }
 
 # Don't optimize build scripts and macros.
 [profile.release.build-override]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ gc-arena = { workspace = true }
 generational-arena = "0.2.8"
 indexmap = "1.9.3"
 tracing = "0.1.37"
-ruffle_render = { path = "../render" }
+ruffle_render = { path = "../render", features = ["tessellator"] }
 ruffle_video = { path = "../video" }
 ruffle_macros = { path = "macros" }
 ruffle_wstr = { path = "../wstr" }
@@ -49,6 +49,8 @@ bytemuck = "1.13.1"
 clap = { version = "4.2.4", features = ["derive"], optional=true }
 realfft = "3.2.0"
 once_cell = "1.17.1"
+hashbrown = { version = "0.13.2", features = ["raw"] }
+scopeguard = "1.1.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.28"

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -861,14 +861,20 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         &mut self,
         action: ConstantPool,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        self.context.avm1.set_constant_pool(Gc::allocate(
-            self.context.gc_context,
-            action
-                .strings
-                .iter()
-                .map(|s| AvmString::new(self.context.gc_context, s.decode(self.encoding())).into())
-                .collect(),
-        ));
+        let constants = action
+            .strings
+            .iter()
+            .map(|s| {
+                self.context
+                    .interner
+                    .intern_wstr(self.context.gc_context, s.decode(self.encoding()))
+                    .into()
+            })
+            .collect();
+
+        self.context
+            .avm1
+            .set_constant_pool(Gc::allocate(self.context.gc_context, constants));
         self.set_constant_pool(self.context.avm1.constant_pool());
 
         Ok(FrameControl::Continue)

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -4,10 +4,10 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::display_object::{DisplayObject, TDisplayObject, TDisplayObjectContainer};
 use crate::string::{AvmString, WStr, WString};
 use gc_arena::Collect;
-use gc_arena::MutationContext;
 use std::str;
 
 mod accessibility;
@@ -516,12 +516,14 @@ pub struct SystemPrototypes<'gc> {
 
 /// Initialize default global scope and builtins for an AVM1 instance.
 pub fn create_globals<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
 ) -> (
     SystemPrototypes<'gc>,
     Object<'gc>,
     as_broadcaster::BroadcasterFunctions<'gc>,
 ) {
+    let gc_context = context.gc_context;
+
     let object_proto = ScriptObject::new(gc_context, None).into();
     let function_proto = function::create_proto(gc_context, object_proto);
 
@@ -1188,7 +1190,7 @@ mod tests {
     use super::*;
 
     fn setup<'gc>(activation: &mut Activation<'_, 'gc>) -> Object<'gc> {
-        create_globals(activation.context.gc_context).1
+        create_globals(&mut activation.context.borrow_gc()).1
     }
 
     test_method!(boolean_function, "Boolean", setup,

--- a/core/src/avm1/globals.rs
+++ b/core/src/avm1/globals.rs
@@ -525,49 +525,49 @@ pub fn create_globals<'gc>(
     let gc_context = context.gc_context;
 
     let object_proto = ScriptObject::new(gc_context, None).into();
-    let function_proto = function::create_proto(gc_context, object_proto);
+    let function_proto = function::create_proto(context, object_proto);
 
-    object::fill_proto(gc_context, object_proto, function_proto);
+    object::fill_proto(context, object_proto, function_proto);
 
-    let button_proto = button::create_proto(gc_context, object_proto, function_proto);
+    let button_proto = button::create_proto(context, object_proto, function_proto);
 
-    let movie_clip_proto = movie_clip::create_proto(gc_context, object_proto, function_proto);
+    let movie_clip_proto = movie_clip::create_proto(context, object_proto, function_proto);
 
-    let sound_proto = sound::create_proto(gc_context, object_proto, function_proto);
+    let sound_proto = sound::create_proto(context, object_proto, function_proto);
 
-    let text_field_proto = text_field::create_proto(gc_context, object_proto, function_proto);
-    let text_format_proto = text_format::create_proto(gc_context, object_proto, function_proto);
+    let text_field_proto = text_field::create_proto(context, object_proto, function_proto);
+    let text_format_proto = text_format::create_proto(context, object_proto, function_proto);
 
-    let array_proto = array::create_proto(gc_context, object_proto, function_proto);
+    let array_proto = array::create_proto(context, object_proto, function_proto);
 
-    let color_proto = color::create_proto(gc_context, object_proto, function_proto);
+    let color_proto = color::create_proto(context, object_proto, function_proto);
 
-    let error_proto = error::create_proto(gc_context, object_proto, function_proto);
+    let error_proto = error::create_proto(context, object_proto, function_proto);
 
-    let xmlnode_proto = xml_node::create_proto(gc_context, object_proto, function_proto);
+    let xmlnode_proto = xml_node::create_proto(context, object_proto, function_proto);
 
-    let xml_proto = xml::create_proto(gc_context, xmlnode_proto, function_proto);
+    let xml_proto = xml::create_proto(context, xmlnode_proto, function_proto);
 
-    let string_proto = string::create_proto(gc_context, object_proto, function_proto);
-    let number_proto = number::create_proto(gc_context, object_proto, function_proto);
-    let boolean_proto = boolean::create_proto(gc_context, object_proto, function_proto);
-    let load_vars_proto = load_vars::create_proto(gc_context, object_proto, function_proto);
+    let string_proto = string::create_proto(context, object_proto, function_proto);
+    let number_proto = number::create_proto(context, object_proto, function_proto);
+    let boolean_proto = boolean::create_proto(context, object_proto, function_proto);
+    let load_vars_proto = load_vars::create_proto(context, object_proto, function_proto);
     let local_connection_proto =
-        local_connection::create_proto(gc_context, object_proto, function_proto);
-    let matrix_proto = matrix::create_proto(gc_context, object_proto, function_proto);
-    let point_proto = point::create_proto(gc_context, object_proto, function_proto);
-    let rectangle_proto = rectangle::create_proto(gc_context, object_proto, function_proto);
+        local_connection::create_proto(context, object_proto, function_proto);
+    let matrix_proto = matrix::create_proto(context, object_proto, function_proto);
+    let point_proto = point::create_proto(context, object_proto, function_proto);
+    let rectangle_proto = rectangle::create_proto(context, object_proto, function_proto);
     let color_transform_proto =
-        color_transform::create_proto(gc_context, object_proto, function_proto);
-    let transform_proto = transform::create_proto(gc_context, object_proto, function_proto);
-    let external_interface_proto = external_interface::create_proto(gc_context, object_proto);
-    let selection_proto = selection::create_proto(gc_context, object_proto);
+        color_transform::create_proto(context, object_proto, function_proto);
+    let transform_proto = transform::create_proto(context, object_proto, function_proto);
+    let external_interface_proto = external_interface::create_proto(context, object_proto);
+    let selection_proto = selection::create_proto(context, object_proto);
 
     let (broadcaster_functions, as_broadcaster) =
-        as_broadcaster::create(gc_context, object_proto, function_proto);
+        as_broadcaster::create(context, object_proto, function_proto);
 
     let movie_clip_loader_proto = movie_clip_loader::create_proto(
-        gc_context,
+        context,
         object_proto,
         function_proto,
         array_proto,
@@ -582,15 +582,15 @@ pub fn create_globals<'gc>(
         movie_clip_loader_proto,
     );
 
-    let video_proto = video::create_proto(gc_context, object_proto, function_proto);
-    let netstream_proto = netstream::create_proto(gc_context, object_proto, function_proto);
+    let video_proto = video::create_proto(context, object_proto, function_proto);
+    let netstream_proto = netstream::create_proto(context, object_proto, function_proto);
 
     //TODO: These need to be constructors and should also set `.prototype` on each one
-    let object = object::create_object_object(gc_context, object_proto, function_proto);
+    let object = object::create_object_object(context, object_proto, function_proto);
 
-    let context_menu_proto = context_menu::create_proto(gc_context, object_proto, function_proto);
+    let context_menu_proto = context_menu::create_proto(context, object_proto, function_proto);
     let context_menu_item_proto =
-        context_menu_item::create_proto(gc_context, object_proto, function_proto);
+        context_menu_item::create_proto(context, object_proto, function_proto);
 
     let button = FunctionObject::constructor(
         gc_context,
@@ -663,7 +663,7 @@ pub fn create_globals<'gc>(
         function_proto,
         text_format_proto,
     );
-    let array = array::create_array_object(gc_context, array_proto, function_proto);
+    let array = array::create_array_object(context, array_proto, function_proto);
     let xmlnode = FunctionObject::constructor(
         gc_context,
         Executable::Native(xml_node::constructor),
@@ -678,11 +678,11 @@ pub fn create_globals<'gc>(
         function_proto,
         xml_proto,
     );
-    let string = string::create_string_object(gc_context, string_proto, function_proto);
-    let number = number::create_number_object(gc_context, number_proto, function_proto);
-    let boolean = boolean::create_boolean_object(gc_context, boolean_proto, function_proto);
-    let date = date::create_constructor(gc_context, object_proto, function_proto);
-    let netstream = netstream::create_class(gc_context, netstream_proto, function_proto);
+    let string = string::create_string_object(context, string_proto, function_proto);
+    let number = number::create_number_object(context, number_proto, function_proto);
+    let boolean = boolean::create_boolean_object(context, boolean_proto, function_proto);
+    let date = date::create_constructor(context, object_proto, function_proto);
+    let netstream = netstream::create_class(context, netstream_proto, function_proto);
 
     let flash = ScriptObject::new(gc_context, Some(object_proto));
 
@@ -690,9 +690,9 @@ pub fn create_globals<'gc>(
     let filters = ScriptObject::new(gc_context, Some(object_proto));
     let display = ScriptObject::new(gc_context, Some(object_proto));
 
-    let matrix = matrix::create_matrix_object(gc_context, matrix_proto, function_proto);
-    let point = point::create_point_object(gc_context, point_proto, function_proto);
-    let rectangle = rectangle::create_rectangle_object(gc_context, rectangle_proto, function_proto);
+    let matrix = matrix::create_matrix_object(context, matrix_proto, function_proto);
+    let point = point::create_point_object(context, point_proto, function_proto);
+    let rectangle = rectangle::create_rectangle_object(context, rectangle_proto, function_proto);
     let color_transform = FunctionObject::constructor(
         gc_context,
         Executable::Native(color_transform::constructor),
@@ -739,7 +739,7 @@ pub fn create_globals<'gc>(
         Attribute::empty(),
     );
 
-    let bitmap_filter_proto = bitmap_filter::create_proto(gc_context, object_proto, function_proto);
+    let bitmap_filter_proto = bitmap_filter::create_proto(context, object_proto, function_proto);
     let bitmap_filter = FunctionObject::constructor(
         gc_context,
         Executable::Native(bitmap_filter::constructor),
@@ -748,23 +748,21 @@ pub fn create_globals<'gc>(
         bitmap_filter_proto,
     );
 
-    let blur_filter =
-        blur_filter::create_constructor(gc_context, bitmap_filter_proto, function_proto);
+    let blur_filter = blur_filter::create_constructor(context, bitmap_filter_proto, function_proto);
 
     let bevel_filter =
-        bevel_filter::create_constructor(gc_context, bitmap_filter_proto, function_proto);
+        bevel_filter::create_constructor(context, bitmap_filter_proto, function_proto);
 
-    let glow_filter =
-        glow_filter::create_constructor(gc_context, bitmap_filter_proto, function_proto);
+    let glow_filter = glow_filter::create_constructor(context, bitmap_filter_proto, function_proto);
 
     let drop_shadow_filter =
-        drop_shadow_filter::create_constructor(gc_context, bitmap_filter_proto, function_proto);
+        drop_shadow_filter::create_constructor(context, bitmap_filter_proto, function_proto);
 
     let color_matrix_filter =
-        color_matrix_filter::create_constructor(gc_context, bitmap_filter_proto, function_proto);
+        color_matrix_filter::create_constructor(context, bitmap_filter_proto, function_proto);
 
     let displacement_map_filter_proto =
-        displacement_map_filter::create_proto(gc_context, bitmap_filter_proto, function_proto);
+        displacement_map_filter::create_proto(context, bitmap_filter_proto, function_proto);
     let displacement_map_filter = FunctionObject::constructor(
         gc_context,
         Executable::Native(displacement_map_filter::constructor),
@@ -774,7 +772,7 @@ pub fn create_globals<'gc>(
     );
 
     let convolution_filter_proto =
-        convolution_filter::create_proto(gc_context, bitmap_filter_proto, function_proto);
+        convolution_filter::create_proto(context, bitmap_filter_proto, function_proto);
     let convolution_filter = FunctionObject::constructor(
         gc_context,
         Executable::Native(convolution_filter::constructor),
@@ -784,7 +782,7 @@ pub fn create_globals<'gc>(
     );
 
     let gradient_bevel_filter_proto =
-        gradient_bevel_filter::create_proto(gc_context, bitmap_filter_proto, function_proto);
+        gradient_bevel_filter::create_proto(context, bitmap_filter_proto, function_proto);
     let gradient_bevel_filter = FunctionObject::constructor(
         gc_context,
         Executable::Native(gradient_bevel_filter::constructor),
@@ -794,7 +792,7 @@ pub fn create_globals<'gc>(
     );
 
     let gradient_glow_filter_proto =
-        gradient_glow_filter::create_proto(gc_context, bitmap_filter_proto, function_proto);
+        gradient_glow_filter::create_proto(context, bitmap_filter_proto, function_proto);
     let gradient_glow_filter = FunctionObject::constructor(
         gc_context,
         Executable::Native(gradient_glow_filter::constructor),
@@ -865,9 +863,9 @@ pub fn create_globals<'gc>(
         Attribute::empty(),
     );
 
-    let bitmap_data_proto = bitmap_data::create_proto(gc_context, object_proto, function_proto);
+    let bitmap_data_proto = bitmap_data::create_proto(context, object_proto, function_proto);
     let bitmap_data =
-        bitmap_data::create_bitmap_data_object(gc_context, bitmap_data_proto, function_proto);
+        bitmap_data::create_bitmap_data_object(context, bitmap_data_proto, function_proto);
 
     display.define_value(
         gc_context,
@@ -878,7 +876,7 @@ pub fn create_globals<'gc>(
 
     let external = ScriptObject::new(gc_context, Some(object_proto));
     let external_interface = external_interface::create_external_interface_object(
-        gc_context,
+        context,
         external_interface_proto,
         function_proto,
     );
@@ -954,10 +952,10 @@ pub fn create_globals<'gc>(
     globals.define_value(gc_context, "Boolean", boolean.into(), Attribute::DONT_ENUM);
     globals.define_value(gc_context, "Date", date.into(), Attribute::DONT_ENUM);
 
-    let shared_object_proto = shared_object::create_proto(gc_context, object_proto, function_proto);
+    let shared_object_proto = shared_object::create_proto(context, object_proto, function_proto);
 
     let shared_obj =
-        shared_object::create_shared_object_object(gc_context, shared_object_proto, function_proto);
+        shared_object::create_shared_object_object(context, shared_object_proto, function_proto);
     globals.define_value(
         gc_context,
         "SharedObject",
@@ -980,7 +978,7 @@ pub fn create_globals<'gc>(
     );
 
     let selection = selection::create_selection_object(
-        gc_context,
+        context,
         selection_proto,
         function_proto,
         broadcaster_functions,
@@ -1007,10 +1005,10 @@ pub fn create_globals<'gc>(
         Attribute::DONT_ENUM,
     );
 
-    let system_security = system_security::create(gc_context, object_proto, function_proto);
-    let system_capabilities = system_capabilities::create(gc_context, object_proto, function_proto);
+    let system_security = system_security::create(context, object_proto, function_proto);
+    let system_capabilities = system_capabilities::create(context, object_proto, function_proto);
     let system_ime = system_ime::create(
-        gc_context,
+        context,
         object_proto,
         function_proto,
         broadcaster_functions,
@@ -1018,7 +1016,7 @@ pub fn create_globals<'gc>(
     );
 
     let system = system::create(
-        gc_context,
+        context,
         object_proto,
         function_proto,
         system_security,
@@ -1030,14 +1028,14 @@ pub fn create_globals<'gc>(
     globals.define_value(
         gc_context,
         "Math",
-        Value::Object(math::create(gc_context, object_proto, function_proto)),
+        Value::Object(math::create(context, object_proto, function_proto)),
         Attribute::DONT_ENUM,
     );
     globals.define_value(
         gc_context,
         "Mouse",
         Value::Object(mouse::create_mouse_object(
-            gc_context,
+            context,
             object_proto,
             function_proto,
             broadcaster_functions,
@@ -1049,7 +1047,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "Key",
         Value::Object(key::create_key_object(
-            gc_context,
+            context,
             object_proto,
             function_proto,
             broadcaster_functions,
@@ -1061,7 +1059,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "Stage",
         Value::Object(stage::create_stage_object(
-            gc_context,
+            context,
             object_proto,
             array_proto,
             function_proto,
@@ -1073,7 +1071,7 @@ pub fn create_globals<'gc>(
         gc_context,
         "Accessibility",
         Value::Object(accessibility::create_accessibility_object(
-            gc_context,
+            context,
             object_proto,
             function_proto,
         )),
@@ -1086,7 +1084,7 @@ pub fn create_globals<'gc>(
         Attribute::DONT_ENUM,
     );
 
-    define_properties_on(GLOBAL_DECLS, gc_context, globals, function_proto);
+    define_properties_on(GLOBAL_DECLS, context, globals, function_proto);
 
     (
         SystemPrototypes {

--- a/core/src/avm1/globals/accessibility.rs
+++ b/core/src/avm1/globals/accessibility.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
 use crate::avm1_stub;
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "isActive" => method(is_active; DONT_DELETE | READ_ONLY);
@@ -41,11 +41,11 @@ pub fn update_properties<'gc>(
 }
 
 pub fn create_accessibility_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let accessibility = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(OBJECT_DECLS, gc_context, accessibility, fn_proto);
+    let accessibility = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(OBJECT_DECLS, context, accessibility, fn_proto);
     accessibility.into()
 }

--- a/core/src/avm1/globals/array.rs
+++ b/core/src/avm1/globals/array.rs
@@ -6,10 +6,10 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
+use crate::context::GcContext;
 use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::string::AvmString;
 use bitflags::bitflags;
-use gc_arena::MutationContext;
 use std::cmp::Ordering;
 
 bitflags! {
@@ -62,12 +62,12 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_array_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     array_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let array = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         Executable::Native(constructor),
         fn_proto,
@@ -78,7 +78,7 @@ pub fn create_array_object<'gc>(
     // TODO: These were added in Flash Player 7, but are available even to SWFv6 and lower
     // when run in Flash Player 7. Make these conditional if we add a parameter to control
     // target Flash Player version.
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     array
 }
 
@@ -743,12 +743,12 @@ fn qsort<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let array = ArrayObject::empty_with_proto(gc_context, proto);
+    let array = ArrayObject::empty_with_proto(context.gc_context, proto);
     let object = array.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/bevel_filter.rs
+++ b/core/src/avm1/globals/bevel_filter.rs
@@ -4,6 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::{AvmString, WStr};
 use gc_arena::{Collect, GcCell, MutationContext};
 use swf::Color;
@@ -432,14 +433,14 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let bevel_filter_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, bevel_filter_proto, fn_proto);
+    let bevel_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, bevel_filter_proto, fn_proto);
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(bevel_filter_method!(0)),
         constructor_to_fn!(bevel_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -10,10 +10,10 @@ use crate::bitmap::bitmap_data::{BitmapDataDrawError, IBitmapDrawable};
 use crate::bitmap::bitmap_data::{ChannelOptions, ThresholdOperation};
 use crate::bitmap::{is_size_valid, operations};
 use crate::character::Character;
+use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
 use crate::swf::BlendMode;
 use crate::{avm1_stub, avm_error};
-use gc_arena::MutationContext;
 use ruffle_render::transform::Transform;
 use std::str::FromStr;
 
@@ -1328,13 +1328,13 @@ pub fn compare<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let bitmap_data_object = BitmapDataObject::empty_object(gc_context, proto);
+    let bitmap_data_object = BitmapDataObject::empty_object(context.gc_context, proto);
     let object = bitmap_data_object.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     bitmap_data_object.into()
 }
 
@@ -1382,18 +1382,18 @@ pub fn load_bitmap<'gc>(
 }
 
 pub fn create_bitmap_data_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     bitmap_data_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let bitmap_data = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
         bitmap_data_proto,
     );
     let object = bitmap_data.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     bitmap_data
 }

--- a/core/src/avm1/globals/bitmap_filter.rs
+++ b/core/src/avm1/globals/bitmap_filter.rs
@@ -5,7 +5,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Attribute, Object, ScriptObject, TObject, Value};
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "clone" => method(clone);
@@ -193,11 +193,11 @@ pub fn clone<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/blur_filter.rs
+++ b/core/src/avm1/globals/blur_filter.rs
@@ -4,6 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use gc_arena::{Collect, GcCell, MutationContext};
 
 #[derive(Clone, Debug, Collect)]
@@ -155,14 +156,14 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let blur_filter_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, blur_filter_proto, fn_proto);
+    let blur_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, blur_filter_proto, fn_proto);
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(blur_filter_method!(0)),
         constructor_to_fn!(blur_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/boolean.rs
+++ b/core/src/avm1/globals/boolean.rs
@@ -6,8 +6,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string; DONT_ENUM | DONT_DELETE);
@@ -46,12 +46,12 @@ pub fn boolean_function<'gc>(
 }
 
 pub fn create_boolean_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     boolean_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         Executable::Native(boolean_function),
         fn_proto,
@@ -61,13 +61,13 @@ pub fn create_boolean_object<'gc>(
 
 /// Creates `Boolean.prototype`.
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let boolean_proto = ValueObject::empty_box(gc_context, proto);
+    let boolean_proto = ValueObject::empty_box(context.gc_context, proto);
     let object = boolean_proto.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     boolean_proto
 }
 

--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -4,9 +4,9 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{globals, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::display_object::{Avm1Button, TDisplayObject};
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 use std::str::FromStr;
 use swf::BlendMode;
 
@@ -45,12 +45,12 @@ const PROTO_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/color.rs
+++ b/core/src/avm1/globals/color.rs
@@ -8,8 +8,9 @@ use crate::avm1::error::Error;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::display_object::{DisplayObject, TDisplayObject};
-use gc_arena::MutationContext;
+
 use swf::Fixed8;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -37,12 +38,12 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/color_matrix_filter.rs
+++ b/core/src/avm1/globals/color_matrix_filter.rs
@@ -4,6 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use gc_arena::{Collect, GcCell, MutationContext};
 
 #[derive(Clone, Debug, Collect)]
@@ -15,9 +16,12 @@ struct ColorMatrixFilterData {
 impl Default for ColorMatrixFilterData {
     fn default() -> Self {
         Self {
+            #[rustfmt::skip]
             matrix: [
-                1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-                0.0, 0.0, 1.0, 0.0,
+                1.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 1.0, 0.0,
             ],
         }
     }
@@ -118,14 +122,14 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let color_matrix_filter_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, color_matrix_filter_proto, fn_proto);
+    let color_matrix_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, color_matrix_filter_proto, fn_proto);
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(color_matrix_filter_method!(0)),
         constructor_to_fn!(color_matrix_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/color_transform.rs
+++ b/core/src/avm1/globals/color_transform.rs
@@ -3,8 +3,9 @@
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::{Collect, GcCell, MutationContext};
+use gc_arena::{Collect, GcCell};
 use swf::{ColorTransform, Fixed8};
 
 #[derive(Clone, Debug, Collect)]
@@ -267,11 +268,11 @@ fn concat<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -4,8 +4,8 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
+use crate::context::GcContext;
 use crate::context_menu;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "copy" => method(copy; DONT_ENUM | DONT_DELETE);
@@ -141,12 +141,12 @@ pub fn hide_builtin_items<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/context_menu_item.rs
+++ b/core/src/avm1/globals/context_menu_item.rs
@@ -4,8 +4,8 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "copy" => method(copy; DONT_ENUM | DONT_DELETE);
@@ -90,11 +90,11 @@ pub fn copy<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/convolution_filter.rs
+++ b/core/src/avm1/globals/convolution_filter.rs
@@ -6,7 +6,7 @@ use crate::avm1::error::Error;
 use crate::avm1::object::convolution_filter::ConvolutionFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "alpha" => property(alpha, set_alpha);
@@ -316,12 +316,12 @@ pub fn set_preserve_alpha<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let filter = ConvolutionFilterObject::empty_object(gc_context, proto);
+    let filter = ConvolutionFilterObject::empty_object(context.gc_context, proto);
     let object = filter.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     filter.into()
 }

--- a/core/src/avm1/globals/date.rs
+++ b/core/src/avm1/globals/date.rs
@@ -3,9 +3,10 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::locale::{get_current_date_time, get_timezone};
 use crate::string::AvmString;
-use gc_arena::{Collect, GcCell, MutationContext};
+use gc_arena::{Collect, GcCell};
 use std::fmt;
 
 #[inline]
@@ -572,22 +573,22 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let date_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, date_proto, fn_proto);
+    let date_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, date_proto, fn_proto);
 
     let date_constructor = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(date_method!(256)),
         Executable::Native(function),
         fn_proto,
         date_proto.into(),
     );
     let object = date_constructor.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
 
     date_constructor
 }

--- a/core/src/avm1/globals/displacement_map_filter.rs
+++ b/core/src/avm1/globals/displacement_map_filter.rs
@@ -6,8 +6,8 @@ use crate::avm1::error::Error;
 use crate::avm1::object::displacement_map_filter::DisplacementMapFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
+use crate::context::GcContext;
 use crate::string::{AvmString, WStr};
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "alpha" => property(alpha, set_alpha);
@@ -302,12 +302,12 @@ pub fn set_scale_y<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let filter = DisplacementMapFilterObject::empty_object(gc_context, proto);
+    let filter = DisplacementMapFilterObject::empty_object(context.gc_context, proto);
     let object = filter.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     filter.into()
 }

--- a/core/src/avm1/globals/drop_shadow_filter.rs
+++ b/core/src/avm1/globals/drop_shadow_filter.rs
@@ -4,6 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use gc_arena::{Collect, GcCell, MutationContext};
 use swf::Color;
 
@@ -373,14 +374,14 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let drop_shadow_filter_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, drop_shadow_filter_proto, fn_proto);
+    let drop_shadow_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, drop_shadow_filter_proto, fn_proto);
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(drop_shadow_filter_method!(0)),
         constructor_to_fn!(drop_shadow_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/error.rs
+++ b/core/src/avm1/globals/error.rs
@@ -4,7 +4,7 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "message" => string("Error");
@@ -27,12 +27,12 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/external_interface.rs
+++ b/core/src/avm1/globals/external_interface.rs
@@ -4,8 +4,8 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
+use crate::context::GcContext;
 use crate::external::{Callback, Value as ExternalValue};
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "available" => property(get_available; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -84,16 +84,16 @@ pub fn call<'gc>(
 }
 
 pub fn create_external_interface_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     object.into()
 }
 
-pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::new(gc_context, Some(proto)).into()
+    ScriptObject::new(context.gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/function.rs
+++ b/core/src/avm1/globals/function.rs
@@ -5,8 +5,8 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{ExecutionName, ExecutionReason};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "call" => method(call; DONT_ENUM | DONT_DELETE);
@@ -117,13 +117,8 @@ pub fn apply<'gc>(
 /// them in order to obtain a valid ECMAScript `Function` prototype. The
 /// returned object is also a bare object, which will need to be linked into
 /// the prototype of `Object`.
-pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
-    let function_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(
-        PROTO_DECLS,
-        gc_context,
-        function_proto,
-        function_proto.into(),
-    );
+pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
+    let function_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, function_proto, function_proto.into());
     function_proto.into()
 }

--- a/core/src/avm1/globals/glow_filter.rs
+++ b/core/src/avm1/globals/glow_filter.rs
@@ -4,6 +4,7 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use gc_arena::{Collect, GcCell, MutationContext};
 use swf::Color;
 
@@ -290,14 +291,14 @@ fn method<'gc>(
 }
 
 pub fn create_constructor<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let glow_filter_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, glow_filter_proto, fn_proto);
+    let glow_filter_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, glow_filter_proto, fn_proto);
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(glow_filter_method!(0)),
         constructor_to_fn!(glow_filter_method!(0)),
         fn_proto,

--- a/core/src/avm1/globals/gradient_bevel_filter.rs
+++ b/core/src/avm1/globals/gradient_bevel_filter.rs
@@ -7,8 +7,8 @@ use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_bevel_filter::GradientBevelFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
+use crate::context::GcContext;
 use crate::string::{AvmString, WStr};
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "distance" => property(distance, set_distance);
@@ -452,12 +452,12 @@ pub fn set_knockout<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let color_matrix_filter = GradientBevelFilterObject::empty_object(gc_context, proto);
+    let color_matrix_filter = GradientBevelFilterObject::empty_object(context.gc_context, proto);
     let object = color_matrix_filter.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     color_matrix_filter.into()
 }

--- a/core/src/avm1/globals/gradient_glow_filter.rs
+++ b/core/src/avm1/globals/gradient_glow_filter.rs
@@ -7,8 +7,8 @@ use crate::avm1::globals::bevel_filter::BevelFilterType;
 use crate::avm1::object::gradient_glow_filter::GradientGlowFilterObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
+use crate::context::GcContext;
 use crate::string::{AvmString, WStr};
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "distance" => property(distance, set_distance);
@@ -452,12 +452,12 @@ pub fn set_knockout<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let color_matrix_filter = GradientGlowFilterObject::empty_object(gc_context, proto);
+    let color_matrix_filter = GradientGlowFilterObject::empty_object(context.gc_context, proto);
     let object = color_matrix_filter.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     color_matrix_filter.into()
 }

--- a/core/src/avm1/globals/key.rs
+++ b/core/src/avm1/globals/key.rs
@@ -3,8 +3,8 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
+use crate::context::GcContext;
 use crate::events::KeyCode;
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "ALT" => int(KeyCode::Alt as i32; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -66,14 +66,14 @@ pub fn get_code<'gc>(
 }
 
 pub fn create_key_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let key = ScriptObject::new(gc_context, Some(proto));
-    broadcaster_functions.initialize(gc_context, key.into(), array_proto);
-    define_properties_on(OBJECT_DECLS, gc_context, key, fn_proto);
+    let key = ScriptObject::new(context.gc_context, Some(proto));
+    broadcaster_functions.initialize(context.gc_context, key.into(), array_proto);
+    define_properties_on(OBJECT_DECLS, context, key, fn_proto);
     key.into()
 }

--- a/core/src/avm1/globals/load_vars.rs
+++ b/core/src/avm1/globals/load_vars.rs
@@ -9,8 +9,8 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
 use crate::backend::navigator::{NavigationMethod, Request};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "load" => method(load; DONT_ENUM | DONT_DELETE);
@@ -37,12 +37,12 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/local_connection.rs
+++ b/core/src/avm1/globals/local_connection.rs
@@ -4,9 +4,9 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
+use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "domain" => method(domain; DONT_DELETE | READ_ONLY);
@@ -45,11 +45,11 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -6,8 +6,9 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
+
 use ruffle_render::matrix::Matrix;
 use swf::Twips;
 
@@ -464,12 +465,12 @@ fn to_string<'gc>(
 }
 
 pub fn create_matrix_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     matrix_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
@@ -478,11 +479,11 @@ pub fn create_matrix_object<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/mouse.rs
+++ b/core/src/avm1/globals/mouse.rs
@@ -3,7 +3,7 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "show" => method(show_mouse; DONT_DELETE | DONT_ENUM | READ_ONLY);
@@ -31,14 +31,14 @@ pub fn hide_mouse<'gc>(
 }
 
 pub fn create_mouse_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let mouse = ScriptObject::new(gc_context, Some(proto));
-    broadcaster_functions.initialize(gc_context, mouse.into(), array_proto);
-    define_properties_on(OBJECT_DECLS, gc_context, mouse, fn_proto);
+    let mouse = ScriptObject::new(context.gc_context, Some(proto));
+    broadcaster_functions.initialize(context.gc_context, mouse.into(), array_proto);
+    define_properties_on(OBJECT_DECLS, context, mouse, fn_proto);
     mouse.into()
 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -9,6 +9,7 @@ use crate::avm1::{self, Object, ScriptObject, TObject, Value};
 use crate::avm_error;
 use crate::avm_warn;
 use crate::backend::navigator::NavigationMethod;
+use crate::context::GcContext;
 use crate::display_object::{
     Bitmap, DisplayObject, EditText, MovieClip, TDisplayObject, TDisplayObjectContainer,
 };
@@ -16,7 +17,7 @@ use crate::ecma_conversions::f64_to_wrapping_i32;
 use crate::prelude::*;
 use crate::string::AvmString;
 use crate::vminterface::Instantiator;
-use gc_arena::MutationContext;
+
 use ruffle_render::shape_utils::DrawCommand;
 use std::str::FromStr;
 use swf::{
@@ -229,12 +230,12 @@ pub fn hit_test<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -9,9 +9,9 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, Value};
 use crate::backend::navigator::Request;
+use crate::context::GcContext;
 use crate::display_object::{TDisplayObject, TDisplayObjectContainer};
 use crate::loader::MovieLoaderEventHandler;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "loadClip" => method(load_clip; DONT_ENUM | DONT_DELETE);
@@ -158,14 +158,14 @@ fn get_progress<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     array_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let mcl_proto = ScriptObject::new(gc_context, Some(proto));
-    broadcaster_functions.initialize(gc_context, mcl_proto.into(), array_proto);
-    define_properties_on(PROTO_DECLS, gc_context, mcl_proto, fn_proto);
+    let mcl_proto = ScriptObject::new(context.gc_context, Some(proto));
+    broadcaster_functions.initialize(context.gc_context, mcl_proto.into(), array_proto);
+    define_properties_on(PROTO_DECLS, context, mcl_proto, fn_proto);
     mcl_proto.into()
 }

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -2,8 +2,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, ScriptObject, Value};
+use crate::context::GcContext;
 use crate::streams::NetStream;
-use gc_arena::MutationContext;
 
 pub fn constructor<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -90,22 +90,22 @@ fn pause<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 
 pub fn create_class<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     netstream_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,

--- a/core/src/avm1/globals/number.rs
+++ b/core/src/avm1/globals/number.rs
@@ -7,8 +7,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string; DONT_ENUM | DONT_DELETE);
@@ -62,31 +62,31 @@ pub fn number_function<'gc>(
 }
 
 pub fn create_number_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     number_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let number = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(number),
         Executable::Native(number_function),
         fn_proto,
         number_proto,
     );
     let object = number.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     number
 }
 
 /// Creates `Number.prototype`.
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let number_proto = ValueObject::empty_box(gc_context, proto);
+    let number_proto = ValueObject::empty_box(context.gc_context, proto);
     let object = number_proto.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     number_proto
 }
 

--- a/core/src/avm1/globals/object.rs
+++ b/core/src/avm1/globals/object.rs
@@ -7,9 +7,9 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm_warn;
+use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "addProperty" => method(add_property; DONT_ENUM | DONT_DELETE);
@@ -240,12 +240,12 @@ fn unwatch<'gc>(
 /// not allocate an object to store either proto. Instead, you must allocate
 /// bare objects for both and let this function fill Object for you.
 pub fn fill_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     object_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) {
     let object = object_proto.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
 }
 
 /// Implements `ASSetPropFlags`.
@@ -317,18 +317,18 @@ pub fn as_set_prop_flags<'gc>(
 }
 
 pub fn create_object_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let object_function = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         Executable::Native(object_function),
         fn_proto,
         proto,
     );
     let object = object_function.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     object_function
 }

--- a/core/src/avm1/globals/point.rs
+++ b/core/src/avm1/globals/point.rs
@@ -5,8 +5,8 @@ use crate::avm1::error::Error;
 use crate::avm1::function::{Executable, ExecutionReason, FunctionObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string);
@@ -284,28 +284,28 @@ fn offset<'gc>(
 }
 
 pub fn create_point_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     point_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let point = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
         point_proto,
     );
     let object = point.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     point
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/rectangle.rs
+++ b/core/src/avm1/globals/rectangle.rs
@@ -6,8 +6,8 @@ use crate::avm1::function::{Executable, FunctionObject};
 use crate::avm1::globals::point::{construct_new_point, point_to_object, value_to_point};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string);
@@ -94,12 +94,12 @@ fn to_string<'gc>(
 }
 
 pub fn create_rectangle_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     rectangle_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
@@ -704,11 +704,11 @@ fn set_bottom_right<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/selection.rs
+++ b/core/src/avm1/globals/selection.rs
@@ -3,8 +3,8 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
+use crate::context::GcContext;
 use crate::display_object::{EditText, TDisplayObject, TextSelection};
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "getBeginIndex" => method(get_begin_index; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -145,19 +145,19 @@ pub fn set_focus<'gc>(
 }
 
 pub fn create_selection_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    broadcaster_functions.initialize(gc_context, object.into(), array_proto);
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    broadcaster_functions.initialize(context.gc_context, object.into(), array_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     object.into()
 }
 
-pub fn create_proto<'gc>(gc_context: MutationContext<'gc, '_>, proto: Object<'gc>) -> Object<'gc> {
+pub fn create_proto<'gc>(context: &mut GcContext<'_, 'gc>, proto: Object<'gc>) -> Object<'gc> {
     // It's a custom prototype but it's empty.
-    ScriptObject::new(gc_context, Some(proto)).into()
+    ScriptObject::new(context.gc_context, Some(proto)).into()
 }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -7,11 +7,12 @@ use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
+use crate::context::GcContext;
 use crate::display_object::TDisplayObject;
 use crate::string::AvmString;
 use flash_lso::types::Value as AmfValue;
 use flash_lso::types::{AMFVersion, Element, Lso};
-use gc_arena::MutationContext;
+
 use std::borrow::Cow;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
@@ -415,19 +416,19 @@ pub fn remove_listener<'gc>(
 }
 
 pub fn create_shared_object_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     shared_object_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let shared_obj = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(constructor),
         constructor_to_fn!(constructor),
         fn_proto,
         shared_object_proto,
     );
     let object = shared_obj.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     shared_obj
 }
 
@@ -540,13 +541,13 @@ pub fn on_sync<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let shared_obj = SharedObject::empty_shared_obj(gc_context, proto);
+    let shared_obj = SharedObject::empty_shared_obj(context.gc_context, proto);
     let object = shared_obj.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     shared_obj.into()
 }
 

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -8,9 +8,9 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, SoundObject, TObject, Value};
 use crate::backend::navigator::Request;
 use crate::character::Character;
+use crate::context::GcContext;
 use crate::display_object::{SoundTransform, TDisplayObject};
 use crate::{avm1_stub, avm_warn};
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "attachSound" => method(attach_sound; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -57,13 +57,13 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let sound = SoundObject::empty_sound(gc_context, proto);
+    let sound = SoundObject::empty_sound(context.gc_context, proto);
     let object = sound.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     sound.into()
 }
 

--- a/core/src/avm1/globals/stage.rs
+++ b/core/src/avm1/globals/stage.rs
@@ -7,9 +7,9 @@ use crate::avm1::error::Error;
 use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, ScriptObject, Value};
+use crate::context::GcContext;
 use crate::display_object::StageDisplayState;
 use crate::string::{AvmString, WStr, WString};
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "align" => property(align, set_align);
@@ -21,15 +21,15 @@ const OBJECT_DECLS: &[Declaration] = declare_properties! {
 };
 
 pub fn create_stage_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     array_proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
 ) -> Object<'gc> {
-    let stage = ScriptObject::new(gc_context, Some(proto));
-    broadcaster_functions.initialize(gc_context, stage.into(), array_proto);
-    define_properties_on(OBJECT_DECLS, gc_context, stage, fn_proto);
+    let stage = ScriptObject::new(context.gc_context, Some(proto));
+    broadcaster_functions.initialize(context.gc_context, stage.into(), array_proto);
+    define_properties_on(OBJECT_DECLS, context, stage, fn_proto);
     stage.into()
 }
 

--- a/core/src/avm1/globals/string.rs
+++ b/core/src/avm1/globals/string.rs
@@ -7,8 +7,8 @@ use crate::avm1::object::value_object::ValueObject;
 use crate::avm1::property::Attribute;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, TObject, Value};
+use crate::context::GcContext;
 use crate::string::{utils as string_utils, AvmString, WString};
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "toString" => method(to_string_value_of; DONT_ENUM | DONT_DELETE);
@@ -72,31 +72,31 @@ pub fn string_function<'gc>(
 }
 
 pub fn create_string_object<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     string_proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
     let string = FunctionObject::constructor(
-        gc_context,
+        context.gc_context,
         Executable::Native(string),
         Executable::Native(string_function),
         fn_proto,
         string_proto,
     );
     let object = string.raw_script_object();
-    define_properties_on(OBJECT_DECLS, gc_context, object, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, object, fn_proto);
     string
 }
 
 /// Creates `String.prototype`.
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let string_proto = ValueObject::empty_box(gc_context, proto);
+    let string_proto = ValueObject::empty_box(context.gc_context, proto);
     let object = string_proto.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     string_proto
 }
 

--- a/core/src/avm1/globals/system.rs
+++ b/core/src/avm1/globals/system.rs
@@ -6,9 +6,9 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::runtime::Avm1;
 use crate::avm1::{ScriptObject, TObject, Value};
 use crate::avm1_stub;
+use crate::context::GcContext;
 use bitflags::bitflags;
 use core::fmt;
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "exactSettings" => property(get_exact_settings, set_exact_settings);
@@ -510,15 +510,16 @@ pub fn on_status<'gc>(
 }
 
 pub fn create<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     security: Object<'gc>,
     capabilities: Object<'gc>,
     ime: Object<'gc>,
 ) -> Object<'gc> {
+    let gc_context = context.gc_context;
     let system = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(OBJECT_DECLS, gc_context, system, fn_proto);
+    define_properties_on(OBJECT_DECLS, context, system, fn_proto);
     system.define_value(gc_context, "IME", ime.into(), Attribute::empty());
     system.define_value(gc_context, "security", security.into(), Attribute::empty());
     system.define_value(

--- a/core/src/avm1/globals/system_capabilities.rs
+++ b/core/src/avm1/globals/system_capabilities.rs
@@ -4,8 +4,8 @@ use crate::avm1::globals::system::SystemCapabilities;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "supports64BitProcesses" => property(get_has_64_bit_support);
@@ -250,11 +250,11 @@ pub fn get_max_idc_level<'gc>(
 }
 
 pub fn create<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let capabilities = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(OBJECT_DECLS, gc_context, capabilities, fn_proto);
+    let capabilities = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(OBJECT_DECLS, context, capabilities, fn_proto);
     capabilities.into()
 }

--- a/core/src/avm1/globals/system_ime.rs
+++ b/core/src/avm1/globals/system_ime.rs
@@ -4,7 +4,7 @@ use crate::avm1::globals::as_broadcaster::BroadcasterFunctions;
 use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "ALPHANUMERIC_FULL" => string("ALPHANUMERIC_FULL"; DONT_ENUM | DONT_DELETE | READ_ONLY);
@@ -80,14 +80,14 @@ fn set_enabled<'gc>(
 }
 
 pub fn create<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
     broadcaster_functions: BroadcasterFunctions<'gc>,
     array_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let ime = ScriptObject::new(gc_context, Some(proto));
-    broadcaster_functions.initialize(gc_context, ime.into(), array_proto);
-    define_properties_on(OBJECT_DECLS, gc_context, ime, fn_proto);
+    let ime = ScriptObject::new(context.gc_context, Some(proto));
+    broadcaster_functions.initialize(context.gc_context, ime.into(), array_proto);
+    define_properties_on(OBJECT_DECLS, context, ime, fn_proto);
     ime.into()
 }

--- a/core/src/avm1/globals/system_security.rs
+++ b/core/src/avm1/globals/system_security.rs
@@ -4,8 +4,8 @@ use crate::avm1::object::Object;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ScriptObject, Value};
 use crate::avm1_stub;
+use crate::context::GcContext;
 use crate::string::AvmString;
-use gc_arena::MutationContext;
 
 const OBJECT_DECLS: &[Declaration] = declare_properties! {
     "PolicyFileResolver" => method(policy_file_resolver);
@@ -84,11 +84,11 @@ fn policy_file_resolver<'gc>(
 }
 
 pub fn create<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let security = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(OBJECT_DECLS, gc_context, security, fn_proto);
+    let security = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(OBJECT_DECLS, context, security, fn_proto);
     security.into()
 }

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -3,11 +3,12 @@ use crate::avm1::error::Error;
 use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{globals, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject, TextSelection};
 use crate::font::round_down_to_pixel;
 use crate::html::TextFormat;
 use crate::string::{AvmString, WStr};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 use swf::Color;
 
 macro_rules! tf_method {
@@ -99,12 +100,12 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }
 pub fn password<'gc>(

--- a/core/src/avm1/globals/text_format.rs
+++ b/core/src/avm1/globals/text_format.rs
@@ -4,11 +4,12 @@ use crate::avm1::object::NativeObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, ArrayObject, Error, Object, ScriptObject, TObject, Value};
 use crate::avm1_stub;
+use crate::context::GcContext;
 use crate::display_object::{AutoSizeMode, EditText, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::html::TextFormat;
 use crate::string::{AvmString, WStr};
-use gc_arena::{GcCell, MutationContext};
+use gc_arena::GcCell;
 
 macro_rules! getter {
     ($name:ident) => {
@@ -615,11 +616,11 @@ pub fn constructor<'gc>(
 
 /// `TextFormat.prototype` constructor
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/transform.rs
+++ b/core/src/avm1/globals/transform.rs
@@ -5,8 +5,8 @@ use crate::avm1::globals::matrix::{matrix_to_object, object_to_matrix};
 use crate::avm1::object::transform_object::TransformObject;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Activation, Error, Object, TObject, Value};
+use crate::context::GcContext;
 use crate::display_object::{MovieClip, TDisplayObject};
-use gc_arena::MutationContext;
 
 macro_rules! tx_getter {
     ( $get:ident ) => {
@@ -75,13 +75,13 @@ pub fn constructor<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let transform_object = TransformObject::empty(gc_context, proto);
+    let transform_object = TransformObject::empty(context.gc_context, proto);
     let object = transform_object.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     transform_object.into()
 }
 

--- a/core/src/avm1/globals/video.rs
+++ b/core/src/avm1/globals/video.rs
@@ -6,8 +6,8 @@ use crate::avm1::object::{NativeObject, Object, TObject};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::value::Value;
 use crate::avm1::ScriptObject;
+use crate::context::GcContext;
 use crate::display_object::{TDisplayObject, Video};
-use gc_arena::MutationContext;
 
 macro_rules! video_method {
     ( $fn: expr ) => {
@@ -56,11 +56,11 @@ pub fn attach_video<'gc>(
 }
 
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let object = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    let object = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     object.into()
 }

--- a/core/src/avm1/globals/xml.rs
+++ b/core/src/avm1/globals/xml.rs
@@ -9,9 +9,9 @@ use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{Object, TObject, Value};
 use crate::avm_warn;
 use crate::backend::navigator::Request;
+use crate::context::GcContext;
 use crate::string::AvmString;
 use crate::xml::{XmlNode, ELEMENT_NODE, TEXT_NODE};
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "docTypeDecl" => property(doc_type_decl; READ_ONLY);
@@ -339,12 +339,12 @@ fn spawn_xml_fetch<'gc>(
 
 /// Construct the prototype for `XML`.
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_proto = XmlObject::empty(gc_context, proto);
+    let xml_proto = XmlObject::empty(context.gc_context, proto);
     let object = xml_proto.raw_script_object();
-    define_properties_on(PROTO_DECLS, gc_context, object, fn_proto);
+    define_properties_on(PROTO_DECLS, context, object, fn_proto);
     xml_proto.into()
 }

--- a/core/src/avm1/globals/xml_node.rs
+++ b/core/src/avm1/globals/xml_node.rs
@@ -4,9 +4,9 @@ use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::{ArrayObject, Object, ScriptObject, TObject, Value};
+use crate::context::GcContext;
 use crate::string::{AvmString, WStr};
 use crate::xml::XmlNode;
-use gc_arena::MutationContext;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "localName" => property(local_name);
@@ -393,11 +393,11 @@ fn namespace_uri<'gc>(
 
 /// Construct the prototype for `XMLNode`.
 pub fn create_proto<'gc>(
-    gc_context: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     proto: Object<'gc>,
     fn_proto: Object<'gc>,
 ) -> Object<'gc> {
-    let xml_node_proto = ScriptObject::new(gc_context, Some(proto));
-    define_properties_on(PROTO_DECLS, gc_context, xml_node_proto, fn_proto);
+    let xml_node_proto = ScriptObject::new(context.gc_context, Some(proto));
+    define_properties_on(PROTO_DECLS, context, xml_node_proto, fn_proto);
     xml_node_proto.into()
 }

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -77,7 +77,7 @@ impl Declaration {
                 let setter = setter.map(|setter| {
                     FunctionObject::function(mc, Executable::Native(setter), fn_proto, fn_proto)
                 });
-                this.add_property(mc, name, getter, setter, self.attributes);
+                this.add_property(mc, name.into(), getter, setter, self.attributes);
                 return Value::Undefined;
             }
             DeclKind::Method(func) => {

--- a/core/src/avm1/property_decl.rs
+++ b/core/src/avm1/property_decl.rs
@@ -3,18 +3,18 @@
 use crate::avm1::function::{Executable, FunctionObject, NativeFunction};
 use crate::avm1::property::Attribute;
 use crate::avm1::{Object, ScriptObject, TObject, Value};
-use gc_arena::MutationContext;
+use crate::context::GcContext;
 
 /// Defines a list of properties on a [`ScriptObject`].
 #[inline(never)]
 pub fn define_properties_on<'gc>(
     decls: &[Declaration],
-    mc: MutationContext<'gc, '_>,
+    context: &mut GcContext<'_, 'gc>,
     this: ScriptObject<'gc>,
     fn_proto: Object<'gc>,
 ) {
     for decl in decls {
-        decl.define_on(mc, this, fn_proto);
+        decl.define_on(context, this, fn_proto);
     }
 }
 
@@ -61,10 +61,15 @@ impl Declaration {
     /// defined a property.
     pub fn define_on<'gc>(
         &self,
-        mc: MutationContext<'gc, '_>,
+        context: &mut GcContext<'_, 'gc>,
         this: ScriptObject<'gc>,
         fn_proto: Object<'gc>,
     ) -> Value<'gc> {
+        let mc = context.gc_context;
+
+        let name = ruffle_wstr::from_utf8(self.name);
+        let name = context.interner.intern_wstr(mc, name);
+
         let value = match self.kind {
             DeclKind::Property { getter, setter } => {
                 let getter =
@@ -72,7 +77,7 @@ impl Declaration {
                 let setter = setter.map(|setter| {
                     FunctionObject::function(mc, Executable::Native(setter), fn_proto, fn_proto)
                 });
-                this.add_property(mc, self.name.into(), getter, setter, self.attributes);
+                this.add_property(mc, name, getter, setter, self.attributes);
                 return Value::Undefined;
             }
             DeclKind::Method(func) => {
@@ -82,13 +87,16 @@ impl Declaration {
             DeclKind::Function(func) => {
                 FunctionObject::function(mc, Executable::Native(func), fn_proto, fn_proto).into()
             }
-            DeclKind::String(s) => s.into(),
+            DeclKind::String(s) => {
+                let s = ruffle_wstr::from_utf8(s);
+                context.interner.intern_wstr(mc, s).into()
+            }
             DeclKind::Bool(b) => b.into(),
             DeclKind::Int(i) => i.into(),
             DeclKind::Float(f) => f.into(),
         };
 
-        this.define_value(mc, self.name, value, self.attributes);
+        this.define_value(mc, name, value, self.attributes);
         value
     }
 }

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -6,7 +6,7 @@ use crate::avm1::object::TObject;
 use crate::avm1::property_map::PropertyMap;
 use crate::avm1::scope::Scope;
 use crate::avm1::{scope, Activation, ActivationIdentifier, Error, Object, Value};
-use crate::context::UpdateContext;
+use crate::context::{GcContext, UpdateContext};
 use crate::frame_lifecycle::FramePhase;
 use crate::prelude::*;
 use crate::string::AvmString;
@@ -73,8 +73,9 @@ pub struct Avm1<'gc> {
 }
 
 impl<'gc> Avm1<'gc> {
-    pub fn new(gc_context: MutationContext<'gc, '_>, player_version: u8) -> Self {
-        let (prototypes, globals, broadcaster_functions) = create_globals(gc_context);
+    pub fn new(context: &mut GcContext<'_, 'gc>, player_version: u8) -> Self {
+        let gc_context = context.gc_context;
+        let (prototypes, globals, broadcaster_functions) = create_globals(context);
 
         Self {
             player_version,

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -29,12 +29,11 @@ pub enum Value<'gc> {
 }
 
 // This type is used very frequently, so make sure it doesn't unexpectedly grow.
-// TODO(moulins): shrink `Value` down again.
-// #[cfg(target_pointer_width = "32")]
-// const _: () = assert!(size_of::<Value<'_>>() == 16);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(size_of::<Value<'_>>() == 16);
 
-// #[cfg(target_pointer_width = "64")]
-// const _: () = assert!(size_of::<Value<'_>>() == 24);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<Value<'_>>() == 24);
 
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {
     fn from(string: AvmString<'gc>) -> Self {

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -890,7 +890,7 @@ mod test {
             );
             assert_eq!(null.to_primitive_num(activation).unwrap(), null);
 
-            let (protos, global, _) = create_globals(activation.context.gc_context);
+            let (protos, global, _) = create_globals(&mut activation.context.borrow_gc());
             let vglobal = Value::Object(global);
 
             assert_eq!(vglobal.to_primitive_num(activation).unwrap(), undefined);

--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -9,7 +9,7 @@ use crate::ecma_conversions::{
     f64_to_wrapping_i16, f64_to_wrapping_i32, f64_to_wrapping_u16, f64_to_wrapping_u32,
     f64_to_wrapping_u8,
 };
-use crate::string::{AvmString, Integer, WStr};
+use crate::string::{AvmAtom, AvmString, Integer, WStr};
 use gc_arena::Collect;
 use std::{borrow::Cow, io::Write, mem::size_of, num::Wrapping};
 
@@ -29,15 +29,22 @@ pub enum Value<'gc> {
 }
 
 // This type is used very frequently, so make sure it doesn't unexpectedly grow.
-#[cfg(target_pointer_width = "32")]
-const _: () = assert!(size_of::<Value<'_>>() == 16);
+// TODO(moulins): shrink `Value` down again.
+// #[cfg(target_pointer_width = "32")]
+// const _: () = assert!(size_of::<Value<'_>>() == 16);
 
-#[cfg(target_pointer_width = "64")]
-const _: () = assert!(size_of::<Value<'_>>() == 24);
+// #[cfg(target_pointer_width = "64")]
+// const _: () = assert!(size_of::<Value<'_>>() == 24);
 
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {
     fn from(string: AvmString<'gc>) -> Self {
         Value::String(string)
+    }
+}
+
+impl<'gc> From<AvmAtom<'gc>> for Value<'gc> {
+    fn from(atom: AvmAtom<'gc>) -> Self {
+        Value::String(atom.into())
     }
 }
 

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -61,7 +61,7 @@ pub use crate::avm2::domain::Domain;
 pub use crate::avm2::error::Error;
 pub use crate::avm2::globals::flash::ui::context_menu::make_context_menu_state;
 pub use crate::avm2::multiname::Multiname;
-pub use crate::avm2::namespace::{Namespace, NamespaceData};
+pub use crate::avm2::namespace::Namespace;
 pub use crate::avm2::object::{
     ArrayObject, ClassObject, EventObject, Object, ScriptObject, SoundChannelObject, StageObject,
     TObject,
@@ -143,29 +143,28 @@ pub struct Avm2<'gc> {
 impl<'gc> Avm2<'gc> {
     /// Construct a new AVM interpreter.
     pub fn new(context: &mut GcContext<'_, 'gc>) -> Self {
-        let mc = context.gc_context;
-        let globals = Domain::global_domain(mc);
+        let globals = Domain::global_domain(context.gc_context);
 
         Self {
             stack: Vec::new(),
             scope_stack: Vec::new(),
-            call_stack: GcCell::allocate(mc, CallStack::new()),
+            call_stack: GcCell::allocate(context.gc_context, CallStack::new()),
             globals,
             system_classes: None,
 
-            public_namespace: Namespace::package("", mc),
-            as3_namespace: Namespace::package("http://adobe.com/AS3/2006/builtin", mc),
-            vector_public_namespace: Namespace::package("__AS3__.vec", mc),
-            vector_internal_namespace: Namespace::internal("__AS3__.vec", mc),
+            public_namespace: Namespace::package("", context),
+            as3_namespace: Namespace::package("http://adobe.com/AS3/2006/builtin", context),
+            vector_public_namespace: Namespace::package("__AS3__.vec", context),
+            vector_internal_namespace: Namespace::internal("__AS3__.vec", context),
             proxy_namespace: Namespace::package(
                 "http://www.adobe.com/2006/actionscript/flash/proxy",
-                mc,
+                context,
             ),
             // these are required to facilitate shared access between Rust and AS
-            flash_display_internal: Namespace::internal("flash.display", mc),
-            flash_utils_internal: Namespace::internal("flash.utils", mc),
-            flash_geom_internal: Namespace::internal("flash.geom", mc),
-            flash_events_internal: Namespace::internal("flash.events", mc),
+            flash_display_internal: Namespace::internal("flash.display", context),
+            flash_utils_internal: Namespace::internal("flash.utils", context),
+            flash_geom_internal: Namespace::internal("flash.geom", context),
+            flash_events_internal: Namespace::internal("flash.events", context),
 
             native_method_table: Default::default(),
             native_instance_allocator_table: Default::default(),

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -5,7 +5,7 @@ use crate::avm2::function::Executable;
 use crate::avm2::globals::SystemClasses;
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::script::{Script, TranslationUnit};
-use crate::context::UpdateContext;
+use crate::context::{GcContext, UpdateContext};
 use crate::display_object::{DisplayObject, DisplayObjectWeak, TDisplayObject};
 use crate::string::AvmString;
 
@@ -142,7 +142,8 @@ pub struct Avm2<'gc> {
 
 impl<'gc> Avm2<'gc> {
     /// Construct a new AVM interpreter.
-    pub fn new(mc: MutationContext<'gc, '_>) -> Self {
+    pub fn new(context: &mut GcContext<'_, 'gc>) -> Self {
+        let mc = context.gc_context;
         let globals = Domain::global_domain(mc);
 
         Self {

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -21,7 +21,7 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::avm2::{value, Avm2, Error};
 use crate::context::{GcContext, UpdateContext};
-use crate::string::AvmString;
+use crate::string::{AvmAtom, AvmString};
 use crate::swf::extensions::ReadSwfExt;
 use gc_arena::{Gc, GcCell};
 use smallvec::SmallVec;
@@ -823,7 +823,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         &mut self,
         method: &'b BytecodeMethod<'gc>,
         index: Index<String>,
-    ) -> Result<AvmString<'gc>, Error<'gc>> {
+    ) -> Result<AvmAtom<'gc>, Error<'gc>> {
         method
             .translation_unit()
             .pool_string(index.0, &mut self.borrow_gc())

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -267,7 +267,7 @@ pub fn set_filters<'gc>(
             if let Some(filters_array) = new_filters.as_array_object() {
                 if let Some(filters_storage) = filters_array.as_array_storage() {
                     let filters_namespace =
-                        Namespace::package("flash.filters", activation.context.gc_context);
+                        Namespace::package("flash.filters", &mut activation.borrow_gc());
                     let filter_class = Multiname::new(filters_namespace, "BitmapFilter");
 
                     let filter_class_object = activation.resolve_class(&filter_class)?;

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -138,7 +138,7 @@ pub fn get_local<'gc>(
 
     // Set the internal name
     let ruffle_name = Multiname::new(
-        Namespace::package("__ruffle__", activation.context.gc_context),
+        Namespace::package("__ruffle__", &mut activation.borrow_gc()),
         "_ruffleName",
     );
     this.set_property(
@@ -186,7 +186,7 @@ pub fn flush<'gc>(
             .coerce_to_object(activation)?;
 
         let ruffle_name = Multiname::new(
-            Namespace::package("__ruffle__", activation.context.gc_context),
+            Namespace::package("__ruffle__", &mut activation.borrow_gc()),
             "_ruffleName",
         );
         let name = this
@@ -238,7 +238,7 @@ pub fn clear<'gc>(
 
         // Delete data from storage backend.
         let ruffle_name = Multiname::new(
-            Namespace::package("__ruffle__", activation.context.gc_context),
+            Namespace::package("__ruffle__", &mut activation.borrow_gc()),
             "_ruffleName",
         );
         let name = this

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -31,11 +31,11 @@ pub fn instance_init<'gc>(
         let namespace = match uri_value {
             Some(Value::Object(Object::QNameObject(qname))) => qname
                 .uri()
-                .map(|uri| Namespace::package(uri, activation.context.gc_context))
+                .map(|uri| Namespace::package(uri, &mut activation.borrow_gc()))
                 .unwrap_or_else(|| Namespace::any(activation.context.gc_context)),
             Some(val) => Namespace::package(
                 val.coerce_to_string(activation)?,
-                activation.context.gc_context,
+                &mut activation.borrow_gc(),
             ),
             None => activation.avm2().public_namespace,
         };

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -24,7 +24,7 @@ pub fn init<'gc>(
             Value::Undefined | Value::Null => None,
             v => Some(Namespace::package(
                 v.coerce_to_string(activation)?,
-                activation.context.gc_context,
+                &mut activation.borrow_gc(),
             )),
         };
         if let Value::Object(Object::QNameObject(qname)) = local_arg {

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -57,12 +57,12 @@ impl<'gc> ParamConfig<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
         let param_name = if let Some(name) = &config.name {
-            txunit.pool_string(name.0, activation.context.gc_context)?
+            txunit.pool_string(name.0, &mut activation.borrow_gc())?
         } else {
             "<Unnamed Parameter>".into()
         };
         let param_type_name = txunit
-            .pool_multiname_static_any(config.kind, activation.context.gc_context)?
+            .pool_multiname_static_any(config.kind, &mut activation.borrow_gc())?
             .deref()
             .clone();
 
@@ -151,7 +151,7 @@ impl<'gc> BytecodeMethod<'gc> {
             }
 
             let return_type = txunit
-                .pool_multiname_static_any(method.return_type, activation.context.gc_context)?
+                .pool_multiname_static_any(method.return_type, &mut activation.borrow_gc())?
                 .deref()
                 .clone();
 

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -57,9 +57,11 @@ impl<'gc> ParamConfig<'gc> {
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
         let param_name = if let Some(name) = &config.name {
-            txunit.pool_string(name.0, &mut activation.borrow_gc())?
+            txunit
+                .pool_string(name.0, &mut activation.borrow_gc())?
+                .into()
         } else {
-            "<Unnamed Parameter>".into()
+            AvmString::from("<Unnamed Parameter>")
         };
         let param_type_name = txunit
             .pool_multiname_static_any(config.kind, &mut activation.borrow_gc())?

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -159,14 +159,18 @@ impl<'gc> Multiname<'gc> {
             AbcMultiname::QName { namespace, name } | AbcMultiname::QNameA { namespace, name } => {
                 Self {
                     ns: NamespaceSet::single(translation_unit.pool_namespace(*namespace, context)?),
-                    name: translation_unit.pool_string_option(name.0, context)?,
+                    name: translation_unit
+                        .pool_string_option(name.0, context)?
+                        .map(|v| v.into()),
                     params: Vec::new(),
                     flags: Default::default(),
                 }
             }
             AbcMultiname::RTQName { name } | AbcMultiname::RTQNameA { name } => Self {
                 ns: NamespaceSet::multiple(vec![], mc),
-                name: translation_unit.pool_string_option(name.0, context)?,
+                name: translation_unit
+                    .pool_string_option(name.0, context)?
+                    .map(|v| v.into()),
                 params: Vec::new(),
                 flags: MultinameFlags::HAS_LAZY_NS,
             },
@@ -185,7 +189,9 @@ impl<'gc> Multiname<'gc> {
                 name,
             } => Self {
                 ns: Self::abc_namespace_set(translation_unit, *namespace_set, context)?,
-                name: translation_unit.pool_string_option(name.0, context)?,
+                name: translation_unit
+                    .pool_string_option(name.0, context)?
+                    .map(|v| v.into()),
                 params: Vec::new(),
                 flags: Default::default(),
             },

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -1,6 +1,6 @@
-use crate::avm2::script::TranslationUnit;
 use crate::avm2::Error;
 use crate::string::AvmString;
+use crate::{avm2::script::TranslationUnit, context::GcContext};
 use gc_arena::{Collect, Gc, MutationContext};
 use std::fmt::Debug;
 use swf::avm2::types::{Index, Namespace as AbcNamespace};
@@ -46,10 +46,10 @@ impl<'gc> Namespace<'gc> {
     pub fn from_abc_namespace(
         translation_unit: TranslationUnit<'gc>,
         namespace_index: Index<AbcNamespace>,
-        mc: MutationContext<'gc, '_>,
+        context: &mut GcContext<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
         if namespace_index.0 == 0 {
-            return Ok(Self::any(mc));
+            return Ok(Self::any(context.gc_context));
         }
 
         let actual_index = namespace_index.0 as usize - 1;
@@ -62,28 +62,28 @@ impl<'gc> Namespace<'gc> {
 
         let ns = match abc_namespace? {
             AbcNamespace::Namespace(idx) => {
-                NamespaceData::Namespace(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::Namespace(translation_unit.pool_string(idx.0, context)?)
             }
             AbcNamespace::Package(idx) => {
-                NamespaceData::Namespace(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::Namespace(translation_unit.pool_string(idx.0, context)?)
             }
             AbcNamespace::PackageInternal(idx) => {
-                NamespaceData::PackageInternal(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::PackageInternal(translation_unit.pool_string(idx.0, context)?)
             }
             AbcNamespace::Protected(idx) => {
-                NamespaceData::Protected(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::Protected(translation_unit.pool_string(idx.0, context)?)
             }
             AbcNamespace::Explicit(idx) => {
-                NamespaceData::Explicit(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::Explicit(translation_unit.pool_string(idx.0, context)?)
             }
             AbcNamespace::StaticProtected(idx) => {
-                NamespaceData::StaticProtected(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::StaticProtected(translation_unit.pool_string(idx.0, context)?)
             }
             AbcNamespace::Private(idx) => {
-                NamespaceData::Private(translation_unit.pool_string(idx.0, mc)?)
+                NamespaceData::Private(translation_unit.pool_string(idx.0, context)?)
             }
         };
-        Ok(Self(Gc::allocate(mc, ns)))
+        Ok(Self(Gc::allocate(context.gc_context, ns)))
     }
 
     pub fn any(mc: MutationContext<'gc, '_>) -> Self {

--- a/core/src/avm2/qname.rs
+++ b/core/src/avm2/qname.rs
@@ -2,6 +2,7 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::Activation;
 use crate::avm2::Error;
 use crate::avm2::{Namespace, NamespaceData};
+use crate::context::GcContext;
 use crate::either::Either;
 use crate::string::{AvmString, WStr, WString};
 use gc_arena::{Collect, MutationContext};
@@ -48,7 +49,7 @@ impl<'gc> QName<'gc> {
     pub fn from_abc_multiname(
         translation_unit: TranslationUnit<'gc>,
         multiname_index: Index<AbcMultiname>,
-        mc: MutationContext<'gc, '_>,
+        context: &mut GcContext<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
         if multiname_index.0 == 0 {
             return Err("Attempted to load a trait name of index zero".into());
@@ -64,8 +65,8 @@ impl<'gc> QName<'gc> {
 
         Ok(match abc_multiname? {
             AbcMultiname::QName { namespace, name } => Self {
-                ns: translation_unit.pool_namespace(*namespace, mc)?,
-                name: translation_unit.pool_string(name.0, mc)?,
+                ns: translation_unit.pool_namespace(*namespace, context)?,
+                name: translation_unit.pool_string(name.0, context)?,
             },
             _ => return Err("Attempted to pull QName from non-QName multiname".into()),
         })

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -232,7 +232,7 @@ impl<'gc> TranslationUnit<'gc> {
         self,
         string_index: u32,
         context: &mut GcContext<'_, 'gc>,
-    ) -> Result<Option<AvmString<'gc>>, Error<'gc>> {
+    ) -> Result<Option<AvmAtom<'gc>>, Error<'gc>> {
         if string_index == 0 {
             Ok(None)
         } else {
@@ -250,10 +250,10 @@ impl<'gc> TranslationUnit<'gc> {
         self,
         string_index: u32,
         context: &mut GcContext<'_, 'gc>,
-    ) -> Result<AvmString<'gc>, Error<'gc>> {
+    ) -> Result<AvmAtom<'gc>, Error<'gc>> {
         let mut write = self.0.write(context.gc_context);
         if let Some(Some(atom)) = write.strings.get(string_index as usize) {
-            return Ok((*atom).into());
+            return Ok(*atom);
         }
 
         let raw = if string_index == 0 {
@@ -272,7 +272,7 @@ impl<'gc> TranslationUnit<'gc> {
             .intern_wstr(context.gc_context, ruffle_wstr::from_utf8(raw));
 
         write.strings[string_index as usize] = Some(atom);
-        Ok(atom.into())
+        Ok(atom)
     }
 
     /// Retrieve a static, or non-runtime, multiname from the current constant

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -191,8 +191,7 @@ impl<'gc> Trait<'gc> {
         abc_trait: &AbcTrait,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Self, Error<'gc>> {
-        let mc = activation.context.gc_context;
-        let name = QName::from_abc_multiname(unit, abc_trait.name, mc)?;
+        let name = QName::from_abc_multiname(unit, abc_trait.name, &mut activation.borrow_gc())?;
 
         Ok(match &abc_trait.kind {
             AbcTraitKind::Slot {
@@ -201,7 +200,7 @@ impl<'gc> Trait<'gc> {
                 value,
             } => {
                 let type_name = unit
-                    .pool_multiname_static_any(*type_name, mc)?
+                    .pool_multiname_static_any(*type_name, &mut activation.borrow_gc())?
                     .deref()
                     .clone();
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;
@@ -262,7 +261,7 @@ impl<'gc> Trait<'gc> {
                 value,
             } => {
                 let type_name = unit
-                    .pool_multiname_static_any(*type_name, mc)?
+                    .pool_multiname_static_any(*type_name, &mut activation.borrow_gc())?
                     .deref()
                     .clone();
                 let default_value = slot_default_value(unit, value, &type_name, activation)?;

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -10,7 +10,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
-use crate::string::{AvmString, WStr};
+use crate::string::{AvmAtom, AvmString, WStr};
 use gc_arena::{Collect, GcCell, MutationContext};
 use std::cell::Ref;
 use std::mem::size_of;
@@ -59,6 +59,12 @@ const _: () = assert!(size_of::<Value<'_>>() == 24);
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {
     fn from(string: AvmString<'gc>) -> Self {
         Value::String(string)
+    }
+}
+
+impl<'gc> From<AvmAtom<'gc>> for Value<'gc> {
+    fn from(atom: AvmAtom<'gc>) -> Self {
+        Value::String(atom.into())
     }
 }
 

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -516,8 +516,8 @@ pub fn abc_default_value<'gc>(
         AbcDefaultValue::Uint(u) => abc_uint(translation_unit, *u).map(|v| v.into()),
         AbcDefaultValue::Double(d) => abc_double(translation_unit, *d).map(|v| v.into()),
         AbcDefaultValue::String(s) => translation_unit
-            .pool_string(s.0, activation.context.gc_context)
-            .map(|v| v.into()),
+            .pool_string(s.0, &mut activation.borrow_gc())
+            .map(Into::into),
         AbcDefaultValue::True => Ok(true.into()),
         AbcDefaultValue::False => Ok(false.into()),
         AbcDefaultValue::Null => Ok(Value::Null),
@@ -528,11 +528,10 @@ pub fn abc_default_value<'gc>(
         | AbcDefaultValue::Protected(ns)
         | AbcDefaultValue::Explicit(ns)
         | AbcDefaultValue::StaticProtected(ns)
-        | AbcDefaultValue::Private(ns) => Ok(NamespaceObject::from_namespace(
-            activation,
-            translation_unit.pool_namespace(*ns, activation.context.gc_context)?,
-        )?
-        .into()),
+        | AbcDefaultValue::Private(ns) => {
+            let ns = translation_unit.pool_namespace(*ns, &mut activation.borrow_gc())?;
+            NamespaceObject::from_namespace(activation, ns).map(Into::into)
+        }
     }
 }
 

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -1,9 +1,12 @@
+use std::borrow::Cow;
+
+mod avm_string;
+mod interner;
+
 pub use ruffle_wstr::*;
 
-use std::ops::Deref;
-
-use gc_arena::{Collect, Gc, MutationContext};
-use std::borrow::Cow;
+pub use avm_string::AvmString;
+pub use interner::AvmStringInterner;
 
 pub trait SwfStrExt {
     /// Converts a SWF-encoded string into a `WStr`.
@@ -18,115 +21,3 @@ impl SwfStrExt for swf::SwfStr {
         }
     }
 }
-
-#[derive(Clone, Copy, Collect)]
-#[collect(no_drop)]
-enum Source<'gc> {
-    Owned(Gc<'gc, OwnedWStr>),
-    Static(&'static WStr),
-}
-
-#[derive(Collect)]
-#[collect(require_static)]
-struct OwnedWStr(WString);
-
-#[derive(Clone, Copy, Collect)]
-#[collect(no_drop)]
-pub struct AvmString<'gc> {
-    source: Source<'gc>,
-}
-
-impl<'gc> AvmString<'gc> {
-    pub fn new<S: Into<WString>>(gc_context: MutationContext<'gc, '_>, string: S) -> Self {
-        Self {
-            source: Source::Owned(Gc::allocate(gc_context, OwnedWStr(string.into()))),
-        }
-    }
-
-    pub fn new_utf8<'s, S: Into<Cow<'s, str>>>(
-        gc_context: MutationContext<'gc, '_>,
-        string: S,
-    ) -> Self {
-        let buf = match string.into() {
-            Cow::Owned(utf8) => WString::from_utf8_owned(utf8),
-            Cow::Borrowed(utf8) => WString::from_utf8(utf8),
-        };
-        Self {
-            source: Source::Owned(Gc::allocate(gc_context, OwnedWStr(buf))),
-        }
-    }
-
-    pub fn new_utf8_bytes(gc_context: MutationContext<'gc, '_>, bytes: &[u8]) -> Self {
-        let buf = ruffle_wstr::from_utf8_bytes(bytes);
-        Self::new(gc_context, buf.into_owned())
-    }
-
-    pub fn as_wstr(&self) -> &WStr {
-        match &self.source {
-            Source::Owned(s) => &s.0,
-            Source::Static(s) => s,
-        }
-    }
-
-    pub fn concat(
-        gc_context: MutationContext<'gc, '_>,
-        left: AvmString<'gc>,
-        right: AvmString<'gc>,
-    ) -> AvmString<'gc> {
-        if left.is_empty() {
-            right
-        } else if right.is_empty() {
-            left
-        } else {
-            let mut out = WString::from(left.as_wstr());
-            out.push_str(&right);
-            Self::new(gc_context, out)
-        }
-    }
-
-    #[inline]
-    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
-        match (this.source, other.source) {
-            (Source::Owned(this), Source::Owned(other)) => Gc::ptr_eq(this, other),
-            (Source::Static(this), Source::Static(other)) => std::ptr::eq(this, other),
-            _ => false,
-        }
-    }
-}
-
-impl Default for AvmString<'_> {
-    fn default() -> Self {
-        Self {
-            source: Source::Static(WStr::empty()),
-        }
-    }
-}
-
-impl<'gc> From<&'static str> for AvmString<'gc> {
-    #[inline]
-    fn from(str: &'static str) -> Self {
-        // TODO(moulins): actually check that `str` is valid ASCII.
-        Self {
-            source: Source::Static(WStr::from_units(str.as_bytes())),
-        }
-    }
-}
-
-impl<'gc> From<&'static WStr> for AvmString<'gc> {
-    #[inline]
-    fn from(str: &'static WStr) -> Self {
-        Self {
-            source: Source::Static(str),
-        }
-    }
-}
-
-impl<'gc> Deref for AvmString<'gc> {
-    type Target = WStr;
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.as_wstr()
-    }
-}
-
-wstr_impl_traits!(impl['gc] for AvmString<'gc>);

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -9,7 +9,7 @@ mod interner;
 pub use ruffle_wstr::*;
 
 pub use avm_string::AvmString;
-pub use interner::AvmStringInterner;
+pub use interner::{AvmAtom, AvmStringInterner};
 
 pub trait SwfStrExt {
     /// Converts a SWF-encoded string into a `WStr`.

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -1,10 +1,10 @@
-use std::borrow::{Borrow, Cow};
-use std::ops::Deref;
-
-use gc_arena::Collect;
+use std::borrow::Cow;
 
 mod avm_string;
 mod interner;
+mod repr;
+
+use repr::AvmStringRepr;
 
 pub use ruffle_wstr::*;
 
@@ -22,33 +22,5 @@ impl SwfStrExt for swf::SwfStr {
             Cow::Borrowed(utf8) => from_utf8(utf8),
             Cow::Owned(utf8) => WString::from_utf8_owned(utf8).into(),
         }
-    }
-}
-
-/// This type only exists because `WString` doesn't implement `Collect`
-#[derive(Collect, Eq, PartialEq, Hash)]
-#[collect(require_static)]
-struct OwnedWStr(WString);
-
-impl Deref for OwnedWStr {
-    type Target = WStr;
-
-    #[inline(always)]
-    fn deref(&self) -> &WStr {
-        &self.0
-    }
-}
-
-impl Borrow<WStr> for OwnedWStr {
-    #[inline(always)]
-    fn borrow(&self) -> &WStr {
-        &self.0
-    }
-}
-
-impl Default for OwnedWStr {
-    #[inline(always)]
-    fn default() -> Self {
-        OwnedWStr(WString::new())
     }
 }

--- a/core/src/string/avm_string.rs
+++ b/core/src/string/avm_string.rs
@@ -1,0 +1,118 @@
+use ruffle_wstr::{wstr_impl_traits, WStr, WString};
+
+use std::ops::Deref;
+
+use gc_arena::{Collect, Gc, MutationContext};
+use std::borrow::Cow;
+
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+enum Source<'gc> {
+    Owned(Gc<'gc, OwnedWStr>),
+    Static(&'static WStr),
+}
+
+#[derive(Collect)]
+#[collect(require_static)]
+struct OwnedWStr(WString);
+
+#[derive(Clone, Copy, Collect)]
+#[collect(no_drop)]
+pub struct AvmString<'gc> {
+    source: Source<'gc>,
+}
+
+impl<'gc> AvmString<'gc> {
+    pub fn new_utf8<'s, S: Into<Cow<'s, str>>>(
+        gc_context: MutationContext<'gc, '_>,
+        string: S,
+    ) -> Self {
+        let buf = match string.into() {
+            Cow::Owned(utf8) => WString::from_utf8_owned(utf8),
+            Cow::Borrowed(utf8) => WString::from_utf8(utf8),
+        };
+        Self {
+            source: Source::Owned(Gc::allocate(gc_context, OwnedWStr(buf))),
+        }
+    }
+
+    pub fn new_utf8_bytes(gc_context: MutationContext<'gc, '_>, bytes: &[u8]) -> Self {
+        let buf = WString::from_utf8_bytes(bytes.to_vec());
+        Self::new(gc_context, buf)
+    }
+
+    pub fn new<S: Into<WString>>(gc_context: MutationContext<'gc, '_>, string: S) -> Self {
+        Self {
+            source: Source::Owned(Gc::allocate(gc_context, OwnedWStr(string.into()))),
+        }
+    }
+
+    pub fn as_wstr(&self) -> &WStr {
+        match &self.source {
+            Source::Owned(s) => &s.0,
+            Source::Static(s) => s,
+        }
+    }
+
+    pub fn concat(
+        gc_context: MutationContext<'gc, '_>,
+        left: AvmString<'gc>,
+        right: AvmString<'gc>,
+    ) -> AvmString<'gc> {
+        if left.is_empty() {
+            right
+        } else if right.is_empty() {
+            left
+        } else {
+            let mut out = WString::from(left.as_wstr());
+            out.push_str(&right);
+            Self::new(gc_context, out)
+        }
+    }
+
+    #[inline]
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        match (this.source, other.source) {
+            (Source::Owned(this), Source::Owned(other)) => Gc::ptr_eq(this, other),
+            (Source::Static(this), Source::Static(other)) => std::ptr::eq(this, other),
+            _ => false,
+        }
+    }
+}
+
+impl Default for AvmString<'_> {
+    fn default() -> Self {
+        Self {
+            source: Source::Static(WStr::empty()),
+        }
+    }
+}
+
+impl<'gc> From<&'static str> for AvmString<'gc> {
+    #[inline]
+    fn from(str: &'static str) -> Self {
+        // TODO(moulins): actually check that `str` is valid ASCII.
+        Self {
+            source: Source::Static(WStr::from_units(str.as_bytes())),
+        }
+    }
+}
+
+impl<'gc> From<&'static WStr> for AvmString<'gc> {
+    #[inline]
+    fn from(str: &'static WStr) -> Self {
+        Self {
+            source: Source::Static(str),
+        }
+    }
+}
+
+impl<'gc> Deref for AvmString<'gc> {
+    type Target = WStr;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_wstr()
+    }
+}
+
+wstr_impl_traits!(impl['gc] for AvmString<'gc>);

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -1,16 +1,18 @@
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
+use std::cell::Cell;
+use std::hash::{BuildHasher, Hash, Hasher};
+use std::marker::PhantomData;
+use std::ops::DerefMut;
 
-use fnv::FnvHashSet;
-use gc_arena::{Collect, MutationContext};
-use ruffle_wstr::WStr;
+use gc_arena::{Collect, CollectionContext, Gc, GcWeak, MutationContext};
+use hashbrown::raw::{Bucket, RawTable};
 
-use super::avm_string::AvmString;
+use crate::string::{AvmString, OwnedWStr, WStr};
 
 #[derive(Collect, Default)]
 #[collect(no_drop)]
 pub struct AvmStringInterner<'gc> {
-    // TODO(moulins): use some kind of weak map
-    interned: FnvHashSet<AvmString<'gc>>,
+    interned: WeakSet<'gc, OwnedWStr>,
 }
 
 impl<'gc> AvmStringInterner<'gc> {
@@ -18,31 +20,244 @@ impl<'gc> AvmStringInterner<'gc> {
         Self::default()
     }
 
-    #[must_use]
-    pub fn intern_wstr<'a, S>(
-        &mut self,
-        gc_context: MutationContext<'gc, '_>,
-        s: S,
-    ) -> AvmString<'gc>
-    where
-        S: AsRef<WStr> + Into<Cow<'a, WStr>>,
-    {
-        if let Some(s) = self.interned.get(s.as_ref()) {
-            *s
-        } else {
-            let s = AvmString::new(gc_context, s.into().into_owned());
-            self.interned.insert(s);
-            s
-        }
+    fn alloc(mc: MutationContext<'gc, '_>, s: Cow<'_, WStr>) -> Gc<'gc, OwnedWStr> {
+        Gc::allocate(mc, OwnedWStr(s.into_owned()))
     }
 
     #[must_use]
-    pub fn intern(&mut self, s: AvmString<'gc>) -> AvmString<'gc> {
-        if let Some(s) = self.interned.get(&s) {
-            *s
-        } else {
-            self.interned.insert(s);
-            s
+    pub fn intern_wstr<'a, S>(&mut self, mc: MutationContext<'gc, '_>, s: S) -> AvmString<'gc>
+    where
+        S: Into<Cow<'a, WStr>>,
+    {
+        let s = s.into();
+        let atom = match self.interned.entry(mc, s.as_ref()) {
+            (Some(atom), _) => atom,
+            (None, h) => self.interned.insert_fresh(mc, h, Self::alloc(mc, s)),
+        };
+
+        AvmString::from_owned(atom)
+    }
+
+    #[must_use]
+    pub fn get<'a>(&self, mc: MutationContext<'gc, '_>, s: &WStr) -> Option<AvmString<'gc>> {
+        self.interned.get(mc, s).map(AvmString::from_owned)
+    }
+
+    #[must_use]
+    pub fn intern(&mut self, mc: MutationContext<'gc, '_>, s: AvmString<'gc>) -> AvmString<'gc> {
+        let atom = match self.interned.entry(mc, s.as_wstr()) {
+            (Some(atom), _) => atom,
+            (None, h) => self.interned.insert_fresh(mc, h, s.to_owned(mc)),
+        };
+
+        AvmString::from_owned(atom)
+    }
+}
+
+/// A set holding weakly to its elements.
+///
+/// Stale entries get regularly cleaned up in response to memory pressure:
+/// - in the tracing phase of each GC cycle;
+/// - upon insertion when the set is at capacity.
+#[derive(Default)]
+struct WeakSet<'gc, T: 'gc> {
+    // Cannot use `HashSet` here, as `GcWeak` cannot implement `Hash`.
+    raw: CollectCell<'gc, RawTable<GcWeak<'gc, T>>>,
+    hasher: fnv::FnvBuildHasher,
+}
+
+struct FindResult<'gc, T: 'gc> {
+    value: Option<Gc<'gc, T>>,
+    stale: Option<Bucket<GcWeak<'gc, T>>>,
+}
+
+impl<'gc, T: 'gc> WeakSet<'gc, T> {
+    fn hash<K: Hash + ?Sized>(build_hasher: &impl BuildHasher, key: &K) -> u64 {
+        let mut hasher = build_hasher.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Finds a live, matching entry with a given hash.
+    /// Returns both the matching entry and the first stale bucket found along the way.
+    fn find_inner(
+        &self,
+        mc: MutationContext<'gc, '_>,
+        hash: u64,
+        mut eq: impl FnMut(&T) -> bool,
+    ) -> FindResult<'gc, T> {
+        let raw = self.raw.as_ref(mc);
+        let mut result = FindResult {
+            value: None,
+            stale: None,
+        };
+
+        // SAFETY: `iter_hash` doesn't outlive `raw`, and only returns full buckets.
+        unsafe {
+            for bucket in raw.iter_hash(hash) {
+                match bucket.as_ref().upgrade(mc) {
+                    Some(strong) if eq(&strong) => {
+                        result.value = Some(strong);
+                        break;
+                    }
+                    None if result.stale.is_none() => {
+                        result.stale = Some(bucket);
+                    }
+                    _ => (),
+                }
+            }
         }
+
+        result
+    }
+
+    /// Finds the given key in the map.
+    fn get<Q>(&self, mc: MutationContext<'gc, '_>, key: &Q) -> Option<Gc<'gc, T>>
+    where
+        T: Borrow<Q> + Hash,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = Self::hash(&self.hasher, key);
+        let result = self.find_inner(mc, hash, |strong| strong.borrow() == key);
+        result.value
+    }
+
+    /// Finds the given key in the map, and return its and its hash.
+    /// TODO: add proper entry API?
+    fn entry<Q>(&mut self, mc: MutationContext<'gc, '_>, key: &Q) -> (Option<Gc<'gc, T>>, u64)
+    where
+        T: Borrow<Q> + Hash,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hasher = &self.hasher;
+        let hash = Self::hash(hasher, key);
+        let result = self.find_inner(mc, hash, |strong| strong.borrow() == key);
+
+        // Clear any stale bucket found; this ensures that reinserting
+        // a freshly pruned key does not grow the table.
+        if let Some(stale) = result.stale {
+            unsafe { self.raw.as_mut().erase(stale) }
+        }
+
+        (result.value, hash)
+    }
+
+    /// Inserts a new key in the set.
+    /// The key must not already exist, and `hash` must be its hash.
+    /// TODO: add proper entry API?
+    fn insert_fresh(
+        &mut self,
+        mc: MutationContext<'gc, '_>,
+        hash: u64,
+        key: Gc<'gc, T>,
+    ) -> Gc<'gc, T>
+    where
+        T: Hash,
+    {
+        let weak = Gc::downgrade(key);
+        let raw = self.raw.as_mut();
+        let hasher = &self.hasher;
+
+        if raw.try_insert_no_grow(hash, weak).is_err() {
+            Self::prune_and_grow(raw, |w| w.upgrade(mc), |k| Self::hash(hasher, &**k));
+            raw.try_insert_no_grow(hash, weak)
+                .expect("failed to grow table");
+        }
+
+        key
+    }
+
+    /// Prune stale entries and resize the table to ensure at least one extra entry can be added.
+    #[cold]
+    fn prune_and_grow<K, B>(
+        raw: &mut RawTable<B>,
+        upgrade: impl Fn(&B) -> Option<K>,
+        hasher: impl Fn(&K) -> u64,
+    ) {
+        // We *really* don't want to reallocate, so try to prune dead references first.
+        let all = raw.len();
+        Self::retain(raw, |b| upgrade(b).is_some());
+        let remaining = raw.len();
+
+        // Only reallocate if few entries were pruned.
+        if remaining >= all / 2 {
+            raw.reserve(all - remaining + 1, |b| match upgrade(b) {
+                Some(k) => hasher(&k),
+                None => unreachable!("unexpected stale entry"),
+            })
+        }
+    }
+
+    /// Filters the entries of a raw table.
+    fn retain<B>(raw: &mut RawTable<B>, mut f: impl FnMut(&mut B) -> bool) {
+        // SAFETY: `iter` doesn't outlive `raw`, and only return full buckets.
+        unsafe {
+            for bucket in raw.iter() {
+                if !f(bucket.as_mut()) {
+                    raw.erase(bucket);
+                }
+            }
+        }
+    }
+}
+
+unsafe impl<'gc, T> Collect for WeakSet<'gc, T> {
+    fn trace(&self, cc: CollectionContext) {
+        // Prune entries known to be dead.
+        // Safe, as we never pick up new GC pointers from outside this allocation.
+        let mut guard = unsafe { self.raw.steal_for_trace() };
+        Self::retain(&mut *guard, |weak| {
+            let keep = !weak.is_dropped();
+            if keep {
+                // NOTE: The explicit dereference is necessary to not
+                // use the no-op `Collect` impl on references.
+                (*weak).trace(cc);
+            }
+            keep
+        });
+    }
+}
+
+/// Small utility to work-around the fact that `Collect::trace` only takes `&self`.
+#[derive(Default)]
+struct CollectCell<'gc, T> {
+    inner: Cell<T>,
+    _marker: PhantomData<Gc<'gc, T>>,
+}
+
+impl<'gc, T> CollectCell<'gc, T> {
+    #[inline(always)]
+    fn as_ref<'a>(&'a self, _mc: MutationContext<'gc, '_>) -> &'a T {
+        unsafe { &*self.inner.as_ptr() }
+    }
+
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    /// SAFETY: must be called inside a `Collect::trace` function.
+    ///
+    /// An alternative would be to require a `CollectionContext` argument, but this is
+    /// still unsound in presence of nested arenas (preventing this would require a `'gc`
+    /// lifetime on `CollectionContext` and `Collect`):
+    ///
+    /// ```rs,ignore
+    /// fn trace(&self, cc: CollectionContext) {
+    ///     rootless_arena(|mc| {
+    ///         let cell = CollectCell::<i32>::default();
+    ///         let borrow: &i32 = dbg!(cell.as_ref(mc)); // 0
+    ///         *cell.steal_for_trace(cc) = 1;
+    ///         dbg!(borrow); // 1 - oh no!
+    ///     });
+    /// }
+    /// ```
+    #[inline(always)]
+    unsafe fn steal_for_trace(&self) -> impl DerefMut<Target = T> + '_
+    where
+        T: Default,
+    {
+        let cell = &self.inner;
+        scopeguard::guard(cell.take(), |stolen| cell.set(stolen))
     }
 }

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::borrow::{Borrow, Cow};
 use std::cell::Cell;
 use std::hash::{BuildHasher, Hash, Hasher};
@@ -42,6 +43,18 @@ impl<'gc> Eq for AvmAtom<'gc> {}
 impl<'gc> Hash for AvmAtom<'gc> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Gc::as_ptr(self.0).hash(state);
+    }
+}
+
+impl<'gc> fmt::Debug for AvmAtom<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_wstr(), f)
+    }
+}
+
+impl<'gc> fmt::Display for AvmAtom<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_wstr(), f)
     }
 }
 

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -1,0 +1,42 @@
+use fnv::FnvHashSet;
+use gc_arena::{Collect, MutationContext};
+use ruffle_wstr::{WStr, WString};
+
+use super::avm_string::AvmString;
+
+#[derive(Collect, Default)]
+#[collect(no_drop)]
+pub struct AvmStringInterner<'gc> {
+    // TODO(moulins): use some kind of weak map
+    interned: FnvHashSet<AvmString<'gc>>,
+}
+
+impl<'gc> AvmStringInterner<'gc> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn intern_wstr<S>(&mut self, gc_context: MutationContext<'gc, '_>, s: S) -> AvmString<'gc>
+    where
+        S: AsRef<WStr> + Into<WString>,
+    {
+        if let Some(s) = self.interned.get(s.as_ref()) {
+            *s
+        } else {
+            let s = AvmString::new(gc_context, s);
+            self.interned.insert(s);
+            s
+        }
+    }
+
+    #[must_use]
+    pub fn intern(&mut self, s: AvmString<'gc>) -> AvmString<'gc> {
+        if let Some(s) = self.interned.get(&s) {
+            *s
+        } else {
+            self.interned.insert(s);
+            s
+        }
+    }
+}

--- a/core/src/string/interner.rs
+++ b/core/src/string/interner.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
+
 use fnv::FnvHashSet;
 use gc_arena::{Collect, MutationContext};
-use ruffle_wstr::{WStr, WString};
+use ruffle_wstr::WStr;
 
 use super::avm_string::AvmString;
 
@@ -17,14 +19,18 @@ impl<'gc> AvmStringInterner<'gc> {
     }
 
     #[must_use]
-    pub fn intern_wstr<S>(&mut self, gc_context: MutationContext<'gc, '_>, s: S) -> AvmString<'gc>
+    pub fn intern_wstr<'a, S>(
+        &mut self,
+        gc_context: MutationContext<'gc, '_>,
+        s: S,
+    ) -> AvmString<'gc>
     where
-        S: AsRef<WStr> + Into<WString>,
+        S: AsRef<WStr> + Into<Cow<'a, WStr>>,
     {
         if let Some(s) = self.interned.get(s.as_ref()) {
             *s
         } else {
-            let s = AvmString::new(gc_context, s);
+            let s = AvmString::new(gc_context, s.into().into_owned());
             self.interned.insert(s);
             s
         }

--- a/core/src/string/repr.rs
+++ b/core/src/string/repr.rs
@@ -1,0 +1,73 @@
+use std::cell::Cell;
+use std::ops::Deref;
+
+use gc_arena::Collect;
+use ruffle_wstr::{ptr as wptr, wstr_impl_traits, WStr, WString};
+
+/// Internal representation of `AvmAtom`s and (owned) `AvmString`.
+///
+/// Using this type directly is dangerous, as it can be used to violate
+/// the interning invariants.
+#[derive(Collect)]
+#[collect(require_static)]
+pub struct AvmStringRepr {
+    ptr: *mut (),
+    meta: wptr::WStrMetadata,
+    // We abuse the 'is_wide' bit for interning.
+    capacity: Cell<wptr::WStrMetadata>,
+}
+
+impl AvmStringRepr {
+    pub fn from_raw(s: WString, interned: bool) -> Self {
+        let (ptr, meta, cap) = s.into_raw_parts();
+        let capacity = Cell::new(wptr::WStrMetadata::new32(cap, interned));
+        Self {
+            ptr,
+            meta,
+            capacity,
+        }
+    }
+
+    #[inline]
+    pub fn as_wstr(&self) -> &WStr {
+        // SAFETY: we own a `WString`.
+        unsafe { &*wptr::from_raw_parts(self.ptr, self.meta) }
+    }
+
+    pub fn is_interned(&self) -> bool {
+        self.capacity.get().is_wide()
+    }
+
+    pub fn mark_interned(&self) {
+        let cap = self.capacity.get();
+        let new_cap = wptr::WStrMetadata::new32(cap.len32(), true);
+        self.capacity.set(new_cap);
+    }
+}
+
+impl Drop for AvmStringRepr {
+    fn drop(&mut self) {
+        // SAFETY: we drop the `WString` we logically own.
+        unsafe {
+            let cap = self.capacity.get().len32();
+            let _ = WString::from_raw_parts(self.ptr, self.meta, cap);
+        }
+    }
+}
+
+impl Deref for AvmStringRepr {
+    type Target = WStr;
+    #[inline]
+    fn deref(&self) -> &WStr {
+        self.as_wstr()
+    }
+}
+
+impl Default for AvmStringRepr {
+    #[inline]
+    fn default() -> Self {
+        Self::from_raw(WString::new(), false)
+    }
+}
+
+wstr_impl_traits!(impl for AvmStringRepr);


### PR DESCRIPTION
This PR builds on #10572.

- Adds a global string interner based on a custom, GC-aware `WeakSet`;
- Reworks the internal `AvmString` representation to distinguish between interned and non-interned strings, enabling faster equality checks for interned strings;
- Adds the `AvmAtom` type to represent guaranteed-interned `AvmString`s;
- Intern all strings loaded from the AVM1 & the AVM2 constant pools;
- Intern all AVM2 namespaces strings (but not the namespaces themselves, nor the strings in `QName`s or `Multiname`s);
- Intern all 'built-in' strings used in AVM1 globals initialization.

To facilitate these changes, I've added a new minimal `GcContext` struct (bundling the `MutationContext` with the interner), which can be used where passing a full `UpdateContext` would be impossible or undesirable.

-------

Performance-wise, I'm seeing ~10% FPS improvements on AVM2-heavy SWFs (like the box2d demo); unfortunately I don't have any good AVM1 benchmark so there's no concrete numbers, but I expect roughly similar figures.

-------

Possible work for future PRs:
- (AVM2) Optimize namespaces by using pointer tagging to encode the kind of namespace without an extra allocation (needs `Gc<T> -> *mut T` roundtrip support from `gc-arena`);
- Remove the need for a separate static `AvmString` variant (would also need `Gc<T> -> *mut T` roundtrip support);
- (AVM1) Avoid re-parsing `SwfStr`s into `AvmString`s on each action execution, maybe by keeping some kind of per-SWF string cache?
- Only store `AvmAtom`s for AVM1 & AVM2 properties; this would allow using the `AvmAtom` address directly as the map key and completely skip string hashing and comparisons in most cases (I've tried doing it in this PR, but had to bail out as the required changes were quickly growing out of control, and this PR is already big enough...);
- (AVM1) Add a way to intern integers as strings directly, to avoid transient string allocations on array accesses;
- etc...