### PR TITLE
avm2: Avoid a function call on every push()

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -503,8 +503,11 @@ impl<'gc> Avm2<'gc> {
         }
         let mut value = value.into();
         if let Value::Object(o) = value {
-            if let Some(prim) = o.as_primitive() {
-                value = *prim;
+            // this is hot, so let's avoid a non-inlined call here
+            if let Object::PrimitiveObject(_) = o {
+                if let Some(prim) = o.as_primitive() {
+                    value = *prim;
+                }
             }
         }
 


### PR DESCRIPTION
`.as_primitive()` doesn't get inlined because of the GcCell check and possible unwrap inside.

`push()` is hot enough that this actually makes a ~~noticeable~~ measurable difference on profiles (at least when combined with other optimizations).