### PR TITLE
core: Apply filters when modifying an object, not just when instantiating

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1911,11 +1911,16 @@ pub trait TDisplayObject<'gc>:
                     self.set_opaque_background(context.gc_context, color);
                 }
             }
+            if let Some(filters) = &place_object.filters {
+                self.set_filters(
+                    context.gc_context,
+                    filters.iter().map(Filter::from).collect(),
+                );
+            }
             // Purposely omitted properties:
             // name, clip_depth, clip_actions
             // These properties are only set on initial placement in `MovieClip::instantiate_child`
             // and can not be modified by subsequent PlaceObject tags.
-            // TODO: Filters need to be applied here.
         }
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -37,7 +37,6 @@ use crate::tag_utils::{self, ControlFlow, DecodeResult, Error, SwfMovie, SwfSlic
 use crate::vminterface::{AvmObject, Instantiator};
 use core::fmt;
 use gc_arena::{Collect, Gc, GcCell, GcWeakCell, MutationContext};
-use ruffle_render::filters::Filter;
 use smallvec::SmallVec;
 use std::cell::{Ref, RefMut};
 use std::collections::HashMap;
@@ -1573,12 +1572,6 @@ impl<'gc> MovieClip<'gc> {
                                 .cloned()
                                 .map(|a| ClipEventHandler::from_action_and_movie(a, movie.clone()))
                                 .collect(),
-                        );
-                    }
-                    if let Some(filters) = &place_object.filters {
-                        child.set_filters(
-                            context.gc_context,
-                            filters.iter().map(Filter::from).collect(),
                         );
                     }
                     // TODO: Missing PlaceObject property: amf_data


### PR DESCRIPTION
In https://github.com/ruffle-rs/ruffle/commit/fc00ae8eb6 , filters are applied in MovieClip.instantiate_child, which is called when creating an object. But the proper place for this is in TDisplayObject.apply_place_object, which is called both by instantiate_child _and_ when modifying an existing object with PlaceObject.

This change has no visible effect on master (since filters are still invisible). But when combined with https://github.com/ruffle-rs/ruffle/pull/11702 , which enables filter rendering, it fixes a bug where filters do not display unless they were set up at the same time as their object was created.



Note: I notice there are still [two TODOs](https://github.com/ruffle-rs/ruffle/blob/6d77ff1fc41aa34848188aa79ddb8c283671df4a/core/src/display_object/movie_clip.rs#L4343-L4400) in the codebase about applying/removing filters when running a GOTO. This PR doesn't touch those.