### PR TITLE
core: Implement handling of text control input

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,16 @@
 [target.'cfg(all())']
 # NOTE that the web build overrides this setting in package.json via the RUSTFLAGS environment variable
 rustflags = [
+    # We need to specify this flag for all targets because Clippy checks all of our code against all targets
+    # and our web code does not compile without this flag
+    "--cfg=web_sys_unstable_apis",
+
     # CLIPPY LINT SETTINGS
     # This is a workaround to configure lints for the entire workspace, pending the ability to configure this via TOML.
     # See: https://github.com/rust-lang/cargo/issues/5034
     #      https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395
+    # TODO: Move these to the root Cargo.toml once support is merged and stable
+    # See: https://github.com/rust-lang/cargo/pull/12148
 
     # Clippy nightly often adds new/buggy lints that we want to ignore.
     # Don't warn about these new lints on stable.

--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -1,4 +1,4 @@
-use crate::events::{KeyCode, PlayerEvent};
+use crate::events::{KeyCode, PlayerEvent, TextControlCode};
 use fluent_templates::loader::langid;
 pub use fluent_templates::LanguageIdentifier;
 use std::borrow::Cow;
@@ -66,6 +66,7 @@ pub struct InputManager {
     keys_down: HashSet<KeyCode>,
     last_key: KeyCode,
     last_char: Option<char>,
+    last_text_control: Option<TextControlCode>,
 }
 
 impl InputManager {
@@ -74,6 +75,7 @@ impl InputManager {
             keys_down: HashSet::new(),
             last_key: KeyCode::Unknown,
             last_char: None,
+            last_text_control: None,
         }
     }
 
@@ -100,6 +102,10 @@ impl InputManager {
             PlayerEvent::KeyUp { key_code, key_char } => {
                 self.last_char = key_char;
                 self.remove_key(key_code);
+                self.last_text_control = None;
+            }
+            PlayerEvent::TextControl { code } => {
+                self.last_text_control = Some(code);
             }
             PlayerEvent::MouseDown { button, .. } => self.add_key(button.into()),
             PlayerEvent::MouseUp { button, .. } => self.remove_key(button.into()),
@@ -117,6 +123,10 @@ impl InputManager {
 
     pub fn last_key_char(&self) -> Option<char> {
         self.last_char
+    }
+
+    pub fn last_text_control(&self) -> Option<TextControlCode> {
+        self.last_text_control
     }
 
     pub fn is_mouse_down(&self) -> bool {

--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -15,6 +15,9 @@ pub trait UiBackend {
     /// Changes the mouse cursor image.
     fn set_mouse_cursor(&mut self, cursor: MouseCursor);
 
+    /// Get the clipboard content
+    fn clipboard_content(&mut self) -> String;
+
     /// Sets the clipboard to the given content.
     fn set_clipboard_content(&mut self, content: String);
 
@@ -144,6 +147,10 @@ impl UiBackend for NullUiBackend {
     fn set_mouse_visible(&mut self, _visible: bool) {}
 
     fn set_mouse_cursor(&mut self, _cursor: MouseCursor) {}
+
+    fn clipboard_content(&mut self) -> String {
+        "".to_string()
+    }
 
     fn set_clipboard_content(&mut self, _content: String) {}
 

--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -159,7 +159,7 @@ impl UiBackend for NullUiBackend {
     fn set_mouse_cursor(&mut self, _cursor: MouseCursor) {}
 
     fn clipboard_content(&mut self) -> String {
-        "".to_string()
+        "".into()
     }
 
     fn set_clipboard_content(&mut self, _content: String) {}

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -1174,19 +1174,21 @@ impl<'gc> EditText<'gc> {
         None
     }
 
+    /// The number of characters that currently can be inserted, considering `TextField.maxChars`
+    /// constraint, current text length, and current text selection length.
     fn available_chars(self) -> usize {
         let read = self.0.read();
         let max_chars = read.max_chars;
         if max_chars == 0 {
             usize::MAX
         } else {
-            let text_len = read.text_spans.text().len();
+            let text_len = read.text_spans.text().len() as i32;
             let selection_len = if let Some(selection) = self.selection() {
-                selection.end() - selection.start()
+                (selection.end() - selection.start()) as i32
             } else {
                 0
             };
-            max_chars.max(0) as usize - (text_len - selection_len)
+            0.max(max_chars.max(0) - (text_len - selection_len)) as usize
         }
     }
 

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -33,7 +33,7 @@ pub enum PlayerEvent {
         codepoint: char,
     },
     TextControl {
-        code: TextControlCode
+        code: TextControlCode,
     },
 }
 
@@ -337,6 +337,10 @@ impl<'gc> ClipEvent<'gc> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TextControlCode {
     // TODO: Extend this
+    MoveLeft,
+    MoveRight,
+    SelectLeft,
+    SelectRight,
     SelectAll,
     Copy,
     Paste,

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -32,6 +32,9 @@ pub enum PlayerEvent {
     TextInput {
         codepoint: char,
     },
+    TextControl {
+        code: TextControlCode
+    },
 }
 
 /// The distance scrolled by the mouse wheel.
@@ -327,6 +330,29 @@ impl<'gc> ClipEvent<'gc> {
             | ClipEvent::MouseMoveInside
             | ClipEvent::MouseUpInside => None,
         }
+    }
+}
+
+/// Control inputs to a text field
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TextControlCode {
+    // TODO: Extend this
+    SelectAll,
+    Copy,
+    Paste,
+    Cut,
+    Backspace,
+    Enter,
+    Delete,
+}
+
+impl TextControlCode {
+    /// Indicates whether this is an event that edits the text content
+    pub fn is_edit_input(self) -> bool {
+        matches!(
+            self,
+            Self::Paste | Self::Cut | Self::Backspace | Self::Enter | Self::Delete
+        )
     }
 }
 

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -336,7 +336,7 @@ impl<'gc> ClipEvent<'gc> {
 /// Control inputs to a text field
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TextControlCode {
-    // TODO: Extend this
+    // TODO: Add control codes for Ctrl+Arrows and Home/End keys
     MoveLeft,
     MoveRight,
     SelectLeft,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1066,6 +1066,11 @@ impl Player {
                         text.text_input(codepoint, context);
                     }
                 }
+                if let PlayerEvent::TextControl { code } = event {
+                    if let Some(text) = context.focus_tracker.get().and_then(|o| o.as_edit_text()) {
+                        text.text_control_input(code, context);
+                    }
+                }
             }
 
             // Propagate clip events.

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -991,16 +991,6 @@ impl Player {
                     if state == ClipEventResult::Handled {
                         key_press_handled = true;
                         break;
-                    } else if let Some(text) =
-                        context.focus_tracker.get().and_then(|o| o.as_edit_text())
-                    {
-                        // Text fields listen for arrow key presses, etc.
-                        if text.handle_text_control_event(context, button_event)
-                            == ClipEventResult::Handled
-                        {
-                            key_press_handled = true;
-                            break;
-                        }
                     }
                 }
             }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -928,7 +928,11 @@ fn winit_to_ruffle_text_control(
             _ => None,
         }
     } else {
-        None
+        match key {
+            VirtualKeyCode::Back => Some(TextControlCode::Backspace),
+            VirtualKeyCode::Delete => Some(TextControlCode::Delete),
+            _ => None,
+        }
     }
 }
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -915,6 +915,7 @@ fn winit_key_to_char(key_code: VirtualKeyCode, is_shift_down: bool) -> Option<ch
 
 /// Converts a `VirtualKeyCode` and `ModifiersState` to a Ruffle `TextControlCode`.
 /// Returns `None` if there is no match.
+/// TODO: Handle Ctrl+Arrows and Home/End keys
 fn winit_to_ruffle_text_control(
     key: VirtualKeyCode,
     modifiers: ModifiersState,

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -22,11 +22,11 @@ use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use rfd::FileDialog;
 use ruffle_core::backend::audio::AudioBackend;
 use ruffle_core::backend::navigator::OpenURLMode;
-use ruffle_core::{
-    config::Letterbox, tag_utils::SwfMovie, LoadBehavior, Player, PlayerBuilder,
-    PlayerEvent, StageDisplayState, StageScaleMode, StaticCallstack, ViewportDimensions,
-};
 use ruffle_core::events::{KeyCode, TextControlCode};
+use ruffle_core::{
+    config::Letterbox, tag_utils::SwfMovie, LoadBehavior, Player, PlayerBuilder, PlayerEvent,
+    StageDisplayState, StageScaleMode, StaticCallstack, ViewportDimensions,
+};
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
@@ -589,7 +589,9 @@ impl App {
                                 let key_char = winit_key_to_char(key, modifiers.shift());
                                 let event = match input.state {
                                     ElementState::Pressed => {
-                                        if let Some(control_code) = winit_to_ruffle_text_control(key, modifiers) {
+                                        if let Some(control_code) =
+                                            winit_to_ruffle_text_control(key, modifiers)
+                                        {
                                             PlayerEvent::TextControl { code: control_code }
                                         } else {
                                             PlayerEvent::KeyDown { key_code, key_char }
@@ -917,6 +919,7 @@ fn winit_to_ruffle_text_control(
     key: VirtualKeyCode,
     modifiers: ModifiersState,
 ) -> Option<TextControlCode> {
+    let shift = modifiers.contains(ModifiersState::SHIFT);
     let ctrl_cmd = modifiers.contains(ModifiersState::CTRL)
         || (modifiers.contains(ModifiersState::LOGO) && cfg!(target_os = "macos"));
     if ctrl_cmd {
@@ -931,6 +934,20 @@ fn winit_to_ruffle_text_control(
         match key {
             VirtualKeyCode::Back => Some(TextControlCode::Backspace),
             VirtualKeyCode::Delete => Some(TextControlCode::Delete),
+            VirtualKeyCode::Left => {
+                if shift {
+                    Some(TextControlCode::SelectLeft)
+                } else {
+                    Some(TextControlCode::MoveLeft)
+                }
+            }
+            VirtualKeyCode::Right => {
+                if shift {
+                    Some(TextControlCode::SelectRight)
+                } else {
+                    Some(TextControlCode::MoveRight)
+                }
+            }
             _ => None,
         }
     }

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -63,9 +63,7 @@ impl UiBackend for DesktopUiBackend {
     }
 
     fn clipboard_content(&mut self) -> String {
-        self.clipboard
-            .get_text()
-            .unwrap_or_else(|_| "".to_string())
+        self.clipboard.get_text().unwrap_or_else(|_| "".to_string())
     }
 
     fn set_clipboard_content(&mut self, content: String) {

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -63,7 +63,7 @@ impl UiBackend for DesktopUiBackend {
     }
 
     fn clipboard_content(&mut self) -> String {
-        self.clipboard.get_text().unwrap_or_else(|_| "".to_string())
+        self.clipboard.get_text().unwrap_or_default()
     }
 
     fn set_clipboard_content(&mut self, content: String) {

--- a/desktop/src/ui.rs
+++ b/desktop/src/ui.rs
@@ -62,6 +62,12 @@ impl UiBackend for DesktopUiBackend {
         self.window.set_cursor_icon(icon);
     }
 
+    fn clipboard_content(&mut self) -> String {
+        self.clipboard
+            .get_text()
+            .unwrap_or_else(|_| "".to_string())
+    }
+
     fn set_clipboard_content(&mut self, content: String) {
         if let Err(e) = self.clipboard.set_text(content) {
             error!("Couldn't set clipboard contents: {:?}", e);

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -60,8 +60,8 @@ version = "0.3.63"
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext",
     "AudioDestinationNode", "AudioNode", "AudioParam", "Blob", "BlobPropertyBag",
-    "ChannelMergerNode", "ChannelSplitterNode", "Element", "Event", "EventTarget", "GainNode",
-    "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement", "HtmlInputElement",
-    "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent", "Request", "RequestInit",
-    "Response", "Storage", "WheelEvent", "Window",
+    "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element", "Event",
+    "EventTarget", "GainNode", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement", 
+    "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent", 
+    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window",
 ]

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1183,6 +1183,9 @@ export class RufflePlayer extends HTMLElement {
             this.virtualKeyboard.focus({ preventScroll: true });
         }
     }
+    protected isVirtualKeyboardFocused(): boolean {
+        return this.shadow.activeElement === this.virtualKeyboard;
+    }
 
     private contextMenuItems(isTouch: boolean): Array<ContextMenuItem | null> {
         const CHECKMARK = String.fromCharCode(0x2713);

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -843,12 +843,12 @@ impl Ruffle {
                             let is_ctrl_cmd = js_event.ctrl_key() || js_event.meta_key();
                             core.handle_event(PlayerEvent::KeyDown { key_code, key_char });
 
-                            if let Some(control_code) = web_to_text_control(
+                            if let Some(control_code) = web_to_ruffle_text_control(
                                 &js_event.key(),
                                 is_ctrl_cmd,
                                 js_event.shift_key(),
                             ) {
-                                core.handle_event(PlayerEvent::TextControl { code: control_code })
+                                core.handle_event(PlayerEvent::TextControl { code: control_code });
                             } else if let Some(codepoint) = key_char {
                                 core.handle_event(PlayerEvent::TextInput { codepoint });
                             }
@@ -1748,14 +1748,20 @@ fn web_key_to_codepoint(key: &str) -> Option<char> {
     }
 }
 
-pub fn web_to_text_control(key: &str, ctrl_key: bool, shift_key: bool) -> Option<TextControlCode> {
+/// Convert a web `KeyboardEvent.key` value to a Ruffle `TextControlCode`,
+/// given the states of the modifier keys. Return `None` if there is no match.
+/// TODO: Handle Ctrl+Arrows and Home/End keys
+pub fn web_to_ruffle_text_control(
+    key: &str,
+    ctrl_key: bool,
+    shift_key: bool,
+) -> Option<TextControlCode> {
     let mut chars = key.chars();
     let (c1, c2) = (chars.next(), chars.next());
     if c2.is_none() {
         // Single character.
         if ctrl_key {
             match c1 {
-                // TODO: Extend this
                 Some('a') => Some(TextControlCode::SelectAll),
                 Some('c') => Some(TextControlCode::Copy),
                 Some('v') => Some(TextControlCode::Paste),

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -843,9 +843,13 @@ impl Ruffle {
                             let is_ctrl_cmd = js_event.ctrl_key() || js_event.meta_key();
                             core.handle_event(PlayerEvent::KeyDown { key_code, key_char });
 
-                            if let Some(control_code) = web_to_text_control(&js_event.key(), is_ctrl_cmd) {
+                            if let Some(control_code) = web_to_text_control(
+                                &js_event.key(),
+                                is_ctrl_cmd,
+                                js_event.shift_key(),
+                            ) {
                                 core.handle_event(PlayerEvent::TextControl { code: control_code })
-                            }else if let Some(codepoint) = key_char {
+                            } else if let Some(codepoint) = key_char {
                                 core.handle_event(PlayerEvent::TextInput { codepoint });
                             }
                         });
@@ -1744,7 +1748,7 @@ fn web_key_to_codepoint(key: &str) -> Option<char> {
     }
 }
 
-pub fn web_to_text_control(key: &str, ctrl_key: bool) -> Option<TextControlCode> {
+pub fn web_to_text_control(key: &str, ctrl_key: bool, shift_key: bool) -> Option<TextControlCode> {
     let mut chars = key.chars();
     let (c1, c2) = (chars.next(), chars.next());
     if c2.is_none() {
@@ -1765,6 +1769,20 @@ pub fn web_to_text_control(key: &str, ctrl_key: bool) -> Option<TextControlCode>
         match key {
             "Delete" => Some(TextControlCode::Delete),
             "Backspace" => Some(TextControlCode::Backspace),
+            "ArrowLeft" => {
+                if shift_key {
+                    Some(TextControlCode::SelectLeft)
+                } else {
+                    Some(TextControlCode::MoveLeft)
+                }
+            }
+            "ArrowRight" => {
+                if shift_key {
+                    Some(TextControlCode::SelectRight)
+                } else {
+                    Some(TextControlCode::MoveRight)
+                }
+            }
             _ => None,
         }
     }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1762,7 +1762,10 @@ pub fn web_to_text_control(key: &str, ctrl_key: bool) -> Option<TextControlCode>
             None
         }
     } else {
-        // TODO: Check for special characters.
-        None
+        match key {
+            "Delete" => Some(TextControlCode::Delete),
+            "Backspace" => Some(TextControlCode::Backspace),
+            _ => None,
+        }
     }
 }

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -65,6 +65,11 @@ impl UiBackend for WebUiBackend {
         self.update_mouse_cursor();
     }
 
+    fn clipboard_content(&mut self) -> String {
+        tracing::warn!("get clipboard not implemented");
+        "".to_string()
+    }
+
     fn set_clipboard_content(&mut self, content: String) {
         // We use `document.execCommand("copy")` as `navigator.clipboard.writeText("string")`
         // is available only in secure contexts (HTTPS).


### PR DESCRIPTION
This is a rebase and update of #2081. The same TODO items still apply, but those would be for a possible future PR. I've moved the left/right arrow key handling into the same code path as the rest of the text control events. ~~I'm marking this PR as a draft because I plan to implement pasting from the clipboard on web - that's the main feature still missing. In the meantime, please provide your reviews/feedback!~~ I've implemented clipboard pasting on web!

https://github.com/ruffle-rs/ruffle/assets/71368227/abf6f939-1f8d-4faf-ad75-829d4da7d8ad

Fixes the save/load menus in #4817, Fixes part of #1891.