### PR TITLE
desktop: `Open Advanced` improvements

### DIFF
--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -11,6 +11,7 @@ file-menu = File
 file-menu-open-quick = Open...
 file-menu-open-advanced = Open Advanced...
 file-menu-close = Close
+file-menu-reload = Reload
 file-menu-exit = Exit
 
 controls-menu = Controls

--- a/desktop/assets/texts/en-US/open_dialog.ftl
+++ b/desktop/assets/texts/en-US/open_dialog.ftl
@@ -4,3 +4,4 @@ open-dialog-path = File or URL
 
 open-dialog-add-parameter = Add
 open-dialog-delete-parameter = Delete
+open-dialog-clear-parameters = Clear all

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -58,11 +58,7 @@ impl App {
         );
 
         if let Some(movie_url) = movie_url {
-            player.create(
-                &PlayerOptions::from(&opt),
-                movie_url,
-                gui.create_movie_view(),
-            );
+            gui.create_movie(&mut player, PlayerOptions::from(&opt), movie_url);
         } else {
             gui.show_open_dialog();
         }
@@ -194,12 +190,10 @@ impl App {
                         }
                         WindowEvent::DroppedFile(file) => {
                             if let Ok(url) = parse_url(&file) {
-                                let movie_view =
-                                    self.gui.lock().expect("Gui lock").create_movie_view();
-                                self.player.create(
-                                    &PlayerOptions::from(&self.opt),
+                                self.gui.lock().expect("Gui lock").create_movie(
+                                    &mut self.player,
+                                    PlayerOptions::from(&self.opt),
                                     url,
-                                    movie_view,
                                 );
                             }
                         }
@@ -430,19 +424,19 @@ impl App {
 
                 winit::event::Event::UserEvent(RuffleEvent::BrowseAndOpen(options)) => {
                     if let Some(url) = pick_file(false).and_then(|p| Url::from_file_path(p).ok()) {
-                        self.player.create(
-                            &options,
+                        self.gui.lock().expect("Gui lock").create_movie(
+                            &mut self.player,
+                            *options,
                             url,
-                            self.gui.lock().expect("Gui lock").create_movie_view(),
                         );
                     }
                 }
 
                 winit::event::Event::UserEvent(RuffleEvent::OpenURL(url, options)) => {
-                    self.player.create(
-                        &options,
+                    self.gui.lock().expect("Gui lock").create_movie(
+                        &mut self.player,
+                        *options,
                         url,
-                        self.gui.lock().expect("Gui lock").create_movie_view(),
                     );
                 }
 

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -423,7 +423,9 @@ impl App {
                 }
 
                 winit::event::Event::UserEvent(RuffleEvent::BrowseAndOpen(options)) => {
-                    if let Some(url) = pick_file(false).and_then(|p| Url::from_file_path(p).ok()) {
+                    if let Some(url) =
+                        pick_file(false, None).and_then(|p| Url::from_file_path(p).ok())
+                    {
                         self.gui.lock().expect("Gui lock").create_movie(
                             &mut self.player,
                             *options,

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -30,12 +30,7 @@ pub struct App {
 
 impl App {
     pub fn new(opt: Opt) -> Result<Self, Error> {
-        let movie_url = if let Some(path) = &opt.input_path {
-            Some(parse_url(path).context("Couldn't load specified path")?)
-        } else {
-            None
-        };
-
+        let movie_url = opt.movie_url.clone();
         let icon_bytes = include_bytes!("../assets/favicon-32.rgba");
         let icon =
             Icon::from_rgba(icon_bytes.to_vec(), 32, 32).context("Couldn't load app icon")?;
@@ -97,7 +92,7 @@ impl App {
         let mut modifiers = ModifiersState::empty();
         let mut fullscreen_down = false;
 
-        if self.opt.input_path.is_none() {
+        if self.opt.movie_url.is_none() {
             // No SWF provided on command line; show window with dummy movie immediately.
             self.window.set_visible(true);
             loaded = LoadingState::Loaded;

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -1,11 +1,12 @@
 use crate::RUFFLE_VERSION;
+use anyhow::Error;
 use clap::Parser;
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::config::Letterbox;
 use ruffle_core::{LoadBehavior, StageScaleMode};
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use url::Url;
 
 #[derive(Parser, Debug)]
@@ -16,8 +17,8 @@ use url::Url;
 )]
 pub struct Opt {
     /// Path or URL of a Flash movie (SWF) to play.
-    #[clap(name = "FILE")]
-    pub input_path: Option<PathBuf>,
+    #[clap(name = "FILE", value_parser(parse_movie_file_or_url))]
+    pub movie_url: Option<Url>,
 
     /// A "flashvars" parameter to provide to the movie.
     /// This can be repeated multiple times, for example -Pkey=value -Pfoo=bar.
@@ -70,7 +71,7 @@ pub struct Opt {
     /// Location to store a wgpu trace output
     #[clap(long)]
     #[cfg(feature = "render_trace")]
-    trace_path: Option<PathBuf>,
+    trace_path: Option<std::path::PathBuf>,
 
     /// Proxy to use when loading movies via URL.
     #[clap(long)]
@@ -113,6 +114,10 @@ pub struct Opt {
     /// The handling mode of links opening a new website.
     #[clap(long, default_value = "allow")]
     pub open_url_mode: OpenURLMode,
+}
+
+fn parse_movie_file_or_url(path: &str) -> Result<Url, Error> {
+    crate::util::parse_url(Path::new(path))
 }
 
 impl Opt {

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -156,6 +156,11 @@ impl RuffleGui {
                 self.open_file(ui);
             }
             if ui.ctx().input_mut(|input| {
+                input.consume_shortcut(&KeyboardShortcut::new(Modifiers::COMMAND | Modifiers::SHIFT, Key::O))
+            }) {
+                self.open_file_advanced();
+            }
+            if ui.ctx().input_mut(|input| {
                 input.consume_shortcut(&KeyboardShortcut::new(Modifiers::COMMAND, Key::Q))
             }) {
                 self.request_exit(ui);
@@ -171,8 +176,8 @@ impl RuffleGui {
             menu::bar(ui, |ui| {
                 menu::menu_button(ui, text(&self.locale, "file-menu"), |ui| {
                     let mut shortcut;
-                    shortcut = KeyboardShortcut::new(Modifiers::COMMAND, Key::O);
 
+                    shortcut = KeyboardShortcut::new(Modifiers::COMMAND, Key::O);
                     if Button::new(text(&self.locale, "file-menu-open-quick"))
                         .shortcut_text(ui.ctx().format_shortcut(&shortcut))
                         .ui(ui)
@@ -181,7 +186,10 @@ impl RuffleGui {
                         self.open_file(ui);
                     }
 
-                    if Button::new(text(&self.locale, "file-menu-open-advanced")).ui(ui).clicked() {
+                    shortcut = KeyboardShortcut::new(Modifiers::COMMAND | Modifiers::SHIFT, Key::O);
+                    if Button::new(text(&self.locale, "file-menu-open-advanced"))
+                        .shortcut_text(ui.ctx().format_shortcut(&shortcut))
+                        .ui(ui).clicked() {
                         ui.close_menu();
                         self.open_file_advanced();
                     }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -141,6 +141,18 @@ impl RuffleGui {
         self.is_as3_warning_visible = true;
     }
 
+    /// Notifies the GUI that a new player was created.
+    fn on_player_created(&mut self, opt: PlayerOptions, movie_url: Url) {
+        // Update dialog state to reflect the newly-opened movie's options.
+        self.is_open_dialog_visible = false;
+        self.open_dialog = OpenDialog::new(
+            opt,
+            Some(movie_url),
+            self.event_loop.clone(),
+            self.locale.clone(),
+        );
+    }
+
     /// Renders the main menu bar at the top of the window.
     fn main_menu_bar(
         &mut self,
@@ -408,7 +420,6 @@ impl RuffleGui {
 
     fn open_file(&mut self, ui: &mut egui::Ui) {
         ui.close_menu();
-        self.is_open_dialog_visible = false;
 
         let _ = self
             .event_loop

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -192,8 +192,7 @@ impl GuiController {
             self.gui.update(
                 context,
                 self.window.fullscreen().is_none(),
-                player.is_some(),
-                &mut player.as_deref_mut(),
+                player.as_deref_mut(),
             );
         });
         self.repaint_after = full_output.repaint_after;

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -2,7 +2,7 @@ use crate::cli::Opt;
 use crate::custom_event::RuffleEvent;
 use crate::gui::movie::{MovieView, MovieViewRenderer};
 use crate::gui::RuffleGui;
-use crate::player::PlayerOptions;
+use crate::player::{PlayerController, PlayerOptions};
 use anyhow::anyhow;
 use egui::Context;
 use ruffle_core::Player;
@@ -12,6 +12,7 @@ use ruffle_render_wgpu::utils::{format_list, get_backend_names};
 use std::rc::Rc;
 use std::sync::{Arc, MutexGuard};
 use std::time::{Duration, Instant};
+use url::Url;
 use winit::dpi::PhysicalSize;
 use winit::event_loop::EventLoop;
 use winit::window::{Theme, Window};
@@ -160,13 +161,20 @@ impl GuiController {
         response.consumed
     }
 
-    pub fn create_movie_view(&self) -> MovieView {
-        MovieView::new(
+    pub fn create_movie(
+        &mut self,
+        player: &mut PlayerController,
+        opt: PlayerOptions,
+        movie_url: Url,
+    ) {
+        let movie_view = MovieView::new(
             self.movie_view_renderer.clone(),
             &self.descriptors.device,
             self.size.width,
             self.size.height,
-        )
+        );
+        player.create(&opt, &movie_url, movie_view);
+        self.gui.on_player_created(opt, movie_url);
     }
 
     pub fn display_unsupported_message(&mut self) {

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -98,7 +98,7 @@ impl GuiController {
         ));
         let egui_renderer = egui_wgpu::Renderer::new(&descriptors.device, surface_format, None, 1);
         let event_loop = event_loop.create_proxy();
-        let gui = RuffleGui::new(event_loop, PlayerOptions::from(opt));
+        let gui = RuffleGui::new(event_loop, opt.movie_url.clone(), PlayerOptions::from(opt));
         Ok(Self {
             descriptors: Arc::new(descriptors),
             egui_ctx,

--- a/desktop/src/gui/open_dialog.rs
+++ b/desktop/src/gui/open_dialog.rs
@@ -360,6 +360,16 @@ impl OpenDialog {
                     .parameters
                     .push((Default::default(), Default::default()));
             }
+
+            if ui
+                .add_enabled(
+                    !self.options.parameters.is_empty(),
+                    Button::new(text(&self.locale, "open-dialog-clear-parameters")),
+                )
+                .clicked()
+            {
+                self.options.parameters.clear();
+            }
         });
 
         Grid::new("open-file-params")

--- a/desktop/src/gui/open_dialog.rs
+++ b/desktop/src/gui/open_dialog.rs
@@ -434,7 +434,17 @@ impl PathOrUrlField {
     pub fn ui(&mut self, locale: &LanguageIdentifier, ui: &mut Ui) -> &mut Self {
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             if ui.button(text(locale, "browse")).clicked() {
-                if let Some(path) = pick_file(true) {
+                let dir = self
+                    .result
+                    .as_ref()
+                    .filter(|url| url.scheme() == "file")
+                    .and_then(|url| url.to_file_path().ok())
+                    .map(|mut path| {
+                        path.pop();
+                        path
+                    });
+
+                if let Some(path) = pick_file(true, dir) {
                     self.value = path.to_string_lossy().to_string();
                 }
             }

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -80,7 +80,7 @@ impl ActivePlayer {
     pub fn new(
         opt: &PlayerOptions,
         event_loop: EventLoopProxy<RuffleEvent>,
-        movie_url: Url,
+        movie_url: &Url,
         window: Rc<Window>,
         descriptors: Arc<Descriptors>,
         movie_view: MovieView,
@@ -190,7 +190,7 @@ impl PlayerController {
         }
     }
 
-    pub fn create(&mut self, opt: &PlayerOptions, movie_url: Url, movie_view: MovieView) {
+    pub fn create(&mut self, opt: &PlayerOptions, movie_url: &Url, movie_view: MovieView) {
         self.player = Some(ActivePlayer::new(
             opt,
             self.event_loop.clone(),

--- a/desktop/src/time_demo.rs
+++ b/desktop/src/time_demo.rs
@@ -43,12 +43,11 @@ fn load_movie(url: &Url, opt: &Opt) -> Result<SwfMovie, Error> {
     Ok(movie)
 }
 
-pub fn run_timedemo(opt: Opt) -> Result<(), Error> {
-    let path = opt
-        .input_path
-        .as_ref()
+pub fn run_timedemo(mut opt: Opt) -> Result<(), Error> {
+    let movie_url = opt
+        .movie_url
+        .take()
         .ok_or_else(|| anyhow!("Input file necessary for timedemo"))?;
-    let movie_url = crate::util::parse_url(path)?;
     let movie = load_movie(&movie_url, &opt).context("Couldn't load movie")?;
     let movie_frames = Some(movie.num_frames());
 
@@ -80,7 +79,7 @@ pub fn run_timedemo(opt: Opt) -> Result<(), Error> {
 
     let mut player_lock = player.lock().expect("Cannot reenter");
 
-    println!("Running {}...", path.to_string_lossy());
+    println!("Running {}...", movie_url);
 
     let start = Instant::now();
     let mut num_frames = 0;


### PR DESCRIPTION
- Remember options across movie loads;
  - using `Open`  will replace any options by the default options provided on the command-line;
- adds `Ctrl-Shift-O` as a shortcut;
- adds a `Clear all` button to the movie parameters section;
- The `Browse` button automatically opens in the current file's directory.

Also, adds a `File > Reload` menu command to quickly reload the current movie.
