### PR TITLE
desktop: Fix interaction between egui and ruffle cursors

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -1,4 +1,5 @@
 use crate::events::{KeyCode, PlayerEvent, TextControlCode};
+use downcast_rs::Downcast;
 use fluent_templates::loader::langid;
 pub use fluent_templates::LanguageIdentifier;
 use std::borrow::Cow;
@@ -7,7 +8,7 @@ use std::collections::HashSet;
 pub type FullscreenError = Cow<'static, str>;
 pub static US_ENGLISH: LanguageIdentifier = langid!("en-US");
 
-pub trait UiBackend {
+pub trait UiBackend: Downcast {
     fn mouse_visible(&self) -> bool;
 
     fn set_mouse_visible(&mut self, visible: bool);
@@ -40,6 +41,7 @@ pub trait UiBackend {
 
     fn language(&self) -> &LanguageIdentifier;
 }
+impl_downcast!(UiBackend);
 
 /// A mouse cursor icon displayed by the Flash Player.
 /// Communicated from the core to the UI backend via `UiBackend::set_mouse_cursor`.

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -17,6 +17,7 @@ pub struct DesktopUiBackend {
     cursor_visible: bool,
     clipboard: Clipboard,
     language: LanguageIdentifier,
+    preferred_cursor: MouseCursor,
 }
 
 impl DesktopUiBackend {
@@ -31,7 +32,21 @@ impl DesktopUiBackend {
             cursor_visible: true,
             clipboard: Clipboard::new().context("Couldn't get platform clipboard")?,
             language,
+            preferred_cursor: MouseCursor::Arrow,
         })
+    }
+
+    pub fn cursor(&self) -> egui::CursorIcon {
+        if self.cursor_visible {
+            match self.preferred_cursor {
+                MouseCursor::Arrow => egui::CursorIcon::Default,
+                MouseCursor::Hand => egui::CursorIcon::PointingHand,
+                MouseCursor::IBeam => egui::CursorIcon::Text,
+                MouseCursor::Grab => egui::CursorIcon::Grab,
+            }
+        } else {
+            egui::CursorIcon::None
+        }
     }
 }
 
@@ -43,19 +58,11 @@ impl UiBackend for DesktopUiBackend {
     }
 
     fn set_mouse_visible(&mut self, visible: bool) {
-        self.window.set_cursor_visible(visible);
         self.cursor_visible = visible;
     }
 
     fn set_mouse_cursor(&mut self, cursor: MouseCursor) {
-        use winit::window::CursorIcon;
-        let icon = match cursor {
-            MouseCursor::Arrow => CursorIcon::Arrow,
-            MouseCursor::Hand => CursorIcon::Hand,
-            MouseCursor::IBeam => CursorIcon::Text,
-            MouseCursor::Grab => CursorIcon::Grab,
-        };
-        self.window.set_cursor_icon(icon);
+        self.preferred_cursor = cursor;
     }
 
     fn clipboard_content(&mut self) -> String {


### PR DESCRIPTION
Fixes #11255

Now the flash-set cursor is used when you're not interacting with the UI, and a UI-based cursor is used when you are.