### PR TITLE
Fix overflow bug in `shapeutils::winding_number_line()`.

### DIFF
--- a/render/src/shape_utils.rs
+++ b/render/src/shape_utils.rs
@@ -889,10 +889,15 @@ fn winding_number_line(
     // A downward segment (+y) decrements the winding number (including the final endpoint)
     // Perp-dot indicates which side of the segment the point is on.
     if begin.y < test_point.y {
-        if end.y >= test_point.y && d1.dx.get() * d0.dy.get() > d1.dy.get() * d0.dx.get() {
+        if end.y >= test_point.y
+            && (d1.dx.get() as i64) * (d0.dy.get() as i64)
+                > (d1.dy.get() as i64) * (d0.dx.get() as i64)
+        {
             return 1;
         }
-    } else if end.y < test_point.y && d1.dx.get() * d0.dy.get() < d1.dy.get() * d0.dx.get() {
+    } else if end.y < test_point.y
+        && (d1.dx.get() as i64) * (d0.dy.get() as i64) < (d1.dy.get() as i64) * (d0.dx.get() as i64)
+    {
         return -1;
     }
 

--- a/swf/src/types/twips.rs
+++ b/swf/src/types/twips.rs
@@ -9,6 +9,12 @@
 ///
 /// [`from_pixels`]: Twips::from_pixels
 /// [`to_pixels`]: Twips::to_pixels
+///
+/// Please be careful when using twips for calculations to avoid overflows.
+/// As an example, since it takes 20 twips to get 1 pixel, 2,000 pixels are
+/// 40,000 twips, or `4*10^4` . If you then have two such numbers,
+/// multiplying them as part of calculations yields `16*10^8`, which is
+/// relatively close to the upper limit of `i32` at about `2*10^9`.
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Twips(i32);
 


### PR DESCRIPTION
Fixes #11077 .

Related PR: #11014 .

An automated test has been added.