### PR TITLE
web: Expand 'max_execution_duration' type in extension.

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -23,7 +23,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     // Backwards-compatibility option
     preloader: true,
     splashScreen: true,
-    maxExecutionDuration: { secs: 15, nanos: 0 },
+    maxExecutionDuration: 15,
     base: null,
     menu: true,
     salign: "",

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -153,6 +153,22 @@ export const enum RenderBackend {
 }
 
 /**
+ * Non-negative duration in seconds.
+ */
+export type SecsDuration = number;
+
+/**
+ * Deprecated duration type, use SecsDuration instead.
+ * Based on https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.new .
+ */
+export interface ObsoleteDuration {
+    secs: number;
+    nanos: number;
+}
+
+export type Duration = SecsDuration | ObsoleteDuration;
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -283,12 +299,9 @@ export interface BaseLoadOptions {
      * Maximum amount of time a script can take before scripting
      * is disabled.
      *
-     * @default { secs: 15, nanos: 0 }
+     * @default 15
      */
-    maxExecutionDuration?: {
-        secs: number;
-        nanos: number;
-    };
+    maxExecutionDuration?: Duration;
 
     /**
      * Specifies the base directory or URL used to resolve all relative path statements in the SWF file.

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -452,6 +452,17 @@ export class RufflePlayer extends HTMLElement {
                 "The configuration option preloader has been replaced with splashScreen. If you own this website, please update the configuration."
             );
         }
+        if (
+            this.loadedConfig &&
+            this.loadedConfig.maxExecutionDuration &&
+            typeof this.loadedConfig.maxExecutionDuration !== "number"
+        ) {
+            console.warn(
+                "Configuration: An obsolete format for duration for 'maxExecutionDuration' was used, " +
+                    "please use a single number indicating seconds instead. For instance '15' instead of " +
+                    "'{secs: 15, nanos: 0}'."
+            );
+        }
         const ruffleConstructor = await loadRuffle(
             this.loadedConfig || {},
             this.onRuffleDownloadProgress.bind(this)

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -130,7 +130,80 @@ where
 {
     use serde::de::Error;
     let value: String = serde::Deserialize::deserialize(deserializer)?;
-    tracing::Level::from_str(&value).map_err(D::Error::custom)
+    tracing::Level::from_str(&value).map_err(Error::custom)
+}
+
+fn deserialize_max_execution_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    struct DurationVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for DurationVisitor {
+        type Value = Duration;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str(
+                "Either a non-negative number (indicating seconds) or a {secs: number, nanos: number}."
+            )
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Ok(Duration::from_secs_f64(if value < 1 {
+                1.0
+            } else {
+                value as f64
+            }))
+        }
+
+        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Ok(Duration::from_secs_f64(if value.is_nan() || value < 1.0 {
+                1.0
+            } else {
+                value
+            }))
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut secs = None;
+            let mut nanos = None;
+            while let Some(key) = map.next_key::<String>()? {
+                let key_s = key.as_str();
+
+                match key_s {
+                    "secs" => {
+                        if secs.is_some() {
+                            return Err(Error::duplicate_field("secs"));
+                        }
+                        secs = Some(map.next_value()?);
+                    }
+                    "nanos" => {
+                        if nanos.is_some() {
+                            return Err(Error::duplicate_field("nanos"));
+                        }
+                        nanos = Some(map.next_value()?);
+                    }
+                    _ => return Err(Error::unknown_field(key_s, &["secs", "nanos"])),
+                }
+            }
+            let secs = secs.ok_or_else(|| Error::missing_field("secs"))?;
+            let nanos = nanos.ok_or_else(|| Error::missing_field("nanos"))?;
+            Ok(Duration::new(secs, nanos))
+        }
+    }
+
+    deserializer.deserialize_any(DurationVisitor)
 }
 
 #[derive(Deserialize)]
@@ -169,6 +242,7 @@ struct Config {
     #[serde(deserialize_with = "deserialize_log_level")]
     log_level: tracing::Level,
 
+    #[serde(deserialize_with = "deserialize_max_execution_duration")]
     max_execution_duration: Duration,
 
     player_version: Option<u8>,


### PR DESCRIPTION
The option 'max_execution_duration' previously only supported the type '{secs: number, nanos: number}'. Now it also supports using floating point numbers (and integers).

Default values have been changed to use floating point numbers.

**New pull request after I messed up git rebase and git force push** https://github.com/ruffle-rs/ruffle/pull/10818