### PR TITLE
extension: Fix popup setting changed reload detection.

### DIFF
--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -26,13 +26,12 @@ window.addEventListener("DOMContentLoaded", async () => {
     document.getElementById("main")!.append(player);
 
     const options = await utils.getOptions();
-    const config = {
-        letterbox: "on" as Letterbox,
-        ...options,
-    };
+
     player.load({
+        ...options,
+        // Override default value for 'letterbox' when playing in the extension player page.
+        letterbox: "on" as Letterbox,
         url: swfUrl,
         base: swfUrl.substring(0, swfUrl.lastIndexOf("/") + 1),
-        ...config,
     });
 });


### PR DESCRIPTION
The problem seems to have been the inclusion of setting values that the previous equality function did not handle correctly. This function broadens the kinds of setting values that can be handled correctly.