### PR TITLE
web: Expand 'max_execution_duration' type in extension.

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -23,7 +23,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     // Backwards-compatibility option
     preloader: true,
     splashScreen: true,
-    maxExecutionDuration: { secs: 15, nanos: 0 },
+    maxExecutionDuration: 15,
     base: null,
     menu: true,
     salign: "",

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -153,6 +153,22 @@ export const enum RenderBackend {
 }
 
 /**
+ * Non-negative duration in seconds.
+ */
+export type SecsDuration = number;
+
+/**
+ * Deprecated duration type, use SecsDuration instead.
+ * Based on https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.new .
+ */
+export interface ObsoleteDuration {
+    secs: number;
+    nanos: number;
+}
+
+export type Duration = SecsDuration | ObsoleteDuration;
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -283,12 +299,9 @@ export interface BaseLoadOptions {
      * Maximum amount of time a script can take before scripting
      * is disabled.
      *
-     * @default { secs: 15, nanos: 0 }
+     * @default 15
      */
-    maxExecutionDuration?: {
-        secs: number;
-        nanos: number;
-    };
+    maxExecutionDuration?: Duration;
 
     /**
      * Specifies the base directory or URL used to resolve all relative path statements in the SWF file.

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -452,6 +452,17 @@ export class RufflePlayer extends HTMLElement {
                 "The configuration option preloader has been replaced with splashScreen. If you own this website, please update the configuration."
             );
         }
+        if (
+            this.loadedConfig &&
+            this.loadedConfig.maxExecutionDuration &&
+            typeof this.loadedConfig.maxExecutionDuration !== "number"
+        ) {
+            console.warn(
+                "Configuration: An obsolete format for duration for 'maxExecutionDuration' was used, " +
+                    "please use a single number indicating seconds instead. For instance '15' instead of " +
+                    "'{secs: 15, nanos: 0}'."
+            );
+        }
         const ruffleConstructor = await loadRuffle(
             this.loadedConfig || {},
             this.onRuffleDownloadProgress.bind(this)


### PR DESCRIPTION
The option 'max_execution_duration' previously only supported the type '{secs: number, nanos: number}'. Now it also supports using floating point numbers (and integers).

Default values have been changed to use floating point numbers.