### PR TITLE
render/core: Fix of panic bug and rendering bug in #10955 .

### DIFF
--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -247,6 +247,7 @@ impl BitmapFormat {
     }
 }
 
+#[inline]
 fn intersection_same_coordinate_system(
     (r1_x_min, r1_y_min, r1_x_max, r1_y_max): (i32, i32, i32, i32),
     (r2_x_min, r2_y_min, r2_x_max, r2_y_max): (i32, i32, i32, i32),
@@ -270,6 +271,7 @@ fn intersection_same_coordinate_system(
     (r3_x_min, r3_y_min, r3_x_max, r3_y_max)
 }
 
+#[inline]
 fn translate_region(
     (r_x_min, r_y_min, r_x_max, r_y_max): (i32, i32, i32, i32),
     (trans_x, trans_y): (i32, i32),


### PR DESCRIPTION
With help from and credit to @Dinnerbone and @n0samu , we have a probable fix for #10955 .

Credit for https://github.com/ruffle-rs/ruffle/pull/11006/commits/19b6cf68a11a1111d48d59358d6a6f2e7fe4d1ae goes fully to @Dinnerbone .

I have run the game "Dont escape 3", and the introduction part of it works now, without any panics or rendering issues as far as I can tell.

See also https://github.com/ruffle-rs/ruffle/pull/10583 .

Fixes #10955 .
Fixes https://github.com/ruffle-rs/ruffle/issues/11007 .
Might fix https://github.com/ruffle-rs/ruffle/issues/11017 .