### PR TITLE
avm2: Implement ErrorObject.display without using Activation

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -327,9 +327,9 @@ impl<'gc> Avm2<'gc> {
         let mut activation = Activation::from_nothing(context.reborrow());
         if let Err(err) = events::dispatch_event(&mut activation, target, event) {
             tracing::error!(
-                "Encountered AVM2 error when dispatching `{}` event: {}",
+                "Encountered AVM2 error when dispatching `{}` event: {:?}",
                 event_name,
-                err.detailed_message(&mut activation),
+                err,
             );
             // TODO: push the error onto `loaderInfo.uncaughtErrorEvents`
         }
@@ -419,9 +419,9 @@ impl<'gc> Avm2<'gc> {
                 if object.is_of_type(on_type, &mut activation.context) {
                     if let Err(err) = events::dispatch_event(&mut activation, object, event) {
                         tracing::error!(
-                            "Encountered AVM2 error when broadcasting `{}` event: {}",
+                            "Encountered AVM2 error when broadcasting `{}` event: {:?}",
                             event_name,
-                            err.detailed_message(&mut activation),
+                            err,
                         );
                         // TODO: push the error onto `loaderInfo.uncaughtErrorEvents`
                     }
@@ -447,7 +447,7 @@ impl<'gc> Avm2<'gc> {
         let mut evt_activation = Activation::from_domain(context.reborrow(), domain);
         callable
             .call(receiver, args, &mut evt_activation)
-            .map_err(|e| e.detailed_message(&mut evt_activation))?;
+            .map_err(|e| format!("{e:?}"))?;
 
         Ok(())
     }

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -417,10 +417,10 @@ pub fn dispatch_event_to_target<'gc>(
 
         if let Err(err) = handler.call(object, &[event.into()], activation) {
             tracing::error!(
-                "Error dispatching event {:?} to handler {:?} : {}",
+                "Error dispatching event {:?} to handler {:?} : {:?}",
                 event,
                 handler,
-                err.detailed_message(activation)
+                err,
             );
         }
     }

--- a/core/src/avm2/globals/error.rs
+++ b/core/src/avm2/globals/error.rs
@@ -1,6 +1,7 @@
 use crate::avm2::activation::Activation;
 pub use crate::avm2::object::error_allocator;
 use crate::avm2::object::Object;
+use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::TObject;
@@ -11,7 +12,7 @@ pub fn get_stack_trace<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(error) = this.and_then(|this| this.as_error_object()) {
-        return Ok(error.display_full(activation)?.into());
+        return Ok(AvmString::new(activation.context.gc_context, error.display_full()?).into());
     }
     Ok(Value::Undefined)
 }

--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -642,11 +642,11 @@ impl<'gc> ChildContainer<'gc> {
                                     &mut activation,
                                 );
                                 if let Err(e) = res {
-                                    tracing::error!("Failed to set child {} ({:?}) to null on parent obj {:?}: {:?}", child.name(), child, parent_obj, e.detailed_message(&mut activation));
+                                    tracing::error!("Failed to set child {} ({:?}) to null on parent obj {:?}: {:?}", child.name(), child, parent_obj, e);
                                 }
                             }
                             Err(e) => {
-                                tracing::error!("Failed to get current value of child {} ({:?}) on parent obj {:?}: {:?}", child.name(), child, parent_obj, e.detailed_message(&mut activation));
+                                tracing::error!("Failed to get current value of child {} ({:?}) on parent obj {:?}: {:?}", child.name(), child, parent_obj, e);
                             }
                         }
                     }

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -746,11 +746,7 @@ impl<'gc> MovieClip<'gc> {
                 swf::DoAbc2Flag::LAZY_INITIALIZE,
                 domain,
             ) {
-                let mut activation = Avm2Activation::from_nothing(context.reborrow());
-                tracing::warn!(
-                    "Error loading ABC file: {}",
-                    e.detailed_message(&mut activation)
-                );
+                tracing::warn!("Error loading ABC file: {e:?}");
             }
         }
 
@@ -775,11 +771,7 @@ impl<'gc> MovieClip<'gc> {
             let name = AvmString::new(context.gc_context, do_abc.name.decode(reader.encoding()));
 
             if let Err(e) = Avm2::do_abc(context, do_abc.data, Some(name), do_abc.flags, domain) {
-                let mut activation = Avm2Activation::from_nothing(context.reborrow());
-                tracing::warn!(
-                    "Error loading ABC file: {}",
-                    e.detailed_message(&mut activation)
-                );
+                tracing::warn!("Error loading ABC file: {e:?}");
             }
         }
 
@@ -869,8 +861,8 @@ impl<'gc> MovieClip<'gc> {
                     }
                 }
                 Err(e) => tracing::warn!(
-                    "Got AVM2 error {} when attempting to assign symbol class {}",
-                    e.detailed_message(&mut activation),
+                    "Got AVM2 error {:?} when attempting to assign symbol class {}",
+                    e,
                     class_name
                 ),
             }
@@ -2121,11 +2113,9 @@ impl<'gc> MovieClip<'gc> {
             let result: Result<(), Avm2Error> = constr_thing();
 
             if let Err(e) = result {
-                let mut activation = Avm2Activation::from_nothing(context.reborrow());
-
                 tracing::error!(
-                    "Got \"{}\" when constructing AVM2 side of movie clip of type {}",
-                    e.detailed_message(&mut activation),
+                    "Got \"{:?}\" when constructing AVM2 side of movie clip of type {}",
+                    e,
                     class_object
                         .try_inner_class_definition()
                         .map(|c| c.read().name().to_qualified_name(context.gc_context))

--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -298,8 +298,8 @@ impl<'gc> Callback<'gc> {
                     Ok(result) => Value::from_avm2(result),
                     Err(e) => {
                         tracing::error!(
-                            "Unhandled error in External Interface callback {name}: {}",
-                            e.detailed_message(&mut activation)
+                            "Unhandled error in External Interface callback {name}: {:?}",
+                            e
                         );
                         Value::Null
                     }

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -156,10 +156,7 @@ impl<'gc> Timers<'gc> {
                     match closure.call(None, &params, &mut avm2_activation) {
                         Ok(v) => v.coerce_to_boolean(),
                         Err(e) => {
-                            tracing::error!(
-                                "Unhandled AVM2 error in timer callback: {}",
-                                e.detailed_message(&mut avm2_activation)
-                            );
+                            tracing::error!("Unhandled AVM2 error in timer callback: {e:?}",);
                             false
                         }
                     }


### PR DESCRIPTION
This lets us print the full error message and stack stacke in contexts where an Activation is not available, including the `Debug` impl.

The 'name' and 'error' fields are accessed using hardcodd slot ids. This is pretty hacky, but will work until we have better handling of slot properties.