### PR TITLE
ci: Provide `sha512sums` in AUR package

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -500,8 +500,16 @@ jobs:
         with:
           format: YYYY.MM.DD
 
+      - name: Download Linux x86_64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-x86_64
+
       - name: Update PKGBUILD
-        run: sed -e "s/@VERSION@/${{ steps.current_time_dots.outputs.formattedTime }}/" -i ./PKGBUILD
+        run: >
+          sed -i ./PKGBUILD
+          -e "s/@VERSION@/${{ steps.current_time_dots.outputs.formattedTime }}/"
+          -e "s/@SHA512SUM@/$(sha512sum ${{ needs.build.needs.create-nightly-release.outputs.package_prefix }}-linux-x86_64.tar.gz | cut -d' ' -f1)/"
 
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@v2.7.0

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ depends=(openssl zlib libxcb alsa-lib)
 provides=(ruffle)
 conflicts=(ruffle-git)
 source=("https://github.com/ruffle-rs/ruffle/releases/download/nightly-${pkgver//./-}/ruffle-nightly-${pkgver//./_}-linux-x86_64.tar.gz")
-sha512sums=('SKIP')
+sha512sums=(@SHA512SUM@)
 
 package() {
 	cd "$srcdir/"


### PR DESCRIPTION
Previously it was skipped, which isn't a good practice.