### PR TITLE
wgpu: Remove 'width' and 'height' fields from Texture

### DIFF
--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -124,8 +124,6 @@ impl WgpuContext3D {
                 bind_linear: Default::default(),
                 bind_nearest: Default::default(),
                 texture: Arc::new(dummy_texture),
-                width: 0,
-                height: 0,
                 copy_count: Cell::new(0),
             }))
         };
@@ -704,16 +702,12 @@ impl Context3D for WgpuContext3D {
                         texture: Arc::new(back_buffer_resolve_texture.unwrap()),
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
-                        width,
-                        height,
                         copy_count: Cell::new(0),
                     }));
                     self.front_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
                         texture: Arc::new(front_buffer_resolve_texture.unwrap()),
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
-                        width,
-                        height,
                         copy_count: Cell::new(0),
                     }));
                 } else {
@@ -724,16 +718,12 @@ impl Context3D for WgpuContext3D {
                         texture: Arc::new(back_buffer_texture),
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
-                        width,
-                        height,
                         copy_count: Cell::new(0),
                     }));
                     self.front_buffer_raw_texture_handle = BitmapHandle(Arc::new(Texture {
                         texture: Arc::new(front_buffer_texture),
                         bind_linear: Default::default(),
                         bind_nearest: Default::default(),
-                        width,
-                        height,
                         copy_count: Cell::new(0),
                     }));
                     self.current_texture_resolve_view = None;

--- a/render/wgpu/src/lib.rs
+++ b/render/wgpu/src/lib.rs
@@ -282,8 +282,6 @@ pub struct Texture {
     pub(crate) texture: Arc<wgpu::Texture>,
     bind_linear: OnceCell<BitmapBinds>,
     bind_nearest: OnceCell<BitmapBinds>,
-    width: u32,
-    height: u32,
     copy_count: Cell<u8>,
 }
 

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -243,8 +243,8 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
 
         let target = as_texture(&target_handle);
         let extent = wgpu::Extent3d {
-            width: target.width,
-            height: target.height,
+            width: target.texture.width(),
+            height: target.texture.height(),
             depth_or_array_layers: 1,
         };
 
@@ -320,8 +320,8 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                     ) {
                         let cached_fresh_handle = target_clone.get_or_insert_with(|| {
                             let extent = wgpu::Extent3d {
-                                width: target.width,
-                                height: target.height,
+                                width: target.texture.width(),
+                                height: target.texture.height(),
                                 depth_or_array_layers: 1,
                             };
                             let fresh_texture =
@@ -356,8 +356,6 @@ impl<T: RenderTarget> WgpuRenderBackend<T> {
                                 texture: Arc::new(fresh_texture),
                                 bind_linear: Default::default(),
                                 bind_nearest: Default::default(),
-                                width: extent.width,
-                                height: extent.height,
                                 copy_count: Cell::new(0),
                             }))
                         });

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -250,7 +250,11 @@ impl<'pass, 'frame: 'pass, 'global: 'frame> CommandRenderer<'pass, 'frame, 'glob
         );
         self.prep_bitmap(&bind.bind_group, blend_mode, render_stage3d);
         self.apply_transform(
-            &(transform.matrix * Matrix::scale(texture.width as f32, texture.height as f32)),
+            &(transform.matrix
+                * Matrix::scale(
+                    texture.texture.width() as f32,
+                    texture.texture.height() as f32,
+                )),
             &transform.color_transform,
         );
 


### PR DESCRIPTION
This is already stored in wgpu::Texture