### PR TITLE
wgpu: Cache Program3D bind group layout

### DIFF
--- a/core/src/avm2/object/context3d_object.rs
+++ b/core/src/avm2/object/context3d_object.rs
@@ -249,9 +249,8 @@ impl<'gc> Context3DObject<'gc> {
             .unwrap()
             .process_command(
                 Context3DCommand::UploadShaders {
-                    vertex_shader: program.vertex_shader_handle(),
+                    module: program.shader_module_handle(),
                     vertex_shader_agal,
-                    fragment_shader: program.fragment_shader_handle(),
                     fragment_shader_agal,
                 },
                 activation.context.gc_context,
@@ -263,15 +262,9 @@ impl<'gc> Context3DObject<'gc> {
         activation: &mut Activation<'_, 'gc>,
         program: Option<Program3DObject<'gc>>,
     ) {
-        let (vertex_shader, fragment_shader) = match program {
-            Some(program) => (
-                program.vertex_shader_handle(),
-                program.fragment_shader_handle(),
-            ),
-            None => (
-                GcCell::allocate(activation.context.gc_context, None),
-                GcCell::allocate(activation.context.gc_context, None),
-            ),
+        let module = match program {
+            Some(program) => program.shader_module_handle(),
+            None => GcCell::allocate(activation.context.gc_context, None),
         };
 
         self.0
@@ -280,10 +273,7 @@ impl<'gc> Context3DObject<'gc> {
             .as_mut()
             .unwrap()
             .process_command(
-                Context3DCommand::SetShaders {
-                    vertex_shader,
-                    fragment_shader,
-                },
+                Context3DCommand::SetShaders { module },
                 activation.context.gc_context,
             );
     }

--- a/core/src/avm2/object/program_3d_object.rs
+++ b/core/src/avm2/object/program_3d_object.rs
@@ -33,8 +33,7 @@ impl<'gc> Program3DObject<'gc> {
             Program3DObjectData {
                 base,
                 context3d,
-                vertex_shader_handle: GcCell::allocate(activation.context.gc_context, None),
-                fragment_shader_handle: GcCell::allocate(activation.context.gc_context, None),
+                shader_module_handle: GcCell::allocate(activation.context.gc_context, None),
             },
         ))
         .into();
@@ -45,12 +44,8 @@ impl<'gc> Program3DObject<'gc> {
         Ok(this)
     }
 
-    pub fn vertex_shader_handle(&self) -> GcCell<'gc, Option<Rc<dyn ShaderModule>>> {
-        self.0.read().vertex_shader_handle
-    }
-
-    pub fn fragment_shader_handle(&self) -> GcCell<'gc, Option<Rc<dyn ShaderModule>>> {
-        self.0.read().fragment_shader_handle
+    pub fn shader_module_handle(&self) -> GcCell<'gc, Option<Rc<dyn ShaderModule>>> {
+        self.0.read().shader_module_handle
     }
 
     pub fn context3d(&self) -> Context3DObject<'gc> {
@@ -66,9 +61,7 @@ pub struct Program3DObjectData<'gc> {
 
     context3d: Context3DObject<'gc>,
 
-    vertex_shader_handle: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
-
-    fragment_shader_handle: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
+    shader_module_handle: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
 }
 
 impl<'gc> TObject<'gc> for Program3DObject<'gc> {

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -429,15 +429,13 @@ pub enum Context3DCommand<'a, 'gc> {
     },
 
     UploadShaders {
-        vertex_shader: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
+        module: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
         vertex_shader_agal: Vec<u8>,
-        fragment_shader: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
         fragment_shader_agal: Vec<u8>,
     },
 
     SetShaders {
-        vertex_shader: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
-        fragment_shader: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
+        module: GcCell<'gc, Option<Rc<dyn ShaderModule>>>,
     },
     SetProgramConstantsFromVector {
         program_type: ProgramType,

--- a/render/wgpu/src/context3d/shader_pair.rs
+++ b/render/wgpu/src/context3d/shader_pair.rs
@@ -1,0 +1,209 @@
+use gc_arena::Collect;
+use lru::LruCache;
+use naga_agal::{SamplerOverride, VertexAttributeFormat};
+use ruffle_render::backend::ShaderModule;
+use std::{
+    borrow::Cow,
+    cell::{RefCell, RefMut},
+    num::NonZeroUsize,
+};
+use wgpu::SamplerBindingType;
+
+use super::{
+    current_pipeline::{
+        BoundTextureData, SAMPLER_CLAMP_LINEAR, SAMPLER_CLAMP_NEAREST,
+        SAMPLER_CLAMP_U_REPEAT_V_LINEAR, SAMPLER_CLAMP_U_REPEAT_V_NEAREST, SAMPLER_REPEAT_LINEAR,
+        SAMPLER_REPEAT_NEAREST, SAMPLER_REPEAT_U_CLAMP_V_LINEAR, SAMPLER_REPEAT_U_CLAMP_V_NEAREST,
+        TEXTURE_START_BIND_INDEX,
+    },
+    MAX_VERTEX_ATTRIBUTES,
+};
+
+use crate::descriptors::Descriptors;
+
+#[derive(Collect)]
+#[collect(require_static)]
+pub struct ShaderPairAgal {
+    vertex_bytecode: Vec<u8>,
+    fragment_bytecode: Vec<u8>,
+    // Caches compiled wgpu shader modules. The cache key represents all of the data
+    // that we need to pass to `naga_agal::agal_to_naga` to compile a shader.
+    compiled: RefCell<LruCache<ShaderCompileData, CompiledShaderProgram>>,
+}
+
+impl ShaderModule for ShaderPairAgal {}
+
+pub struct CompiledShaderProgram {
+    pub vertex_module: wgpu::ShaderModule,
+    pub fragment_module: wgpu::ShaderModule,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl ShaderPairAgal {
+    pub fn new(vertex_bytecode: Vec<u8>, fragment_bytecode: Vec<u8>) -> Self {
+        Self {
+            vertex_bytecode,
+            fragment_bytecode,
+            // TODO - figure out a good size for this cache.
+            compiled: RefCell::new(LruCache::new(NonZeroUsize::new(2).unwrap())),
+        }
+    }
+
+    pub fn compile(
+        &self,
+        descriptors: &Descriptors,
+        data: ShaderCompileData,
+    ) -> RefMut<'_, CompiledShaderProgram> {
+        let compiled = self.compiled.borrow_mut();
+        RefMut::map(compiled, |compiled| {
+            // TODO: Figure out a way to avoid the clone when we have a cache hit
+            compiled.get_or_insert_mut(data.clone(), || {
+                let vertex_naga_module = naga_agal::agal_to_naga(
+                    &self.vertex_bytecode,
+                    &data.vertex_attributes,
+                    &data.sampler_overrides,
+                )
+                .unwrap();
+                let vertex_module =
+                    descriptors
+                        .device
+                        .create_shader_module(wgpu::ShaderModuleDescriptor {
+                            label: Some("AGAL vertex shader"),
+                            source: wgpu::ShaderSource::Naga(Cow::Owned(vertex_naga_module)),
+                        });
+
+                let fragment_naga_module = naga_agal::agal_to_naga(
+                    &self.fragment_bytecode,
+                    &data.vertex_attributes,
+                    &data.sampler_overrides,
+                )
+                .unwrap();
+                let fragment_module =
+                    descriptors
+                        .device
+                        .create_shader_module(wgpu::ShaderModuleDescriptor {
+                            label: Some("AGAL fragment shader"),
+                            source: wgpu::ShaderSource::Naga(Cow::Owned(fragment_naga_module)),
+                        });
+
+                let mut layout_entries = vec![
+                    // Vertex shader program constants
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::VERTEX,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    // Fragment shader program constants
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    // One sampler per filter/wrapping combination - see BitmapFilters
+                    // An AGAL shader can use any of these samplers, so
+                    // we need to bind them all.
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_REPEAT_LINEAR,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_REPEAT_NEAREST,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_CLAMP_LINEAR,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_CLAMP_NEAREST,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_CLAMP_U_REPEAT_V_LINEAR,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_CLAMP_U_REPEAT_V_NEAREST,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_REPEAT_U_CLAMP_V_LINEAR,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: SAMPLER_REPEAT_U_CLAMP_V_NEAREST,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ];
+
+                for (i, bound_texture) in data.bound_textures.iter().enumerate() {
+                    if let Some(bound_texture) = bound_texture {
+                        let dimension = if bound_texture.cube {
+                            wgpu::TextureViewDimension::Cube
+                        } else {
+                            wgpu::TextureViewDimension::D2
+                        };
+                        layout_entries.push(wgpu::BindGroupLayoutEntry {
+                            binding: TEXTURE_START_BIND_INDEX + i as u32,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Texture {
+                                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                                view_dimension: dimension,
+                                multisampled: false,
+                            },
+                            count: None,
+                        });
+                    }
+                }
+
+                let globals_layout_label = create_debug_label!("Globals bind group layout");
+                let bind_group_layout =
+                    descriptors
+                        .device
+                        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                            label: globals_layout_label.as_deref(),
+                            entries: &layout_entries,
+                        });
+
+                CompiledShaderProgram {
+                    vertex_module,
+                    fragment_module,
+                    bind_group_layout,
+                }
+            })
+        })
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Clone)]
+pub struct ShaderCompileData {
+    pub sampler_overrides: [Option<SamplerOverride>; 8],
+    pub vertex_attributes: [Option<VertexAttributeFormat>; MAX_VERTEX_ATTRIBUTES],
+    pub bound_textures: [Option<BoundTextureData>; 8],
+}


### PR DESCRIPTION
The bind group layout only depends on the texture registers (and 2D/cubemap type) accessed by the fragment shader, not on the runtime texture bound with Context3D. This means that we can build and cache it when we compile the AGAL program to a Naga module.

Since the bind group layout is used for the overall pipeline, I've refactored the shader caching code into `ShaderPairAgal`, which holds both the vertex and fragment shader bytecode, and compiles both in the `compile` function.