### PR TITLE
extension: Revert #11040

### DIFF
--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -56,9 +56,6 @@
     "status_result_running": {
         "message": "Ruffle is loaded and ready to run Flash content on the current tab."
     },
-    "status_result_running_protected": {
-        "message": "Ruffle is loaded and running the Flash content that you requested."
-    },
     "status_result_optout": {
         "message": "Ruffle is not loaded because the current page has marked itself as incompatible."
     },

--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -43,9 +43,8 @@
         "open_in_tab": true,
     },
     "permissions": [
-        "<all_urls>",
         "storage",
-        "tabs",
+        "<all_urls>",
         "webRequest",
         "webRequestBlocking",
     ],

--- a/web/packages/extension/src/popup.ts
+++ b/web/packages/extension/src/popup.ts
@@ -14,15 +14,14 @@ let reloadButton: HTMLButtonElement;
 // prettier-ignore
 const STATUS_COLORS = {
     "status_init": "gray",
-    "status_message_init": "gray",
     "status_no_tabs": "red",
-    "status_result_disabled": "gray",
-    "status_result_error": "red",
-    "status_result_optout": "gray",
-    "status_result_protected": "gray",
-    "status_result_running": "green",
-    "status_result_running_protected": "green",
     "status_tabs_error": "red",
+    "status_message_init": "gray",
+    "status_result_protected": "gray",
+    "status_result_error": "red",
+    "status_result_running": "green",
+    "status_result_optout": "gray",
+    "status_result_disabled": "gray",
 };
 
 async function queryTabStatus(
@@ -53,17 +52,6 @@ async function queryTabStatus(
     }
 
     activeTab = tabs[0]!;
-
-    const url = activeTab.url ? new URL(activeTab.url) : null;
-    if (
-        url &&
-        url.origin === window.location.origin &&
-        url.pathname === "/player.html"
-    ) {
-        listener("status_result_running_protected");
-        return;
-    }
-
     listener("status_message_init");
 
     let response;


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#11040 per https://github.com/ruffle-rs/ruffle/issues/11098#issuecomment-1552649360. This was an unnecessary addition to Ruffle's required permissions which may have tripped Google's systems and caused our updates to be rejected.