### PR TITLE
avm2: Partial implementation of Loader.unload

### DIFF
--- a/core/src/avm2/globals/flash/display/Loader.as
+++ b/core/src/avm2/globals/flash/display/Loader.as
@@ -27,12 +27,7 @@ package flash.display {
 
 		public native function loadBytes(data: ByteArray, context: LoaderContext = null):void;
 		
-		public function unload():void {
-			stub_method("flash.display.Loader", "unload");
-			// Content seems to prefer an error here, over an empty implementation.
-			// https://github.com/ruffle-rs/ruffle/pull/8909
-			throw new Error("flash.display.Loader.unload - not yet implemented");
-		}
+		public native function unload():void;
 
 		public function unloadAndStop(gc:Boolean = true):void {
 			stub_method("flash.display.Loader", "unloadAndStop");

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -11,6 +11,7 @@ use crate::avm2::value::Value;
 use crate::avm2::ClassObject;
 use crate::avm2::Multiname;
 use crate::avm2::{Error, Object};
+use crate::avm2_stub_method;
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::display_object::LoaderDisplay;
 use crate::display_object::MovieClip;
@@ -223,5 +224,20 @@ pub fn load_bytes<'gc>(
         );
         activation.context.navigator.spawn_future(future);
     }
+    Ok(Value::Undefined)
+}
+
+pub fn unload<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Option<Object<'gc>>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // TODO: Broadcast an "unload" event on the LoaderInfo and reset LoaderInfo properties
+    avm2_stub_method!(activation, "flash.display.Loader", "unload");
+    let _ = crate::avm2::globals::flash::display::display_object_container::remove_child_at(
+        activation,
+        this,
+        &[0.into()],
+    );
     Ok(Value::Undefined)
 }


### PR DESCRIPTION
Progresses #10960 and #9901- the clips now get unloaded, but sound continues playing because <s>the AS2 code to stop the sound never gets executed (mixed AVM).</s>the clips continue looping, even when being orphans.