### PR TITLE
desktop: Add volume option to CLI

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -20,6 +20,7 @@ use anyhow::{anyhow, Context, Error};
 use clap::Parser;
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use rfd::FileDialog;
+use ruffle_core::backend::audio::AudioBackend;
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::{
     config::Letterbox, events::KeyCode, tag_utils::SwfMovie, LoadBehavior, Player, PlayerBuilder,
@@ -44,7 +45,6 @@ use winit::event::{
 };
 use winit::event_loop::{ControlFlow, EventLoop, EventLoopBuilder};
 use winit::window::{Fullscreen, Icon, Window, WindowBuilder};
-use ruffle_core::backend::audio::AudioBackend;
 
 thread_local! {
     static CALLSTACK: RefCell<Option<StaticCallstack>> = RefCell::default();
@@ -325,7 +325,7 @@ impl App {
             Ok(mut audio) => {
                 audio.set_volume(opt.volume);
                 builder = builder.with_audio(audio);
-            },
+            }
             Err(e) => {
                 tracing::error!("Unable to create audio device: {}", e);
             }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -110,7 +110,7 @@ struct Opt {
     #[clap(long, short, default_value = "show-all")]
     scale: StageScaleMode,
 
-    /// Audio volume
+    /// Audio volume as a number between 0 (muted) and 1 (full volume)
     #[clap(long, short, default_value = "1.0")]
     volume: f32,
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -44,6 +44,7 @@ use winit::event::{
 };
 use winit::event_loop::{ControlFlow, EventLoop, EventLoopBuilder};
 use winit::window::{Fullscreen, Icon, Window, WindowBuilder};
+use ruffle_core::backend::audio::AudioBackend;
 
 thread_local! {
     static CALLSTACK: RefCell<Option<StaticCallstack>> = RefCell::default();
@@ -108,6 +109,10 @@ struct Opt {
     /// The scale mode of the stage.
     #[clap(long, short, default_value = "show-all")]
     scale: StageScaleMode,
+
+    /// Audio volume
+    #[clap(long, short, default_value = "1.0")]
+    volume: f32,
 
     /// Prevent movies from changing the stage scale mode.
     #[clap(long, action)]
@@ -317,7 +322,10 @@ impl App {
         let mut builder = PlayerBuilder::new();
 
         match audio::CpalAudioBackend::new() {
-            Ok(audio) => builder = builder.with_audio(audio),
+            Ok(mut audio) => {
+                audio.set_volume(opt.volume);
+                builder = builder.with_audio(audio);
+            },
             Err(e) => {
                 tracing::error!("Unable to create audio device: {}", e);
             }


### PR DESCRIPTION
Simple addition to let desktop users adjust global audio volume when starting ruffle from the command line.