### PR TITLE
desktop,chore: Fix incorrect linker arguments on windows when using gnu linker(ld.exe)

### DIFF
--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -29,7 +29,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     // accommodate this (the default on Linux is high enough). We
     // do the same thing for wasm in web/build.rs.
     if std::env::var("TARGET").unwrap().contains("windows") {
-        println!("cargo:rustc-link-arg=/STACK:4000000");
+        if std::env::var("TARGET").unwrap().contains("msvc") {
+            println!("cargo:rustc-link-arg=/STACK:4000000");
+        }else{
+            println!("cargo:rustc-link-arg=-Xlinker");
+            println!("cargo:rustc-link-arg=--stack");
+            println!("cargo:rustc-link-arg=4000000");
+        }
     }
 
     Ok(())

--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if std::env::var("TARGET").unwrap().contains("windows") {
         if std::env::var("TARGET").unwrap().contains("msvc") {
             println!("cargo:rustc-link-arg=/STACK:4000000");
-        }else{
+        } else {
             println!("cargo:rustc-link-arg=-Xlinker");
             println!("cargo:rustc-link-arg=--stack");
             println!("cargo:rustc-link-arg=4000000");


### PR DESCRIPTION
Fix incorrect linker arguments on windows when using gnu linker(ld.exe)
when not using msvc linker, the original build script will cause an error when building the desktop package