### PR TITLE
extension: Log used renderer.

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -486,6 +486,10 @@ impl RenderBackend for WebCanvasRenderBackend {
         Cow::Borrowed("Renderer: Canvas")
     }
 
+    fn name(&self) -> &'static str {
+        "canvas"
+    }
+
     fn set_quality(&mut self, _quality: StageQuality) {}
 }
 

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -67,6 +67,10 @@ pub trait RenderBackend: Downcast {
     fn context3d_present(&mut self, context: &mut dyn Context3D) -> Result<(), Error>;
 
     fn debug_info(&self) -> Cow<'static, str>;
+    /// An internal name that is used to identify the render-backend.
+    /// For valid values, look at:
+    /// web/packages/core/src/load-options.ts:RenderBackend
+    fn name(&self) -> &'static str;
 
     fn set_quality(&mut self, quality: StageQuality);
 }

--- a/render/src/backend/null.rs
+++ b/render/src/backend/null.rs
@@ -93,5 +93,9 @@ impl RenderBackend for NullRenderer {
         Cow::Borrowed("Renderer: Null")
     }
 
+    fn name(&self) -> &'static str {
+        ""
+    }
+
     fn set_quality(&mut self, _quality: StageQuality) {}
 }

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -1101,6 +1101,10 @@ impl RenderBackend for WebGlRenderBackend {
         Cow::Owned(result.join("\n"))
     }
 
+    fn name(&self) -> &'static str {
+        "webgl"
+    }
+
     fn set_quality(&mut self, _quality: StageQuality) {}
 }
 

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -378,6 +378,10 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         Cow::Owned(result.join("\n"))
     }
 
+    fn name(&self) -> &'static str {
+        "webgpu"
+    }
+
     fn set_quality(&mut self, quality: StageQuality) {
         self.surface = Surface::new(
             &self.descriptors,

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -511,10 +511,17 @@ export class RufflePlayer extends HTMLElement {
             this.loadedConfig
         );
         this._cachedDebugInfo = this.instance!.renderer_debug_info();
+
+        const actuallyUsedRendererName = this.instance!.renderer_name();
+
         console.log(
-            "New Ruffle instance created (WebAssembly extensions: " +
+            "%c" +
+                "New Ruffle instance created (WebAssembly extensions: " +
                 (ruffleConstructor.is_wasm_simd_used() ? "ON" : "OFF") +
-                ")"
+                " | Used renderer: " +
+                (actuallyUsedRendererName ?? "") +
+                ")",
+            "background: #37528C; color: #FFAD33"
         );
 
         // In Firefox, AudioContext.state is always "suspended" when the object has just been created.

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -378,6 +378,11 @@ impl Ruffle {
             .unwrap_or(JsValue::NULL)
     }
 
+    pub fn renderer_name(&self) -> JsValue {
+        self.with_core(|core| JsValue::from_str(core.renderer().name()))
+            .unwrap_or(JsValue::NULL)
+    }
+
     // after the context menu is closed, remember to call `clear_custom_menu_items`!
     pub fn prepare_context_menu(&mut self) -> JsValue {
         self.with_core_mut(|core| {


### PR DESCRIPTION
Log which renderer-backend was actually used in the browser console.

This is basically the same as https://github.com/ruffle-rs/ruffle/pull/10903 , but without the toggle option for whether to warn or not if the actually used renderer is not the same as the preferred renderer.

Related to: https://github.com/ruffle-rs/ruffle/pull/10835 , https://github.com/ruffle-rs/ruffle/pull/10831 , https://github.com/ruffle-rs/ruffle/pull/10900 .

CC: @n0samu @relrelb .