### PR TITLE
core: Fix moving objects while being dragged

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -3045,16 +3045,6 @@ pub fn start_drag<'gc>(
         .map(|o| o.as_bool(activation.context.swf.version()))
         .unwrap_or(false);
 
-    let offset = if lock_center {
-        // The object's origin point is locked to the mouse.
-        Default::default()
-    } else {
-        // The object moves relative to current mouse position.
-        // Calculate the offset from the mouse to the object in world space.
-        let object_position = display_object.local_to_global(Default::default());
-        object_position - *activation.context.mouse_position
-    };
-
     let constraint = if args.len() > 1 {
         // Invalid values turn into 0.
         let mut x_min = args
@@ -3106,7 +3096,8 @@ pub fn start_drag<'gc>(
 
     let drag_object = crate::player::DragObject {
         display_object,
-        offset,
+        last_mouse_position: *activation.context.mouse_position,
+        lock_center,
         constraint,
     };
     *activation.context.drag_object = Some(drag_object);

--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -14,6 +14,7 @@ use crate::string::{AvmString, WStr};
 use crate::types::Percent;
 use gc_arena::{Collect, GcCell, GcWeakCell, MutationContext};
 use std::fmt;
+use swf::Twips;
 
 /// A ScriptObject that is inherently tied to a display node.
 #[derive(Clone, Copy, Collect)]
@@ -462,7 +463,7 @@ impl<'gc> DisplayPropertyMap<'gc> {
 }
 
 fn x<'gc>(_activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.x().into()
+    this.x().to_pixels().into()
 }
 
 fn set_x<'gc>(
@@ -470,14 +471,14 @@ fn set_x<'gc>(
     this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_x(activation.context.gc_context, val);
+    if let Some(x) = property_coerce_to_number(activation, val)? {
+        this.set_x(activation.context.gc_context, Twips::from_pixels(x));
     }
     Ok(())
 }
 
 fn y<'gc>(_activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
-    this.y().into()
+    this.y().to_pixels().into()
 }
 
 fn set_y<'gc>(
@@ -485,8 +486,8 @@ fn set_y<'gc>(
     this: DisplayObject<'gc>,
     val: Value<'gc>,
 ) -> Result<(), Error<'gc>> {
-    if let Some(val) = property_coerce_to_number(activation, val)? {
-        this.set_y(activation.context.gc_context, val);
+    if let Some(y) = property_coerce_to_number(activation, val)? {
+        this.set_y(activation.context.gc_context, Twips::from_pixels(y));
     }
     Ok(())
 }

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -3,7 +3,9 @@
 use crate::avm2::activation::Activation;
 use crate::avm2::error::make_error_2008;
 use crate::avm2::filters::FilterAvm2Ext;
+pub use crate::avm2::object::stage_allocator as display_object_allocator;
 use crate::avm2::object::{Object, TObject};
+use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
@@ -20,9 +22,6 @@ use crate::{avm2_stub_getter, avm2_stub_setter};
 use ruffle_render::filters::Filter;
 use std::str::FromStr;
 use swf::BlendMode;
-
-pub use crate::avm2::object::stage_allocator as display_object_allocator;
-use crate::avm2::parameters::ParametersExt;
 
 /// Implements `flash.display.DisplayObject`'s native instance constructor.
 pub fn native_instance_init<'gc>(
@@ -307,7 +306,7 @@ pub fn get_x<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
-        return Ok(dobj.x().into());
+        return Ok(dobj.x().to_pixels().into());
     }
 
     Ok(Value::Undefined)
@@ -320,9 +319,8 @@ pub fn set_x<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
-        let new_x = args.get_f64(activation, 0)?;
-
-        dobj.set_x(activation.context.gc_context, new_x);
+        let x = args.get_f64(activation, 0)?;
+        dobj.set_x(activation.context.gc_context, Twips::from_pixels(x));
     }
 
     Ok(Value::Undefined)
@@ -335,7 +333,7 @@ pub fn get_y<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
-        return Ok(dobj.y().into());
+        return Ok(dobj.y().to_pixels().into());
     }
 
     Ok(Value::Undefined)
@@ -348,9 +346,8 @@ pub fn set_y<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
-        let new_y = args.get_f64(activation, 0)?;
-
-        dobj.set_y(activation.context.gc_context, new_y);
+        let y = args.get_f64(activation, 0)?;
+        dobj.set_y(activation.context.gc_context, Twips::from_pixels(y));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -155,7 +155,6 @@ pub fn set_button_mode<'gc>(
 }
 
 /// Starts dragging this display object, making it follow the cursor.
-/// Runs via the `startDrag` method or `StartDrag` AVM1 action.
 pub fn start_drag<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Option<Object<'gc>>,
@@ -163,17 +162,6 @@ pub fn start_drag<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(display_object) = this.and_then(|this| this.as_display_object()) {
         let lock_center = args.get_bool(0);
-
-        let offset = if lock_center {
-            // The object's origin point is locked to the mouse.
-            Default::default()
-        } else {
-            // The object moves relative to current mouse position.
-            // Calculate the offset from the mouse to the object in world space.
-            let object_position = display_object.local_to_global(Default::default());
-            let mouse_position = *activation.context.mouse_position;
-            object_position - mouse_position
-        };
 
         let rectangle = args.try_get_object(activation, 1);
         let constraint = if let Some(rectangle) = rectangle {
@@ -218,7 +206,8 @@ pub fn start_drag<'gc>(
 
         let drag_object = crate::player::DragObject {
             display_object,
-            offset,
+            last_mouse_position: *activation.context.mouse_position,
+            lock_center,
             constraint,
         };
         *activation.context.drag_object = Some(drag_object);

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -201,22 +201,22 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.transform.color_transform = color_transform;
     }
 
-    fn x(&self) -> f64 {
-        self.transform.matrix.tx.to_pixels()
+    fn x(&self) -> Twips {
+        self.transform.matrix.tx
     }
 
-    fn set_x(&mut self, value: f64) {
+    fn set_x(&mut self, x: Twips) {
         self.set_transformed_by_script(true);
-        self.transform.matrix.tx = Twips::from_pixels(value)
+        self.transform.matrix.tx = x;
     }
 
-    fn y(&self) -> f64 {
-        self.transform.matrix.ty.to_pixels()
+    fn y(&self) -> Twips {
+        self.transform.matrix.ty
     }
 
-    fn set_y(&mut self, value: f64) {
+    fn set_y(&mut self, y: Twips) {
         self.set_transformed_by_script(true);
-        self.transform.matrix.ty = Twips::from_pixels(value)
+        self.transform.matrix.ty = y;
     }
 
     /// Caches the scale and rotation factors for this display object, if necessary.
@@ -812,26 +812,26 @@ pub trait TDisplayObject<'gc>:
 
     /// The `x` position in pixels of this display object in local space.
     /// Returned by the `_x`/`x` ActionScript properties.
-    fn x(&self) -> f64 {
+    fn x(&self) -> Twips {
         self.base().x()
     }
 
     /// Sets the `x` position in pixels of this display object in local space.
     /// Set by the `_x`/`x` ActionScript properties.
-    fn set_x(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
-        self.base_mut(gc_context).set_x(value);
+    fn set_x(&self, gc_context: MutationContext<'gc, '_>, x: Twips) {
+        self.base_mut(gc_context).set_x(x);
     }
 
     /// The `y` position in pixels of this display object in local space.
     /// Returned by the `_y`/`y` ActionScript properties.
-    fn y(&self) -> f64 {
+    fn y(&self) -> Twips {
         self.base().y()
     }
 
     /// Sets the `y` position in pixels of this display object in local space.
     /// Set by the `_y`/`y` ActionScript properties.
-    fn set_y(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
-        self.base_mut(gc_context).set_y(value);
+    fn set_y(&self, gc_context: MutationContext<'gc, '_>, y: Twips) {
+        self.base_mut(gc_context).set_y(y);
     }
 
     /// The rotation in degrees this display object in local space.

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1574,32 +1574,30 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
     }
 
     // The returned position x and y of a text field is offset by the text bounds.
-    fn x(&self) -> f64 {
+    fn x(&self) -> Twips {
         let edit_text = self.0.read();
         let offset = edit_text.bounds.x_min;
-        (edit_text.base.base.transform.matrix.tx + offset).to_pixels()
+        edit_text.base.base.x() + offset
     }
 
-    fn set_x(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_x(&self, gc_context: MutationContext<'gc, '_>, x: Twips) {
         let mut edit_text = self.0.write(gc_context);
         let offset = edit_text.bounds.x_min;
-        edit_text.base.base.transform.matrix.tx = Twips::from_pixels(value) - offset;
-        edit_text.base.base.set_transformed_by_script(true);
+        edit_text.base.base.set_x(x - offset);
         drop(edit_text);
         self.redraw_border(gc_context);
     }
 
-    fn y(&self) -> f64 {
+    fn y(&self) -> Twips {
         let edit_text = self.0.read();
         let offset = edit_text.bounds.y_min;
-        (edit_text.base.base.transform.matrix.ty + offset).to_pixels()
+        edit_text.base.base.y() + offset
     }
 
-    fn set_y(&self, gc_context: MutationContext<'gc, '_>, value: f64) {
+    fn set_y(&self, gc_context: MutationContext<'gc, '_>, y: Twips) {
         let mut edit_text = self.0.write(gc_context);
         let offset = edit_text.bounds.y_min;
-        edit_text.base.base.transform.matrix.ty = Twips::from_pixels(value) - offset;
-        edit_text.base.base.set_transformed_by_script(true);
+        edit_text.base.base.set_y(y - offset);
         drop(edit_text);
         self.redraw_border(gc_context);
     }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1197,8 +1197,8 @@ impl Player {
                     drag_point = parent.mouse_to_local(drag_point);
                 }
                 drag_point = drag_object.constraint.clamp(drag_point);
-                display_object.set_x(context.gc_context, drag_point.x.to_pixels());
-                display_object.set_y(context.gc_context, drag_point.y.to_pixels());
+                display_object.set_x(context.gc_context, drag_point.x);
+                display_object.set_y(context.gc_context, drag_point.y);
 
                 // Update _droptarget property of dragged object.
                 if let Some(movie_clip) = display_object.as_movie_clip() {


### PR DESCRIPTION
`startDrag()` used to capture the offset between the mouse cursor and dragged object. This is buggy when the dragged object position is changed *while* being dragged, as the original offset no longer holds.

Change the dragging mechanism to be based purely on mouse deltas, eliminating said offset completely.

Fixes #10775.