### PR TITLE
extension: Fix options-related bug

### DIFF
--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -1,5 +1,6 @@
 import * as utils from "./utils";
 import type { BaseLoadOptions, Duration } from "ruffle-core";
+import { DEFAULT_CONFIG as CORE_DEFAULT_CONFIG } from "ruffle-core";
 
 export interface Options extends BaseLoadOptions {
     ruffleEnable: boolean;
@@ -124,7 +125,8 @@ export async function bindOptions(
 
     for (const [key, element] of elements.entries()) {
         // Bind initial value.
-        element.value = options[key];
+        element.value =
+            options[key] ?? CORE_DEFAULT_CONFIG[key as keyof BaseLoadOptions];
 
         // Prevent transition on load.
         // Method from https://stackoverflow.com/questions/11131875.

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -26,13 +26,10 @@ window.addEventListener("DOMContentLoaded", async () => {
     document.getElementById("main")!.append(player);
 
     const options = await utils.getOptions();
-    const config = {
+    player.load({
         letterbox: "on" as Letterbox,
         ...options,
-    };
-    player.load({
         url: swfUrl,
         base: swfUrl.substring(0, swfUrl.lastIndexOf("/") + 1),
-        ...config,
     });
 });

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -1,8 +1,6 @@
 import type { Options } from "./common";
-import { DEFAULT_CONFIG as CORE_DEFAULT_CONFIG } from "ruffle-core";
 
-const DEFAULT_OPTIONS: Required<Options> = {
-    ...CORE_DEFAULT_CONFIG,
+const DEFAULT_OPTIONS: Options = {
     ruffleEnable: true,
     ignoreOptout: false,
     autostart: false,


### PR DESCRIPTION
With #10829, `DEFAULT_OPTIONS` contained all config properties, making it distinct (by `objectsEqual()` in `popup.ts`) from any other `Options` instance, due to each one having a unique `parameters` property. This caused the "Reload tab to apply changes" appear unconditionally in the popup page.

Moreover, it caused #10844 because the `base` config was always overridden to `null` in `player.ts`.

As a fix, move `CORE_DEFAULT_CONFIG` away from `DEFAULT_OPTIONS`, using it just for initial options binding in `common.ts`. This restores the state before #10829, where only extension-specific options are saved, but still not-yet-set options are bound to their default value, preventing empty selection boxes in the options page.

Supersedes #10850.
Fixes #10844.