### PR TITLE
tests: Enable tracing_subscriber in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4529,6 +4529,8 @@ dependencies = [
  "ruffle_video_software",
  "serde",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "63dab12871321e0e5ada10ff1f1de8f4cf1764f9" }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 # Don't optimize build scripts and macros.
 [profile.release.build-override]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ fnv = "1.0.7"
 gc-arena = { workspace = true }
 generational-arena = "0.2.9"
 indexmap = "1.9.3"
-tracing = "0.1.37"
+tracing = { workspace = true }
 ruffle_render = { path = "../render", features = ["tessellator"] }
 ruffle_video = { path = "../video" }
 ruffle_macros = { path = "macros" }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -17,9 +17,9 @@ ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymose
 ruffle_render = { path = "../render", features = ["clap"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing = { workspace = true}
+tracing-subscriber = { workspace = true }
 generational-arena = "0.2.9"
-tracing = "0.1.37"
 winit = "0.28.6"
 webbrowser = "0.8.10"
 url = "2.4.0"

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 ruffle_wstr = { path = "../wstr" }
 swf = { path = "../swf"}
-tracing = "0.1.37"
+tracing = { workspace = true }
 gif = "0.12.0"
 png = { version = "0.17.9" }
 flate2 = "1.0.26"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 wgpu = { version = "0.16", features = ["naga"] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 ruffle_render = { path = "..", features = ["tessellator"] }
 bytemuck = { version = "1.13.1", features = ["derive"] }
 raw-window-handle = "0.5"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,6 +28,8 @@ imgtests = ["ruffle_video_software"]
 approx = "0.5.1"
 pretty_assertions = "1.3.0"
 env_logger = "0.10.0"
+tracing = { workspace = true}
+tracing-subscriber = { workspace = true }
 serde = "1.0"
 toml = "0.7.4"
 libtest-mimic = "0.6.0"

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -16,12 +16,17 @@ mod util;
 
 fn set_logger() {
     let _ = env_logger::Builder::from_env(
-        env_logger::Env::default()
-            .default_filter_or("info,ruffle_render_wgpu=warn,wgpu_core=warn,wgpu_hal=warn"),
+        env_logger::Env::default().default_filter_or("info,wgpu_core=warn,wgpu_hal=warn"),
     )
     .format_timestamp(None)
     .is_test(true)
     .try_init();
+
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .finish();
+    // Ignore error if it's already been set
+    let _ = tracing::subscriber::set_global_default(subscriber);
 }
 
 fn is_candidate(args: &Arguments, test_name: &str) -> bool {

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -30,7 +30,7 @@ profiling = []
 console_error_panic_hook = { version = "0.1.7", optional = true }
 generational-arena = "0.2.9"
 js-sys = "0.3.63"
-tracing = { version = "0.1.37", features = ["log"] }
+tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { version = "0.3.17", default-features = false, features = ["registry"] }
 tracing-log = "0.1.3"
 tracing-wasm = "0.2.1"

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 js-sys = "0.3.63"
-tracing = "0.1.37"
+tracing = { workspace = true }
 wasm-bindgen = "=0.2.86"
 
 [dependencies.web-sys]


### PR DESCRIPTION
Previously, we weren't displaying any Ruffle logs when running tests.