### PR TITLE
web: Fix Ruffle extension failing to load when publicPath config is set

### DIFF
--- a/web/packages/core/src/current-script.ts
+++ b/web/packages/core/src/current-script.ts
@@ -1,0 +1,27 @@
+// This must be in global scope because `document.currentScript`
+// works only while the script is initially being processed.
+export let currentScriptURL = "";
+try {
+    if (
+        document.currentScript !== undefined &&
+        document.currentScript !== null &&
+        "src" in document.currentScript &&
+        document.currentScript.src !== ""
+    ) {
+        let src = document.currentScript.src;
+
+        // CDNs allow omitting the filename. If it's omitted, append a slash to
+        // prevent the last component from being dropped.
+        if (!src.endsWith(".js") && !src.endsWith("/")) {
+            src += "/";
+        }
+
+        currentScriptURL = new URL(".", src).href;
+    }
+} catch (e) {
+    console.warn("Unable to get currentScript URL");
+}
+
+export const isExtension = new URL(currentScriptURL).protocol.includes(
+    "extension"
+);

--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -3,8 +3,8 @@ import { RuffleEmbed } from "./ruffle-embed";
 import { installPlugin, FLASH_PLUGIN } from "./plugin-polyfill";
 import { publicPath } from "./public-path";
 import type { DataLoadOptions, URLLoadOptions } from "./load-options";
+import { isExtension } from "./current-script";
 
-let isExtension: boolean;
 const globalConfig: DataLoadOptions | URLLoadOptions | object =
     window.RufflePlayer?.config ?? {};
 const jsScriptUrl = publicPath(globalConfig) + "ruffle.js";
@@ -50,14 +50,12 @@ function polyfillFlashInstances(): void {
         for (const elem of Array.from(objects)) {
             if (RuffleObject.isInterdictable(elem)) {
                 const ruffleObject = RuffleObject.fromNativeObjectElement(elem);
-                ruffleObject.setIsExtension(isExtension);
                 elem.replaceWith(ruffleObject);
             }
         }
         for (const elem of Array.from(embeds)) {
             if (RuffleEmbed.isInterdictable(elem)) {
                 const ruffleEmbed = RuffleEmbed.fromNativeEmbedElement(elem);
-                ruffleEmbed.setIsExtension(isExtension);
                 elem.replaceWith(ruffleEmbed);
             }
         }
@@ -214,11 +212,8 @@ export function pluginPolyfill(): void {
 
 /**
  * Polyfills legacy Flash content on the page.
- *
- * @param isExt Whether or not Ruffle is running as a browser's extension.
  */
-export function polyfill(isExt: boolean): void {
-    isExtension = isExt;
+export function polyfill(): void {
     const usingExtension =
         navigator.plugins.namedItem("Ruffle Extension")?.filename ===
         "ruffle.js";

--- a/web/packages/core/src/public-api.ts
+++ b/web/packages/core/src/public-api.ts
@@ -163,9 +163,7 @@ export class PublicAPI {
             const polyfills =
                 "polyfills" in this.config ? this.config.polyfills : true;
             if (polyfills !== false) {
-                this.sources[this.newestName]!.polyfill(
-                    this.newestName === "extension"
-                );
+                this.sources[this.newestName]!.polyfill();
             }
         }
     }

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -1,28 +1,5 @@
 import type { DataLoadOptions, URLLoadOptions } from "./load-options";
-
-// This must be in global scope because `document.currentScript`
-// works only while the script is initially being processed.
-let currentScriptURL = "";
-try {
-    if (
-        document.currentScript !== undefined &&
-        document.currentScript !== null &&
-        "src" in document.currentScript &&
-        document.currentScript.src !== ""
-    ) {
-        let src = document.currentScript.src;
-
-        // CDNs allow omitting the filename. If it's omitted, append a slash to
-        // prevent the last component from being dropped.
-        if (!src.endsWith(".js") && !src.endsWith("/")) {
-            src += "/";
-        }
-
-        currentScriptURL = new URL(".", src).href;
-    }
-} catch (e) {
-    console.warn("Unable to get currentScript URL");
-}
+import { currentScriptURL } from "./current-script";
 
 /**
  * Attempt to discover the public path of the current Ruffle source. This can

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -1,5 +1,5 @@
 import type { DataLoadOptions, URLLoadOptions } from "./load-options";
-import { currentScriptURL } from "./current-script";
+import { currentScriptURL, isExtension } from "./current-script";
 
 /**
  * Attempt to discover the public path of the current Ruffle source. This can
@@ -24,6 +24,7 @@ export function publicPath(
     // Default to the directory where this script resides.
     let path = currentScriptURL;
     if (
+        !isExtension &&
         "publicPath" in config &&
         config.publicPath !== null &&
         config.publicPath !== undefined

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -15,6 +15,7 @@ import { swfFileName } from "./swf-utils";
 import { buildInfo } from "./build-info";
 import { text, textAsParagraphs } from "./i18n";
 import JSZip from "jszip";
+import { isExtension } from "./current-script";
 
 const RUFFLE_ORIGIN = "https://ruffle.rs";
 const DIMENSION_REGEX = /^\s*(\d+(\.\d+)?(%)?)/;
@@ -155,7 +156,7 @@ export class RufflePlayer extends HTMLElement {
     private panicked = false;
     private rendererDebugInfo = "";
 
-    private isExtension = false;
+    private isExtension = isExtension;
     private longPressTimer: ReturnType<typeof setTimeout> | null = null;
     private pointerDownPosition: Point | null = null;
     private pointerMoveMaxDistance = 0;
@@ -2060,10 +2061,6 @@ export class RufflePlayer extends HTMLElement {
         this.dispatchEvent(new Event(RufflePlayer.LOADED_METADATA));
         // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
         this.dispatchEvent(new Event(RufflePlayer.LOADED_DATA));
-    }
-
-    setIsExtension(isExtension: boolean): void {
-        this.isExtension = isExtension;
     }
 }
 

--- a/web/packages/core/src/source-api.ts
+++ b/web/packages/core/src/source-api.ts
@@ -21,11 +21,9 @@ export const SourceAPI = {
      * Start up the polyfills.
      *
      * Do not run polyfills for more than one Ruffle source at a time.
-     *
-     * @param isExt Whether or not Ruffle is running as a browser's extension.
      */
-    polyfill(isExt: boolean): void {
-        polyfill(isExt);
+    polyfill(): void {
+        polyfill();
     },
 
     /**

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -22,7 +22,6 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     const player = ruffle.createPlayer();
     player.id = "player";
-    player.setIsExtension(true);
     document.getElementById("main")!.append(player);
 
     const options = await utils.getOptions();


### PR DESCRIPTION
This fixes 2 related problems:
1. The Ruffle extension was obeying the `publicPath` config option, even though it only makes sense for selfhosted Ruffle.
2. Ruffle's `isExtension` variable was only being set for polyfilled Ruffle elements, not for elements created with the JS API.

Fixes #11603.
Fixes #8413.
Also fixes the Ruffle player failing to load when the extension is enabled on [this page](https://www.eftelingfanzine.com/efteling-simulaties/bobbaan/) from #3284. (It's the same issue as #8413, but more easily/reliably reproducible).