### PR TITLE
core: Fix wrong `blend_over()` - but with failing tests.

### DIFF
--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -128,12 +128,24 @@ impl Color {
 
     #[must_use]
     pub fn blend_over(&self, source: &Self) -> Self {
-        let sa = source.alpha();
+        let tr = self.red() as u16;
+        let tg = self.green() as u16;
+        let tb = self.blue() as u16;
+        let ta = self.alpha() as u16;
 
-        let r = source.red() + ((self.red() as u16 * (255 - sa as u16)) >> 8) as u8;
-        let g = source.green() + ((self.green() as u16 * (255 - sa as u16)) >> 8) as u8;
-        let b = source.blue() + ((self.blue() as u16 * (255 - sa as u16)) >> 8) as u8;
-        let a = source.alpha() + ((self.alpha() as u16 * (255 - sa as u16)) >> 8) as u8;
+        let sr = source.red() as u16;
+        let sg = source.green() as u16;
+        let sb = source.blue() as u16;
+
+        let sa = source.alpha() as u16;
+        let neg_sa = 255 - source.alpha() as u16;
+
+        // TODO: Best to divide with 256/>>8? Or divide with 255?
+        let r = ((sr * sa + tr * neg_sa) >> 8) as u8;
+        let g = ((sg * sa + tg * neg_sa) >> 8) as u8;
+        let b = ((sb * sa + tb * neg_sa) >> 8) as u8;
+        // TODO: What should be done with alpha here?
+        let a = ((sa * sa + ta * neg_sa) >> 8) as u8;
         Self::argb(a, r, g, b)
     }
 }


### PR DESCRIPTION
This change seemingly fixes the new bug related to the SWF in https://github.com/ruffle-rs/ruffle/issues/10954 (the issue in #10954 describes a previous, already fixed bug, the new bug has not been described in any issue, but described and investigated on Discord). This new bug came to surface with the latest nightly (2023-05-13), for the SWF in #10954 , where the bug causes flashing with crazy colors once the game is started from the game's main menu (the bug was expressed and came to surface, but not introduced as far as I can tell, with the changes in https://github.com/ruffle-rs/ruffle/pull/11006 ). This PR is not regressing neither the panic bug nor the visual issue for https://github.com/ruffle-rs/ruffle/issues/10955 and https://github.com/ruffle-rs/ruffle/issues/11007 .

**Superseded by:** https://github.com/ruffle-rs/ruffle/pull/11044 .

~~The apparent cause of the bug is https://github.com/ruffle-rs/ruffle/pull/2488 , made some two years ago. Ruffle was much less mature back then (the code likely changed much more and unit tests were likely less cost-efficient overall development-wise), and it in my opinion makes sense that there were fewer unit tests back then for new code.~~

~~I believe that the primary cause of the bug was a lack of unit tests, which is understandable given that Ruffle was much newer back then. I suspect that a secondary cause of the bug was all the type-casts, which made the code more obscure and difficult to comprehend. I have made the code clearer, at the cost of making it more verbose, which I think is justified in this case.~~

~~For some reason, two tests are failing, so all the automatically run tests will presumably fail. I do not understand or know why they fail, I will need help from you to figure that out.~~

~~There are two `TODO`s in the code, which I would like to request reviewers to also consider.~~

~~Finally, I feel that it would be prudent for me to write some unit tests for `blend_over()`. Or at least create an issue, since it would be nice if this PR was figured out before the next nightly release. Though this fix is not that urgent, I believe, and it might be better to wait for the next nightly instead of hurrying.~~