### PR TITLE
avm2: Store at most a single type parameter in names/clasess

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -338,20 +338,15 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 )
             })?;
 
-        // Type parameters should specialize the returned class.
+        // A type parameter should specialize the returned class.
         // Unresolvable parameter types are treated as Any, which is treated as
         // Object.
-        if !type_name.params().is_empty() {
-            let mut param_types = Vec::with_capacity(type_name.params().len());
-
-            for param in type_name.params() {
-                param_types.push(match self.resolve_type(param)? {
-                    Some(o) => Value::Object(o.into()),
-                    None => Value::Null,
-                });
-            }
-
-            return Ok(Some(class.apply(self, &param_types[..])?));
+        if let Some(param) = type_name.param() {
+            let param_type = match self.resolve_type(&param)? {
+                Some(o) => Value::Object(o.into()),
+                None => Value::Null,
+            };
+            return Ok(Some(class.apply(self, param_type)?));
         }
 
         Ok(Some(class))
@@ -2057,7 +2052,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             .into());
         }
 
-        let applied = base.apply(self, &args[..])?;
+        let applied = base.apply(self, args[0])?;
         self.push_stack(applied);
 
         Ok(FrameControl::Continue)

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -233,7 +233,7 @@ impl<'gc> Domain<'gc> {
                 let class = res.as_object().ok_or_else(|| {
                     Error::RustError(format!("Vector type {:?} was not an object", res).into())
                 })?;
-                return class.apply(activation, &[type_class]).map(|obj| obj.into());
+                return class.apply(activation, type_class).map(|obj| obj.into());
             }
         }
         res

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -110,7 +110,7 @@ pub fn class_init<'gc>(
 
         let class_class = activation.avm2().classes().class;
         let int_class = activation.avm2().classes().int;
-        let int_vector_class = this.apply(activation, &[int_class.into()])?;
+        let int_vector_class = this.apply(activation, int_class.into())?;
         let int_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$int");
 
         globals.install_const_late(
@@ -126,7 +126,7 @@ pub fn class_init<'gc>(
         );
 
         let uint_class = activation.avm2().classes().uint;
-        let uint_vector_class = this.apply(activation, &[uint_class.into()])?;
+        let uint_vector_class = this.apply(activation, uint_class.into())?;
         let uint_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$uint");
 
         globals.install_const_late(
@@ -142,7 +142,7 @@ pub fn class_init<'gc>(
         );
 
         let number_class = activation.avm2().classes().number;
-        let number_vector_class = this.apply(activation, &[number_class.into()])?;
+        let number_vector_class = this.apply(activation, number_class.into())?;
         let number_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$double");
 
         globals.install_const_late(
@@ -157,7 +157,7 @@ pub fn class_init<'gc>(
             activation.context.gc_context,
         );
 
-        let plain_vector_class = this.apply(activation, &[Value::Null])?;
+        let plain_vector_class = this.apply(activation, Value::Null)?;
         let object_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$object");
 
         globals.install_const_late(

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -81,9 +81,9 @@ pub struct Multiname<'gc> {
     /// multiname is satisfied by any name in the namespace.
     name: Option<AvmString<'gc>>,
 
-    /// The type parameters required to satisfy this multiname. If empty, then
-    /// this multiname is satisfied by any type parameters in any amount.
-    params: Vec<Gc<'gc, Multiname<'gc>>>,
+    /// The type parameter required to satisfy this multiname. If None, then
+    /// this multiname is satisfied by any type parameter or no type parameter
+    param: Option<Gc<'gc, Multiname<'gc>>>,
 
     flags: MultinameFlags,
 }
@@ -162,7 +162,7 @@ impl<'gc> Multiname<'gc> {
                     name: translation_unit
                         .pool_string_option(name.0, context)?
                         .map(|v| v.into()),
-                    params: Vec::new(),
+                    param: None,
                     flags: Default::default(),
                 }
             }
@@ -171,13 +171,13 @@ impl<'gc> Multiname<'gc> {
                 name: translation_unit
                     .pool_string_option(name.0, context)?
                     .map(|v| v.into()),
-                params: Vec::new(),
+                param: None,
                 flags: MultinameFlags::HAS_LAZY_NS,
             },
             AbcMultiname::RTQNameL | AbcMultiname::RTQNameLA => Self {
                 ns: NamespaceSet::multiple(vec![], mc),
                 name: None,
-                params: Vec::new(),
+                param: None,
                 flags: MultinameFlags::HAS_LAZY_NS | MultinameFlags::HAS_LAZY_NAME,
             },
             AbcMultiname::Multiname {
@@ -192,14 +192,14 @@ impl<'gc> Multiname<'gc> {
                 name: translation_unit
                     .pool_string_option(name.0, context)?
                     .map(|v| v.into()),
-                params: Vec::new(),
+                param: None,
                 flags: Default::default(),
             },
             AbcMultiname::MultinameL { namespace_set }
             | AbcMultiname::MultinameLA { namespace_set } => Self {
                 ns: Self::abc_namespace_set(translation_unit, *namespace_set, context)?,
                 name: None,
-                params: Vec::new(),
+                param: None,
                 flags: MultinameFlags::HAS_LAZY_NAME,
             },
             AbcMultiname::TypeName {
@@ -219,12 +219,8 @@ impl<'gc> Multiname<'gc> {
                     .into());
                 }
 
-                for param_type in parameters {
-                    let param_multiname =
-                        translation_unit.pool_multiname_static_any(*param_type, context)?;
-
-                    base.params.push(param_multiname);
-                }
+                base.param =
+                    Some(translation_unit.pool_multiname_static_any(parameters[0], context)?);
                 base
             }
         };
@@ -273,7 +269,7 @@ impl<'gc> Multiname<'gc> {
         Ok(Self {
             ns,
             name,
-            params: self.params.clone(),
+            param: self.param,
             flags: self.flags & MultinameFlags::ATTRIBUTE,
         })
     }
@@ -300,7 +296,7 @@ impl<'gc> Multiname<'gc> {
         Self {
             ns: NamespaceSet::single(Namespace::any(mc)),
             name: None,
-            params: Vec::new(),
+            param: None,
             flags: Default::default(),
         }
     }
@@ -309,7 +305,7 @@ impl<'gc> Multiname<'gc> {
         Self {
             ns: NamespaceSet::single(ns),
             name: Some(name.into()),
-            params: Vec::new(),
+            param: None,
             flags: Default::default(),
         }
     }
@@ -319,7 +315,7 @@ impl<'gc> Multiname<'gc> {
         Self {
             ns: NamespaceSet::single(ns),
             name: Some(name.into()),
-            params: Vec::new(),
+            param: None,
             flags: MultinameFlags::ATTRIBUTE,
         }
     }
@@ -374,8 +370,8 @@ impl<'gc> Multiname<'gc> {
     }
 
     /// List the parameters that the selected class must match.
-    pub fn params(&self) -> &[Gc<'gc, Multiname<'gc>>] {
-        &self.params[..]
+    pub fn param(&self) -> Option<Gc<'gc, Multiname<'gc>>> {
+        self.param
     }
 
     pub fn to_qualified_name(&self, mc: MutationContext<'gc, '_>) -> AvmString<'gc> {
@@ -397,16 +393,9 @@ impl<'gc> Multiname<'gc> {
             uri.push_str(WStr::from_units(b"::*"));
         }
 
-        if !self.params.is_empty() {
+        if let Some(param) = self.param {
             uri.push_str(WStr::from_units(b"<"));
-
-            for (i, param) in self.params.iter().enumerate() {
-                uri.push_str(&param.to_qualified_name(mc));
-                if i < self.params.len() - 1 {
-                    uri.push_str(WStr::from_units(b","));
-                }
-            }
-
+            uri.push_str(&param.to_qualified_name(mc));
             uri.push_str(WStr::from_units(b">"));
         }
 
@@ -461,7 +450,7 @@ impl<'gc> From<QName<'gc>> for Multiname<'gc> {
         Self {
             ns: NamespaceSet::single(q.namespace()),
             name: Some(q.local_name()),
-            params: Vec::new(),
+            param: None,
             flags: Default::default(),
         }
     }

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -909,7 +909,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn apply(
         &self,
         _activation: &mut Activation<'_, 'gc>,
-        _params: &[Value<'gc>],
+        _param: Value<'gc>,
     ) -> Result<ClassObject<'gc>, Error<'gc>> {
         Err("Not a parameterized type".into())
     }

--- a/core/src/avm2/object/vector_object.rs
+++ b/core/src/avm2/object/vector_object.rs
@@ -73,7 +73,7 @@ impl<'gc> VectorObject<'gc> {
         let value_type = vector.value_type();
         let vector_class = activation.avm2().classes().vector;
 
-        let applied_class = vector_class.apply(activation, &[value_type.into()])?;
+        let applied_class = vector_class.apply(activation, value_type.into())?;
 
         let mut object: Object<'gc> = VectorObject(GcCell::allocate(
             activation.context.gc_context,


### PR DESCRIPTION
The only generic class is `Vector`, which only has a single parameter. However, we currently store a list of type parameters in several places, which requires redundant checks that the list only has one entry.

Instead, we now store an `Option` everwhere except for `swf::Multiname::TypeName` (since the actual SWF format supports multiple type parameters). We still perform the same check when loading bytecode (the swf Multiname should only have at most one type parameter), but the rest of the codebase can deal with an `Option` instead.