### PR TITLE
core: Correctly apply blend modes and filters from button records

### DIFF
--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -14,6 +14,7 @@ use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::vminterface::Instantiator;
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
+use ruffle_render::filters::Filter;
 use std::cell::{Ref, RefMut};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -173,6 +174,11 @@ impl<'gc> Avm1Button<'gc> {
                 // Set transform of child (and modify previous child if it already existed)
                 child.set_matrix(context.gc_context, record.matrix.into());
                 child.set_color_transform(context.gc_context, record.color_transform);
+                child.set_blend_mode(context.gc_context, record.blend_mode);
+                child.set_filters(
+                    context.gc_context,
+                    record.filters.iter().map(Filter::from).collect(),
+                );
             }
         }
 

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -18,6 +18,7 @@ use crate::tag_utils::{SwfMovie, SwfSlice};
 use crate::vminterface::Instantiator;
 use core::fmt;
 use gc_arena::{Collect, GcCell, MutationContext};
+use ruffle_render::filters::Filter;
 use std::cell::{Ref, RefMut};
 use std::sync::Arc;
 
@@ -211,6 +212,11 @@ impl<'gc> Avm2Button<'gc> {
 
                         if swf_state != swf::ButtonState::HIT_TEST {
                             child.set_color_transform(context.gc_context, record.color_transform);
+                            child.set_blend_mode(context.gc_context, record.blend_mode);
+                            child.set_filters(
+                                context.gc_context,
+                                record.filters.iter().map(Filter::from).collect(),
+                            );
                         }
 
                         children.push((child, record.depth));


### PR DESCRIPTION
Makes some of the Papa's games look better (see https://github.com/ruffle-rs/ruffle/issues/9201#issuecomment-1517500384).

This should also fix the glow filter not applying to the buttons in https://github.com/ruffle-rs/ruffle/pull/11878#issuecomment-1619919537.