### PR TITLE
Fix post-FLV-merge regressions

### DIFF
--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -96,6 +96,13 @@ pub enum VideoStream {
 #[collect(no_drop)]
 pub enum VideoSource<'gc> {
     /// A video bitstream embedded inside of a SWF movie.
+    /// 
+    /// NOTE: Fields within this enum will be shared across all instances of a
+    /// particular character. If you need to mutate the video source, consider
+    /// reallocating a new source for your specific video instead.
+    /// 
+    /// This warning does not apply to `NetStream` or `Unconnected` videos,
+    /// which are never aliased.
     Swf {
         /// The video stream definition.
         #[collect(require_static)]

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -180,8 +180,7 @@ impl<'gc> Video<'gc> {
     pub fn attach_netstream(self, context: &mut UpdateContext<'_, 'gc>, stream: NetStream<'gc>) {
         let mut video = self.0.write(context.gc_context);
 
-        *video.source.write(context.gc_context) = VideoSource::NetStream { stream };
-
+        video.source = GcCell::allocate(context.gc_context, VideoSource::NetStream { stream });
         video.stream = VideoStream::Uninstantiated(0);
         video.keyframes = BTreeSet::new();
     }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -72,7 +72,7 @@ pub struct VideoData<'gc> {
     size: (i32, i32),
 
     /// The last decoded frame in the video stream.
-    /// 
+    ///
     /// NOTE: This is only used for SWF-source video streams.
     #[collect(require_static)]
     decoded_frame: Option<(u32, BitmapInfo)>,
@@ -96,11 +96,11 @@ pub enum VideoStream {
 #[collect(no_drop)]
 pub enum VideoSource<'gc> {
     /// A video bitstream embedded inside of a SWF movie.
-    /// 
+    ///
     /// NOTE: Fields within this enum will be shared across all instances of a
     /// particular character. If you need to mutate the video source, consider
     /// reallocating a new source for your specific video instead.
-    /// 
+    ///
     /// This warning does not apply to `NetStream` or `Unconnected` videos,
     /// which are never aliased.
     Swf {
@@ -246,10 +246,7 @@ impl<'gc> Video<'gc> {
         };
 
         let num_frames = match &*read.source.read() {
-            VideoSource::Swf {
-                streamdef,
-                ..
-            } => streamdef.num_frames as usize,
+            VideoSource::Swf { streamdef, .. } => streamdef.num_frames as usize,
             VideoSource::NetStream { .. } => return,
             VideoSource::Unconnected { .. } => return,
         };
@@ -319,10 +316,7 @@ impl<'gc> Video<'gc> {
         };
 
         let res = match &*source.read() {
-            VideoSource::Swf {
-                streamdef,
-                frames,
-            } => match frames.get(&frame_id) {
+            VideoSource::Swf { streamdef, frames } => match frames.get(&frame_id) {
                 Some((slice_start, slice_end)) => {
                     let encframe = EncodedFrame {
                         codec: streamdef.codec,
@@ -533,10 +527,7 @@ impl<'gc> TDisplayObject<'gc> for Video<'gc> {
         // TODO: smoothing flag should be a video property
         let (smoothed_flag, num_frames, version, decoded_frame, codec) = match &*read.source.read()
         {
-            VideoSource::Swf {
-                streamdef,
-                frames,
-            } => (
+            VideoSource::Swf { streamdef, frames } => (
                 streamdef.is_smoothed,
                 Some(frames.len()),
                 read.movie.version(),


### PR DESCRIPTION
Fixes #11822 and #11823.

In the FLV PR (#10756) I moved the `decoded_frame` parameter from `VideoData` to `VideoSource::Swf` since it's only ever used for SWF video streams. However, the host structure in this case will be shared across all instances of a given `Video`, which is... very bad. In the case of the two above-mentioned bugs, multiple instances of the same video stream were overwriting their last decoded frame numbers and losing track of video decoder state. Even if it hadn't caused a panic it would have broken video seeking badly.

So I just moved it back to `Video`.

I also considered putting `VideoSource` behind a `Gc` to prevent similar bugs from happening, but we actually *do* need to be able to mutate the source during preload. During my failed attempt to do that, I spotted a related bug that hasn't cropped up yet: if you attach a netstream to an SWF `Video` it'll attach to *all instances* of that video. That's also been preemptively fixed in this PR and will hopefully not bite me in the arse later on. 😅

I also added warnings in the docstrings about mutating `VideoSource::Swf`.