### PR TITLE
avm2: Optimize coerce_to_primitive for boxed primitives

### DIFF
--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -655,6 +655,7 @@ impl<'gc> Value<'gc> {
         });
 
         match self {
+            Value::Object(Object::PrimitiveObject(o)) => o.value_of(activation.context.gc_context),
             Value::Object(o) if hint == Hint::String => {
                 let mut prim = *self;
                 let object = *o;


### PR DESCRIPTION
This mostly just helps calling String methods, which unavoidably box the String and later call coerce_to_string->coerce_to_primitive on it. Saves some dynamic lookup+call work, saw it measurably reduce overhead on some swfs.

(Long term we should have another way (coerce only when called via prototype method, not class method) - and ofc ideally, not have it be boxed at all.)