### PR TITLE
core: Don't hold a borrow on Avm1Button whilst adding children

### DIFF
--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -140,7 +140,9 @@ impl<'gc> Avm1Button<'gc> {
         // TODO: This behavior probably differs in AVM2 (I suspect they always get recreated).
         let mut children = Vec::new();
 
-        for record in &self.0.read().static_data.read().records {
+        // [NA] This copies static_data so we can borrow it without keeping `self.0` borrowed
+        let static_data = self.0.read().static_data;
+        for record in &static_data.read().records {
             if record.states.contains(state.into()) {
                 // State contains this depth, so we don't have to remove it.
                 removed_depths.remove(&record.depth.into());


### PR DESCRIPTION
Fixes #11706

Wasn't able to make a test that actually reproduced this