### PR TITLE
web: Use default configuration in extension.

### DIFF
--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -1,6 +1,8 @@
 import type { Options } from "./common";
+import { DEFAULT_CONFIG as CORE_DEFAULT_CONFIG } from "ruffle-core";
 
-const DEFAULT_OPTIONS: Options = {
+const DEFAULT_OPTIONS: Required<Options> = {
+    ...CORE_DEFAULT_CONFIG,
     ruffleEnable: true,
     ignoreOptout: false,
     autostart: false,


### PR DESCRIPTION
I noticed by accident that some configuration settings had not been initialized in the extension, this PR should fix it.

Before:

![before](https://user-images.githubusercontent.com/131509408/234433717-61bd486e-a5d2-48ab-8904-9315c201fbdf.png)

After:

![after](https://user-images.githubusercontent.com/131509408/234433732-05e703fb-4c61-4715-9673-795fb26765b6.png)

("Preferred renderer" not being set is correct, since its default value is `null`).