### PR TITLE
build(deps-dev): bump archiver from 5.3.0 to 5.3.1 in /web

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2237,13 +2237,13 @@
             }
         },
         "node_modules/archiver": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
-            "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.1.tgz",
+            "integrity": "sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==",
             "dev": true,
             "dependencies": {
                 "archiver-utils": "^2.1.0",
-                "async": "^3.2.0",
+                "async": "^3.2.3",
                 "buffer-crc32": "^0.2.1",
                 "readable-stream": "^3.6.0",
                 "readdir-glob": "^1.0.0",
@@ -11228,7 +11228,7 @@
                 "@tsconfig/recommended": "^1.0.1",
                 "@types/chrome": "^0.0.179",
                 "@types/firefox-webext-browser": "^94.0.0",
-                "archiver": "^5.3.0",
+                "archiver": "^5.3.1",
                 "json5": "^2.2.1",
                 "sign-addon": "^4.0.1",
                 "temp-dir": "^2.0.0",
@@ -13023,13 +13023,13 @@
             }
         },
         "archiver": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
-            "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.1.tgz",
+            "integrity": "sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==",
             "dev": true,
             "requires": {
                 "archiver-utils": "^2.1.0",
-                "async": "^3.2.0",
+                "async": "^3.2.3",
                 "buffer-crc32": "^0.2.1",
                 "readable-stream": "^3.6.0",
                 "readdir-glob": "^1.0.0",
@@ -17908,7 +17908,7 @@
                 "@tsconfig/recommended": "^1.0.1",
                 "@types/chrome": "^0.0.179",
                 "@types/firefox-webext-browser": "^94.0.0",
-                "archiver": "^5.3.0",
+                "archiver": "^5.3.1",
                 "json5": "^2.2.1",
                 "ruffle-core": "^0.1.0",
                 "sign-addon": "^4.0.1",

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -17,7 +17,7 @@
         "@tsconfig/recommended": "^1.0.1",
         "@types/chrome": "^0.0.179",
         "@types/firefox-webext-browser": "^94.0.0",
-        "archiver": "^5.3.0",
+        "archiver": "^5.3.1",
         "json5": "^2.2.1",
         "sign-addon": "^4.0.1",
         "temp-dir": "^2.0.0",


### PR DESCRIPTION
The skateboard game in 3D doesn't worked on Chrome and Microsoft Edge
https://www.flashgames.jp/Stunt-Skateboard-3D-online
https://en.gameslol.net/stunt-skateboard-3d-486.html

<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%">
                <param name="movie" value="http://www8.agame.com/games/flash/s/stunt_skateboard_3d_v103/Preloader.swf" />
                    <param name="quality" value="high" /><param name="base" value="http://www8.agame.com/games/flash/s/stunt_skateboard_3d_v103/" /><param name="allowScriptAccess" value="always" /><param name="flashvars" value="id=152660&amp;s=79&amp;c=2" /><param name="wmode" value="direct" />
              <!--[if !IE]>-->
              <object type="application/x-shockwave-flash" data="http://www8.agame.com/games/flash/s/stunt_skateboard_3d_v103/Preloader.swf" width="100%" height="100%">
              <!--<![endif]-->
                <p></p>
              <!--[if !IE]>-->
                    <param name="quality" value="high" /><param name="base" value="http://www8.agame.com/games/flash/s/stunt_skateboard_3d_v103/" /><param name="allowScriptAccess" value="always" /><param name="flashvars" value="id=152660&amp;s=79&amp;c=2" /><param name="wmode" value="direct" />                  </object>
              <!--<![endif]-->
            </object>