### PR TITLE
web: Allow extra MIME types in the polyfill

### DIFF
--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -133,31 +133,36 @@ export class RuffleEmbed extends RufflePlayer {
      * Checks if the given element may be polyfilled with this one.
      *
      * @param elem Element to check.
-     * @returns True if the element looks like a flash embed.
+     * @returns True if the element looks like a Flash embed.
      */
     static isInterdictable(elem: Element): boolean {
+        const src = elem.getAttribute("src");
+        const type = elem.getAttribute("type");
+
+        // Don't polyfill when no file is specified.
+        if (!src) {
+            return false;
+        }
+
         // Don't polyfill if the element is inside a specific node.
         if (isFallbackElement(elem)) {
             return false;
         }
-        // Don't polyfill when no file is specified.
-        if (!elem.getAttribute("src")) {
-            return false;
-        }
-        // Don't polyfill when the file is a Youtube Flash source.
-        if (isYoutubeFlashSource(elem.getAttribute("src"))) {
-            // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well
+
+        // Don't polyfill when the file is a YouTube Flash source.
+        if (isYoutubeFlashSource(src)) {
+            // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well.
             workaroundYoutubeMixedContent(elem, "src");
             return false;
         }
 
         // Check for MIME type.
-        const type = elem.getAttribute("type");
+        const isSwf = isSwfFilename(src);
         if (!type) {
             // If no MIME type is specified, polyfill if movie is an SWF file.
-            return isSwfFilename(elem.getAttribute("src"));
+            return isSwf;
         } else {
-            return isSwfMimeType(type);
+            return isSwfMimeType(type, isSwf);
         }
     }
 

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -8,7 +8,7 @@ import {
 } from "./ruffle-player";
 import { NetworkingAccessMode, WindowMode } from "./load-options";
 import { registerElement } from "./register-element";
-import { isSwfFilename, isSwfMimeType } from "./swf-utils";
+import { isSwf } from "./swf-utils";
 
 /**
  * A polyfill html element.
@@ -156,14 +156,7 @@ export class RuffleEmbed extends RufflePlayer {
             return false;
         }
 
-        // Check for MIME type.
-        const isSwf = isSwfFilename(src);
-        if (!type) {
-            // If no MIME type is specified, polyfill if movie is an SWF file.
-            return isSwf;
-        } else {
-            return isSwfMimeType(type, isSwf);
-        }
+        return isSwf(src, type);
     }
 
     /**

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -223,13 +223,14 @@ export class RuffleObject extends RufflePlayer {
      * Checks if the given element may be polyfilled with this one.
      *
      * @param elem Element to check.
-     * @returns True if the element looks like a flash object.
+     * @returns True if the element looks like a Flash object.
      */
     static isInterdictable(elem: Element): boolean {
         // Don't polyfill if the element is inside a specific node.
         if (isFallbackElement(elem)) {
             return false;
         }
+
         // Don't polyfill if there's already a <ruffle-object> or a <ruffle-embed> inside the <object>.
         if (
             elem.getElementsByTagName("ruffle-object").length > 0 ||
@@ -238,31 +239,30 @@ export class RuffleObject extends RufflePlayer {
             return false;
         }
 
-        // Don't polyfill if no movie specified.
         const data = elem.attributes.getNamedItem("data")?.value.toLowerCase();
         const params = paramsOf(elem);
         let isSwf;
         // Check for SWF file.
         if (data) {
-            // Don't polyfill when the file is a Youtube Flash source.
+            // Don't polyfill when the file is a YouTube Flash source.
             if (isYoutubeFlashSource(data)) {
-                // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well
+                // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well.
                 workaroundYoutubeMixedContent(elem, "data");
                 return false;
             }
             isSwf = isSwfFilename(data);
         } else if (params && params["movie"]) {
-            // Don't polyfill when the file is a Youtube Flash source.
+            // Don't polyfill when the file is a YouTube Flash source.
             if (isYoutubeFlashSource(params["movie"])) {
-                // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well
-                const movie_elem = elem.querySelector("param[name='movie']");
-                if (movie_elem) {
-                    workaroundYoutubeMixedContent(movie_elem, "value");
-                    // The data attribute needs to be set for the re-fetch to happen
-                    // It also needs to be set on Firefox for the YouTube object rewrite to work, regardless of mixed content
-                    const movie_src = movie_elem.getAttribute("value");
-                    if (movie_src) {
-                        elem.setAttribute("data", movie_src);
+                // Workaround YouTube mixed content; this isn't what browsers do automatically, but while we're here, we may as well.
+                const movieElem = elem.querySelector("param[name='movie']");
+                if (movieElem) {
+                    workaroundYoutubeMixedContent(movieElem, "value");
+                    // The data attribute needs to be set for the re-fetch to happen.
+                    // It also needs to be set on Firefox for the YouTube object rewrite to work, regardless of mixed content.
+                    const movieSrc = movieElem.getAttribute("value");
+                    if (movieSrc) {
+                        elem.setAttribute("data", movieSrc);
                     }
                 }
                 return false;
@@ -301,7 +301,7 @@ export class RuffleObject extends RufflePlayer {
             // If no MIME type is specified, polyfill if movie is an SWF file.
             return isSwf;
         } else {
-            return isSwfMimeType(type.value);
+            return isSwfMimeType(type.value, isSwf);
         }
     }
 

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -10,7 +10,7 @@ import { FLASH_ACTIVEX_CLASSID } from "./flash-identifiers";
 import { registerElement } from "./register-element";
 import type { URLLoadOptions, WindowMode } from "./load-options";
 import { RuffleEmbed } from "./ruffle-embed";
-import { isSwfFilename, isSwfMimeType } from "./swf-utils";
+import { isSwf } from "./swf-utils";
 import { NetworkingAccessMode } from "./load-options";
 
 /**
@@ -240,9 +240,11 @@ export class RuffleObject extends RufflePlayer {
         }
 
         const data = elem.attributes.getNamedItem("data")?.value.toLowerCase();
+        const type = elem.attributes.getNamedItem("type")?.value ?? null;
         const params = paramsOf(elem);
-        let isSwf;
+
         // Check for SWF file.
+        let filename;
         if (data) {
             // Don't polyfill when the file is a YouTube Flash source.
             if (isYoutubeFlashSource(data)) {
@@ -250,7 +252,7 @@ export class RuffleObject extends RufflePlayer {
                 workaroundYoutubeMixedContent(elem, "data");
                 return false;
             }
-            isSwf = isSwfFilename(data);
+            filename = data;
         } else if (params && params["movie"]) {
             // Don't polyfill when the file is a YouTube Flash source.
             if (isYoutubeFlashSource(params["movie"])) {
@@ -267,7 +269,7 @@ export class RuffleObject extends RufflePlayer {
                 }
                 return false;
             }
-            isSwf = isSwfFilename(params["movie"]);
+            filename = params["movie"];
         } else {
             // Don't polyfill when no file is specified.
             return false;
@@ -295,14 +297,7 @@ export class RuffleObject extends RufflePlayer {
             return false;
         }
 
-        // Check for MIME type.
-        const type = elem.attributes.getNamedItem("type");
-        if (!type) {
-            // If no MIME type is specified, polyfill if movie is an SWF file.
-            return isSwf;
-        } else {
-            return isSwfMimeType(type.value, isSwf);
-        }
+        return isSwf(filename, type);
     }
 
     /**

--- a/web/packages/core/src/swf-utils.ts
+++ b/web/packages/core/src/swf-utils.ts
@@ -6,10 +6,10 @@ import {
 } from "./flash-identifiers";
 
 /**
- * Returns whether the given filename ends in a known flash extension.
+ * Returns whether the given filename ends in a known Flash extension.
  *
  * @param filename The filename to test.
- * @returns True if the filename is a flash movie (swf or spl).
+ * @returns True if the filename is a Flash movie (swf or spl).
  */
 export function isSwfFilename(filename: string | null): boolean {
     if (filename) {
@@ -31,21 +31,33 @@ export function isSwfFilename(filename: string | null): boolean {
 }
 
 /**
- * Returns whether the given MIME type is a known flash type.
+ * Returns whether the given MIME type is a known Flash type.
  *
  * @param mimeType The MIME type to test.
- * @returns True if the MIME type is a flash MIME type.
+ * @param allowExtraMimes Whether the polyfill should allow extra MIME types.
+ * @returns True if the MIME type is a Flash MIME type.
  */
-export function isSwfMimeType(mimeType: string): boolean {
-    switch (mimeType.toLowerCase()) {
+export function isSwfMimeType(
+    mimeType: string,
+    allowExtraMimes: boolean
+): boolean {
+    mimeType = mimeType.toLowerCase();
+    switch (mimeType) {
         case FLASH_MIMETYPE.toLowerCase():
         case FUTURESPLASH_MIMETYPE.toLowerCase():
         case FLASH7_AND_8_MIMETYPE.toLowerCase():
         case FLASH_MOVIE_MIMETYPE.toLowerCase():
             return true;
         default:
-            return false;
+            if (allowExtraMimes) {
+                switch (mimeType) {
+                    case "application/octet-stream":
+                    case "binary/octet-stream":
+                        return true;
+                }
+            }
     }
+    return false;
 }
 
 /**

--- a/web/packages/core/src/swf-utils.ts
+++ b/web/packages/core/src/swf-utils.ts
@@ -11,20 +11,18 @@ import {
  * @param filename The filename to test.
  * @returns True if the filename is a Flash movie (swf or spl).
  */
-export function isSwfFilename(filename: string | null): boolean {
-    if (filename) {
-        let pathname = "";
-        try {
-            // A base URL is required if `filename` is a relative URL, but we don't need to detect the real URL origin.
-            pathname = new URL(filename, "https://example.com").pathname;
-        } catch (err) {
-            // Some invalid filenames, like `///`, could raise a TypeError. Let's fail silently in this situation.
-        }
-        if (pathname && pathname.length >= 4) {
-            const extension = pathname.slice(-4).toLowerCase();
-            if (extension === ".swf" || extension === ".spl") {
-                return true;
-            }
+function isSwfFilename(filename: string): boolean {
+    let pathname = "";
+    try {
+        // A base URL is required if `filename` is a relative URL, but we don't need to detect the real URL origin.
+        pathname = new URL(filename, "https://example.com").pathname;
+    } catch (err) {
+        // Some invalid filenames, like `///`, could raise a TypeError. Let's fail silently in this situation.
+    }
+    if (pathname && pathname.length >= 4) {
+        const extension = pathname.slice(-4).toLowerCase();
+        if (extension === ".swf" || extension === ".spl") {
+            return true;
         }
     }
     return false;
@@ -34,13 +32,10 @@ export function isSwfFilename(filename: string | null): boolean {
  * Returns whether the given MIME type is a known Flash type.
  *
  * @param mimeType The MIME type to test.
- * @param allowExtraMimes Whether the polyfill should allow extra MIME types.
+ * @param allowExtraMimes Whether extra MIME types, non-Flash related, are allowed.
  * @returns True if the MIME type is a Flash MIME type.
  */
-export function isSwfMimeType(
-    mimeType: string,
-    allowExtraMimes: boolean
-): boolean {
+function isSwfMimeType(mimeType: string, allowExtraMimes: boolean): boolean {
     mimeType = mimeType.toLowerCase();
     switch (mimeType) {
         case FLASH_MIMETYPE.toLowerCase():
@@ -50,6 +45,9 @@ export function isSwfMimeType(
             return true;
         default:
             if (allowExtraMimes) {
+                // Allow extra MIME types to improve detection of Flash content.
+                // Extension: Some sites (e.g. swfchan.net) might (wrongly?) serve files with octet-stream.
+                // Polyfill: Other sites (e.g. #11050) might use octet-stream when defining an <embed> tag.
                 switch (mimeType) {
                     case "application/octet-stream":
                     case "binary/octet-stream":
@@ -58,6 +56,23 @@ export function isSwfMimeType(
             }
     }
     return false;
+}
+
+/**
+ * Returns whether the given filename and MIME type resolve as a Flash content.
+ *
+ * @param filename The filename to test.
+ * @param mimeType The MIME type to test.
+ * @returns True if the given arguments resolve as a Flash content.
+ */
+export function isSwf(filename: string, mimeType: string | null): boolean {
+    const isSwfExtension = isSwfFilename(filename);
+    if (!mimeType) {
+        // If no MIME type is specified (null or empty string), returns whether the movie ends in a known Flash extension.
+        return isSwfExtension;
+    } else {
+        return isSwfMimeType(mimeType, isSwfExtension);
+    }
 }
 
 /**

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -23,11 +23,7 @@ function isSwf(
         .match(/^\s*(.*?)\s*(?:;.*)?$/)![1]!;
 
     // Some sites (e.g. swfchan.net) might (wrongly?) send octet-stream, so check file extension too.
-    if (mimeType.endsWith("octet-stream")) {
-        return isSwfFilename(details.url);
-    } else {
-        return isSwfMimeType(mimeType);
-    }
+    return isSwfMimeType(mimeType, isSwfFilename(details.url));
 }
 
 function onHeadersReceived(

--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -1,12 +1,12 @@
 import * as utils from "./utils";
-import { isSwfFilename, isSwfMimeType } from "ruffle-core";
+import { isSwf as isSwfCore } from "ruffle-core";
 
 function isSwf(
     details:
         | chrome.webRequest.WebResponseHeadersDetails
         | browser.webRequest._OnHeadersReceivedDetails
 ) {
-    // TypeScript doesn't compile without this explicit type delaration.
+    // TypeScript doesn't compile without this explicit type declaration.
     const headers: (
         | chrome.webRequest.HttpHeader
         | browser.webRequest._HttpHeaders
@@ -22,8 +22,7 @@ function isSwf(
         .value!.toLowerCase()
         .match(/^\s*(.*?)\s*(?:;.*)?$/)![1]!;
 
-    // Some sites (e.g. swfchan.net) might (wrongly?) send octet-stream, so check file extension too.
-    return isSwfMimeType(mimeType, isSwfFilename(details.url));
+    return isSwfCore(details.url, mimeType);
 }
 
 function onHeadersReceived(


### PR DESCRIPTION
Closes #11050, by making the polyfill more lenient with the "application/octet-stream" and "binary/octet-stream" MIME types, as suggested by @n0samu in https://github.com/ruffle-rs/ruffle/issues/11050#issuecomment-1547507019.