### PR TITLE
core: Unify loader event handler and AVM2 data into MovieLoaderVMData

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -10,6 +10,7 @@ use crate::backend::navigator::{NavigationMethod, Request};
 use crate::context::UpdateContext;
 use crate::display_object::{DisplayObject, MovieClip, TDisplayObject, TDisplayObjectContainer};
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
+use crate::loader::MovieLoaderVMData;
 use crate::string::{AvmString, SwfStrExt as _, WStr, WString};
 use crate::tag_utils::SwfSlice;
 use crate::vminterface::Instantiator;
@@ -1209,8 +1210,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                             level,
                             Request::get(url.to_string()),
                             None,
-                            None,
-                            None,
+                            MovieLoaderVMData::Avm1 { broadcaster: None },
                         );
                         self.context.navigator.spawn_future(future);
                     }
@@ -1340,8 +1340,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         clip_target,
                         request,
                         None,
-                        None,
-                        None,
+                        MovieLoaderVMData::Avm1 { broadcaster: None },
                     );
                     self.context.navigator.spawn_future(future);
                 }
@@ -1362,8 +1361,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                         clip_target,
                         Request::get(url.to_utf8_lossy().into_owned()),
                         None,
-                        None,
-                        None,
+                        MovieLoaderVMData::Avm1 { broadcaster: None },
                     );
                     self.context.navigator.spawn_future(future);
                 }

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -1546,8 +1546,7 @@ fn load_movie<'gc>(
         DisplayObject::MovieClip(target),
         request,
         None,
-        None,
-        None,
+        crate::loader::MovieLoaderVMData::Avm1 { broadcaster: None },
     );
     activation.context.navigator.spawn_future(future);
 

--- a/core/src/avm1/globals/movie_clip_loader.rs
+++ b/core/src/avm1/globals/movie_clip_loader.rs
@@ -11,7 +11,7 @@ use crate::avm1::{ArrayObject, Object, Value};
 use crate::backend::navigator::Request;
 use crate::context::GcContext;
 use crate::display_object::{TDisplayObject, TDisplayObjectContainer};
-use crate::loader::MovieLoaderEventHandler;
+use crate::loader::MovieLoaderVMData;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "loadClip" => method(load_clip; DONT_ENUM | DONT_DELETE);
@@ -65,8 +65,9 @@ fn load_clip<'gc>(
                     target,
                     Request::get(url.to_utf8_lossy().into_owned()),
                     None,
-                    Some(MovieLoaderEventHandler::Avm1Broadcast(this)),
-                    None,
+                    MovieLoaderVMData::Avm1 {
+                        broadcaster: Some(this),
+                    },
                 );
                 activation.context.navigator.spawn_future(future);
 

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -15,7 +15,7 @@ use crate::avm2_stub_method;
 use crate::backend::navigator::{NavigationMethod, Request};
 use crate::display_object::LoaderDisplay;
 use crate::display_object::MovieClip;
-use crate::loader::{Avm2LoaderData, MovieLoaderEventHandler};
+use crate::loader::MovieLoaderVMData;
 use crate::tag_utils::SwfMovie;
 use std::sync::Arc;
 
@@ -87,13 +87,13 @@ pub fn load<'gc>(
             content.into(),
             request,
             Some(url),
-            Some(MovieLoaderEventHandler::Avm2LoaderInfo(loader_info)),
-            Some(Avm2LoaderData {
+            MovieLoaderVMData::Avm2 {
+                loader_info,
                 context,
                 default_domain: activation
                     .caller_domain()
                     .expect("Missing caller domain in Loader.load"),
-            }),
+            },
         );
         activation.context.navigator.spawn_future(future);
     }
@@ -218,13 +218,13 @@ pub fn load_bytes<'gc>(
             activation.context.player.clone(),
             content.into(),
             bytearray.bytes().to_vec(),
-            Some(MovieLoaderEventHandler::Avm2LoaderInfo(loader_info)),
-            Some(Avm2LoaderData {
+            MovieLoaderVMData::Avm2 {
+                loader_info,
                 context,
                 default_domain: activation
                     .caller_domain()
                     .expect("Missing caller domain in Loader.loadBytes"),
-            }),
+            },
         );
         activation.context.navigator.spawn_future(future);
     }

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -231,7 +231,7 @@ impl<'gc> LoaderInfoObject<'gc> {
                 Some(LoaderStream::Swf(_, root)) => root
                     .as_movie_clip()
                     .map(|mc| mc.loaded_bytes() >= mc.total_bytes())
-                    .unwrap_or(false),
+                    .unwrap_or(true),
                 _ => false,
             };
 


### PR DESCRIPTION
`AVM2Data` was always provided with
`MovieLoaderEventHandler::Avm2LoaderInfo`, so we can unify them into a single enum.