### PR TITLE
desktop: Add suspend/resume buttons

### DIFF
--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -13,6 +13,10 @@ file-menu-open-url = Open URL...
 file-menu-close = Close
 file-menu-exit = Exit
 
+controls-menu = Controls
+controls-menu-suspend = Suspend
+controls-menu-resume = Resume
+
 help-menu = Help
 help-menu-join-discord = Join Discord
 help-menu-report-a-bug = Report a Bug...

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -8,7 +8,7 @@ use crate::gui::MovieView;
 use crate::{CALLSTACK, RENDER_INFO, SWF_INFO};
 use anyhow::anyhow;
 use ruffle_core::backend::audio::AudioBackend;
-use ruffle_core::{Player, PlayerBuilder};
+use ruffle_core::{Player, PlayerBuilder, PlayerEvent};
 use ruffle_render::backend::RenderBackend;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
 use ruffle_render_wgpu::descriptors::Descriptors;
@@ -162,6 +162,14 @@ impl PlayerController {
                     .try_lock()
                     .expect("Player lock must be available"),
             ),
+        }
+    }
+
+    pub fn handle_event(&self, event: PlayerEvent) {
+        if let Some(mut player) = self.get() {
+            if player.is_playing() {
+                player.handle_event(event);
+            }
         }
     }
 


### PR DESCRIPTION
Will come in handy with (not-yet-made) debugging overlays, to prevent values shifting all the time.
Also it's cool to just pause things.

I'm thinking a future option might be "pause in background" or something similar.