### PR TITLE
core: Fix avm2 code interfering with avm1

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -346,12 +346,11 @@ pub trait TDisplayObjectContainer<'gc>:
         if removed_from_render_list {
             if !context.is_action_script_3() {
                 child.avm1_unload(context);
-            }
+            } else if !matches!(child.object2(), Avm2Value::Null) {
+                //TODO: This is an awful, *awful* hack to deal with the fact
+                //that unloaded AVM1 clips see their parents, while AVM2 clips
+                //don't.
 
-            //TODO: This is an awful, *awful* hack to deal with the fact
-            //that unloaded AVM1 clips see their parents, while AVM2 clips
-            //don't.
-            if !matches!(child.object2(), Avm2Value::Null) {
                 child.set_parent(context, None);
             }
         }
@@ -400,9 +399,7 @@ pub trait TDisplayObjectContainer<'gc>:
 
             if !context.is_action_script_3() {
                 removed.avm1_unload(context);
-            }
-
-            if !matches!(removed.object2(), Avm2Value::Null) {
+            } else if !matches!(removed.object2(), Avm2Value::Null) {
                 removed.set_parent(context, None);
             }
 


### PR DESCRIPTION
[A previous change](https://github.com/ruffle-rs/ruffle/pull/8944/files#diff-7b448c1d34980fdeb5c34bbaf557a6eb287d89d2bf091c943c46bbe00004c9ac) that was meant to only target AVM2 caused #7783 (an AVM1 game) to partially work by a total fluke.