### PR TITLE
web: Various improvements to options

### DIFF
--- a/web/packages/extension/assets/_locales/de/messages.json
+++ b/web/packages/extension/assets/_locales/de/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Flash-Inhalte in Ruffle abspielen"
     },
-    "settings_page_ignore_optout": {
-        "message": "Flash-Inhalte abspielen, auch wenn die Seite Ruffle abgeschaltet hat"
-    },
     "settings_ignore_optout": {
-        "message": "Ignoriere Kompatibilitätswarnungen von Websites"
+        "message": "Flash-Inhalte abspielen, auch wenn die Seite Ruffle abgeschaltet hat"
     },
     "status_init": {
         "message": "Prüfe den aktuellen Tab…"

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -21,7 +21,7 @@
         "message": "Log level"
     },
     "settings_max_execution_duration": {
-        "message": "How long can ActionScript execute for before being forcefully stopped (in seconds)"
+        "message": "Maximum allowed ActionScript execution duration (in seconds)"
     },
     "settings_player_version": {
         "message": "Flash player version number to emulate (range 1-32)"

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Play Flash content in Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Play Flash content even on sites that disable Ruffle"
-    },
     "settings_ignore_optout": {
-        "message": "Ignore website compatibility warnings"
+        "message": "Play Flash content even on sites that disallow Ruffle"
     },
     "settings_show_swf_download": {
         "message": "Show SWF download in context menu"
@@ -26,6 +23,9 @@
     "settings_player_version": {
         "message": "Flash player version number to emulate (range 1-32)"
     },
+    "settings_preferred_renderer": {
+        "message": "Preferred renderer"
+    },
     "status_init": {
         "message": "Reading current tab…"
     },
@@ -39,13 +39,13 @@
         "message": "Checking Ruffle status on current tab…"
     },
     "status_result_running": {
-        "message": "Ruffle is loaded and running Flash content on the current tab."
+        "message": "Ruffle is loaded and ready to run Flash content on the current tab."
     },
     "status_result_optout": {
         "message": "Ruffle is not loaded because the current page has marked itself as incompatible."
     },
     "status_result_disabled": {
-        "message": "Ruffle is not loaded because it was disabled by the user."
+        "message": "Ruffle is not loaded because it is disabled."
     },
     "status_result_error": {
         "message": "An error occurred when querying the current tab's instance of Ruffle."

--- a/web/packages/extension/assets/_locales/es/messages.json
+++ b/web/packages/extension/assets/_locales/es/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Ejecutar Flash con Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Ejecutar Flash incluso con Ruffle desactivado por la página"
-    },
     "settings_ignore_optout": {
-        "message": "Ignorar avisos de compatibilidad en páginas de internet"
+        "message": "Ejecutar Flash incluso con Ruffle desactivado por la página"
     },
     "settings_show_swf_download": {
         "message": "Mostrar descarga de SWF en el menú contextual"

--- a/web/packages/extension/assets/_locales/fr/messages.json
+++ b/web/packages/extension/assets/_locales/fr/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Lire du contenu Flash avec Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Lire du contenu Flash même sur les sites qui désactivent Ruffle"
-    },
     "settings_ignore_optout": {
-        "message": "Ignorer les avertissements de compatibilité des sites Internet"
+        "message": "Lire du contenu Flash même sur les sites qui désactivent Ruffle"
     },
     "settings_show_swf_download": {
         "message": "Permet le téléchargement des SWFs depuis le menu contextuel"

--- a/web/packages/extension/assets/_locales/hu/messages.json
+++ b/web/packages/extension/assets/_locales/hu/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Flash tartalom lejátszása Ruffle-lel"
     },
-    "settings_page_ignore_optout": {
-        "message": "Flash tartalom lejátszása Ruffle-lel azon oldalakon is, amik nem akarják azt"
-    },
     "settings_ignore_optout": {
-        "message": "Eltekintés a weboldalak kompatibilitási figyelmeztetéseitől"
+        "message": "Flash tartalom lejátszása Ruffle-lel azon oldalakon is, amik nem akarják azt"
     },
     "status_init": {
         "message": "Jelenlegi fül olvasása…"

--- a/web/packages/extension/assets/_locales/it/messages.json
+++ b/web/packages/extension/assets/_locales/it/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Riproduci i contenuti Flash in Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Riproduci i contenuti Flash anche in siti che disabilitano Ruffle"
-    },
     "settings_ignore_optout": {
-        "message": "Ignora gli avvertimenti di compatibilità dei siti"
+        "message": "Riproduci i contenuti Flash anche in siti che disabilitano Ruffle"
     },
     "settings_show_swf_download": {
         "message": "Mostra l'opzione per scaricare gli SWF nel menu contestuale"

--- a/web/packages/extension/assets/_locales/ja/messages.json
+++ b/web/packages/extension/assets/_locales/ja/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "RuffleでFlashコンテンツを再生する"
     },
-    "settings_page_ignore_optout": {
-        "message": "Ruffleを無効にしたサイトでもFlashコンテンツを再生する"
-    },
     "settings_ignore_optout": {
-        "message": "Webサイトの互換性に関する警告を無視する"
+        "message": "Ruffleを無効にしたサイトでもFlashコンテンツを再生する"
     },
     "settings_show_swf_download": {
         "message": "SWFのダウンロードをコンテキストメニューに表示する"

--- a/web/packages/extension/assets/_locales/ko/messages.json
+++ b/web/packages/extension/assets/_locales/ko/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Ruffle에서 플래시 콘텐츠 재생하기"
     },
-    "settings_page_ignore_optout": {
-        "message": "Ruffle을 비활성화한 사이트에서도 플래시 콘텐츠 재생하기"
-    },
     "settings_ignore_optout": {
-        "message": "웹 사이트 호환성 경고를 무시하기"
+        "message": "Ruffle을 비활성화한 사이트에서도 플래시 콘텐츠 재생하기"
     },
     "settings_show_swf_download": {
         "message": "컨텍스트 메뉴에 SWF 다운로드 버튼 표시"

--- a/web/packages/extension/assets/_locales/nl/messages.json
+++ b/web/packages/extension/assets/_locales/nl/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Flash-inhoud afspelen in Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Flash-inhoud afspelen zelfs op sites die Ruffle uitschakelen"
-    },
     "settings_ignore_optout": {
-        "message": "Waarschuwingen voor de compatibiliteit van websites negeren"
+        "message": "Flash-inhoud afspelen zelfs op sites die Ruffle uitschakelen"
     },
     "status_init": {
         "message": "Huidig tabblad lezen…"

--- a/web/packages/extension/assets/_locales/pt_PT/messages.json
+++ b/web/packages/extension/assets/_locales/pt_PT/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Reproduzir conteúdo Flash no Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Reproduzir conteúdo Flash mesmo em sites que desabilitam o Ruffle"
-    },
     "settings_ignore_optout": {
-        "message": "Ignorar avisos de compatibilidade do site"
+        "message": "Reproduzir conteúdo Flash mesmo em sites que desabilitam o Ruffle"
     },
     "settings_show_swf_download": {
         "message": "Permitir o download de SWFs pelo menu de contexto"

--- a/web/packages/extension/assets/_locales/ro/messages.json
+++ b/web/packages/extension/assets/_locales/ro/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Redă conținut Flash în Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Redă conținut Flash chiar și pe site-uri care dezactivează Ruffle"
-    },
     "settings_ignore_optout": {
-        "message": "Ignoră avertismentele privind compatibilitatea site-urilor web"
+        "message": "Redă conținut Flash chiar și pe site-uri care dezactivează Ruffle"
     },
     "status_init": {
         "message": "Se citește fila actuală…"

--- a/web/packages/extension/assets/_locales/ru/messages.json
+++ b/web/packages/extension/assets/_locales/ru/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Проигрывать Flash-контент в Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Проигрывать Flash-контент даже на тех сайтах, где Ruffle отключен"
-    },
     "settings_ignore_optout": {
-        "message": "Игнорировать предупреждения о совместимости с сайтами"
+        "message": "Проигрывать Flash-контент даже на тех сайтах, где Ruffle отключен"
     },
     "status_init": {
         "message": "Чтение текущей вкладки..."

--- a/web/packages/extension/assets/_locales/sv/messages.json
+++ b/web/packages/extension/assets/_locales/sv/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Spela upp Flash-innehåll i Ruffle"
     },
-    "settings_page_ignore_optout": {
-        "message": "Spela upp Flash-innehåll även på sidor som inaktiverar Ruffle"
-    },
     "settings_ignore_optout": {
-        "message": "Ignorera webbsidekompatibilitetsvarningar"
+        "message": "Spela upp Flash-innehåll även på sidor som inaktiverar Ruffle"
     },
     "status_init": {
         "message": "Avläser aktuell flik…"

--- a/web/packages/extension/assets/_locales/tr/messages.json
+++ b/web/packages/extension/assets/_locales/tr/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "Flash içeriğini Ruffle ile oynat"
     },
-    "settings_page_ignore_optout": {
-        "message": "Ruffle'a engel olan sitelerde dahi Flash içeriğini oynatmaya çalış"
-    },
     "settings_ignore_optout": {
-        "message": "Sitelerin uyumsuzluk uyarılarını yoksay"
+        "message": "Ruffle'a engel olan sitelerde dahi Flash içeriğini oynatmaya çalış"
     },
     "status_init": {
         "message": "Mevcut sekme okunuyor…"

--- a/web/packages/extension/assets/_locales/zh_CN/messages.json
+++ b/web/packages/extension/assets/_locales/zh_CN/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "使用 Ruffle 播放 Flash 内容"
     },
-    "settings_page_ignore_optout": {
-        "message": "即便站点禁用了 Ruffle 也播放 Flash 内容"
-    },
     "settings_ignore_optout": {
-        "message": "忽略网站兼容性警告"
+        "message": "即便站点禁用了 Ruffle 也播放 Flash 内容"
     },
     "settings_show_swf_download": {
         "message": "在右键菜单中显示SWF下载选项"

--- a/web/packages/extension/assets/_locales/zh_TW/messages.json
+++ b/web/packages/extension/assets/_locales/zh_TW/messages.json
@@ -2,11 +2,8 @@
     "settings_ruffle_enable": {
         "message": "使用 Ruffle 播放 Flash 内容"
     },
-    "settings_page_ignore_optout": {
-        "message": "即便網站禁用了 Ruffle 也可以播放 Flash 内容"
-    },
     "settings_ignore_optout": {
-        "message": "忽略網站相容性警告"
+        "message": "即便網站禁用了 Ruffle 也可以播放 Flash 内容"
     },
     "settings_show_swf_download": {
         "message": "顯示下載SWF檔案(右鍵選單)"

--- a/web/packages/extension/assets/css/common.css
+++ b/web/packages/extension/assets/css/common.css
@@ -36,19 +36,18 @@ body {
     transform: scale(104%);
 }
 
-/*
- * Controls.
- */
+/* Controls */
 
-/* Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW */
+.options {
+    display: flex;
+    flex-flow: column;
+    gap: 24px;
+}
+
 .option {
     position: relative;
     display: flex;
     align-items: center;
-}
-
-.option:not(:first-child) {
-    margin-top: 24px;
 }
 
 .option input,
@@ -62,7 +61,7 @@ body {
     padding-right: 80px;
 }
 
-/* Checkbox. */
+/* Checkbox (Based on "Pure CSS Slider Checkboxes": https://codepen.io/Qvcool/pen/bdzVYW) */
 
 .option.checkbox input {
     width: 40px;
@@ -107,7 +106,7 @@ body {
     right: 1px;
 }
 
-/* Number input. */
+/* Number input */
 
 .option.number-input input {
     width: 60px;

--- a/web/packages/extension/assets/css/options.css
+++ b/web/packages/extension/assets/css/options.css
@@ -7,3 +7,11 @@
     margin: auto;
     padding: 24px 32px;
 }
+
+details > .options {
+    padding-top: 10px;
+}
+
+details > summary {
+    cursor: pointer;
+}

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -19,7 +19,7 @@
                     class="logo" />
             </a>
         </div>
-        <div class="container">
+        <div class="options container">
             <div class="option checkbox">
                 <input type="checkbox" id="ruffle_enable" />
                 <label for="ruffle_enable">Play Flash content in Ruffle</label>
@@ -36,41 +36,44 @@
                 <input type="checkbox" id="warn_on_unsupported_content" />
                 <label for="warn_on_unsupported_content">Warn on unsupported content</label>
             </div>
-            <div class="option checkbox">
-                <input type="checkbox" id="ignore_optout" />
-                <label for="ignore_optout">Ignore website compatibility warnings</label>
-            </div>
-            <div class="option select">
-                <select id="log_level">
-                    <option value="info">Info</option>
-                    <option value="warn">Warning</option>
-                    <option value="error">Error</option>
-                </select>
-                <label for="log_level">Log level</label>
-            </div>
-            <div class="option select">
-                <select id="preferred_renderer">
-                    <option value="webgpu">WebGPU</option>
-                    <option value="wgpu-webgl">Wgpu (via WebGL)</option>
-                    <option value="webgl">WebGL</option>
-                    <option value="canvas">Canvas2D</option>
-                </select>
-                <label for="preferred_renderer">Preferred renderer</label>
-            </div>
-            <div class="option number-input">
-                <input type="number" id="max_execution_duration"
-                       min="1"
-                />
-                <label for="max_execution_duration">How long can ActionScript execute for before being forcefully stopped (in seconds)</label>
-            </div>
-            <div class="option number-input">
-                <input type="number" id="player_version"
-                       min="1"
-                       max="32"
-                       placeholder="32"
-                />
-                <label for="player_version">Flash player version number to emulate (range 1-32)</label>
-            </div>
+            <details>
+                <summary>Advanced Options</summary>
+                <div class="options">
+                    <div class="option checkbox">
+                        <input type="checkbox" id="ignore_optout" />
+                        <label for="ignore_optout">Ignore website compatibility warnings</label>
+                    </div>
+                    <div class="option select">
+                        <select id="log_level">
+                            <option value="info">Info</option>
+                            <option value="warn">Warning</option>
+                            <option value="error">Error</option>
+                        </select>
+                        <label for="log_level">Log level</label>
+                    </div>
+                    <div class="option select">
+                        <select id="preferred_renderer">
+                            <option value="webgpu">WebGPU</option>
+                            <option value="wgpu-webgl">Wgpu (via WebGL)</option>
+                            <option value="webgl">WebGL</option>
+                            <option value="canvas">Canvas2D</option>
+                        </select>
+                        <label for="preferred_renderer">Preferred renderer</label>
+                    </div>
+                    <div class="option number-input">
+                        <input type="number" id="player_version"
+                               min="1"
+                               max="32"
+                               placeholder="32"
+                        />
+                        <label for="player_version">Flash player version number to emulate (range 1-32)</label>
+                    </div>
+                    <div class="option number-input">
+                        <input type="number" id="max_execution_duration" min="1" />
+                        <label for="max_execution_duration">Maximum allowed ActionScript execution duration (in seconds)</label>
+                    </div>
+                </div>
+            </details>
         </div>
         <script src="dist/options.js"></script>
     </body>

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -41,7 +41,7 @@
                 <div class="options">
                     <div class="option checkbox">
                         <input type="checkbox" id="ignore_optout" />
-                        <label for="ignore_optout">Ignore website compatibility warnings</label>
+                        <label for="ignore_optout">Play Flash content even on sites that disallow Ruffle</label>
                     </div>
                     <div class="option select">
                         <select id="log_level">

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -53,6 +53,7 @@
                     </div>
                     <div class="option select">
                         <select id="preferred_renderer">
+                            <option value="">Automatic</option>
                             <option value="webgpu">WebGPU</option>
                             <option value="wgpu-webgl">Wgpu (via WebGL)</option>
                             <option value="webgl">WebGL</option>

--- a/web/packages/extension/assets/popup.html
+++ b/web/packages/extension/assets/popup.html
@@ -22,7 +22,7 @@
             <div id="status-indicator"></div>
             <span id="status-text">Ruffle is running.</span>
         </div>
-        <div class="container">
+        <div class="options container">
             <div class="option checkbox">
                 <input type="checkbox" id="ruffle_enable" />
                 <label for="ruffle_enable">Play Flash content in Ruffle</label>

--- a/web/packages/extension/src/common.ts
+++ b/web/packages/extension/src/common.ts
@@ -72,7 +72,7 @@ class NumberOption implements OptionElement<number | null> {
     }
 }
 
-class SelectOption implements OptionElement<string> {
+class SelectOption implements OptionElement<string | null> {
     constructor(
         private readonly select: HTMLSelectElement,
         readonly label: HTMLLabelElement
@@ -85,10 +85,13 @@ class SelectOption implements OptionElement<string> {
     get value() {
         const index = this.select.selectedIndex;
         const option = this.select.options[index]!;
-        return option.value;
+        // Convert the empty string to `null`.
+        return option.value || null;
     }
 
-    set value(value: string) {
+    set value(value: string | null) {
+        // Convert `null` to the empty string.
+        value ??= "";
         const options = Array.from(this.select.options);
         const index = options.findIndex((option) => option.value === value);
         this.select.selectedIndex = index;


### PR DESCRIPTION
Intended to supersede #10831, this PR does the following:
- Adds a collapsible "Advanced options" section to the extension settings page and moves less commonly used options there. (Thanks to @relrelb)
- Adds an "Automatic" option for preferred renderer in the extension settings page (Thanks to @iwannabethedev)
- Adds missing extension messages and improves wording for some existing ones. (Thanks to everyone who suggested these)
- ~~Adds an `enableFallbackRenderers` option that can be used to disable all fallback renderers. This is an attempt to address https://github.com/ruffle-rs/ruffle/pull/9904#discussion_r1174630515 in a way that I find more palatable than #10835. Even so, I would rather not add this option because I think its usefulness to developers is outweighed by the opportunities it creates for users and webmasters to cause problems for themselves. If you all agree, I would be very happy to remove this part of this PR!~~ Removed!