### PR TITLE
web: Add `forceRenderer` config

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -36,4 +36,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     polyfills: true,
     playerVersion: null,
     preferredRenderer: null,
+    forceRenderer: null,
 };

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -393,6 +393,20 @@ export interface BaseLoadOptions {
     preferredRenderer?: RenderBackend | null;
 
     /**
+     * The forced render backend of the Ruffle player.
+     *
+     * This option should only be used for testing;
+     * the available backends may change in future releases.
+     * By default, Ruffle chooses the most featureful backend supported by the user's system,
+     * falling back to more basic backends if necessary.
+     * The available values in order of default preference are:
+     * "webgpu", "wgpu-webgl", "webgl", "canvas".
+     *
+     * @default null
+     */
+    forceRenderer?: RenderBackend | null;
+
+    /**
      * The URL at which Ruffle can load its extra files (i.e. `.wasm`).
      *
      * @default null

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -644,6 +644,10 @@ export class RufflePlayer extends HTMLElement {
             !("url" in options) || typeof options.url === "string",
             "`url` must be a string"
         );
+        check(
+            !("preferredRenderer" in options && "forceRenderer" in options),
+            "`preferredRenderer` and `forceRenderer` are mutual exclusive"
+        );
         return options;
     }
     /**

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -21,7 +21,7 @@
         "message": "Log level"
     },
     "settings_max_execution_duration": {
-        "message": "How long can ActionScript execute for before being forcefully stopped (in seconds)"
+        "message": "Maximum allowed ActionScript execution duration (in seconds)"
     },
     "settings_player_version": {
         "message": "Flash player version number to emulate (range 1-32)"

--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -36,19 +36,18 @@ body {
     transform: scale(104%);
 }
 
-/*
- * Controls.
- */
+/* Controls */
 
-/* Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW */
+.options {
+    display: flex;
+    flex-flow: column;
+    gap: 24px;
+}
+
 .option {
     position: relative;
     display: flex;
     align-items: center;
-}
-
-.option:not(:first-child) {
-    margin-top: 24px;
 }
 
 .option input,
@@ -62,7 +61,7 @@ body {
     padding-right: 80px;
 }
 
-/* Checkbox. */
+/* Checkbox (Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW) */
 
 .option.checkbox input {
     width: 40px;
@@ -107,7 +106,7 @@ body {
     right: 1px;
 }
 
-/* Number input. */
+/* Number input */
 
 .option.number-input input {
     width: 60px;

--- a/web/packages/extension/assets/css/options.css
+++ b/web/packages/extension/assets/css/options.css
@@ -7,3 +7,7 @@
     margin: auto;
     padding: 24px 32px;
 }
+
+details > .options {
+    padding-top: 10px;
+}

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -68,6 +68,16 @@
                         <input type="checkbox" id="ignore_optout" />
                         <label for="ignore_optout">Ignore website compatibility warnings</label>
                     </div>
+                    <div class="option select">
+                        <select id="force_renderer">
+                            <option value="">None</option>
+                            <option value="webgpu">WebGPU</option>
+                            <option value="wgpu-webgl">Wgpu (via WebGL)</option>
+                            <option value="webgl">WebGL</option>
+                            <option value="canvas">Canvas2D</option>
+                        </select>
+                        <label for="force_renderer">Force renderer</label>
+                    </div>
                     <div class="option number-input">
                         <input type="number" id="max_execution_duration" min="1" />
                         <label for="max_execution_duration">Maximum allowed ActionScript execution duration (in seconds)</label>

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -19,7 +19,7 @@
                     class="logo" />
             </a>
         </div>
-        <div class="container">
+        <div class="options container">
             <div class="option checkbox">
                 <input type="checkbox" id="ruffle_enable" />
                 <label for="ruffle_enable">Play Flash content in Ruffle</label>
@@ -36,18 +36,6 @@
                 <input type="checkbox" id="warn_on_unsupported_content" />
                 <label for="warn_on_unsupported_content">Warn on unsupported content</label>
             </div>
-            <div class="option checkbox">
-                <input type="checkbox" id="ignore_optout" />
-                <label for="ignore_optout">Ignore website compatibility warnings</label>
-            </div>
-            <div class="option select">
-                <select id="log_level">
-                    <option value="info">Info</option>
-                    <option value="warn">Warning</option>
-                    <option value="error">Error</option>
-                </select>
-                <label for="log_level">Log level</label>
-            </div>
             <div class="option select">
                 <select id="preferred_renderer">
                     <option value="webgpu">WebGPU</option>
@@ -58,12 +46,6 @@
                 <label for="preferred_renderer">Preferred renderer</label>
             </div>
             <div class="option number-input">
-                <input type="number" id="max_execution_duration"
-                       min="1"
-                />
-                <label for="max_execution_duration">How long can ActionScript execute for before being forcefully stopped (in seconds)</label>
-            </div>
-            <div class="option number-input">
                 <input type="number" id="player_version"
                        min="1"
                        max="32"
@@ -71,6 +53,27 @@
                 />
                 <label for="player_version">Flash player version number to emulate (range 1-32)</label>
             </div>
+            <details>
+                <summary>Advanced Options</summary>
+                <div class="options">
+                    <div class="option select">
+                        <select id="log_level">
+                            <option value="info">Info</option>
+                            <option value="warn">Warning</option>
+                            <option value="error">Error</option>
+                        </select>
+                        <label for="log_level">Log level</label>
+                    </div>
+                    <div class="option checkbox">
+                        <input type="checkbox" id="ignore_optout" />
+                        <label for="ignore_optout">Ignore website compatibility warnings</label>
+                    </div>
+                    <div class="option number-input">
+                        <input type="number" id="max_execution_duration" min="1" />
+                        <label for="max_execution_duration">Maximum allowed ActionScript execution duration (in seconds)</label>
+                    </div>
+                </div>
+            </details>
         </div>
         <script src="dist/options.js"></script>
     </body>

--- a/web/packages/extension/assets/popup.html
+++ b/web/packages/extension/assets/popup.html
@@ -22,7 +22,7 @@
             <div id="status-indicator"></div>
             <span id="status-text">Ruffle is running.</span>
         </div>
-        <div class="container">
+        <div class="options container">
             <div class="option checkbox">
                 <input type="checkbox" id="ruffle_enable" />
                 <label for="ruffle_enable">Play Flash content in Ruffle</label>

--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -72,7 +72,7 @@ class NumberOption implements OptionElement<number | null> {
     }
 }
 
-class SelectOption implements OptionElement<string> {
+class SelectOption implements OptionElement<string | null> {
     constructor(
         private readonly select: HTMLSelectElement,
         readonly label: HTMLLabelElement
@@ -85,10 +85,13 @@ class SelectOption implements OptionElement<string> {
     get value() {
         const index = this.select.selectedIndex;
         const option = this.select.options[index]!;
-        return option.value;
+        // Convert the empty string to `null`.
+        return option.value || null;
     }
 
-    set value(value: string) {
+    set value(value: string | null) {
+        // Convert `null` to the empty string.
+        value ??= "";
         const options = Array.from(this.select.options);
         const index = options.findIndex((option) => option.value === value);
         this.select.selectedIndex = index;

--- a/web/packages/extension/src/options.ts
+++ b/web/packages/extension/src/options.ts
@@ -3,5 +3,10 @@ import { bindOptions } from "./common";
 
 window.addEventListener("DOMContentLoaded", () => {
     document.title = utils.i18n.getMessage("settings_page");
-    bindOptions();
+    const preferredRenderer = document.getElementById(
+        "preferred_renderer"
+    )! as HTMLSelectElement;
+    bindOptions((options) => {
+        preferredRenderer.disabled = !!options.forceRenderer;
+    });
 });


### PR DESCRIPTION
Apart from `preferredRenderer`, which works in a "best effort" manner, is it useful to have a "mandatory" config for testing purposes. That is, if a forced renderer backend fails to initialized, then no further fallback is performed.