### PR TITLE
web: Submit the extension at 2AM Saturday UTC.

### DIFF
--- a/.github/workflows/release_amo.yml
+++ b/.github/workflows/release_amo.yml
@@ -3,7 +3,7 @@ name: Release to addons.mozilla.org
 on:
   #Run weekly every Friday
   schedule:
-   - cron: "0 0 * * 5"
+   - cron: "0 2 * * 6"
   
   #Allow for manual releases if needed
   workflow_dispatch:


### PR DESCRIPTION
The reason for this is twofold:

 * Running the release at the same time as the build means we are likely to miss the actual XPI file we need to build. This is a race condition introduced by this being a different workflow that waiting a bit should at least paper over.
  * While our policy was "release on Fridays", this was Friday in US time. Workflows are scheduled in UTC, so it was coinciding with the Thursday nightly.