### PR TITLE
wgpu: Cache compiled naga-agal shader module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "lyon"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3784,7 @@ dependencies = [
  "gif",
  "h263-rs-yuv",
  "jpeg-decoder",
+ "lru",
  "lyon",
  "png",
  "ruffle_wstr",
@@ -3832,6 +3842,7 @@ dependencies = [
  "futures",
  "gc-arena",
  "image",
+ "lru",
  "naga",
  "naga-agal",
  "naga_oil",

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -24,6 +24,7 @@ enum-map = "2.5.0"
 serde = { version = "1.0.163", features = ["derive"] }
 clap = { version = "4.3.1", features = ["derive"], optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "d5d78eb251c1ce1f1da57c63db14f0fdc77a4b36"}
+lru = "0.10.0"
 
 [dependencies.jpeg-decoder]
 version = "0.3.0"

--- a/render/naga-agal/src/lib.rs
+++ b/render/naga-agal/src/lib.rs
@@ -10,7 +10,7 @@ pub const SHADER_ENTRY_POINT: &str = "main";
 pub const MAX_VERTEX_ATTRIBUTES: usize = 8;
 pub const MAX_TEXTURES: usize = 8;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum VertexAttributeFormat {
     Float1,
     Float2,

--- a/render/naga-agal/src/types.rs
+++ b/render/naga-agal/src/types.rs
@@ -127,20 +127,20 @@ impl SourceField {
     }
 }
 
-#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Filter {
     Nearest = 0,
     Linear = 1,
 }
 
-#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Mipmap {
     Disable = 0,
     Nearest = 1,
     Linear = 2,
 }
 
-#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Wrapping {
     Clamp = 0,
     Repeat = 1,
@@ -181,7 +181,7 @@ pub struct SamplerField {
     pub reg_type: RegisterType,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SamplerOverride {
     pub wrapping: Wrapping,
     pub filter: Filter,

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -26,6 +26,7 @@ naga-agal = { path = "../naga-agal" }
 downcast-rs = "1.2.0"
 profiling = { version = "1.0", default-features = false, optional = true }
 naga = { version = "0.12.2", features = ["validate", "wgsl-out"] }
+lru = "0.10.0"
 
 # desktop
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]


### PR DESCRIPTION
We use an `lru::LruCache` inside `ShaderModuleAgal`. This automatically gives us the proper garbage-collection behavior (when the Flash Program3D instance is garbage collected, we'll drop the `ShaderModuleAgal` and the cache).

The cache is keyed on the data needed to compile the shader (vertex attributes and sampler overrides). This lets us avoid shader recompilations when a Stage3D program repeatedly uses the same Program3D with different sampler overrides / vertex attribute formats.