### PR TITLE
avm2: nit: Provide error number in error message

### DIFF
--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -89,7 +89,7 @@ fn validate_remove_operation<'gc>(
 
     Err(Error::AvmError(argument_error(
         activation,
-        "The supplied DisplayObject must be a child of the caller.",
+        "Error #2025: The supplied DisplayObject must be a child of the caller.",
         2025,
     )?))
 }


### PR DESCRIPTION
For `display_object_container.validate_remove_operation`.