### PR TITLE
tests: Unconditionally save 'actual.txt' with Ruffle output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ target/
 
 # Flash recovery files
 RECOVER_*.fla
+
+tests/**/actual.txt
+tests/**/actual-*.png
+tests/**/difference-*.png

--- a/tests/tests/util/test.rs
+++ b/tests/tests/util/test.rs
@@ -65,6 +65,9 @@ impl Test {
 
     pub fn compare_output(&self, actual_output: &str) -> Result<()> {
         let expected_output = std::fs::read_to_string(&self.output_path)?.replace("\r\n", "\n");
+        let mut actual_path = self.output_path.clone();
+        actual_path.set_file_name("actual.txt");
+        std::fs::write(actual_path, actual_output)?;
 
         if let Some(approximations) = &self.options.approximations {
             std::assert_eq!(


### PR DESCRIPTION
When a test has large amounts of output, the diff printed by Ruffle can be difficult to understand. Also, it can be useful to see the real floating point values for a passing test with approximate floating point comparison enabled.

I've modified the test runner to save the actual Ruffle trace output to 'actual.txt' (in the same directory as 'output.txt'). For simplicity, this is done regardless of whether or not the test passes or fails.

To prevent messy 'git status' output and accidental commits, I've added all of the test-generated files ('actual.txt', 'different-*.png', and 'actual-*png') to .gitignore