### PR TITLE
web: Parse more configs using a custom deserializer

### DIFF
--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -890,6 +890,12 @@ impl<'gc> TInteractiveObject<'gc> for Stage<'gc> {
 
 pub struct ParseEnumError;
 
+impl Display for ParseEnumError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "ParseEnumError")
+    }
+}
+
 /// The scale mode of a stage.
 /// This controls the behavior when the player viewport size differs from the SWF size.
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,7 +48,7 @@ mod xml;
 
 pub use avm1::globals::system::SandboxType;
 pub use context_menu::ContextMenuItem;
-pub use display_object::{StageAlign, StageDisplayState, StageScaleMode};
+pub use display_object::{StageAlign, StageDisplayState, StageScaleMode, WindowMode};
 pub use events::PlayerEvent;
 pub use indexmap;
 pub use loader::LoadBehavior;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,10 +2,6 @@
 #![allow(clippy::extra_unused_type_parameters)]
 
 #[macro_use]
-mod display_object;
-pub use display_object::{StageDisplayState, StageScaleMode};
-
-#[macro_use]
 extern crate smallvec;
 
 #[macro_use]
@@ -14,22 +10,27 @@ extern crate downcast_rs;
 #[macro_use]
 extern crate num_derive;
 
-#[macro_use]
 mod avm1;
 mod avm2;
+pub mod backend;
 mod binary_data;
 pub mod bitmap;
 mod character;
+pub mod compatibility_rules;
+pub mod config;
 pub mod context;
 pub mod context_menu;
+mod display_object;
 mod drawing;
 mod ecma_conversions;
 pub(crate) mod either;
 pub mod events;
+pub mod external;
 pub mod focus_tracker;
 mod font;
 mod frame_lifecycle;
 mod html;
+pub mod i18n;
 mod library;
 pub mod limits;
 pub mod loader;
@@ -38,21 +39,16 @@ mod player;
 mod prelude;
 mod streams;
 pub mod string;
+pub mod stub;
 pub mod tag_utils;
 pub mod timer;
 mod types;
 mod vminterface;
 mod xml;
 
-pub mod backend;
-pub mod compatibility_rules;
-pub mod config;
-pub mod external;
-pub mod i18n;
-pub mod stub;
-
 pub use avm1::globals::system::SandboxType;
 pub use context_menu::ContextMenuItem;
+pub use display_object::{StageAlign, StageDisplayState, StageScaleMode};
 pub use events::PlayerEvent;
 pub use indexmap;
 pub use loader::LoadBehavior;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -826,17 +826,13 @@ impl Player {
 
     pub fn set_show_menu(&mut self, show_menu: bool) {
         self.mutate_with_update_context(|context| {
-            let stage = context.stage;
-            stage.set_show_menu(context, show_menu);
+            context.stage.set_show_menu(context, show_menu);
         })
     }
 
-    pub fn set_stage_align(&mut self, stage_align: &str) {
+    pub fn set_stage_align(&mut self, stage_align: StageAlign) {
         self.mutate_with_update_context(|context| {
-            let stage = context.stage;
-            if let Ok(stage_align) = StageAlign::from_str(stage_align) {
-                stage.set_align(context, stage_align);
-            }
+            context.stage.set_align(context, stage_align);
         })
     }
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -59,7 +59,6 @@ use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
 use std::ops::DerefMut;
 use std::rc::{Rc, Weak as RcWeak};
-use std::str::FromStr;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 use tracing::{info, instrument};
@@ -842,12 +841,9 @@ impl Player {
         })
     }
 
-    pub fn set_window_mode(&mut self, window_mode: &str) {
+    pub fn set_window_mode(&mut self, window_mode: WindowMode) {
         self.mutate_with_update_context(|context| {
-            let stage = context.stage;
-            if let Ok(window_mode) = WindowMode::from_str(window_mode) {
-                stage.set_window_mode(context, window_mode);
-            }
+            context.stage.set_window_mode(context, window_mode);
         })
     }
 

--- a/render/src/quality.rs
+++ b/render/src/quality.rs
@@ -97,6 +97,12 @@ impl Display for StageQuality {
 
 pub struct StageQualityError;
 
+impl Display for StageQualityError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "StageQualityError")
+    }
+}
+
 impl FromStr for StageQuality {
     type Err = StageQualityError;
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -261,7 +261,8 @@ struct Config {
     #[serde(deserialize_with = "deserialize_from_str")]
     salign: StageAlign,
 
-    quality: Option<String>,
+    #[serde(deserialize_with = "deserialize_from_str")]
+    quality: StageQuality,
 
     scale: Option<String>,
 
@@ -547,13 +548,6 @@ impl Ruffle {
             }
         };
 
-        let default_quality = if ruffle_web_common::is_mobile_or_tablet() {
-            tracing::info!("Running on a mobile device; defaulting to low quality");
-            StageQuality::Low
-        } else {
-            StageQuality::High
-        };
-
         let trace_observer = Arc::new(RefCell::new(JsValue::UNDEFINED));
         let core = builder
             .with_log(log_adapter::WebLogBackend::new(trace_observer.clone()))
@@ -568,12 +562,7 @@ impl Ruffle {
             } else {
                 CompatibilityRules::empty()
             })
-            .with_quality(
-                config
-                    .quality
-                    .and_then(|q| StageQuality::from_str(&q).ok())
-                    .unwrap_or(default_quality),
-            )
+            .with_quality(config.quality)
             .with_scale_mode(
                 config
                     .scale

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -20,7 +20,7 @@ use ruffle_core::external::{
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::{
     Color, Player, PlayerBuilder, PlayerEvent, SandboxType, StageAlign, StageScaleMode,
-    StaticCallstack, ViewportDimensions,
+    StaticCallstack, ViewportDimensions, WindowMode,
 };
 use ruffle_render::quality::StageQuality;
 use ruffle_video_software::backend::SoftwareVideoBackend;
@@ -271,7 +271,8 @@ struct Config {
 
     frame_rate: Option<f64>,
 
-    wmode: Option<String>,
+    #[serde(deserialize_with = "deserialize_from_str")]
+    wmode: WindowMode,
 
     warn_on_unsupported_content: bool,
 
@@ -576,7 +577,7 @@ impl Ruffle {
             core.set_background_color(config.background_color);
             core.set_show_menu(config.show_menu);
             core.set_stage_align(config.salign);
-            core.set_window_mode(config.wmode.as_deref().unwrap_or("window"));
+            core.set_window_mode(config.wmode);
 
             // Create the external interface.
             if allow_script_access && allow_networking == NetworkingAccessMode::All {
@@ -1445,7 +1446,7 @@ async fn create_renderer(
     )))]
     std::compile_error!("You must enable one of the render backend features (e.g., webgl).");
 
-    let _is_transparent = config.wmode.as_deref() == Some("transparent");
+    let _is_transparent = config.wmode == WindowMode::Transparent;
 
     let mut renderer_list = vec!["webgpu", "wgpu-webgl", "webgl", "canvas"];
     if let Some(preferred_renderer) = &config.preferred_renderer {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -264,7 +264,8 @@ struct Config {
     #[serde(deserialize_with = "deserialize_from_str")]
     quality: StageQuality,
 
-    scale: Option<String>,
+    #[serde(deserialize_with = "deserialize_from_str")]
+    scale: StageScaleMode,
 
     force_scale: bool,
 
@@ -563,13 +564,7 @@ impl Ruffle {
                 CompatibilityRules::empty()
             })
             .with_quality(config.quality)
-            .with_scale_mode(
-                config
-                    .scale
-                    .and_then(|s| StageScaleMode::from_str(&s).ok())
-                    .unwrap_or(StageScaleMode::ShowAll),
-                config.force_scale,
-            )
+            .with_scale_mode(config.scale, config.force_scale)
             .with_frame_rate(config.frame_rate)
             // FIXME - should this be configurable?
             .with_sandbox_type(SandboxType::Remote)


### PR DESCRIPTION
Introduce and use a generic `deserialize_from_str` function. The following configs are adapted:
* `salign`
* `quality`
* `scale`
* `wmode`

Additionally, `log_level` is adapted to `deserialize_from_str as well.