### PR TITLE
web: Update JSDoc lint rules

### DIFF
--- a/web/packages/core/src/.eslintrc.yaml
+++ b/web/packages/core/src/.eslintrc.yaml
@@ -3,15 +3,13 @@ env:
 plugins:
   - jsdoc
 extends:
-  - plugin:jsdoc/recommended
+  - plugin:jsdoc/recommended-typescript-error
 rules:
-  jsdoc/no-types: error
-  jsdoc/require-returns-type: 'off'
-  jsdoc/require-param-type: 'off'
-  jsdoc/check-tag-names:
-    - warn
-    - definedTags:
-        - internal
+  jsdoc/tag-lines:
+    - error
+    - always
+    - count: 0
+      startLines: 1
 settings:
   jsdoc:
     ignorePrivate: true

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -19,6 +19,7 @@ const jsScriptUrl = publicPath(globalConfig) + "ruffle.js";
  */
 let objects: HTMLCollectionOf<HTMLObjectElement>;
 let embeds: HTMLCollectionOf<HTMLEmbedElement>;
+
 /**
  *
  */
@@ -61,6 +62,7 @@ function polyfillFlashInstances(): void {
  */
 let iframes: HTMLCollectionOf<HTMLIFrameElement>;
 let frames: HTMLCollectionOf<HTMLFrameElement>;
+
 /**
  *
  */
@@ -169,7 +171,6 @@ async function injectRuffle(
 
 /**
  * Listen for changes to the DOM.
- *
  */
 function initMutationObserver(): void {
     const observer = new MutationObserver(function (mutationsList) {

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -56,7 +56,6 @@ export class PublicAPI {
      *
      * This is used to upgrade from a prior version of the public API, or from
      * a user-defined configuration object placed in the public API slot.
-     * @protected
      */
     protected constructor(prev: PublicAPI | null | Record<string, unknown>) {
         this.sources = {};
@@ -245,8 +244,6 @@ export class PublicAPI {
      *
      * Unfortunately, we can't disable polyfills after-the-fact, so this
      * only lets you disable the init event...
-     *
-     * @protected
      */
     protected superseded(): void {
         this.invoked = true;

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -370,8 +370,6 @@ export class RufflePlayer extends HTMLElement {
     /**
      * Updates the internal shadow DOM to reflect any set attributes from
      * this element.
-     *
-     * @protected
      */
     protected updateStyles(): void {
         if (this.dynamicStyles.sheet) {
@@ -1485,7 +1483,6 @@ export class RufflePlayer extends HTMLElement {
      * Used by the polyfill elements, RuffleObject and RuffleEmbed.
      *
      * @param element The element to copy all attributes from.
-     * @protected
      */
     protected copyElement(element: Element): void {
         if (element) {


### PR DESCRIPTION
* Extend from `plugin:jsdoc/recommended-typescript-error`, which is more suitable for TypeScript and errors by default.
* Remove default and disabled but passing rules.
* Configure `jsdoc/tag-lines` to match JSDoc style of current codebase.