### PR TITLE
web: Fix panic error details display

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1901,7 +1901,7 @@ export class RufflePlayer extends HTMLElement {
 
                 const panicText = document.createElement("textarea");
                 panicText.value = errorText;
-                panicBody.appendChild(panicText);
+                panicBody.replaceChildren(panicText);
                 return false;
             };
         }


### PR DESCRIPTION
Fix wrong display of panic error details caused by #10819:
![image](https://user-images.githubusercontent.com/71368227/235383934-77c841a8-0426-4c34-a7cd-7297a3806fe4.png)
