### PR TITLE
extension: Don't say that Ruffle cannot load on "player.html"

### DIFF
--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -56,6 +56,9 @@
     "status_result_running": {
         "message": "Ruffle is loaded and ready to run Flash content on the current tab."
     },
+    "status_result_running_protected": {
+        "message": "Ruffle is loaded and running the Flash content that you requested."
+    },
     "status_result_optout": {
         "message": "Ruffle is not loaded because the current page has marked itself as incompatible."
     },

--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -43,8 +43,9 @@
         "open_in_tab": true,
     },
     "permissions": [
-        "storage",
         "<all_urls>",
+        "storage",
+        "tabs",
         "webRequest",
         "webRequestBlocking",
     ],

--- a/web/packages/extension/src/popup.ts
+++ b/web/packages/extension/src/popup.ts
@@ -14,14 +14,15 @@ let reloadButton: HTMLButtonElement;
 // prettier-ignore
 const STATUS_COLORS = {
     "status_init": "gray",
-    "status_no_tabs": "red",
-    "status_tabs_error": "red",
     "status_message_init": "gray",
-    "status_result_protected": "gray",
-    "status_result_error": "red",
-    "status_result_running": "green",
-    "status_result_optout": "gray",
+    "status_no_tabs": "red",
     "status_result_disabled": "gray",
+    "status_result_error": "red",
+    "status_result_optout": "gray",
+    "status_result_protected": "gray",
+    "status_result_running": "green",
+    "status_result_running_protected": "green",
+    "status_tabs_error": "red",
 };
 
 async function queryTabStatus(
@@ -52,6 +53,17 @@ async function queryTabStatus(
     }
 
     activeTab = tabs[0]!;
+
+    const url = activeTab.url ? new URL(activeTab.url) : null;
+    if (
+        url &&
+        url.origin === window.location.origin &&
+        url.pathname === "/player.html"
+    ) {
+        listener("status_result_running_protected");
+        return;
+    }
+
     listener("status_message_init");
 
     let response;


### PR DESCRIPTION
In the current builds, when you open a SWF directly (say [Ultimate Flash Sonic](https://uploads.ungrounded.net/151000/151706_ultimate_sonic.swf)) and click the Ruffle icon in your browser, it says that "Ruffle cannot load on protected browser pages.". This PR fixes that minor issue.

A new string is also introduced to that end (let me know if the wording can be improved). I also wonder if we should change the string that mentions the "protected browser pages", since this notion may not be obvious for some users.