### PR TITLE
web: Don't auto-panic on browsers without ReadableStream

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -71,13 +71,7 @@ async function fetchRuffle(
     // The Pale Moon browser currently lacks support for ReadableStream.
     // Unfortunately, currently it also lacks a sufficient WASM runtime.
     // If this becomes the last thing Pale Moon lacks, allow Ruffle to work.
-    const readableStreamDefined = (() => {
-        try {
-            return typeof new ReadableStream() === "object";
-        } catch (e: unknown) {
-            return false;
-        }
-    })();
+    const readableStreamDefined = typeof ReadableStream === "function";
     if (progressCallback && readableStreamDefined) {
         const contentLength =
             wasmResponse?.headers?.get("content-length") || "";

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -68,6 +68,9 @@ async function fetchRuffle(
         ? new URL("../dist/ruffle_web-wasm_extensions_bg.wasm", import.meta.url)
         : new URL("../dist/ruffle_web_bg.wasm", import.meta.url);
     const wasmResponse = await fetch(wasmUrl);
+    // The Pale Moon browser currently lacks support for ReadableStream.
+    // Unfortunately, currently it also lacks a sufficient WASM runtime.
+    // If this becomes the last thing Pale Moon lacks, allow Ruffle to work.
     const readableStreamDefined = (() => {
         try {
             return typeof new ReadableStream() === "object";

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -68,7 +68,14 @@ async function fetchRuffle(
         ? new URL("../dist/ruffle_web-wasm_extensions_bg.wasm", import.meta.url)
         : new URL("../dist/ruffle_web_bg.wasm", import.meta.url);
     const wasmResponse = await fetch(wasmUrl);
-    if (progressCallback) {
+    const readableStreamDefined = (() => {
+        try {
+            return typeof new ReadableStream() === "object";
+        } catch (e: unknown) {
+            return false;
+        }
+    })();
+    if (progressCallback && readableStreamDefined) {
         const contentLength =
             wasmResponse?.headers?.get("content-length") || "";
         let bytesLoaded = 0;


### PR DESCRIPTION
This can be considered to get Pale Moon closer to working with Ruffle, though it still fails to load because Pale Moon has incomplete WASM support.

It's arguable whether we should concern ourselves with doing this, but it's simple, so my feeling is that it's a good idea. It's impossible to predict whether Pale Moon will have sufficient WASM support to run Ruffle first or support for ReadableStream first, but my feeling is it would be bad if this became the final blocker for Ruffle there.