### PR TITLE
web: Don't inherit page CSS

### DIFF
--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -6,6 +6,8 @@ export const ruffleShadowTemplate = document.createElement("template");
 ruffleShadowTemplate.innerHTML = `
     <style>
         :host {
+            all: initial;
+
             --ruffle-blue: #37528c;
             --ruffle-orange: #ffad33;
 
@@ -20,7 +22,6 @@ ruffleShadowTemplate.innerHTML = `
             user-select: none;
             -webkit-user-select: none;
             -webkit-tap-highlight-color: transparent;
-            line-height: normal;
         }
 
         /* Ruffle's width/height CSS interferes with Safari's fullscreen CSS. */


### PR DESCRIPTION
Prevents Ruffle from inheriting page CSS, ensuring that it displays as expected. Prevents bugs like #8978 without needing to explicitly set every relevant style to its default value.