### PR TITLE
avm2: Work on flash.system.Capabilities

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -77,6 +77,9 @@ const BROADCAST_WHITELIST: [&str; 4] = ["enterFrame", "exitFrame", "frameConstru
 #[derive(Collect)]
 #[collect(no_drop)]
 pub struct Avm2<'gc> {
+    /// The Flash Player version we're emulating.
+    player_version: u8,
+
     /// Values currently present on the operand stack.
     stack: Vec<Value<'gc>>,
 
@@ -142,10 +145,11 @@ pub struct Avm2<'gc> {
 
 impl<'gc> Avm2<'gc> {
     /// Construct a new AVM interpreter.
-    pub fn new(context: &mut GcContext<'_, 'gc>) -> Self {
+    pub fn new(context: &mut GcContext<'_, 'gc>, player_version: u8) -> Self {
         let globals = Domain::global_domain(context.gc_context);
 
         Self {
+            player_version,
             stack: Vec::new(),
             scope_stack: Vec::new(),
             call_stack: GcCell::allocate(context.gc_context, CallStack::new()),

--- a/core/src/avm2/globals/flash/system.rs
+++ b/core/src/avm2/globals/flash/system.rs
@@ -2,5 +2,6 @@
 #![allow(clippy::module_inception)]
 
 pub mod application_domain;
+pub mod capabilities;
 pub mod security;
 pub mod system;

--- a/core/src/avm2/globals/flash/system/Capabilities.as
+++ b/core/src/avm2/globals/flash/system/Capabilities.as
@@ -1,18 +1,21 @@
 package flash.system {
+    import __ruffle__.stub_getter;
     public final class Capabilities {
         public static function get os(): String {
+            stub_getter("flash.system.Capabilities", "os");
             return "Linux 5.10.49"
         }
-        public static function get playerType(): String {
-            return "StandAlone"
-        }
-        public static function get version(): String {
-            return "LNX 32,0,0,465"
-        }
+        
+        public native static function get playerType(): String;
+        
+        public native static function get version(): String;
+        
         public static function get manufacturer(): String {
+            stub_getter("flash.system.Capabilities", "manufacturer");
             return "Adobe Linux"
         }
         public static function get language(): String {
+            stub_getter("flash.system.Capabilities", "language");
             return "en"
         }
         public static function get isDebugger(): Boolean {

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -1,0 +1,33 @@
+//! `flash.display.Capabilities` native methods
+
+use crate::avm2::{Activation, AvmString, Error, Object, Value};
+
+/// Implements `flash.system.Capabilities.version`
+pub fn get_version<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // TODO: Report the correct OS instead of always reporting Linux
+    Ok(AvmString::new_utf8(
+        activation.context.gc_context,
+        format!("LNX {},0,0,0", activation.avm2().player_version),
+    )
+    .into())
+}
+
+/// Implements `flash.system.Capabilities.playerType`
+pub fn get_player_type<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    _this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // TODO: When should "External" be returned?
+    let player_type = if cfg!(target_family = "wasm") {
+        "PlugIn"
+    } else {
+        "StandAlone"
+    };
+
+    Ok(AvmString::new_utf8(activation.context.gc_context, player_type).into())
+}

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2217,7 +2217,7 @@ impl PlayerBuilder {
                     audio_manager: AudioManager::new(),
                     action_queue: ActionQueue::new(),
                     avm1: Avm1::new(&mut init, player_version),
-                    avm2: Avm2::new(&mut init),
+                    avm2: Avm2::new(&mut init, player_version),
                     interner,
                     current_context_menu: None,
                     drag_object: None,


### PR DESCRIPTION
Eventually, code from #10469 can be reused to implement the rest of the `flash.system.Capabilities` getters.

Fixes #9180.