### PR TITLE
video/vp6: Fix glitching with some VP6A videos

### DIFF
--- a/video/software/src/decoder/vp6.rs
+++ b/video/software/src/decoder/vp6.rs
@@ -219,10 +219,13 @@ impl VideoDecoder for Vp6Decoder {
 
         // Adding in the alpha component, if present.
         if self.with_alpha {
+            // Apparently it's possible for the alpha channel to be coded in a different size than the Y channel.
+            let (alpha_width, alpha_height) = frame.get_dimensions(3);
             debug_assert!(frame.get_stride(3) == frame.get_dimensions(3).0);
+
             let alpha_offset = frame.get_offset(3);
-            let alpha = &yuv[alpha_offset..alpha_offset + width * height];
-            let a = crop(alpha, width, bounds);
+            let alpha = &yuv[alpha_offset..alpha_offset + alpha_width * alpha_height];
+            let a = crop(alpha, alpha_width, bounds);
 
             let mut data = y.to_vec();
             data.extend(u);


### PR DESCRIPTION
Specifically, when Y and A frame sizes differ. For some reason this being possible hasn't even occurred to me, it just happened to work before.

This regressed in 2ad4399 (#9753).

Fixes #10700.