### PR TITLE
web: Download all sols as single .zip

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1649,15 +1649,6 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
-        "node_modules/@zip.js/zip.js": {
-            "version": "2.7.6",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.6.tgz",
-            "integrity": "sha512-j9gaYG84Qd3tI3X7BiOpL5bckbbAetpxtpilKnSyW5rMTnrXwH6GtXkL8rEBxnPk100exbfxNlORwFagX7fMfg==",
-            "engines": {
-                "deno": ">=1.0.0",
-                "node": ">=16.5.0"
-            }
-        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -3284,8 +3275,7 @@
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-            "dev": true
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
         },
         "node_modules/cosmiconfig": {
             "version": "8.1.3",
@@ -5742,6 +5732,11 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5827,8 +5822,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ini": {
             "version": "1.3.8",
@@ -6933,6 +6927,49 @@
                 "node": ">=0.6.0"
             }
         },
+        "node_modules/jszip": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/jszip/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "node_modules/jszip/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/jszip/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/jszip/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
         "node_modules/jwa": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -7059,6 +7096,14 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dependencies": {
+                "immediate": "~3.0.5"
             }
         },
         "node_modules/lighthouse-logger": {
@@ -8530,6 +8575,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9016,8 +9066,7 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -10166,6 +10215,11 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -11692,8 +11746,7 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",
@@ -12680,7 +12733,7 @@
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
-                "@zip.js/zip.js": "^2.7.6",
+                "jszip": "^3.10.1",
                 "wasm-feature-detect": "^1.5.1"
             },
             "devDependencies": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1649,6 +1649,15 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "node_modules/@zip.js/zip.js": {
+            "version": "2.7.6",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.6.tgz",
+            "integrity": "sha512-j9gaYG84Qd3tI3X7BiOpL5bckbbAetpxtpilKnSyW5rMTnrXwH6GtXkL8rEBxnPk100exbfxNlORwFagX7fMfg==",
+            "engines": {
+                "deno": ">=1.0.0",
+                "node": ">=16.5.0"
+            }
+        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -12671,6 +12680,7 @@
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
+                "@zip.js/zip.js": "^2.7.6",
                 "wasm-feature-detect": "^1.5.1"
             },
             "devDependencies": {

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -41,7 +41,7 @@
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\",\\\"verbatimModuleSyntax\\\":false} mocha"
     },
     "dependencies": {
-        "@zip.js/zip.js": "^2.7.6",
+        "jszip": "^3.10.1",
         "wasm-feature-detect": "^1.5.1"
     },
     "devDependencies": {

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -41,6 +41,7 @@
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\",\\\"verbatimModuleSyntax\\\":false} mocha"
     },
     "dependencies": {
+        "@zip.js/zip.js": "^2.7.6",
         "wasm-feature-detect": "^1.5.1"
     },
     "devDependencies": {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -14,6 +14,7 @@ import type { MovieMetadata } from "./movie-metadata";
 import { swfFileName } from "./swf-utils";
 import { buildInfo } from "./build-info";
 import { text, textAsParagraphs } from "./i18n";
+import * as zip from "@zip.js/zip.js";
 
 const RUFFLE_ORIGIN = "https://ruffle.rs";
 const DIMENSION_REGEX = /^\s*(\d+(\.\d+)?(%)?)/;
@@ -897,10 +898,26 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
-     * Called when entering / leaving fullscreen
+     * Called when entering / leaving fullscreen.
      */
     private fullScreenChange(): void {
         this.instance?.set_fullscreen(this.isFullscreen);
+    }
+
+    /**
+     * Prompt the user to download a file.
+     *
+     * @param href The content to download.
+     * @param name The name to give the file.
+     */
+    private saveFile(href: string, name: string): void {
+        const link = document.createElement("a");
+        link.href = href;
+        link.style.display = "none";
+        link.download = name;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
     }
 
     private base64ToBlob(bytesBase64: string, mimeString: string): Blob {
@@ -912,30 +929,6 @@ export class RufflePlayer extends HTMLElement {
         }
         const blob = new Blob([ab], { type: mimeString });
         return blob;
-    }
-
-    /**
-     * Download base-64 string as file
-     *
-     * @param bytesBase64 The base-64 encoded SOL string
-     * @param mimeType The MIME type
-     * @param fileName The name to give the file
-     */
-    private saveFile(
-        bytesBase64: string,
-        mimeType: string,
-        fileName: string
-    ): void {
-        const blob = this.base64ToBlob(bytesBase64, mimeType);
-        const blobURL = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.href = blobURL;
-        link.style.display = "none";
-        link.download = fileName;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(blobURL);
     }
 
     /**
@@ -1060,13 +1053,15 @@ export class RufflePlayer extends HTMLElement {
                 const downloadSpan = document.createElement("SPAN");
                 downloadSpan.textContent = text("save-download");
                 downloadSpan.className = "save-option";
-                downloadSpan.addEventListener("click", () =>
-                    this.saveFile(
+                downloadSpan.addEventListener("click", () => {
+                    const blob = this.base64ToBlob(
                         solData,
-                        "application/octet-stream",
-                        solName + ".sol"
-                    )
-                );
+                        "application/octet-stream"
+                    );
+                    const blobURL = URL.createObjectURL(blob);
+                    this.saveFile(blobURL, solName + ".sol");
+                    URL.revokeObjectURL(blobURL);
+                });
                 downloadCol.appendChild(downloadSpan);
                 const replaceCol = document.createElement("TD");
                 const replaceInput = <HTMLInputElement>(
@@ -1105,20 +1100,35 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
-     * Gets the local save information as SOL files and downloads them.
+     * Gets the local save information as SOL files and downloads them as a single ZIP file.
      */
-    private backupSaves(): void {
+    private async backupSaves(): Promise<void> {
+        const zipWriter = new zip.ZipWriter(
+            new zip.BlobWriter("application/zip"),
+            { bufferedWrite: true }
+        );
+        const duplicateNames: string[] = [];
         Object.keys(localStorage).forEach((key) => {
-            const solName = key.split("/").pop();
+            let solName = String(key.split("/").pop());
             const solData = localStorage.getItem(key);
             if (solData && this.isB64SOL(solData)) {
-                this.saveFile(
+                const blob = this.base64ToBlob(
                     solData,
-                    "application/octet-stream",
-                    solName + ".sol"
+                    "application/octet-stream"
                 );
+                const duplicate = duplicateNames.filter(
+                    (value) => value === solName
+                ).length;
+                duplicateNames.push(solName);
+                if (duplicate > 0) {
+                    solName += ` (${duplicate + 1})`;
+                }
+                zipWriter.add(solName + ".sol", new zip.BlobReader(blob));
             }
         });
+        const blobURL = URL.createObjectURL(await zipWriter.close());
+        this.saveFile(blobURL, "saves.zip");
+        URL.revokeObjectURL(blobURL);
     }
 
     /**
@@ -1141,15 +1151,9 @@ export class RufflePlayer extends HTMLElement {
                     return;
                 }
                 const blob = await response.blob();
-                const blobUrl = URL.createObjectURL(blob);
-                const swfDownloadA = document.createElement("a");
-                swfDownloadA.style.display = "none";
-                swfDownloadA.href = blobUrl;
-                swfDownloadA.download = swfFileName(this.swfUrl);
-                document.body.appendChild(swfDownloadA);
-                swfDownloadA.click();
-                document.body.removeChild(swfDownloadA);
-                URL.revokeObjectURL(blobUrl);
+                const blobURL = URL.createObjectURL(blob);
+                this.saveFile(blobURL, swfFileName(this.swfUrl));
+                URL.revokeObjectURL(blobURL);
             } else {
                 console.error("SWF download failed");
             }


### PR DESCRIPTION
Clicking "Backup all saves (download all sols)" in the Save Manager currently triggers a download prompt for each available sol. This can be a bit annoying when you have dozens or hundreds of saves. This PR changes this behavior by placing the saves in a ZIP file.