### PR TITLE
web: Support copying to clipboard

### DIFF
--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -11,8 +11,17 @@ pub fn set_clipboard<'gc>(
     _this: Option<Object<'gc>>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    //TODO: in FP9+ this function only works when called from a button handler in the Plugin due to
-    // sandbox restrictions
+    // The following restrictions only apply to the plugin.
+    // TODO: Check the type of event that triggered the function call.
+    #[cfg(target_family = "wasm")]
+    if false {
+        return Err(Error::AvmError(crate::avm2::error::error(
+            activation,
+            "Error #2176: Certain actions, such as those that display a pop-up window, may only be invoked upon user interaction, for example by a mouse click or button press.",
+            2176,
+        )?));
+    }
+
     let new_content = args
         .get(0)
         .unwrap_or(&Value::Undefined)

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -61,7 +61,7 @@ features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext",
     "AudioDestinationNode", "AudioNode", "AudioParam", "Blob", "BlobPropertyBag",
     "ChannelMergerNode", "ChannelSplitterNode", "Element", "Event", "EventTarget", "GainNode",
-    "HtmlCanvasElement", "HtmlElement", "HtmlFormElement", "HtmlInputElement", "KeyboardEvent",
-    "Location", "PointerEvent", "Request", "RequestInit", "Response", "Storage", "WheelEvent",
-    "Window",
+    "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement", "HtmlInputElement",
+    "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent", "Request", "RequestInit",
+    "Response", "Storage", "WheelEvent", "Window",
 ]


### PR DESCRIPTION
Closes #6476.

I also tried to address the TODO for the AVM2 `set_clipboard` but I wasn't able to find a way to retrieve the type of event that triggered the function call.