### PR TITLE
web: Fix localStorage check on Firefox when dom.storage.enabled is false

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1038,7 +1038,9 @@ export class RufflePlayer extends HTMLElement {
             return;
         }
         try {
-            localStorage;
+            if (localStorage === null) {
+                return;
+            }
         } catch (e: unknown) {
             return;
         }


### PR DESCRIPTION
Apparently, in this situation, rather than throw a SecurityError as mentioned on https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage, localStorage is just null.