### PR TITLE
core: Add options to set and force the stage alignment

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[macro_use]
 mod display_object;
-pub use display_object::{StageDisplayState, StageScaleMode};
+pub use display_object::{StageAlign, StageDisplayState, StageScaleMode};
 
 #[macro_use]
 extern crate smallvec;

--- a/desktop/assets/texts/en-US/settings.ftl
+++ b/desktop/assets/texts/en-US/settings.ftl
@@ -34,14 +34,24 @@ quality-high8x8linear = High (8x8) Linear
 quality-high16x16 = High (16x16)
 quality-high16x16linear = High (16x16) Linear
 
+align = Stage Alignment
+align-center = Center
+align-left = Left
+align-right = Right
+align-top = Top
+align-bottom = Bottom
+align-top-left = Top-Left
+align-bottom-left = Bottom-Left
+align-top-right = Top-Right
+align-bottom-right = Bottom-Right
+align-force = Force
+
 scale-mode = Scale Mode
 scale-mode-exactfit = Exact Fit
 scale-mode-noborder = No Border
 scale-mode-noscale = No Scale
 scale-mode-showall = Show All
-
-force-scale-mode = Force Scale Mode
-force-scale-mode-check = Force
+scale-mode-force = Force
 
 warn-if-unsupported = Warn if Unsupported
 warn-if-unsupported-check = Warn

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -3,7 +3,7 @@ use anyhow::Error;
 use clap::Parser;
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::config::Letterbox;
-use ruffle_core::{LoadBehavior, StageScaleMode};
+use ruffle_core::{LoadBehavior, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use std::path::Path;
@@ -55,6 +55,14 @@ pub struct Opt {
     /// Default quality of the movie.
     #[clap(long, short, default_value = "high")]
     pub quality: StageQuality,
+
+    /// The alignment of the stage.
+    #[clap(long, short)]
+    pub align: Option<StageAlign>,
+
+    /// Prevent movies from changing the stage alignment.
+    #[clap(long, action)]
+    pub force_align: bool,
 
     /// The scale mode of the stage.
     #[clap(long, short, default_value = "show-all")]

--- a/desktop/src/gui/open_dialog.rs
+++ b/desktop/src/gui/open_dialog.rs
@@ -6,7 +6,7 @@ use egui::{
     Align2, Button, Checkbox, ComboBox, DragValue, Grid, Slider, TextEdit, Ui, Widget, Window,
 };
 use ruffle_core::backend::navigator::OpenURLMode;
-use ruffle_core::{LoadBehavior, StageScaleMode};
+use ruffle_core::{LoadBehavior, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;
 use std::path::Path;
 use unic_langid::LanguageIdentifier;
@@ -281,43 +281,119 @@ impl OpenDialog {
                     });
                 ui.end_row();
 
-                ui.label(text(&self.locale, "scale-mode"));
-                ComboBox::from_id_source("open-file-advanced-options-scale")
-                    .selected_text(match self.options.scale {
-                        StageScaleMode::ExactFit => text(&self.locale, "scale-mode-exactfit"),
-                        StageScaleMode::NoBorder => text(&self.locale, "scale-mode-noborder"),
-                        StageScaleMode::NoScale => text(&self.locale, "scale-mode-noscale"),
-                        StageScaleMode::ShowAll => text(&self.locale, "scale-mode-showall"),
-                    })
-                    .show_ui(ui, |ui| {
-                        ui.selectable_value(
-                            &mut self.options.scale,
-                            StageScaleMode::ExactFit,
-                            text(&self.locale, "scale-mode-exactfit"),
-                        );
-                        ui.selectable_value(
-                            &mut self.options.scale,
-                            StageScaleMode::NoBorder,
-                            text(&self.locale, "scale-mode-noborder"),
-                        );
-                        ui.selectable_value(
-                            &mut self.options.scale,
-                            StageScaleMode::NoScale,
-                            text(&self.locale, "scale-mode-noscale"),
-                        );
-                        ui.selectable_value(
-                            &mut self.options.scale,
-                            StageScaleMode::ShowAll,
-                            text(&self.locale, "scale-mode-showall"),
-                        );
-                    });
+                ui.label(text(&self.locale, "align"));
+                ui.horizontal(|ui| {
+                    ComboBox::from_id_source("open-file-advanced-options-align")
+                        .selected_text(match self.options.align {
+                            StageAlign::TOP => text(&self.locale, "align-top"),
+                            StageAlign::BOTTOM => text(&self.locale, "align-bottom"),
+                            StageAlign::LEFT => text(&self.locale, "align-left"),
+                            StageAlign::RIGHT => text(&self.locale, "align-right"),
+                            _ => {
+                                let align = self.options.align;
+                                if align == StageAlign::TOP | StageAlign::LEFT {
+                                    text(&self.locale, "align-top-left")
+                                } else if align == StageAlign::TOP | StageAlign::RIGHT {
+                                    text(&self.locale, "align-top-right")
+                                } else if align == StageAlign::BOTTOM | StageAlign::LEFT {
+                                    text(&self.locale, "align-bottom-left")
+                                } else if align == StageAlign::BOTTOM | StageAlign::RIGHT {
+                                    text(&self.locale, "align-bottom-right")
+                                } else {
+                                    text(&self.locale, "align-center")
+                                }
+                            }
+                        })
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::default(),
+                                text(&self.locale, "align-center"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::TOP,
+                                text(&self.locale, "align-top"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::BOTTOM,
+                                text(&self.locale, "align-bottom"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::LEFT,
+                                text(&self.locale, "align-left"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::RIGHT,
+                                text(&self.locale, "align-right"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::TOP | StageAlign::LEFT,
+                                text(&self.locale, "align-top-left"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::TOP | StageAlign::RIGHT,
+                                text(&self.locale, "align-top-right"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::BOTTOM | StageAlign::LEFT,
+                                text(&self.locale, "align-bottom-left"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.align,
+                                StageAlign::BOTTOM | StageAlign::RIGHT,
+                                text(&self.locale, "align-bottom-right"),
+                            );
+                        });
+                    ui.checkbox(
+                        &mut self.options.force_align,
+                        text(&self.locale, "align-force"),
+                    );
+                });
                 ui.end_row();
 
-                ui.label(text(&self.locale, "force-scale-mode"));
-                ui.checkbox(
-                    &mut self.options.force_scale,
-                    text(&self.locale, "force-scale-mode-check"),
-                );
+                ui.label(text(&self.locale, "scale-mode"));
+                ui.horizontal(|ui| {
+                    ComboBox::from_id_source("open-file-advanced-options-scale")
+                        .selected_text(match self.options.scale {
+                            StageScaleMode::ExactFit => text(&self.locale, "scale-mode-exactfit"),
+                            StageScaleMode::NoBorder => text(&self.locale, "scale-mode-noborder"),
+                            StageScaleMode::NoScale => text(&self.locale, "scale-mode-noscale"),
+                            StageScaleMode::ShowAll => text(&self.locale, "scale-mode-showall"),
+                        })
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(
+                                &mut self.options.scale,
+                                StageScaleMode::ExactFit,
+                                text(&self.locale, "scale-mode-exactfit"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.scale,
+                                StageScaleMode::NoBorder,
+                                text(&self.locale, "scale-mode-noborder"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.scale,
+                                StageScaleMode::NoScale,
+                                text(&self.locale, "scale-mode-noscale"),
+                            );
+                            ui.selectable_value(
+                                &mut self.options.scale,
+                                StageScaleMode::ShowAll,
+                                text(&self.locale, "scale-mode-showall"),
+                            );
+                        });
+                    ui.checkbox(
+                        &mut self.options.force_scale,
+                        text(&self.locale, "scale-mode-force"),
+                    );
+                });
                 ui.end_row();
 
                 ui.label(text(&self.locale, "dummy-external-interface"));

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -11,7 +11,7 @@ use anyhow::anyhow;
 use ruffle_core::backend::audio::AudioBackend;
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::config::Letterbox;
-use ruffle_core::{LoadBehavior, Player, PlayerBuilder, PlayerEvent, StageScaleMode};
+use ruffle_core::{LoadBehavior, Player, PlayerBuilder, PlayerEvent, StageAlign, StageScaleMode};
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
@@ -31,6 +31,8 @@ pub struct PlayerOptions {
     pub max_execution_duration: f64,
     pub base: Option<Url>,
     pub quality: StageQuality,
+    pub align: StageAlign,
+    pub force_align: bool,
     pub scale: StageScaleMode,
     pub volume: f32,
     pub force_scale: bool,
@@ -54,6 +56,8 @@ impl From<&Opt> for PlayerOptions {
             max_execution_duration: value.max_execution_duration,
             base: value.base.clone(),
             quality: value.quality,
+            align: value.align.unwrap_or_default(),
+            force_align: value.force_align,
             scale: value.scale,
             volume: value.volume,
             force_scale: value.force_scale,
@@ -138,6 +142,7 @@ impl ActivePlayer {
             .with_max_execution_duration(Duration::from_secs_f64(opt.max_execution_duration))
             .with_quality(opt.quality)
             .with_warn_on_unsupported_content(opt.warn_on_unsupported_content)
+            .with_align(opt.align, opt.force_align)
             .with_scale_mode(opt.scale, opt.force_scale)
             .with_fullscreen(opt.fullscreen)
             .with_load_behavior(opt.load_behavior)

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -31,6 +31,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     base: null,
     menu: true,
     salign: "",
+    forceAlign: false,
     quality: "high",
     scale: "showAll",
     forceScale: false,

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -415,6 +415,13 @@ export interface BaseLoadOptions {
     salign?: string;
 
     /**
+     * If set to true, movies are prevented from changing the stage alignment.
+     *
+     * @default false
+     */
+    forceAlign?: boolean;
+
+    /**
      * This is equivalent to Stage.quality.
      *
      * @default "high"

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -32,6 +32,7 @@ const defaultConfig = {
     letterbox: "on",
     logLevel: "warn",
     forceScale: true,
+    forceAlign: true,
 };
 
 const swfToFlashVersion = {

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -33,6 +33,7 @@ window.addEventListener("DOMContentLoaded", async () => {
         base: swfUrl.substring(0, swfUrl.lastIndexOf("/") + 1),
         // Override some default values when playing in the extension player page.
         letterbox: "on" as Letterbox,
+        forceAlign: true,
         forceScale: true,
     });
 });

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -19,8 +19,8 @@ use ruffle_core::external::{
 };
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::{
-    Color, Player, PlayerBuilder, PlayerEvent, SandboxType, StageScaleMode, StaticCallstack,
-    ViewportDimensions,
+    Color, Player, PlayerBuilder, PlayerEvent, SandboxType, StageAlign, StageScaleMode,
+    StaticCallstack, ViewportDimensions,
 };
 use ruffle_render::quality::StageQuality;
 use ruffle_video_software::backend::SoftwareVideoBackend;
@@ -260,6 +260,8 @@ struct Config {
     show_menu: bool,
 
     salign: Option<String>,
+
+    force_align: bool,
 
     quality: Option<String>,
 
@@ -580,11 +582,18 @@ impl Ruffle {
                     .and_then(|q| StageQuality::from_str(&q).ok())
                     .unwrap_or(default_quality),
             )
+            .with_align(
+                config
+                    .salign
+                    .and_then(|s| StageAlign::from_str(&s).ok())
+                    .unwrap_or_default(),
+                config.force_align,
+            )
             .with_scale_mode(
                 config
                     .scale
                     .and_then(|s| StageScaleMode::from_str(&s).ok())
-                    .unwrap_or(StageScaleMode::ShowAll),
+                    .unwrap_or_default(),
                 config.force_scale,
             )
             .with_frame_rate(config.frame_rate)
@@ -597,7 +606,6 @@ impl Ruffle {
             // Set config parameters.
             core.set_background_color(config.background_color);
             core.set_show_menu(config.show_menu);
-            core.set_stage_align(config.salign.as_deref().unwrap_or(""));
             core.set_window_mode(config.wmode.as_deref().unwrap_or("window"));
             callstack = Some(core.callstack());
         }


### PR DESCRIPTION
This is basically the same as #9406, except for `salign` instead of `scale`. It can be annoying when games position themselves in a corner of the screen - this allows users to force them to be centered (or move them to any corner, if for some reason they want to).

**Before**
![image](https://github.com/ruffle-rs/ruffle/assets/71368227/f45934fa-f36e-4e66-8839-42a39a3cc4bd)

**After**
![image](https://github.com/ruffle-rs/ruffle/assets/71368227/3124b5bc-da74-4a7c-b4a8-429d436c3f7c)