### PR TITLE
core: Improve compatibility rule for Kongregate

### DIFF
--- a/core/src/compatibility_rules.rs
+++ b/core/src/compatibility_rules.rs
@@ -53,7 +53,7 @@ impl CompatibilityRules {
             name: "kongregate_sitelock".to_string(),
             swf_domain_rewrite_rules: vec![UrlRewriteRule::new(
                 "*.konggames.com",
-                "kongregate.com",
+                "chat.kongregate.com",
             )],
         };
 


### PR DESCRIPTION
Kongregate used to serve their SWFs from chat.kongregate.com, and some games check for this specifically.
Fixes the omega catalog in [Learn to Fly 2](https://www.kongregate.com/games/light_bringer777/learn-to-fly-2).
![image](https://user-images.githubusercontent.com/71368227/236370844-0fe14a05-1a4b-4a38-9b5c-db5a96c52724.png)