### PR TITLE
Add wireframe mode toggle to debug menu

### DIFF
--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -31,4 +31,5 @@ debug-menu-open-stage = View Stage Info
 debug-menu-open-movie = View Movie
 debug-menu-open-movie-list = Show Known Movies
 debug-menu-search-display-objects = Search Display Objects...
+debug-menu-wireframe-mode = Wireframe Mode
 

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -222,7 +222,7 @@ impl GuiController {
                 full_output.platform_output.cursor_icon = player
                     .ui()
                     .downcast_ref::<DesktopUiBackend>()
-                    .unwrap_or_else(|| panic!("UI Backend should be DesktopUiBackend"))
+                    .expect("UI Backend should be DesktopUiBackend")
                     .cursor();
             }
         }

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -23,7 +23,7 @@ pub struct Descriptors {
     copy_pipeline: Mutex<FnvHashMap<(u32, wgpu::TextureFormat), Arc<wgpu::RenderPipeline>>>,
     copy_srgb_pipeline: Mutex<FnvHashMap<(u32, wgpu::TextureFormat), Arc<wgpu::RenderPipeline>>>,
     pub shaders: Shaders,
-    pipelines: Mutex<FnvHashMap<(u32, wgpu::TextureFormat), Arc<Pipelines>>>,
+    pipelines: Mutex<FnvHashMap<(u32, wgpu::PolygonMode, wgpu::TextureFormat), Arc<Pipelines>>>,
     pub default_color_bind_group: wgpu::BindGroup,
     pub filters: Filters,
 }
@@ -238,19 +238,25 @@ impl Descriptors {
             .clone()
     }
 
-    pub fn pipelines(&self, msaa_sample_count: u32, format: wgpu::TextureFormat) -> Arc<Pipelines> {
+    pub fn pipelines(
+        &self,
+        msaa_sample_count: u32,
+        polygon_mode: wgpu::PolygonMode,
+        format: wgpu::TextureFormat,
+    ) -> Arc<Pipelines> {
         let mut pipelines = self
             .pipelines
             .lock()
             .expect("Pipelines should not be already locked");
         pipelines
-            .entry((msaa_sample_count, format))
+            .entry((msaa_sample_count, polygon_mode, format))
             .or_insert_with(|| {
                 Arc::new(Pipelines::new(
                     &self.device,
                     &self.shaders,
                     format,
                     msaa_sample_count,
+                    polygon_mode,
                     &self.bind_layouts,
                 ))
             })

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -85,6 +85,7 @@ impl Pipelines {
         shaders: &Shaders,
         format: wgpu::TextureFormat,
         msaa_sample_count: u32,
+        polygon_mode: wgpu::PolygonMode,
         bind_layouts: &BindLayouts,
     ) -> Self {
         let colort_bindings = if device.limits().max_push_constant_size > 0 {
@@ -121,6 +122,7 @@ impl Pipelines {
             format,
             &shaders.color_shader,
             msaa_sample_count,
+            polygon_mode,
             &VERTEX_BUFFERS_DESCRIPTION_COLOR,
             &colort_bindings,
             wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
@@ -144,6 +146,7 @@ impl Pipelines {
             format,
             &shaders.gradient_shader,
             msaa_sample_count,
+            polygon_mode,
             &VERTEX_BUFFERS_DESCRIPTION_POS,
             &gradient_bindings,
             wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
@@ -167,6 +170,7 @@ impl Pipelines {
                 format,
                 &shaders.blend_shaders[blend],
                 msaa_sample_count,
+                polygon_mode,
                 &VERTEX_BUFFERS_DESCRIPTION_POS,
                 &complex_blend_bindings,
                 wgpu::BlendState::REPLACE,
@@ -195,6 +199,7 @@ impl Pipelines {
                     format,
                     &shaders.bitmap_shader,
                     msaa_sample_count,
+                    polygon_mode,
                     &VERTEX_BUFFERS_DESCRIPTION_POS,
                     &bitmap_blend_bindings,
                     blend.blend_state(),
@@ -227,6 +232,7 @@ impl Pipelines {
             })],
             &VERTEX_BUFFERS_DESCRIPTION_POS,
             msaa_sample_count,
+            polygon_mode,
         ));
 
         let bitmap_opaque_dummy_depth = device.create_render_pipeline(&create_pipeline_descriptor(
@@ -253,6 +259,7 @@ impl Pipelines {
             })],
             &VERTEX_BUFFERS_DESCRIPTION_POS,
             msaa_sample_count,
+            polygon_mode,
         ));
 
         Self {
@@ -276,6 +283,7 @@ fn create_pipeline_descriptor<'a>(
     color_target_state: &'a [Option<wgpu::ColorTargetState>],
     vertex_buffer_layout: &'a [wgpu::VertexBufferLayout<'a>],
     msaa_sample_count: u32,
+    polygon_mode: wgpu::PolygonMode,
 ) -> wgpu::RenderPipelineDescriptor<'a> {
     wgpu::RenderPipelineDescriptor {
         label,
@@ -295,7 +303,7 @@ fn create_pipeline_descriptor<'a>(
             strip_index_format: None,
             front_face: wgpu::FrontFace::Ccw,
             cull_mode: None,
-            polygon_mode: wgpu::PolygonMode::default(),
+            polygon_mode,
             unclipped_depth: false,
             conservative: false,
         },
@@ -316,6 +324,7 @@ fn create_shape_pipeline(
     format: wgpu::TextureFormat,
     shader: &wgpu::ShaderModule,
     msaa_sample_count: u32,
+    polygon_mode: wgpu::PolygonMode,
     vertex_buffers_layout: &[wgpu::VertexBufferLayout<'_>],
     bind_group_layouts: &[&wgpu::BindGroupLayout],
     blend: wgpu::BlendState,
@@ -353,6 +362,7 @@ fn create_shape_pipeline(
             })],
             vertex_buffers_layout,
             msaa_sample_count,
+            polygon_mode,
         ))
     };
 
@@ -370,6 +380,7 @@ fn create_shape_pipeline(
             })],
             vertex_buffers_layout,
             msaa_sample_count,
+            polygon_mode,
         )),
         |mask_state| match mask_state {
             MaskState::NoMask => mask_render_state(

--- a/render/wgpu/src/surface/commands.rs
+++ b/render/wgpu/src/surface/commands.rs
@@ -467,6 +467,7 @@ pub enum LayerRef<'a> {
 #[allow(clippy::too_many_arguments)]
 pub fn chunk_blends<'a>(
     commands: Vec<Command>,
+    as_wireframe: bool,
     descriptors: &'a Descriptors,
     uniform_buffers: &mut UniformBuffer<'a, Transforms>,
     color_buffers: &mut UniformBuffer<'a, ColorAdjustments>,
@@ -503,6 +504,7 @@ pub fn chunk_blends<'a>(
                 let clear_color = blend_type.default_color();
                 let target = surface.draw_commands(
                     RenderTargetMode::FreshWithColor(clear_color),
+                    as_wireframe,
                     descriptors,
                     meshes,
                     commands,


### PR DESCRIPTION
This adds a checkbox to toggle wireframe mode to the debug menu.
Doing so by switching to an entirely different set of pipelines, with `PolygonMode::Line`, as suggested by @adrian17 and @Dinnerbone.
Those are created lazily, so hopefully they won't add any additional startup delay.

I'm not at all sure how this is how it should be done.
My main concern is inflating the `RenderBackend` trait too much with less relevant stuff.

![image](https://github.com/ruffle-rs/ruffle/assets/288816/2e120da9-b2c1-4e5e-90fe-50aed4d00889)