### PR TITLE
core: Bail out of operations::color_transform if [xy]_min==[xy]_max

### DIFF
--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -469,7 +469,7 @@ pub fn color_transform<'gc>(
     let x_max = x_max.min(target.width());
     let y_max = y_max.min(target.height());
 
-    if x_max == 0 || y_max == 0 {
+    if x_max == 0 || y_max == 0 || x_min == x_max || y_min == y_max {
         return;
     }
 


### PR DESCRIPTION
In the special case where y_min==y_max==(height-1), we would create a bad 'encompassing' region - subtracing one from the max would make it smaller than the min, causing `PixelRegion::encompassing_pixels` to treat it as the minimum, and add one to `height - 1`

There's no work to do when x_min==x_max or y_min==y_max, so we can also skip the sync and GC write in this case.