### PR TITLE
web: Avoid array.at() for browser compatibility

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1167,7 +1167,7 @@ export class RufflePlayer extends HTMLElement {
         const items: Array<ContextMenuItem | null> = [];
         const addSeparator = () => {
             // Don't start with or duplicate separators.
-            if (items.length > 0 && items.at(-1) !== null) {
+            if (items.length > 0 && items[items.length - 1] !== null) {
                 items.push(null);
             }
         };


### PR DESCRIPTION
`.at()` is available since 92, while we still declare support for 87+.
note: I didn't build it to test it, I just tested the snippet.