### PR TITLE
avm2: Use `method_name` as last resort if available in stack trace

### DIFF
--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -299,6 +299,12 @@ pub fn display_function<'gc>(
                         } else {
                             output.push_str(&method_trait.name().local_name());
                         }
+                    } else if !method.method_name().is_empty() {
+                        // Last resort if we can't find a name anywhere else.
+                        // SWF's with debug information will provide a method name attached
+                        // to the method definition, so we can use that.
+                        output.push_char('/');
+                        output.push_utf8(method.method_name());
                     }
                     // TODO: What happens if we can't find the trait?
                 }


### PR DESCRIPTION
While this condition is rare, it occurs in crossbridge SWF's. This will make stack traces like the one in #10851 a lot more helpful.

The stack trace from that issue would now look like this:
```
    at flash.utils::ByteArray/flash::utils::ByteArray::length()
    at global/F_avm2_casRamLength()
    at global/F___sys_mmap()
    at global/F_mmap()
    at global/F_pages_map()
    at global/F_base_pages_alloc()
    at global/F_base_alloc()
    at global/F_arenas_extend()
    at global/F_malloc_init()
    at global/F_malloc()
    at global/F__Znwj()
    at global/F__Z16CreateGameObjectv()
    at global/F_main()
    at global/F__start1()
    at com.adobe.flascc::CModule$/callI()
    at com.adobe.flascc::CModule$/start()
    at com.adobe.flascc::CModule$/startAsync()
    at com.adobe.flascc::Console/enterFrame()
```