### PR TITLE
chore: Run `npm update --save` in `web`

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,11 +14,11 @@
             "devDependencies": {
                 "@typescript-eslint/eslint-plugin": "^5.60.1",
                 "@typescript-eslint/parser": "^5.60.1",
-                "@wdio/cli": "^8.10.7",
-                "@wdio/local-runner": "^8.10.7",
-                "@wdio/mocha-framework": "^8.10.7",
-                "@wdio/spec-reporter": "^8.10.6",
-                "@wdio/static-server-service": "^8.10.6",
+                "@wdio/cli": "^8.11.2",
+                "@wdio/local-runner": "^8.11.2",
+                "@wdio/mocha-framework": "^8.11.0",
+                "@wdio/spec-reporter": "^8.11.2",
+                "@wdio/static-server-service": "^8.11.0",
                 "chai": "^4.3.7",
                 "chai-html": "^2.1.0",
                 "copy-webpack-plugin": "^11.0.0",
@@ -35,13 +35,13 @@
                 "typescript": "^5.1.6",
                 "wdio-chromedriver-service": "^8.1.1",
                 "webpack": "^5.88.1",
-                "webpack-cli": "^5.1.3"
+                "webpack-cli": "^5.1.4"
             },
             "engines": {
                 "npm": ">=7"
             },
             "optionalDependencies": {
-                "chromedriver": "^114.0.0"
+                "chromedriver": "^114.0.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3346,9 +3346,9 @@
             }
         },
         "node_modules/copy-webpack-plugin/node_modules/globby": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
-            "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.1.tgz",
+            "integrity": "sha512-DPCBxctI7dN4EeIqjW2KGqgdcUMbrhJ9AzON+PlxCtvppWhubTLD4+a0GFxiym14ZvacUydTPjLPc2DlKz7EIg==",
             "dev": true,
             "dependencies": {
                 "dir-glob": "^3.0.1",
@@ -12469,7 +12469,6 @@
             }
         },
         "packages/core": {
-            "name": "ruffle-core",
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
@@ -12481,18 +12480,17 @@
                 "@fluent/langneg": "^0.7.0",
                 "@tsconfig/strictest": "^2.0.1",
                 "@types/mocha": "^10.0.1",
-                "eslint": "^8.42.0",
-                "eslint-plugin-jsdoc": "^46.2.4",
+                "eslint": "^8.44.0",
+                "eslint-plugin-jsdoc": "^46.4.3",
                 "mocha": "^10.2.0",
                 "replace-in-file": "^7.0.1",
                 "shx": "^0.3.4",
                 "ts-node": "^10.9.1",
                 "typedoc": "^0.24.8",
-                "typescript": "^5.1.3"
+                "typescript": "^5.1.6"
             }
         },
         "packages/demo": {
-            "name": "ruffle-demo",
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
@@ -12501,11 +12499,10 @@
             "devDependencies": {
                 "css-loader": "^6.8.1",
                 "style-loader": "^3.3.3",
-                "webpack-cli": "^5.1.3"
+                "webpack-cli": "^5.1.4"
             }
         },
         "packages/extension": {
-            "name": "ruffle-extension",
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
@@ -12524,24 +12521,23 @@
                 "json5": "^2.2.3",
                 "sign-addon": "^6.0.0",
                 "temp-dir": "^3.0.0",
-                "ts-loader": "^9.4.3",
-                "typescript": "^5.1.3",
-                "webpack-cli": "^5.1.3"
+                "ts-loader": "^9.4.4",
+                "typescript": "^5.1.6",
+                "webpack-cli": "^5.1.4"
             }
         },
         "packages/selfhosted": {
-            "name": "ruffle-selfhosted",
             "version": "0.1.0",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
                 "ruffle-core": "^0.1.0"
             },
             "devDependencies": {
-                "@wdio/cli": "^8.10.7",
+                "@wdio/cli": "^8.11.2",
                 "json5": "^2.2.3",
-                "webpack": "^5.85.0",
-                "webpack-cli": "^5.1.3",
-                "webpack-dev-server": "^4.15.0"
+                "webpack": "^5.88.1",
+                "webpack-cli": "^5.1.4",
+                "webpack-dev-server": "^4.15.1"
             }
         }
     }

--- a/web/package.json
+++ b/web/package.json
@@ -11,33 +11,33 @@
         "npm": ">=7"
     },
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.59.8",
-        "@typescript-eslint/parser": "^5.59.8",
-        "@wdio/cli": "^8.10.7",
-        "@wdio/local-runner": "^8.10.7",
-        "@wdio/mocha-framework": "^8.10.7",
-        "@wdio/spec-reporter": "^8.10.6",
-        "@wdio/static-server-service": "^8.10.6",
+        "@typescript-eslint/eslint-plugin": "^5.60.1",
+        "@typescript-eslint/parser": "^5.60.1",
+        "@wdio/cli": "^8.11.2",
+        "@wdio/local-runner": "^8.11.2",
+        "@wdio/mocha-framework": "^8.11.0",
+        "@wdio/spec-reporter": "^8.11.2",
+        "@wdio/static-server-service": "^8.11.0",
         "chai": "^4.3.7",
         "chai-html": "^2.1.0",
         "copy-webpack-plugin": "^11.0.0",
         "cross-env": "^7.0.3",
-        "eslint": "^8.42.0",
+        "eslint": "^8.44.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "mocha": "^10.2.0",
         "prettier": "^2.8.8",
-        "stylelint": "^15.6.3",
+        "stylelint": "^15.9.0",
         "stylelint-config-standard": "^33.0.0",
         "stylelint-prettier": "^3.0.0",
-        "ts-loader": "^9.4.3",
-        "typescript": "^5.1.3",
+        "ts-loader": "^9.4.4",
+        "typescript": "^5.1.6",
         "wdio-chromedriver-service": "^8.1.1",
-        "webpack": "^5.85.0",
-        "webpack-cli": "^5.1.3"
+        "webpack": "^5.88.1",
+        "webpack-cli": "^5.1.4"
     },
     "optionalDependencies": {
-        "chromedriver": "^114.0.0"
+        "chromedriver": "^114.0.2"
     },
     "scripts": {
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",

--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -18,25 +18,20 @@
         "//5": "# https://github.com/rust-lang/cargo/issues/10271",
         "//6": "# Enabling `build-std` would also be great, but it's not stable yet.",
         "prebuild": "npm run build:wasm-vanilla && npm run build:wasm-extensions",
-
         "build:wasm-vanilla": "cross-env OUT_NAME=ruffle_web CARGO_PROFILE=web-vanilla-wasm RUSTFLAGS=\"$RUSTFLAGS --cfg=web_sys_unstable_apis -Aunknown_lints\" npm run build:wasm",
-
         "//7": "# Dispatches to either building the real, or copying the fake (stand-in),",
         "//8": "# 'with-extensions' module.",
         "build:wasm-extensions": "node -e \"process.exit(process.env.ENABLE_WASM_EXTENSIONS == 'true' ? 0 : 1)\" && npm run build:wasm-extensions-real || npm run build:wasm-extensions-fake",
         "build:wasm-extensions-real": "echo \"Building module with WebAssembly extensions\" && cross-env OUT_NAME=ruffle_web-wasm_extensions CARGO_PROFILE=web-wasm-extensions RUSTFLAGS=\"$RUSTFLAGS --cfg=web_sys_unstable_apis -Aunknown_lints -C target-feature=+bulk-memory,+simd128,+nontrapping-fptoint,+sign-ext,+reference-types\" WASM_BINDGEN_FLAGS=\"--reference-types\" WASM_OPT_FLAGS=\"--enable-reference-types\" npm run build:wasm",
         "build:wasm-extensions-fake": "echo \"Copying the vanilla module as stand-in\" && shx cp dist/ruffle_web_bg.wasm dist/ruffle_web-wasm_extensions_bg.wasm && shx cp dist/ruffle_web_bg.wasm.d.ts dist/ruffle_web-wasm_extensions_bg.wasm.d.ts && shx cp dist/ruffle_web.js dist/ruffle_web-wasm_extensions.js && shx cp dist/ruffle_web.d.ts dist/ruffle_web-wasm_extensions.d.ts",
-
         "//9": "# This just chains together the three commands after it.",
         "build:wasm": "npm run build:cargo && npm run build:wasm-bindgen && npm run build:wasm-opt",
         "build:cargo": "cross-env-shell cargo build --profile \"$CARGO_PROFILE\" --target wasm32-unknown-unknown --features \\\"$CARGO_FEATURES\\\" $CARGO_FLAGS",
         "build:wasm-bindgen": "cross-env-shell wasm-bindgen \"../../../target/wasm32-unknown-unknown/${CARGO_PROFILE}/ruffle_web.wasm\" --target web --out-dir dist --out-name \"$OUT_NAME\" $WASM_BINDGEN_FLAGS",
         "build:wasm-opt": "cross-env-shell wasm-opt -o \"dist/${OUT_NAME}_bg.wasm\" -O -g \"dist/${OUT_NAME}_bg.wasm\" $WASM_OPT_FLAGS || npm run build:wasm-opt-failed",
         "build:wasm-opt-failed": "echo 'NOTE: Since wasm-opt could not be found (or it failed), the resulting module might not perform that well, but it should still work.' && echo ; [ \"$CI\" != true ] # > nul",
-
         "build": "tsc --build --force",
         "postbuild": "node tools/set_version.js && node tools/bundle_texts.js",
-
         "docs": "typedoc",
         "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\",\\\"verbatimModuleSyntax\\\":false} mocha"
     },
@@ -45,18 +40,18 @@
         "wasm-feature-detect": "^1.5.1"
     },
     "devDependencies": {
+        "@fluent/bundle": "^0.18.0",
+        "@fluent/langneg": "^0.7.0",
         "@tsconfig/strictest": "^2.0.1",
         "@types/mocha": "^10.0.1",
-        "eslint": "^8.42.0",
-        "eslint-plugin-jsdoc": "^46.2.4",
+        "eslint": "^8.44.0",
+        "eslint-plugin-jsdoc": "^46.4.3",
         "mocha": "^10.2.0",
         "replace-in-file": "^7.0.1",
         "shx": "^0.3.4",
         "ts-node": "^10.9.1",
         "typedoc": "^0.24.8",
-        "typescript": "^5.1.3",
-        "@fluent/bundle": "^0.18.0",
-        "@fluent/langneg": "^0.7.0"
+        "typescript": "^5.1.6"
     },
     "sideEffects": false
 }

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -14,6 +14,6 @@
     "devDependencies": {
         "css-loader": "^6.8.1",
         "style-loader": "^3.3.3",
-        "webpack-cli": "^5.1.3"
+        "webpack-cli": "^5.1.4"
     }
 }

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -27,8 +27,8 @@
         "json5": "^2.2.3",
         "sign-addon": "^6.0.0",
         "temp-dir": "^3.0.0",
-        "ts-loader": "^9.4.3",
-        "typescript": "^5.1.3",
-        "webpack-cli": "^5.1.3"
+        "ts-loader": "^9.4.4",
+        "typescript": "^5.1.6",
+        "webpack-cli": "^5.1.4"
     }
 }

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -20,10 +20,10 @@
         "ruffle-core": "^0.1.0"
     },
     "devDependencies": {
-        "@wdio/cli": "^8.10.7",
+        "@wdio/cli": "^8.11.2",
         "json5": "^2.2.3",
-        "webpack": "^5.85.0",
-        "webpack-cli": "^5.1.3",
-        "webpack-dev-server": "^4.15.0"
+        "webpack": "^5.88.1",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^4.15.1"
     }
 }


### PR DESCRIPTION
Also `npm install` to make sure `package-lock.json` is clean.

No idea why neither of the version-nudging bots did any of this.

This supersedes https://github.com/ruffle-rs/ruffle/pull/11840.