### PR TITLE
avm1: shrink `Value` by boxing `MovieClipReference`s

### DIFF
--- a/core/src/avm1/value.rs
+++ b/core/src/avm1/value.rs
@@ -11,7 +11,7 @@ use crate::ecma_conversions::{
 };
 use crate::string::{AvmString, Integer, WStr};
 use gc_arena::Collect;
-use std::{borrow::Cow, io::Write, num::Wrapping};
+use std::{borrow::Cow, io::Write, mem::size_of, num::Wrapping};
 
 use super::object_reference::MovieClipReference;
 
@@ -27,6 +27,13 @@ pub enum Value<'gc> {
     Object(Object<'gc>),
     MovieClip(MovieClipReference<'gc>),
 }
+
+// This type is used very frequently, so make sure it doesn't unexpectedly grow.
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(size_of::<Value<'_>>() == 16);
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<Value<'_>>() == 24);
 
 impl<'gc> From<AvmString<'gc>> for Value<'gc> {
     fn from(string: AvmString<'gc>) -> Self {


### PR DESCRIPTION
Brings `Value` from 48 bytes to 24 bytes on 64-bits targets (and similarly for 32-bits).

This doesn't actually cost an extra allocation as we can replace an inner `Gc<Vec<_>>` by a `Box<[_]>` directly.