### PR TITLE
web: Update current Node.js version

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -294,7 +294,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "19"
+          node-version: "20"
           registry-url: https://registry.npmjs.org
 
       # wasm-bindgen-cli version must match wasm-bindgen crate version.

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["18", "19"]
+        node_version: ["18", "20"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: ["18", "19"]
+        node_version: ["18", "20"]
         rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 

--- a/web/README.md
+++ b/web/README.md
@@ -48,7 +48,7 @@ For the compiler to be able to output WebAssembly, an additional target has to b
 
 #### Java
 
-Follow the instructions [to install OpenJDK](https://openjdk.org/projects/jdk/19/) on your machine.
+Follow the instructions [to install OpenJDK](https://openjdk.org/projects/jdk/20/) on your machine.
 
 We do not have a specific Java support policy. Any Java version that supports running the AS3 compiler
 should work. Additionally, headless JREs should also work.
@@ -57,7 +57,7 @@ should work. Additionally, headless JREs should also work.
 
 Follow the instructions to [install Node.js](https://nodejs.org/) on your machine.
 
-We recommend using the currently active LTS 18, but we do also run tests with current Node.js 19.
+We recommend using the currently active LTS 18, but we do also run tests with current Node.js 20.
 
 Note that npm 7 or newer is required. It should come bundled with Node.js 15 or newer, but can be upgraded with older Node.js versions using `npm install -g npm` as root/Administrator.
 


### PR DESCRIPTION
Per https://nodejs.org/en/about/releases/:

* Node.js 19 became "maintenance" on April 1st.
* Node.js 20 became "current" on April 18th, and will become "active LTS" on October 24th.

In order prepare for potentially breaking changes, update the tested Node.js versions from 18 and 19 to 18 and 20.

By the way, refer to JDK 20 installation, which is the latest release.