### PR TITLE
(Non-functional) XML hasOwnProperty support

### DIFF
--- a/core/src/avm2/globals/XML.as
+++ b/core/src/avm2/globals/XML.as
@@ -36,6 +36,7 @@ package {
         AS3 native function copy():XML;
         AS3 native function parent():*;
         AS3 native function elements(name:*):XMLList;
+        override AS3 native function hasOwnProperty(name:String):Boolean;
         AS3 native function attributes():XMLList;
         AS3 native function attribute(name:*):XMLList;
         AS3 native function nodeKind():String;
@@ -96,6 +97,11 @@ package {
         prototype.elements = function(name:*):XMLList {
             var self:XML = this;
             return self.AS3::elements(name);
+        }
+
+        prototype.hasOwnProperty = function(name:String):Boolean {
+            var self:XML = this;
+            return self.AS3::hasOwnProperty(name);
         }
 
         prototype.toString = function():String {

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -106,6 +106,12 @@ pub fn name_to_multiname<'gc>(
     }
 
     let name = name.coerce_to_string(activation)?;
+
+    if name.starts_with(b'@') {
+        let name = AvmString::new(activation.context.gc_context, &name[1..]);
+        return Ok(Multiname::attribute(activation.avm2().public_namespace, name));
+    }
+
     Ok(if &*name == b"*" {
         Multiname::any(activation.context.gc_context)
     } else {
@@ -225,6 +231,16 @@ pub fn elements<'gc>(
     };
 
     Ok(XmlListObject::new(activation, children, Some(xml.into())).into())
+}
+
+pub fn has_own_property<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Option<Object<'gc>>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    let xml = this.unwrap().as_xml_object().unwrap();
+    let multiname = name_to_multiname(activation, &args[0])?;
+    Ok(xml.has_own_property(&multiname).into())
 }
 
 pub fn attributes<'gc>(

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -306,6 +306,16 @@ impl<'gc> Multiname<'gc> {
         }
     }
 
+    /// Creates a new Multiname with the `MultinameFlags::ATTRIBUTE` flag.
+    pub fn attribute(ns: Namespace<'gc>, name: impl Into<AvmString<'gc>>) -> Self {
+        Self {
+            ns: NamespaceSet::single(ns),
+            name: Some(name.into()),
+            params: Vec::new(),
+            flags: MultinameFlags::ATTRIBUTE,
+        }
+    }
+
     pub fn namespace_set(&self) -> &[Namespace<'gc>] {
         match &self.ns {
             NamespaceSet::Single(ns) => std::slice::from_ref(ns),


### PR DESCRIPTION
I am posting this now to get some feedback on this build error, that is caused by trying to add `override` to the method definition: 

```
error: failed to run custom build command for `ruffle_core v0.1.0 (/home/tom/projects/ruffle/core)`

Caused by:
  process didn't exit successfully: `/home/tom/projects/ruffle/target/release/build/ruffle_core-ea88957b1db90d09/build-script-build` (exit status: 101)
  --- stderr
  [Compiler] Error #1004: Namespace was not found or is not a compile-time constant.
     /home/tom/projects/ruffle/core/src/avm2/globals/XML.as, Ln 7, Col 9: 
             AS3 static function setSettings(settings:Object): void {
     ........^

  [globals.as$2, , , RegExp, RegExp, RegExp]::undefined on line 6 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , XML, XML, XML]::undefined on line 25 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.events, flash.events, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:Event]::NaN on line 137 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , RegExp, RegExp, RegExp]::undefined on line 4 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.events, flash.events, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:Event]::NaN on line 137 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.events, flash.events, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:Event]::NaN on line 139 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.globalization, flash.globalization, flash.globalization:CurrencyParseResult, flash.globalization:CurrencyParseResult, flash.globalization:CurrencyParseResult]::NaN on line 27 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.events, flash.events, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:Event]::NaN on line 145 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.events, flash.events, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:Event]::NaN on line 139 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.display, flash.display, flash.display:Graphics, flash.display:Graphics, flash.display:Graphics]::NaN on line 45 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , XMLList, XMLList, XMLList]::undefined on line 2 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , Math, Math, Math]::Infinity on line 58 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , Math, Math, Math]::Infinity on line 57 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , QName, QName, QName]::undefined on line 6 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.display, flash.display, flash.display:Graphics, flash.display:Graphics, flash.display:Graphics]::NaN on line 48 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.display, flash.display, flash.display:GraphicsStroke, flash.display:GraphicsStroke, flash.display:GraphicsStroke]::NaN on line 19 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , , QName, QName, QName]::undefined on line 7 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  [globals.as$2, , flash.events, flash.events, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:TouchEvent, flash.events:Event]::NaN on line 139 of file /home/tom/projects/ruffle/core/src/avm2/globals/globals.as not resolved
  Files: 3 Time: 545ms
  thread 'main' panicked at 'Failed to build playerglobal: Os { code: 2, kind: NotFound, message: "No such file or directory" }', core/build.rs:7:6
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

It also looks like Flash doesn't really follow the specification, because XML.hasOwnProperty seems to handle XML names, but Object.prototype.hasOwnProperty doesn't. So this implementation is actually closer to the real world than I thought.

```
var xml = <a hello="world" />;
trace('xml.hasOwnProperty("@hello")', xml.hasOwnProperty("@hello")); // true
trace('Object.prototype.hasOwnProperty.call(xml, "@hello")', Object.prototype.hasOwnProperty.call(xml, "@hello")); // false
```