### PR TITLE
web/docs: Display enums in source order

### DIFF
--- a/web/packages/core/typedoc.json
+++ b/web/packages/core/typedoc.json
@@ -1,5 +1,6 @@
 {
    "entryPoints": ["./src/index.ts"],
    "excludePrivate": true,
-   "excludeProtected": true
+   "excludeProtected": true,
+   "sort": "enum-member-source-order"
 }


### PR DESCRIPTION
Now possible thanks to https://github.com/TypeStrong/typedoc/issues/2237.

This sorts our enums like [LogLevel](https://ruffle.rs/js-docs/master/enums/LogLevel.html) in source order while keeping the existing order for everything else.