### PR TITLE
ci: Add crowdin github actions

### DIFF
--- a/.github/workflows/download_translations.yml
+++ b/.github/workflows/download_translations.yml
@@ -1,0 +1,33 @@
+name: Download translations from Crowdin
+
+on:
+  schedule:
+    - cron: '0 21 * * *'
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Crowdin push
+        uses: crowdin/github-action@v1
+        with:
+          config: 'crowdin.yml'
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_crowdin_translations
+
+          create_pull_request: true
+          pull_request_title: 'chore: Update translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_labels: 'localization'
+          pull_request_base_branch_name: 'master'
+          commit_message: 'chore: Update translations from Crowdin'
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload_texts.yml
+++ b/.github/workflows/upload_texts.yml
@@ -1,0 +1,24 @@
+name: Upload source texts to Crowdin
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1 # Should be 1 to avoid parallel builds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Crowdin push
+        uses: crowdin/github-action@v1
+        with:
+          config: 'crowdin.yml'
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,16 +1,9 @@
 # To use the crowdin-cli, set an access token in CROWDIN_PERSONAL_TOKEN or a ~/.crowdin.yml
 # File structure documentation can be found at: https://developer.crowdin.com/configuration-file/
 
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
 "project_id": 582621 # This is https://crowdin.com/project/ruffle
 "preserve_hierarchy": true # Keep the directory structure so that we know, for example, "messages.json" belongs to the extension
-
-# Github integration
-"pull_request_title": "Update text translations"
-"pull_request_labels": [
-  "localization"
-]
-"commit_message": "chore: Updates translations in %original_file_name% from Crowdin"
-"append_commit_message": false
 
 # Files we want to translate
 "files": [


### PR DESCRIPTION
100% untested.

~Needs a new secret added, `CROWDIN_PERSONAL_TOKEN`. Get this from https://crowdin.com/settings#api-key~ (This is done)

Pushes source texts when they land in master, and makes a new PR for translations if there is any new ones, once per day. If that's too much (I don't think they'll be that often) we can reconsider it.

The translation PRs are trivial and don't need reviewing really.