### PR TITLE
Canvas & webgl bitmap data cleanup

### DIFF
--- a/render/canvas/src/lib.rs
+++ b/render/canvas/src/lib.rs
@@ -141,7 +141,6 @@ struct CanvasBitmap {
 #[allow(dead_code)]
 #[derive(Debug)]
 struct BitmapData {
-    bitmap: Bitmap,
     image_data: ImageData,
     canvas: HtmlCanvasElement,
     context: CanvasRenderingContext2d,
@@ -180,7 +179,6 @@ impl BitmapData {
             .put_image_data(&image_data, 0.0, 0.0)
             .into_js_result()?;
         Ok(BitmapData {
-            bitmap,
             image_data,
             canvas,
             context,

--- a/render/webgl/src/lib.rs
+++ b/render/webgl/src/lib.rs
@@ -150,7 +150,8 @@ pub struct WebGlRenderBackend {
 #[derive(Debug)]
 struct RegistryData {
     gl: Gl,
-    bitmap: Bitmap,
+    width: u32,
+    height: u32,
     texture: WebGlTexture,
 }
 
@@ -1018,7 +1019,8 @@ impl RenderBackend for WebGlRenderBackend {
 
         Ok(BitmapHandle(Arc::new(RegistryData {
             gl: self.gl.clone(),
-            bitmap,
+            width: bitmap.width(),
+            height: bitmap.height(),
             texture,
         })))
     }
@@ -1134,10 +1136,7 @@ impl CommandHandler for WebGlRenderBackend {
 
         // Scale the quad to the bitmap's dimensions.
         let matrix = transform.matrix
-            * ruffle_render::matrix::Matrix::scale(
-                entry.bitmap.width() as f32,
-                entry.bitmap.height() as f32,
-            );
+            * ruffle_render::matrix::Matrix::scale(entry.width as f32, entry.height as f32);
 
         let world_matrix = [
             [matrix.a, matrix.b, 0.0, 0.0],


### PR DESCRIPTION
This stops us from holding on to way more memory than we need to, and a small refactor split off from my upcoming cacheAsBitmap work