### PR TITLE
tests: Make the audio backend tick every frame in the runner

### DIFF
--- a/tests/tests/swfs/avm2/audio_computespectrum/test.toml
+++ b/tests/tests/swfs/avm2/audio_computespectrum/test.toml
@@ -1,5 +1,4 @@
 num_frames = 240
-sleep_to_meet_frame_rate = true
 
 [player_options]
 with_audio = true


### PR DESCRIPTION
With no separate thread and sleeping to worry about, this should make the `computespectrum` test 100% reproducible, and not take 10 seconds to run.

Should prevent spurious failures such as:
https://github.com/ruffle-rs/ruffle/actions/runs/4962589152/jobs/8880836781?pr=11027

Somehow I wasn't aware that this "push" style execution model is also available in the `AudioBackend` trait when I originally made that test... :upside_down_face: 