### PR TITLE
core: Mark stack-heavy DO functions as noinline

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1663,6 +1663,7 @@ pub trait TDisplayObject<'gc>:
     /// Since we construct AVM2 display objects after they are allocated and
     /// placed on the render list, these steps have to be done by the child
     /// object to signal to its parent that it was added.
+    #[inline(never)]
     fn on_construction_complete(&self, context: &mut UpdateContext<'_, 'gc>) {
         if !self.placed_by_script() {
             // Since we construct AVM2 display objects after they are

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -2059,6 +2059,7 @@ impl<'gc> MovieClip<'gc> {
     /// This function does *not* call the constructor; it is intended that you
     /// will construct the object first before doing so. This function is
     /// intended to be called from `construct_frame`.
+    #[inline(never)]
     fn allocate_as_avm2_object(
         self,
         context: &mut UpdateContext<'_, 'gc>,
@@ -2092,6 +2093,7 @@ impl<'gc> MovieClip<'gc> {
     /// This function does *not* allocate the object; it is intended that you
     /// will allocate the object first before doing so. This function is
     /// intended to be called from `post_instantiate`.
+    #[inline(never)]
     fn construct_as_avm2_object(self, context: &mut UpdateContext<'_, 'gc>) {
         let class_object = self
             .0


### PR DESCRIPTION
This should make the stack size commit of https://github.com/ruffle-rs/ruffle/pull/11261 unnecessary.
@Aaron1011 can you try it out please? I'm confident it'll work on desktop, but slightly worried about wasm-opt messing things up.