### PR TITLE
web: Add extension option for setting max. exec. time.

### DIFF
--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -118,6 +118,16 @@ export const enum WindowMode {
 }
 
 /**
+ * Based on https://doc.rust-lang.org/stable/std/time/struct.Duration.html .
+ * Each member is an integer and non-negative.
+ */
+export interface Duration {
+
+    secs: number,
+    nanos: number,
+};
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -250,10 +260,7 @@ export interface BaseLoadOptions {
      *
      * @default { secs: 15, nanos: 0 }
      */
-    maxExecutionDuration?: {
-        secs: number;
-        nanos: number;
-    };
+    maxExecutionDuration?: Duration;
 
     /**
      * Specifies the base directory or URL used to resolve all relative path statements in the SWF file.

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -122,10 +122,9 @@ export const enum WindowMode {
  * Each member is an integer and non-negative.
  */
 export interface Duration {
-
-    secs: number,
-    nanos: number,
-};
+    secs: number;
+    nanos: number;
+}
 
 /**
  * Any options used for loading a movie.

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -20,6 +20,9 @@
     "settings_log_level": {
         "message": "Log level"
     },
+    "settings_max_execution_duration": {
+        "message": "How long can actionscript execute for before being forcefully stopped (in seconds)"
+    },
     "status_init": {
         "message": "Reading current tab…"
     },

--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -109,10 +109,8 @@ body {
 
 /* Number input. */
 
-.number_input input {
-
+.option.number-input input {
     width: 60px;
     height: 20px;
     margin: auto;
 }
-

--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -36,6 +36,10 @@ body {
     transform: scale(104%);
 }
 
+/*
+ * Controls.
+ */
+
 /* Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW */
 .option {
     position: relative;
@@ -53,6 +57,13 @@ body {
     right: 0;
 }
 
+.option label {
+    display: inline-block;
+    padding-right: 80px;
+}
+
+/* Checkbox. */
+
 .option.checkbox input {
     width: 40px;
     height: 20px;
@@ -60,11 +71,6 @@ body {
     cursor: pointer;
     z-index: 1;
     opacity: 0;
-}
-
-.option label {
-    display: inline-block;
-    padding-right: 40px;
 }
 
 .option.checkbox label::before,
@@ -100,3 +106,13 @@ body {
     background: var(--ruffle-orange);
     right: 1px;
 }
+
+/* Number input. */
+
+.number_input input {
+
+    width: 60px;
+    height: 20px;
+    margin: auto;
+}
+

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -47,6 +47,12 @@
                 <input type="checkbox" id="autostart" />
                 <label for="autostart">Play automatically without splash screen (then click to unmute)</label>
             </div>
+            <div class="option number_input">
+                <input type="number" id="max_execution_duration"
+                    min="1"
+                />
+                <label for="max_execution_duration">How long can actionscript execute for before being forcefully stopped (in seconds)</label>
+            </div>
         </div>
         <script src="dist/options.js"></script>
     </body>

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -47,7 +47,7 @@
                 <input type="checkbox" id="autostart" />
                 <label for="autostart">Play automatically without splash screen (then click to unmute)</label>
             </div>
-            <div class="option number_input">
+            <div class="option number-input">
                 <input type="number" id="max_execution_duration"
                     min="1"
                 />

--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -38,7 +38,9 @@ class CheckboxOption implements OptionElement<boolean> {
     }
 }
 
-class MaxExecutionDuration_NumberInputOption implements OptionElement<Duration> {
+class MaxExecutionDuration_NumberInputOption
+    implements OptionElement<Duration>
+{
     constructor(
         private readonly numberInput: HTMLInputElement,
         readonly label: HTMLLabelElement
@@ -88,16 +90,12 @@ function getElement(option: Element): OptionElement<unknown> {
 
     const [input] = option.getElementsByTagName("input");
     if (input) {
-
         if (input.type === "checkbox") {
-
             return new CheckboxOption(input, label);
         }
 
         if (input.type === "number") {
-
             if (input.id === "max_execution_duration") {
-
                 return new MaxExecutionDuration_NumberInputOption(input, label);
             }
         }

--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -1,6 +1,8 @@
 import * as utils from "./utils";
 import type { LogLevel } from "ruffle-core";
 
+import type { Duration } from "ruffle-core";
+
 export interface Options {
     ruffleEnable: boolean;
     ignoreOptout: boolean;
@@ -8,6 +10,7 @@ export interface Options {
     logLevel: LogLevel;
     showSwfDownload: boolean;
     autostart: boolean;
+    maxExecutionDuration: Duration;
 }
 
 interface OptionElement<T> {
@@ -32,6 +35,28 @@ class CheckboxOption implements OptionElement<boolean> {
 
     set value(value: boolean) {
         this.checkbox.checked = value;
+    }
+}
+
+class MaxExecutionDuration_NumberInputOption implements OptionElement<Duration> {
+    constructor(
+        private readonly numberInput: HTMLInputElement,
+        readonly label: HTMLLabelElement
+    ) {}
+
+    get input() {
+        return this.numberInput;
+    }
+
+    get value() {
+        return {
+            secs: Math.max(1, Math.round(parseInt(this.numberInput.value))),
+            nanos: 0,
+        };
+    }
+
+    set value(value: Duration) {
+        this.numberInput.value = "" + value.secs;
     }
 }
 
@@ -61,9 +86,21 @@ class SelectOption implements OptionElement<string> {
 function getElement(option: Element): OptionElement<unknown> {
     const label = option.getElementsByTagName("label")[0]!;
 
-    const [checkbox] = option.getElementsByTagName("input");
-    if (checkbox && checkbox.type === "checkbox") {
-        return new CheckboxOption(checkbox, label);
+    const [input] = option.getElementsByTagName("input");
+    if (input) {
+
+        if (input.type === "checkbox") {
+
+            return new CheckboxOption(input, label);
+        }
+
+        if (input.type === "number") {
+
+            if (input.id === "max_execution_duration") {
+
+                return new MaxExecutionDuration_NumberInputOption(input, label);
+            }
+        }
     }
 
     const [select] = option.getElementsByTagName("select");

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -176,6 +176,7 @@ function isXMLDocument(): boolean {
             autoplay: options.autostart ? "on" : "auto",
             unmuteOverlay: options.autostart ? "hidden" : "visible",
             splashScreen: !options.autostart,
+            maxExecutionDuration: options.maxExecutionDuration,
         },
     });
 })();

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -8,6 +8,7 @@ const DEFAULT_OPTIONS: Options = {
     logLevel: "error" as LogLevel,
     showSwfDownload: false,
     autostart: false,
+    maxExecutionDuration: {secs: 15, nanos: 0},
 };
 
 export let i18n: {

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -8,7 +8,7 @@ const DEFAULT_OPTIONS: Options = {
     logLevel: "error" as LogLevel,
     showSwfDownload: false,
     autostart: false,
-    maxExecutionDuration: {secs: 15, nanos: 0},
+    maxExecutionDuration: { secs: 15, nanos: 0 },
 };
 
 export let i18n: {


### PR DESCRIPTION
Add an option to the 'options' menu for the extension for setting the maximum execution time for Actionscript code.

Since this option is likely to be rarely changed by users, it has not been added to the 'popup' UI, only the 'settings' UI.

The changes only modify the CSS layout to a minor degree. I might look into making the UI layout CSS more robust in a later pull request, though no promises.