### PR TITLE
swf: Introduce `PointDelta`

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -962,8 +962,8 @@ fn create_linear_gradient(
         let end = matrix * Point::new(Twips::new(16384), Twips::ZERO);
         // If we have to scale the gradient due to spread mode, scale the endpoints away from the center.
         let delta = end - start;
-        let dx = 0.5 * (gradient_scale - 1.0) * delta.x.to_pixels();
-        let dy = 0.5 * (gradient_scale - 1.0) * delta.y.to_pixels();
+        let dx = 0.5 * (gradient_scale - 1.0) * delta.dx.to_pixels();
+        let dy = 0.5 * (gradient_scale - 1.0) * delta.dy.to_pixels();
         Ok(context.create_linear_gradient(
             start.x.to_pixels() - dx,
             start.y.to_pixels() - dy,
@@ -998,11 +998,11 @@ fn create_radial_gradient(
                 Twips::new((focal_point.clamp(-0.98, 0.98) * 16384.0) as i32),
                 Twips::ZERO,
             );
-        let center = matrix * Point::new(Twips::ZERO, Twips::ZERO);
+        let center = matrix * Point::ZERO;
         let end = matrix * Point::new(Twips::new(16384), Twips::ZERO);
         let delta = end - center;
-        let dx = delta.x.to_pixels();
-        let dy = delta.y.to_pixels();
+        let dx = delta.dx.to_pixels();
+        let dy = delta.dy.to_pixels();
         let radius = (dx * dx + dy * dy).sqrt();
         context
             .create_radial_gradient(

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -59,7 +59,7 @@ impl Matrix {
         ty: Twips::ZERO,
     };
 
-    pub fn scale(scale_x: f32, scale_y: f32) -> Self {
+    pub const fn scale(scale_x: f32, scale_y: f32) -> Self {
         Self {
             a: scale_x,
             c: 0.0,
@@ -615,15 +615,17 @@ mod tests {
     // Twips multiplied by the identity/default matrix should be unchanged.
     test_multiply_twips!(
         multiply_twips_identity_matrix,
+        (Matrix::default(), Point::ZERO, Point::ZERO),
+        (Matrix::default(), PointDelta::ZERO, PointDelta::ZERO),
         (
             Matrix::default(),
-            Point::new(Twips::ZERO, Twips::ZERO),
-            Point::new(Twips::ZERO, Twips::ZERO),
+            Point::new(Twips::ZERO, Twips::new(10)),
+            Point::new(Twips::ZERO, Twips::new(10)),
         ),
         (
             Matrix::default(),
-            Point::new(Twips::ZERO, Twips::new(10)),
-            Point::new(Twips::ZERO, Twips::new(10)),
+            PointDelta::new(Twips::ZERO, Twips::new(10)),
+            PointDelta::new(Twips::ZERO, Twips::new(10)),
         ),
         (
             Matrix::default(),
@@ -632,88 +634,68 @@ mod tests {
         ),
         (
             Matrix::default(),
+            PointDelta::new(Twips::new(10), Twips::ZERO),
+            PointDelta::new(Twips::new(10), Twips::ZERO),
+        ),
+        (
+            Matrix::default(),
             Point::new(Twips::new(-251), Twips::new(152)),
             Point::new(Twips::new(-251), Twips::new(152)),
+        ),
+        (
+            Matrix::default(),
+            PointDelta::new(Twips::new(-251), Twips::new(152)),
+            PointDelta::new(Twips::new(-251), Twips::new(152)),
         ),
     );
 
-    // Multiply by translate matrices; values should be shifted.
+    // Multiply by translate matrices; points should be shifted, point deltas should be unchanged.
     test_multiply_twips!(
         multiply_twips_translate,
         (
-            Matrix {
-                a: 1.0,
-                c: 0.0,
-                tx: Twips::new(10),
-                b: 0.0,
-                d: 1.0,
-                ty: Twips::new(5),
-            },
-            Point::new(Twips::ZERO, Twips::ZERO),
+            Matrix::translate(Twips::new(10), Twips::new(5)),
+            Point::ZERO,
             Point::new(Twips::new(10), Twips::new(5)),
         ),
         (
-            Matrix {
-                a: 1.0,
-                c: 0.0,
-                tx: Twips::new(-200),
-                b: 0.0,
-                d: 1.0,
-                ty: Twips::ZERO
-            },
+            Matrix::translate(Twips::new(10), Twips::new(5)),
+            PointDelta::ZERO,
+            PointDelta::ZERO,
+        ),
+        (
+            Matrix::translate(Twips::new(-200), Twips::ZERO),
             Point::new(Twips::new(50), Twips::new(20)),
             Point::new(Twips::new(-150), Twips::new(20)),
+        ),
+        (
+            Matrix::translate(Twips::new(-200), Twips::ZERO),
+            PointDelta::new(Twips::new(50), Twips::new(20)),
+            PointDelta::new(Twips::new(50), Twips::new(20)),
         ),
     );
 
     // Multiply by scalar matrices; values should be scaled up/down.
     test_multiply_twips!(
         multiply_twips_scale,
+        (Matrix::scale(3.0, 3.0), Point::ZERO, Point::ZERO),
+        (Matrix::scale(3.0, 3.0), PointDelta::ZERO, PointDelta::ZERO),
         (
-            Matrix {
-                a: 3.0,
-                c: 0.0,
-                tx: Twips::ZERO,
-                b: 0.0,
-                d: 3.0,
-                ty: Twips::ZERO
-            },
-            Point::new(Twips::ZERO, Twips::ZERO),
-            Point::new(Twips::ZERO, Twips::ZERO),
-        ),
-        (
-            Matrix {
-                a: 3.0,
-                c: 0.0,
-                tx: Twips::ZERO,
-                b: 0.0,
-                d: 3.0,
-                ty: Twips::ZERO
-            },
+            Matrix::scale(3.0, 3.0),
             Point::new(Twips::new(10), Twips::new(10)),
             Point::new(Twips::new(30), Twips::new(30)),
         ),
         (
-            Matrix {
-                a: 0.6,
-                c: 0.0,
-                tx: Twips::ZERO,
-                b: 0.0,
-                d: 0.2,
-                ty: Twips::ZERO
-            },
+            Matrix::scale(3.0, 3.0),
+            PointDelta::new(Twips::new(10), Twips::new(10)),
+            PointDelta::new(Twips::new(30), Twips::new(30)),
+        ),
+        (
+            Matrix::scale(0.6, 0.2),
             Point::new(Twips::new(5), Twips::new(10)),
             Point::new(Twips::new(3), Twips::new(2)),
         ),
         (
-            Matrix {
-                a: 0.5,
-                c: 0.0,
-                tx: Twips::ZERO,
-                b: 0.0,
-                d: 0.5,
-                ty: Twips::ZERO
-            },
+            Matrix::scale(0.5, 0.5),
             Point::new(Twips::new(5), Twips::new(5)),
             Point::new(Twips::new(2), Twips::new(2)),
         ),
@@ -743,8 +725,32 @@ mod tests {
                 d: 0.0,
                 ty: Twips::ZERO
             },
+            PointDelta::new(Twips::new(10), Twips::ZERO),
+            PointDelta::new(Twips::ZERO, Twips::new(10)),
+        ),
+        (
+            Matrix {
+                a: 0.0,
+                c: -1.0,
+                tx: Twips::ZERO,
+                b: 1.0,
+                d: 0.0,
+                ty: Twips::ZERO
+            },
             Point::new(Twips::ZERO, Twips::new(10)),
             Point::new(Twips::new(-10), Twips::ZERO),
+        ),
+        (
+            Matrix {
+                a: 0.0,
+                c: -1.0,
+                tx: Twips::ZERO,
+                b: 1.0,
+                d: 0.0,
+                ty: Twips::ZERO
+            },
+            PointDelta::new(Twips::ZERO, Twips::new(10)),
+            PointDelta::new(Twips::new(-10), Twips::ZERO),
         ),
         (
             Matrix {
@@ -760,27 +766,35 @@ mod tests {
         ),
         (
             Matrix {
-                a: f32::cos(std::f32::consts::FRAC_PI_4),
-                c: f32::sin(std::f32::consts::FRAC_PI_4),
+                a: 0.0,
+                c: 1.0,
                 tx: Twips::ZERO,
-                b: -f32::sin(std::f32::consts::FRAC_PI_4),
-                d: f32::cos(std::f32::consts::FRAC_PI_4),
+                b: -1.0,
+                d: 0.0,
                 ty: Twips::ZERO
             },
+            PointDelta::new(Twips::new(10), Twips::new(10)),
+            PointDelta::new(Twips::new(10), Twips::new(-10)),
+        ),
+        (
+            Matrix::rotate(-std::f32::consts::FRAC_PI_4),
             Point::new(Twips::new(100), Twips::ZERO),
             Point::new(Twips::new(71), Twips::new(-71)),
         ),
         (
-            Matrix {
-                a: f32::cos(std::f32::consts::FRAC_PI_4),
-                c: f32::sin(std::f32::consts::FRAC_PI_4),
-                tx: Twips::ZERO,
-                b: -f32::sin(std::f32::consts::FRAC_PI_4),
-                d: f32::cos(std::f32::consts::FRAC_PI_4),
-                ty: Twips::ZERO
-            },
+            Matrix::rotate(-std::f32::consts::FRAC_PI_4),
+            PointDelta::new(Twips::new(100), Twips::ZERO),
+            PointDelta::new(Twips::new(71), Twips::new(-71)),
+        ),
+        (
+            Matrix::rotate(-std::f32::consts::FRAC_PI_4),
             Point::new(Twips::new(100), Twips::new(100)),
             Point::new(Twips::new(141), Twips::ZERO),
+        ),
+        (
+            Matrix::rotate(-std::f32::consts::FRAC_PI_4),
+            PointDelta::new(Twips::new(100), Twips::new(100)),
+            PointDelta::new(Twips::new(141), Twips::ZERO),
         ),
     );
 
@@ -790,54 +804,106 @@ mod tests {
         (
             // Result of scaling by 3 * rotation by 45 degrees
             Matrix {
-                a: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
-                c: 3.0 * f32::sin(std::f32::consts::FRAC_PI_4),
+                a: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
+                c: 3.0 * std::f32::consts::FRAC_PI_4.sin(),
                 tx: Twips::ZERO,
-                b: 3.0 * -f32::sin(std::f32::consts::FRAC_PI_4),
-                d: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
+                b: 3.0 * -std::f32::consts::FRAC_PI_4.sin(),
+                d: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(100), Twips::new(100)),
             Point::new(Twips::new(424), Twips::ZERO),
         ),
         (
+            // Result of scaling by 3 * rotation by 45 degrees
+            Matrix {
+                a: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
+                c: 3.0 * std::f32::consts::FRAC_PI_4.sin(),
+                tx: Twips::ZERO,
+                b: 3.0 * -std::f32::consts::FRAC_PI_4.sin(),
+                d: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
+                ty: Twips::ZERO
+            },
+            PointDelta::new(Twips::new(100), Twips::new(100)),
+            PointDelta::new(Twips::new(424), Twips::ZERO),
+        ),
+        (
             // Result of translating by (-5, 5) * rotation by 45 degrees
             Matrix {
-                a: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
-                c: 3.0 * f32::sin(std::f32::consts::FRAC_PI_4),
+                a: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
+                c: 3.0 * std::f32::consts::FRAC_PI_4.sin(),
                 tx: Twips::new(-5),
-                b: 3.0 * -f32::sin(std::f32::consts::FRAC_PI_4),
-                d: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
+                b: 3.0 * -std::f32::consts::FRAC_PI_4.sin(),
+                d: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
                 ty: Twips::new(5),
             },
             Point::new(Twips::new(100), Twips::new(100)),
             Point::new(Twips::new(419), Twips::new(5)),
         ),
         (
+            // Result of translating by (-5, 5) * rotation by 45 degrees
+            Matrix {
+                a: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
+                c: 3.0 * std::f32::consts::FRAC_PI_4.sin(),
+                tx: Twips::new(-5),
+                b: 3.0 * -std::f32::consts::FRAC_PI_4.sin(),
+                d: 3.0 * std::f32::consts::FRAC_PI_4.cos(),
+                ty: Twips::new(5),
+            },
+            PointDelta::new(Twips::new(100), Twips::new(100)),
+            PointDelta::new(Twips::new(424), Twips::ZERO),
+        ),
+        (
             // Result of rotation by 45 degrees * translating by (-5, 5)
             Matrix {
-                a: f32::cos(std::f32::consts::FRAC_PI_4),
-                c: f32::sin(std::f32::consts::FRAC_PI_4),
+                a: std::f32::consts::FRAC_PI_4.cos(),
+                c: std::f32::consts::FRAC_PI_4.sin(),
                 tx: Twips::new(-5),
-                b: -f32::sin(std::f32::consts::FRAC_PI_4),
-                d: f32::cos(std::f32::consts::FRAC_PI_4),
+                b: -std::f32::consts::FRAC_PI_4.sin(),
+                d: std::f32::consts::FRAC_PI_4.cos(),
                 ty: Twips::new(5),
             },
             Point::new(Twips::new(100), Twips::new(100)),
             Point::new(Twips::new(136), Twips::new(5)),
         ),
         (
+            // Result of rotation by 45 degrees * translating by (-5, 5)
+            Matrix {
+                a: std::f32::consts::FRAC_PI_4.cos(),
+                c: std::f32::consts::FRAC_PI_4.sin(),
+                tx: Twips::new(-5),
+                b: -std::f32::consts::FRAC_PI_4.sin(),
+                d: std::f32::consts::FRAC_PI_4.cos(),
+                ty: Twips::new(5),
+            },
+            PointDelta::new(Twips::new(100), Twips::new(100)),
+            PointDelta::new(Twips::new(141), Twips::ZERO),
+        ),
+        (
             // Result of translating by (-5, 5) * rotation by 45 degrees
             Matrix {
-                a: f32::cos(std::f32::consts::FRAC_PI_4),
-                c: f32::sin(std::f32::consts::FRAC_PI_4),
+                a: std::f32::consts::FRAC_PI_4.cos(),
+                c: std::f32::consts::FRAC_PI_4.sin(),
                 tx: Twips::ZERO,
-                b: -f32::sin(std::f32::consts::FRAC_PI_4),
-                d: f32::cos(std::f32::consts::FRAC_PI_4),
-                ty: Twips::new((10.0 * f32::sin(std::f32::consts::FRAC_PI_4)) as i32),
+                b: -std::f32::consts::FRAC_PI_4.sin(),
+                d: std::f32::consts::FRAC_PI_4.cos(),
+                ty: Twips::new((10.0 * std::f32::consts::FRAC_PI_4.sin()) as i32),
             },
             Point::new(Twips::new(105), Twips::new(95)),
             Point::new(Twips::new(141), Twips::ZERO),
+        ),
+        (
+            // Result of translating by (-5, 5) * rotation by 45 degrees
+            Matrix {
+                a: std::f32::consts::FRAC_PI_4.cos(),
+                c: std::f32::consts::FRAC_PI_4.sin(),
+                tx: Twips::ZERO,
+                b: -std::f32::consts::FRAC_PI_4.sin(),
+                d: std::f32::consts::FRAC_PI_4.cos(),
+                ty: Twips::new((10.0 * std::f32::consts::FRAC_PI_4.sin()) as i32),
+            },
+            PointDelta::new(Twips::new(105), Twips::new(95)),
+            PointDelta::new(Twips::new(141), Twips::new(-7)),
         ),
     );
 }

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -263,7 +263,7 @@ mod tests {
     use approx::{assert_ulps_eq, AbsDiffEq, UlpsEq};
 
     macro_rules! test_inverse {
-        ( $test: ident, $($args: expr),* ) => {
+        ($test: ident, $($args: expr),* $(,)?) => {
             #[test]
             fn $test() {
                 $(
@@ -279,7 +279,7 @@ mod tests {
     }
 
     macro_rules! test_multiply {
-        ( $test: ident, $($args: expr),* ) => {
+        ($test: ident, $($args: expr),* $(,)?) => {
             #[test]
             fn $test() {
                 $(
@@ -291,7 +291,7 @@ mod tests {
     }
 
     macro_rules! test_multiply_twips {
-        ( $test: ident, $($args: expr),* ) => {
+        ($test: ident, $($args: expr),* $(,)?) => {
             #[test]
             fn $test() {
                 $(
@@ -336,7 +336,7 @@ mod tests {
     // Identity matrix inverted should be unchanged.
     test_inverse!(
         inverse_identity_matrix,
-        (Matrix::default(), Some(Matrix::default()))
+        (Matrix::default(), Some(Matrix::default())),
     );
 
     // Standard test cases; there's nothing special about these matrices.
@@ -349,7 +349,7 @@ mod tests {
                 tx: Twips::from_pixels(7.0),
                 b: 2.0,
                 d: 5.0,
-                ty: Twips::from_pixels(2.0)
+                ty: Twips::from_pixels(2.0),
             },
             Some(Matrix {
                 a: -1.666_666_6,
@@ -357,8 +357,8 @@ mod tests {
                 tx: Twips::from_pixels(9.0),
                 b: 0.666_666_6,
                 d: -0.333_333_3,
-                ty: Twips::from_pixels(-4.0)
-            })
+                ty: Twips::from_pixels(-4.0),
+            }),
         ),
         (
             Matrix {
@@ -367,7 +367,7 @@ mod tests {
                 tx: Twips::from_pixels(-7.0),
                 b: -2.0,
                 d: -5.0,
-                ty: Twips::from_pixels(-2.0)
+                ty: Twips::from_pixels(-2.0),
             },
             Some(Matrix {
                 a: 1.666_666_6,
@@ -375,8 +375,8 @@ mod tests {
                 tx: Twips::from_pixels(9.0),
                 b: -0.666_666_6,
                 d: 0.333_333_3,
-                ty: Twips::from_pixels(-4.0)
-            })
+                ty: Twips::from_pixels(-4.0),
+            }),
         ),
         (
             Matrix {
@@ -385,7 +385,7 @@ mod tests {
                 tx: Twips::from_pixels(1.0),
                 b: -2.7,
                 d: 3.4,
-                ty: Twips::from_pixels(-2.4)
+                ty: Twips::from_pixels(-2.4),
             },
             Some(Matrix {
                 a: 0.407_673_9,
@@ -393,8 +393,8 @@ mod tests {
                 tx: Twips::from_pixels(-0.752_997_6),
                 b: 0.323_741,
                 d: 0.179_856_1,
-                ty: Twips::from_pixels(0.107_913_67)
-            })
+                ty: Twips::from_pixels(0.107_913_67),
+            }),
         ),
         (
             Matrix {
@@ -403,7 +403,7 @@ mod tests {
                 tx: Twips::from_pixels(10.0),
                 b: 0.0,
                 d: -1.0,
-                ty: Twips::from_pixels(5.0)
+                ty: Twips::from_pixels(5.0),
             },
             Some(Matrix {
                 a: -0.5,
@@ -411,9 +411,9 @@ mod tests {
                 tx: Twips::from_pixels(5.0),
                 b: 0.0,
                 d: -1.0,
-                ty: Twips::from_pixels(5.0)
-            })
-        )
+                ty: Twips::from_pixels(5.0),
+            }),
+        ),
     );
 
     // Non-invertible matrices
@@ -429,8 +429,8 @@ mod tests {
                 tx: Twips::from_pixels(123.0),
                 ty: Twips::from_pixels(234.0),
             },
-            None
-        )
+            None,
+        ),
     );
 
     // Anything multiplied by the identity matrix should be unchanged.
@@ -445,7 +445,7 @@ mod tests {
                 tx: Twips::from_pixels(7.0),
                 b: 2.0,
                 d: 5.0,
-                ty: Twips::from_pixels(2.0)
+                ty: Twips::from_pixels(2.0),
             },
             Matrix {
                 a: 1.0,
@@ -453,7 +453,7 @@ mod tests {
                 tx: Twips::from_pixels(7.0),
                 b: 2.0,
                 d: 5.0,
-                ty: Twips::from_pixels(2.0)
+                ty: Twips::from_pixels(2.0),
             }
         ),
         (
@@ -463,7 +463,7 @@ mod tests {
                 tx: Twips::from_pixels(7.0),
                 b: 2.0,
                 d: 5.0,
-                ty: Twips::from_pixels(2.0)
+                ty: Twips::from_pixels(2.0),
             },
             Matrix::default(),
             Matrix {
@@ -472,9 +472,9 @@ mod tests {
                 tx: Twips::from_pixels(7.0),
                 b: 2.0,
                 d: 5.0,
-                ty: Twips::from_pixels(2.0)
-            }
-        )
+                ty: Twips::from_pixels(2.0),
+            },
+        ),
     );
 
     // General test cases for matrix multiplication.
@@ -487,7 +487,7 @@ mod tests {
                 tx: Twips::new(2),
                 b: 5.0,
                 d: 3.0,
-                ty: Twips::new(1)
+                ty: Twips::new(1),
             },
             Matrix {
                 a: 1.0,
@@ -495,7 +495,7 @@ mod tests {
                 tx: Twips::new(5),
                 b: 2.0,
                 d: 4.0,
-                ty: Twips::new(6)
+                ty: Twips::new(6),
             },
             Matrix {
                 a: 14.0,
@@ -503,8 +503,8 @@ mod tests {
                 tx: Twips::new(56),
                 b: 11.0,
                 d: 27.0,
-                ty: Twips::new(44)
-            }
+                ty: Twips::new(44),
+            },
         ),
         (
             Matrix {
@@ -513,7 +513,7 @@ mod tests {
                 tx: Twips::new(5),
                 b: 2.0,
                 d: 4.0,
-                ty: Twips::new(6)
+                ty: Twips::new(6),
             },
             Matrix {
                 a: 6.0,
@@ -521,7 +521,7 @@ mod tests {
                 tx: Twips::new(2),
                 b: 5.0,
                 d: 3.0,
-                ty: Twips::new(1)
+                ty: Twips::new(1),
             },
             Matrix {
                 a: 21.0,
@@ -529,8 +529,8 @@ mod tests {
                 tx: Twips::new(10),
                 b: 32.0,
                 d: 20.0,
-                ty: Twips::new(14)
-            }
+                ty: Twips::new(14),
+            },
         ),
         (
             Matrix {
@@ -539,7 +539,7 @@ mod tests {
                 tx: Twips::new(3),
                 b: 4.0,
                 d: 5.0,
-                ty: Twips::new(6)
+                ty: Twips::new(6),
             },
             Matrix {
                 a: 6.0,
@@ -547,7 +547,7 @@ mod tests {
                 tx: Twips::new(4),
                 b: 3.0,
                 d: 2.0,
-                ty: Twips::new(1)
+                ty: Twips::new(1),
             },
             Matrix {
                 a: 12.0,
@@ -555,8 +555,8 @@ mod tests {
                 tx: Twips::new(9),
                 b: 39.0,
                 d: 30.0,
-                ty: Twips::new(27)
-            }
+                ty: Twips::new(27),
+            },
         ),
         (
             Matrix {
@@ -565,7 +565,7 @@ mod tests {
                 tx: Twips::new(4),
                 b: 3.0,
                 d: 2.0,
-                ty: Twips::new(1)
+                ty: Twips::new(1),
             },
             Matrix {
                 a: 1.0,
@@ -573,7 +573,7 @@ mod tests {
                 tx: Twips::new(3),
                 b: 4.0,
                 d: 5.0,
-                ty: Twips::new(6)
+                ty: Twips::new(6),
             },
             Matrix {
                 a: 26.0,
@@ -581,8 +581,8 @@ mod tests {
                 tx: Twips::new(52),
                 b: 11.0,
                 d: 16.0,
-                ty: Twips::new(22)
-            }
+                ty: Twips::new(22),
+            },
         ),
         (
             Matrix {
@@ -591,7 +591,7 @@ mod tests {
                 tx: Twips::new(3),
                 b: 4.0,
                 d: 5.0,
-                ty: Twips::new(6)
+                ty: Twips::new(6),
             },
             Matrix {
                 a: 1.0,
@@ -599,7 +599,7 @@ mod tests {
                 tx: Twips::new(3),
                 b: 4.0,
                 d: 5.0,
-                ty: Twips::new(6)
+                ty: Twips::new(6),
             },
             Matrix {
                 a: 9.0,
@@ -607,9 +607,9 @@ mod tests {
                 tx: Twips::new(18),
                 b: 24.0,
                 d: 33.0,
-                ty: Twips::new(48)
-            }
-        )
+                ty: Twips::new(48),
+            },
+        ),
     );
 
     // Twips multiplied by the identity/default matrix should be unchanged.
@@ -618,23 +618,23 @@ mod tests {
         (
             Matrix::default(),
             Point::new(Twips::ZERO, Twips::ZERO),
-            Point::new(Twips::ZERO, Twips::ZERO)
+            Point::new(Twips::ZERO, Twips::ZERO),
         ),
         (
             Matrix::default(),
             Point::new(Twips::ZERO, Twips::new(10)),
-            Point::new(Twips::ZERO, Twips::new(10))
+            Point::new(Twips::ZERO, Twips::new(10)),
         ),
         (
             Matrix::default(),
             Point::new(Twips::new(10), Twips::ZERO),
-            Point::new(Twips::new(10), Twips::ZERO)
+            Point::new(Twips::new(10), Twips::ZERO),
         ),
         (
             Matrix::default(),
             Point::new(Twips::new(-251), Twips::new(152)),
-            Point::new(Twips::new(-251), Twips::new(152))
-        )
+            Point::new(Twips::new(-251), Twips::new(152)),
+        ),
     );
 
     // Multiply by translate matrices; values should be shifted.
@@ -647,10 +647,10 @@ mod tests {
                 tx: Twips::new(10),
                 b: 0.0,
                 d: 1.0,
-                ty: Twips::new(5)
+                ty: Twips::new(5),
             },
             Point::new(Twips::ZERO, Twips::ZERO),
-            Point::new(Twips::new(10), Twips::new(5))
+            Point::new(Twips::new(10), Twips::new(5)),
         ),
         (
             Matrix {
@@ -662,8 +662,8 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(50), Twips::new(20)),
-            Point::new(Twips::new(-150), Twips::new(20))
-        )
+            Point::new(Twips::new(-150), Twips::new(20)),
+        ),
     );
 
     // Multiply by scalar matrices; values should be scaled up/down.
@@ -679,7 +679,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::ZERO, Twips::ZERO),
-            Point::new(Twips::ZERO, Twips::ZERO)
+            Point::new(Twips::ZERO, Twips::ZERO),
         ),
         (
             Matrix {
@@ -691,7 +691,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(10), Twips::new(10)),
-            Point::new(Twips::new(30), Twips::new(30))
+            Point::new(Twips::new(30), Twips::new(30)),
         ),
         (
             Matrix {
@@ -703,7 +703,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(5), Twips::new(10)),
-            Point::new(Twips::new(3), Twips::new(2))
+            Point::new(Twips::new(3), Twips::new(2)),
         ),
         (
             Matrix {
@@ -715,8 +715,8 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(5), Twips::new(5)),
-            Point::new(Twips::new(2), Twips::new(2))
-        )
+            Point::new(Twips::new(2), Twips::new(2)),
+        ),
     );
 
     // Multiply by rotation matrices; values should be rotated around origin.
@@ -732,7 +732,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(10), Twips::ZERO),
-            Point::new(Twips::ZERO, Twips::new(10))
+            Point::new(Twips::ZERO, Twips::new(10)),
         ),
         (
             Matrix {
@@ -744,7 +744,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::ZERO, Twips::new(10)),
-            Point::new(Twips::new(-10), Twips::ZERO)
+            Point::new(Twips::new(-10), Twips::ZERO),
         ),
         (
             Matrix {
@@ -756,7 +756,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(10), Twips::new(10)),
-            Point::new(Twips::new(10), Twips::new(-10))
+            Point::new(Twips::new(10), Twips::new(-10)),
         ),
         (
             Matrix {
@@ -768,7 +768,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(100), Twips::ZERO),
-            Point::new(Twips::new(71), Twips::new(-71))
+            Point::new(Twips::new(71), Twips::new(-71)),
         ),
         (
             Matrix {
@@ -780,8 +780,8 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(100), Twips::new(100)),
-            Point::new(Twips::new(141), Twips::ZERO)
-        )
+            Point::new(Twips::new(141), Twips::ZERO),
+        ),
     );
 
     // Testing transformation matrices that have more than 1 translation applied.
@@ -798,7 +798,7 @@ mod tests {
                 ty: Twips::ZERO
             },
             Point::new(Twips::new(100), Twips::new(100)),
-            Point::new(Twips::new(424), Twips::ZERO)
+            Point::new(Twips::new(424), Twips::ZERO),
         ),
         (
             // Result of translating by (-5, 5) * rotation by 45 degrees
@@ -808,10 +808,10 @@ mod tests {
                 tx: Twips::new(-5),
                 b: 3.0 * -f32::sin(std::f32::consts::FRAC_PI_4),
                 d: 3.0 * f32::cos(std::f32::consts::FRAC_PI_4),
-                ty: Twips::new(5)
+                ty: Twips::new(5),
             },
             Point::new(Twips::new(100), Twips::new(100)),
-            Point::new(Twips::new(419), Twips::new(5))
+            Point::new(Twips::new(419), Twips::new(5)),
         ),
         (
             // Result of rotation by 45 degrees * translating by (-5, 5)
@@ -821,10 +821,10 @@ mod tests {
                 tx: Twips::new(-5),
                 b: -f32::sin(std::f32::consts::FRAC_PI_4),
                 d: f32::cos(std::f32::consts::FRAC_PI_4),
-                ty: Twips::new(5)
+                ty: Twips::new(5),
             },
             Point::new(Twips::new(100), Twips::new(100)),
-            Point::new(Twips::new(136), Twips::new(5))
+            Point::new(Twips::new(136), Twips::new(5)),
         ),
         (
             // Result of translating by (-5, 5) * rotation by 45 degrees
@@ -834,11 +834,11 @@ mod tests {
                 tx: Twips::ZERO,
                 b: -f32::sin(std::f32::consts::FRAC_PI_4),
                 d: f32::cos(std::f32::consts::FRAC_PI_4),
-                ty: Twips::new((10.0 * f32::sin(std::f32::consts::FRAC_PI_4)) as i32)
+                ty: Twips::new((10.0 * f32::sin(std::f32::consts::FRAC_PI_4)) as i32),
             },
             Point::new(Twips::new(105), Twips::new(95)),
-            Point::new(Twips::new(141), Twips::ZERO)
-        )
+            Point::new(Twips::new(141), Twips::ZERO),
+        ),
     );
 }
 

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -1,4 +1,4 @@
-use swf::{Fixed16, Point, Rectangle, Twips};
+use swf::{Fixed16, Point, PointDelta, Rectangle, Twips};
 
 /// The transformation matrix used by Flash display objects.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -170,6 +170,7 @@ impl Matrix {
 
 impl std::ops::Mul for Matrix {
     type Output = Self;
+
     fn mul(self, rhs: Self) -> Self {
         let (rhs_tx, rhs_ty) = (rhs.tx.get() as f32, rhs.ty.get() as f32);
         let (out_tx, out_ty) = (
@@ -196,6 +197,18 @@ impl std::ops::Mul<Point<Twips>> for Matrix {
         let out_x = Twips::new(round_to_i32(self.a * x + self.c * y).wrapping_add(self.tx.get()));
         let out_y = Twips::new(round_to_i32(self.b * x + self.d * y).wrapping_add(self.ty.get()));
         Point::new(out_x, out_y)
+    }
+}
+
+impl std::ops::Mul<PointDelta<Twips>> for Matrix {
+    type Output = PointDelta<Twips>;
+
+    fn mul(self, delta: PointDelta<Twips>) -> PointDelta<Twips> {
+        let dx = delta.dx.get() as f32;
+        let dy = delta.dy.get() as f32;
+        let out_dx = Twips::new(round_to_i32(self.a * dx + self.c * dy));
+        let out_dy = Twips::new(round_to_i32(self.b * dx + self.d * dy));
+        PointDelta::new(out_dx, out_dy)
     }
 }
 

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -36,7 +36,7 @@ pub use fixed::{Fixed16, Fixed8};
 pub use glow_filter::{GlowFilter, GlowFilterFlags};
 pub use gradient_filter::{GradientFilter, GradientFilterFlags};
 pub use matrix::Matrix;
-pub use point::Point;
+pub use point::{Point, PointDelta};
 pub use rectangle::Rectangle;
 pub use twips::Twips;
 

--- a/swf/src/types/point.rs
+++ b/swf/src/types/point.rs
@@ -69,49 +69,92 @@ impl Point<Twips> {
     }
 }
 
-impl<T: Coordinate> Add for Point<T> {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, other: Self) -> Self {
-        Self {
-            x: self.x + other.x,
-            y: self.y + other.y,
-        }
-    }
-}
-
-impl<T: Coordinate> AddAssign for Point<T> {
-    #[inline]
-    fn add_assign(&mut self, other: Self) {
-        self.x += other.x;
-        self.y += other.y;
-    }
-}
-
-impl<T: Coordinate> Sub for Point<T> {
-    type Output = Self;
-
-    #[inline]
-    fn sub(self, other: Self) -> Self {
-        Self {
-            x: self.x - other.x,
-            y: self.y - other.y,
-        }
-    }
-}
-
-impl<T: Coordinate> SubAssign for Point<T> {
-    #[inline]
-    fn sub_assign(&mut self, other: Self) {
-        self.x -= other.x;
-        self.y -= other.y;
-    }
-}
-
 impl<T: Coordinate> fmt::Display for Point<T> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {})", self.x, self.y)
+    }
+}
+
+/// A difference between two 2D points.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PointDelta<T: Coordinate> {
+    pub dx: T,
+    pub dy: T,
+}
+
+impl<T: Coordinate> PointDelta<T> {
+    /// The `PointDelta` object with a value of `(0, 0)`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// assert_eq!(swf::PointDelta::<swf::Twips>::ZERO.dx, swf::Twips::ZERO);
+    /// assert_eq!(swf::PointDelta::<swf::Twips>::ZERO.dy, swf::Twips::ZERO);
+    /// ```
+    pub const ZERO: Self = Self {
+        dx: T::ZERO,
+        dy: T::ZERO,
+    };
+
+    pub const fn new(dx: T, dy: T) -> Self {
+        Self { dx, dy }
+    }
+}
+
+// point + delta
+impl<T: Coordinate> Add<PointDelta<T>> for Point<T> {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: PointDelta<T>) -> Self {
+        Self {
+            x: self.x + other.dx,
+            y: self.y + other.dy,
+        }
+    }
+}
+
+// point += delta
+impl<T: Coordinate> AddAssign<PointDelta<T>> for Point<T> {
+    #[inline]
+    fn add_assign(&mut self, other: PointDelta<T>) {
+        self.x += other.dx;
+        self.y += other.dy;
+    }
+}
+
+// point - delta
+impl<T: Coordinate> Sub<PointDelta<T>> for Point<T> {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: PointDelta<T>) -> Self {
+        Self {
+            x: self.x - other.dx,
+            y: self.y - other.dy,
+        }
+    }
+}
+
+// point -= delta
+impl<T: Coordinate> SubAssign<PointDelta<T>> for Point<T> {
+    #[inline]
+    fn sub_assign(&mut self, other: PointDelta<T>) {
+        self.x -= other.dx;
+        self.y -= other.dy;
+    }
+}
+
+// point - point
+impl<T: Coordinate> Sub for Point<T> {
+    type Output = PointDelta<T>;
+
+    #[inline]
+    fn sub(self, other: Self) -> PointDelta<T> {
+        PointDelta {
+            dx: self.x - other.x,
+            dy: self.y - other.y,
+        }
     }
 }


### PR DESCRIPTION
Generally, when transforming a difference between two points, `p1` and `p2`, with a matrix `m`, we would like the following property to hold:

```
m * (p1 - p2) == m * p1 - m * p2
```

Unfortunately, it wasn't like this before, because matrices have a translation component, which is non-linear. In `m * p1 - m * p2`, the translations of `m * p1` and `m * p2` are the same and therefore cancel out each other. However, in `m * (p1 - p2)` the translation stays.

In order to preserve this property, introduce a new `PointDelta` type which is not subject to translation when transformed by a matrix.

For now, the following operations are supported:

* `Point - Point -> PointDelta`
* `Point + PointDelta -> Point`
* `Point += PointDelta`
* `Point - PointDelta -> Point`
* `Point -= PointDelta`

As a consequence, the expression `position + global_to_local_matrix * mouse_delta` in `update_drag()` now ignores translation, which fixes #817.