### PR TITLE
desktop: rewrite AS3 warning popup in egui

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -452,6 +452,13 @@ impl App {
                     );
                 }
 
+                winit::event::Event::UserEvent(RuffleEvent::DisplayUnsupportedMessage) => {
+                    self.gui
+                        .lock()
+                        .expect("Gui lock")
+                        .display_unsupported_message();
+                }
+
                 winit::event::Event::UserEvent(RuffleEvent::CloseFile) => {
                     self.player.destroy();
                 }

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -24,4 +24,6 @@ pub enum RuffleEvent {
 
     /// The user selected an item in the right-click context menu.
     ContextMenuItemClicked(usize),
+
+    DisplayUnsupportedMessage,
 }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -60,6 +60,7 @@ pub const MENU_HEIGHT: u32 = 24;
 pub struct RuffleGui {
     event_loop: EventLoopProxy<RuffleEvent>,
     is_about_visible: bool,
+    is_as3_warning_visible: bool,
     context_menu: Vec<ruffle_core::ContextMenuItem>,
     locale: LanguageIdentifier,
     default_player_options: PlayerOptions,
@@ -79,6 +80,7 @@ impl RuffleGui {
         Self {
             event_loop,
             is_about_visible: false,
+            is_as3_warning_visible: false,
             context_menu: vec![],
             locale,
             default_player_options,
@@ -101,6 +103,8 @@ impl RuffleGui {
         self.about_window(egui_ctx);
         self.open_dialog(egui_ctx);
 
+        self.as3_warning(egui_ctx);
+
         if !self.context_menu.is_empty() {
             self.context_menu(egui_ctx);
         }
@@ -112,6 +116,10 @@ impl RuffleGui {
 
     pub fn is_context_menu_visible(&self) -> bool {
         !self.context_menu.is_empty()
+    }
+
+    pub fn display_unsupported_message(&mut self) {
+        self.is_as3_warning_visible = true;
     }
 
     /// Renders the main menu bar at the top of the window.
@@ -206,6 +214,35 @@ impl RuffleGui {
                 });
             });
         });
+    }
+
+    fn as3_warning(&mut self, egui_ctx: &egui::Context) {
+        let mut keep_open = true;
+        egui::Window::new("AS3 warning")
+            .collapsible(false)
+            .resizable(false)
+            .title_bar(false)
+            .anchor(Align2::CENTER_TOP, (0.0, 50.0))
+            .open(&mut self.is_as3_warning_visible)
+            .show(egui_ctx, |ui| {
+                ui.set_min_width(400.0);
+                ui.label("The Ruffle emulator may not yet fully support all of ActionScript 3 used by this content.");
+                ui.label("Some parts of the content may not work as expected.");
+
+                ui.label("See the following link for more info:");
+                ui.hyperlink_to(
+                    "https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users",
+                    "https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users",
+                );
+                ui.label("(click anywhere to continue)");
+
+                if ui.input(|i| i.key_pressed(Key::Escape) || i.pointer.any_click()) {
+                    keep_open = false;
+                }
+            });
+        if !keep_open {
+            self.is_as3_warning_visible = false;
+        }
     }
 
     fn about_window(&mut self, egui_ctx: &egui::Context) {

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -169,6 +169,10 @@ impl GuiController {
         )
     }
 
+    pub fn display_unsupported_message(&mut self) {
+        self.gui.display_unsupported_message();
+    }
+
     pub fn render(&mut self, mut player: Option<MutexGuard<Player>>) {
         let surface_texture = self
             .surface

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -121,7 +121,10 @@ impl ActivePlayer {
             .with_navigator(navigator)
             .with_renderer(renderer)
             .with_storage(DiskStorageBackend::new().expect("Couldn't create storage backend"))
-            .with_ui(DesktopUiBackend::new(window.clone()).expect("Couldn't create ui backend"))
+            .with_ui(
+                DesktopUiBackend::new(event_loop.clone(), window.clone())
+                    .expect("Couldn't create ui backend"),
+            )
             .with_autoplay(true)
             .with_letterbox(opt.letterbox)
             .with_max_execution_duration(Duration::from_secs_f64(opt.max_execution_duration))


### PR DESCRIPTION
Not a fan of how many layers I needed to go through hah ;D

Benefits:
- doesn't block the main thread anymore
- can be dismissed by clicking anywhere
- the link is actually clickable :)

Ideally this code can be later reused to replace the generic AS3 popup by a per-feature popup, but that's out of scope.
I didn't touch the other messages supported by the DesktopUiBackend.