### PR TITLE
avm2: flash.sampler stubs

### DIFF
--- a/core/src/avm2/globals/flash/sampler.as
+++ b/core/src/avm2/globals/flash/sampler.as
@@ -1,0 +1,26 @@
+package flash.sampler {
+    import __ruffle__.stub_method;
+
+    public function getSize(param1:*):Number {
+        stub_method("flash.sampler", "getSize");
+        return 0;
+    }
+
+    public function clearSamples():void {
+        stub_method("flash.sampler", "clearSamples");
+    }
+
+    public function startSampling():void {
+        stub_method("flash.sampler", "startSampling");
+    }
+
+    public function stopSampling():void {
+        stub_method("flash.sampler", "stopSampling");
+    }
+    
+    public function getSamples():Object {
+        stub_method("flash.sampler", "getSamples");
+        return {};
+    }
+}
+

--- a/core/src/avm2/globals/flash/sampler/DeleteObjectSample.as
+++ b/core/src/avm2/globals/flash/sampler/DeleteObjectSample.as
@@ -1,0 +1,8 @@
+package flash.sampler {
+    public final class DeleteObjectSample extends Sample {
+        public const id:Number;
+     
+        public const size:Number;
+    }
+}
+

--- a/core/src/avm2/globals/flash/sampler/NewObjectSample.as
+++ b/core/src/avm2/globals/flash/sampler/NewObjectSample.as
@@ -1,0 +1,20 @@
+package flash.sampler {
+    import __ruffle__.stub_getter;
+
+    public final class NewObjectSample extends Sample {
+        public const id:Number;
+     
+        public const type:Class;
+
+        public function get object():* {
+            stub_getter("flash.sampler.NewObjectSample", "object");
+            return {};
+        }
+
+        public function get size():Number {
+            stub_getter("flash.sampler.NewObjectSample", "size");
+            return 0;
+        }
+    }
+}
+

--- a/core/src/avm2/globals/flash/sampler/Sample.as
+++ b/core/src/avm2/globals/flash/sampler/Sample.as
@@ -1,0 +1,8 @@
+package flash.sampler {
+    public class Sample {
+        public const time:Number;
+      
+        public const stack:Array;
+    }
+}
+

--- a/core/src/avm2/globals/flash/sampler/StackFrame.as
+++ b/core/src/avm2/globals/flash/sampler/StackFrame.as
@@ -1,0 +1,20 @@
+package flash.sampler {
+    public final class StackFrame {
+        public const name:String;
+
+        public const file:String;
+
+        public const line:uint;
+   
+        public const scriptID:Number;
+      
+        public function toString():String {
+            if (this.file) {
+                return this.name + "()[" + this.file + ":" + this.line + "]";
+            } else {
+                return this.name + "()";
+            }
+        }
+    }
+}
+

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -275,12 +275,18 @@ include "flash/net/URLStream.as"
 include "flash/net/URLVariables.as"
 include "flash/net/XMLSocket.as"
 
-include "flash/profiler/Telemetry.as"
 include "flash/printing/PrintJob.as"
-include "flash/printing/PrintJobOrientation.as"
 include "flash/printing/PrintJobOptions.as"
+include "flash/printing/PrintJobOrientation.as"
 
 include "flash/profiler.as"
+include "flash/profiler/Telemetry.as"
+
+include "flash/sampler.as"
+include "flash/sampler/Sample.as"
+include "flash/sampler/DeleteObjectSample.as" // DeleteObjectSample and NewObjectSample extend Sample
+include "flash/sampler/NewObjectSample.as"
+include "flash/sampler/StackFrame.as"
 
 include "flash/security/CertificateStatus.as"
 include "flash/security/X509Certificate.as"


### PR DESCRIPTION
Fixes #8831 (though it has performance issues)
Some of the `flash.sampler` functions seem like they would be relatively easy to implement in Ruffle- there are a two which report the number of times getters/setters have been invoked, and one which checks if the given property is a getter/setter.