### PR TITLE
extension: Log used renderer; Warn if not preferred.

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -36,4 +36,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     polyfills: true,
     playerVersion: null,
     preferredRenderer: null,
+    warnIfPreferredRendererIsNotUsed: false,
 };

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -393,6 +393,16 @@ export interface BaseLoadOptions {
     preferredRenderer?: RenderBackend | null;
 
     /**
+     * If `preferredRenderer` has been set, turning this on
+     * shows a warning popup if the actually used renderer is
+     * not the preferred renderer. Is first and foremost useful
+     * for debugging for Ruffle-developers.
+     *
+     * @default false
+     */
+    warnIfPreferredRendererIsNotUsed?: boolean;
+
+    /**
      * The URL at which Ruffle can load its extra files (i.e. `.wasm`).
      *
      * @default null

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -3,7 +3,11 @@ import { loadRuffle } from "./load-ruffle";
 import { ruffleShadowTemplate } from "./shadow-template";
 import { lookupElement } from "./register-element";
 import { DEFAULT_CONFIG } from "./config";
-import type { DataLoadOptions, URLLoadOptions } from "./load-options";
+import type {
+    DataLoadOptions,
+    URLLoadOptions,
+    RenderBackend,
+} from "./load-options";
 import { AutoPlay, UnmuteOverlay, WindowMode } from "./load-options";
 import type { MovieMetadata } from "./movie-metadata";
 import { swfFileName } from "./swf-utils";
@@ -516,6 +520,37 @@ export class RufflePlayer extends HTMLElement {
                 (ruffleConstructor.is_wasm_simd_used() ? "ON" : "OFF") +
                 ")"
         );
+        {
+            const actuallyUsedRenderer =
+                this.instance!.get_actually_used_renderer() as
+                    | RenderBackend
+                    | null
+                    | "";
+
+            if (actuallyUsedRenderer) {
+                console.log(
+                    "%cUsed renderer: " + actuallyUsedRenderer,
+                    "background: #000; color: #fff"
+                );
+
+                if (
+                    this.loadedConfig &&
+                    this.loadedConfig.warnIfPreferredRendererIsNotUsed &&
+                    this.loadedConfig.preferredRenderer &&
+                    actuallyUsedRenderer !== this.loadedConfig.preferredRenderer
+                ) {
+                    const message =
+                        "The actually used renderer was not your preferred renderer:\n" +
+                        "Preferred renderer: " +
+                        this.loadedConfig.preferredRenderer +
+                        "\n" +
+                        "Actually used renderer: " +
+                        actuallyUsedRenderer;
+                    console.warn(message);
+                    window.alert(message);
+                }
+            }
+        }
 
         // In Firefox, AudioContext.state is always "suspended" when the object has just been created.
         // It may change by itself to "running" some milliseconds later. So we need to wait a little

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -26,6 +26,9 @@
     "settings_player_version": {
         "message": "Flash player version number to emulate (range 1-32)"
     },
+    "settings_warn_if_preferred_renderer_is_not_used": {
+        "message": "Warn if the preferred renderer is not used"
+    },
     "status_init": {
         "message": "Reading current tab…"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -71,6 +71,10 @@
                 />
                 <label for="player_version">Flash player version number to emulate (range 1-32)</label>
             </div>
+            <div class="option checkbox">
+                <input type="checkbox" id="warn_if_preferred_renderer_is_not_used" />
+                <label for="warn_if_preferred_renderer_is_not_used">Warn if the preferred renderer is not used</label>
+            </div>
         </div>
         <script src="dist/options.js"></script>
     </body>


### PR DESCRIPTION
Log which renderer-backend was actually used in the browser console.

Add an option for toggling whether to warn or not
if the actually used renderer is not the same as
the preferred renderer, warning both in the console and also with a `window.alert()` popup. This option is meant first and foremost for Ruffle-developers.

@n0samu @relrelb 