### PR TITLE
core: Store Color as an u32 instead of a i32

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -97,8 +97,8 @@ fn constructor<'gc>(
         None => true,
     };
     let fill_color = match args.get(3) {
-        Some(fill_color) => fill_color.coerce_to_i32(activation)?,
-        None => -1,
+        Some(fill_color) => fill_color.coerce_to_u32(activation)?,
+        None => u32::MAX,
     };
 
     if !is_size_valid(activation.swf_version(), width, height) {
@@ -193,7 +193,8 @@ fn get_pixel<'gc>(
             if let (Some(x_val), Some(y_val)) = (args.get(0), args.get(1)) {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let col = operations::get_pixel(bitmap_data, x, y);
+                // AVM1 returns a signed int, so we need to convert it.
+                let col = operations::get_pixel(bitmap_data, x, y) as i32;
                 return Ok(col.into());
             }
         }
@@ -212,7 +213,8 @@ fn get_pixel32<'gc>(
             if let (Some(x_val), Some(y_val)) = (args.get(0), args.get(1)) {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let col = operations::get_pixel32(bitmap_data, x, y);
+                // AVM1 returns a signed int, so we need to convert it.
+                let col = operations::get_pixel32(bitmap_data, x, y) as i32;
                 return Ok(col.into());
             }
         }
@@ -233,7 +235,7 @@ fn set_pixel<'gc>(
             {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let color = color_val.coerce_to_i32(activation)?;
+                let color = color_val.coerce_to_u32(activation)?;
 
                 operations::set_pixel(
                     activation.context.gc_context,
@@ -263,7 +265,7 @@ fn set_pixel32<'gc>(
             {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let color = color_val.coerce_to_i32(activation)?;
+                let color = color_val.coerce_to_u32(activation)?;
 
                 operations::set_pixel32(activation.context.gc_context, bitmap_data, x, y, color);
             }
@@ -356,7 +358,7 @@ fn fill_rect<'gc>(
     if let NativeObject::BitmapData(bitmap_data) = this.native() {
         if !bitmap_data.disposed() {
             if let Some(color_val) = args.get(1) {
-                let color = color_val.coerce_to_i32(activation)?;
+                let color = color_val.coerce_to_u32(activation)?;
 
                 let x = rectangle.get("x", activation)?.coerce_to_i32(activation)?;
                 let y = rectangle.get("y", activation)?.coerce_to_i32(activation)?;
@@ -430,7 +432,7 @@ fn flood_fill<'gc>(
             {
                 let x = x_val.coerce_to_u32(activation)?;
                 let y = y_val.coerce_to_u32(activation)?;
-                let color = color_val.coerce_to_i32(activation)?;
+                let color = color_val.coerce_to_u32(activation)?;
 
                 operations::flood_fill(activation.context.gc_context, bitmap_data, x, y, color);
             }
@@ -658,8 +660,8 @@ fn get_color_bounds_rect<'gc>(
                 .as_bool(activation.swf_version());
 
             if let (Some(mask_val), Some(color_val)) = (args.get(0), args.get(1)) {
-                let mask = mask_val.coerce_to_i32(activation)?;
-                let color = color_val.coerce_to_i32(activation)?;
+                let mask = mask_val.coerce_to_u32(activation)?;
+                let color = color_val.coerce_to_u32(activation)?;
 
                 let (x, y, w, h) =
                     operations::color_bounds_rect(bitmap_data, find_color, mask, color);
@@ -1188,7 +1190,7 @@ fn pixel_dissolve<'gc>(
                     };
 
                     let fill_color = match args.get(5) {
-                        Some(fill_color) => fill_color.coerce_to_i32(activation)?,
+                        Some(fill_color) => fill_color.coerce_to_u32(activation)?,
                         None => 0,
                     };
 
@@ -1289,7 +1291,7 @@ fn threshold<'gc>(
                 .unwrap_or(&Value::Undefined)
                 .coerce_to_u32(activation)?;
 
-            let colour = args.get(5).unwrap_or(&0.into()).coerce_to_i32(activation)?;
+            let colour = args.get(5).unwrap_or(&0.into()).coerce_to_u32(activation)?;
 
             let mask = args
                 .get(6)

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -107,7 +107,7 @@ pub fn init<'gc>(
             let width = args.get_u32(activation, 0)?;
             let height = args.get_u32(activation, 1)?;
             let transparency = args.get_bool(2);
-            let fill_color = args.get_i32(activation, 3)?;
+            let fill_color = args.get_u32(activation, 3)?;
 
             if !is_size_valid(activation.context.swf.version(), width, height) {
                 return Err(Error::AvmError(argument_error(
@@ -344,7 +344,7 @@ pub fn get_pixel32<'gc>(
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
         let pixel = operations::get_pixel32(bitmap_data, x, y);
-        return Ok((pixel as u32).into());
+        return Ok(pixel.into());
     }
 
     Ok(Value::Undefined)
@@ -359,7 +359,7 @@ pub fn set_pixel<'gc>(
     if let Some(bitmap_data) = this.and_then(|t| t.as_bitmap_data()) {
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
-        let color = args.get_i32(activation, 2)?;
+        let color = args.get_u32(activation, 2)?;
         operations::set_pixel(
             activation.context.gc_context,
             bitmap_data,
@@ -383,7 +383,7 @@ pub fn set_pixel32<'gc>(
 
         let x = args.get_u32(activation, 0)?;
         let y = args.get_u32(activation, 1)?;
-        let color = args.get_i32(activation, 2)?;
+        let color = args.get_u32(activation, 2)?;
 
         operations::set_pixel32(activation.context.gc_context, bitmap_data, x, y, color);
     }
@@ -482,7 +482,7 @@ pub fn flood_fill<'gc>(
         if !bitmap_data.disposed() {
             let x = args.get_u32(activation, 0)?;
             let y = args.get_u32(activation, 1)?;
-            let color = args.get_i32(activation, 2)?;
+            let color = args.get_u32(activation, 2)?;
 
             operations::flood_fill(activation.context.gc_context, bitmap_data, x, y, color);
         }
@@ -567,8 +567,8 @@ pub fn get_color_bounds_rect<'gc>(
         if !bitmap_data.disposed() {
             let find_color = args.get_bool(2);
 
-            let mask = args.get_i32(activation, 0)?;
-            let color = args.get_i32(activation, 1)?;
+            let mask = args.get_u32(activation, 0)?;
+            let color = args.get_u32(activation, 1)?;
 
             let (x, y, w, h) = operations::color_bounds_rect(bitmap_data, find_color, mask, color);
 
@@ -911,7 +911,7 @@ pub fn fill_rect<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let rectangle = args.get_object(activation, 0, "rect")?;
 
-    let color = args.get_i32(activation, 1)?;
+    let color = args.get_u32(activation, 1)?;
 
     if let Some(bitmap_data) = this.and_then(|this| this.as_bitmap_data()) {
         bitmap_data.check_valid(activation)?;
@@ -1191,7 +1191,7 @@ pub fn threshold<'gc>(
             );
             let operation = args.try_get_string(activation, 3)?;
             let threshold = args.get_u32(activation, 4)?;
-            let color = args.get_i32(activation, 5)?;
+            let color = args.get_u32(activation, 5)?;
             let mask = args.get_u32(activation, 6)?;
             let copy_source = args.get_bool(7);
 
@@ -1343,7 +1343,7 @@ pub fn pixel_dissolve<'gc>(
             )?));
         }
 
-        let fill_color = args.get_i32(activation, 5)?;
+        let fill_color = args.get_u32(activation, 5)?;
 
         // Apparently, if this check fails, a type error for `null` is given.
         if let Some(src_bitmap_data) = src_bitmap_data.as_bitmap_data() {

--- a/core/src/bitmap/bitmap_data.rs
+++ b/core/src/bitmap/bitmap_data.rs
@@ -38,11 +38,11 @@ impl LehmerRng {
 /// Note that most operations only make sense on one of these representations:
 /// For example, blending on premultiplied values, and applying a `ColorTransform` on
 /// unmultiplied values. Make sure to convert the color to the correct form beforehand.
-// TODO: Maybe split the type into `PremultipliedColor(i32)` and
-//   `UnmultipliedColor(i32)`?
+// TODO: Maybe split the type into `PremultipliedColor(u32)` and
+//   `UnmultipliedColor(u32)`?
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Collect)]
 #[collect(no_drop)]
-pub struct Color(i32);
+pub struct Color(u32);
 
 #[derive(Debug, Clone)]
 pub enum BitmapDataDrawError {
@@ -125,7 +125,7 @@ impl Color {
 
     #[must_use]
     pub fn argb(alpha: u8, red: u8, green: u8, blue: u8) -> Self {
-        Self(i32::from_le_bytes([blue, green, red, alpha]))
+        Self(u32::from_le_bytes([blue, green, red, alpha]))
     }
 
     #[must_use]
@@ -155,20 +155,14 @@ impl std::fmt::Display for Color {
     }
 }
 
-impl From<Color> for i32 {
+impl From<Color> for u32 {
     fn from(c: Color) -> Self {
         c.0
     }
 }
 
-impl From<Color> for u32 {
-    fn from(c: Color) -> Self {
-        c.0 as u32
-    }
-}
-
-impl From<i32> for Color {
-    fn from(i: i32) -> Self {
+impl From<u32> for Color {
+    fn from(i: u32) -> Self {
         Color(i)
     }
 }
@@ -483,7 +477,7 @@ impl std::fmt::Debug for BitmapData<'_> {
 }
 
 impl<'gc> BitmapData<'gc> {
-    pub fn new(width: u32, height: u32, transparency: bool, fill_color: i32) -> Self {
+    pub fn new(width: u32, height: u32, transparency: bool, fill_color: u32) -> Self {
         Self {
             pixels: vec![
                 Color(fill_color).to_premultiplied_alpha(transparency);

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -31,7 +31,7 @@ pub fn fill_rect<'gc>(
     y: i32,
     width: i32,
     height: i32,
-    color: i32,
+    color: u32,
 ) {
     let mut rect = PixelRegion::for_region_i32(x, y, width, height);
     rect.clamp(target.width(), target.height());
@@ -63,7 +63,7 @@ pub fn set_pixel32<'gc>(
     target: BitmapDataWrapper<'gc>,
     x: u32,
     y: u32,
-    color: i32,
+    color: u32,
 ) {
     if x >= target.width() || y >= target.height() {
         return;
@@ -79,7 +79,7 @@ pub fn set_pixel32<'gc>(
     write.set_cpu_dirty(PixelRegion::for_pixel(x, y));
 }
 
-pub fn get_pixel32(target: BitmapDataWrapper, x: u32, y: u32) -> i32 {
+pub fn get_pixel32(target: BitmapDataWrapper, x: u32, y: u32) -> u32 {
     if x >= target.width() || y >= target.height() {
         return 0;
     }
@@ -110,7 +110,7 @@ pub fn set_pixel<'gc>(
     write.set_cpu_dirty(PixelRegion::for_whole_size(x, y));
 }
 
-pub fn get_pixel(target: BitmapDataWrapper, x: u32, y: u32) -> i32 {
+pub fn get_pixel(target: BitmapDataWrapper, x: u32, y: u32) -> u32 {
     if x >= target.width() || y >= target.height() {
         return 0;
     }
@@ -133,7 +133,7 @@ pub fn flood_fill<'gc>(
     target: BitmapDataWrapper<'gc>,
     x: u32,
     y: u32,
-    color: i32,
+    color: u32,
 ) {
     if x >= target.width() || y >= target.height() {
         return;
@@ -434,7 +434,7 @@ pub fn copy_channel<'gc>(
             write.set_pixel32_raw(
                 dst_x,
                 dst_y,
-                Color::from(result_color as i32).to_premultiplied_alpha(transparency),
+                Color::from(result_color).to_premultiplied_alpha(transparency),
             );
         }
     }
@@ -503,7 +503,7 @@ pub fn threshold<'gc>(
     dest_point: (i32, i32),
     operation: ThresholdOperation,
     threshold: u32,
-    colour: i32,
+    colour: u32,
     mask: u32,
     copy_source: bool,
 ) -> u32 {
@@ -560,7 +560,7 @@ pub fn threshold<'gc>(
             };
 
             // If the test, as defined by the operation pass then set to input colour
-            if operation.matches(i32::from(source_color) as u32 & mask, masked_threshold) {
+            if operation.matches(u32::from(source_color) & mask, masked_threshold) {
                 modified_count += 1;
                 write.set_pixel32_raw(dest_x, dest_y, Color::from(colour));
             } else {
@@ -697,7 +697,7 @@ pub fn palette_map<'gc>(
             let a = channel_arrays.3[source_color.alpha() as usize];
 
             let sum = u32::wrapping_add(u32::wrapping_add(r, g), u32::wrapping_add(b, a));
-            let mix_color = Color::from(sum as i32).to_premultiplied_alpha(true);
+            let mix_color = Color::from(sum).to_premultiplied_alpha(true);
 
             write.set_pixel32_raw(dest_x, dest_y, mix_color);
         }
@@ -855,8 +855,8 @@ pub fn hit_test_bitmapdata<'gc>(
 pub fn color_bounds_rect(
     target: BitmapDataWrapper,
     find_color: bool,
-    mask: i32,
-    color: i32,
+    mask: u32,
+    color: u32,
 ) -> (u32, u32, u32, u32) {
     let mut min_x = target.width();
     let mut max_x = 0;
@@ -868,7 +868,7 @@ pub fn color_bounds_rect(
 
     for x in 0..read.width() {
         for y in 0..read.height() {
-            let pixel_raw: i32 = read.get_pixel32_raw(x, y).into();
+            let pixel_raw: u32 = read.get_pixel32_raw(x, y).into();
             let color_matches = if find_color {
                 (pixel_raw & mask) == color
             } else {
@@ -1570,7 +1570,7 @@ pub fn get_pixels_as_byte_array<'gc>(
     for y in region.y_min..region.y_max {
         for x in region.x_min..region.x_max {
             let color = read.get_pixel32_raw(x, y);
-            result.write_int(color.to_un_multiplied_alpha().into())?;
+            result.write_unsigned_int(color.to_un_multiplied_alpha().into())?;
         }
     }
 
@@ -1603,7 +1603,7 @@ pub fn set_pixels_from_byte_array<'gc>(
         for y in region.y_min..region.y_max {
             for x in region.x_min..region.x_max {
                 // Copy data from bytearray until EOFError or finished
-                let color = bytearray.read_int()?;
+                let color = bytearray.read_unsigned_int()?;
                 write.set_pixel32_raw(
                     x,
                     y,
@@ -1627,7 +1627,7 @@ pub fn pixel_dissolve<'gc>(
     dest_point: (i32, i32),
     random_seed: i32,
     num_pixels: i32,
-    fill_color: i32,
+    fill_color: u32,
 ) -> i32 {
     /// Returns at least 2. Always returns an even number.
     fn get_feistel_block_size(sequence_length: u32) -> u32 {
@@ -1697,7 +1697,7 @@ pub fn pixel_dissolve<'gc>(
     fn write_pixel(
         write: &mut RefMut<BitmapData>,
         different_source_than_target: &Option<Ref<BitmapData>>,
-        fill_color: i32,
+        fill_color: u32,
         transparency: bool,
         base_point: (u32, u32),
         read_offset: (u32, u32),

--- a/render/src/bitmap.rs
+++ b/render/src/bitmap.rs
@@ -199,7 +199,7 @@ impl Bitmap {
         &mut self.data
     }
 
-    pub fn as_colors(&self) -> impl Iterator<Item = i32> + '_ {
+    pub fn as_colors(&self) -> impl Iterator<Item = u32> + '_ {
         let chunks = match self.format {
             BitmapFormat::Rgb => self.data.chunks_exact(3),
             BitmapFormat::Rgba => self.data.chunks_exact(4),
@@ -212,7 +212,7 @@ impl Bitmap {
             let green = chunk[1];
             let blue = chunk[2];
             let alpha = chunk.get(3).copied().unwrap_or(0xFF);
-            i32::from_le_bytes([blue, green, red, alpha])
+            u32::from_le_bytes([blue, green, red, alpha])
         })
     }
 }


### PR DESCRIPTION
This is a packed ARGB value, so it doesn't make sense for it to be signed.