### PR TITLE
extension: Add UI presentation for playerVersion default value.

### DIFF
--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -67,6 +67,7 @@
                 <input type="number" id="player_version"
                        min="1"
                        max="32"
+                       placeholder="32"
                 />
                 <label for="player_version">Flash player version number to emulate (range 1-32)</label>
             </div>


### PR DESCRIPTION
The shown UI value is hard-coded to be 32 when the internal value for `playerVersion` is `null`, but that should be alright, since it is guessed that the default value will continue being 32 for many years according to discussions elsewhere. And it should be easy to change or figure something else out if this does not hold for whatever reason.