### PR TITLE
avm2: Make `caller_domain` an `Option`, and call `expect` when actually needed

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -580,7 +580,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         this: Option<Object<'gc>>,
         subclass_object: Option<ClassObject<'gc>>,
         outer: ScopeChain<'gc>,
-        caller_domain: Domain<'gc>,
+        caller_domain: Option<Domain<'gc>>,
     ) -> Result<Self, Error<'gc>> {
         let local_registers = RegisterSet::new(0);
 
@@ -592,7 +592,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             local_registers,
             return_value: None,
             outer,
-            caller_domain: Some(caller_domain),
+            caller_domain,
             subclass_object,
             activation_class: None,
             stack_depth: context.avm2.stack.len(),
@@ -676,9 +676,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .chain(self.context.gc_context, self.scope_frame())
     }
 
-    /// Returns the domain of the original AS3 caller.
-    pub fn caller_domain(&self) -> Domain<'gc> {
-        self.caller_domain.expect("No caller domain available - use Activation::from_domain when constructing your domain")
+    /// Returns the domain of the original AS3 caller. This will be `None`
+    /// if this activation was constructed with `from_nothing`
+    pub fn caller_domain(&self) -> Option<Domain<'gc>> {
+        self.caller_domain
     }
 
     /// Returns the global scope of this activation.

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -90,7 +90,9 @@ pub fn load<'gc>(
             Some(MovieLoaderEventHandler::Avm2LoaderInfo(loader_info)),
             Some(Avm2LoaderData {
                 context,
-                default_domain: activation.caller_domain(),
+                default_domain: activation
+                    .caller_domain()
+                    .expect("Missing caller domain in Loader.load"),
             }),
         );
         activation.context.navigator.spawn_future(future);
@@ -219,7 +221,9 @@ pub fn load_bytes<'gc>(
             Some(MovieLoaderEventHandler::Avm2LoaderInfo(loader_info)),
             Some(Avm2LoaderData {
                 context,
-                default_domain: activation.caller_domain(),
+                default_domain: activation
+                    .caller_domain()
+                    .expect("Missing caller domain in Loader.loadBytes"),
             }),
         );
         activation.context.navigator.spawn_future(future);

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -38,7 +38,9 @@ pub fn get_current_domain<'gc>(
     _this: Option<Object<'gc>>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let appdomain = activation.caller_domain();
+    let appdomain = activation
+        .caller_domain()
+        .expect("Missing caller domain in ApplicationDomain.currentDomain");
 
     Ok(DomainObject::from_domain(activation, appdomain)?.into())
 }

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -254,7 +254,9 @@ pub fn get_definition_by_name<'gc>(
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let appdomain = activation.caller_domain();
+    let appdomain = activation
+        .caller_domain()
+        .expect("Missing caller domain in getDefinitionByName");
     let name = args
         .get(0)
         .unwrap_or(&Value::Undefined)


### PR DESCRIPTION
There are only a few places where we actually need to use the `caller_domain`, so we don't actually need it available for most native method calls. This means that `Activation::from_nothing` can be used in the vast majority of cases without causing a panic later on.