### PR TITLE
extension: Set charset attribute of script tag instead of escaping characters

### DIFF
--- a/web/packages/core/tools/bundle_texts.js
+++ b/web/packages/core/tools/bundle_texts.js
@@ -37,20 +37,7 @@ locales.forEach((locale) => {
 const options = {
     files: "dist/**",
     from: [/\{\s*\/\*\s*%BUNDLED_TEXTS%\s*\*\/\s*}/g],
-    to: [
-        JSON.stringify(bundled_texts, null, 2).replace(
-            // Escape most non-ASCII characters to prevent strings from looking broken on non-UTF-8 encoded pages.
-            /[\u{0080}-\u{FFFF}]/gu,
-            (char) => {
-                const code = char.charCodeAt(0);
-                if (code > 0xff) {
-                    return `\\u${code.toString(16).padStart(4, "0")}`;
-                } else {
-                    return `\\x${code.toString(16)}`;
-                }
-            }
-        ),
-    ],
+    to: [JSON.stringify(bundled_texts, null, 2)],
 };
 
 replace.sync(options);

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -64,6 +64,7 @@ function injectScriptURL(url: string): Promise<void> {
         script.addEventListener("load", () => resolve());
         script.addEventListener("error", (e) => reject(e));
     });
+    script.charset = "utf-8";
     script.src = url;
     (document.head || document.documentElement).append(script);
     return promise;


### PR DESCRIPTION
Explained in https://github.com/ruffle-rs/ruffle/issues/11098#issuecomment-1552406624. I've tested that this fix works equally well for English, Korean and French locales on the following pages:
- http://www.futureexpress.net/ (mentioned on Discord)
- http://omoshiro.gozaru.jp/html/dare.html (#11056)
- https://www.ccdmd.qc.ca/fr/modules/diagnostics/ (originally showed garbled text like Toad's screenshot before his PR #11023, fixed by that PR and still works with this one)