### PR TITLE
extension: Add option for setting max. exec. time

### DIFF
--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -20,6 +20,9 @@
     "settings_log_level": {
         "message": "Log level"
     },
+    "settings_max_execution_duration": {
+        "message": "How long can ActionScript execute for before being forcefully stopped (in seconds)"
+    },
     "status_init": {
         "message": "Reading current tab…"
     },

--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -36,6 +36,10 @@ body {
     transform: scale(104%);
 }
 
+/*
+ * Controls.
+ */
+
 /* Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW */
 .option {
     position: relative;
@@ -53,6 +57,13 @@ body {
     right: 0;
 }
 
+.option label {
+    display: inline-block;
+    padding-right: 80px;
+}
+
+/* Checkbox. */
+
 .option.checkbox input {
     width: 40px;
     height: 20px;
@@ -60,11 +71,6 @@ body {
     cursor: pointer;
     z-index: 1;
     opacity: 0;
-}
-
-.option label {
-    display: inline-block;
-    padding-right: 40px;
 }
 
 .option.checkbox label::before,
@@ -99,4 +105,12 @@ body {
 .option.checkbox input:checked + label::after {
     background: var(--ruffle-orange);
     right: 1px;
+}
+
+/* Number input. */
+
+.option.number-input input {
+    width: 60px;
+    height: 20px;
+    margin: auto;
 }

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -57,6 +57,12 @@
                 </select>
                 <label for="preferred_renderer">Preferred renderer</label>
             </div>
+            <div class="option number-input">
+                <input type="number" id="max_execution_duration"
+                       min="1"
+                />
+                <label for="max_execution_duration">How long can ActionScript execute for before being forcefully stopped (in seconds)</label>
+            </div>
         </div>
         <script src="dist/options.js"></script>
     </body>


### PR DESCRIPTION
Add an option to the 'options' menu for the extension for setting the maximum execution time for Actionscript code.

Since this option is likely to be rarely changed by users, it has not been added to the 'popup' UI, only the 'settings' UI.

The changes only modify the CSS layout to a minor degree. I might look into making the UI layout CSS more robust in a later pull request, though no promises.

**This PR is for the same functionality as for #10787 , but from a separate branch and up to date with the newest changes.**