### PR TITLE
chore: Bump `tracing-tracy` to version-match `profiling`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
 dependencies = [
  "profiling-procmacros",
- "tracy-client 0.15.2",
+ "tracy-client",
 ]
 
 [[package]]
@@ -4785,13 +4785,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-tracy"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3ebef1f9f0d00aaa29239537effef65b82c56040c680f540fc6cedfac7b230"
+checksum = "55c48ef3e655220d4e43a6be44aa84f078c3004357251cab45f9cc15551a593e"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
- "tracy-client 0.14.2",
+ "tracy-client",
 ]
 
 [[package]]
@@ -4807,33 +4807,13 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3b9ab635a5b91dd66b7a1591a89f7d52423e6a9143b230bb4c503f41296c0c"
-dependencies = [
- "loom",
- "once_cell",
- "tracy-client-sys 0.19.0",
-]
-
-[[package]]
-name = "tracy-client"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608"
 dependencies = [
  "loom",
  "once_cell",
- "tracy-client-sys 0.21.0",
-]
-
-[[package]]
-name = "tracy-client-sys"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcbdba03a3cfc5f757469fd5b6d795fc461484c97e47e94b0fc7db93261d9c5"
-dependencies = [
- "cc",
+ "tracy-client-sys",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4", default-features = false, features = [] }
 fluent-templates = "0.8.0"
 
 # Deliberately held back to match tracy client used by profiling crate
-tracing-tracy = { version = "=0.10.0", optional = true }
+tracing-tracy = { version = "=0.10.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
This fixes `thread 'main' panicked at 'span! without a running Client'` when enabling the `tracy` feature.