### PR TITLE
extension: Make `Options` extend `BaseLoadOptions`

### DIFF
--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -1,12 +1,9 @@
 import * as utils from "./utils";
-import type { LogLevel } from "ruffle-core";
+import type { BaseLoadOptions } from "ruffle-core";
 
-export interface Options {
+export interface Options extends BaseLoadOptions {
     ruffleEnable: boolean;
     ignoreOptout: boolean;
-    warnOnUnsupportedContent: boolean;
-    logLevel: LogLevel;
-    showSwfDownload: boolean;
     autostart: boolean;
 }
 

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -170,9 +170,7 @@ function isXMLDocument(): boolean {
     await sendMessageToPage({
         type: "load",
         config: {
-            warnOnUnsupportedContent: options.warnOnUnsupportedContent,
-            logLevel: options.logLevel,
-            showSwfDownload: options.showSwfDownload,
+            ...options,
             autoplay: options.autostart ? "on" : "auto",
             unmuteOverlay: options.autostart ? "hidden" : "visible",
             splashScreen: !options.autostart,

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -1,12 +1,8 @@
 import type { Options } from "./common";
-import type { LogLevel } from "ruffle-core";
 
 const DEFAULT_OPTIONS: Options = {
     ruffleEnable: true,
     ignoreOptout: false,
-    warnOnUnsupportedContent: true,
-    logLevel: "error" as LogLevel,
-    showSwfDownload: false,
     autostart: false,
 };
 


### PR DESCRIPTION
Omit config values from `DEFAULT_OPTIONS`, which are already part of `DEFAULT_CONFIG` in `ruffle-core`. Also use spread syntax to avoid naming each config that should pass to `ruffle-core`.