### PR TITLE
avm1: Correct `matrix::object_to_matrix_or_default`

### DIFF
--- a/core/src/avm1/globals/matrix.rs
+++ b/core/src/avm1/globals/matrix.rs
@@ -107,41 +107,30 @@ pub fn object_to_matrix<'gc>(
 
 /// Returns a `Matrix` with the properties from `object`.
 ///
-/// Returns the identity matrix if any of the `a`, `b`, `c`, `d`, or `tx` properties do not exist.
+/// Returns the identity matrix if any of the `a`, `b`, `c`, `d`, `tx` or `ty` properties do not exist.
 pub fn object_to_matrix_or_default<'gc>(
     object: Object<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Matrix, Error<'gc>> {
-    // These lookups do not search the prototype chain and ignore virtual properties.
-    let a = object
-        .get_local_stored("a", activation)
-        .unwrap_or(Value::Undefined)
-        .coerce_to_f64(activation)? as f32;
-    let b = object
-        .get_local_stored("b", activation)
-        .unwrap_or(Value::Undefined)
-        .coerce_to_f64(activation)? as f32;
-    let c = object
-        .get_local_stored("c", activation)
-        .unwrap_or(Value::Undefined)
-        .coerce_to_f64(activation)? as f32;
-    let d = object
-        .get_local_stored("d", activation)
-        .unwrap_or(Value::Undefined)
-        .coerce_to_f64(activation)? as f32;
-    let tx = Twips::from_pixels(
-        object
-            .get_local_stored("tx", activation)
-            .unwrap_or(Value::Undefined)
-            .coerce_to_f64(activation)?,
-    );
-    let ty = Twips::from_pixels(
-        object
-            .get_local_stored("ty", activation)
-            .unwrap_or(Value::Undefined)
-            .coerce_to_f64(activation)?,
-    );
-    Ok(Matrix { a, b, c, d, tx, ty })
+    if let (Some(a), Some(b), Some(c), Some(d), Some(tx), Some(ty)) = (
+        // These lookups do not search the prototype chain and ignore virtual properties.
+        object.get_local_stored("a", activation),
+        object.get_local_stored("b", activation),
+        object.get_local_stored("c", activation),
+        object.get_local_stored("d", activation),
+        object.get_local_stored("tx", activation),
+        object.get_local_stored("ty", activation),
+    ) {
+        let a = a.coerce_to_f64(activation)? as f32;
+        let b = b.coerce_to_f64(activation)? as f32;
+        let c = c.coerce_to_f64(activation)? as f32;
+        let d = d.coerce_to_f64(activation)? as f32;
+        let tx = Twips::from_pixels(tx.coerce_to_f64(activation)?);
+        let ty = Twips::from_pixels(ty.coerce_to_f64(activation)?);
+        Ok(Matrix { a, b, c, d, tx, ty })
+    } else {
+        Ok(Matrix::IDENTITY)
+    }
 }
 
 pub fn matrix_to_value<'gc>(


### PR DESCRIPTION
The comment for this function says that it
> returns the identity matrix if any of the `a`, `b`, `c`, `d`, or `tx` properties do not exist

but that wasn't the case.

Fixes #3721 which calls `pz[n].beginBitmapFill(tmp2);` without specifying an optional matrix argument.