### PR TITLE
avm2: Add void type

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -36,6 +36,7 @@ mod string;
 mod toplevel;
 mod r#uint;
 mod vector;
+mod void;
 mod xml;
 mod xml_list;
 
@@ -52,6 +53,7 @@ pub struct SystemClasses<'gc> {
     pub number: ClassObject<'gc>,
     pub int: ClassObject<'gc>,
     pub uint: ClassObject<'gc>,
+    pub void: ClassObject<'gc>,
     pub namespace: ClassObject<'gc>,
     pub array: ClassObject<'gc>,
     pub movieclip: ClassObject<'gc>,
@@ -175,6 +177,7 @@ impl<'gc> SystemClasses<'gc> {
             number: object,
             int: object,
             uint: object,
+            void: object,
             namespace: object,
             array: object,
             movieclip: object,
@@ -547,6 +550,10 @@ pub fn load_player_globals<'gc>(
         script
     );
     avm2_system_class!(array, activation, array::create_class(activation), script);
+
+    // TODO: this should _not_ be exposed as a ClassObject, getDefinitionByName etc.
+    // it should only be visible as an type for typecheck/cast purposes.
+    avm2_system_class!(void, activation, void::create_class(activation), script);
 
     function(activation, "", "trace", toplevel::trace, script)?;
     function(

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -1,0 +1,34 @@
+// note: this should be a ClassObject-less class,
+// with only the instance side.
+
+use crate::avm2::activation::Activation;
+use crate::avm2::class::Class;
+use crate::avm2::method::Method;
+use crate::avm2::object::Object;
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use crate::avm2::QName;
+use gc_arena::GcCell;
+
+fn void_init<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    // note: after class refactor, this method should be unreachable!()
+    // or not exist at all.
+    Ok(Value::Undefined)
+}
+
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+    let mc = activation.context.gc_context;
+    let class = Class::new(
+        QName::new(activation.avm2().public_namespace, "void"),
+        None,
+        Method::from_builtin(void_init, "", mc),
+        Method::from_builtin(void_init, "", mc),
+        mc,
+    );
+
+    class
+}

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1014,6 +1014,12 @@ impl<'gc> Value<'gc> {
         }
 
         if matches!(self, Value::Undefined) || matches!(self, Value::Null) {
+            if GcCell::ptr_eq(
+                class,
+                activation.avm2().classes().void.inner_class_definition(),
+            ) {
+                return Ok(Value::Undefined);
+            }
             return Ok(Value::Null);
         }
 
@@ -1118,6 +1124,15 @@ impl<'gc> Value<'gc> {
             activation.avm2().classes().int.inner_class_definition(),
         ) {
             return self.is_i32();
+        }
+
+        if let Value::Undefined = self {
+            if GcCell::ptr_eq(
+                type_object,
+                activation.avm2().classes().void.inner_class_definition(),
+            ) {
+                return true;
+            }
         }
 
         if let Ok(o) = self.coerce_to_object(activation) {


### PR DESCRIPTION
Still gotta add a test for this.
Note that this as-is lets you do much more than intended, like `new void()` or `var T = void`, which FP doesn't support. Can't really fix this without the class refactor :c  
I don't think this is a major issue, but if you think this is a major risk after all, then we should go with some more targeted hack in type-related opcodes.