### PR TITLE
avm2: flash.net.getClassByAlias/registerClassAlias stub improvements

### DIFF
--- a/core/src/avm2/globals/flash/net.as
+++ b/core/src/avm2/globals/flash/net.as
@@ -2,11 +2,22 @@ package flash.net {
 
     import flash.net.URLRequest;
     import __ruffle__.stub_method;
+    
+    internal var _classLookups:Object = {};
 
     public native function navigateToURL(request:URLRequest, window:String = null):void;
 
-    public function registerClassAlias(a:String, b:Object):void {
+    public function registerClassAlias(name:String, object:Class):void {
         stub_method("flash.net", "registerClassAlias");
+        this._classLookups[name] = object;
+    }
+    
+    public function getClassByAlias(name:String):Class {
+        if (this._classLookups[name]) {
+            return this._classLookups[name];
+        } else {
+            return null;
+        }
     }
 
     public function sendToURL(request:URLRequest):void {


### PR DESCRIPTION
Along with #11465, this fixe s #10179.
Also progresses #9276, which needs `TextField.insertXMLText` next.