### PR TITLE
desktop: Tell macOS that Ruffle can open SWF files

### DIFF
--- a/desktop/packages/macOS/Contents/Info.plist
+++ b/desktop/packages/macOS/Contents/Info.plist
@@ -26,5 +26,24 @@
     </array>
     <key>NSAccentColorName</key>
     <string>RuffleOrange</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>swf</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Flash file</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Default</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.macromedia.shockwave-flash</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Currently, macOS doesn't recognise that Ruffle is capable of opening SWF files. Therefore, Ruffle isn't included in the list of programs to open an SWF file with, and you need to manually change the settings to open SWFs with Ruffle.

This Pull Request changes that; it includes the necessary metadata in the Info.plist file to tell macOS that Ruffle can open SWF files and should be the default program to open an SWF file with.

Additionally, this should cause SWF file icons to be generated during the build process. This means that SWF files will have the Ruffle logo on their file icon.