### PR TITLE
wgpu: Removed most uniforms from filters, they're not used or needed

### DIFF
--- a/render/wgpu/shaders/filter/blur.wgsl
+++ b/render/wgpu/shaders/filter/blur.wgsl
@@ -1,10 +1,5 @@
 #import filter
 
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-};
-
 struct Filter {
     blur_x: f32,
     blur_y: f32,
@@ -12,14 +7,12 @@ struct Filter {
     height: f32,
 }
 
-#if use_push_constants == true
-    @group(2) @binding(0) var<uniform> filter_args: Filter;
-#else
-    @group(4) @binding(0) var<uniform> filter_args: Filter;
-#endif
+@group(0) @binding(0) var texture: texture_2d<f32>;
+@group(0) @binding(1) var texture_sampler: sampler;
+@group(0) @binding(2) var<uniform> filter_args: Filter;
 
 @vertex
-fn main_vertex(in: filter::FilterVertexInput) -> filter::VertexOutput {
+fn main_vertex(in: filter::VertexInput) -> filter::VertexOutput {
     return filter::main_vertex(in);
 }
 
@@ -35,7 +28,7 @@ fn main_fragment(in: filter::VertexOutput) -> @location(0) vec4<f32> {
     for (var x = -blur_x; x <= blur_x; x += 0.5) {
         for (var y = -blur_y; y <= blur_y; y += 0.5) {
             var offset = vec3<f32>(x / f.width, y / f.height, 0.0);
-            let sample = textureSample(filter::texture, filter::texture_sampler, in.uv + offset.xy);
+            let sample = textureSample(texture, texture_sampler, in.uv + offset.xy);
             let weight = 1.0;
             color += sample * weight;
             sum += weight;

--- a/render/wgpu/shaders/filter/color_matrix.wgsl
+++ b/render/wgpu/shaders/filter/color_matrix.wgsl
@@ -1,10 +1,5 @@
 #import filter
 
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) uv: vec2<f32>,
-};
-
 struct Filter {
     r_to_r: f32,
     g_to_r: f32,
@@ -31,20 +26,18 @@ struct Filter {
     a_extra: f32,
 }
 
-#if use_push_constants == true
-    @group(2) @binding(0) var<uniform> filter_args: Filter;
-#else
-    @group(4) @binding(0) var<uniform> filter_args: Filter;
-#endif
+@group(0) @binding(0) var texture: texture_2d<f32>;
+@group(0) @binding(1) var texture_sampler: sampler;
+@group(0) @binding(2) var<uniform> filter_args: Filter;
 
 @vertex
-fn main_vertex(in: filter::FilterVertexInput) -> filter::VertexOutput {
+fn main_vertex(in: filter::VertexInput) -> filter::VertexOutput {
     return filter::main_vertex(in);
 }
 
 @fragment
 fn main_fragment(in: filter::VertexOutput) -> @location(0) vec4<f32> {
-    var src = textureSample(filter::texture, filter::texture_sampler, in.uv);
+    var src = textureSample(texture, texture_sampler, in.uv);
     var f = filter_args;
     var color = vec4<f32>(
         clamp((f.r_to_r * src.r / src.a) + (f.g_to_r * src.g / src.a) + (f.b_to_r * src.b / src.a) + (f.a_to_r * src.a) + (f.r_extra / 255.0), 0.0, 1.0),

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -2,7 +2,7 @@ use crate::layouts::BindLayouts;
 use crate::pipelines::VERTEX_BUFFERS_DESCRIPTION_POS;
 use crate::shaders::Shaders;
 use crate::{
-    create_buffer_with_data, BitmapSamplers, Pipelines, PosColorVertex, PosVertex,
+    create_buffer_with_data, BitmapSamplers, FilterVertex, Pipelines, PosColorVertex, PosVertex,
     TextureTransforms, Transforms, DEFAULT_COLOR_ADJUSTMENTS,
 };
 use fnv::FnvHashMap;
@@ -250,6 +250,7 @@ impl Descriptors {
 pub struct Quad {
     pub vertices_pos: wgpu::Buffer,
     pub vertices_pos_color: wgpu::Buffer,
+    pub filter_vertices: wgpu::Buffer,
     pub indices: wgpu::Buffer,
     pub texture_transforms: wgpu::Buffer,
 }
@@ -288,6 +289,24 @@ impl Quad {
                 color: [1.0, 1.0, 1.0, 1.0],
             },
         ];
+        let filter_vertices = [
+            FilterVertex {
+                position: [0.0, 0.0],
+                uv: [0.0, 0.0],
+            },
+            FilterVertex {
+                position: [1.0, 0.0],
+                uv: [1.0, 0.0],
+            },
+            FilterVertex {
+                position: [1.0, 1.0],
+                uv: [1.0, 1.0],
+            },
+            FilterVertex {
+                position: [0.0, 1.0],
+                uv: [0.0, 1.0],
+            },
+        ];
         let indices: [u32; 6] = [0, 1, 2, 0, 2, 3];
 
         let vbo_pos = create_buffer_with_data(
@@ -302,6 +321,13 @@ impl Quad {
             bytemuck::cast_slice(&vertices_pos_color),
             wgpu::BufferUsages::VERTEX,
             create_debug_label!("Quad vbo (pos & color)"),
+        );
+
+        let vbo_filter = create_buffer_with_data(
+            device,
+            bytemuck::cast_slice(&filter_vertices),
+            wgpu::BufferUsages::VERTEX,
+            create_debug_label!("Quad vbo (filter)"),
         );
 
         let ibo = create_buffer_with_data(
@@ -328,6 +354,7 @@ impl Quad {
         Self {
             vertices_pos: vbo_pos,
             vertices_pos_color: vbo_pos_color,
+            filter_vertices: vbo_filter,
             indices: ibo,
             texture_transforms: tex_transforms,
         }

--- a/render/wgpu/src/layouts.rs
+++ b/render/wgpu/src/layouts.rs
@@ -182,32 +182,70 @@ impl BindLayouts {
 
         let color_matrix_filter =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                entries: &[wgpu::BindGroupLayoutEntry {
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: wgpu::BufferSize::new(
+                                std::mem::size_of::<[f32; 20]>() as u64,
+                            ),
+                        },
+                        count: None,
+                    },
+                ],
+                label: create_debug_label!("Color matrix filter binds").as_deref(),
+            });
+
+        let blur_filter = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
                     binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
                     visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
                         min_binding_size: wgpu::BufferSize::new(
-                            std::mem::size_of::<[f32; 20]>() as u64
+                            std::mem::size_of::<[f32; 4]>() as u64
                         ),
                     },
                     count: None,
-                }],
-                label: create_debug_label!("Color matrix filter binds").as_deref(),
-            });
-
-        let blur_filter = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<[f32; 4]>() as u64),
                 },
-                count: None,
-            }],
+            ],
             label: create_debug_label!("Blur filter binds").as_deref(),
         });
 

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -138,6 +138,13 @@ impl From<TessVertex> for PosColorVertex {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
+struct FilterVertex {
+    position: [f32; 2],
+    uv: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pod, Zeroable)]
 struct GradientUniforms {
     focal_point: f32,
     interpolation: i32,

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -8,8 +8,7 @@ use crate::mesh::Mesh;
 use crate::surface::commands::{chunk_blends, Chunk, CommandRenderer};
 use crate::utils::{remove_srgb, supported_sample_count};
 use crate::{
-    ColorAdjustments, Descriptors, MaskState, Pipelines, PushConstants, TextureTransforms,
-    Transforms, UniformBuffer, DEFAULT_COLOR_ADJUSTMENTS,
+    ColorAdjustments, Descriptors, FilterVertex, MaskState, Pipelines, Transforms, UniformBuffer,
 };
 use ruffle_render::commands::CommandList;
 use ruffle_render::filters::Filter;
@@ -416,31 +415,7 @@ impl Surface {
             RenderTargetMode::FreshWithColor(wgpu::Color::TRANSPARENT),
             draw_encoder,
         );
-        let texture_transform =
-            make_texture_transform(descriptors, source_size, source_point, source_texture);
         let source_view = source_texture.create_view(&Default::default());
-        let bitmap_group = descriptors
-            .device
-            .create_bind_group(&wgpu::BindGroupDescriptor {
-                label: create_debug_label!("Bitmap copy group").as_deref(),
-                layout: &descriptors.bind_layouts.bitmap,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: texture_transform.as_entire_binding(),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::TextureView(&source_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::Sampler(
-                            descriptors.bitmap_samplers.get_sampler(false, false),
-                        ),
-                    },
-                ],
-            });
         let buffer = descriptors
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -448,15 +423,33 @@ impl Surface {
                 contents: bytemuck::cast_slice(&filter.matrix),
                 usage: wgpu::BufferUsages::UNIFORM,
             });
+        let vertices = create_filter_vertices(
+            &descriptors.device,
+            source_texture,
+            source_point,
+            source_size,
+        );
         let filter_group = descriptors
             .device
             .create_bind_group(&wgpu::BindGroupDescriptor {
                 label: create_debug_label!("Filter group").as_deref(),
                 layout: &descriptors.bind_layouts.color_matrix_filter,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: buffer.as_entire_binding(),
-                }],
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&source_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(
+                            descriptors.bitmap_samplers.get_sampler(false, false),
+                        ),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: buffer.as_entire_binding(),
+                    },
+                ],
             });
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Color matrix filter").as_deref(),
@@ -465,33 +458,9 @@ impl Surface {
         });
         render_pass.set_pipeline(&self.pipelines.color_matrix_filter);
 
-        render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
-        if descriptors.limits.max_push_constant_size > 0 {
-            render_pass.set_push_constants(
-                wgpu::ShaderStages::VERTEX_FRAGMENT,
-                0,
-                bytemuck::cast_slice(&[PushConstants {
-                    transforms: Transforms {
-                        world_matrix: [
-                            [target.width() as f32, 0.0, 0.0, 0.0],
-                            [0.0, target.height() as f32, 0.0, 0.0],
-                            [0.0, 0.0, 1.0, 0.0],
-                            [0.0, 0.0, 0.0, 1.0],
-                        ],
-                    },
-                    colors: DEFAULT_COLOR_ADJUSTMENTS,
-                }]),
-            );
-            render_pass.set_bind_group(1, &bitmap_group, &[]);
-            render_pass.set_bind_group(2, &filter_group, &[]);
-        } else {
-            render_pass.set_bind_group(1, target.whole_frame_bind_group(descriptors), &[0]);
-            render_pass.set_bind_group(2, &descriptors.default_color_bind_group, &[0]);
-            render_pass.set_bind_group(3, &bitmap_group, &[]);
-            render_pass.set_bind_group(4, &filter_group, &[]);
-        }
+        render_pass.set_bind_group(0, &filter_group, &[]);
 
-        render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
+        render_pass.set_vertex_buffer(0, vertices.slice(..));
         render_pass.set_index_buffer(
             descriptors.quad.indices.slice(..),
             wgpu::IndexFormat::Uint32,
@@ -542,17 +511,23 @@ impl Surface {
             ),
         ];
 
-        let texture_transform =
-            make_texture_transform(descriptors, source_size, source_point, source_texture);
+        // TODO: Vertices should be per pass, and each pass needs diff sizes
+        let vertices = create_filter_vertices(
+            &descriptors.device,
+            source_texture,
+            source_point,
+            source_size,
+        );
+
         let source_view = source_texture.create_view(&Default::default());
         for i in 0..2 {
             let blur_x = (filter.blur_x.to_f32() - 1.0).max(0.0);
             let blur_y = (filter.blur_y.to_f32() - 1.0).max(0.0);
             let current = &targets[i % 2];
-            let (previous_view, previous_transform, previous_width, previous_height) = if i == 0 {
+            let (previous_view, previous_vertices, previous_width, previous_height) = if i == 0 {
                 (
                     &source_view,
-                    texture_transform.as_entire_binding(),
+                    vertices.slice(..),
                     source_texture.width() as f32,
                     source_texture.height() as f32,
                 )
@@ -560,33 +535,11 @@ impl Surface {
                 let previous = &targets[(i - 1) % 2];
                 (
                     previous.color_view(),
-                    descriptors.quad.texture_transforms.as_entire_binding(),
+                    descriptors.quad.filter_vertices.slice(..),
                     previous.width() as f32,
                     previous.height() as f32,
                 )
             };
-            let bitmap_group = descriptors
-                .device
-                .create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: create_debug_label!("Bitmap copy group").as_deref(),
-                    layout: &descriptors.bind_layouts.bitmap,
-                    entries: &[
-                        wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: previous_transform,
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 1,
-                            resource: wgpu::BindingResource::TextureView(previous_view),
-                        },
-                        wgpu::BindGroupEntry {
-                            binding: 2,
-                            resource: wgpu::BindingResource::Sampler(
-                                descriptors.bitmap_samplers.get_sampler(false, true),
-                            ),
-                        },
-                    ],
-                });
             let buffer = descriptors
                 .device
                 .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -604,10 +557,22 @@ impl Surface {
                 .create_bind_group(&wgpu::BindGroupDescriptor {
                     label: create_debug_label!("Filter group").as_deref(),
                     layout: &descriptors.bind_layouts.blur_filter,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: buffer.as_entire_binding(),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(previous_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Sampler(
+                                descriptors.bitmap_samplers.get_sampler(false, true),
+                            ),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: buffer.as_entire_binding(),
+                        },
+                    ],
                 });
             let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: create_debug_label!("Blur filter").as_deref(),
@@ -616,33 +581,9 @@ impl Surface {
             });
             render_pass.set_pipeline(&self.pipelines.blur_filter);
 
-            render_pass.set_bind_group(0, current.globals().bind_group(), &[]);
-            if descriptors.limits.max_push_constant_size > 0 {
-                render_pass.set_push_constants(
-                    wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    0,
-                    bytemuck::cast_slice(&[PushConstants {
-                        transforms: Transforms {
-                            world_matrix: [
-                                [current.width() as f32, 0.0, 0.0, 0.0],
-                                [0.0, current.height() as f32, 0.0, 0.0],
-                                [0.0, 0.0, 1.0, 0.0],
-                                [0.0, 0.0, 0.0, 1.0],
-                            ],
-                        },
-                        colors: DEFAULT_COLOR_ADJUSTMENTS,
-                    }]),
-                );
-                render_pass.set_bind_group(1, &bitmap_group, &[]);
-                render_pass.set_bind_group(2, &filter_group, &[]);
-            } else {
-                render_pass.set_bind_group(1, current.whole_frame_bind_group(descriptors), &[0]);
-                render_pass.set_bind_group(2, &descriptors.default_color_bind_group, &[0]);
-                render_pass.set_bind_group(3, &bitmap_group, &[]);
-                render_pass.set_bind_group(4, &filter_group, &[]);
-            }
+            render_pass.set_bind_group(0, &filter_group, &[]);
 
-            render_pass.set_vertex_buffer(0, descriptors.quad.vertices_pos.slice(..));
+            render_pass.set_vertex_buffer(0, previous_vertices);
             render_pass.set_index_buffer(
                 descriptors.quad.indices.slice(..),
                 wgpu::IndexFormat::Uint32,
@@ -657,46 +598,38 @@ impl Surface {
     }
 }
 
-fn make_texture_transform(
-    descriptors: &Descriptors,
-    source_size: (u32, u32),
-    source_point: (u32, u32),
+fn create_filter_vertices(
+    device: &wgpu::Device,
     source_texture: &wgpu::Texture,
+    source_point: (u32, u32),
+    source_size: (u32, u32),
 ) -> wgpu::Buffer {
-    descriptors
-        .device
-        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: None,
-            contents: bytemuck::cast_slice(&[TextureTransforms {
-                // This is is column-major order.
-                u_matrix: [
-                    [
-                        // If we're applying the filter to a source rectangle that's smaller than
-                        // the full source texture, then the scale factor will be less than 1.
-                        // This will produce U-V coordinates that do not extend to the full [0, 1]
-                        // range, which makes us sample just the source region.
-                        source_size.0 as f32 / source_texture.width() as f32,
-                        0.0,
-                        0.0,
-                        0.0,
-                    ],
-                    [
-                        0.0,
-                        source_size.1 as f32 / source_texture.height() as f32,
-                        0.0,
-                        0.0,
-                    ],
-                    [0.0, 0.0, 1.0, 0.0],
-                    // Offset to 'source_point'. Note that we divide by the full texture size,
-                    // since that's what the UV coordinates are sampling from.
-                    [
-                        source_point.0 as f32 / source_texture.width() as f32,
-                        source_point.1 as f32 / source_texture.height() as f32,
-                        0.0,
-                        0.0,
-                    ],
-                ],
-            }]),
-            usage: wgpu::BufferUsages::UNIFORM,
-        })
+    let source_width = source_texture.width() as f32;
+    let source_height = source_texture.height() as f32;
+    let left = source_point.0;
+    let top = source_point.1;
+    let right = left + source_size.0;
+    let bottom = top + source_size.1;
+    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: create_debug_label!("Filter vertices").as_deref(),
+        contents: bytemuck::cast_slice(&[
+            FilterVertex {
+                position: [0.0, 0.0],
+                uv: [left as f32 / source_width, top as f32 / source_height],
+            },
+            FilterVertex {
+                position: [1.0, 0.0],
+                uv: [right as f32 / source_width, top as f32 / source_height],
+            },
+            FilterVertex {
+                position: [1.0, 1.0],
+                uv: [right as f32 / source_width, bottom as f32 / source_height],
+            },
+            FilterVertex {
+                position: [0.0, 1.0],
+                uv: [left as f32 / source_width, bottom as f32 / source_height],
+            },
+        ]),
+        usage: wgpu::BufferUsages::VERTEX,
+    })
 }


### PR DESCRIPTION
This should make filters faster and fix the panic for setting push constants that aren't there after a browser optimizes them out