### PR TITLE
chore: Use `swf::Point` in many places

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -3051,9 +3051,8 @@ pub fn start_drag<'gc>(
     } else {
         // The object moves relative to current mouse position.
         // Calculate the offset from the mouse to the object in world space.
-        let (object_x, object_y) = display_object.local_to_global(Default::default());
-        let (mouse_x, mouse_y) = *activation.context.mouse_position;
-        (object_x - mouse_x, object_y - mouse_y)
+        let object_position = display_object.local_to_global(Default::default());
+        object_position - *activation.context.mouse_position
     };
 
     let constraint = if args.len() > 1 {

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -201,9 +201,8 @@ pub fn hit_test<'gc>(
         if x.is_finite() && y.is_finite() {
             // The docs say the point is in "Stage coordinates", but actually they are in root coordinates.
             // root can be moved via _root._x etc., so we actually have to transform from root to world space.
-            let point = movie_clip
-                .avm1_root()
-                .local_to_global((Twips::from_pixels(x), Twips::from_pixels(y)));
+            let local = Point::from_pixels(x, y);
+            let point = movie_clip.avm1_root().local_to_global(local);
             let ret = if shape {
                 movie_clip.hit_test_shape(
                     &mut activation.context,
@@ -1167,11 +1166,10 @@ fn local_to_global<'gc>(
                 .get_local_stored("y", activation)
                 .unwrap_or(Value::Undefined),
         ) {
-            let x = Twips::from_pixels(x);
-            let y = Twips::from_pixels(y);
-            let (out_x, out_y) = movie_clip.local_to_global((x, y));
-            point.set("x", out_x.to_pixels().into(), activation)?;
-            point.set("y", out_y.to_pixels().into(), activation)?;
+            let local = Point::from_pixels(x, y);
+            let global = movie_clip.local_to_global(local);
+            point.set("x", global.x.to_pixels().into(), activation)?;
+            point.set("y", global.y.to_pixels().into(), activation)?;
         } else {
             avm_warn!(
                 activation,
@@ -1304,10 +1302,10 @@ fn global_to_local<'gc>(
                 .get_local_stored("y", activation)
                 .unwrap_or(Value::Undefined),
         ) {
-            let pt = (Twips::from_pixels(x), Twips::from_pixels(y));
-            let (out_x, out_y) = movie_clip.global_to_local(pt).unwrap_or(pt);
-            point.set("x", out_x.to_pixels().into(), activation)?;
-            point.set("y", out_y.to_pixels().into(), activation)?;
+            let global = Point::from_pixels(x, y);
+            let local = movie_clip.global_to_local(global).unwrap_or(global);
+            point.set("x", local.x.to_pixels().into(), activation)?;
+            point.set("y", local.y.to_pixels().into(), activation)?;
         } else {
             avm_warn!(
                 activation,

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -770,13 +770,13 @@ fn set_quality<'gc>(
 }
 
 fn x_mouse<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    let (local_x, _) = this.mouse_to_local(*activation.context.mouse_position);
-    local_x.to_pixels().into()
+    let local = this.mouse_to_local(*activation.context.mouse_position);
+    local.x.to_pixels().into()
 }
 
 fn y_mouse<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    let (_, local_y) = this.mouse_to_local(*activation.context.mouse_position);
-    local_y.to_pixels().into()
+    let local = this.mouse_to_local(*activation.context.mouse_position);
+    local.y.to_pixels().into()
 }
 
 fn property_coerce_to_number<'gc>(

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -170,9 +170,9 @@ pub fn start_drag<'gc>(
         } else {
             // The object moves relative to current mouse position.
             // Calculate the offset from the mouse to the object in world space.
-            let (object_x, object_y) = display_object.local_to_global(Default::default());
-            let (mouse_x, mouse_y) = *activation.context.mouse_position;
-            (object_x - mouse_x, object_y - mouse_y)
+            let object_position = display_object.local_to_global(Default::default());
+            let mouse_position = *activation.context.mouse_position;
+            object_position - mouse_position
         };
 
         let rectangle = args.try_get_object(activation, 1);

--- a/core/src/avm2/globals/flash/events/mouse_event.rs
+++ b/core/src/avm2/globals/flash/events/mouse_event.rs
@@ -3,7 +3,7 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::display_object::TDisplayObject;
-use swf::Twips;
+use swf::Point;
 
 /// Implements `stageX`'s getter.
 pub fn get_stage_x<'gc>(
@@ -16,7 +16,6 @@ pub fn get_stage_x<'gc>(
             let local_x = this
                 .get_public_property("localX", activation)?
                 .coerce_to_number(activation)?;
-
             let local_y = this
                 .get_public_property("localY", activation)?
                 .coerce_to_number(activation)?;
@@ -24,13 +23,11 @@ pub fn get_stage_x<'gc>(
             if local_x.is_nan() || local_y.is_nan() {
                 return Ok(Value::Number(local_x));
             } else if let Some(target) = evt.target().and_then(|t| t.as_display_object()) {
-                let x_as_twips = Twips::from_pixels(local_x);
-                let y_as_twips = Twips::from_pixels(local_y);
+                let local = Point::from_pixels(local_x, local_y);
                 // `local_to_global` does a matrix multiplication, which in general
                 // depends on both the x and y coordinates.
-                let xformed = target.local_to_global((x_as_twips, y_as_twips)).0;
-
-                return Ok(Value::Number(xformed.to_pixels()));
+                let global = target.local_to_global(local);
+                return Ok(Value::Number(global.x.to_pixels()));
             } else {
                 return Ok(Value::Number(local_x * 0.0));
             }
@@ -51,7 +48,6 @@ pub fn get_stage_y<'gc>(
             let local_x = this
                 .get_public_property("localX", activation)?
                 .coerce_to_number(activation)?;
-
             let local_y = this
                 .get_public_property("localY", activation)?
                 .coerce_to_number(activation)?;
@@ -59,13 +55,11 @@ pub fn get_stage_y<'gc>(
             if local_x.is_nan() || local_y.is_nan() {
                 return Ok(Value::Number(local_y));
             } else if let Some(target) = evt.target().and_then(|t| t.as_display_object()) {
-                let x_as_twips = Twips::from_pixels(local_x);
-                let y_as_twips = Twips::from_pixels(local_y);
+                let local = Point::from_pixels(local_x, local_y);
                 // `local_to_global` does a matrix multiplication, which in general
                 // depends on both the x and y coordinates.
-                let xformed = target.local_to_global((x_as_twips, y_as_twips)).1;
-
-                return Ok(Value::Number(xformed.to_pixels()));
+                let global = target.local_to_global(local);
+                return Ok(Value::Number(global.y.to_pixels()));
             } else {
                 return Ok(Value::Number(local_y * 0.0));
             }

--- a/core/src/avm2/object/event_object.rs
+++ b/core/src/avm2/object/event_object.rs
@@ -99,7 +99,7 @@ impl<'gc> EventObject<'gc> {
     where
         S: Into<AvmString<'gc>>,
     {
-        let local_pos = target.mouse_to_local(*activation.context.mouse_position);
+        let local = target.mouse_to_local(*activation.context.mouse_position);
 
         let event_type: AvmString<'gc> = event_type.into();
 
@@ -114,9 +114,9 @@ impl<'gc> EventObject<'gc> {
                     // cancellable
                     false.into(),
                     // localX
-                    local_pos.0.to_pixels().into(),
+                    local.x.to_pixels().into(),
                     // localY
-                    local_pos.1.to_pixels().into(),
+                    local.y.to_pixels().into(),
                     // relatedObject
                     related_object
                         .map(|o| o.as_displayobject().object2())

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -135,7 +135,7 @@ pub struct UpdateContext<'a, 'gc> {
     pub input: &'a InputManager,
 
     /// The location of the mouse when it was last over the player.
-    pub mouse_position: &'a (Twips, Twips),
+    pub mouse_position: &'a Point<Twips>,
 
     /// The object being dragged via a `startDrag` action.
     pub drag_object: &'a mut Option<crate::player::DragObject<'gc>>,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -789,20 +789,20 @@ pub trait TDisplayObject<'gc>:
     }
 
     /// Converts a local position to a global stage position
-    fn local_to_global(&self, local: (Twips, Twips)) -> (Twips, Twips) {
+    fn local_to_global(&self, local: Point<Twips>) -> Point<Twips> {
         self.local_to_global_matrix() * local
     }
 
     /// Converts a local position on the stage to a local position on this display object
     /// Returns `None` if the object has zero scale.
-    fn global_to_local(&self, global: (Twips, Twips)) -> Option<(Twips, Twips)> {
+    fn global_to_local(&self, global: Point<Twips>) -> Option<Point<Twips>> {
         self.global_to_local_matrix().map(|matrix| matrix * global)
     }
 
     /// Converts a mouse position on the stage to a local position on this display object.
     /// If the object has zero scale, then the stage `TWIPS_TO_PIXELS` matrix will be used.
     /// This matches Flash's behavior for `mouseX`/`mouseY` on an object with zero scale.
-    fn mouse_to_local(&self, global: (Twips, Twips)) -> (Twips, Twips) {
+    fn mouse_to_local(&self, global: Point<Twips>) -> Point<Twips> {
         // MIKE: I suspect the `TWIPS_TO_PIXELS` scale should always be involved in the
         // calculation somehow, not just in the non-invertible case.
         self.global_to_local_matrix()
@@ -1618,8 +1618,8 @@ pub trait TDisplayObject<'gc>:
     fn set_object2(&self, _context: &mut UpdateContext<'_, 'gc>, _to: Avm2Object<'gc>) {}
 
     /// Tests if a given stage position point intersects with the world bounds of this object.
-    fn hit_test_bounds(&self, pos: (Twips, Twips)) -> bool {
-        self.world_bounds().contains(pos)
+    fn hit_test_bounds(&self, point: Point<Twips>) -> bool {
+        self.world_bounds().contains(point)
     }
 
     /// Tests if a given object's world bounds intersects with the world bounds
@@ -1632,11 +1632,11 @@ pub trait TDisplayObject<'gc>:
     fn hit_test_shape(
         &self,
         _context: &mut UpdateContext<'_, 'gc>,
-        pos: (Twips, Twips),
+        point: Point<Twips>,
         _options: HitTestOptions,
     ) -> bool {
         // Default to using bounding box.
-        self.hit_test_bounds(pos)
+        self.hit_test_bounds(point)
     }
 
     fn post_instantiation(

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -333,7 +333,7 @@ impl<'gc> TDisplayObject<'gc> for Avm1Button<'gc> {
     fn hit_test_shape(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         options: HitTestOptions,
     ) -> bool {
         for child in self.iter_render_list() {
@@ -534,7 +534,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
     fn mouse_pick_avm1(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         require_button_mode: bool,
     ) -> Option<InteractiveObject<'gc>> {
         // The button is hovered if the mouse is over any child nodes.

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -620,7 +620,7 @@ impl<'gc> TDisplayObject<'gc> for Avm2Button<'gc> {
     fn hit_test_shape(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         options: HitTestOptions,
     ) -> bool {
         if !options.contains(HitTestOptions::SKIP_INVISIBLE) || self.visible() {
@@ -771,7 +771,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
     fn mouse_pick_avm2(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        mut point: Point<Twips>,
         require_button_mode: bool,
     ) -> Avm2MousePick<'gc> {
         // The button is hovered if the mouse is over any child nodes.
@@ -794,7 +794,6 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
             if let Some(hit_area) = hit_area {
                 //TODO: the if below should probably always be taken, why does the hit area
                 // sometimes have a parent?
-                let mut point = point;
                 if hit_area.parent().is_none() {
                     // hit_area is not actually a child, so transform point into local space before passing it down.
                     point = if let Some(point) = self.global_to_local(point) {

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1138,13 +1138,11 @@ impl<'gc> EditText<'gc> {
         self.0.write(context.gc_context).max_chars = value;
     }
 
-    pub fn screen_position_to_index(self, position: (Twips, Twips)) -> Option<usize> {
+    pub fn screen_position_to_index(self, position: Point<Twips>) -> Option<usize> {
         let text = self.0.read();
-        let Some(position) = self.global_to_local(position) else { return None; };
-        let position = (
-            position.0 + Twips::from_pixels(Self::INTERNAL_PADDING),
-            position.1 + Twips::from_pixels(Self::INTERNAL_PADDING),
-        );
+        let Some(mut position) = self.global_to_local(position) else { return None; };
+        position.x += Twips::from_pixels(Self::INTERNAL_PADDING);
+        position.y += Twips::from_pixels(Self::INTERNAL_PADDING);
 
         for layout_box in text.layout.iter() {
             let origin = layout_box.bounds().origin();
@@ -1163,12 +1161,12 @@ impl<'gc> EditText<'gc> {
                     self.text_transform(color, baseline_adjustment),
                     params,
                     |pos, _transform, _glyph: &Glyph, advance, x| {
-                        if local_position.0 >= x
-                            && local_position.0 <= x + advance
-                            && local_position.1 >= Twips::ZERO
-                            && local_position.1 <= params.height()
+                        if local_position.x >= x
+                            && local_position.x <= x + advance
+                            && local_position.y >= Twips::ZERO
+                            && local_position.y <= params.height()
                         {
-                            if local_position.0 >= x + (advance / 2) {
+                            if local_position.x >= x + (advance / 2) {
                                 result = Some(string_utils::next_char_boundary(text, pos));
                             } else {
                                 result = Some(pos);
@@ -1834,7 +1832,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
     fn mouse_pick_avm1(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         _require_button_mode: bool,
     ) -> Option<InteractiveObject<'gc>> {
         // The text is hovered if the mouse is over any child nodes.
@@ -1852,7 +1850,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
     fn mouse_pick_avm2(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         _require_button_mode: bool,
     ) -> Avm2MousePick<'gc> {
         // The text is hovered if the mouse is over any child nodes.

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -200,7 +200,7 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
     fn hit_test_shape(
         &self,
         _context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         _options: HitTestOptions,
     ) -> bool {
         // Transform point to local coordinates and test.
@@ -213,7 +213,11 @@ impl<'gc> TDisplayObject<'gc> for Graphic<'gc> {
                 }
             } else {
                 let shape = &self.0.read().static_data.shape;
-                return ruffle_render::shape_utils::shape_hit_test(shape, point, &local_matrix);
+                return ruffle_render::shape_utils::shape_hit_test(
+                    shape,
+                    (point.x, point.y),
+                    &local_matrix,
+                );
             }
         }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -6,6 +6,7 @@ use crate::backend::ui::MouseCursor;
 use crate::context::UpdateContext;
 use crate::display_object::avm1_button::Avm1Button;
 use crate::display_object::avm2_button::Avm2Button;
+use crate::display_object::container::DisplayObjectContainer;
 use crate::display_object::edit_text::EditText;
 use crate::display_object::loader_display::LoaderDisplay;
 use crate::display_object::movie_clip::MovieClip;
@@ -21,9 +22,7 @@ use ruffle_macros::enum_trait_object;
 use std::cell::{Ref, RefMut};
 use std::fmt::Debug;
 use std::time::Duration;
-use swf::Twips;
-
-use super::DisplayObjectContainer;
+use swf::{Point, Twips};
 
 /// Find the lowest common ancestor between the display objects in `from` and
 /// `to`.
@@ -446,7 +445,7 @@ pub trait TInteractiveObject<'gc>:
     fn mouse_pick_avm1(
         &self,
         _context: &mut UpdateContext<'_, 'gc>,
-        _pos: (Twips, Twips),
+        _point: Point<Twips>,
         _require_button_mode: bool,
     ) -> Option<InteractiveObject<'gc>> {
         None
@@ -455,7 +454,7 @@ pub trait TInteractiveObject<'gc>:
     fn mouse_pick_avm2(
         &self,
         _context: &mut UpdateContext<'_, 'gc>,
-        _pos: (Twips, Twips),
+        _point: Point<Twips>,
         _require_button_mode: bool,
     ) -> Avm2MousePick<'gc> {
         Avm2MousePick::Miss

--- a/core/src/display_object/loader_display.rs
+++ b/core/src/display_object/loader_display.rs
@@ -173,12 +173,12 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
     fn mouse_pick_avm1(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        pos: (Twips, Twips),
+        point: Point<Twips>,
         require_button_mode: bool,
     ) -> Option<InteractiveObject<'gc>> {
         for child in self.iter_render_list().rev() {
             if let Some(int) = child.as_interactive() {
-                if let Some(result) = int.mouse_pick_avm1(context, pos, require_button_mode) {
+                if let Some(result) = int.mouse_pick_avm1(context, point, require_button_mode) {
                     return Some(result);
                 }
             }
@@ -190,14 +190,14 @@ impl<'gc> TInteractiveObject<'gc> for LoaderDisplay<'gc> {
     fn mouse_pick_avm2(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        pos: (Twips, Twips),
+        point: Point<Twips>,
         require_button_mode: bool,
     ) -> Avm2MousePick<'gc> {
         // We have at most one child
         if let Some(child) = self.iter_render_list().next() {
             if let Some(int) = child.as_interactive() {
                 return int
-                    .mouse_pick_avm2(context, pos, require_button_mode)
+                    .mouse_pick_avm2(context, point, require_button_mode)
                     .combine_with_parent((*self).into());
             }
         }

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -150,7 +150,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
     fn hit_test_shape(
         &self,
         _context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         _options: HitTestOptions,
     ) -> bool {
         if self.world_bounds().contains(point) {
@@ -159,7 +159,7 @@ impl<'gc> TDisplayObject<'gc> for MorphShape<'gc> {
                 let point = local_matrix * point;
                 return ruffle_render::shape_utils::shape_hit_test(
                     &frame.shape,
-                    point,
+                    (point.x, point.y),
                     &local_matrix,
                 );
             } else {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2562,7 +2562,7 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
     fn hit_test_shape(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         options: HitTestOptions,
     ) -> bool {
         if options.contains(HitTestOptions::SKIP_INVISIBLE)
@@ -2879,7 +2879,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     fn mouse_pick_avm1(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         require_button_mode: bool,
     ) -> Option<InteractiveObject<'gc>> {
         if self.visible() {
@@ -2964,7 +2964,7 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
     fn mouse_pick_avm2(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        point: (Twips, Twips),
+        point: Point<Twips>,
         require_button_mode: bool,
     ) -> Avm2MousePick<'gc> {
         if self.visible() {

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -170,7 +170,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
     fn hit_test_shape(
         &self,
         context: &mut UpdateContext<'_, 'gc>,
-        mut point: (Twips, Twips),
+        mut point: Point<Twips>,
         _options: HitTestOptions,
     ) -> bool {
         if self.world_bounds().contains(point) {
@@ -216,7 +216,7 @@ impl<'gc> TDisplayObject<'gc> for Text<'gc> {
                             if glyph_shape.shape_bounds.contains(point)
                                 && ruffle_render::shape_utils::shape_hit_test(
                                     &glyph_shape,
-                                    point,
+                                    (point.x, point.y),
                                     &local_matrix,
                                 )
                             {

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -4,7 +4,7 @@ pub use crate::display_object::{
 };
 pub use ruffle_render::matrix::Matrix;
 pub use std::ops::{Bound, RangeBounds};
-pub use swf::{CharacterId, Color, Rectangle, Twips};
+pub use swf::{CharacterId, Color, Point, Rectangle, Twips};
 pub use tracing::{error, info, trace, warn};
 
 /// A depth for a Flash display object in AVM1.

--- a/swf/src/types/matrix.rs
+++ b/swf/src/types/matrix.rs
@@ -1,4 +1,4 @@
-use crate::{Fixed16, Twips};
+use crate::{Fixed16, Point, Twips};
 use std::ops;
 
 /// The transformation matrix used by Flash display objects.
@@ -135,22 +135,28 @@ impl ops::Mul for Matrix {
     }
 }
 
-impl ops::Mul<(Twips, Twips)> for Matrix {
-    type Output = (Twips, Twips);
+impl ops::Mul<Point<Twips>> for Matrix {
+    type Output = Point<Twips>;
+
     #[inline]
-    fn mul(self, (x, y): (Twips, Twips)) -> (Twips, Twips) {
-        let (x, y) = (x.get(), y.get());
-        let out_x = (self
-            .a
-            .wrapping_mul_int(x)
-            .wrapping_add(self.c.wrapping_mul_int(y)))
-        .wrapping_add(self.tx.get());
-        let out_y = (self
-            .b
-            .wrapping_mul_int(x)
-            .wrapping_add(self.d.wrapping_mul_int(y)))
-        .wrapping_add(self.ty.get());
-        (Twips::new(out_x), Twips::new(out_y))
+    fn mul(self, point: Point<Twips>) -> Point<Twips> {
+        let x = point.x.get();
+        let y = point.y.get();
+        let out_x = Twips::new(
+            (self
+                .a
+                .wrapping_mul_int(x)
+                .wrapping_add(self.c.wrapping_mul_int(y)))
+            .wrapping_add(self.tx.get()),
+        );
+        let out_y = Twips::new(
+            (self
+                .b
+                .wrapping_mul_int(x)
+                .wrapping_add(self.d.wrapping_mul_int(y)))
+            .wrapping_add(self.ty.get()),
+        );
+        Point::new(out_x, out_y)
     }
 }
 

--- a/swf/src/types/point.rs
+++ b/swf/src/types/point.rs
@@ -1,45 +1,48 @@
 use crate::Twips;
 use std::fmt;
-use std::ops;
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+
+pub trait Coordinate:
+    Copy + Add<Output = Self> + Sub<Output = Self> + AddAssign + SubAssign + fmt::Display
+{
+    const ZERO: Self;
+}
+
+impl Coordinate for i32 {
+    const ZERO: Self = 0;
+}
+
+impl Coordinate for Twips {
+    const ZERO: Self = Self::ZERO;
+}
 
 /// A 2D position defined by x and y coordinates.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct Point {
-    pub x: Twips,
-    pub y: Twips,
+pub struct Point<T: Coordinate> {
+    pub x: T,
+    pub y: T,
 }
 
-impl Point {
+impl<T: Coordinate> Point<T> {
     /// The `Point` object with a value of `(0, 0)`.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// assert_eq!(swf::Point::ZERO.to_pixels(), (0.0, 0.0));
+    /// assert_eq!(swf::Point::<swf::Twips>::ZERO.x, swf::Twips::ZERO);
+    /// assert_eq!(swf::Point::<swf::Twips>::ZERO.y, swf::Twips::ZERO);
     /// ```
     pub const ZERO: Self = Self {
-        x: Twips::ZERO,
-        y: Twips::ZERO,
+        x: T::ZERO,
+        y: T::ZERO,
     };
 
-    /// Creates a new `Point` object. Note that the `x` and `y` values are in twips,
-    /// not pixels. Use the [`from_pixels`] method to convert from pixel units.
-    ///
-    /// [`from_pixels`]: Point::from_pixels
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let point = swf::Point::new(40, 40);
-    /// ```
-    #[inline]
-    pub const fn new(x: i32, y: i32) -> Self {
-        Self {
-            x: Twips::new(x),
-            y: Twips::new(y),
-        }
+    pub const fn new(x: T, y: T) -> Self {
+        Self { x, y }
     }
+}
 
+impl Point<Twips> {
     /// Converts the given number of `pixels` into twips.
     ///
     /// This may be a lossy conversion; any precision more than a twip (1/20 pixels) is truncated.
@@ -64,29 +67,9 @@ impl Point {
             y: Twips::from_pixels(y),
         }
     }
-
-    /// Converts this `Point` into pixel units.
-    ///
-    /// This is a lossless operation.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// // 800 twips is equivalent to 40 pixels.
-    /// let point = swf::Point::new(800, 200);
-    /// assert_eq!(point.to_pixels(), (40.0, 10.0));
-    ///
-    /// // Twips are sub-pixel: 713 twips represent 35.65 pixels.
-    /// let point = swf::Point::new(713, 200);
-    /// assert_eq!(point.to_pixels(), (35.65, 10.0));
-    /// ```
-    #[inline]
-    pub fn to_pixels(self) -> (f64, f64) {
-        (self.x.to_pixels(), self.y.to_pixels())
-    }
 }
 
-impl ops::Add for Point {
+impl<T: Coordinate> Add for Point<T> {
     type Output = Self;
 
     #[inline]
@@ -98,7 +81,7 @@ impl ops::Add for Point {
     }
 }
 
-impl ops::AddAssign for Point {
+impl<T: Coordinate> AddAssign for Point<T> {
     #[inline]
     fn add_assign(&mut self, other: Self) {
         self.x += other.x;
@@ -106,8 +89,9 @@ impl ops::AddAssign for Point {
     }
 }
 
-impl ops::Sub for Point {
+impl<T: Coordinate> Sub for Point<T> {
     type Output = Self;
+
     #[inline]
     fn sub(self, other: Self) -> Self {
         Self {
@@ -117,7 +101,7 @@ impl ops::Sub for Point {
     }
 }
 
-impl ops::SubAssign for Point {
+impl<T: Coordinate> SubAssign for Point<T> {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
         self.x -= other.x;
@@ -125,45 +109,7 @@ impl ops::SubAssign for Point {
     }
 }
 
-impl ops::Mul<i32> for Point {
-    type Output = Self;
-    #[inline]
-    fn mul(self, other: i32) -> Self {
-        Self {
-            x: self.x * other,
-            y: self.y * other,
-        }
-    }
-}
-
-impl ops::MulAssign<i32> for Point {
-    #[inline]
-    fn mul_assign(&mut self, other: i32) {
-        self.x *= other;
-        self.y *= other;
-    }
-}
-
-impl ops::Div<i32> for Point {
-    type Output = Self;
-    #[inline]
-    fn div(self, other: i32) -> Self {
-        Self {
-            x: self.x / other,
-            y: self.y / other,
-        }
-    }
-}
-
-impl ops::DivAssign<i32> for Point {
-    #[inline]
-    fn div_assign(&mut self, other: i32) {
-        self.x /= other;
-        self.y /= other;
-    }
-}
-
-impl fmt::Display for Point {
+impl<T: Coordinate> fmt::Display for Point<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {})", self.x, self.y)

--- a/swf/src/types/rectangle.rs
+++ b/swf/src/types/rectangle.rs
@@ -1,8 +1,6 @@
-use crate::Twips;
-use std::cmp::Ord;
-use std::ops::{Add, Sub};
+use crate::{types::point::Coordinate as PointCoordinate, Point, Twips};
 
-pub trait Coordinate: Copy + Ord + Add<Output = Self> + Sub<Output = Self> {
+pub trait Coordinate: PointCoordinate + Ord {
     const INVALID: Self;
 }
 
@@ -64,29 +62,29 @@ impl<T: Coordinate> Rectangle<T> {
 
     /// Clamp a given point inside this rectangle.
     #[must_use]
-    pub fn clamp(&self, (x, y): (T, T)) -> (T, T) {
+    pub fn clamp(&self, point: Point<T>) -> Point<T> {
         if self.is_valid() {
-            (
-                x.clamp(self.x_min, self.x_max),
-                y.clamp(self.y_min, self.y_max),
+            Point::new(
+                point.x.clamp(self.x_min, self.x_max),
+                point.y.clamp(self.y_min, self.y_max),
             )
         } else {
-            (x, y)
+            point
         }
     }
 
     #[must_use]
-    pub fn encompass(mut self, x: T, y: T) -> Self {
+    pub fn encompass(mut self, point: Point<T>) -> Self {
         if self.is_valid() {
-            self.x_min = self.x_min.min(x);
-            self.x_max = self.x_max.max(x);
-            self.y_min = self.y_min.min(y);
-            self.y_max = self.y_max.max(y);
+            self.x_min = self.x_min.min(point.x);
+            self.x_max = self.x_max.max(point.x);
+            self.y_min = self.y_min.min(point.y);
+            self.y_max = self.y_max.max(point.y);
         } else {
-            self.x_min = x;
-            self.x_max = x;
-            self.y_min = y;
-            self.y_max = y;
+            self.x_min = point.x;
+            self.x_max = point.x;
+            self.y_min = point.y;
+            self.y_max = point.y;
         }
         self
     }
@@ -116,8 +114,11 @@ impl<T: Coordinate> Rectangle<T> {
     }
 
     #[must_use]
-    pub fn contains(&self, (x, y): (T, T)) -> bool {
-        x >= self.x_min && x <= self.x_max && y >= self.y_min && y <= self.y_max
+    pub fn contains(&self, point: Point<T>) -> bool {
+        point.x >= self.x_min
+            && point.x <= self.x_max
+            && point.y >= self.y_min
+            && point.y <= self.y_max
     }
 }
 


### PR DESCRIPTION
Convert nearly all instances of `(Twips, Twips)` (maybe besides in `shape_utils.rs`) to `swf::Point<Twips>`.

Fixes #6973.