### PR TITLE
cleanup: Rename GlutinAsyncExecutor -> WinitAsyncExecutor.

### DIFF
--- a/desktop/src/executor.rs
+++ b/desktop/src/executor.rs
@@ -20,12 +20,12 @@ struct TaskHandle {
     handle: Index,
 
     /// The executor the task belongs to.
-    executor: Arc<Mutex<GlutinAsyncExecutor>>,
+    executor: Arc<Mutex<WinitAsyncExecutor>>,
 }
 
 impl TaskHandle {
     /// Construct a handle to a given task.
-    fn for_task(task: Index, executor: Arc<Mutex<GlutinAsyncExecutor>>) -> Self {
+    fn for_task(task: Index, executor: Arc<Mutex<WinitAsyncExecutor>>) -> Self {
         Self {
             handle: task,
             executor,
@@ -121,7 +121,7 @@ impl TaskHandle {
     );
 }
 
-pub struct GlutinAsyncExecutor {
+pub struct WinitAsyncExecutor {
     /// List of all spawned tasks.
     task_queue: Arena<Task>,
 
@@ -138,8 +138,8 @@ pub struct GlutinAsyncExecutor {
     waiting_for_poll: bool,
 }
 
-impl GlutinAsyncExecutor {
-    /// Construct a new executor for the Glutin event loop.
+impl WinitAsyncExecutor {
+    /// Construct a new executor for the winit event loop.
     ///
     /// This function returns the executor itself, plus the `Sender` necessary
     /// to spawn new tasks.

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -4,7 +4,7 @@ use crate::backends::{
 };
 use crate::cli::Opt;
 use crate::custom_event::RuffleEvent;
-use crate::executor::GlutinAsyncExecutor;
+use crate::executor::WinitAsyncExecutor;
 use crate::gui::MovieView;
 use crate::{CALLSTACK, RENDER_INFO, SWF_INFO};
 use anyhow::anyhow;
@@ -80,7 +80,7 @@ impl From<&Opt> for PlayerOptions {
 /// which may be lost when this Player is closed (dropped)
 struct ActivePlayer {
     player: Arc<Mutex<Player>>,
-    executor: Arc<Mutex<GlutinAsyncExecutor>>,
+    executor: Arc<Mutex<WinitAsyncExecutor>>,
 }
 
 impl ActivePlayer {
@@ -104,7 +104,7 @@ impl ActivePlayer {
             }
         };
 
-        let (executor, channel) = GlutinAsyncExecutor::new(event_loop.clone());
+        let (executor, channel) = WinitAsyncExecutor::new(event_loop.clone());
         let navigator = ExternalNavigatorBackend::new(
             opt.base.to_owned().unwrap_or_else(|| movie_url.clone()),
             channel,


### PR DESCRIPTION
It should probably have been renamed as part of, or shortly after, f0445d94b.