### PR TITLE
avm2: Support dependent strings, small string optimizations

### DIFF
--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -548,8 +548,15 @@ fn substr<'gc>(
         this.len().min(start_index + len as usize)
     };
 
-    let ret = WString::from(&this[start_index..end_index]);
-    return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    //let ret = WString::from(&this[start_index..end_index]);
+    //return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    return Ok(AvmString::new_dependent(
+        activation.context.gc_context,
+        this,
+        start_index,
+        end_index,
+    )
+    .into());
 }
 
 /// Implements `String.substring`

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -129,11 +129,14 @@ fn char_at<'gc>(
         }
 
         let index = if !n.is_nan() { n as usize } else { 0 };
-        let ret = s
-            .get(index)
-            .map(WString::from_unit)
-            .map(|s| AvmString::new(activation.context.gc_context, s))
-            .unwrap_or_default();
+        let ret = if let Some(c) = s.get(index) {
+            activation
+                .context
+                .interner
+                .get_char(activation.context.gc_context, c)
+        } else {
+            activation.context.interner.empty()
+        };
         return Ok(ret.into());
     }
 
@@ -445,8 +448,11 @@ fn slice<'gc>(
     };
 
     if start_index < end_index {
-        let ret = WString::from(&this[start_index..end_index]);
-        Ok(AvmString::new(activation.context.gc_context, ret).into())
+        Ok(activation
+            .context
+            .interner
+            .substring(activation.context.gc_context, this, start_index, end_index)
+            .into())
     } else {
         Ok("".into())
     }
@@ -483,10 +489,12 @@ fn split<'gc>(
         this.iter()
             .take(limit)
             .map(|c| {
-                Value::from(AvmString::new(
-                    activation.context.gc_context,
-                    WString::from_unit(c),
-                ))
+                Value::from(
+                    activation
+                        .context
+                        .interner
+                        .get_char(activation.context.gc_context, c),
+                )
             })
             .collect()
     } else {
@@ -548,15 +556,11 @@ fn substr<'gc>(
         this.len().min(start_index + len as usize)
     };
 
-    //let ret = WString::from(&this[start_index..end_index]);
-    //return Ok(AvmString::new(activation.context.gc_context, ret).into());
-    return Ok(AvmString::new_dependent(
-        activation.context.gc_context,
-        this,
-        start_index,
-        end_index,
-    )
-    .into());
+    Ok(activation
+        .context
+        .interner
+        .substring(activation.context.gc_context, this, start_index, end_index)
+        .into())
 }
 
 /// Implements `String.substring`
@@ -590,8 +594,11 @@ fn substring<'gc>(
         std::mem::swap(&mut end_index, &mut start_index);
     }
 
-    let ret = WString::from(&this[start_index..end_index]);
-    return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    Ok(activation
+        .context
+        .interner
+        .substring(activation.context.gc_context, this, start_index, end_index)
+        .into())
 }
 
 /// Implements `String.toLowerCase`

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2367,7 +2367,7 @@ impl PlayerBuilder {
         external_interface_providers: Vec<Box<dyn ExternalInterfaceProvider>>,
         fs_command_provider: Box<dyn FsCommandProvider>,
     ) -> GcRoot<'gc> {
-        let mut interner = AvmStringInterner::new();
+        let mut interner = AvmStringInterner::new(gc_context);
         let mut init = GcContext {
             gc_context,
             interner: &mut interner,

--- a/core/src/string/avm_string.rs
+++ b/core/src/string/avm_string.rs
@@ -67,14 +67,8 @@ impl<'gc> AvmString<'gc> {
         start: usize,
         end: usize,
     ) -> Self {
-        // TODO: somewhere (note sure if here) we need to
-        // 1. store and return an interned "" singleton
-        // 2. store and return a cache of interned 1-ascii-letter singletons
-        // we don't want a random "a" to keep the entire source alive.
-        // also whatever we call this layer, maybe call it new_substring.
-        //
-        // also optional 3.
-        // moulins suggested that a substring of a static string maybe also should be a static string
+        // TODO: if source is dependent too, attach to the owner instead
+        // TODO?: if string is static, just make a new static AvmString
         let repr = AvmStringRepr::new_dependent(string, start, end);
         Self {
             source: Source::Owned(Gc::new(gc_context, repr)),
@@ -122,6 +116,15 @@ impl<'gc> From<AvmAtom<'gc>> for AvmString<'gc> {
     fn from(atom: AvmAtom<'gc>) -> Self {
         Self {
             source: Source::Owned(atom.0),
+        }
+    }
+}
+
+impl<'gc> From<Gc<'gc, AvmStringRepr<'gc>>> for AvmString<'gc> {
+    #[inline]
+    fn from(repr: Gc<'gc, AvmStringRepr<'gc>>) -> Self {
+        Self {
+            source: Source::Owned(repr),
         }
     }
 }

--- a/core/src/string/avm_string.rs
+++ b/core/src/string/avm_string.rs
@@ -67,11 +67,17 @@ impl<'gc> AvmString<'gc> {
         start: usize,
         end: usize,
     ) -> Self {
-        // TODO: if source is dependent too, attach to the owner instead
         // TODO?: if string is static, just make a new static AvmString
         let repr = AvmStringRepr::new_dependent(string, start, end);
         Self {
             source: Source::Owned(Gc::new(gc_context, repr)),
+        }
+    }
+
+    pub fn owner(&self) -> Option<AvmString<'gc>> {
+        match &self.source {
+            Source::Owned(s) => s.owner(),
+            Source::Static(_) => None,
         }
     }
 

--- a/core/src/string/repr.rs
+++ b/core/src/string/repr.rs
@@ -4,20 +4,29 @@ use std::ops::Deref;
 use gc_arena::Collect;
 use ruffle_wstr::{ptr as wptr, wstr_impl_traits, WStr, WString};
 
+use crate::string::avm_string::AvmString;
+
 /// Internal representation of `AvmAtom`s and (owned) `AvmString`.
 ///
 /// Using this type directly is dangerous, as it can be used to violate
 /// the interning invariants.
 #[derive(Collect)]
-#[collect(require_static)]
-pub struct AvmStringRepr {
+#[collect(unsafe_drop)]
+pub struct AvmStringRepr<'gc> {
+    #[collect(require_static)]
     ptr: *mut (),
+
+    #[collect(require_static)]
     meta: wptr::WStrMetadata,
+
     // We abuse the 'is_wide' bit for interning.
+    #[collect(require_static)]
     capacity: Cell<wptr::WStrMetadata>,
+
+    owner: Option<AvmString<'gc>>,
 }
 
-impl AvmStringRepr {
+impl<'gc> AvmStringRepr<'gc> {
     pub fn from_raw(s: WString, interned: bool) -> Self {
         let (ptr, meta, cap) = s.into_raw_parts();
         let capacity = Cell::new(wptr::WStrMetadata::new32(cap, interned));
@@ -25,7 +34,29 @@ impl AvmStringRepr {
             ptr,
             meta,
             capacity,
+            owner: None,
         }
+    }
+
+    pub fn new_dependent(s: AvmString<'gc>, start: usize, end: usize) -> Self {
+        let wstr = &s[start..end];
+        let wstr_ptr = wstr as *const WStr;
+
+        let meta = unsafe { wptr::WStrMetadata::of(wstr_ptr) };
+        let capacity = Cell::new(wptr::WStrMetadata::new32(meta.len32(), false));
+        let ptr = wstr_ptr as *mut WStr as *mut ();
+
+        Self {
+            owner: Some(s),
+            ptr,
+            meta,
+            capacity,
+        }
+    }
+
+    #[inline]
+    pub fn is_dependent(&self) -> bool {
+        self.owner.is_some()
     }
 
     #[inline]
@@ -39,23 +70,28 @@ impl AvmStringRepr {
     }
 
     pub fn mark_interned(&self) {
+        if self.is_dependent() {
+            panic!("bug: we interned a dependent string");
+        }
         let cap = self.capacity.get();
         let new_cap = wptr::WStrMetadata::new32(cap.len32(), true);
         self.capacity.set(new_cap);
     }
 }
 
-impl Drop for AvmStringRepr {
+impl<'gc> Drop for AvmStringRepr<'gc> {
     fn drop(&mut self) {
-        // SAFETY: we drop the `WString` we logically own.
-        unsafe {
-            let cap = self.capacity.get().len32();
-            let _ = WString::from_raw_parts(self.ptr, self.meta, cap);
+        if self.owner.is_none() {
+            // SAFETY: we drop the `WString` we logically own.
+            unsafe {
+                let cap = self.capacity.get().len32();
+                let _ = WString::from_raw_parts(self.ptr, self.meta, cap);
+            }
         }
     }
 }
 
-impl Deref for AvmStringRepr {
+impl<'gc> Deref for AvmStringRepr<'gc> {
     type Target = WStr;
     #[inline]
     fn deref(&self) -> &WStr {
@@ -63,11 +99,11 @@ impl Deref for AvmStringRepr {
     }
 }
 
-impl Default for AvmStringRepr {
+impl<'gc> Default for AvmStringRepr<'gc> {
     #[inline]
     fn default() -> Self {
         Self::from_raw(WString::new(), false)
     }
 }
 
-wstr_impl_traits!(impl for AvmStringRepr);
+wstr_impl_traits!(impl['gc] for AvmStringRepr<'gc>);

--- a/core/src/string/repr.rs
+++ b/core/src/string/repr.rs
@@ -23,6 +23,7 @@ pub struct AvmStringRepr<'gc> {
     #[collect(require_static)]
     capacity: Cell<wptr::WStrMetadata>,
 
+    // If Some, the string is dependent.
     owner: Option<AvmString<'gc>>,
 }
 
@@ -43,6 +44,7 @@ impl<'gc> AvmStringRepr<'gc> {
         let wstr_ptr = wstr as *const WStr;
 
         let meta = unsafe { wptr::WStrMetadata::of(wstr_ptr) };
+        // Dependent strings are never interned
         let capacity = Cell::new(wptr::WStrMetadata::new32(meta.len32(), false));
         let ptr = wstr_ptr as *mut WStr as *mut ();
 


### PR DESCRIPTION
This plugs in basic support for dependent strings, which are roughly similar to dependent strings in avmplus or Firefox.
This way, calling `LONG_STRING.substr(1)` is O(1) instead of O(n). And this way, scripts like
```
         while(data.length > 0)
         {
            char = data.charAt(0);
            data = data.substr(1);
            // ...code...
```
are no longer quadratic in space and time.

MVP scope:
- `substring()`, `substr()`, `slice()`
- `charAt()`, `split("")`
- cached, interned `""` and ASCII chars
- `a.substr().substr().substr()` points at the original parent string - no chain of depenednts

Out of MVP scope:
- other AVM2 APIs
- AVM1 APIs
- substring of a static string should be a static string (it's obvious on how to implement, but not obvious on how to nicely structure the code around it, it's already stretched across many layers)

Very out of scope:
- APIs that return `"".into()` and especially places that don't have direct access to `context.interner` at all.