### PR TITLE
web: Use for..of instead of for..in loops

### DIFF
--- a/web/packages/core/src/i18n.ts
+++ b/web/packages/core/src/i18n.ts
@@ -17,14 +17,12 @@ const BUNDLED_TEXTS: LocaleBundle = {
 
 const bundles: Record<string, FluentBundle> = {};
 
-for (const locale in BUNDLED_TEXTS) {
+for (const [locale, files] of Object.entries(BUNDLED_TEXTS)) {
     const bundle = new FluentBundle(locale);
-    const files = BUNDLED_TEXTS[locale];
     if (files) {
-        for (const filename in files) {
-            const text = files[filename];
+        for (const [filename, text] of Object.entries(files)) {
             if (text) {
-                for (const error in bundle.addResource(
+                for (const error of bundle.addResource(
                     new FluentResource(text)
                 )) {
                     console.error(


### PR DESCRIPTION
Some websites add enumerable properties to Array,prototype, which causes spurious errors to be logged when we iterate through the array returned by `bundle.addResource`. That's because `for..in` iterates through all enumerable properties of any object. It's better practice to use `for..of` loops instead, and iterating through Object.entries also makes the code a little cleaner.

This stops the error spam in the console on Kongregate and the site from #11589. It doesn't fix the main problem in #11589 or fix loading localizations on Kongregate though. Localizations are broken on Kongregate because they override some methods on Array.prototype with broken implementations, according to Dinnerbone.