### PR TITLE
avm2: Replace Option<Object<'gc>> with Object<'gc> in all native methods

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -232,7 +232,7 @@ impl<'gc> Avm2<'gc> {
                     .context
                     .avm2
                     .push_global_init(init_activation.context.gc_context, script);
-                let r = (method.method)(&mut init_activation, Some(scope), &[]);
+                let r = (method.method)(&mut init_activation, scope, &[]);
                 init_activation
                     .context
                     .avm2

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -152,7 +152,7 @@ impl<'gc> Executable<'gc> {
                     .context
                     .avm2
                     .push_call(activation.context.gc_context, self);
-                method(&mut activation, Some(receiver), &arguments)
+                method(&mut activation, receiver, &arguments)
             }
             Executable::Action(bm) => {
                 if bm.method.is_unchecked() {

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -67,35 +67,35 @@ const PUBLIC_PROTO_METHODS: &[(&str, NativeMethodImpl)] = &[
 /// Implements `Array`'s instance initializer.
 pub fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
+    activation.super_init(this, &[])?;
 
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            if args.len() == 1 {
-                if let Some(expected_len) = args
-                    .get(0)
-                    .and_then(|v| v.as_number(activation.context.gc_context).ok())
-                {
-                    if expected_len < 0.0 || expected_len.is_nan() || expected_len.fract() != 0.0 {
-                        return Err(Error::AvmError(range_error(
-                            activation,
-                            &format!("Error #1005: Array index is not a positive integer ({expected_len})"),
-                            1005,
-                        )?));
-                    }
-
-                    array.set_length(expected_len as usize);
-
-                    return Ok(Value::Undefined);
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        if args.len() == 1 {
+            if let Some(expected_len) = args
+                .get(0)
+                .and_then(|v| v.as_number(activation.context.gc_context).ok())
+            {
+                if expected_len < 0.0 || expected_len.is_nan() || expected_len.fract() != 0.0 {
+                    return Err(Error::AvmError(range_error(
+                        activation,
+                        &format!(
+                            "Error #1005: Array index is not a positive integer ({expected_len})"
+                        ),
+                        1005,
+                    )?));
                 }
-            }
 
-            for (i, arg) in args.iter().enumerate() {
-                array.set(i, *arg);
+                array.set_length(expected_len as usize);
+
+                return Ok(Value::Undefined);
             }
+        }
+
+        for (i, arg) in args.iter().enumerate() {
+            array.set(i, *arg);
         }
     }
 
@@ -104,7 +104,7 @@ pub fn instance_init<'gc>(
 
 pub fn class_call<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(activation
@@ -118,44 +118,41 @@ pub fn class_call<'gc>(
 /// Implements `Array`'s class initializer.
 pub fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let scope = activation.create_scopechain();
-        let gc_context = activation.context.gc_context;
-        let this_class = this.as_class_object().unwrap();
-        let array_proto = this_class.prototype();
+    let scope = activation.create_scopechain();
+    let gc_context = activation.context.gc_context;
+    let this_class = this.as_class_object().unwrap();
+    let array_proto = this_class.prototype();
 
-        for (name, method) in PUBLIC_PROTO_METHODS {
-            array_proto.set_string_property_local(
-                *name,
-                FunctionObject::from_method(
-                    activation,
-                    Method::from_builtin(*method, name, gc_context),
-                    scope,
-                    None,
-                    Some(this_class),
-                )
-                .into(),
+    for (name, method) in PUBLIC_PROTO_METHODS {
+        array_proto.set_string_property_local(
+            *name,
+            FunctionObject::from_method(
                 activation,
-            )?;
-            array_proto.set_local_property_is_enumerable(gc_context, (*name).into(), false);
-        }
+                Method::from_builtin(*method, name, gc_context),
+                scope,
+                None,
+                Some(this_class),
+            )
+            .into(),
+            activation,
+        )?;
+        array_proto.set_local_property_is_enumerable(gc_context, (*name).into(), false);
     }
+
     Ok(Value::Undefined)
 }
 
 /// Implements `Array.length`'s getter
 pub fn length<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(array) = this.as_array_storage() {
-            return Ok(array.length().into());
-        }
+    if let Some(array) = this.as_array_storage() {
+        return Ok(array.length().into());
     }
 
     Ok(Value::Undefined)
@@ -164,17 +161,15 @@ pub fn length<'gc>(
 /// Implements `Array.length`'s setter
 pub fn set_length<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            let size = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_u32(activation)?;
-            array.set_length(size as usize);
-        }
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        let size = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_u32(activation)?;
+        array.set_length(size as usize);
     }
 
     Ok(Value::Undefined)
@@ -192,11 +187,12 @@ pub fn build_array<'gc>(
 #[allow(clippy::map_clone)] //You can't clone `Option<Ref<T>>` without it
 pub fn concat<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut base_array = this
-        .and_then(|this| this.as_array_storage().map(|a| a.clone()))
+        .as_array_storage()
+        .map(|a| a.clone())
         .unwrap_or_else(|| ArrayStorage::new(0));
 
     for arg in args {
@@ -237,7 +233,7 @@ pub fn resolve_array_hole<'gc>(
 
 pub fn join_inner<'gc, 'a, 'ctxt, C>(
     activation: &mut Activation<'a, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
     mut conv: C,
 ) -> Result<Value<'gc>, Error<'gc>>
@@ -249,27 +245,25 @@ where
         separator = ",".into();
     }
 
-    if let Some(this) = this {
-        if let Some(array) = this.as_array_storage() {
-            let string_separator = separator.coerce_to_string(activation)?;
-            let mut accum = Vec::with_capacity(array.length());
+    if let Some(array) = this.as_array_storage() {
+        let string_separator = separator.coerce_to_string(activation)?;
+        let mut accum = Vec::with_capacity(array.length());
 
-            for (i, item) in array.iter().enumerate() {
-                let item = resolve_array_hole(activation, this, i, item)?;
+        for (i, item) in array.iter().enumerate() {
+            let item = resolve_array_hole(activation, this, i, item)?;
 
-                if matches!(item, Value::Undefined) || matches!(item, Value::Null) {
-                    accum.push("".into());
-                } else {
-                    accum.push(conv(item, activation)?.coerce_to_string(activation)?);
-                }
+            if matches!(item, Value::Undefined) || matches!(item, Value::Null) {
+                accum.push("".into());
+            } else {
+                accum.push(conv(item, activation)?.coerce_to_string(activation)?);
             }
-
-            return Ok(AvmString::new(
-                activation.context.gc_context,
-                crate::string::join(&accum, &string_separator),
-            )
-            .into());
         }
+
+        return Ok(AvmString::new(
+            activation.context.gc_context,
+            crate::string::join(&accum, &string_separator),
+        )
+        .into());
     }
 
     Ok(Value::Undefined)
@@ -278,7 +272,7 @@ where
 /// Implements `Array.join`
 pub fn join<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     join_inner(activation, this, args, |v, _act| Ok(v))
@@ -287,7 +281,7 @@ pub fn join<'gc>(
 /// Implements `Array.toString`
 pub fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     join_inner(activation, this, &[",".into()], |v, _act| Ok(v))
@@ -296,7 +290,7 @@ pub fn to_string<'gc>(
 /// Implements `Array.toLocaleString`
 pub fn to_locale_string<'gc>(
     act: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     join_inner(act, this, &[",".into()], |v, activation| {
@@ -415,23 +409,21 @@ impl<'gc> ArrayIter<'gc> {
 /// Implements `Array.forEach`
 pub fn for_each<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            callback.call(receiver, &[item, i.into(), this.into()], activation)?;
-        }
+        callback.call(receiver, &[item, i.into(), this.into()], activation)?;
     }
 
     Ok(Value::Undefined)
@@ -440,155 +432,137 @@ pub fn for_each<'gc>(
 /// Implements `Array.map`
 pub fn map<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut new_array = ArrayStorage::new(0);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut new_array = ArrayStorage::new(0);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
-            let new_item = callback.call(receiver, &[item, i.into(), this.into()], activation)?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
+        let new_item = callback.call(receiver, &[item, i.into(), this.into()], activation)?;
 
-            new_array.push(new_item);
-        }
-
-        return build_array(activation, new_array);
+        new_array.push(new_item);
     }
 
-    Ok(Value::Undefined)
+    build_array(activation, new_array)
 }
 
 /// Implements `Array.filter`
 pub fn filter<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut new_array = ArrayStorage::new(0);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut new_array = ArrayStorage::new(0);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
-            let is_allowed = callback
-                .call(receiver, &[item, i.into(), this.into()], activation)?
-                .coerce_to_boolean();
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
+        let is_allowed = callback
+            .call(receiver, &[item, i.into(), this.into()], activation)?
+            .coerce_to_boolean();
 
-            if is_allowed {
-                new_array.push(item);
-            }
+        if is_allowed {
+            new_array.push(item);
         }
-
-        return build_array(activation, new_array);
     }
 
-    Ok(Value::Undefined)
+    build_array(activation, new_array)
 }
 
 /// Implements `Array.every`
 pub fn every<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            let result = callback
-                .call(receiver, &[item, i.into(), this.into()], activation)?
-                .coerce_to_boolean();
+        let result = callback
+            .call(receiver, &[item, i.into(), this.into()], activation)?
+            .coerce_to_boolean();
 
-            if !result {
-                return Ok(false.into());
-            }
+        if !result {
+            return Ok(false.into());
         }
-
-        return Ok(true.into());
     }
 
-    Ok(Value::Undefined)
+    Ok(true.into())
 }
 
 /// Implements `Array.some`
 pub fn some<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            let result = callback
-                .call(receiver, &[item, i.into(), this.into()], activation)?
-                .coerce_to_boolean();
+        let result = callback
+            .call(receiver, &[item, i.into(), this.into()], activation)?
+            .coerce_to_boolean();
 
-            if result {
-                return Ok(true.into());
-            }
+        if result {
+            return Ok(true.into());
         }
-
-        return Ok(false.into());
     }
 
-    Ok(Value::Undefined)
+    Ok(false.into())
 }
 
 /// Implements `Array.indexOf`
 pub fn index_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(array) = this.as_array_storage() {
-            let search_val = args.get(0).cloned().unwrap_or(Value::Undefined);
-            let from = args
-                .get(1)
-                .cloned()
-                .unwrap_or_else(|| 0.into())
-                .coerce_to_u32(activation)?;
+    if let Some(array) = this.as_array_storage() {
+        let search_val = args.get(0).cloned().unwrap_or(Value::Undefined);
+        let from = args
+            .get(1)
+            .cloned()
+            .unwrap_or_else(|| 0.into())
+            .coerce_to_u32(activation)?;
 
-            for (i, val) in array.iter().enumerate() {
-                let val = resolve_array_hole(activation, this, i, val)?;
-                if i >= from as usize && val == search_val {
-                    return Ok(i.into());
-                }
+        for (i, val) in array.iter().enumerate() {
+            let val = resolve_array_hole(activation, this, i, val)?;
+            if i >= from as usize && val == search_val {
+                return Ok(i.into());
             }
-
-            return Ok((-1).into());
         }
+
+        return Ok((-1).into());
     }
 
     Ok(Value::Undefined)
@@ -597,27 +571,25 @@ pub fn index_of<'gc>(
 /// Implements `Array.lastIndexOf`
 pub fn last_index_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(array) = this.as_array_storage() {
-            let search_val = args.get(0).cloned().unwrap_or(Value::Undefined);
-            let from = args
-                .get(1)
-                .cloned()
-                .unwrap_or_else(|| i32::MAX.into())
-                .coerce_to_u32(activation)?;
+    if let Some(array) = this.as_array_storage() {
+        let search_val = args.get(0).cloned().unwrap_or(Value::Undefined);
+        let from = args
+            .get(1)
+            .cloned()
+            .unwrap_or_else(|| i32::MAX.into())
+            .coerce_to_u32(activation)?;
 
-            for (i, val) in array.iter().enumerate().rev() {
-                let val = resolve_array_hole(activation, this, i, val)?;
-                if i <= from as usize && val == search_val {
-                    return Ok(i.into());
-                }
+        for (i, val) in array.iter().enumerate().rev() {
+            let val = resolve_array_hole(activation, this, i, val)?;
+            if i <= from as usize && val == search_val {
+                return Ok(i.into());
             }
-
-            return Ok((-1).into());
         }
+
+        return Ok((-1).into());
     }
 
     Ok(Value::Undefined)
@@ -626,13 +598,11 @@ pub fn last_index_of<'gc>(
 /// Implements `Array.pop`
 pub fn pop<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            return Ok(array.pop());
-        }
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        return Ok(array.pop());
     }
 
     Ok(Value::Undefined)
@@ -641,16 +611,14 @@ pub fn pop<'gc>(
 /// Implements `Array.push`
 pub fn push<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            for arg in args {
-                array.push(*arg)
-            }
-            return Ok(array.length().into());
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        for arg in args {
+            array.push(*arg)
         }
+        return Ok(array.length().into());
     }
 
     Ok(Value::Undefined)
@@ -658,36 +626,33 @@ pub fn push<'gc>(
 
 pub fn reverse<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            let mut last_non_hole_index = None;
-            for (i, val) in array.iter().enumerate() {
-                if val.is_some() {
-                    last_non_hole_index = Some(i + 1);
-                }
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        let mut last_non_hole_index = None;
+        for (i, val) in array.iter().enumerate() {
+            if val.is_some() {
+                last_non_hole_index = Some(i + 1);
             }
-
-            let mut new_array = ArrayStorage::new(0);
-
-            for i in
-                (0..last_non_hole_index.unwrap_or_else(|| array.length().saturating_sub(1))).rev()
-            {
-                if let Some(value) = array.get(i) {
-                    new_array.push(value)
-                } else {
-                    new_array.push_hole()
-                }
-            }
-
-            new_array.set_length(array.length());
-
-            swap(&mut *array, &mut new_array);
-
-            return Ok(this.into());
         }
+
+        let mut new_array = ArrayStorage::new(0);
+
+        for i in (0..last_non_hole_index.unwrap_or_else(|| array.length().saturating_sub(1))).rev()
+        {
+            if let Some(value) = array.get(i) {
+                new_array.push(value)
+            } else {
+                new_array.push_hole()
+            }
+        }
+
+        new_array.set_length(array.length());
+
+        swap(&mut *array, &mut new_array);
+
+        return Ok(this.into());
     }
 
     Ok(Value::Undefined)
@@ -696,13 +661,11 @@ pub fn reverse<'gc>(
 /// Implements `Array.shift`
 pub fn shift<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            return Ok(array.shift());
-        }
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        return Ok(array.shift());
     }
 
     Ok(Value::Undefined)
@@ -711,16 +674,14 @@ pub fn shift<'gc>(
 /// Implements `Array.unshift`
 pub fn unshift<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            for arg in args.iter().rev() {
-                array.unshift(*arg)
-            }
-            return Ok(array.length().into());
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        for arg in args.iter().rev() {
+            array.unshift(*arg)
         }
+        return Ok(array.length().into());
     }
 
     Ok(Value::Undefined)
@@ -745,39 +706,37 @@ pub fn resolve_index<'gc>(
 /// Implements `Array.slice`
 pub fn slice<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let array_length = this.as_array_storage().map(|a| a.length());
+    let array_length = this.as_array_storage().map(|a| a.length());
 
-        if let Some(array_length) = array_length {
-            let actual_start = resolve_index(
-                activation,
-                args.get(0).cloned().unwrap_or_else(|| 0.into()),
-                array_length,
-            )?;
-            let actual_end = resolve_index(
-                activation,
-                args.get(1).cloned().unwrap_or_else(|| 0xFFFFFF.into()),
-                array_length,
-            )?;
-            let mut new_array = ArrayStorage::new(0);
-            for i in actual_start..actual_end {
-                if i >= array_length {
-                    break;
-                }
-
-                new_array.push(resolve_array_hole(
-                    activation,
-                    this,
-                    i,
-                    this.as_array_storage().unwrap().get(i),
-                )?);
+    if let Some(array_length) = array_length {
+        let actual_start = resolve_index(
+            activation,
+            args.get(0).cloned().unwrap_or_else(|| 0.into()),
+            array_length,
+        )?;
+        let actual_end = resolve_index(
+            activation,
+            args.get(1).cloned().unwrap_or_else(|| 0xFFFFFF.into()),
+            array_length,
+        )?;
+        let mut new_array = ArrayStorage::new(0);
+        for i in actual_start..actual_end {
+            if i >= array_length {
+                break;
             }
 
-            return build_array(activation, new_array);
+            new_array.push(resolve_array_hole(
+                activation,
+                this,
+                i,
+                this.as_array_storage().unwrap().get(i),
+            )?);
         }
+
+        return build_array(activation, new_array);
     }
 
     Ok(Value::Undefined)
@@ -786,51 +745,49 @@ pub fn slice<'gc>(
 /// Implements `Array.splice`
 pub fn splice<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let array_length = this.as_array_storage().map(|a| a.length());
+    let array_length = this.as_array_storage().map(|a| a.length());
 
-        if let Some(array_length) = array_length {
-            if let Some(start) = args.get(0).cloned() {
-                let actual_start = resolve_index(activation, start, array_length)?;
-                let delete_count = args
-                    .get(1)
-                    .cloned()
-                    .unwrap_or_else(|| array_length.into())
-                    .coerce_to_i32(activation)?;
+    if let Some(array_length) = array_length {
+        if let Some(start) = args.get(0).cloned() {
+            let actual_start = resolve_index(activation, start, array_length)?;
+            let delete_count = args
+                .get(1)
+                .cloned()
+                .unwrap_or_else(|| array_length.into())
+                .coerce_to_i32(activation)?;
 
-                let actual_end = min(array_length, actual_start + delete_count as usize);
-                let args_slice = if args.len() > 2 {
-                    args[2..].iter().cloned()
-                } else {
-                    [].iter().cloned()
-                };
+            let actual_end = min(array_length, actual_start + delete_count as usize);
+            let args_slice = if args.len() > 2 {
+                args[2..].iter().cloned()
+            } else {
+                [].iter().cloned()
+            };
 
-                let contents = this
-                    .as_array_storage()
-                    .map(|a| a.iter().collect::<Vec<Option<Value<'gc>>>>())
-                    .unwrap();
+            let contents = this
+                .as_array_storage()
+                .map(|a| a.iter().collect::<Vec<Option<Value<'gc>>>>())
+                .unwrap();
 
-                let mut resolved = Vec::with_capacity(contents.len());
-                for (i, v) in contents.iter().enumerate() {
-                    resolved.push(resolve_array_hole(activation, this, i, *v)?);
-                }
-
-                let removed = resolved
-                    .splice(actual_start..actual_end, args_slice)
-                    .collect::<Vec<Value<'gc>>>();
-                let removed_array = ArrayStorage::from_args(&removed[..]);
-
-                let mut resolved_array = ArrayStorage::from_args(&resolved[..]);
-
-                if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-                    swap(&mut *array, &mut resolved_array)
-                }
-
-                return build_array(activation, removed_array);
+            let mut resolved = Vec::with_capacity(contents.len());
+            for (i, v) in contents.iter().enumerate() {
+                resolved.push(resolve_array_hole(activation, this, i, *v)?);
             }
+
+            let removed = resolved
+                .splice(actual_start..actual_end, args_slice)
+                .collect::<Vec<Value<'gc>>>();
+            let removed_array = ArrayStorage::from_args(&removed[..]);
+
+            let mut resolved_array = ArrayStorage::from_args(&resolved[..]);
+
+            if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+                swap(&mut *array, &mut resolved_array)
+            }
+
+            return build_array(activation, removed_array);
         }
     }
 
@@ -1039,88 +996,84 @@ fn extract_array_values<'gc>(
 /// Impl `Array.sort`
 pub fn sort<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let (compare_fnc, options) = if args.len() > 1 {
-            (
-                Some(
-                    args.get(0)
-                        .cloned()
-                        .unwrap_or(Value::Undefined)
-                        .as_callable(activation, None, None)?,
-                ),
-                SortOptions::from_bits_truncate(
-                    args.get(1)
-                        .cloned()
-                        .unwrap_or_else(|| 0.into())
-                        .coerce_to_u32(activation)? as u8,
-                ),
-            )
-        } else {
-            (
-                None,
-                SortOptions::from_bits_truncate(
-                    args.get(0)
-                        .cloned()
-                        .unwrap_or_else(|| 0.into())
-                        .coerce_to_u32(activation)? as u8,
-                ),
-            )
-        };
+    let (compare_fnc, options) = if args.len() > 1 {
+        (
+            Some(
+                args.get(0)
+                    .cloned()
+                    .unwrap_or(Value::Undefined)
+                    .as_callable(activation, None, None)?,
+            ),
+            SortOptions::from_bits_truncate(
+                args.get(1)
+                    .cloned()
+                    .unwrap_or_else(|| 0.into())
+                    .coerce_to_u32(activation)? as u8,
+            ),
+        )
+    } else {
+        (
+            None,
+            SortOptions::from_bits_truncate(
+                args.get(0)
+                    .cloned()
+                    .unwrap_or_else(|| 0.into())
+                    .coerce_to_u32(activation)? as u8,
+            ),
+        )
+    };
 
-        let mut values = if let Some(values) = extract_array_values(activation, this.into())? {
-            values
-                .iter()
-                .enumerate()
-                .map(|(i, v)| (i, *v))
-                .collect::<Vec<(usize, Value<'gc>)>>()
-        } else {
-            return Ok(0.into());
-        };
+    let mut values = if let Some(values) = extract_array_values(activation, this.into())? {
+        values
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (i, *v))
+            .collect::<Vec<(usize, Value<'gc>)>>()
+    } else {
+        return Ok(0.into());
+    };
 
-        let unique_satisfied = if let Some(v) = compare_fnc {
-            sort_inner(
-                activation,
-                &mut values,
-                options,
-                constrain(|activation, a, b| {
-                    let order = v
-                        .call(this.into(), &[a, b], activation)?
-                        .coerce_to_number(activation)?;
+    let unique_satisfied = if let Some(v) = compare_fnc {
+        sort_inner(
+            activation,
+            &mut values,
+            options,
+            constrain(|activation, a, b| {
+                let order = v
+                    .call(this.into(), &[a, b], activation)?
+                    .coerce_to_number(activation)?;
 
-                    if order > 0.0 {
-                        Ok(Ordering::Greater)
-                    } else if order < 0.0 {
-                        Ok(Ordering::Less)
-                    } else {
-                        Ok(Ordering::Equal)
-                    }
-                }),
-            )?
-        } else if options.contains(SortOptions::NUMERIC) {
-            sort_inner(activation, &mut values, options, compare_numeric)?
-        } else if options.contains(SortOptions::CASE_INSENSITIVE) {
-            sort_inner(
-                activation,
-                &mut values,
-                options,
-                compare_string_case_insensitive,
-            )?
-        } else {
-            sort_inner(
-                activation,
-                &mut values,
-                options,
-                compare_string_case_sensitive,
-            )?
-        };
+                if order > 0.0 {
+                    Ok(Ordering::Greater)
+                } else if order < 0.0 {
+                    Ok(Ordering::Less)
+                } else {
+                    Ok(Ordering::Equal)
+                }
+            }),
+        )?
+    } else if options.contains(SortOptions::NUMERIC) {
+        sort_inner(activation, &mut values, options, compare_numeric)?
+    } else if options.contains(SortOptions::CASE_INSENSITIVE) {
+        sort_inner(
+            activation,
+            &mut values,
+            options,
+            compare_string_case_insensitive,
+        )?
+    } else {
+        sort_inner(
+            activation,
+            &mut values,
+            options,
+            compare_string_case_sensitive,
+        )?
+    };
 
-        return sort_postprocess(activation, this, options, unique_satisfied, values);
-    }
-
-    Ok(0.into())
+    sort_postprocess(activation, this, options, unique_satisfied, values)
 }
 
 /// Given a value, extract its array values.
@@ -1178,77 +1131,75 @@ fn extract_maybe_array_sort_options<'gc>(
 /// Impl `Array.sortOn`
 pub fn sort_on<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(field_names_value) = args.get(0).cloned() {
-            let field_names = extract_maybe_array_strings(activation, field_names_value)?;
-            let mut options = extract_maybe_array_sort_options(
-                activation,
-                args.get(1).cloned().unwrap_or_else(|| 0.into()),
-            )?;
+    if let Some(field_names_value) = args.get(0).cloned() {
+        let field_names = extract_maybe_array_strings(activation, field_names_value)?;
+        let mut options = extract_maybe_array_sort_options(
+            activation,
+            args.get(1).cloned().unwrap_or_else(|| 0.into()),
+        )?;
 
-            let first_option = options.get(0).cloned().unwrap_or_else(SortOptions::empty)
-                & (SortOptions::UNIQUE_SORT | SortOptions::RETURN_INDEXED_ARRAY);
-            let mut values = if let Some(values) = extract_array_values(activation, this.into())? {
-                values
-                    .iter()
-                    .enumerate()
-                    .map(|(i, v)| (i, *v))
-                    .collect::<Vec<(usize, Value<'gc>)>>()
-            } else {
-                return Ok(0.into());
-            };
+        let first_option = options.get(0).cloned().unwrap_or_else(SortOptions::empty)
+            & (SortOptions::UNIQUE_SORT | SortOptions::RETURN_INDEXED_ARRAY);
+        let mut values = if let Some(values) = extract_array_values(activation, this.into())? {
+            values
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (i, *v))
+                .collect::<Vec<(usize, Value<'gc>)>>()
+        } else {
+            return Ok(0.into());
+        };
 
-            if options.len() < field_names.len() {
-                options.resize(
-                    field_names.len(),
-                    options.last().cloned().unwrap_or_else(SortOptions::empty),
-                );
-            }
+        if options.len() < field_names.len() {
+            options.resize(
+                field_names.len(),
+                options.last().cloned().unwrap_or_else(SortOptions::empty),
+            );
+        }
 
-            let unique_satisfied = sort_inner(
-                activation,
-                &mut values,
-                first_option,
-                constrain(|activation, a, b| {
-                    for (field_name, options) in field_names.iter().zip(options.iter()) {
-                        // note: these are incorrect: pretty sure
-                        // if the object is null/undefined or does not have the field,
-                        // it's treated as if the field's value was undefined.
-                        // TODO: verify this and fix it
-                        let a_object = a.coerce_to_object(activation)?;
-                        let a_field = a_object.get_public_property(*field_name, activation)?;
+        let unique_satisfied = sort_inner(
+            activation,
+            &mut values,
+            first_option,
+            constrain(|activation, a, b| {
+                for (field_name, options) in field_names.iter().zip(options.iter()) {
+                    // note: these are incorrect: pretty sure
+                    // if the object is null/undefined or does not have the field,
+                    // it's treated as if the field's value was undefined.
+                    // TODO: verify this and fix it
+                    let a_object = a.coerce_to_object(activation)?;
+                    let a_field = a_object.get_public_property(*field_name, activation)?;
 
-                        let b_object = b.coerce_to_object(activation)?;
-                        let b_field = b_object.get_public_property(*field_name, activation)?;
+                    let b_object = b.coerce_to_object(activation)?;
+                    let b_field = b_object.get_public_property(*field_name, activation)?;
 
-                        let ord = if options.contains(SortOptions::NUMERIC) {
-                            compare_numeric(activation, a_field, b_field)?
-                        } else if options.contains(SortOptions::CASE_INSENSITIVE) {
-                            compare_string_case_insensitive(activation, a_field, b_field)?
-                        } else {
-                            compare_string_case_sensitive(activation, a_field, b_field)?
-                        };
+                    let ord = if options.contains(SortOptions::NUMERIC) {
+                        compare_numeric(activation, a_field, b_field)?
+                    } else if options.contains(SortOptions::CASE_INSENSITIVE) {
+                        compare_string_case_insensitive(activation, a_field, b_field)?
+                    } else {
+                        compare_string_case_sensitive(activation, a_field, b_field)?
+                    };
 
-                        if matches!(ord, Ordering::Equal) {
-                            continue;
-                        }
-
-                        if options.contains(SortOptions::DESCENDING) {
-                            return Ok(ord.reverse());
-                        } else {
-                            return Ok(ord);
-                        }
+                    if matches!(ord, Ordering::Equal) {
+                        continue;
                     }
 
-                    Ok(Ordering::Equal)
-                }),
-            )?;
+                    if options.contains(SortOptions::DESCENDING) {
+                        return Ok(ord.reverse());
+                    } else {
+                        return Ok(ord);
+                    }
+                }
 
-            return sort_postprocess(activation, this, first_option, unique_satisfied, values);
-        }
+                Ok(Ordering::Equal)
+            }),
+        )?;
+
+        return sort_postprocess(activation, this, first_option, unique_satisfied, values);
     }
 
     Ok(0.into())
@@ -1257,19 +1208,17 @@ pub fn sort_on<'gc>(
 /// Implements `Array.removeAt`
 pub fn remove_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
-            let index = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_i32(activation)?;
+    if let Some(mut array) = this.as_array_storage_mut(activation.context.gc_context) {
+        let index = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)?;
 
-            return Ok(array.remove(index).unwrap_or(Value::Undefined));
-        }
+        return Ok(array.remove(index).unwrap_or(Value::Undefined));
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -16,7 +16,7 @@ use gc_arena::GcCell;
 /// error.
 pub fn instance_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Err("Classes cannot be constructed.".into())
@@ -25,7 +25,7 @@ pub fn instance_init<'gc>(
 /// Implement's `Class`'s class initializer.
 pub fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)
@@ -33,14 +33,13 @@ pub fn class_init<'gc>(
 
 fn prototype<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(class) = this.as_class_object() {
-            return Ok(class.prototype().into());
-        }
+    if let Some(class) = this.as_class_object() {
+        return Ok(class.prototype().into());
     }
+
     Ok(Value::Undefined)
 }
 

--- a/core/src/avm2/globals/error.rs
+++ b/core/src/avm2/globals/error.rs
@@ -8,10 +8,10 @@ use crate::avm2::TObject;
 
 pub fn get_stack_trace<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(error) = this.and_then(|this| this.as_error_object()) {
+    if let Some(error) = this.as_error_object() {
         return Ok(AvmString::new(activation.context.gc_context, error.display_full()?).into());
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/crypto.rs
+++ b/core/src/avm2/globals/flash/crypto.rs
@@ -7,7 +7,7 @@ use rand::{rngs::OsRng, RngCore};
 /// Implements `flash.crypto.generateRandomBytes`
 pub fn generate_random_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let length = args

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -73,25 +73,23 @@ pub fn bitmap_allocator<'gc>(
 /// Implements `flash.display.Bitmap`'s `init` method, which is called from the constructor
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let bitmap_data = args
-            .try_get_object(activation, 0)
-            .and_then(|o| o.as_bitmap_data());
-        //TODO: Pixel snapping is not supported
-        let _pixel_snapping = args.get_string(activation, 1);
-        let smoothing = args.get_bool(2);
+    let bitmap_data = args
+        .try_get_object(activation, 0)
+        .and_then(|o| o.as_bitmap_data());
+    //TODO: Pixel snapping is not supported
+    let _pixel_snapping = args.get_string(activation, 1);
+    let smoothing = args.get_bool(2);
 
-        if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
-            if let Some(bitmap_data) = bitmap_data {
-                bitmap.set_bitmap_data(&mut activation.context, bitmap_data);
-            }
-            bitmap.set_smoothing(activation.context.gc_context, smoothing);
-        } else {
-            unreachable!();
+    if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
+        if let Some(bitmap_data) = bitmap_data {
+            bitmap.set_bitmap_data(&mut activation.context, bitmap_data);
         }
+        bitmap.set_smoothing(activation.context.gc_context, smoothing);
+    } else {
+        unreachable!();
     }
 
     Ok(Value::Undefined)
@@ -100,13 +98,10 @@ pub fn init<'gc>(
 /// Implements `Bitmap.bitmapData`'s getter.
 pub fn get_bitmap_data<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|dobj| dobj.as_bitmap())
-    {
+    if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
         let mut value = bitmap.bitmap_data_wrapper().object2();
 
         // AS3 expects an unset BitmapData to be null, not 'undefined'
@@ -122,13 +117,10 @@ pub fn get_bitmap_data<'gc>(
 /// Implements `Bitmap.bitmapData`'s setter.
 pub fn set_bitmap_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|dobj| dobj.as_bitmap())
-    {
+    if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
         let bitmap_data = args.get(0).unwrap_or(&Value::Null);
         let bitmap_data = if matches!(bitmap_data, Value::Null) {
             BitmapDataWrapper::dummy(activation.context.gc_context)
@@ -147,7 +139,7 @@ pub fn set_bitmap_data<'gc>(
 /// Stub `Bitmap.pixelSnapping`'s getter
 pub fn get_pixel_snapping<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.Bitmap", "pixelSnapping");
@@ -157,7 +149,7 @@ pub fn get_pixel_snapping<'gc>(
 /// Stub `Bitmap.pixelSnapping`'s setter
 pub fn set_pixel_snapping<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.Bitmap", "pixelSnapping");
@@ -167,13 +159,10 @@ pub fn set_pixel_snapping<'gc>(
 /// Implement `Bitmap.smoothing`'s getter
 pub fn get_smoothing<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|dobj| dobj.as_bitmap())
-    {
+    if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
         return Ok(bitmap.smoothing().into());
     }
 
@@ -183,13 +172,10 @@ pub fn get_smoothing<'gc>(
 /// Implement `Bitmap.smoothing`'s setter
 pub fn set_smoothing<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(bitmap) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|dobj| dobj.as_bitmap())
-    {
+    if let Some(bitmap) = this.as_display_object().and_then(|dobj| dobj.as_bitmap()) {
         let smoothing = args.get_bool(0);
         bitmap.set_smoothing(activation.context.gc_context, smoothing);
     }

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -66,17 +66,15 @@ pub fn initialize_for_allocator<'gc>(
 /// Implements `flash.display.DisplayObject`'s native instance constructor.
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
+    activation.super_init(this, &[])?;
 
-        if let Some(dobj) = this.as_display_object() {
-            if let Some(container) = dobj.as_container() {
-                for child in container.iter_render_list() {
-                    child.construct_frame(&mut activation.context);
-                }
+    if let Some(dobj) = this.as_display_object() {
+        if let Some(container) = dobj.as_container() {
+            for child in container.iter_render_list() {
+                child.construct_frame(&mut activation.context);
             }
         }
     }
@@ -87,10 +85,10 @@ pub fn native_instance_init<'gc>(
 /// Implements `alpha`'s getter.
 pub fn get_alpha<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.alpha().into());
     }
 
@@ -100,10 +98,10 @@ pub fn get_alpha<'gc>(
 /// Implements `alpha`'s setter.
 pub fn set_alpha<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_alpha = args.get_f64(activation, 0)?;
         dobj.set_alpha(activation.context.gc_context, new_alpha);
     }
@@ -114,10 +112,10 @@ pub fn set_alpha<'gc>(
 /// Implements `height`'s getter.
 pub fn get_height<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.height().into());
     }
 
@@ -127,10 +125,10 @@ pub fn get_height<'gc>(
 /// Implements `height`'s setter.
 pub fn set_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_height = args.get_f64(activation, 0)?;
 
         if new_height >= 0.0 {
@@ -144,10 +142,10 @@ pub fn set_height<'gc>(
 /// Implements `scaleY`'s getter.
 pub fn get_scale_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.scale_y(activation.context.gc_context).unit().into());
     }
 
@@ -157,10 +155,10 @@ pub fn get_scale_y<'gc>(
 /// Implements `scaleY`'s setter.
 pub fn set_scale_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_scale = args.get_f64(activation, 0)?;
         dobj.set_scale_y(activation.context.gc_context, Percent::from_unit(new_scale));
     }
@@ -171,10 +169,10 @@ pub fn set_scale_y<'gc>(
 /// Implements `width`'s getter.
 pub fn get_width<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.width().into());
     }
 
@@ -184,10 +182,10 @@ pub fn get_width<'gc>(
 /// Implements `width`'s setter.
 pub fn set_width<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_width = args.get_f64(activation, 0)?;
 
         if new_width >= 0.0 {
@@ -201,10 +199,10 @@ pub fn set_width<'gc>(
 /// Implements `scaleX`'s getter.
 pub fn get_scale_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.scale_x(activation.context.gc_context).unit().into());
     }
 
@@ -214,10 +212,10 @@ pub fn get_scale_x<'gc>(
 /// Implements `scaleX`'s setter.
 pub fn set_scale_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_scale = args.get_f64(activation, 0)?;
         dobj.set_scale_x(activation.context.gc_context, Percent::from_unit(new_scale));
     }
@@ -227,10 +225,10 @@ pub fn set_scale_x<'gc>(
 
 pub fn get_filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let array = dobj
             .filters()
             .into_iter()
@@ -253,10 +251,10 @@ fn build_argument_type_error<'gc>(
 
 pub fn set_filters<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_filters = args.try_get_object(activation, 0);
 
         if let Some(new_filters) = new_filters {
@@ -299,10 +297,10 @@ pub fn set_filters<'gc>(
 /// Implements `x`'s getter.
 pub fn get_x<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.x().to_pixels().into());
     }
 
@@ -312,10 +310,10 @@ pub fn get_x<'gc>(
 /// Implements `x`'s setter.
 pub fn set_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
         dobj.set_x(activation.context.gc_context, Twips::from_pixels(x));
     }
@@ -326,10 +324,10 @@ pub fn set_x<'gc>(
 /// Implements `y`'s getter.
 pub fn get_y<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.y().to_pixels().into());
     }
 
@@ -339,10 +337,10 @@ pub fn get_y<'gc>(
 /// Implements `y`'s setter.
 pub fn set_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let y = args.get_f64(activation, 0)?;
         dobj.set_y(activation.context.gc_context, Twips::from_pixels(y));
     }
@@ -352,7 +350,7 @@ pub fn set_y<'gc>(
 
 pub fn get_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.DisplayObject", "z");
@@ -361,7 +359,7 @@ pub fn get_z<'gc>(
 
 pub fn set_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.DisplayObject", "z");
@@ -370,7 +368,7 @@ pub fn set_z<'gc>(
 
 pub fn get_rotation_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationX");
@@ -379,7 +377,7 @@ pub fn get_rotation_x<'gc>(
 
 pub fn set_rotation_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationX");
@@ -388,7 +386,7 @@ pub fn set_rotation_x<'gc>(
 
 pub fn get_rotation_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationY");
@@ -397,7 +395,7 @@ pub fn get_rotation_y<'gc>(
 
 pub fn set_rotation_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationY");
@@ -406,7 +404,7 @@ pub fn set_rotation_y<'gc>(
 
 pub fn get_rotation_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.DisplayObject", "rotationZ");
@@ -415,7 +413,7 @@ pub fn get_rotation_z<'gc>(
 
 pub fn set_rotation_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.DisplayObject", "rotationZ");
@@ -424,7 +422,7 @@ pub fn set_rotation_z<'gc>(
 
 pub fn get_scale_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.DisplayObject", "scaleZ");
@@ -433,7 +431,7 @@ pub fn get_scale_z<'gc>(
 
 pub fn set_scale_z<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.DisplayObject", "scaleZ");
@@ -443,10 +441,10 @@ pub fn set_scale_z<'gc>(
 /// Implements `rotation`'s getter.
 pub fn get_rotation<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let rot: f64 = dobj.rotation(activation.context.gc_context).into();
         let rem = rot % 360.0;
 
@@ -463,10 +461,10 @@ pub fn get_rotation<'gc>(
 /// Implements `rotation`'s setter.
 pub fn set_rotation<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_rotation = args.get_f64(activation, 0)?;
 
         dobj.set_rotation(activation.context.gc_context, Degrees::from(new_rotation));
@@ -478,10 +476,10 @@ pub fn set_rotation<'gc>(
 /// Implements `name`'s getter.
 pub fn get_name<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.name().into());
     }
 
@@ -491,10 +489,10 @@ pub fn get_name<'gc>(
 /// Implements `name`'s setter.
 pub fn set_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_name = args.get_string(activation, 0)?;
 
         if dobj.instantiated_by_timeline() {
@@ -513,10 +511,10 @@ pub fn set_name<'gc>(
 /// Implements `parent`.
 pub fn get_parent<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj
             .avm2_parent()
             .map(|parent| parent.object2())
@@ -529,10 +527,10 @@ pub fn get_parent<'gc>(
 /// Implements `root`.
 pub fn get_root<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj
             .avm2_root()
             .map(|root| root.object2())
@@ -545,10 +543,10 @@ pub fn get_root<'gc>(
 /// Implements `stage`.
 pub fn get_stage<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj
             .avm2_stage(&activation.context)
             .map(|stage| stage.object2())
@@ -561,10 +559,10 @@ pub fn get_stage<'gc>(
 /// Implements `visible`'s getter.
 pub fn get_visible<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         return Ok(dobj.visible().into());
     }
 
@@ -574,10 +572,10 @@ pub fn get_visible<'gc>(
 /// Implements `visible`'s setter.
 pub fn set_visible<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let new_visible = args.get_bool(0);
 
         dobj.set_visible(activation.context.gc_context, new_visible);
@@ -589,10 +587,10 @@ pub fn set_visible<'gc>(
 /// Implements `mouseX`.
 pub fn get_mouse_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let local_mouse = dobj.mouse_to_local(*activation.context.mouse_position);
         return Ok(local_mouse.x.to_pixels().into());
     }
@@ -603,10 +601,10 @@ pub fn get_mouse_x<'gc>(
 /// Implements `mouseY`.
 pub fn get_mouse_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let local_mouse = dobj.mouse_to_local(*activation.context.mouse_position);
         return Ok(local_mouse.y.to_pixels().into());
     }
@@ -617,10 +615,10 @@ pub fn get_mouse_y<'gc>(
 /// Implements `hitTestPoint`.
 pub fn hit_test_point<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
         let y = args.get_f64(activation, 1)?;
         let shape_flag = args.get_bool(2);
@@ -654,10 +652,10 @@ pub fn hit_test_point<'gc>(
 /// Implements `hitTestObject`.
 pub fn hit_test_object<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         if let Some(rhs_dobj) = args.get_object(activation, 0, "obj")?.as_display_object() {
             return Ok(dobj.hit_test_object(rhs_dobj).into());
         }
@@ -669,10 +667,10 @@ pub fn hit_test_object<'gc>(
 /// Implements `loaderInfo` getter
 pub fn get_loader_info<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         // Contrary to the DisplayObject.loaderInfo documentation,
         // Flash Player defines 'loaderInfo' for non-root DisplayObjects.
         // It always returns the LoaderInfo from the root object.
@@ -689,65 +687,60 @@ pub fn get_loader_info<'gc>(
 
 pub fn get_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        return Ok(activation
-            .avm2()
-            .classes()
-            .transform
-            .construct(activation, &[this.into()])?
-            .into());
-    }
-    Ok(Value::Undefined)
+    Ok(activation
+        .avm2()
+        .classes()
+        .transform
+        .construct(activation, &[this.into()])?
+        .into())
 }
 
 pub fn set_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let transform = args.get_object(activation, 0, "transform")?;
+    let transform = args.get_object(activation, 0, "transform")?;
 
-        // FIXME - consider 3D matrix and pixel bounds
-        let matrix = transform
-            .get_public_property("matrix", activation)?
-            .coerce_to_object(activation)?;
-        let color_transform = transform
-            .get_public_property("colorTransform", activation)?
-            .coerce_to_object(activation)?;
+    // FIXME - consider 3D matrix and pixel bounds
+    let matrix = transform
+        .get_public_property("matrix", activation)?
+        .coerce_to_object(activation)?;
+    let color_transform = transform
+        .get_public_property("colorTransform", activation)?
+        .coerce_to_object(activation)?;
 
-        let matrix =
-            crate::avm2::globals::flash::geom::transform::object_to_matrix(matrix, activation)?;
-        let color_transform =
-            crate::avm2::globals::flash::geom::transform::object_to_color_transform(
-                color_transform,
-                activation,
-            )?;
+    let matrix =
+        crate::avm2::globals::flash::geom::transform::object_to_matrix(matrix, activation)?;
+    let color_transform = crate::avm2::globals::flash::geom::transform::object_to_color_transform(
+        color_transform,
+        activation,
+    )?;
 
-        let dobj = this.as_display_object().unwrap();
-        let mut write = dobj.base_mut(activation.context.gc_context);
-        write.set_matrix(matrix);
-        write.set_color_transform(color_transform);
-        drop(write);
-        if let Some(parent) = dobj.parent() {
-            // Self-transform changes are automatically handled,
-            // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
-            parent.invalidate_cached_bitmap(activation.context.gc_context);
-        }
+    let dobj = this.as_display_object().unwrap();
+    let mut write = dobj.base_mut(activation.context.gc_context);
+    write.set_matrix(matrix);
+    write.set_color_transform(color_transform);
+    drop(write);
+    if let Some(parent) = dobj.parent() {
+        // Self-transform changes are automatically handled,
+        // we only want to inform ancestors to avoid unnecessary invalidations for tx/ty
+        parent.invalidate_cached_bitmap(activation.context.gc_context);
     }
+
     Ok(Value::Undefined)
 }
 
 /// Implements `DisplayObject.blendMode`'s getter.
 pub fn get_blend_mode<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let mode =
             AvmString::new_utf8(activation.context.gc_context, dobj.blend_mode().to_string());
         return Ok(mode.into());
@@ -758,10 +751,10 @@ pub fn get_blend_mode<'gc>(
 /// Implements `DisplayObject.blendMode`'s setter.
 pub fn set_blend_mode<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let mode = args.get_string(activation, 0)?;
 
         if let Ok(mode) = BlendMode::from_str(&mode.to_string()) {
@@ -792,10 +785,10 @@ fn new_rectangle<'gc>(
 
 pub fn get_scroll_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         if dobj.has_scroll_rect() {
             return Ok(new_rectangle(activation, dobj.next_scroll_rect())?.into());
         } else {
@@ -827,10 +820,10 @@ pub fn object_to_rectangle<'gc>(
 
 pub fn set_scroll_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         if let Some(rectangle) = args.try_get_object(activation, 0) {
             // Flash only updates the "internal" scrollRect used by `localToLocal` when the next
             // frame is rendered. However, accessing `DisplayObject.scrollRect` from ActionScript
@@ -858,10 +851,10 @@ pub fn set_scroll_rect<'gc>(
 
 pub fn local_to_global<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let point = args.get_object(activation, 0, "point")?;
         let x = point
             .get_public_property("x", activation)?
@@ -888,10 +881,10 @@ pub fn local_to_global<'gc>(
 
 pub fn global_to_local<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let point = args.get_object(activation, 0, "point")?;
         let x = point
             .get_public_property("x", activation)?
@@ -918,10 +911,10 @@ pub fn global_to_local<'gc>(
 
 pub fn get_bounds<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let target = args
             .try_get_object(activation, 0)
             .and_then(|o| o.as_display_object())
@@ -947,7 +940,7 @@ pub fn get_bounds<'gc>(
 
 pub fn get_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: This should get the bounds ignoring strokes. Always equal to or smaller than getBounds.
@@ -957,10 +950,10 @@ pub fn get_rect<'gc>(
 
 pub fn get_mask<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         return Ok(this.masker().map_or(Value::Null, |m| m.object2()));
     }
     Ok(Value::Undefined)
@@ -968,10 +961,10 @@ pub fn get_mask<'gc>(
 
 pub fn set_mask<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let mask = args.try_get_object(activation, 0);
 
         if let Some(mask) = mask {
@@ -990,10 +983,10 @@ pub fn set_mask<'gc>(
 
 pub fn get_cache_as_bitmap<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         return Ok(this.is_bitmap_cached().into());
     }
     Ok(Value::Undefined)
@@ -1001,10 +994,10 @@ pub fn get_cache_as_bitmap<'gc>(
 
 pub fn set_cache_as_bitmap<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let cache = args.get(0).unwrap_or(&Value::Undefined).coerce_to_boolean();
         this.set_bitmap_cached_preference(activation.context.gc_context, cache);
     }
@@ -1014,11 +1007,11 @@ pub fn set_cache_as_bitmap<'gc>(
 /// `opaqueBackground`'s getter.
 pub fn get_opaque_background<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(color) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.opaque_background())
     {
         return Ok(color.to_rgb().into());
@@ -1030,10 +1023,10 @@ pub fn get_opaque_background<'gc>(
 /// `opaqueBackground`'s setter.
 pub fn set_opaque_background<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|this| this.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         let color = match value {
             Value::Null | Value::Undefined => None,

--- a/core/src/avm2/globals/flash/display/display_object_container.rs
+++ b/core/src/avm2/globals/flash/display/display_object_container.rs
@@ -16,12 +16,10 @@ use std::cmp::min;
 /// Implements `flash.display.DisplayObjectContainer`'s native instance constructor.
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
-    }
+    activation.super_init(this, &[])?;
 
     Ok(Value::Undefined)
 }
@@ -123,11 +121,11 @@ pub(super) fn add_child_to_displaylist<'gc>(
 /// Implements `DisplayObjectContainer.getChildAt`
 pub fn get_child_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_container())
     {
         let index = args.get_i32(activation, 0)?;
@@ -149,11 +147,11 @@ pub fn get_child_at<'gc>(
 /// Implements `DisplayObjectContainer.getChildByName`
 pub fn get_child_by_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_container())
     {
         let name = args.get_string(activation, 0)?;
@@ -171,10 +169,10 @@ pub fn get_child_by_name<'gc>(
 /// Implements `DisplayObjectContainer.addChild`
 pub fn add_child<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(ctr) = parent.as_container() {
             let child = args.get_object(activation, 0, "child")?;
             if child.as_display_object().is_none() {
@@ -203,10 +201,10 @@ pub fn add_child<'gc>(
 /// Implements `DisplayObjectContainer.addChildAt`
 pub fn add_child_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         let child = args
             .get_object(activation, 0, "child")?
             .as_display_object()
@@ -225,10 +223,10 @@ pub fn add_child_at<'gc>(
 /// Implements `DisplayObjectContainer.removeChild`
 pub fn remove_child<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         let child = args
             .get_object(activation, 0, "child")?
             .as_display_object()
@@ -246,11 +244,11 @@ pub fn remove_child<'gc>(
 /// Implements `DisplayObjectContainer.numChildren`
 pub fn get_num_children<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(parent) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_container())
     {
         return Ok(parent.num_children().into());
@@ -262,10 +260,10 @@ pub fn get_num_children<'gc>(
 /// Implements `DisplayObjectContainer.contains`
 pub fn contains<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if parent.as_container().is_some() {
             if let Some(child) = args.get_object(activation, 0, "child")?.as_display_object() {
                 let mut maybe_child_parent = Some(child);
@@ -286,10 +284,10 @@ pub fn contains<'gc>(
 /// Implements `DisplayObjectContainer.getChildIndex`
 pub fn get_child_index<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(ctr) = parent.as_container() {
             let target_child = args.get_object(activation, 0, "child")?.as_display_object();
 
@@ -309,10 +307,10 @@ pub fn get_child_index<'gc>(
 /// Implements `DisplayObjectContainer.removeChildAt`
 pub fn remove_child_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(mut ctr) = parent.as_container() {
             let target_child = args.get_i32(activation, 0)?;
 
@@ -344,10 +342,10 @@ pub fn remove_child_at<'gc>(
 /// Implements `DisplayObjectContainer.removeChildren`
 pub fn remove_children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(mut ctr) = parent.as_container() {
             let from = args.get_i32(activation, 0)?;
             let to = args.get_i32(activation, 1)?;
@@ -406,10 +404,10 @@ pub fn remove_children<'gc>(
 /// Implements `DisplayObjectContainer.setChildIndex`
 pub fn set_child_index<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         let child = args
             .get_object(activation, 0, "child")?
             .as_display_object()
@@ -433,10 +431,10 @@ pub fn set_child_index<'gc>(
 /// Implements `DisplayObjectContainer.swapChildrenAt`
 pub fn swap_children_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(mut ctr) = parent.as_container() {
             let index0 = args.get_i32(activation, 0)?;
             let index1 = args.get_i32(activation, 1)?;
@@ -476,10 +474,10 @@ pub fn swap_children_at<'gc>(
 /// Implements `DisplayObjectContainer.swapChildren`
 pub fn swap_children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(mut ctr) = parent.as_container() {
             let child0 = args
                 .get_object(activation, 0, "child1")?
@@ -512,10 +510,10 @@ pub fn swap_children<'gc>(
 /// Implements `DisplayObjectContainer.stopAllMovieClips`
 pub fn stop_all_movie_clips<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(parent) = this.and_then(|this| this.as_display_object()) {
+    if let Some(parent) = this.as_display_object() {
         if let Some(mc) = parent.as_movie_clip() {
             mc.stop(&mut activation.context);
         }
@@ -524,7 +522,10 @@ pub fn stop_all_movie_clips<'gc>(
             for child in ctr.iter_render_list() {
                 if child.as_container().is_some() {
                     let child_this = child.object2().as_object();
-                    stop_all_movie_clips(activation, child_this, &[])?;
+
+                    if let Some(child_this) = child_this {
+                        stop_all_movie_clips(activation, child_this, &[])?;
+                    }
                 }
             }
         }
@@ -535,7 +536,7 @@ pub fn stop_all_movie_clips<'gc>(
 
 pub fn get_objects_under_point<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(
@@ -548,7 +549,7 @@ pub fn get_objects_under_point<'gc>(
 
 pub fn are_inaccessible_objects_under_point<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(
@@ -561,11 +562,11 @@ pub fn are_inaccessible_objects_under_point<'gc>(
 
 pub fn get_mouse_children<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_container())
     {
         return Ok(dobj.raw_container().mouse_children().into());
@@ -575,11 +576,11 @@ pub fn get_mouse_children<'gc>(
 
 pub fn set_mouse_children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_container())
     {
         let mouse_children = args.get_bool(0);
@@ -592,7 +593,7 @@ pub fn set_mouse_children<'gc>(
 
 pub fn get_tab_children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(
@@ -606,7 +607,7 @@ pub fn get_tab_children<'gc>(
 
 pub fn set_tab_children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(

--- a/core/src/avm2/globals/flash/display/graphics.rs
+++ b/core/src/avm2/globals/flash/display/graphics.rs
@@ -28,10 +28,10 @@ fn color_from_args(rgb: u32, alpha: f64) -> Color {
 /// Implements `Graphics.beginFill`.
 pub fn begin_fill<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let color = args.get_u32(activation, 0)?;
         let alpha = args.get_f64(activation, 1)?;
 
@@ -46,10 +46,10 @@ pub fn begin_fill<'gc>(
 /// Implements `Graphics.beginBitmapFill`.
 pub fn begin_bitmap_fill<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let bitmap = args
             .get_object(activation, 0, "bitmap")?
             .as_bitmap_data()
@@ -93,10 +93,10 @@ pub fn begin_bitmap_fill<'gc>(
 /// Implements `Graphics.beginGradientFill`.
 pub fn begin_gradient_fill<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let gradient_type = args.get_string(activation, 0);
         let gradient_type = parse_gradient_type(activation, gradient_type?)?;
         let colors = args.get_object(activation, 1, "colors")?;
@@ -216,10 +216,10 @@ fn parse_spread_method(spread_method: AvmString) -> GradientSpread {
 /// Implements `Graphics.clear`
 pub fn clear<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
             draw.clear()
         }
@@ -231,10 +231,10 @@ pub fn clear<'gc>(
 /// Implements `Graphics.curveTo`.
 pub fn curve_to<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let control_x = args.get_f64(activation, 0)?;
         let control_y = args.get_f64(activation, 1)?;
         let anchor_x = args.get_f64(activation, 2)?;
@@ -254,10 +254,10 @@ pub fn curve_to<'gc>(
 /// Implements `Graphics.endFill`.
 pub fn end_fill<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         if let Some(mut draw) = this.as_drawing(activation.context.gc_context) {
             draw.set_fill_style(None);
         }
@@ -309,10 +309,10 @@ fn scale_mode_to_allow_scale_bits<'gc>(scale_mode: &WStr) -> Result<(bool, bool)
 /// Implements `Graphics.lineStyle`.
 pub fn line_style<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let thickness = args.get_f64(activation, 0)?;
 
         if thickness.is_nan() {
@@ -356,10 +356,10 @@ pub fn line_style<'gc>(
 /// Implements `Graphics.lineTo`.
 pub fn line_to<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
 
@@ -374,10 +374,10 @@ pub fn line_to<'gc>(
 /// Implements `Graphics.moveTo`.
 pub fn move_to<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
 
@@ -392,10 +392,10 @@ pub fn move_to<'gc>(
 /// Implements `Graphics.drawRect`.
 pub fn draw_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let x = Twips::from_pixels(args.get_f64(activation, 0)?);
         let y = Twips::from_pixels(args.get_f64(activation, 1)?);
         let width = Twips::from_pixels(args.get_f64(activation, 2)?);
@@ -669,10 +669,10 @@ fn draw_round_rect_internal(
 /// Implements `Graphics.drawRoundRect`.
 pub fn draw_round_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
         let y = args.get_f64(activation, 1)?;
         let width = args.get_f64(activation, 2)?;
@@ -699,10 +699,10 @@ pub fn draw_round_rect<'gc>(
 /// Implements `Graphics.drawCircle`.
 pub fn draw_circle<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
         let y = args.get_f64(activation, 1)?;
         let radius = args.get_f64(activation, 2)?;
@@ -726,10 +726,10 @@ pub fn draw_circle<'gc>(
 /// Implements `Graphics.drawEllipse`.
 pub fn draw_ellipse<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let x = args.get_f64(activation, 0)?;
         let y = args.get_f64(activation, 1)?;
         let width = args.get_f64(activation, 2)?;
@@ -746,10 +746,10 @@ pub fn draw_ellipse<'gc>(
 /// Implements `Graphics.lineGradientStyle`
 pub fn line_gradient_style<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let gradient_type = args.get_string(activation, 0);
         let gradient_type = parse_gradient_type(activation, gradient_type?)?;
         let colors = args.get_object(activation, 1, "colors")?;
@@ -809,7 +809,7 @@ pub fn line_gradient_style<'gc>(
 /// Implements `Graphics.cubicCurveTo`
 pub fn cubic_curve_to<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.display.Graphics", "cubicCurveTo");
@@ -819,10 +819,10 @@ pub fn cubic_curve_to<'gc>(
 /// Implements `Graphics.copyFrom`
 pub fn copy_from<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let source = args
             .get_object(activation, 0, "sourceGraphics")?
             .as_display_object()
@@ -844,10 +844,10 @@ pub fn copy_from<'gc>(
 /// Implements `Graphics.drawPath`
 pub fn draw_path<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap().as_display_object().unwrap();
+    let this = this.as_display_object().unwrap();
     let mut drawing = this.as_drawing(activation.context.gc_context).unwrap();
     let commands = args.get_object(activation, 0, "commands")?;
     let data = args.get_object(activation, 1, "data")?;
@@ -949,7 +949,7 @@ pub fn draw_path<'gc>(
 /// Implements `Graphics.drawRoundRectComplex`
 pub fn draw_round_rect_complex<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.display.Graphics", "drawRoundRectComplex");
@@ -959,7 +959,7 @@ pub fn draw_round_rect_complex<'gc>(
 /// Implements `Graphics.drawTriangles`
 pub fn draw_triangles<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.display.Graphics", "drawTriangles");
@@ -969,7 +969,7 @@ pub fn draw_triangles<'gc>(
 /// Implements `Graphics.drawGraphicsData`
 pub fn draw_graphics_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.display.Graphics", "drawGraphicsData");
@@ -979,10 +979,10 @@ pub fn draw_graphics_data<'gc>(
 /// Implements `Graphics.lineBitmapStyle`
 pub fn line_bitmap_style<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_display_object()) {
+    if let Some(this) = this.as_display_object() {
         let bitmap = args
             .get_object(activation, 0, "bitmap")?
             .as_bitmap_data()
@@ -1026,7 +1026,7 @@ pub fn line_bitmap_style<'gc>(
 /// Implements `Graphics.readGraphicsData`
 pub fn read_graphics_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.display.Graphics", "readGraphicsData");

--- a/core/src/avm2/globals/flash/display/interactive_object.rs
+++ b/core/src/avm2/globals/flash/display/interactive_object.rs
@@ -11,12 +11,10 @@ use crate::{avm2_stub_getter, avm2_stub_setter};
 /// Implements `flash.display.InteractiveObject`'s native instance constructor.
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
-    }
+    activation.super_init(this, &[])?;
 
     Ok(Value::Undefined)
 }
@@ -24,11 +22,11 @@ pub fn native_instance_init<'gc>(
 /// Implements `InteractiveObject.mouseEnabled`'s getter.
 pub fn get_mouse_enabled<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(int) = this
-        .and_then(|t| t.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_interactive())
     {
         return Ok(int.mouse_enabled().into());
@@ -40,11 +38,11 @@ pub fn get_mouse_enabled<'gc>(
 /// Implements `InteractiveObject.mouseEnabled`'s setter.
 pub fn set_mouse_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(int) = this
-        .and_then(|t| t.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_bool(0);
@@ -57,11 +55,11 @@ pub fn set_mouse_enabled<'gc>(
 /// Implements `InteractiveObject.doubleClickEnabled`'s getter.
 pub fn get_double_click_enabled<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(int) = this
-        .and_then(|t| t.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_interactive())
     {
         return Ok(int.double_click_enabled().into());
@@ -73,11 +71,11 @@ pub fn get_double_click_enabled<'gc>(
 /// Implements `InteractiveObject.doubleClickEnabled`'s setter.
 pub fn set_double_click_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(int) = this
-        .and_then(|t| t.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_bool(0);
@@ -90,11 +88,11 @@ pub fn set_double_click_enabled<'gc>(
 /// Implements `InteractiveObject.contextMenu`'s getter.
 pub fn get_context_menu<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(int) = this
-        .and_then(|t| t.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_interactive())
     {
         return Ok(int.context_menu());
@@ -106,11 +104,11 @@ pub fn get_context_menu<'gc>(
 /// Implements `InteractiveObject.contextMenu`'s setter.
 pub fn set_context_menu<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(int) = this
-        .and_then(|t| t.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_interactive())
     {
         let value = args.get_value(0);
@@ -122,7 +120,7 @@ pub fn set_context_menu<'gc>(
 
 pub fn get_tab_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.InteractiveObject", "tabEnabled");
@@ -132,7 +130,7 @@ pub fn get_tab_enabled<'gc>(
 
 pub fn set_tab_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.InteractiveObject", "tabIndex");
@@ -142,7 +140,7 @@ pub fn set_tab_enabled<'gc>(
 
 pub fn get_tab_index<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.InteractiveObject", "tabIndex");
@@ -152,7 +150,7 @@ pub fn get_tab_index<'gc>(
 
 pub fn set_tab_index<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.InteractiveObject", "tabIndex");
@@ -162,7 +160,7 @@ pub fn set_tab_index<'gc>(
 
 pub fn get_focus_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.InteractiveObject", "focusRect");
@@ -171,7 +169,7 @@ pub fn get_focus_rect<'gc>(
 
 pub fn set_focus_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // NOTE: all values other than true or null are converted to false. (false/null do differ)

--- a/core/src/avm2/globals/flash/display/loader.rs
+++ b/core/src/avm2/globals/flash/display/loader.rs
@@ -56,61 +56,60 @@ pub fn loader_allocator<'gc>(
 
 pub fn load<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let url_request = args.get_object(activation, 0, "request")?;
-        let context = args.try_get_object(activation, 1);
+    let url_request = args.get_object(activation, 0, "request")?;
+    let context = args.try_get_object(activation, 1);
 
-        // This is a dummy MovieClip, which will get overwritten in `Loader`
-        let content = MovieClip::new(
-            Arc::new(SwfMovie::empty(activation.context.swf.version())),
+    // This is a dummy MovieClip, which will get overwritten in `Loader`
+    let content = MovieClip::new(
+        Arc::new(SwfMovie::empty(activation.context.swf.version())),
+        activation.context.gc_context,
+    );
+
+    let loader_info = this
+        .get_property(
+            &Multiname::new(
+                activation.avm2().flash_display_internal,
+                "_contentLoaderInfo",
+            ),
+            activation,
+        )?
+        .as_object()
+        .unwrap();
+
+    // Update the LoaderStream - we still have a fake SwfMovie, but we now have the real target clip.
+    loader_info
+        .as_loader_info_object()
+        .unwrap()
+        .set_loader_stream(
+            LoaderStream::NotYetLoaded(
+                Arc::new(SwfMovie::empty(activation.context.swf.version())),
+                Some(content.into()),
+                false,
+            ),
             activation.context.gc_context,
         );
 
-        let loader_info = this
-            .get_property(
-                &Multiname::new(
-                    activation.avm2().flash_display_internal,
-                    "_contentLoaderInfo",
-                ),
-                activation,
-            )?
-            .as_object()
-            .unwrap();
+    let request = request_from_url_request(activation, url_request)?;
 
-        // Update the LoaderStream - we still have a fake SwfMovie, but we now have the real target clip.
-        loader_info
-            .as_loader_info_object()
-            .unwrap()
-            .set_loader_stream(
-                LoaderStream::NotYetLoaded(
-                    Arc::new(SwfMovie::empty(activation.context.swf.version())),
-                    Some(content.into()),
-                    false,
-                ),
-                activation.context.gc_context,
-            );
+    let url = request.url().to_string();
+    let future = activation.context.load_manager.load_movie_into_clip(
+        activation.context.player.clone(),
+        content.into(),
+        request,
+        Some(url),
+        MovieLoaderVMData::Avm2 {
+            loader_info,
+            context,
+            default_domain: activation
+                .caller_domain()
+                .expect("Missing caller domain in Loader.load"),
+        },
+    );
+    activation.context.navigator.spawn_future(future);
 
-        let request = request_from_url_request(activation, url_request)?;
-
-        let url = request.url().to_string();
-        let future = activation.context.load_manager.load_movie_into_clip(
-            activation.context.player.clone(),
-            content.into(),
-            request,
-            Some(url),
-            MovieLoaderVMData::Avm2 {
-                loader_info,
-                context,
-                default_domain: activation
-                    .caller_domain()
-                    .expect("Missing caller domain in Loader.load"),
-            },
-        );
-        activation.context.navigator.spawn_future(future);
-    }
     Ok(Value::Undefined)
 }
 
@@ -204,50 +203,49 @@ pub fn request_from_url_request<'gc>(
 
 pub fn load_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let arg0 = args.get_object(activation, 0, "data")?;
-        let bytearray = arg0.as_bytearray().unwrap();
-        let context = args.try_get_object(activation, 1);
+    let arg0 = args.get_object(activation, 0, "data")?;
+    let bytearray = arg0.as_bytearray().unwrap();
+    let context = args.try_get_object(activation, 1);
 
-        // This is a dummy MovieClip, which will get overwritten in `Loader`
-        let content = MovieClip::new(
-            Arc::new(SwfMovie::empty(activation.context.swf.version())),
-            activation.context.gc_context,
-        );
+    // This is a dummy MovieClip, which will get overwritten in `Loader`
+    let content = MovieClip::new(
+        Arc::new(SwfMovie::empty(activation.context.swf.version())),
+        activation.context.gc_context,
+    );
 
-        let loader_info = this
-            .get_property(
-                &Multiname::new(
-                    activation.avm2().flash_display_internal,
-                    "_contentLoaderInfo",
-                ),
-                activation,
-            )?
-            .as_object()
-            .unwrap();
-        let future = activation.context.load_manager.load_movie_into_clip_bytes(
-            activation.context.player.clone(),
-            content.into(),
-            bytearray.bytes().to_vec(),
-            MovieLoaderVMData::Avm2 {
-                loader_info,
-                context,
-                default_domain: activation
-                    .caller_domain()
-                    .expect("Missing caller domain in Loader.loadBytes"),
-            },
-        );
-        activation.context.navigator.spawn_future(future);
-    }
+    let loader_info = this
+        .get_property(
+            &Multiname::new(
+                activation.avm2().flash_display_internal,
+                "_contentLoaderInfo",
+            ),
+            activation,
+        )?
+        .as_object()
+        .unwrap();
+    let future = activation.context.load_manager.load_movie_into_clip_bytes(
+        activation.context.player.clone(),
+        content.into(),
+        bytearray.bytes().to_vec(),
+        MovieLoaderVMData::Avm2 {
+            loader_info,
+            context,
+            default_domain: activation
+                .caller_domain()
+                .expect("Missing caller domain in Loader.loadBytes"),
+        },
+    );
+    activation.context.navigator.spawn_future(future);
+
     Ok(Value::Undefined)
 }
 
 pub fn unload<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: Broadcast an "unload" event on the LoaderInfo and reset LoaderInfo properties

--- a/core/src/avm2/globals/flash/display/loader_info.rs
+++ b/core/src/avm2/globals/flash/display/loader_info.rs
@@ -18,12 +18,10 @@ const INSUFFICIENT: &str =
 /// Implements `flash.display.LoaderInfo`'s native instance constructor.
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
-    }
+    activation.super_init(this, &[])?;
 
     Ok(Value::Undefined)
 }
@@ -31,22 +29,20 @@ pub fn native_instance_init<'gc>(
 /// `actionScriptVersion` getter
 pub fn get_action_script_version<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(movie, _) => {
-                    let version = if movie.is_action_script_3() { 3 } else { 2 };
-                    return Ok(version.into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(movie, _) => {
+                let version = if movie.is_action_script_3() { 3 } else { 2 };
+                return Ok(version.into());
             }
         }
     }
@@ -57,23 +53,21 @@ pub fn get_action_script_version<'gc>(
 /// `applicationDomain` getter
 pub fn get_application_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(movie, _, _) | LoaderStream::Swf(movie, _) => {
-                    let domain = activation
-                        .context
-                        .library
-                        .library_for_movie_mut(movie.clone())
-                        .avm2_domain();
-                    return Ok(DomainObject::from_domain(activation, domain)?.into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(movie, _, _) | LoaderStream::Swf(movie, _) => {
+                let domain = activation
+                    .context
+                    .library
+                    .library_for_movie_mut(movie.clone())
+                    .avm2_domain();
+                return Ok(DomainObject::from_domain(activation, domain)?.into());
             }
         }
     }
@@ -84,19 +78,17 @@ pub fn get_application_domain<'gc>(
 /// `bytesTotal` getter
 pub fn get_bytes_total<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(swf, _, _) => return Ok(swf.compressed_len().into()),
-                LoaderStream::Swf(movie, _) => {
-                    return Ok(movie.compressed_len().into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(swf, _, _) => return Ok(swf.compressed_len().into()),
+            LoaderStream::Swf(movie, _) => {
+                return Ok(movie.compressed_len().into());
             }
         }
     }
@@ -107,25 +99,23 @@ pub fn get_bytes_total<'gc>(
 /// `bytesLoaded` getter
 pub fn get_bytes_loaded<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, None, _) => return Ok(0.into()),
-                LoaderStream::Swf(_, root) | LoaderStream::NotYetLoaded(_, Some(root), _) => {
-                    return Ok(root
-                        .as_movie_clip()
-                        .map(|mc| mc.compressed_loaded_bytes())
-                        .unwrap_or_default()
-                        .into())
-                }
-            };
-        }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, None, _) => return Ok(0.into()),
+            LoaderStream::Swf(_, root) | LoaderStream::NotYetLoaded(_, Some(root), _) => {
+                return Ok(root
+                    .as_movie_clip()
+                    .map(|mc| mc.compressed_loaded_bytes())
+                    .unwrap_or_default()
+                    .into())
+            }
+        };
     }
 
     Ok(Value::Undefined)
@@ -134,21 +124,19 @@ pub fn get_bytes_loaded<'gc>(
 /// `content` getter
 pub fn get_content<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::Swf(_, root) | LoaderStream::NotYetLoaded(_, Some(root), _) => {
-                    return Ok(root.object2());
-                }
-                _ => {
-                    return Ok(Value::Null);
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::Swf(_, root) | LoaderStream::NotYetLoaded(_, Some(root), _) => {
+                return Ok(root.object2());
+            }
+            _ => {
+                return Ok(Value::Null);
             }
         }
     }
@@ -159,19 +147,17 @@ pub fn get_content<'gc>(
 /// `contentType` getter
 pub fn get_content_type<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => return Ok(Value::Null),
-                LoaderStream::Swf(_, _) => {
-                    return Ok("application/x-shockwave-flash".into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => return Ok(Value::Null),
+            LoaderStream::Swf(_, _) => {
+                return Ok("application/x-shockwave-flash".into());
             }
         }
     }
@@ -182,21 +168,19 @@ pub fn get_content_type<'gc>(
 /// `frameRate` getter
 pub fn get_frame_rate<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(root, _) => {
-                    return Ok(root.frame_rate().to_f64().into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(root, _) => {
+                return Ok(root.frame_rate().to_f64().into());
             }
         }
     }
@@ -207,21 +191,19 @@ pub fn get_frame_rate<'gc>(
 /// `height` getter
 pub fn get_height<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(root, _) => {
-                    return Ok(root.height().to_pixels().into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(root, _) => {
+                return Ok(root.height().to_pixels().into());
             }
         }
     }
@@ -232,7 +214,7 @@ pub fn get_height<'gc>(
 /// `isURLInaccessible` getter
 pub fn get_is_url_inaccessible<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.LoaderInfo", "isURLInaccessible");
@@ -242,22 +224,20 @@ pub fn get_is_url_inaccessible<'gc>(
 /// `sameDomain` getter
 pub fn get_same_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(_root, _) => {
-                    avm2_stub_getter!(activation, "flash.display.LoaderInfo", "sameDomain");
-                    return Ok(false.into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(_root, _) => {
+                avm2_stub_getter!(activation, "flash.display.LoaderInfo", "sameDomain");
+                return Ok(false.into());
             }
         }
     }
@@ -268,22 +248,20 @@ pub fn get_same_domain<'gc>(
 /// `childAllowsParent` getter
 pub fn get_child_allows_parent<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(_root, _) => {
-                    avm2_stub_getter!(activation, "flash.display.LoaderInfo", "childAllowsParent");
-                    return Ok(false.into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(_root, _) => {
+                avm2_stub_getter!(activation, "flash.display.LoaderInfo", "childAllowsParent");
+                return Ok(false.into());
             }
         }
     }
@@ -294,46 +272,43 @@ pub fn get_child_allows_parent<'gc>(
 /// `parentAllowsChild` getter
 pub fn get_parent_allows_child<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(_root, _) => {
-                    avm2_stub_getter!(activation, "flash.display.LoaderInfo", "parentAllowsChild");
-                    return Ok(false.into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(_root, _) => {
+                avm2_stub_getter!(activation, "flash.display.LoaderInfo", "parentAllowsChild");
+                return Ok(false.into());
             }
         }
     }
+
     Ok(Value::Undefined)
 }
 
 /// `swfVersion` getter
 pub fn get_swf_version<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(root, _) => {
-                    return Ok(root.version().into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(root, _) => {
+                return Ok(root.version().into());
             }
         }
     }
@@ -344,20 +319,18 @@ pub fn get_swf_version<'gc>(
 /// `url` getter
 pub fn get_url<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            let root = match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, false) => return Ok(Value::Null),
-                LoaderStream::NotYetLoaded(root, _, true) | LoaderStream::Swf(root, _) => root,
-            };
-            return Ok(AvmString::new_utf8(activation.context.gc_context, root.url()).into());
-        }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        let root = match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, false) => return Ok(Value::Null),
+            LoaderStream::NotYetLoaded(root, _, true) | LoaderStream::Swf(root, _) => root,
+        };
+        return Ok(AvmString::new_utf8(activation.context.gc_context, root.url()).into());
     }
 
     Ok(Value::Undefined)
@@ -366,21 +339,19 @@ pub fn get_url<'gc>(
 /// `width` getter
 pub fn get_width<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, _, _) => {
-                    return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
-                }
-                LoaderStream::Swf(root, _) => {
-                    return Ok(root.width().to_pixels().into());
-                }
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, _, _) => {
+                return Err(Error::AvmError(error(_activation, INSUFFICIENT, 2099)?));
+            }
+            LoaderStream::Swf(root, _) => {
+                return Ok(root.width().to_pixels().into());
             }
         }
     }
@@ -391,61 +362,59 @@ pub fn get_width<'gc>(
 /// `bytes` getter
 pub fn get_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            let root = match &*loader_stream {
-                LoaderStream::NotYetLoaded(_, None, _) => {
-                    // If we haven't even started loading yet (we have no root clip),
-                    // then return null. FIXME - we should probably store the ByteArray
-                    // in a field, and initialize it when we start loading.
-                    return Ok(Value::Null);
-                }
-                LoaderStream::NotYetLoaded(swf, Some(_), _) => swf,
-                LoaderStream::Swf(root, _) => root,
-            };
-
-            let ba_class = activation.context.avm2.classes().bytearray;
-            let ba = ba_class.construct(activation, &[])?;
-
-            if root.data().is_empty() {
-                return Ok(ba.into());
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        let root = match &*loader_stream {
+            LoaderStream::NotYetLoaded(_, None, _) => {
+                // If we haven't even started loading yet (we have no root clip),
+                // then return null. FIXME - we should probably store the ByteArray
+                // in a field, and initialize it when we start loading.
+                return Ok(Value::Null);
             }
+            LoaderStream::NotYetLoaded(swf, Some(_), _) => swf,
+            LoaderStream::Swf(root, _) => root,
+        };
 
-            let mut ba_write = ba.as_bytearray_mut(activation.context.gc_context).unwrap();
+        let ba_class = activation.context.avm2.classes().bytearray;
+        let ba = ba_class.construct(activation, &[])?;
 
-            // First, write a fake header corresponding to an
-            // uncompressed SWF
-            let mut header = root.header().swf_header().clone();
-            header.compression = Compression::None;
-
-            write_swf(&header, &[], &mut *ba_write).unwrap();
-
-            // `swf` always writes an implicit end tag, let's cut that
-            // off. We scroll back 2 bytes before writing the actual
-            // datastream as it is guaranteed to at least be as long as
-            // the implicit end tag we want to get rid of.
-            let correct_header_length = ba_write.len() - 2;
-            ba_write.set_position(correct_header_length);
-            ba_write.write_bytes(root.data())?;
-
-            // `swf` wrote the wrong length (since we wrote the data
-            // ourselves), so we need to overwrite it ourselves.
-            ba_write.set_position(4);
-            ba_write.set_endian(Endian::Little);
-            ba_write.write_unsigned_int((root.data().len() + correct_header_length) as u32)?;
-
-            // Finally, reset the array to the correct state.
-            ba_write.set_position(0);
-            ba_write.set_endian(Endian::Big);
-
+        if root.data().is_empty() {
             return Ok(ba.into());
         }
+
+        let mut ba_write = ba.as_bytearray_mut(activation.context.gc_context).unwrap();
+
+        // First, write a fake header corresponding to an
+        // uncompressed SWF
+        let mut header = root.header().swf_header().clone();
+        header.compression = Compression::None;
+
+        write_swf(&header, &[], &mut *ba_write).unwrap();
+
+        // `swf` always writes an implicit end tag, let's cut that
+        // off. We scroll back 2 bytes before writing the actual
+        // datastream as it is guaranteed to at least be as long as
+        // the implicit end tag we want to get rid of.
+        let correct_header_length = ba_write.len() - 2;
+        ba_write.set_position(correct_header_length);
+        ba_write.write_bytes(root.data())?;
+
+        // `swf` wrote the wrong length (since we wrote the data
+        // ourselves), so we need to overwrite it ourselves.
+        ba_write.set_position(4);
+        ba_write.set_endian(Endian::Little);
+        ba_write.write_unsigned_int((root.data().len() + correct_header_length) as u32)?;
+
+        // Finally, reset the array to the correct state.
+        ba_write.set_position(0);
+        ba_write.set_endian(Endian::Big);
+
+        return Ok(ba.into());
     }
 
     Ok(Value::Undefined)
@@ -454,10 +423,10 @@ pub fn get_bytes<'gc>(
 /// `loader` getter
 pub fn get_loader<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(loader_info) = this.as_ref().and_then(|this| this.as_loader_info_object()) {
+    if let Some(loader_info) = this.as_loader_info_object() {
         Ok(loader_info.loader().map_or(Value::Null, |v| v.into()))
     } else {
         Ok(Value::Undefined)
@@ -467,22 +436,20 @@ pub fn get_loader<'gc>(
 /// `loaderURL` getter
 pub fn get_loader_url<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            let root = match &*loader_stream {
-                LoaderStream::NotYetLoaded(swf, _, _) => swf,
-                LoaderStream::Swf(root, _) => root,
-            };
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        let root = match &*loader_stream {
+            LoaderStream::NotYetLoaded(swf, _, _) => swf,
+            LoaderStream::Swf(root, _) => root,
+        };
 
-            let loader_url = root.loader_url().unwrap_or_else(|| root.url());
-            return Ok(AvmString::new_utf8(activation.context.gc_context, loader_url).into());
-        }
+        let loader_url = root.loader_url().unwrap_or_else(|| root.url());
+        return Ok(AvmString::new_utf8(activation.context.gc_context, loader_url).into());
     }
 
     Ok(Value::Undefined)
@@ -491,34 +458,32 @@ pub fn get_loader_url<'gc>(
 /// `parameters` getter
 pub fn get_parameters<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(loader_stream) = this
-            .as_loader_info_object()
-            .and_then(|o| o.as_loader_stream())
-        {
-            let root = match &*loader_stream {
-                LoaderStream::NotYetLoaded(root, _, _) => root,
-                LoaderStream::Swf(root, _) => root,
-            };
+    if let Some(loader_stream) = this
+        .as_loader_info_object()
+        .and_then(|o| o.as_loader_stream())
+    {
+        let root = match &*loader_stream {
+            LoaderStream::NotYetLoaded(root, _, _) => root,
+            LoaderStream::Swf(root, _) => root,
+        };
 
-            let mut params_obj = activation
-                .avm2()
-                .classes()
-                .object
-                .construct(activation, &[])?;
-            let parameters = root.parameters();
+        let mut params_obj = activation
+            .avm2()
+            .classes()
+            .object
+            .construct(activation, &[])?;
+        let parameters = root.parameters();
 
-            for (k, v) in parameters.iter() {
-                let avm_k = AvmString::new_utf8(activation.context.gc_context, k);
-                let avm_v = AvmString::new_utf8(activation.context.gc_context, v);
-                params_obj.set_public_property(avm_k, avm_v.into(), activation)?;
-            }
-
-            return Ok(params_obj.into());
+        for (k, v) in parameters.iter() {
+            let avm_k = AvmString::new_utf8(activation.context.gc_context, k);
+            let avm_v = AvmString::new_utf8(activation.context.gc_context, v);
+            params_obj.set_public_property(avm_k, avm_v.into(), activation)?;
         }
+
+        return Ok(params_obj.into());
     }
 
     Ok(Value::Undefined)
@@ -527,10 +492,10 @@ pub fn get_parameters<'gc>(
 /// `sharedEvents` getter
 pub fn get_shared_events<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(loader_info) = this.as_ref().and_then(|this| this.as_loader_info_object()) {
+    if let Some(loader_info) = this.as_loader_info_object() {
         return Ok(loader_info.shared_events().into());
     }
     Ok(Value::Undefined)
@@ -539,10 +504,10 @@ pub fn get_shared_events<'gc>(
 /// `uncaughtErrorEvents` getter
 pub fn get_uncaught_error_events<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(loader_info) = this.as_ref().and_then(|this| this.as_loader_info_object()) {
+    if let Some(loader_info) = this.as_loader_info_object() {
         return Ok(loader_info.uncaught_error_events().into());
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -14,11 +14,11 @@ use crate::string::{AvmString, WString};
 /// specify what methods of a clip's class run on which frames.
 pub fn add_frame_script<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         for (frame_id, callable) in args.chunks_exact(2).map(|s| (s[0], s[1])) {
@@ -37,11 +37,11 @@ pub fn add_frame_script<'gc>(
 /// Implements `currentFrame`.
 pub fn get_current_frame<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         if let Some(Scene {
@@ -62,11 +62,11 @@ pub fn get_current_frame<'gc>(
 /// Implements `currentFrameLabel`.
 pub fn get_current_frame_label<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         return Ok(mc
@@ -87,11 +87,11 @@ pub fn get_current_frame_label<'gc>(
 /// Implements `currentLabel`.
 pub fn get_current_label<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         return Ok(mc
@@ -142,11 +142,11 @@ fn labels_for_scene<'gc>(
 /// Implements `currentLabels`.
 pub fn get_current_labels<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         let scene = mc.current_scene().unwrap_or_else(|| Scene {
@@ -163,11 +163,11 @@ pub fn get_current_labels<'gc>(
 /// Implements `currentScene`.
 pub fn get_current_scene<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         let scene = mc.current_scene().unwrap_or_else(|| Scene {
@@ -193,11 +193,11 @@ pub fn get_current_scene<'gc>(
 
 pub fn get_enabled<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         return Ok(mc.avm2_enabled().into());
@@ -208,11 +208,11 @@ pub fn get_enabled<'gc>(
 
 pub fn set_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         let enabled = args.get_bool(0);
@@ -226,11 +226,11 @@ pub fn set_enabled<'gc>(
 /// Implements `scenes`.
 pub fn get_scenes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         let mut mc_scenes = mc.scenes();
@@ -271,11 +271,11 @@ pub fn get_scenes<'gc>(
 /// Implements `framesLoaded`.
 pub fn get_frames_loaded<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         return Ok(mc.frames_loaded().into());
@@ -287,11 +287,11 @@ pub fn get_frames_loaded<'gc>(
 /// Implements `isPlaying`.
 pub fn get_is_playing<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         return Ok((mc.programmatically_played() && mc.playing()).into());
@@ -303,11 +303,11 @@ pub fn get_is_playing<'gc>(
 /// Implements `totalFrames`.
 pub fn get_total_frames<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         return Ok(mc.total_frames().into());
@@ -319,11 +319,11 @@ pub fn get_total_frames<'gc>(
 /// Implements `gotoAndPlay`.
 pub fn goto_and_play<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         mc.set_programmatically_played(activation.context.gc_context);
@@ -336,11 +336,11 @@ pub fn goto_and_play<'gc>(
 /// Implements `gotoAndStop`.
 pub fn goto_and_stop<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         goto_frame(activation, mc, args, true)?;
@@ -416,11 +416,11 @@ pub fn goto_frame<'gc>(
 /// Implements `stop`.
 pub fn stop<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         mc.stop(&mut activation.context);
@@ -432,11 +432,11 @@ pub fn stop<'gc>(
 /// Implements `play`.
 pub fn play<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         mc.set_programmatically_played(activation.context.gc_context);
@@ -449,11 +449,11 @@ pub fn play<'gc>(
 /// Implements `prevFrame`.
 pub fn prev_frame<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         mc.prev_frame(&mut activation.context);
@@ -465,11 +465,11 @@ pub fn prev_frame<'gc>(
 /// Implements `nextFrame`.
 pub fn next_frame<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         mc.next_frame(&mut activation.context);
@@ -481,11 +481,11 @@ pub fn next_frame<'gc>(
 /// Implements `prevScene`.
 pub fn prev_scene<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         if let Some(Scene {
@@ -504,11 +504,11 @@ pub fn prev_scene<'gc>(
 /// Implements `nextScene`.
 pub fn next_scene<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|dobj| dobj.as_movie_clip())
     {
         if let Some(Scene {

--- a/core/src/avm2/globals/flash/display/shader_data.rs
+++ b/core/src/avm2/globals/flash/display/shader_data.rs
@@ -16,10 +16,9 @@ pub use crate::avm2::object::shader_data_allocator;
 /// Implements `ShaderData.init`, which is called from the constructor
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut this = this.unwrap();
     let bytecode = args.get_object(activation, 0, "bytecode")?;
     let bytecode = bytecode.as_bytearray().unwrap();
     let shader = parse_shader(bytecode.bytes()).expect("Failed to parse PixelBender");

--- a/core/src/avm2/globals/flash/display/shader_job.rs
+++ b/core/src/avm2/globals/flash/display/shader_job.rs
@@ -133,11 +133,9 @@ pub fn get_shader_args<'gc>(
 /// Implements `ShaderJob.start`.
 pub fn start<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
-
     avm2_stub_method!(
         activation,
         "flash.display.ShaderJob",

--- a/core/src/avm2/globals/flash/display/shape.rs
+++ b/core/src/avm2/globals/flash/display/shape.rs
@@ -44,29 +44,27 @@ pub fn shape_allocator<'gc>(
 /// Implements `graphics`.
 pub fn get_graphics<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut this) = this {
-        if let Some(dobj) = this.as_display_object() {
-            // Lazily initialize the `Graphics` object in a hidden property.
-            let graphics = match this.get_property(
-                &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
-                activation,
-            )? {
-                Value::Undefined | Value::Null => {
-                    let graphics = Value::from(StageObject::graphics(activation, dobj)?);
-                    this.set_property(
-                        &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
-                        graphics,
-                        activation,
-                    )?;
-                    graphics
-                }
-                graphics => graphics,
-            };
-            return Ok(graphics);
-        }
+    if let Some(dobj) = this.as_display_object() {
+        // Lazily initialize the `Graphics` object in a hidden property.
+        let graphics = match this.get_property(
+            &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+            activation,
+        )? {
+            Value::Undefined | Value::Null => {
+                let graphics = Value::from(StageObject::graphics(activation, dobj)?);
+                this.set_property(
+                    &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+                    graphics,
+                    activation,
+                )?;
+                graphics
+            }
+            graphics => graphics,
+        };
+        return Ok(graphics);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display/simple_button.rs
+++ b/core/src/avm2/globals/flash/display/simple_button.rs
@@ -56,47 +56,45 @@ pub fn simple_button_allocator<'gc>(
 /// Implements `flash.display.SimpleButton`'s 'init' method. which is called from the constructor
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(new_do) = this
-            .as_display_object()
-            .and_then(|this| this.as_avm2_button())
-        {
-            let up_state = args
-                .try_get_object(activation, 0)
-                .and_then(|o| o.as_display_object());
-            if up_state.is_some() {
-                new_do.set_state_child(&mut activation.context, ButtonState::UP, up_state);
-            }
-
-            let over_state = args
-                .try_get_object(activation, 1)
-                .and_then(|o| o.as_display_object());
-            if over_state.is_some() {
-                new_do.set_state_child(&mut activation.context, ButtonState::OVER, over_state);
-            }
-
-            let down_state = args
-                .try_get_object(activation, 2)
-                .and_then(|o| o.as_display_object());
-            if down_state.is_some() {
-                new_do.set_state_child(&mut activation.context, ButtonState::DOWN, down_state);
-            }
-
-            let hit_state = args
-                .try_get_object(activation, 3)
-                .and_then(|o| o.as_display_object());
-            if hit_state.is_some() {
-                new_do.set_state_child(&mut activation.context, ButtonState::HIT_TEST, hit_state);
-            }
-
-            // This performs the child state construction.
-            new_do.construct_frame(&mut activation.context);
-        } else {
-            unreachable!();
+    if let Some(new_do) = this
+        .as_display_object()
+        .and_then(|this| this.as_avm2_button())
+    {
+        let up_state = args
+            .try_get_object(activation, 0)
+            .and_then(|o| o.as_display_object());
+        if up_state.is_some() {
+            new_do.set_state_child(&mut activation.context, ButtonState::UP, up_state);
         }
+
+        let over_state = args
+            .try_get_object(activation, 1)
+            .and_then(|o| o.as_display_object());
+        if over_state.is_some() {
+            new_do.set_state_child(&mut activation.context, ButtonState::OVER, over_state);
+        }
+
+        let down_state = args
+            .try_get_object(activation, 2)
+            .and_then(|o| o.as_display_object());
+        if down_state.is_some() {
+            new_do.set_state_child(&mut activation.context, ButtonState::DOWN, down_state);
+        }
+
+        let hit_state = args
+            .try_get_object(activation, 3)
+            .and_then(|o| o.as_display_object());
+        if hit_state.is_some() {
+            new_do.set_state_child(&mut activation.context, ButtonState::HIT_TEST, hit_state);
+        }
+
+        // This performs the child state construction.
+        new_do.construct_frame(&mut activation.context);
+    } else {
+        unreachable!();
     }
 
     Ok(Value::Undefined)
@@ -105,11 +103,11 @@ pub fn init<'gc>(
 /// Implements `downState`'s getter.
 pub fn get_down_state<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok(btn
@@ -124,11 +122,11 @@ pub fn get_down_state<'gc>(
 /// Implements `downState`'s setter.
 pub fn set_down_state<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         let new_state = args
@@ -144,11 +142,11 @@ pub fn set_down_state<'gc>(
 /// Implements `overState`'s getter.
 pub fn get_over_state<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok(btn
@@ -163,11 +161,11 @@ pub fn get_over_state<'gc>(
 /// Implements `overState`'s setter.
 pub fn set_over_state<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         let new_state = args
@@ -183,11 +181,11 @@ pub fn set_over_state<'gc>(
 /// Implements `hitTestState`'s getter.
 pub fn get_hit_test_state<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok(btn
@@ -202,11 +200,11 @@ pub fn get_hit_test_state<'gc>(
 /// Implements `hitTestState`'s setter.
 pub fn set_hit_test_state<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         let new_state = args
@@ -222,11 +220,11 @@ pub fn set_hit_test_state<'gc>(
 /// Implements `upState`'s getter.
 pub fn get_up_state<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok(btn
@@ -241,11 +239,11 @@ pub fn get_up_state<'gc>(
 /// Implements `upState`'s setter.
 pub fn set_up_state<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         let new_state = args
@@ -261,11 +259,11 @@ pub fn set_up_state<'gc>(
 /// Implements `trackAsMenu`'s getter
 pub fn get_track_as_menu<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok((btn.button_tracking() == ButtonTracking::Menu).into());
@@ -277,11 +275,11 @@ pub fn get_track_as_menu<'gc>(
 /// Implements `trackAsMenu`'s setter
 pub fn set_track_as_menu<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         match args.get_bool(0) {
@@ -296,11 +294,11 @@ pub fn set_track_as_menu<'gc>(
 /// Implements `enabled`'s getter
 pub fn get_enabled<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok(btn.enabled().into());
@@ -312,11 +310,11 @@ pub fn get_enabled<'gc>(
 /// Implements `enabled`'s setter
 pub fn set_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         btn.set_enabled(&mut activation.context, args.get_bool(0));
@@ -328,11 +326,11 @@ pub fn set_enabled<'gc>(
 /// Implements `useHandCursor`'s getter
 pub fn get_use_hand_cursor<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         return Ok(btn.use_hand_cursor().into());
@@ -344,11 +342,11 @@ pub fn get_use_hand_cursor<'gc>(
 /// Implements `useHandCursor`'s setter
 pub fn set_use_hand_cursor<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(btn) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_avm2_button())
     {
         btn.set_use_hand_cursor(&mut activation.context, args.get_bool(0));

--- a/core/src/avm2/globals/flash/display/sprite.rs
+++ b/core/src/avm2/globals/flash/display/sprite.rs
@@ -62,11 +62,11 @@ pub fn init_empty_sprite<'gc>(
 /// Implements `dropTarget`'s getter
 pub fn get_drop_target<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|o| o.as_movie_clip())
         .and_then(|o| o.drop_target())
     {
@@ -79,29 +79,27 @@ pub fn get_drop_target<'gc>(
 /// Implements `graphics`.
 pub fn get_graphics<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut this) = this {
-        if let Some(dobj) = this.as_display_object() {
-            // Lazily initialize the `Graphics` object in a hidden property.
-            let graphics = match this.get_property(
-                &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
-                activation,
-            )? {
-                Value::Undefined | Value::Null => {
-                    let graphics = Value::from(StageObject::graphics(activation, dobj)?);
-                    this.set_property(
-                        &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
-                        graphics,
-                        activation,
-                    )?;
-                    graphics
-                }
-                graphics => graphics,
-            };
-            return Ok(graphics);
-        }
+    if let Some(dobj) = this.as_display_object() {
+        // Lazily initialize the `Graphics` object in a hidden property.
+        let graphics = match this.get_property(
+            &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+            activation,
+        )? {
+            Value::Undefined | Value::Null => {
+                let graphics = Value::from(StageObject::graphics(activation, dobj)?);
+                this.set_property(
+                    &Multiname::new(activation.avm2().flash_display_internal, "_graphics"),
+                    graphics,
+                    activation,
+                )?;
+                graphics
+            }
+            graphics => graphics,
+        };
+        return Ok(graphics);
     }
 
     Ok(Value::Undefined)
@@ -110,10 +108,10 @@ pub fn get_graphics<'gc>(
 /// Implements `soundTransform`'s getter
 pub fn get_sound_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|o| o.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let dobj_st = dobj.base().sound_transform().clone();
 
         return Ok(dobj_st.into_avm2_object(activation)?.into());
@@ -125,10 +123,10 @@ pub fn get_sound_transform<'gc>(
 /// Implements `soundTransform`'s setter
 pub fn set_sound_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this.and_then(|o| o.as_display_object()) {
+    if let Some(dobj) = this.as_display_object() {
         let as3_st = args.get_object(activation, 0, "value")?;
         let dobj_st = SoundTransform::from_avm2_object(activation, as3_st)?;
 
@@ -141,13 +139,10 @@ pub fn set_sound_transform<'gc>(
 /// Implements `buttonMode`'s getter
 pub fn get_button_mode<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
-        .and_then(|o| o.as_movie_clip())
-    {
+    if let Some(mc) = this.as_display_object().and_then(|o| o.as_movie_clip()) {
         return Ok(mc.forced_button_mode().into());
     }
 
@@ -157,13 +152,10 @@ pub fn get_button_mode<'gc>(
 /// Implements `buttonMode`'s setter
 pub fn set_button_mode<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
-        .and_then(|o| o.as_movie_clip())
-    {
+    if let Some(mc) = this.as_display_object().and_then(|o| o.as_movie_clip()) {
         let forced_button_mode = args.get_bool(0);
 
         mc.set_forced_button_mode(&mut activation.context, forced_button_mode);
@@ -175,10 +167,10 @@ pub fn set_button_mode<'gc>(
 /// Starts dragging this display object, making it follow the cursor.
 pub fn start_drag<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(display_object) = this.and_then(|this| this.as_display_object()) {
+    if let Some(display_object) = this.as_display_object() {
         let lock_center = args.get_bool(0);
 
         let rectangle = args.try_get_object(activation, 1);
@@ -235,7 +227,7 @@ pub fn start_drag<'gc>(
 
 pub fn stop_drag<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // It doesn't matter which clip we call this on; it simply stops any active drag.
@@ -252,11 +244,11 @@ pub fn stop_drag<'gc>(
 /// Implements `useHandCursor`'s getter
 pub fn get_use_hand_cursor<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_movie_clip())
     {
         return Ok(mc.avm2_use_hand_cursor().into());
@@ -268,11 +260,11 @@ pub fn get_use_hand_cursor<'gc>(
 /// Implements `useHandCursor`'s setter
 pub fn set_use_hand_cursor<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_movie_clip())
     {
         mc.set_avm2_use_hand_cursor(&mut activation.context, args.get_bool(0));
@@ -284,11 +276,11 @@ pub fn set_use_hand_cursor<'gc>(
 /// Implements `hitArea`'s getter
 pub fn get_hit_area<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|o| o.as_display_object())
+        .as_display_object()
         .and_then(|o| o.as_movie_clip())
         .and_then(|o| o.hit_area())
     {
@@ -301,11 +293,11 @@ pub fn get_hit_area<'gc>(
 /// Implements `hitArea`'s setter
 pub fn set_hit_area<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(mc) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_movie_clip())
     {
         let object = args

--- a/core/src/avm2/globals/flash/display/stage.rs
+++ b/core/src/avm2/globals/flash/display/stage.rs
@@ -15,12 +15,10 @@ use swf::Color;
 /// Implements `flash.display.Stage`'s native instance constructor.
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, args)?;
-    }
+    activation.super_init(this, args)?;
 
     Ok(Value::Undefined)
 }
@@ -28,7 +26,7 @@ pub fn native_instance_init<'gc>(
 /// Implement `align`'s getter
 pub fn get_align<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let align = activation.context.stage.align();
@@ -57,7 +55,7 @@ pub fn get_align<'gc>(
 /// Implement `align`'s setter
 pub fn set_align<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let align = args.get_string(activation, 0)?.parse().unwrap_or_default();
@@ -71,11 +69,11 @@ pub fn set_align<'gc>(
 /// Implement `browserZoomFactor`'s getter
 pub fn get_browser_zoom_factor<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_stage())
         .is_some()
     {
@@ -93,13 +91,10 @@ pub fn get_browser_zoom_factor<'gc>(
 /// Implement `color`'s getter
 pub fn get_color<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let color = dobj.background_color().unwrap_or(Color::WHITE);
         return Ok(color.to_rgba().into());
     }
@@ -110,13 +105,10 @@ pub fn get_color<'gc>(
 /// Implement `color`'s setter
 pub fn set_color<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let color = Color::from_rgb(args.get_u32(activation, 0)?, 255);
         dobj.set_background_color(activation.context.gc_context, Some(color));
     }
@@ -127,11 +119,11 @@ pub fn set_color<'gc>(
 /// Implement `contentsScaleFactor`'s getter
 pub fn get_contents_scale_factor<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_stage())
         .is_some()
     {
@@ -149,7 +141,7 @@ pub fn get_contents_scale_factor<'gc>(
 /// Implement `displayState`'s getter
 pub fn get_display_state<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let display_state = AvmString::new_utf8(
@@ -162,7 +154,7 @@ pub fn get_display_state<'gc>(
 /// Implement `displayState`'s setter
 pub fn set_display_state<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Ok(mut display_state) = args.get_string(activation, 0)?.parse() {
@@ -184,7 +176,7 @@ pub fn set_display_state<'gc>(
 /// Implement `focus`'s getter
 pub fn get_focus<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(activation
@@ -199,7 +191,7 @@ pub fn get_focus<'gc>(
 /// Implement `focus`'s setter
 pub fn set_focus<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let focus = activation.context.focus_tracker;
@@ -220,7 +212,7 @@ pub fn set_focus<'gc>(
 /// Implement `frameRate`'s getter
 pub fn get_frame_rate<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok((*activation.context.frame_rate).into())
@@ -229,7 +221,7 @@ pub fn get_frame_rate<'gc>(
 /// Implement `frameRate`'s setter
 pub fn set_frame_rate<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if !activation.context.forced_frame_rate {
@@ -242,7 +234,7 @@ pub fn set_frame_rate<'gc>(
 
 pub fn get_show_default_context_menu<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(activation.context.stage.show_menu().into())
@@ -250,7 +242,7 @@ pub fn get_show_default_context_menu<'gc>(
 
 pub fn set_show_default_context_menu<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let show_default_context_menu = args.get_bool(0);
@@ -264,7 +256,7 @@ pub fn set_show_default_context_menu<'gc>(
 /// Implement `scaleMode`'s getter
 pub fn get_scale_mode<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let scale_mode = AvmString::new_utf8(
@@ -277,7 +269,7 @@ pub fn get_scale_mode<'gc>(
 /// Implement `scaleMode`'s setter
 pub fn set_scale_mode<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Ok(scale_mode) = args.get_string(activation, 0)?.parse() {
@@ -296,13 +288,10 @@ pub fn set_scale_mode<'gc>(
 /// This setting is currently ignored in Ruffle.
 pub fn get_stage_focus_rect<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         return Ok(dobj.stage_focus_rect().into());
     }
 
@@ -314,13 +303,10 @@ pub fn get_stage_focus_rect<'gc>(
 /// This setting is currently ignored in Ruffle.
 pub fn set_stage_focus_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         let rf = args.get_bool(0);
         dobj.set_stage_focus_rect(activation.context.gc_context, rf);
     }
@@ -331,13 +317,10 @@ pub fn set_stage_focus_rect<'gc>(
 /// Implement `stageWidth`'s getter
 pub fn get_stage_width<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         return Ok(dobj.stage_size().0.into());
     }
 
@@ -347,7 +330,7 @@ pub fn get_stage_width<'gc>(
 /// Implement `stageWidth`'s setter
 pub fn set_stage_width<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // For some reason this value is settable but it does nothing.
@@ -357,13 +340,10 @@ pub fn set_stage_width<'gc>(
 /// Implement `stageHeight`'s getter
 pub fn get_stage_height<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(dobj) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(dobj) = this.as_display_object().and_then(|this| this.as_stage()) {
         return Ok(dobj.stage_size().1.into());
     }
 
@@ -373,7 +353,7 @@ pub fn get_stage_height<'gc>(
 /// Implement `stageHeight`'s setter
 pub fn set_stage_height<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // For some reason this value is settable but it does nothing.
@@ -383,7 +363,7 @@ pub fn set_stage_height<'gc>(
 /// Implement `allowsFullScreen`'s getter
 pub fn get_allows_full_screen<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.Stage", "allowsFullScreen");
@@ -393,7 +373,7 @@ pub fn get_allows_full_screen<'gc>(
 /// Implement `allowsFullScreenInteractive`'s getter
 pub fn get_allows_full_screen_interactive<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(
@@ -407,7 +387,7 @@ pub fn get_allows_full_screen_interactive<'gc>(
 /// Implement `quality`'s getter
 pub fn get_quality<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let quality = activation.context.stage.quality().into_avm_str();
@@ -417,7 +397,7 @@ pub fn get_quality<'gc>(
 /// Implement `quality`'s setter
 pub fn set_quality<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // Invalid values result in no change.
@@ -433,13 +413,10 @@ pub fn set_quality<'gc>(
 /// Implement `stage3Ds`'s getter
 pub fn get_stage3ds<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(stage) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(stage) = this.as_display_object().and_then(|this| this.as_stage()) {
         let storage = ArrayStorage::from_storage(
             stage
                 .stage3ds()
@@ -456,13 +433,10 @@ pub fn get_stage3ds<'gc>(
 /// Implement `invalidate`
 pub fn invalidate<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(stage) = this
-        .and_then(|this| this.as_display_object())
-        .and_then(|this| this.as_stage())
-    {
+    if let Some(stage) = this.as_display_object().and_then(|this| this.as_stage()) {
         stage.set_invalidated(activation.context.gc_context, true);
     }
     Ok(Value::Undefined)
@@ -471,7 +445,7 @@ pub fn invalidate<'gc>(
 /// Stage.fullScreenSourceRect's getter
 pub fn get_full_screen_source_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.Stage", "fullScreenSourceRect");
@@ -481,7 +455,7 @@ pub fn get_full_screen_source_rect<'gc>(
 /// Stage.fullScreenSourceRect's setter
 pub fn set_full_screen_source_rect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.display.Stage", "fullScreenSourceRect");
@@ -491,7 +465,7 @@ pub fn set_full_screen_source_rect<'gc>(
 /// Stage.fullScreenHeight's getter
 pub fn get_full_screen_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.Stage", "fullScreenHeight");
@@ -501,7 +475,7 @@ pub fn get_full_screen_height<'gc>(
 /// Stage.fullScreenWidth's getter
 pub fn get_full_screen_width<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.display.Stage", "fullScreenWidth");

--- a/core/src/avm2/globals/flash/display/stage_3d.rs
+++ b/core/src/avm2/globals/flash/display/stage_3d.rs
@@ -8,36 +8,35 @@ pub use crate::avm2::object::stage_3d_allocator;
 
 pub fn request_context3d_internal<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this_stage3d = this.as_stage_3d().unwrap();
-        if this_stage3d.context3d().is_none() {
-            let context = activation.context.renderer.create_context3d()?;
-            let context3d_obj = Context3DObject::from_context(activation, context)?;
-            this_stage3d.set_context3d(context3d_obj, activation.context.gc_context);
+    let this_stage3d = this.as_stage_3d().unwrap();
+    if this_stage3d.context3d().is_none() {
+        let context = activation.context.renderer.create_context3d()?;
+        let context3d_obj = Context3DObject::from_context(activation, context)?;
+        this_stage3d.set_context3d(context3d_obj, activation.context.gc_context);
 
-            let event = activation
-                .avm2()
-                .classes()
-                .event
-                .construct(activation, &["context3DCreate".into()])?;
+        let event = activation
+            .avm2()
+            .classes()
+            .event
+            .construct(activation, &["context3DCreate".into()])?;
 
-            // FIXME - fire this at least one frame later,
-            // since some seems to expect this (e.g. the adobe triangle example)
-            this.call_public_property("dispatchEvent", &[event.into()], activation)?;
-        }
+        // FIXME - fire this at least one frame later,
+        // since some seems to expect this (e.g. the adobe triangle example)
+        this.call_public_property("dispatchEvent", &[event.into()], activation)?;
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_context_3d<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_stage_3d()) {
+    if let Some(this) = this.as_stage_3d() {
         return Ok(this.context3d().map_or(Value::Null, |obj| obj.into()));
     }
     Ok(Value::Undefined)
@@ -45,10 +44,10 @@ pub fn get_context_3d<'gc>(
 
 pub fn get_visible<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_stage_3d()) {
+    if let Some(this) = this.as_stage_3d() {
         return Ok(this.visible().into());
     }
     Ok(Value::Undefined)
@@ -56,10 +55,10 @@ pub fn get_visible<'gc>(
 
 pub fn set_visible<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_stage_3d()) {
+    if let Some(this) = this.as_stage_3d() {
         this.set_visible(args.get_bool(0), activation.context.gc_context);
     }
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -15,10 +15,10 @@ use swf::{Rectangle, Twips};
 
 pub fn create_index_buffer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // FIXME - get bufferUsage and pass it through
         let num_indices = args.get_u32(activation, 0)?;
         return context.create_index_buffer(num_indices, activation);
@@ -28,10 +28,10 @@ pub fn create_index_buffer<'gc>(
 
 pub fn create_vertex_buffer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // FIXME - get bufferUsage and pass it through
         let num_vertices = args.get_u32(activation, 0)?;
         let data_32_per_vertex = args.get_u32(activation, 1)?;
@@ -52,10 +52,10 @@ pub fn create_vertex_buffer<'gc>(
 
 pub fn configure_back_buffer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(mut context) = this.as_context_3d() {
         let width = args.get_u32(activation, 0)?;
         let height = args.get_u32(activation, 1)?;
         let anti_alias = args.get_u32(activation, 2)?;
@@ -127,10 +127,10 @@ pub fn configure_back_buffer<'gc>(
 
 pub fn set_vertex_buffer_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         let index = args.get_u32(activation, 0)?;
         let buffer = if matches!(args[1], Value::Null) {
             None
@@ -175,10 +175,10 @@ pub fn set_vertex_buffer_at<'gc>(
 
 pub fn create_program<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         return context.create_program(activation);
     }
     Ok(Value::Undefined)
@@ -186,10 +186,10 @@ pub fn create_program<'gc>(
 
 pub fn set_program<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         let program = args
             .try_get_object(activation, 0)
             .map(|p| p.as_program_3d().unwrap());
@@ -200,10 +200,10 @@ pub fn set_program<'gc>(
 
 pub fn draw_triangles<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         let index_buffer = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -221,10 +221,10 @@ pub fn draw_triangles<'gc>(
 
 pub fn present<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         context.present(activation)?;
     }
     Ok(Value::Undefined)
@@ -232,10 +232,10 @@ pub fn present<'gc>(
 
 pub fn set_culling<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         let culling = args.get_string(activation, 0)?;
 
         let culling = if &*culling == b"none" {
@@ -258,10 +258,10 @@ pub fn set_culling<'gc>(
 
 pub fn set_program_constants_from_matrix<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         let program_type = args.get_string(activation, 0)?;
 
         let is_vertex = if &*program_type == b"vertex" {
@@ -318,10 +318,10 @@ pub fn set_program_constants_from_matrix<'gc>(
 
 pub fn set_program_constants_from_vector<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         let program_type = args.get_string(activation, 0)?;
 
         let program_type = if &*program_type == b"vertex" {
@@ -372,10 +372,10 @@ pub fn set_program_constants_from_vector<'gc>(
 
 pub fn clear<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let red = args[0].as_number(activation.context.gc_context)?;
         let green = args[1].as_number(activation.context.gc_context)?;
@@ -391,10 +391,10 @@ pub fn clear<'gc>(
 
 pub fn create_texture<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let width = args[0].as_integer(activation.context.gc_context)? as u32;
         let height = args[1].as_integer(activation.context.gc_context)? as u32;
@@ -424,10 +424,10 @@ pub fn create_texture<'gc>(
 
 pub fn create_rectangle_texture<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let width = args[0].as_integer(activation.context.gc_context)? as u32;
         let height = args[1].as_integer(activation.context.gc_context)? as u32;
@@ -460,10 +460,10 @@ pub fn create_rectangle_texture<'gc>(
 
 pub fn create_cube_texture<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let size = args[0].as_integer(activation.context.gc_context)? as u32;
         let format = args[1].coerce_to_string(activation)?;
@@ -492,10 +492,10 @@ pub fn create_cube_texture<'gc>(
 
 pub fn set_texture_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let sampler = args[0].as_integer(activation.context.gc_context)? as u32;
         let mut cube = false;
@@ -516,10 +516,10 @@ pub fn set_texture_at<'gc>(
 
 pub fn set_color_mask<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let red = args[0].coerce_to_boolean();
         let green = args[1].coerce_to_boolean();
@@ -532,10 +532,10 @@ pub fn set_color_mask<'gc>(
 
 pub fn set_depth_test<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let depth_mask = args[0].coerce_to_boolean();
         let pass_compare_mode = args[1].coerce_to_string(activation)?;
@@ -552,10 +552,10 @@ pub fn set_depth_test<'gc>(
 
 pub fn set_blend_factors<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let source_factor = args[0].coerce_to_string(activation)?;
         let destination_factor = args[1].coerce_to_string(activation)?;
@@ -579,10 +579,10 @@ pub fn set_blend_factors<'gc>(
 
 pub fn set_render_to_texture<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let context = this.unwrap().as_context_3d().unwrap();
+    let context = this.as_context_3d().unwrap();
     let texture = args
         .get_object(activation, 0, "texture")?
         .as_texture()
@@ -631,20 +631,20 @@ pub fn set_render_to_texture<'gc>(
 
 pub fn set_render_to_back_buffer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let context = this.unwrap().as_context_3d().unwrap();
+    let context = this.as_context_3d().unwrap();
     context.set_render_to_back_buffer(activation);
     Ok(Value::Undefined)
 }
 
 pub fn set_sampler_state_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(context) = this.and_then(|this| this.as_context_3d()) {
+    if let Some(context) = this.as_context_3d() {
         // This is a native method, so all of the arguments have been checked and coerced for us
         let sampler = args[0].as_integer(activation.context.gc_context)? as u32;
         let wrap = args[1].coerce_to_string(activation)?;
@@ -688,10 +688,10 @@ pub fn set_sampler_state_at<'gc>(
 
 pub fn set_scissor_rectangle<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let context3d = this.unwrap().as_context_3d().unwrap();
+    let context3d = this.as_context_3d().unwrap();
     let rectangle = args.try_get_object(activation, 0);
     let rectangle = if let Some(rectangle) = rectangle {
         let x = rectangle

--- a/core/src/avm2/globals/flash/display3D/index_buffer_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/index_buffer_3d.rs
@@ -13,10 +13,10 @@ pub fn index_buffer_3d_allocator<'gc>(
 
 pub fn upload_from_byte_array<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(index_buffer) = this.and_then(|this| this.as_index_buffer()) {
+    if let Some(index_buffer) = this.as_index_buffer() {
         let byte_array = args.get_object(activation, 0, "byteArray")?;
         let byte_array = byte_array
             .as_bytearray()
@@ -44,10 +44,10 @@ pub fn upload_from_byte_array<'gc>(
 
 pub fn upload_from_vector<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(index_buffer) = this.and_then(|this| this.as_index_buffer()) {
+    if let Some(index_buffer) = this.as_index_buffer() {
         let vector = args
             .get(0)
             .unwrap_or(&Value::Undefined)

--- a/core/src/avm2/globals/flash/display3D/program_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/program_3d.rs
@@ -6,10 +6,10 @@ use crate::avm2::{Error, Object};
 
 pub fn upload<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_program_3d()) {
+    if let Some(this) = this.as_program_3d() {
         let vertex_agal = args
             .get(0)
             .unwrap_or(&Value::Undefined)

--- a/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/cube_texture.rs
@@ -6,10 +6,10 @@ use crate::avm2_stub_method;
 
 pub fn upload_from_bitmap_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(texture) = this.and_then(|this| this.as_texture()) {
+    if let Some(texture) = this.as_texture() {
         if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             let side = args[1].coerce_to_u32(activation)?;
             let mip_level = args[2].coerce_to_u32(activation)?;

--- a/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/rectangle_texture.rs
@@ -5,10 +5,10 @@ use crate::avm2::{Error, Object};
 
 pub fn upload_from_bitmap_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(texture) = this.and_then(|this| this.as_texture()) {
+    if let Some(texture) = this.as_texture() {
         if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             texture.context3d().copy_bitmap_to_texture(
                 source.sync(),

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -6,10 +6,10 @@ use crate::avm2_stub_method;
 
 pub fn upload_from_bitmap_data<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(texture) = this.and_then(|this| this.as_texture()) {
+    if let Some(texture) = this.as_texture() {
         if let Some(source) = args[0].coerce_to_object(activation)?.as_bitmap_data() {
             let mip_level = args[1].coerce_to_u32(activation)?;
             if mip_level == 0 {

--- a/core/src/avm2/globals/flash/display3D/vertex_buffer_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/vertex_buffer_3d.rs
@@ -14,10 +14,10 @@ pub fn vertex_buffer_3d_allocator<'gc>(
 
 pub fn upload_from_byte_array<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(vertex_buffer) = this.and_then(|this| this.as_vertex_buffer()) {
+    if let Some(vertex_buffer) = this.as_vertex_buffer() {
         let byte_array = args
             .get(0)
             .unwrap_or(&Value::Undefined)
@@ -52,10 +52,10 @@ pub fn upload_from_byte_array<'gc>(
 
 pub fn upload_from_vector<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(vertex_buffer) = this.and_then(|this| this.as_vertex_buffer()) {
+    if let Some(vertex_buffer) = this.as_vertex_buffer() {
         let vector = args
             .get(0)
             .unwrap_or(&Value::Undefined)

--- a/core/src/avm2/globals/flash/events/event.rs
+++ b/core/src/avm2/globals/flash/events/event.rs
@@ -10,10 +10,9 @@ use crate::avm2::parameters::ParametersExt;
 
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let mut evt = this.as_event_mut(activation.context.gc_context).unwrap();
     evt.set_event_type(args.get_string(activation, 0)?);
     evt.set_bubbles(args.get_bool(1));
@@ -24,10 +23,10 @@ pub fn init<'gc>(
 /// Implements `bubbles` property's getter
 pub fn get_bubbles<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         return Ok(evt.is_bubbling().into());
     }
 
@@ -37,10 +36,10 @@ pub fn get_bubbles<'gc>(
 /// Implements `cancelable` property's getter
 pub fn get_cancelable<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         return Ok(evt.is_cancelable().into());
     }
 
@@ -50,10 +49,10 @@ pub fn get_cancelable<'gc>(
 /// Implements `type` property's getter
 pub fn get_type<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         return Ok(evt.event_type().into());
     }
 
@@ -63,10 +62,10 @@ pub fn get_type<'gc>(
 /// Implements `target` property's getter
 pub fn get_target<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         return Ok(evt.target().map(|o| o.into()).unwrap_or(Value::Null));
     }
 
@@ -76,10 +75,10 @@ pub fn get_target<'gc>(
 /// Implements `currentTarget` property's getter
 pub fn get_current_target<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         return Ok(evt
             .current_target()
             .map(|o| o.into())
@@ -92,10 +91,10 @@ pub fn get_current_target<'gc>(
 /// Implements `eventPhase` property's getter
 pub fn get_event_phase<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         let event_phase = evt.phase() as u32;
         return Ok(event_phase.into());
     }
@@ -106,10 +105,10 @@ pub fn get_event_phase<'gc>(
 /// Implements `isDefaultPrevented`
 pub fn is_default_prevented<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(evt) = this.unwrap().as_event() {
+    if let Some(evt) = this.as_event() {
         return Ok(evt.is_cancelled().into());
     }
 
@@ -119,10 +118,10 @@ pub fn is_default_prevented<'gc>(
 /// Implements `preventDefault`
 pub fn prevent_default<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut evt) = this.unwrap().as_event_mut(activation.context.gc_context) {
+    if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
         evt.cancel();
     }
 
@@ -132,10 +131,10 @@ pub fn prevent_default<'gc>(
 /// Implements `stopPropagation`
 pub fn stop_propagation<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut evt) = this.unwrap().as_event_mut(activation.context.gc_context) {
+    if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
         evt.stop_propagation();
     }
 
@@ -145,10 +144,10 @@ pub fn stop_propagation<'gc>(
 /// Implements `stopImmediatePropagation`
 pub fn stop_immediate_propagation<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut evt) = this.unwrap().as_event_mut(activation.context.gc_context) {
+    if let Some(mut evt) = this.as_event_mut(activation.context.gc_context) {
         evt.stop_immediate_propagation();
     }
 

--- a/core/src/avm2/globals/flash/events/gesture_event.rs
+++ b/core/src/avm2/globals/flash/events/gesture_event.rs
@@ -7,7 +7,7 @@ use crate::avm2::Error;
 // Borrow mouse_event's `stageX` getter
 pub fn get_stage_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     mouse_event::get_stage_x(activation, this, args)
@@ -16,7 +16,7 @@ pub fn get_stage_x<'gc>(
 // Borrow mouse_event's `stageY` getter
 pub fn get_stage_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     mouse_event::get_stage_y(activation, this, args)

--- a/core/src/avm2/globals/flash/events/keyboard_event.rs
+++ b/core/src/avm2/globals/flash/events/keyboard_event.rs
@@ -2,7 +2,7 @@ use crate::avm2::{Activation, Error, Object, Value};
 
 pub fn update_after_event<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     *activation.context.needs_render = true;

--- a/core/src/avm2/globals/flash/events/mouse_event.rs
+++ b/core/src/avm2/globals/flash/events/mouse_event.rs
@@ -8,29 +8,27 @@ use swf::Point;
 /// Implements `stageX`'s getter.
 pub fn get_stage_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(evt) = this.as_event() {
-            let local_x = this
-                .get_public_property("localX", activation)?
-                .coerce_to_number(activation)?;
-            let local_y = this
-                .get_public_property("localY", activation)?
-                .coerce_to_number(activation)?;
+    if let Some(evt) = this.as_event() {
+        let local_x = this
+            .get_public_property("localX", activation)?
+            .coerce_to_number(activation)?;
+        let local_y = this
+            .get_public_property("localY", activation)?
+            .coerce_to_number(activation)?;
 
-            if local_x.is_nan() || local_y.is_nan() {
-                return Ok(Value::Number(local_x));
-            } else if let Some(target) = evt.target().and_then(|t| t.as_display_object()) {
-                let local = Point::from_pixels(local_x, local_y);
-                // `local_to_global` does a matrix multiplication, which in general
-                // depends on both the x and y coordinates.
-                let global = target.local_to_global(local);
-                return Ok(Value::Number(global.x.to_pixels()));
-            } else {
-                return Ok(Value::Number(local_x * 0.0));
-            }
+        if local_x.is_nan() || local_y.is_nan() {
+            return Ok(Value::Number(local_x));
+        } else if let Some(target) = evt.target().and_then(|t| t.as_display_object()) {
+            let local = Point::from_pixels(local_x, local_y);
+            // `local_to_global` does a matrix multiplication, which in general
+            // depends on both the x and y coordinates.
+            let global = target.local_to_global(local);
+            return Ok(Value::Number(global.x.to_pixels()));
+        } else {
+            return Ok(Value::Number(local_x * 0.0));
         }
     }
 
@@ -40,29 +38,27 @@ pub fn get_stage_x<'gc>(
 /// Implements `stageY`'s getter.
 pub fn get_stage_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(evt) = this.as_event() {
-            let local_x = this
-                .get_public_property("localX", activation)?
-                .coerce_to_number(activation)?;
-            let local_y = this
-                .get_public_property("localY", activation)?
-                .coerce_to_number(activation)?;
+    if let Some(evt) = this.as_event() {
+        let local_x = this
+            .get_public_property("localX", activation)?
+            .coerce_to_number(activation)?;
+        let local_y = this
+            .get_public_property("localY", activation)?
+            .coerce_to_number(activation)?;
 
-            if local_x.is_nan() || local_y.is_nan() {
-                return Ok(Value::Number(local_y));
-            } else if let Some(target) = evt.target().and_then(|t| t.as_display_object()) {
-                let local = Point::from_pixels(local_x, local_y);
-                // `local_to_global` does a matrix multiplication, which in general
-                // depends on both the x and y coordinates.
-                let global = target.local_to_global(local);
-                return Ok(Value::Number(global.y.to_pixels()));
-            } else {
-                return Ok(Value::Number(local_y * 0.0));
-            }
+        if local_x.is_nan() || local_y.is_nan() {
+            return Ok(Value::Number(local_y));
+        } else if let Some(target) = evt.target().and_then(|t| t.as_display_object()) {
+            let local = Point::from_pixels(local_x, local_y);
+            // `local_to_global` does a matrix multiplication, which in general
+            // depends on both the x and y coordinates.
+            let global = target.local_to_global(local);
+            return Ok(Value::Number(global.y.to_pixels()));
+        } else {
+            return Ok(Value::Number(local_y * 0.0));
         }
     }
 
@@ -71,7 +67,7 @@ pub fn get_stage_y<'gc>(
 
 pub fn update_after_event<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     *activation.context.needs_render = true;

--- a/core/src/avm2/globals/flash/events/timer_event.rs
+++ b/core/src/avm2/globals/flash/events/timer_event.rs
@@ -5,7 +5,7 @@ use crate::avm2::Error;
 
 pub fn update_after_event<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     *activation.context.needs_render = true;

--- a/core/src/avm2/globals/flash/events/touch_event.rs
+++ b/core/src/avm2/globals/flash/events/touch_event.rs
@@ -5,7 +5,7 @@ use crate::avm2::Error;
 
 pub fn update_after_event<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     *activation.context.needs_render = true;

--- a/core/src/avm2/globals/flash/external/external_interface.rs
+++ b/core/src/avm2/globals/flash/external/external_interface.rs
@@ -5,7 +5,7 @@ use crate::external::{Callback, Value as ExternalValue};
 
 pub fn call<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let name = args.get_string(activation, 0)?;
@@ -41,7 +41,7 @@ fn check_available<'gc>(activation: &mut Activation<'_, 'gc>) -> Result<(), Erro
 
 pub fn get_available<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(activation.context.external_interface.available().into())
@@ -49,7 +49,7 @@ pub fn get_available<'gc>(
 
 pub fn add_callback<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let name = args.get_string(activation, 0)?;

--- a/core/src/avm2/globals/flash/geom/transform.rs
+++ b/core/src/avm2/globals/flash/geom/transform.rs
@@ -24,10 +24,10 @@ fn get_display_object<'gc>(
 
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    this.unwrap().set_property(
+    this.set_property(
         &Multiname::new(activation.avm2().flash_geom_internal, "_displayObject"),
         args.get_value(0),
         activation,
@@ -37,10 +37,9 @@ pub fn init<'gc>(
 
 pub fn get_color_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let display_object = get_display_object(this, activation)?;
     let display_object = display_object.base();
     color_transform_to_object(display_object.color_transform(), activation)
@@ -48,10 +47,9 @@ pub fn get_color_transform<'gc>(
 
 pub fn set_color_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let ct = object_to_color_transform(args.get_object(activation, 0, "value")?, activation)?;
     let dobj = get_display_object(this, activation)?;
     dobj.set_color_transform(activation.context.gc_context, ct);
@@ -63,20 +61,18 @@ pub fn set_color_transform<'gc>(
 
 pub fn get_matrix<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let matrix = *get_display_object(this, activation)?.base().matrix();
     matrix_to_object(matrix, activation)
 }
 
 pub fn set_matrix<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let matrix = object_to_matrix(args.get_object(activation, 0, "value")?, activation)?;
     let dobj = get_display_object(this, activation)?;
     dobj.set_matrix(activation.context.gc_context, matrix);
@@ -90,11 +86,9 @@ pub fn set_matrix<'gc>(
 
 pub fn get_concatenated_matrix<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
-
     let dobj = get_display_object(this, activation)?;
     let mut node = Some(dobj);
     while let Some(obj) = node {
@@ -131,7 +125,7 @@ pub fn get_concatenated_matrix<'gc>(
 
 pub fn get_concatenated_color_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(
@@ -255,10 +249,9 @@ pub fn object_to_matrix<'gc>(
 
 pub fn get_pixel_bounds<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let display_object = get_display_object(this, activation)?;
     rectangle_to_object(display_object.world_bounds(), activation)
 }

--- a/core/src/avm2/globals/flash/media/sound_channel.rs
+++ b/core/src/avm2/globals/flash/media/sound_channel.rs
@@ -11,11 +11,11 @@ pub use crate::avm2::object::sound_channel_allocator;
 /// Implements `SoundChannel.leftPeak`
 pub fn get_left_peak<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(instance) = this
-        .and_then(|this| this.as_sound_channel())
+        .as_sound_channel()
         .and_then(|channel| channel.instance())
     {
         if let Some(peak) = activation.context.audio.get_sound_peak(instance) {
@@ -29,11 +29,11 @@ pub fn get_left_peak<'gc>(
 /// Implements `SoundChannel.rightPeak`
 pub fn get_right_peak<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(instance) = this
-        .and_then(|this| this.as_sound_channel())
+        .as_sound_channel()
         .and_then(|channel| channel.instance())
     {
         if let Some(peak) = activation.context.audio.get_sound_peak(instance) {
@@ -47,10 +47,10 @@ pub fn get_right_peak<'gc>(
 /// Impl `SoundChannel.position`
 pub fn get_position<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(instance) = this.and_then(|this| this.as_sound_channel()) {
+    if let Some(instance) = this.as_sound_channel() {
         return Ok(instance.position(&mut activation.context).into());
     }
     Ok(Value::Undefined)
@@ -59,10 +59,10 @@ pub fn get_position<'gc>(
 /// Implements `soundTransform`'s getter
 pub fn get_sound_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(channel) = this.and_then(|this| this.as_sound_channel()) {
+    if let Some(channel) = this.as_sound_channel() {
         let dobj_st = channel.sound_transform(activation).unwrap_or_default();
 
         return Ok(dobj_st.into_avm2_object(activation)?.into());
@@ -74,10 +74,10 @@ pub fn get_sound_transform<'gc>(
 /// Implements `soundTransform`'s setter
 pub fn set_sound_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(sound_channel) = this.and_then(|this| this.as_sound_channel()) {
+    if let Some(sound_channel) = this.as_sound_channel() {
         let as3_st = args
             .get(0)
             .cloned()
@@ -94,10 +94,10 @@ pub fn set_sound_transform<'gc>(
 /// Impl `SoundChannel.stop`
 pub fn stop<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(sound_channel) = this.and_then(|this| this.as_sound_channel()) {
+    if let Some(sound_channel) = this.as_sound_channel() {
         sound_channel.stop(activation);
     }
 

--- a/core/src/avm2/globals/flash/media/sound_mixer.rs
+++ b/core/src/avm2/globals/flash/media/sound_mixer.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, OnceLock};
 /// Flash Player behavior.
 pub fn get_sound_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let dobj_st = activation.context.global_sound_transform().clone();
@@ -29,7 +29,7 @@ pub fn get_sound_transform<'gc>(
 /// Flash Player behavior.
 pub fn set_sound_transform<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let as3_st = args
@@ -47,7 +47,7 @@ pub fn set_sound_transform<'gc>(
 /// Implements `SoundMixer.stopAll`
 pub fn stop_all<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     activation.context.stop_all_sounds();
@@ -58,7 +58,7 @@ pub fn stop_all<'gc>(
 /// Implements `bufferTime`'s getter
 pub fn get_buffer_time<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(activation.context.audio_manager.stream_buffer_time().into())
@@ -67,7 +67,7 @@ pub fn get_buffer_time<'gc>(
 /// Implements `bufferTime`'s setter
 pub fn set_buffer_time<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let buffer_time = args
@@ -87,7 +87,7 @@ pub fn set_buffer_time<'gc>(
 /// `SoundMixer.areSoundsInaccessible`
 pub fn are_sounds_inaccessible<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(
@@ -101,7 +101,7 @@ pub fn are_sounds_inaccessible<'gc>(
 /// Implements `SoundMixer.computeSpectrum`
 pub fn compute_spectrum<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let arg0 = args[0].as_object().unwrap();

--- a/core/src/avm2/globals/flash/media/sound_transform.rs
+++ b/core/src/avm2/globals/flash/media/sound_transform.rs
@@ -9,44 +9,38 @@ use crate::avm2::Error;
 /// Implements `SoundTransform.pan`'s getter.
 pub fn get_pan<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let left_to_right = this
-            .get_public_property("leftToRight", activation)?
-            .coerce_to_number(activation)?;
-        let right_to_left = this
-            .get_public_property("rightToLeft", activation)?
-            .coerce_to_number(activation)?;
+    let left_to_right = this
+        .get_public_property("leftToRight", activation)?
+        .coerce_to_number(activation)?;
+    let right_to_left = this
+        .get_public_property("rightToLeft", activation)?
+        .coerce_to_number(activation)?;
 
-        if left_to_right != 0.0 || right_to_left != 0.0 {
-            return Ok(0.0.into());
-        }
-
-        let left_to_left = this
-            .get_public_property("leftToLeft", activation)?
-            .coerce_to_number(activation)?;
-
-        return Ok((1.0 - left_to_left.powf(2.0)).into());
+    if left_to_right != 0.0 || right_to_left != 0.0 {
+        return Ok(0.0.into());
     }
 
-    Ok(Value::Undefined)
+    let left_to_left = this
+        .get_public_property("leftToLeft", activation)?
+        .coerce_to_number(activation)?;
+
+    Ok((1.0 - left_to_left.powf(2.0)).into())
 }
 
 /// Implements `SoundTransform.pan`'s setter.
 pub fn set_pan<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut this) = this {
-        let pan = args.get_f64(activation, 0)?;
-        this.set_public_property("leftToLeft", (1.0 - pan).sqrt().into(), activation)?;
-        this.set_public_property("rightToRight", (1.0 + pan).sqrt().into(), activation)?;
-        this.set_public_property("leftToRight", (0.0).into(), activation)?;
-        this.set_public_property("rightToLeft", (0.0).into(), activation)?;
-    }
+    let pan = args.get_f64(activation, 0)?;
+    this.set_public_property("leftToLeft", (1.0 - pan).sqrt().into(), activation)?;
+    this.set_public_property("rightToRight", (1.0 + pan).sqrt().into(), activation)?;
+    this.set_public_property("leftToRight", (0.0).into(), activation)?;
+    this.set_public_property("rightToLeft", (0.0).into(), activation)?;
 
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -41,16 +41,14 @@ pub fn video_allocator<'gc>(
 /// Implements `flash.media.Video`'s `init` method, which is called from the constructor
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(video) = this.as_display_object().and_then(|dobj| dobj.as_video()) {
-            let width = args.get_i32(activation, 0)?;
-            let height = args.get_i32(activation, 1)?;
+    if let Some(video) = this.as_display_object().and_then(|dobj| dobj.as_video()) {
+        let width = args.get_i32(activation, 0)?;
+        let height = args.get_i32(activation, 1)?;
 
-            video.set_size(activation.context.gc_context, width, height);
-        }
+        video.set_size(activation.context.gc_context, width, height);
     }
 
     Ok(Value::Undefined)
@@ -58,13 +56,10 @@ pub fn init<'gc>(
 
 pub fn attach_net_stream<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(video) = this
-        .and_then(|o| o.as_display_object())
-        .and_then(|dobj| dobj.as_video())
-    {
+    if let Some(video) = this.as_display_object().and_then(|dobj| dobj.as_video()) {
         let source = args.get(0).cloned().and_then(|v| v.as_object());
 
         if let Some(stream) = source.and_then(|o| o.as_netstream()) {

--- a/core/src/avm2/globals/flash/net.rs
+++ b/core/src/avm2/globals/flash/net.rs
@@ -13,7 +13,7 @@ pub mod url_loader;
 /// Implements `flash.net.navigateToURL`
 pub fn navigate_to_url<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let request = args

--- a/core/src/avm2/globals/flash/net/local_connection.rs
+++ b/core/src/avm2/globals/flash/net/local_connection.rs
@@ -4,7 +4,7 @@ use crate::string::AvmString;
 /// Implements `domain` getter
 pub fn get_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let movie = activation.context.swf;

--- a/core/src/avm2/globals/flash/net/net_connection.rs
+++ b/core/src/avm2/globals/flash/net/net_connection.rs
@@ -5,10 +5,9 @@ use crate::{
 
 pub fn connect<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     if let Value::Null = args[0] {
         let event = EventObject::net_status_event(
             activation,

--- a/core/src/avm2/globals/flash/net/net_stream.rs
+++ b/core/src/avm2/globals/flash/net/net_stream.rs
@@ -4,10 +4,10 @@ pub use crate::avm2::object::netstream_allocator as net_stream_allocator;
 
 pub fn get_bytes_loaded<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(ns) = this.and_then(|o| o.as_netstream()) {
+    if let Some(ns) = this.as_netstream() {
         return Ok(ns.bytes_loaded().into());
     }
 
@@ -16,10 +16,10 @@ pub fn get_bytes_loaded<'gc>(
 
 pub fn get_bytes_total<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(ns) = this.and_then(|o| o.as_netstream()) {
+    if let Some(ns) = this.as_netstream() {
         return Ok(ns.bytes_total().into());
     }
 
@@ -28,10 +28,10 @@ pub fn get_bytes_total<'gc>(
 
 pub fn play<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(ns) = this.and_then(|o| o.as_netstream()) {
+    if let Some(ns) = this.as_netstream() {
         let name = args
             .get(0)
             .cloned()
@@ -47,10 +47,10 @@ pub fn play<'gc>(
 
 pub fn pause<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(ns) = this.and_then(|o| o.as_netstream()) {
+    if let Some(ns) = this.as_netstream() {
         ns.pause(&mut activation.context);
     }
 
@@ -59,10 +59,10 @@ pub fn pause<'gc>(
 
 pub fn resume<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(ns) = this.and_then(|o| o.as_netstream()) {
+    if let Some(ns) = this.as_netstream() {
         ns.resume(&mut activation.context);
     }
 
@@ -71,10 +71,10 @@ pub fn resume<'gc>(
 
 pub fn toggle_pause<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(ns) = this.and_then(|o| o.as_netstream()) {
+    if let Some(ns) = this.as_netstream() {
         ns.toggle_paused(&mut activation.context);
     }
 

--- a/core/src/avm2/globals/flash/net/object_encoding.rs
+++ b/core/src/avm2/globals/flash/net/object_encoding.rs
@@ -6,7 +6,7 @@ use crate::{avm2_stub_getter, avm2_stub_setter};
 
 pub fn get_dynamic_property_writer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(
@@ -19,7 +19,7 @@ pub fn get_dynamic_property_writer<'gc>(
 
 pub fn set_dynamic_property_writer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 
 pub fn get_local<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: It appears that Flash does some kind of escaping here:
@@ -133,7 +133,7 @@ pub fn get_local<'gc>(
     }
 
     // Data property only should exist when created with getLocal/Remote
-    let sharedobject_cls = this.unwrap(); // `this` of a static method is the class
+    let sharedobject_cls = this; // `this` of a static method is the class
     let mut this = sharedobject_cls.construct(activation, &[])?;
 
     // Set the internal name
@@ -177,44 +177,41 @@ pub fn get_local<'gc>(
 
 pub fn flush<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let data = this
-            .get_public_property("data", activation)?
-            .coerce_to_object(activation)?;
+    let data = this
+        .get_public_property("data", activation)?
+        .coerce_to_object(activation)?;
 
-        let ruffle_name = Multiname::new(
-            Namespace::package("__ruffle__", &mut activation.borrow_gc()),
-            "_ruffleName",
-        );
-        let name = this
-            .get_property(&ruffle_name, activation)?
-            .coerce_to_string(activation)?;
-        let name = name.to_utf8_lossy();
+    let ruffle_name = Multiname::new(
+        Namespace::package("__ruffle__", &mut activation.borrow_gc()),
+        "_ruffleName",
+    );
+    let name = this
+        .get_property(&ruffle_name, activation)?
+        .coerce_to_string(activation)?;
+    let name = name.to_utf8_lossy();
 
-        let mut elements = Vec::new();
-        crate::avm2::amf::recursive_serialize(activation, data, &mut elements, AMFVersion::AMF3)?;
-        let mut lso = Lso::new(
-            elements,
-            name.split('/')
-                .last()
-                .map(|e| e.to_string())
-                .unwrap_or_else(|| "<unknown>".to_string()),
-            AMFVersion::AMF3,
-        );
+    let mut elements = Vec::new();
+    crate::avm2::amf::recursive_serialize(activation, data, &mut elements, AMFVersion::AMF3)?;
+    let mut lso = Lso::new(
+        elements,
+        name.split('/')
+            .last()
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string()),
+        AMFVersion::AMF3,
+    );
 
-        let bytes = flash_lso::write::write_to_bytes(&mut lso).unwrap_or_default();
+    let bytes = flash_lso::write::write_to_bytes(&mut lso).unwrap_or_default();
 
-        return Ok(activation.context.storage.put(&name, &bytes).into());
-    }
-    Ok(Value::Undefined)
+    Ok(activation.context.storage.put(&name, &bytes).into())
 }
 
 pub fn close<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.net.SharedObject", "close");
@@ -223,29 +220,28 @@ pub fn close<'gc>(
 
 pub fn clear<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut this) = this {
-        // Create a fresh data object.
-        let data = activation
-            .avm2()
-            .classes()
-            .object
-            .construct(activation, &[])?
-            .into();
-        this.set_public_property("data", data, activation)?;
+    // Create a fresh data object.
+    let data = activation
+        .avm2()
+        .classes()
+        .object
+        .construct(activation, &[])?
+        .into();
+    this.set_public_property("data", data, activation)?;
 
-        // Delete data from storage backend.
-        let ruffle_name = Multiname::new(
-            Namespace::package("__ruffle__", &mut activation.borrow_gc()),
-            "_ruffleName",
-        );
-        let name = this
-            .get_property(&ruffle_name, activation)?
-            .coerce_to_string(activation)?;
-        let name = name.to_utf8_lossy();
-        activation.context.storage.remove_key(&name);
-    }
+    // Delete data from storage backend.
+    let ruffle_name = Multiname::new(
+        Namespace::package("__ruffle__", &mut activation.borrow_gc()),
+        "_ruffleName",
+    );
+    let name = this
+        .get_property(&ruffle_name, activation)?
+        .coerce_to_string(activation)?;
+    let name = name.to_utf8_lossy();
+    activation.context.storage.remove_key(&name);
+
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/net/url_loader.rs
+++ b/core/src/avm2/globals/flash/net/url_loader.rs
@@ -10,33 +10,30 @@ use crate::loader::DataFormat;
 /// Native function definition for `URLLoader.load`
 pub fn load<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let request = match args.get(0) {
-            Some(Value::Object(request)) => request,
-            // This should never actually happen
-            _ => return Ok(Value::Undefined),
-        };
+    let request = match args.get(0) {
+        Some(Value::Object(request)) => request,
+        // This should never actually happen
+        _ => return Ok(Value::Undefined),
+    };
 
-        let data_format = this
-            .get_public_property("dataFormat", activation)?
-            .coerce_to_string(activation)?;
+    let data_format = this
+        .get_public_property("dataFormat", activation)?
+        .coerce_to_string(activation)?;
 
-        let data_format = if &data_format == b"binary" {
-            DataFormat::Binary
-        } else if &data_format == b"text" {
-            DataFormat::Text
-        } else if &data_format == b"variables" {
-            DataFormat::Variables
-        } else {
-            return Err(format!("Unknown data format: {data_format}").into());
-        };
+    let data_format = if &data_format == b"binary" {
+        DataFormat::Binary
+    } else if &data_format == b"text" {
+        DataFormat::Text
+    } else if &data_format == b"variables" {
+        DataFormat::Variables
+    } else {
+        return Err(format!("Unknown data format: {data_format}").into());
+    };
 
-        return spawn_fetch(activation, this, *request, data_format);
-    }
-    Ok(Value::Undefined)
+    spawn_fetch(activation, this, *request, data_format)
 }
 
 fn spawn_fetch<'gc>(

--- a/core/src/avm2/globals/flash/system/application_domain.rs
+++ b/core/src/avm2/globals/flash/system/application_domain.rs
@@ -13,20 +13,18 @@ pub use crate::avm2::object::application_domain_allocator;
 /// is called from the constructor
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let parent_domain = if matches!(args[0], Value::Null) {
-            activation.avm2().stage_domain()
-        } else {
-            args.get_object(activation, 0, "parentDomain")?
-                .as_application_domain()
-                .expect("Invalid parent domain")
-        };
-        let fresh_domain = Domain::movie_domain(activation, parent_domain);
-        this.init_application_domain(activation.context.gc_context, fresh_domain);
-    }
+    let parent_domain = if matches!(args[0], Value::Null) {
+        activation.avm2().stage_domain()
+    } else {
+        args.get_object(activation, 0, "parentDomain")?
+            .as_application_domain()
+            .expect("Invalid parent domain")
+    };
+    let fresh_domain = Domain::movie_domain(activation, parent_domain);
+    this.init_application_domain(activation.context.gc_context, fresh_domain);
 
     Ok(Value::Undefined)
 }
@@ -34,7 +32,7 @@ pub fn init<'gc>(
 /// `currentDomain` static property.
 pub fn get_current_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let appdomain = activation
@@ -47,10 +45,10 @@ pub fn get_current_domain<'gc>(
 /// `parentDomain` property
 pub fn get_parent_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(appdomain) = this.and_then(|this| this.as_application_domain()) {
+    if let Some(appdomain) = this.as_application_domain() {
         if let Some(parent_domain) = appdomain.parent_domain() {
             if parent_domain.is_playerglobals_domain(activation) {
                 return Ok(Value::Null);
@@ -65,10 +63,10 @@ pub fn get_parent_domain<'gc>(
 /// `getDefinition` method
 pub fn get_definition<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(appdomain) = this.and_then(|this| this.as_application_domain()) {
+    if let Some(appdomain) = this.as_application_domain() {
         let name = args
             .get(0)
             .cloned()
@@ -83,10 +81,10 @@ pub fn get_definition<'gc>(
 /// `hasDefinition` method
 pub fn has_definition<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(appdomain) = this.and_then(|this| this.as_application_domain()) {
+    if let Some(appdomain) = this.as_application_domain() {
         let name = args
             .get(0)
             .cloned()
@@ -107,10 +105,10 @@ pub fn has_definition<'gc>(
 /// NOTE: Normally only available in Flash Player 11.3+.
 pub fn get_qualified_definition_names<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(appdomain) = this.and_then(|this| this.as_application_domain()) {
+    if let Some(appdomain) = this.as_application_domain() {
         // NOTE: According to the docs of 'getQualifiedDeinitionNames',
         // it is able to throw a 'SecurityError' if "The definition belongs
         // to a domain to which the calling code does not have access."
@@ -139,12 +137,12 @@ pub fn get_qualified_definition_names<'gc>(
 /// `domainMemory` property setter
 pub fn set_domain_memory<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(Value::Object(arg)) = args.get(0) {
         if let Some(bytearray_obj) = arg.as_bytearray_object() {
-            if let Some(appdomain) = this.and_then(|this| this.as_application_domain()) {
+            if let Some(appdomain) = this.as_application_domain() {
                 appdomain.set_domain_memory(activation.context.gc_context, bytearray_obj);
             }
         }
@@ -156,10 +154,10 @@ pub fn set_domain_memory<'gc>(
 /// `domainMemory` property getter
 pub fn get_domain_memory<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(appdomain) = this.and_then(|this| this.as_application_domain()) {
+    if let Some(appdomain) = this.as_application_domain() {
         let bytearray_object: Object<'gc> = appdomain.domain_memory().into();
         return Ok(bytearray_object.into());
     }

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -5,7 +5,7 @@ use crate::avm2::{Activation, AvmString, Error, Object, Value};
 /// Implements `flash.system.Capabilities.version`
 pub fn get_version<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: Report the correct OS instead of always reporting Linux
@@ -19,7 +19,7 @@ pub fn get_version<'gc>(
 /// Implements `flash.system.Capabilities.playerType`
 pub fn get_player_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // TODO: When should "External" be returned?
@@ -35,7 +35,7 @@ pub fn get_player_type<'gc>(
 /// Implements `flash.system.Capabilities.screenResolutionX`
 pub fn get_screen_resolution_x<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let viewport_dimensions = activation.context.renderer.viewport_dimensions();
@@ -47,7 +47,7 @@ pub fn get_screen_resolution_x<'gc>(
 /// Implements `flash.system.Capabilities.screenResolutionY`
 pub fn get_screen_resolution_y<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let viewport_dimensions = activation.context.renderer.viewport_dimensions();
@@ -59,7 +59,7 @@ pub fn get_screen_resolution_y<'gc>(
 /// Implements `flash.system.Capabilities.pixelAspectRatio`
 pub fn get_pixel_aspect_ratio<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // source: https://web.archive.org/web/20230611050355/https://flylib.com/books/en/4.13.1.272/1/
@@ -69,7 +69,7 @@ pub fn get_pixel_aspect_ratio<'gc>(
 /// Implements `flash.system.Capabilities.screenDPI`
 pub fn get_screen_dpi<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // source: https://tracker.adobe.com/#/view/FP-3949775

--- a/core/src/avm2/globals/flash/system/security.rs
+++ b/core/src/avm2/globals/flash/system/security.rs
@@ -9,7 +9,7 @@ use crate::string::AvmString;
 
 pub fn get_sandbox_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let sandbox_type = activation.context.system.sandbox_type.to_string();
@@ -18,7 +18,7 @@ pub fn get_sandbox_type<'gc>(
 
 pub fn allow_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.system.Security", "allowDomain");
@@ -27,7 +27,7 @@ pub fn allow_domain<'gc>(
 
 pub fn allow_insecure_domain<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.system.Security", "allowInsecureDomain");
@@ -36,7 +36,7 @@ pub fn allow_insecure_domain<'gc>(
 
 pub fn load_policy_file<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.system.Security", "loadPolicyFile");
@@ -45,7 +45,7 @@ pub fn load_policy_file<'gc>(
 
 pub fn show_settings<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.system.Security", "showSettings");

--- a/core/src/avm2/globals/flash/system/system.rs
+++ b/core/src/avm2/globals/flash/system/system.rs
@@ -8,7 +8,7 @@ use crate::avm2::Error;
 /// Implements `flash.system.System.setClipboard` method
 pub fn set_clipboard<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // The following restrictions only apply to the plugin.

--- a/core/src/avm2/globals/flash/text/font.rs
+++ b/core/src/avm2/globals/flash/text/font.rs
@@ -12,10 +12,10 @@ use crate::string::AvmString;
 /// Implements `Font.fontName`
 pub fn get_font_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some((movie, character_id)) = this.and_then(|this| this.instance_of()).and_then(|this| {
+    if let Some((movie, character_id)) = this.instance_of().and_then(|this| {
         activation
             .context
             .library
@@ -42,10 +42,10 @@ pub fn get_font_name<'gc>(
 /// Implements `Font.fontStyle`
 pub fn get_font_style<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some((movie, character_id)) = this.and_then(|this| this.instance_of()).and_then(|this| {
+    if let Some((movie, character_id)) = this.instance_of().and_then(|this| {
         activation
             .context
             .library
@@ -73,10 +73,10 @@ pub fn get_font_style<'gc>(
 /// Implements `Font.fontType`
 pub fn get_font_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some((movie, character_id)) = this.and_then(|this| this.instance_of()).and_then(|this| {
+    if let Some((movie, character_id)) = this.instance_of().and_then(|this| {
         activation
             .context
             .library
@@ -100,10 +100,10 @@ pub fn get_font_type<'gc>(
 /// Implements `Font.hasGlyphs`
 pub fn has_glyphs<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some((movie, character_id)) = this.and_then(|this| this.instance_of()).and_then(|this| {
+    if let Some((movie, character_id)) = this.instance_of().and_then(|this| {
         activation
             .context
             .library
@@ -128,7 +128,7 @@ pub fn has_glyphs<'gc>(
 /// `Font.enumerateFonts`
 pub fn enumerate_fonts<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.text.Font", "enumerateFonts");
@@ -138,7 +138,7 @@ pub fn enumerate_fonts<'gc>(
 /// `Font.registerFont`
 pub fn register_font<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "flash.text.Font", "registerFont");

--- a/core/src/avm2/globals/flash/text/static_text.rs
+++ b/core/src/avm2/globals/flash/text/static_text.rs
@@ -16,7 +16,7 @@ pub fn static_text_allocator<'gc>(
 /// Implements `StaticText.text`
 pub fn get_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.StaticText", "text");

--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -49,7 +49,7 @@ pub fn text_field_allocator<'gc>(
 
 pub fn get_always_show_selection<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.TextField", "alwaysShowSelection");
@@ -58,7 +58,7 @@ pub fn get_always_show_selection<'gc>(
 
 pub fn set_always_show_selection<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.text.TextField", "alwaysShowSelection");
@@ -67,11 +67,11 @@ pub fn set_always_show_selection<'gc>(
 
 pub fn get_auto_size<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(match this.autosize() {
@@ -87,11 +87,11 @@ pub fn get_auto_size<'gc>(
 
 pub fn set_auto_size<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let value = args.get_string(activation, 0)?;
@@ -114,11 +114,11 @@ pub fn set_auto_size<'gc>(
 
 pub fn get_background<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok((this.has_background()).into());
@@ -129,11 +129,11 @@ pub fn get_background<'gc>(
 
 pub fn set_background<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let has_background = args.get_bool(0);
@@ -145,11 +145,11 @@ pub fn set_background<'gc>(
 
 pub fn get_background_color<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.background_color().to_rgb().into());
@@ -160,11 +160,11 @@ pub fn get_background_color<'gc>(
 
 pub fn set_background_color<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let rgb = args.get_u32(activation, 0)?;
@@ -177,11 +177,11 @@ pub fn set_background_color<'gc>(
 
 pub fn get_border<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.has_border().into());
@@ -192,11 +192,11 @@ pub fn get_border<'gc>(
 
 pub fn set_border<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let border = args.get_bool(0);
@@ -208,11 +208,11 @@ pub fn set_border<'gc>(
 
 pub fn get_border_color<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.border_color().to_rgb().into());
@@ -223,11 +223,11 @@ pub fn get_border_color<'gc>(
 
 pub fn set_border_color<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let rgb = args.get_u32(activation, 0)?;
@@ -240,7 +240,7 @@ pub fn set_border_color<'gc>(
 
 pub fn get_condense_white<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.TextField", "condenseWhite");
@@ -249,7 +249,7 @@ pub fn get_condense_white<'gc>(
 
 pub fn set_condense_white<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.text.TextField", "condenseWhite");
@@ -258,11 +258,11 @@ pub fn set_condense_white<'gc>(
 
 pub fn get_default_text_format<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(TextFormatObject::from_text_format(activation, this.new_text_format())?.into());
@@ -273,11 +273,11 @@ pub fn get_default_text_format<'gc>(
 
 pub fn set_default_text_format<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let new_text_format = args.get(0).unwrap_or(&Value::Undefined).as_object();
@@ -294,11 +294,11 @@ pub fn set_default_text_format<'gc>(
 
 pub fn get_display_as_password<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.is_password().into());
@@ -309,11 +309,11 @@ pub fn get_display_as_password<'gc>(
 
 pub fn set_display_as_password<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let is_password = args.get_bool(0);
@@ -326,11 +326,11 @@ pub fn set_display_as_password<'gc>(
 
 pub fn get_embed_fonts<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok((!this.is_device_font()).into());
@@ -341,11 +341,11 @@ pub fn get_embed_fonts<'gc>(
 
 pub fn set_embed_fonts<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let is_embed_fonts = args.get_bool(0);
@@ -358,11 +358,11 @@ pub fn set_embed_fonts<'gc>(
 
 pub fn get_html_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(AvmString::new(activation.context.gc_context, this.html_text()).into());
@@ -373,11 +373,11 @@ pub fn get_html_text<'gc>(
 
 pub fn set_html_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let html_text = args.get_string(activation, 0)?;
@@ -391,11 +391,11 @@ pub fn set_html_text<'gc>(
 
 pub fn get_length<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.text_length().into());
@@ -406,11 +406,11 @@ pub fn get_length<'gc>(
 
 pub fn get_multiline<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.is_multiline().into());
@@ -421,11 +421,11 @@ pub fn get_multiline<'gc>(
 
 pub fn set_multiline<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let is_multiline = args.get_bool(0);
@@ -438,11 +438,11 @@ pub fn set_multiline<'gc>(
 
 pub fn get_selectable<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.is_selectable().into());
@@ -453,11 +453,11 @@ pub fn get_selectable<'gc>(
 
 pub fn set_selectable<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let is_selectable = args.get_bool(0);
@@ -470,11 +470,11 @@ pub fn set_selectable<'gc>(
 
 pub fn get_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(AvmString::new(activation.context.gc_context, this.text()).into());
@@ -485,11 +485,11 @@ pub fn get_text<'gc>(
 
 pub fn set_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let text = args.get_string(activation, 0)?;
@@ -503,11 +503,11 @@ pub fn set_text<'gc>(
 
 pub fn get_text_color<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         if let Some(color) = this.new_text_format().color {
@@ -522,11 +522,11 @@ pub fn get_text_color<'gc>(
 
 pub fn set_text_color<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let text_color = args
@@ -553,11 +553,11 @@ pub fn set_text_color<'gc>(
 
 pub fn get_text_height<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let metrics = this.measure_text(&mut activation.context);
@@ -569,11 +569,11 @@ pub fn get_text_height<'gc>(
 
 pub fn get_text_width<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let metrics = this.measure_text(&mut activation.context);
@@ -585,11 +585,11 @@ pub fn get_text_width<'gc>(
 
 pub fn get_type<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         match this.is_editable() {
@@ -603,11 +603,11 @@ pub fn get_type<'gc>(
 
 pub fn set_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let is_editable = args.get_string(activation, 0)?;
@@ -626,11 +626,11 @@ pub fn set_type<'gc>(
 
 pub fn get_word_wrap<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.is_word_wrap().into());
@@ -641,11 +641,11 @@ pub fn get_word_wrap<'gc>(
 
 pub fn set_word_wrap<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let is_word_wrap = args.get_bool(0);
@@ -658,11 +658,11 @@ pub fn set_word_wrap<'gc>(
 
 pub fn append_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let new_text = args.get_string(activation, 0)?;
@@ -681,11 +681,11 @@ pub fn append_text<'gc>(
 
 pub fn get_text_format<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let mut begin_index = args
@@ -716,11 +716,11 @@ pub fn get_text_format<'gc>(
 
 pub fn replace_selected_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let value = args.get_string(activation, 0)?;
@@ -741,11 +741,11 @@ pub fn replace_selected_text<'gc>(
 
 pub fn replace_text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let begin_index = args
@@ -773,11 +773,11 @@ pub fn replace_text<'gc>(
 
 pub fn set_selection<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let begin_index = args
@@ -805,11 +805,11 @@ pub fn set_selection<'gc>(
 
 pub fn set_text_format<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let tf = args.get(0).unwrap_or(&Value::Undefined).as_object();
@@ -855,11 +855,11 @@ pub fn set_text_format<'gc>(
 
 pub fn get_anti_alias_type<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return if this.render_settings().is_advanced() {
@@ -874,11 +874,11 @@ pub fn get_anti_alias_type<'gc>(
 
 pub fn set_anti_alias_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let old_settings = this.render_settings();
@@ -901,11 +901,11 @@ pub fn set_anti_alias_type<'gc>(
 
 pub fn get_grid_fit_type<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return match this.render_settings().grid_fit() {
@@ -920,11 +920,11 @@ pub fn get_grid_fit_type<'gc>(
 
 pub fn set_grid_fit_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let old_settings = this.render_settings();
@@ -953,11 +953,11 @@ pub fn set_grid_fit_type<'gc>(
 
 pub fn get_thickness<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.render_settings().thickness().into());
@@ -968,11 +968,11 @@ pub fn get_thickness<'gc>(
 
 pub fn set_thickness<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let old_settings = this.render_settings();
@@ -996,11 +996,11 @@ pub fn set_thickness<'gc>(
 
 pub fn get_sharpness<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.render_settings().sharpness().into());
@@ -1011,11 +1011,11 @@ pub fn get_sharpness<'gc>(
 
 pub fn set_sharpness<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let old_settings = this.render_settings();
@@ -1039,11 +1039,11 @@ pub fn set_sharpness<'gc>(
 
 pub fn get_num_lines<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.layout_lines().into());
@@ -1054,11 +1054,11 @@ pub fn get_num_lines<'gc>(
 
 pub fn get_line_metrics<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let line_num = args
@@ -1093,11 +1093,11 @@ pub fn get_line_metrics<'gc>(
 
 pub fn get_bottom_scroll_v<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.bottom_scroll().into());
@@ -1108,11 +1108,11 @@ pub fn get_bottom_scroll_v<'gc>(
 
 pub fn get_max_scroll_v<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.maxscroll().into());
@@ -1123,11 +1123,11 @@ pub fn get_max_scroll_v<'gc>(
 
 pub fn get_max_scroll_h<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.maxhscroll().into());
@@ -1138,11 +1138,11 @@ pub fn get_max_scroll_h<'gc>(
 
 pub fn get_scroll_v<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.scroll().into());
@@ -1153,11 +1153,11 @@ pub fn get_scroll_v<'gc>(
 
 pub fn set_scroll_v<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let input = args
@@ -1173,11 +1173,11 @@ pub fn set_scroll_v<'gc>(
 
 pub fn get_scroll_h<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.hscroll().into());
@@ -1188,11 +1188,11 @@ pub fn get_scroll_h<'gc>(
 
 pub fn set_scroll_h<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         // NOTE: The clamping behavior here is identical to AVM1.
@@ -1212,11 +1212,11 @@ pub fn set_scroll_h<'gc>(
 
 pub fn get_max_chars<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         return Ok(this.max_chars().into());
@@ -1227,11 +1227,11 @@ pub fn get_max_chars<'gc>(
 
 pub fn set_max_chars<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this
-        .and_then(|this| this.as_display_object())
+        .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
         let input = args
@@ -1247,7 +1247,7 @@ pub fn set_max_chars<'gc>(
 
 pub fn get_mouse_wheel_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.TextField", "mouseWheelEnabled");
@@ -1256,7 +1256,7 @@ pub fn get_mouse_wheel_enabled<'gc>(
 
 pub fn set_mouse_wheel_enabled<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.text.TextField", "mouseWheelEnabled");
@@ -1265,7 +1265,7 @@ pub fn set_mouse_wheel_enabled<'gc>(
 
 pub fn get_restrict<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.TextField", "restrict");
@@ -1274,7 +1274,7 @@ pub fn get_restrict<'gc>(
 
 pub fn set_restrict<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.text.TextField", "restrict");

--- a/core/src/avm2/globals/flash/text/text_format.rs
+++ b/core/src/avm2/globals/flash/text/text_format.rs
@@ -11,192 +11,182 @@ pub use crate::avm2::object::textformat_allocator as text_format_allocator;
 
 pub fn get_align<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .align
-                .as_ref()
-                .map_or(Value::Null, |align| match align {
-                    swf::TextAlign::Left => "left".into(),
-                    swf::TextAlign::Center => "center".into(),
-                    swf::TextAlign::Right => "right".into(),
-                    swf::TextAlign::Justify => "justify".into(),
-                }));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .align
+            .as_ref()
+            .map_or(Value::Null, |align| match align {
+                swf::TextAlign::Left => "left".into(),
+                swf::TextAlign::Center => "center".into(),
+                swf::TextAlign::Right => "right".into(),
+                swf::TextAlign::Justify => "justify".into(),
+            }));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_align<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            let value = match value {
-                Value::Undefined | Value::Null => {
-                    text_format.align = None;
-                    return Ok(Value::Undefined);
-                }
-                value => value.coerce_to_string(activation)?,
-            };
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        let value = match value {
+            Value::Undefined | Value::Null => {
+                text_format.align = None;
+                return Ok(Value::Undefined);
+            }
+            value => value.coerce_to_string(activation)?,
+        };
 
-            text_format.align = if value == WStr::from_units(b"left") {
-                Some(swf::TextAlign::Left)
-            } else if value == WStr::from_units(b"center") {
-                Some(swf::TextAlign::Center)
-            } else if value == WStr::from_units(b"right") {
-                Some(swf::TextAlign::Right)
-            } else if value == WStr::from_units(b"justify") {
-                Some(swf::TextAlign::Justify)
-            } else {
-                return Err(make_error_2008(activation, "align"));
-            };
-        }
+        text_format.align = if value == WStr::from_units(b"left") {
+            Some(swf::TextAlign::Left)
+        } else if value == WStr::from_units(b"center") {
+            Some(swf::TextAlign::Center)
+        } else if value == WStr::from_units(b"right") {
+            Some(swf::TextAlign::Right)
+        } else if value == WStr::from_units(b"justify") {
+            Some(swf::TextAlign::Justify)
+        } else {
+            return Err(make_error_2008(activation, "align"));
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_block_indent<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .block_indent
-                .as_ref()
-                .map_or(Value::Null, |&block_indent| block_indent.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .block_indent
+            .as_ref()
+            .map_or(Value::Null, |&block_indent| block_indent.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_block_indent<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.block_indent = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.block_indent = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_bold<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .bold
-                .as_ref()
-                .map_or(Value::Null, |&bold| bold.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .bold
+            .as_ref()
+            .map_or(Value::Null, |&bold| bold.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_bold<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.bold = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_boolean()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.bold = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_boolean()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_bullet<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .bullet
-                .as_ref()
-                .map_or(Value::Null, |&bullet| bullet.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .bullet
+            .as_ref()
+            .map_or(Value::Null, |&bullet| bullet.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_bullet<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.bullet = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_boolean()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.bullet = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_boolean()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_color<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .color
-                .as_ref()
-                .map_or(Value::Null, |color| (color.to_rgba() as i32).into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .color
+            .as_ref()
+            .map_or(Value::Null, |color| (color.to_rgba() as i32).into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_color<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.color = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(swf::Color::from_rgba(value.coerce_to_u32(activation)?)),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.color = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(swf::Color::from_rgba(value.coerce_to_u32(activation)?)),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_display<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.text.TextFormat", "display");
@@ -205,7 +195,7 @@ pub fn get_display<'gc>(
 
 pub fn set_display<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_setter!(activation, "flash.text.TextFormat", "display");
@@ -214,443 +204,417 @@ pub fn set_display<'gc>(
 
 pub fn get_font<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format.font.as_ref().map_or(Value::Null, |font| {
-                AvmString::new(activation.context.gc_context, font.as_wstr()).into()
-            }));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format.font.as_ref().map_or(Value::Null, |font| {
+            AvmString::new(activation.context.gc_context, font.as_wstr()).into()
+        }));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_font<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.font = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_string(activation)?.as_wstr().into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.font = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_string(activation)?.as_wstr().into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_indent<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .indent
-                .as_ref()
-                .map_or(Value::Null, |&indent| indent.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .indent
+            .as_ref()
+            .map_or(Value::Null, |&indent| indent.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_indent<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.indent = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.indent = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_italic<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .italic
-                .as_ref()
-                .map_or(Value::Null, |&italic| italic.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .italic
+            .as_ref()
+            .map_or(Value::Null, |&italic| italic.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_italic<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.italic = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_boolean()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.italic = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_boolean()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_kerning<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .kerning
-                .as_ref()
-                .map_or(Value::Null, |&kerning| kerning.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .kerning
+            .as_ref()
+            .map_or(Value::Null, |&kerning| kerning.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_kerning<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.kerning = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_boolean()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.kerning = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_boolean()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_leading<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .leading
-                .as_ref()
-                .map_or(Value::Null, |&leading| leading.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .leading
+            .as_ref()
+            .map_or(Value::Null, |&leading| leading.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_leading<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.leading = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.leading = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_left_margin<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .left_margin
-                .as_ref()
-                .map_or(Value::Null, |&left_margin| left_margin.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .left_margin
+            .as_ref()
+            .map_or(Value::Null, |&left_margin| left_margin.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_left_margin<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.left_margin = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.left_margin = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_letter_spacing<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .letter_spacing
-                .as_ref()
-                .map_or(Value::Null, |&letter_spacing| letter_spacing.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .letter_spacing
+            .as_ref()
+            .map_or(Value::Null, |&letter_spacing| letter_spacing.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_letter_spacing<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.letter_spacing = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_number(activation)?),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.letter_spacing = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_number(activation)?),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_right_margin<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .right_margin
-                .as_ref()
-                .map_or(Value::Null, |&right_margin| right_margin.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .right_margin
+            .as_ref()
+            .map_or(Value::Null, |&right_margin| right_margin.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_right_margin<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.right_margin = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.right_margin = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_size<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .size
-                .as_ref()
-                .map_or(Value::Null, |&size| size.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .size
+            .as_ref()
+            .map_or(Value::Null, |&size| size.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_size<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.size = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.size = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(round_to_even(value.coerce_to_number(activation)?).into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_tab_stops<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return text_format
-                .tab_stops
-                .as_ref()
-                .map_or(Ok(Value::Null), |tab_stops| {
-                    let tab_stop_storage = tab_stops.iter().copied().collect();
-                    Ok(ArrayObject::from_storage(activation, tab_stop_storage)?.into())
-                });
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return text_format
+            .tab_stops
+            .as_ref()
+            .map_or(Ok(Value::Null), |tab_stops| {
+                let tab_stop_storage = tab_stops.iter().copied().collect();
+                Ok(ArrayObject::from_storage(activation, tab_stop_storage)?.into())
+            });
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_tab_stops<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.tab_stops = match value {
-                Value::Undefined | Value::Null => None,
-                value => {
-                    let object = value.coerce_to_object(activation)?;
-                    let length = object.as_array_storage().map_or(0, |v| v.length());
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.tab_stops = match value {
+            Value::Undefined | Value::Null => None,
+            value => {
+                let object = value.coerce_to_object(activation)?;
+                let length = object.as_array_storage().map_or(0, |v| v.length());
 
-                    let tab_stops: Result<Vec<_>, Error<'gc>> = (0..length)
-                        .map(|i| {
-                            let element = object.get_public_property(
-                                AvmString::new_utf8(activation.context.gc_context, i.to_string()),
-                                activation,
-                            )?;
-                            Ok(round_to_even(element.coerce_to_number(activation)?).into())
-                        })
-                        .collect();
-                    Some(tab_stops?)
-                }
-            };
-        }
+                let tab_stops: Result<Vec<_>, Error<'gc>> = (0..length)
+                    .map(|i| {
+                        let element = object.get_public_property(
+                            AvmString::new_utf8(activation.context.gc_context, i.to_string()),
+                            activation,
+                        )?;
+                        Ok(round_to_even(element.coerce_to_number(activation)?).into())
+                    })
+                    .collect();
+                Some(tab_stops?)
+            }
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_target<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format.target.as_ref().map_or(Value::Null, |target| {
-                AvmString::new(activation.context.gc_context, target.as_wstr()).into()
-            }));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format.target.as_ref().map_or(Value::Null, |target| {
+            AvmString::new(activation.context.gc_context, target.as_wstr()).into()
+        }));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_target<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.target = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_string(activation)?.as_wstr().into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.target = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_string(activation)?.as_wstr().into()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_underline<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format
-                .underline
-                .as_ref()
-                .map_or(Value::Null, |&underline| underline.into()));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format
+            .underline
+            .as_ref()
+            .map_or(Value::Null, |&underline| underline.into()));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_underline<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.underline = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_boolean()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.underline = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_boolean()),
+        };
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_url<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(text_format) = this.as_text_format() {
-            return Ok(text_format.url.as_ref().map_or(Value::Null, |url| {
-                AvmString::new(activation.context.gc_context, url.as_wstr()).into()
-            }));
-        }
+    if let Some(text_format) = this.as_text_format() {
+        return Ok(text_format.url.as_ref().map_or(Value::Null, |url| {
+            AvmString::new(activation.context.gc_context, url.as_wstr()).into()
+        }));
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn set_url<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
-            let value = args.get(0).unwrap_or(&Value::Undefined);
-            text_format.url = match value {
-                Value::Undefined | Value::Null => None,
-                value => Some(value.coerce_to_string(activation)?.as_wstr().into()),
-            };
-        }
+    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+        let value = args.get(0).unwrap_or(&Value::Undefined);
+        text_format.url = match value {
+            Value::Undefined | Value::Null => None,
+            value => Some(value.coerce_to_string(activation)?.as_wstr().into()),
+        };
     }
+
     Ok(Value::Undefined)
 }

--- a/core/src/avm2/globals/flash/ui/context_menu.rs
+++ b/core/src/avm2/globals/flash/ui/context_menu.rs
@@ -6,21 +6,19 @@ use crate::context_menu;
 
 pub fn hide_built_in_items<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Value::Object(mut items) = this.get_public_property("builtInItems", activation)? {
-            // items is a ContextMenuBuiltInItems
-            items.set_public_property("forwardAndBack", Value::Bool(false), activation)?;
-            items.set_public_property("loop", Value::Bool(false), activation)?;
-            items.set_public_property("play", Value::Bool(false), activation)?;
-            items.set_public_property("print", Value::Bool(false), activation)?;
-            items.set_public_property("quality", Value::Bool(false), activation)?;
-            items.set_public_property("rewind", Value::Bool(false), activation)?;
-            items.set_public_property("save", Value::Bool(false), activation)?;
-            items.set_public_property("zoom", Value::Bool(false), activation)?;
-        }
+    if let Value::Object(mut items) = this.get_public_property("builtInItems", activation)? {
+        // items is a ContextMenuBuiltInItems
+        items.set_public_property("forwardAndBack", Value::Bool(false), activation)?;
+        items.set_public_property("loop", Value::Bool(false), activation)?;
+        items.set_public_property("play", Value::Bool(false), activation)?;
+        items.set_public_property("print", Value::Bool(false), activation)?;
+        items.set_public_property("quality", Value::Bool(false), activation)?;
+        items.set_public_property("rewind", Value::Bool(false), activation)?;
+        items.set_public_property("save", Value::Bool(false), activation)?;
+        items.set_public_property("zoom", Value::Bool(false), activation)?;
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/flash/ui/keyboard.rs
+++ b/core/src/avm2/globals/flash/ui/keyboard.rs
@@ -8,7 +8,7 @@ use crate::string::AvmString;
 
 pub fn get_caps_lock<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "capsLock");
@@ -17,7 +17,7 @@ pub fn get_caps_lock<'gc>(
 
 pub fn get_has_virtual_keyboard<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "hasVirtualKeyboard");
@@ -26,7 +26,7 @@ pub fn get_has_virtual_keyboard<'gc>(
 
 pub fn get_num_lock<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "numLock");
@@ -35,7 +35,7 @@ pub fn get_num_lock<'gc>(
 
 pub fn get_physical_keyboard_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "physicalKeyboardType");
@@ -44,7 +44,7 @@ pub fn get_physical_keyboard_type<'gc>(
 
 pub fn is_accessible<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_getter!(activation, "flash.ui.Keyboard", "isAccessible");

--- a/core/src/avm2/globals/flash/ui/mouse.rs
+++ b/core/src/avm2/globals/flash/ui/mouse.rs
@@ -7,7 +7,7 @@ use crate::avm2::Error;
 
 pub fn hide<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     activation.context.ui.set_mouse_visible(false);
@@ -16,7 +16,7 @@ pub fn hide<'gc>(
 
 pub fn show<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     activation.context.ui.set_mouse_visible(true);

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -18,7 +18,7 @@ pub mod timer;
 /// Implements `flash.utils.getTimer`
 pub fn get_timer<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok((Instant::now()
@@ -30,7 +30,7 @@ pub fn get_timer<'gc>(
 /// Implements `flash.utils.setInterval`
 pub fn set_interval<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.len() < 2 {
@@ -59,7 +59,7 @@ pub fn set_interval<'gc>(
 /// Implements `flash.utils.clearInterval`
 pub fn clear_interval<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let id = args
@@ -73,7 +73,7 @@ pub fn clear_interval<'gc>(
 /// Implements `flash.utils.setTimeout`
 pub fn set_timeout<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.len() < 2 {
@@ -102,7 +102,7 @@ pub fn set_timeout<'gc>(
 /// Implements `flash.utils.clearTimeout`
 pub fn clear_timeout<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let id = args
@@ -116,7 +116,7 @@ pub fn clear_timeout<'gc>(
 /// Implements `flash.utils.escapeMultiByte`
 pub fn escape_multi_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let s = args
@@ -150,7 +150,7 @@ where
 /// Implements `flash.utils.unescapeMultiByte`
 pub fn unescape_multi_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let s = args
@@ -189,7 +189,7 @@ pub fn unescape_multi_byte<'gc>(
 /// Implements `flash.utils.getQualifiedClassName`
 pub fn get_qualified_class_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // This is a native method, which enforces the argument count.
@@ -220,7 +220,7 @@ pub fn get_qualified_class_name<'gc>(
 /// Implements `flash.utils.getQualifiedSuperclassName`
 pub fn get_qualified_superclass_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let obj = args
@@ -251,7 +251,7 @@ pub fn get_qualified_superclass_name<'gc>(
 /// Implements native method `flash.utils.getDefinitionByName`
 pub fn get_definition_by_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let appdomain = activation
@@ -267,7 +267,7 @@ pub fn get_definition_by_name<'gc>(
 // Implements `flash.utils.describeType`
 pub fn describe_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = args[0].coerce_to_object(activation)?;

--- a/core/src/avm2/globals/flash/utils/byte_array.rs
+++ b/core/src/avm2/globals/flash/utils/byte_array.rs
@@ -14,18 +14,16 @@ use flash_lso::types::{AMFVersion, Element};
 /// Writes a single byte to the bytearray
 pub fn write_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let byte = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_i32(activation)?;
-            bytearray.write_bytes(&[byte as u8])?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let byte = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)?;
+        bytearray.write_bytes(&[byte as u8])?;
     }
 
     Ok(Value::Undefined)
@@ -34,54 +32,52 @@ pub fn write_byte<'gc>(
 /// Writes multiple bytes to the bytearray from another bytearray
 pub fn write_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let bytearray = args
-            .get(0)
-            .unwrap_or(&Value::Undefined)
-            .coerce_to_object(activation)?;
-        let offset = args
-            .get(1)
-            .unwrap_or(&Value::Integer(0))
-            .coerce_to_u32(activation)? as usize;
-        let length = args
-            .get(2)
-            .unwrap_or(&Value::Integer(0))
-            .coerce_to_u32(activation)? as usize;
-        if !Object::ptr_eq(this, bytearray) {
-            // The ByteArray we are reading from is different than the ByteArray we are writing to,
-            // so we are allowed to borrow both at the same time without worrying about a panic
+    let bytearray = args
+        .get(0)
+        .unwrap_or(&Value::Undefined)
+        .coerce_to_object(activation)?;
+    let offset = args
+        .get(1)
+        .unwrap_or(&Value::Integer(0))
+        .coerce_to_u32(activation)? as usize;
+    let length = args
+        .get(2)
+        .unwrap_or(&Value::Integer(0))
+        .coerce_to_u32(activation)? as usize;
+    if !Object::ptr_eq(this, bytearray) {
+        // The ByteArray we are reading from is different than the ByteArray we are writing to,
+        // so we are allowed to borrow both at the same time without worrying about a panic
 
-            let ba_read = bytearray
-                .as_bytearray()
-                .ok_or("ArgumentError: Parameter must be a bytearray")?;
-            let to_write = ba_read
-                .read_at(
-                    // If length is 0, lets read the remaining bytes of ByteArray from the supplied offset
-                    if length != 0 {
-                        length
-                    } else {
-                        ba_read.len().saturating_sub(offset)
-                    },
-                    offset,
-                )
-                .map_err(|e| e.to_avm(activation))?;
+        let ba_read = bytearray
+            .as_bytearray()
+            .ok_or("ArgumentError: Parameter must be a bytearray")?;
+        let to_write = ba_read
+            .read_at(
+                // If length is 0, lets read the remaining bytes of ByteArray from the supplied offset
+                if length != 0 {
+                    length
+                } else {
+                    ba_read.len().saturating_sub(offset)
+                },
+                offset,
+            )
+            .map_err(|e| e.to_avm(activation))?;
 
-            if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-                bytearray.write_bytes(to_write)?;
-            }
-        } else if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            // The ByteArray we are reading from is the same as the ByteArray we are writing to,
-            // so we only need to borrow once, and we can use `write_bytes_within` to write bytes from our own ByteArray
-            let amnt = if length != 0 {
-                length
-            } else {
-                bytearray.len().saturating_sub(offset)
-            };
-            bytearray.write_bytes_within(offset, amnt)?;
+        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+            bytearray.write_bytes(to_write)?;
         }
+    } else if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        // The ByteArray we are reading from is the same as the ByteArray we are writing to,
+        // so we only need to borrow once, and we can use `write_bytes_within` to write bytes from our own ByteArray
+        let amnt = if length != 0 {
+            length
+        } else {
+            bytearray.len().saturating_sub(offset)
+        };
+        bytearray.write_bytes_within(offset, amnt)?;
     }
 
     Ok(Value::Undefined)
@@ -90,69 +86,66 @@ pub fn write_bytes<'gc>(
 // Reads the bytes from the current bytearray into another bytearray
 pub fn read_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let bytearray = args
-            .get(0)
-            .unwrap_or(&Value::Undefined)
-            .coerce_to_object(activation)?;
-        let offset = args
-            .get(1)
-            .unwrap_or(&Value::Integer(0))
-            .coerce_to_u32(activation)? as usize;
-        let length = args
-            .get(2)
-            .unwrap_or(&Value::Integer(0))
-            .coerce_to_u32(activation)? as usize;
+    let bytearray = args
+        .get(0)
+        .unwrap_or(&Value::Undefined)
+        .coerce_to_object(activation)?;
+    let offset = args
+        .get(1)
+        .unwrap_or(&Value::Integer(0))
+        .coerce_to_u32(activation)? as usize;
+    let length = args
+        .get(2)
+        .unwrap_or(&Value::Integer(0))
+        .coerce_to_u32(activation)? as usize;
 
-        if !Object::ptr_eq(this, bytearray) {
-            if let Some(bytearray_read) = this.as_bytearray() {
-                let to_write = bytearray_read
-                    .read_bytes(
-                        // If length is 0, lets read the remaining bytes of ByteArray
-                        if length != 0 {
-                            length
-                        } else {
-                            bytearray_read.bytes_available()
-                        },
-                    )
-                    .map_err(|e| e.to_avm(activation))?;
+    if !Object::ptr_eq(this, bytearray) {
+        if let Some(bytearray_read) = this.as_bytearray() {
+            let to_write = bytearray_read
+                .read_bytes(
+                    // If length is 0, lets read the remaining bytes of ByteArray
+                    if length != 0 {
+                        length
+                    } else {
+                        bytearray_read.bytes_available()
+                    },
+                )
+                .map_err(|e| e.to_avm(activation))?;
 
-                let mut ba_write = bytearray
-                    .as_bytearray_mut(activation.context.gc_context)
-                    .ok_or("ArgumentError: Parameter must be a bytearray")?;
+            let mut ba_write = bytearray
+                .as_bytearray_mut(activation.context.gc_context)
+                .ok_or("ArgumentError: Parameter must be a bytearray")?;
 
-                ba_write.write_at(to_write, offset)?;
-            }
-        } else if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let amnt = if length != 0 {
-                length
-            } else {
-                bytearray.bytes_available()
-            };
-            let pos = bytearray.position();
-            bytearray.write_at_within(pos, amnt, offset)?;
+            ba_write.write_at(to_write, offset)?;
         }
+    } else if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let amnt = if length != 0 {
+            length
+        } else {
+            bytearray.bytes_available()
+        };
+        let pos = bytearray.position();
+        bytearray.write_at_within(pos, amnt, offset)?;
     }
+
     Ok(Value::Undefined)
 }
 pub fn write_utf<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            if let Some(utf_string) = args.get(0) {
-                let utf_string = utf_string.coerce_to_string(activation)?;
-                // NOTE: there is a bug on old Flash Player (e.g. v11.3); if the string to
-                // write ends with an unpaired high surrogate, the routine bails out and nothing
-                // is written.
-                // The bug is fixed on newer FP versions (e.g. v32), but the fix isn't SWF-version-gated.
-                bytearray.write_utf(&utf_string.to_utf8_lossy())?;
-            }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        if let Some(utf_string) = args.get(0) {
+            let utf_string = utf_string.coerce_to_string(activation)?;
+            // NOTE: there is a bug on old Flash Player (e.g. v11.3); if the string to
+            // write ends with an unpaired high surrogate, the routine bails out and nothing
+            // is written.
+            // The bug is fixed on newer FP versions (e.g. v32), but the fix isn't SWF-version-gated.
+            bytearray.write_utf(&utf_string.to_utf8_lossy())?;
         }
     }
 
@@ -161,34 +154,30 @@ pub fn write_utf<'gc>(
 
 pub fn read_utf<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(AvmString::new_utf8_bytes(
-                activation.context.gc_context,
-                bytearray.read_utf().map_err(|e| e.to_avm(activation))?,
-            )
-            .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(AvmString::new_utf8_bytes(
+            activation.context.gc_context,
+            bytearray.read_utf().map_err(|e| e.to_avm(activation))?,
+        )
+        .into());
     }
 
     Ok(Value::Undefined)
 }
 pub fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            let mut bytes = bytearray.bytes();
-            if let Some(without_bom) = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
-                bytes = without_bom;
-            }
-            return Ok(AvmString::new_utf8_bytes(activation.context.gc_context, bytes).into());
+    if let Some(bytearray) = this.as_bytearray() {
+        let mut bytes = bytearray.bytes();
+        if let Some(without_bom) = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
+            bytes = without_bom;
         }
+        return Ok(AvmString::new_utf8_bytes(activation.context.gc_context, bytes).into());
     }
 
     Ok(Value::Undefined)
@@ -196,14 +185,12 @@ pub fn to_string<'gc>(
 
 pub fn clear<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            bytearray.clear();
-            bytearray.shrink_to_fit();
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        bytearray.clear();
+        bytearray.shrink_to_fit();
     }
 
     Ok(Value::Undefined)
@@ -211,13 +198,11 @@ pub fn clear<'gc>(
 
 pub fn get_position<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray.position().into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray.position().into());
     }
 
     Ok(Value::Undefined)
@@ -225,17 +210,15 @@ pub fn get_position<'gc>(
 
 pub fn set_position<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            let num = args
-                .get(0)
-                .unwrap_or(&Value::Integer(0))
-                .coerce_to_u32(activation)?;
-            bytearray.set_position(num as usize);
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        let num = args
+            .get(0)
+            .unwrap_or(&Value::Integer(0))
+            .coerce_to_u32(activation)?;
+        bytearray.set_position(num as usize);
     }
 
     Ok(Value::Undefined)
@@ -243,13 +226,11 @@ pub fn set_position<'gc>(
 
 pub fn get_bytes_available<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray.bytes_available().into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray.bytes_available().into());
     }
 
     Ok(Value::Undefined)
@@ -257,13 +238,11 @@ pub fn get_bytes_available<'gc>(
 
 pub fn get_length<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray.len().into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray.len().into());
     }
 
     Ok(Value::Undefined)
@@ -271,17 +250,15 @@ pub fn get_length<'gc>(
 
 pub fn set_length<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let len = args
-                .get(0)
-                .unwrap_or(&Value::Integer(0))
-                .coerce_to_u32(activation)? as usize;
-            bytearray.set_length(len);
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let len = args
+            .get(0)
+            .unwrap_or(&Value::Integer(0))
+            .coerce_to_u32(activation)? as usize;
+        bytearray.set_length(len);
     }
 
     Ok(Value::Undefined)
@@ -289,16 +266,14 @@ pub fn set_length<'gc>(
 
 pub fn get_endian<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(match bytearray.endian() {
-                Endian::Big => "bigEndian".into(),
-                Endian::Little => "littleEndian".into(),
-            });
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(match bytearray.endian() {
+            Endian::Big => "bigEndian".into(),
+            Endian::Little => "littleEndian".into(),
+        });
     }
 
     Ok(Value::Undefined)
@@ -306,22 +281,20 @@ pub fn get_endian<'gc>(
 
 pub fn set_endian<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let endian = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_string(activation)?;
-            if &endian == b"bigEndian" {
-                bytearray.set_endian(Endian::Big);
-            } else if &endian == b"littleEndian" {
-                bytearray.set_endian(Endian::Little);
-            } else {
-                return Err("Parameter type must be one of the accepted values.".into());
-            }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let endian = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_string(activation)?;
+        if &endian == b"bigEndian" {
+            bytearray.set_endian(Endian::Big);
+        } else if &endian == b"littleEndian" {
+            bytearray.set_endian(Endian::Little);
+        } else {
+            return Err("Parameter type must be one of the accepted values.".into());
         }
     }
 
@@ -330,16 +303,14 @@ pub fn set_endian<'gc>(
 
 pub fn read_short<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_short()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_short()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -347,16 +318,14 @@ pub fn read_short<'gc>(
 
 pub fn read_unsigned_short<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_unsigned_short()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_unsigned_short()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -364,16 +333,14 @@ pub fn read_unsigned_short<'gc>(
 
 pub fn read_double<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_double()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_double()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -381,16 +348,14 @@ pub fn read_double<'gc>(
 
 pub fn read_float<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_float()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_float()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -398,16 +363,14 @@ pub fn read_float<'gc>(
 
 pub fn read_int<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_int()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_int()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -415,16 +378,14 @@ pub fn read_int<'gc>(
 
 pub fn read_unsigned_int<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_unsigned_int()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_unsigned_int()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -432,16 +393,14 @@ pub fn read_unsigned_int<'gc>(
 
 pub fn read_boolean<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_boolean()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_boolean()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -449,16 +408,14 @@ pub fn read_boolean<'gc>(
 
 pub fn read_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_byte()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_byte()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -466,25 +423,23 @@ pub fn read_byte<'gc>(
 
 pub fn read_utf_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            let len = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_u32(activation)?;
-            return Ok(AvmString::new_utf8(
-                activation.context.gc_context,
-                String::from_utf8_lossy(
-                    bytearray
-                        .read_utf_bytes(len as usize)
-                        .map_err(|e| e.to_avm(activation))?,
-                ),
-            )
-            .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        let len = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_u32(activation)?;
+        return Ok(AvmString::new_utf8(
+            activation.context.gc_context,
+            String::from_utf8_lossy(
+                bytearray
+                    .read_utf_bytes(len as usize)
+                    .map_err(|e| e.to_avm(activation))?,
+            ),
+        )
+        .into());
     }
 
     Ok(Value::Undefined)
@@ -492,16 +447,14 @@ pub fn read_utf_bytes<'gc>(
 
 pub fn read_unsigned_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok(bytearray
-                .read_unsigned_byte()
-                .map_err(|e| e.to_avm(activation))?
-                .into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok(bytearray
+            .read_unsigned_byte()
+            .map_err(|e| e.to_avm(activation))?
+            .into());
     }
 
     Ok(Value::Undefined)
@@ -509,17 +462,15 @@ pub fn read_unsigned_byte<'gc>(
 
 pub fn write_float<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let num = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_number(activation)?;
-            bytearray.write_float(num as f32)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let num = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_number(activation)?;
+        bytearray.write_float(num as f32)?;
     }
 
     Ok(Value::Undefined)
@@ -527,17 +478,15 @@ pub fn write_float<'gc>(
 
 pub fn write_double<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let num = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_number(activation)?;
-            bytearray.write_double(num)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let num = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_number(activation)?;
+        bytearray.write_double(num)?;
     }
 
     Ok(Value::Undefined)
@@ -545,14 +494,12 @@ pub fn write_double<'gc>(
 
 pub fn write_boolean<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let num = args.get(0).unwrap_or(&Value::Undefined).coerce_to_boolean();
-            bytearray.write_boolean(num)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let num = args.get(0).unwrap_or(&Value::Undefined).coerce_to_boolean();
+        bytearray.write_boolean(num)?;
     }
 
     Ok(Value::Undefined)
@@ -560,17 +507,15 @@ pub fn write_boolean<'gc>(
 
 pub fn write_int<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let num = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_i32(activation)?;
-            bytearray.write_int(num)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let num = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_i32(activation)?;
+        bytearray.write_int(num)?;
     }
 
     Ok(Value::Undefined)
@@ -578,17 +523,15 @@ pub fn write_int<'gc>(
 
 pub fn write_unsigned_int<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let num = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_u32(activation)?;
-            bytearray.write_unsigned_int(num)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let num = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_u32(activation)?;
+        bytearray.write_unsigned_int(num)?;
     }
 
     Ok(Value::Undefined)
@@ -596,17 +539,15 @@ pub fn write_unsigned_int<'gc>(
 
 pub fn write_short<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let num = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_i32(activation)?;
-            bytearray.write_short(num as i16)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let num = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_i32(activation)?;
+        bytearray.write_short(num as i16)?;
     }
 
     Ok(Value::Undefined)
@@ -614,25 +555,23 @@ pub fn write_short<'gc>(
 
 pub fn write_multi_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let string = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_string(activation)?;
-            let charset_label = args
-                .get(1)
-                .unwrap_or(&"UTF-8".into())
-                .coerce_to_string(activation)?;
-            let encoder =
-                Encoding::for_label(charset_label.to_utf8_lossy().as_bytes()).unwrap_or(UTF_8);
-            let utf8 = string.to_utf8_lossy();
-            let (encoded_bytes, _, _) = encoder.encode(&utf8);
-            bytearray.write_bytes(&encoded_bytes)?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let string = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_string(activation)?;
+        let charset_label = args
+            .get(1)
+            .unwrap_or(&"UTF-8".into())
+            .coerce_to_string(activation)?;
+        let encoder =
+            Encoding::for_label(charset_label.to_utf8_lossy().as_bytes()).unwrap_or(UTF_8);
+        let utf8 = string.to_utf8_lossy();
+        let (encoded_bytes, _, _) = encoder.encode(&utf8);
+        bytearray.write_bytes(&encoded_bytes)?;
     }
 
     Ok(Value::Undefined)
@@ -640,34 +579,32 @@ pub fn write_multi_byte<'gc>(
 
 pub fn read_multi_byte<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            let len = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_u32(activation)?;
-            let charset_label = args
-                .get(1)
-                .unwrap_or(&"UTF-8".into())
-                .coerce_to_string(activation)?;
-            let mut bytes = bytearray
-                .read_bytes(len as usize)
-                .map_err(|e| e.to_avm(activation))?;
+    if let Some(bytearray) = this.as_bytearray() {
+        let len = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_u32(activation)?;
+        let charset_label = args
+            .get(1)
+            .unwrap_or(&"UTF-8".into())
+            .coerce_to_string(activation)?;
+        let mut bytes = bytearray
+            .read_bytes(len as usize)
+            .map_err(|e| e.to_avm(activation))?;
 
-            // Flash cuts off the string at the first null byte (after checking that
-            // the original length fits in the ByteArray)
-            if let Some(null) = bytes.iter().position(|b| *b == b'\0') {
-                bytes = &bytes[..null];
-            }
-
-            let encoder =
-                Encoding::for_label(charset_label.to_utf8_lossy().as_bytes()).unwrap_or(UTF_8);
-            let (decoded_str, _, _) = encoder.decode(bytes);
-            return Ok(AvmString::new_utf8(activation.context.gc_context, decoded_str).into());
+        // Flash cuts off the string at the first null byte (after checking that
+        // the original length fits in the ByteArray)
+        if let Some(null) = bytes.iter().position(|b| *b == b'\0') {
+            bytes = &bytes[..null];
         }
+
+        let encoder =
+            Encoding::for_label(charset_label.to_utf8_lossy().as_bytes()).unwrap_or(UTF_8);
+        let (decoded_str, _, _) = encoder.decode(bytes);
+        return Ok(AvmString::new_utf8(activation.context.gc_context, decoded_str).into());
     }
 
     Ok(Value::Undefined)
@@ -675,17 +612,15 @@ pub fn read_multi_byte<'gc>(
 
 pub fn write_utf_bytes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let string = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_string(activation)?;
-            bytearray.write_bytes(string.to_utf8_lossy().as_bytes())?;
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let string = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_string(activation)?;
+        bytearray.write_bytes(string.to_utf8_lossy().as_bytes())?;
     }
 
     Ok(Value::Undefined)
@@ -693,30 +628,28 @@ pub fn write_utf_bytes<'gc>(
 
 pub fn compress<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let algorithm = args
-                .get(0)
-                .unwrap_or(&"zlib".into())
-                .coerce_to_string(activation)?;
-            let algorithm = match algorithm.parse() {
-                Ok(algorithm) => algorithm,
-                Err(_) => {
-                    return Err(Error::AvmError(crate::avm2::error::io_error(
-                        activation,
-                        "Error #2058: There was an error decompressing the data.",
-                        2058,
-                    )?))
-                }
-            };
-            let buffer = bytearray.compress(algorithm);
-            bytearray.clear();
-            bytearray.write_bytes(&buffer)?;
-            bytearray.set_position(bytearray.len());
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let algorithm = args
+            .get(0)
+            .unwrap_or(&"zlib".into())
+            .coerce_to_string(activation)?;
+        let algorithm = match algorithm.parse() {
+            Ok(algorithm) => algorithm,
+            Err(_) => {
+                return Err(Error::AvmError(crate::avm2::error::io_error(
+                    activation,
+                    "Error #2058: There was an error decompressing the data.",
+                    2058,
+                )?))
+            }
+        };
+        let buffer = bytearray.compress(algorithm);
+        bytearray.clear();
+        bytearray.write_bytes(&buffer)?;
+        bytearray.set_position(bytearray.len());
     }
 
     Ok(Value::Undefined)
@@ -724,39 +657,37 @@ pub fn compress<'gc>(
 
 pub fn uncompress<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let algorithm = args
-                .get(0)
-                .unwrap_or(&"zlib".into())
-                .coerce_to_string(activation)?;
-            let algorithm = match algorithm.parse() {
-                Ok(algorithm) => algorithm,
-                Err(_) => {
-                    return Err(Error::AvmError(crate::avm2::error::io_error(
-                        activation,
-                        "Error #2058: There was an error decompressing the data.",
-                        2058,
-                    )?))
-                }
-            };
-            let buffer = match bytearray.decompress(algorithm) {
-                Some(buffer) => buffer,
-                None => {
-                    return Err(Error::AvmError(crate::avm2::error::io_error(
-                        activation,
-                        "Error #2058: There was an error decompressing the data.",
-                        2058,
-                    )?))
-                }
-            };
-            bytearray.clear();
-            bytearray.write_bytes(&buffer)?;
-            bytearray.set_position(0);
-        }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let algorithm = args
+            .get(0)
+            .unwrap_or(&"zlib".into())
+            .coerce_to_string(activation)?;
+        let algorithm = match algorithm.parse() {
+            Ok(algorithm) => algorithm,
+            Err(_) => {
+                return Err(Error::AvmError(crate::avm2::error::io_error(
+                    activation,
+                    "Error #2058: There was an error decompressing the data.",
+                    2058,
+                )?))
+            }
+        };
+        let buffer = match bytearray.decompress(algorithm) {
+            Some(buffer) => buffer,
+            None => {
+                return Err(Error::AvmError(crate::avm2::error::io_error(
+                    activation,
+                    "Error #2058: There was an error decompressing the data.",
+                    2058,
+                )?))
+            }
+        };
+        bytearray.clear();
+        bytearray.write_bytes(&buffer)?;
+        bytearray.set_position(0);
     }
 
     Ok(Value::Undefined)
@@ -764,40 +695,38 @@ pub fn uncompress<'gc>(
 
 pub fn read_object<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            let bytes = bytearray
-                .read_at(bytearray.bytes_available(), bytearray.position())
-                .map_err(|e| e.to_avm(activation))?;
-            let (bytes_left, value) = match bytearray.object_encoding() {
-                ObjectEncoding::Amf0 => {
-                    let mut decoder = AMF0Decoder::default();
-                    let (extra, amf) = decoder
-                        .parse_single_element(bytes)
-                        .map_err(|_| "Error: Invalid object")?;
-                    (
-                        extra.len(),
-                        crate::avm2::amf::deserialize_value(activation, &amf)?,
-                    )
-                }
-                ObjectEncoding::Amf3 => {
-                    let mut decoder = AMF3Decoder::default();
-                    let (extra, amf) = decoder
-                        .parse_single_element(bytes)
-                        .map_err(|_| "Error: Invalid object")?;
-                    (
-                        extra.len(),
-                        crate::avm2::amf::deserialize_value(activation, &amf)?,
-                    )
-                }
-            };
+    if let Some(bytearray) = this.as_bytearray() {
+        let bytes = bytearray
+            .read_at(bytearray.bytes_available(), bytearray.position())
+            .map_err(|e| e.to_avm(activation))?;
+        let (bytes_left, value) = match bytearray.object_encoding() {
+            ObjectEncoding::Amf0 => {
+                let mut decoder = AMF0Decoder::default();
+                let (extra, amf) = decoder
+                    .parse_single_element(bytes)
+                    .map_err(|_| "Error: Invalid object")?;
+                (
+                    extra.len(),
+                    crate::avm2::amf::deserialize_value(activation, &amf)?,
+                )
+            }
+            ObjectEncoding::Amf3 => {
+                let mut decoder = AMF3Decoder::default();
+                let (extra, amf) = decoder
+                    .parse_single_element(bytes)
+                    .map_err(|_| "Error: Invalid object")?;
+                (
+                    extra.len(),
+                    crate::avm2::amf::deserialize_value(activation, &amf)?,
+                )
+            }
+        };
 
-            bytearray.set_position(bytearray.len() - bytes_left);
-            return Ok(value);
-        }
+        bytearray.set_position(bytearray.len() - bytes_left);
+        return Ok(value);
     }
 
     Ok(Value::Undefined)
@@ -805,46 +734,43 @@ pub fn read_object<'gc>(
 
 pub fn write_object<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let obj = args.get(0).cloned().unwrap_or(Value::Undefined);
-            let amf_version = match bytearray.object_encoding() {
-                ObjectEncoding::Amf0 => AMFVersion::AMF0,
-                ObjectEncoding::Amf3 => AMFVersion::AMF3,
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let obj = args.get(0).cloned().unwrap_or(Value::Undefined);
+        let amf_version = match bytearray.object_encoding() {
+            ObjectEncoding::Amf0 => AMFVersion::AMF0,
+            ObjectEncoding::Amf3 => AMFVersion::AMF3,
+        };
+        if let Some(amf) = crate::avm2::amf::serialize_value(activation, obj, amf_version) {
+            let element = Element::new("", amf);
+            let mut lso = flash_lso::types::Lso::new(vec![element], "", amf_version);
+            let bytes = flash_lso::write::write_to_bytes(&mut lso)
+                .map_err(|_| "Failed to serialize object")?;
+            // This is kind of hacky: We need to strip out the header and any padding so that we only write
+            // the value. In the future, there should be a method to do this in the flash_lso crate.
+            let element_padding = match amf_version {
+                AMFVersion::AMF0 => 8,
+                AMFVersion::AMF3 => 7,
             };
-            if let Some(amf) = crate::avm2::amf::serialize_value(activation, obj, amf_version) {
-                let element = Element::new("", amf);
-                let mut lso = flash_lso::types::Lso::new(vec![element], "", amf_version);
-                let bytes = flash_lso::write::write_to_bytes(&mut lso)
-                    .map_err(|_| "Failed to serialize object")?;
-                // This is kind of hacky: We need to strip out the header and any padding so that we only write
-                // the value. In the future, there should be a method to do this in the flash_lso crate.
-                let element_padding = match amf_version {
-                    AMFVersion::AMF0 => 8,
-                    AMFVersion::AMF3 => 7,
-                };
-                bytearray.write_bytes(
-                    &bytes[flash_lso::write::header_length(&lso.header) + element_padding
-                        ..bytes.len() - 1],
-                )?;
-            }
+            bytearray.write_bytes(
+                &bytes[flash_lso::write::header_length(&lso.header) + element_padding
+                    ..bytes.len() - 1],
+            )?;
         }
     }
+
     Ok(Value::Undefined)
 }
 
 pub fn get_object_encoding<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(bytearray) = this.as_bytearray() {
-            return Ok((bytearray.object_encoding() as u8).into());
-        }
+    if let Some(bytearray) = this.as_bytearray() {
+        return Ok((bytearray.object_encoding() as u8).into());
     }
 
     Ok(Value::Undefined)
@@ -852,20 +778,18 @@ pub fn get_object_encoding<'gc>(
 
 pub fn set_object_encoding<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
-            let new_encoding = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_u32(activation)?;
-            match new_encoding {
-                0 => bytearray.set_object_encoding(ObjectEncoding::Amf0),
-                3 => bytearray.set_object_encoding(ObjectEncoding::Amf3),
-                _ => return Err("Parameter type must be one of the accepted values.".into()),
-            }
+    if let Some(mut bytearray) = this.as_bytearray_mut(activation.context.gc_context) {
+        let new_encoding = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_u32(activation)?;
+        match new_encoding {
+            0 => bytearray.set_object_encoding(ObjectEncoding::Amf0),
+            3 => bytearray.set_object_encoding(ObjectEncoding::Amf3),
+            _ => return Err("Parameter type must be one of the accepted values.".into()),
         }
     }
 

--- a/core/src/avm2/globals/flash/utils/proxy.rs
+++ b/core/src/avm2/globals/flash/utils/proxy.rs
@@ -7,7 +7,7 @@ pub use crate::avm2::object::proxy_allocator;
 
 pub fn is_attribute<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(Value::Object(Object::QNameObject(qname_object))) = args.get(0) {

--- a/core/src/avm2/globals/flash/utils/timer.rs
+++ b/core/src/avm2/globals/flash/utils/timer.rs
@@ -10,10 +10,9 @@ use crate::timer::TimerCallback;
 /// Implements `Timer.stop`
 pub fn stop<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut this = this.expect("`this` should be set in native method!");
     let id = this
         .get_property(
             &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),
@@ -37,10 +36,9 @@ pub fn stop<'gc>(
 /// Implements `Timer.start`
 pub fn start<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    mut this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let mut this = this.expect("`this` should be set in native method!");
     let id = this
         .get_property(
             &Multiname::new(activation.avm2().flash_utils_internal, "_timerId"),

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -17,7 +17,7 @@ use gc_arena::GcCell;
 /// Implements `global`'s instance constructor.
 pub fn instance_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)
@@ -26,7 +26,7 @@ pub fn instance_init<'gc>(
 /// Implements `global`'s class constructor.
 pub fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -14,19 +14,17 @@ use gc_arena::GcCell;
 /// Implements `int`'s instance initializer.
 fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
-            if matches!(*prim, Value::Undefined | Value::Null) {
-                *prim = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Undefined)
-                    .coerce_to_i32(activation)?
-                    .into();
-            }
+    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
+        if matches!(*prim, Value::Undefined | Value::Null) {
+            *prim = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Undefined)
+                .coerce_to_i32(activation)?
+                .into();
         }
     }
 
@@ -36,12 +34,10 @@ fn instance_init<'gc>(
 /// Implements `int`'s native instance initializer.
 fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, args)?;
-    }
+    activation.super_init(this, args)?;
 
     Ok(Value::Undefined)
 }
@@ -49,82 +45,80 @@ fn native_instance_init<'gc>(
 /// Implements `int`'s class initializer.
 fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let scope = activation.create_scopechain();
-        let gc_context = activation.context.gc_context;
-        let this_class = this.as_class_object().unwrap();
-        let int_proto = this_class.prototype();
+    let scope = activation.create_scopechain();
+    let gc_context = activation.context.gc_context;
+    let this_class = this.as_class_object().unwrap();
+    let int_proto = this_class.prototype();
 
-        int_proto.set_string_property_local(
-            "toExponential",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_exponential, "toExponential", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+    int_proto.set_string_property_local(
+        "toExponential",
+        FunctionObject::from_method(
             activation,
-        )?;
-        int_proto.set_string_property_local(
-            "toFixed",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_fixed, "toFixed", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_exponential, "toExponential", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    int_proto.set_string_property_local(
+        "toFixed",
+        FunctionObject::from_method(
             activation,
-        )?;
-        int_proto.set_string_property_local(
-            "toPrecision",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_precision, "toPrecision", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_fixed, "toFixed", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    int_proto.set_string_property_local(
+        "toPrecision",
+        FunctionObject::from_method(
             activation,
-        )?;
-        int_proto.set_string_property_local(
-            "toString",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_string, "toString", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_precision, "toPrecision", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    int_proto.set_string_property_local(
+        "toString",
+        FunctionObject::from_method(
             activation,
-        )?;
-        int_proto.set_string_property_local(
-            "valueOf",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(value_of, "valueOf", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_string, "toString", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    int_proto.set_string_property_local(
+        "valueOf",
+        FunctionObject::from_method(
             activation,
-        )?;
+            Method::from_builtin(value_of, "valueOf", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
 
-        int_proto.set_local_property_is_enumerable(gc_context, "toExponential".into(), false);
-        int_proto.set_local_property_is_enumerable(gc_context, "toFixed".into(), false);
-        int_proto.set_local_property_is_enumerable(gc_context, "toPrecision".into(), false);
-        int_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
-        int_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
-    }
+    int_proto.set_local_property_is_enumerable(gc_context, "toExponential".into(), false);
+    int_proto.set_local_property_is_enumerable(gc_context, "toFixed".into(), false);
+    int_proto.set_local_property_is_enumerable(gc_context, "toPrecision".into(), false);
+    int_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
+    int_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
 
     Ok(Value::Undefined)
 }
@@ -132,31 +126,29 @@ fn class_init<'gc>(
 /// Implements `int.toExponential`
 fn to_exponential<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if digits > 20 {
-                    return Err("toExponential can only print with 0 through 20 digits.".into());
-                }
-
-                return Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("{number:.digits$e}")
-                        .replace('e', "e+")
-                        .replace("e+-", "e-")
-                        .replace("e+0", ""),
-                )
-                .into());
+            if digits > 20 {
+                return Err("toExponential can only print with 0 through 20 digits.".into());
             }
+
+            return Ok(AvmString::new_utf8(
+                activation.context.gc_context,
+                format!("{number:.digits$e}")
+                    .replace('e', "e+")
+                    .replace("e+-", "e-")
+                    .replace("e+0", ""),
+            )
+            .into());
         }
     }
 
@@ -166,28 +158,26 @@ fn to_exponential<'gc>(
 /// Implements `int.toFixed`
 fn to_fixed<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if digits > 20 {
-                    return Err("toFixed can only print with 0 through 20 digits.".into());
-                }
-
-                return Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("{0:.1$}", number as f64, digits),
-                )
-                .into());
+            if digits > 20 {
+                return Err("toFixed can only print with 0 through 20 digits.".into());
             }
+
+            return Ok(AvmString::new_utf8(
+                activation.context.gc_context,
+                format!("{0:.1$}", number as f64, digits),
+            )
+            .into());
         }
     }
 
@@ -197,24 +187,22 @@ fn to_fixed<'gc>(
 /// Implements `int.toPrecision`
 fn to_precision<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let wanted_digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let wanted_digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if wanted_digits < 1 || wanted_digits > 21 {
-                    return Err("toPrecision can only print with 1 through 21 digits.".into());
-                }
-
-                return Ok(print_with_precision(activation, number as f64, wanted_digits)?.into());
+            if wanted_digits < 1 || wanted_digits > 21 {
+                return Err("toPrecision can only print with 1 through 21 digits.".into());
             }
+
+            return Ok(print_with_precision(activation, number as f64, wanted_digits)?.into());
         }
     }
 
@@ -224,24 +212,22 @@ fn to_precision<'gc>(
 /// Implements `int.toString`
 fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let radix = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(10))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let radix = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(10))
+                .coerce_to_u32(activation)? as usize;
 
-                if radix < 2 || radix > 36 {
-                    return Err("toString can only print in bases 2 thru 36.".into());
-                }
-
-                return Ok(print_with_radix(activation, number as f64, radix)?.into());
+            if radix < 2 || radix > 36 {
+                return Err("toString can only print in bases 2 thru 36.".into());
             }
+
+            return Ok(print_with_radix(activation, number as f64, radix)?.into());
         }
     }
 
@@ -251,13 +237,11 @@ fn to_string<'gc>(
 /// Implements `int.valueOf`
 fn value_of<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            return Ok(*this);
-        }
+    if let Some(this) = this.as_primitive() {
+        return Ok(*this);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/json.rs
+++ b/core/src/avm2/globals/json.rs
@@ -264,7 +264,7 @@ impl<'gc> AvmSerializer<'gc> {
 /// Implements `JSON.parse`.
 pub fn parse<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let input = args.get_string(activation, 0)?;
@@ -286,7 +286,7 @@ pub fn parse<'gc>(
 /// Implements `JSON.stringify`.
 pub fn stringify<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let val = args.get_value(0);

--- a/core/src/avm2/globals/math.rs
+++ b/core/src/avm2/globals/math.rs
@@ -10,7 +10,7 @@ macro_rules! wrap_std {
     ($name:ident, $std:expr) => {
         pub fn $name<'gc>(
             activation: &mut Activation<'_, 'gc>,
-            _this: Option<Object<'gc>>,
+            _this: Object<'gc>,
             args: &[Value<'gc>],
         ) -> Result<Value<'gc>, Error<'gc>> {
             if let Some(input) = args.get(0) {
@@ -37,7 +37,7 @@ wrap_std!(tan, f64::tan);
 
 pub fn round<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(x) = args.get(0) {
@@ -52,7 +52,7 @@ pub fn round<'gc>(
 
 pub fn atan2<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let y = args
@@ -68,7 +68,7 @@ pub fn atan2<'gc>(
 
 pub fn max<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut cur_max = f64::NEG_INFINITY;
@@ -85,7 +85,7 @@ pub fn max<'gc>(
 
 pub fn min<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut cur_min = f64::INFINITY;
@@ -102,7 +102,7 @@ pub fn min<'gc>(
 
 pub fn pow<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let n = args
@@ -118,7 +118,7 @@ pub fn pow<'gc>(
 
 pub fn random<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(activation.context.rng.gen_range(0.0f64..1.0f64).into())

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -15,10 +15,10 @@ use gc_arena::GcCell;
 /// Implements `Namespace`'s instance initializer.
 pub fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|this| this.as_namespace_object()) {
+    if let Some(this) = this.as_namespace_object() {
         let uri_value = match args {
             [_prefix, uri] => {
                 avm2_stub_constructor!(activation, "Namespace", "Namespace prefix not supported");
@@ -47,7 +47,7 @@ pub fn instance_init<'gc>(
 
 fn class_call<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_constructor!(activation, "Namespace");
@@ -57,12 +57,10 @@ fn class_call<'gc>(
 /// Implements `Namespace`'s native instance initializer.
 pub fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, args)?;
-    }
+    activation.super_init(this, args)?;
 
     Ok(Value::Undefined)
 }
@@ -70,7 +68,7 @@ pub fn native_instance_init<'gc>(
 /// Implements `Namespace`'s class initializer.
 pub fn class_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)
@@ -79,10 +77,10 @@ pub fn class_init<'gc>(
 /// Implements `Namespace.prefix`'s getter
 pub fn prefix<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if this.and_then(|t| t.as_namespace_object()).is_some() {
+    if this.as_namespace_object().is_some() {
         avm2_stub_getter!(activation, "Namespace", "prefix");
         return Ok("".into());
     }
@@ -93,10 +91,10 @@ pub fn prefix<'gc>(
 /// Implements `Namespace.uri`'s getter
 pub fn uri<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(o) = this.and_then(|t| t.as_namespace_object()) {
+    if let Some(o) = this.as_namespace_object() {
         return Ok(o.namespace().as_uri().into());
     }
 

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -13,19 +13,17 @@ use gc_arena::GcCell;
 /// Implements `Number`'s instance initializer.
 fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
-            if matches!(*prim, Value::Undefined | Value::Null) {
-                *prim = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Number(0.0))
-                    .coerce_to_number(activation)?
-                    .into();
-            }
+    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
+        if matches!(*prim, Value::Undefined | Value::Null) {
+            *prim = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Number(0.0))
+                .coerce_to_number(activation)?
+                .into();
         }
     }
 
@@ -35,12 +33,10 @@ fn instance_init<'gc>(
 /// Implements `Number`'s native instance initializer.
 fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, args)?;
-    }
+    activation.super_init(this, args)?;
 
     Ok(Value::Undefined)
 }
@@ -48,81 +44,79 @@ fn native_instance_init<'gc>(
 /// Implements `Number`'s class initializer.
 fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let scope = activation.create_scopechain();
-        let gc_context = activation.context.gc_context;
-        let this_class = this.as_class_object().unwrap();
-        let number_proto = this_class.prototype();
+    let scope = activation.create_scopechain();
+    let gc_context = activation.context.gc_context;
+    let this_class = this.as_class_object().unwrap();
+    let number_proto = this_class.prototype();
 
-        number_proto.set_string_property_local(
-            "toExponential",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_exponential, "toExponential", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+    number_proto.set_string_property_local(
+        "toExponential",
+        FunctionObject::from_method(
             activation,
-        )?;
-        number_proto.set_string_property_local(
-            "toFixed",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_fixed, "toFixed", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_exponential, "toExponential", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    number_proto.set_string_property_local(
+        "toFixed",
+        FunctionObject::from_method(
             activation,
-        )?;
-        number_proto.set_string_property_local(
-            "toPrecision",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_precision, "toPrecision", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_fixed, "toFixed", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    number_proto.set_string_property_local(
+        "toPrecision",
+        FunctionObject::from_method(
             activation,
-        )?;
-        number_proto.set_string_property_local(
-            "toString",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_string, "toString", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_precision, "toPrecision", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    number_proto.set_string_property_local(
+        "toString",
+        FunctionObject::from_method(
             activation,
-        )?;
-        number_proto.set_string_property_local(
-            "valueOf",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(value_of, "valueOf", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_string, "toString", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    number_proto.set_string_property_local(
+        "valueOf",
+        FunctionObject::from_method(
             activation,
-        )?;
-        number_proto.set_local_property_is_enumerable(gc_context, "toExponential".into(), false);
-        number_proto.set_local_property_is_enumerable(gc_context, "toFixed".into(), false);
-        number_proto.set_local_property_is_enumerable(gc_context, "toPrecision".into(), false);
-        number_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
-        number_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
-    }
+            Method::from_builtin(value_of, "valueOf", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    number_proto.set_local_property_is_enumerable(gc_context, "toExponential".into(), false);
+    number_proto.set_local_property_is_enumerable(gc_context, "toFixed".into(), false);
+    number_proto.set_local_property_is_enumerable(gc_context, "toPrecision".into(), false);
+    number_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
+    number_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
 
     Ok(Value::Undefined)
 }
@@ -130,13 +124,11 @@ fn class_init<'gc>(
 /// Implements `Number.toLocaleString`
 fn to_locale_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            return Ok(this.coerce_to_string(activation)?.into());
-        }
+    if let Some(this) = this.as_primitive() {
+        return Ok(this.coerce_to_string(activation)?.into());
     }
 
     Ok(Value::Undefined)
@@ -145,31 +137,29 @@ fn to_locale_string<'gc>(
 /// Implements `Number.toExponential`
 fn to_exponential<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Number(number) = *this {
-                let digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Number(number) = *this {
+            let digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if digits > 20 {
-                    return Err("toExponential can only print with 0 through 20 digits.".into());
-                }
-
-                return Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("{number:.digits$e}")
-                        .replace('e', "e+")
-                        .replace("e+-", "e-")
-                        .replace("e+0", ""),
-                )
-                .into());
+            if digits > 20 {
+                return Err("toExponential can only print with 0 through 20 digits.".into());
             }
+
+            return Ok(AvmString::new_utf8(
+                activation.context.gc_context,
+                format!("{number:.digits$e}")
+                    .replace('e', "e+")
+                    .replace("e+-", "e-")
+                    .replace("e+0", ""),
+            )
+            .into());
         }
     }
 
@@ -179,28 +169,26 @@ fn to_exponential<'gc>(
 /// Implements `Number.toFixed`
 fn to_fixed<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Number(number) = *this {
-                let digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Number(number) = *this {
+            let digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if digits > 20 {
-                    return Err("toFixed can only print with 0 through 20 digits.".into());
-                }
-
-                return Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("{number:.digits$}"),
-                )
-                .into());
+            if digits > 20 {
+                return Err("toFixed can only print with 0 through 20 digits.".into());
             }
+
+            return Ok(AvmString::new_utf8(
+                activation.context.gc_context,
+                format!("{number:.digits$}"),
+            )
+            .into());
         }
     }
 
@@ -241,24 +229,22 @@ pub fn print_with_precision<'gc>(
 /// Implements `Number.toPrecision`
 fn to_precision<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Number(number) = *this {
-                let wanted_digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Number(number) = *this {
+            let wanted_digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if wanted_digits < 1 || wanted_digits > 21 {
-                    return Err("toPrecision can only print with 1 through 21 digits.".into());
-                }
-
-                return Ok(print_with_precision(activation, number, wanted_digits)?.into());
+            if wanted_digits < 1 || wanted_digits > 21 {
+                return Err("toPrecision can only print with 1 through 21 digits.".into());
             }
+
+            return Ok(print_with_precision(activation, number, wanted_digits)?.into());
         }
     }
 
@@ -310,24 +296,22 @@ pub fn print_with_radix<'gc>(
 /// Implements `Number.toString`
 fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Number(number) = *this {
-                let radix = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(10))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Number(number) = *this {
+            let radix = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(10))
+                .coerce_to_u32(activation)? as usize;
 
-                if radix < 2 || radix > 36 {
-                    return Err("toString can only print in bases 2 thru 36.".into());
-                }
-
-                return Ok(print_with_radix(activation, number, radix)?.into());
+            if radix < 2 || radix > 36 {
+                return Err("toString can only print in bases 2 thru 36.".into());
             }
+
+            return Ok(print_with_radix(activation, number, radix)?.into());
         }
     }
 
@@ -337,13 +321,11 @@ fn to_string<'gc>(
 /// Implements `Number.valueOf`
 fn value_of<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            return Ok(*this);
-        }
+    if let Some(this) = this.as_primitive() {
+        return Ok(*this);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/object.rs
+++ b/core/src/avm2/globals/object.rs
@@ -14,7 +14,7 @@ use gc_arena::GcCell;
 /// Implements `Object`'s instance initializer.
 pub fn instance_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)
@@ -22,7 +22,7 @@ pub fn instance_init<'gc>(
 
 fn class_call<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this_class = activation.subclass_object().unwrap();
@@ -40,120 +40,114 @@ fn class_call<'gc>(
 /// Implements `Object`'s class initializer
 pub fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let scope = activation.create_scopechain();
-        let gc_context = activation.context.gc_context;
-        let this_class = this.as_class_object().unwrap();
-        let object_proto = this_class.prototype();
+    let scope = activation.create_scopechain();
+    let gc_context = activation.context.gc_context;
+    let this_class = this.as_class_object().unwrap();
+    let object_proto = this_class.prototype();
 
-        object_proto.set_string_property_local(
-            "hasOwnProperty",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(has_own_property, "hasOwnProperty", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+    object_proto.set_string_property_local(
+        "hasOwnProperty",
+        FunctionObject::from_method(
             activation,
-        )?;
-        object_proto.set_string_property_local(
-            "propertyIsEnumerable",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(property_is_enumerable, "propertyIsEnumerable", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(has_own_property, "hasOwnProperty", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    object_proto.set_string_property_local(
+        "propertyIsEnumerable",
+        FunctionObject::from_method(
             activation,
-        )?;
-        object_proto.set_string_property_local(
-            "setPropertyIsEnumerable",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(
-                    set_property_is_enumerable,
-                    "setPropertyIsEnumerable",
-                    gc_context,
-                ),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(property_is_enumerable, "propertyIsEnumerable", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    object_proto.set_string_property_local(
+        "setPropertyIsEnumerable",
+        FunctionObject::from_method(
             activation,
-        )?;
-        object_proto.set_string_property_local(
-            "isPrototypeOf",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(is_prototype_of, "isPrototypeOf", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(
+                set_property_is_enumerable,
+                "setPropertyIsEnumerable",
+                gc_context,
+            ),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    object_proto.set_string_property_local(
+        "isPrototypeOf",
+        FunctionObject::from_method(
             activation,
-        )?;
-        object_proto.set_string_property_local(
-            "toString",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_string, "toString", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(is_prototype_of, "isPrototypeOf", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    object_proto.set_string_property_local(
+        "toString",
+        FunctionObject::from_method(
             activation,
-        )?;
-        object_proto.set_string_property_local(
-            "toLocaleString",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_locale_string, "toLocaleString", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_string, "toString", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    object_proto.set_string_property_local(
+        "toLocaleString",
+        FunctionObject::from_method(
             activation,
-        )?;
-        object_proto.set_string_property_local(
-            "valueOf",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(value_of, "valueOf", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_locale_string, "toLocaleString", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    object_proto.set_string_property_local(
+        "valueOf",
+        FunctionObject::from_method(
             activation,
-        )?;
+            Method::from_builtin(value_of, "valueOf", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
 
-        object_proto.set_local_property_is_enumerable(gc_context, "hasOwnProperty".into(), false);
-        object_proto.set_local_property_is_enumerable(
-            gc_context,
-            "propertyIsEnumerable".into(),
-            false,
-        );
-        object_proto.set_local_property_is_enumerable(
-            gc_context,
-            "setPropertyIsEnumerable".into(),
-            false,
-        );
-        object_proto.set_local_property_is_enumerable(gc_context, "isPrototypeOf".into(), false);
-        object_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
-        object_proto.set_local_property_is_enumerable(gc_context, "toLocaleString".into(), false);
-        object_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
-    }
+    object_proto.set_local_property_is_enumerable(gc_context, "hasOwnProperty".into(), false);
+    object_proto.set_local_property_is_enumerable(gc_context, "propertyIsEnumerable".into(), false);
+    object_proto.set_local_property_is_enumerable(
+        gc_context,
+        "setPropertyIsEnumerable".into(),
+        false,
+    );
+    object_proto.set_local_property_is_enumerable(gc_context, "isPrototypeOf".into(), false);
+    object_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
+    object_proto.set_local_property_is_enumerable(gc_context, "toLocaleString".into(), false);
+    object_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
 
     Ok(Value::Undefined)
 }
@@ -161,51 +155,36 @@ pub fn class_init<'gc>(
 /// Implements `Object.prototype.toString`
 fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        this.to_string(activation)
-    } else {
-        Ok(Value::Undefined)
-    }
+    this.to_string(activation)
 }
 
 /// Implements `Object.prototype.toLocaleString`
 fn to_locale_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        this.to_locale_string(activation)
-    } else {
-        Ok(Value::Undefined)
-    }
+    this.to_locale_string(activation)
 }
 
 /// Implements `Object.prototype.valueOf`
 fn value_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        this.value_of(activation.context.gc_context)
-    } else {
-        Ok(Value::Undefined)
-    }
+    this.value_of(activation.context.gc_context)
 }
 
 /// `Object.prototype.hasOwnProperty`
 pub fn has_own_property<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this: Result<Object<'gc>, Error<'gc>> =
-        this.ok_or_else(|| "No valid this parameter".into());
-    let this = this?;
     let name: Result<&Value<'gc>, Error<'gc>> =
         args.get(0).ok_or_else(|| "No name specified".into());
     let name = name?.coerce_to_string(activation)?;
@@ -216,16 +195,13 @@ pub fn has_own_property<'gc>(
 /// `Object.prototype.isPrototypeOf`
 pub fn is_prototype_of<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let search_proto: Result<Object<'gc>, Error<'gc>> =
-        this.ok_or_else(|| "No valid this parameter".into());
-    let search_proto = search_proto?;
     let mut target_proto = args.get(0).cloned().unwrap_or(Value::Undefined);
 
     while let Value::Object(proto) = target_proto {
-        if Object::ptr_eq(search_proto, proto) {
+        if Object::ptr_eq(this, proto) {
             return Ok(true.into());
         }
 
@@ -238,12 +214,9 @@ pub fn is_prototype_of<'gc>(
 /// `Object.prototype.propertyIsEnumerable`
 pub fn property_is_enumerable<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this: Result<Object<'gc>, Error<'gc>> =
-        this.ok_or_else(|| "No valid this parameter".into());
-    let this = this?;
     let name: Result<&Value<'gc>, Error<'gc>> =
         args.get(0).ok_or_else(|| "No name specified".into());
     let name = name?.coerce_to_string(activation)?;
@@ -254,12 +227,9 @@ pub fn property_is_enumerable<'gc>(
 /// `Object.prototype.setPropertyIsEnumerable`
 pub fn set_property_is_enumerable<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this: Result<Object<'gc>, Error<'gc>> =
-        this.ok_or_else(|| "No valid this parameter".into());
-    let this = this?;
     let name: Result<&Value<'gc>, Error<'gc>> =
         args.get(0).ok_or_else(|| "No name specified".into());
     let name = name?.coerce_to_string(activation)?;
@@ -274,7 +244,7 @@ pub fn set_property_is_enumerable<'gc>(
 /// Undocumented `Object.init`, which is a no-op
 pub fn init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/q_name.rs
+++ b/core/src/avm2/globals/q_name.rs
@@ -11,10 +11,10 @@ pub use crate::avm2::object::q_name_allocator;
 /// Implements `QName`'s `init` method, which is called from the constructor.
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap().as_qname_object().unwrap();
+    let this = this.as_qname_object().unwrap();
     let namespace = if !matches!(args[1], Value::Undefined) {
         let ns_arg = args.get(0).cloned().unwrap();
         let local_arg = args.get(1).cloned().unwrap_or(Value::Undefined);
@@ -61,10 +61,10 @@ pub fn init<'gc>(
 /// Implements `QName.localName`'s getter
 pub fn get_local_name<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_qname_object()) {
+    if let Some(this) = this.as_qname_object() {
         return Ok(this.local_name().into());
     }
 
@@ -74,10 +74,10 @@ pub fn get_local_name<'gc>(
 /// Implements `QName.uri`'s getter
 pub fn get_uri<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_qname_object()) {
+    if let Some(this) = this.as_qname_object() {
         return Ok(this.uri().map(Value::from).unwrap_or(Value::Null));
     }
 
@@ -87,10 +87,10 @@ pub fn get_uri<'gc>(
 /// Implements `QName.AS3::toString` and `QName.prototype.toString`
 pub fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this.and_then(|t| t.as_qname_object()) {
+    if let Some(this) = this.as_qname_object() {
         return Ok(this.name().as_uri(activation.context.gc_context).into());
     }
 

--- a/core/src/avm2/globals/reg_exp.rs
+++ b/core/src/avm2/globals/reg_exp.rs
@@ -13,54 +13,52 @@ pub use crate::avm2::object::reg_exp_allocator;
 /// Implements `RegExp`'s `init` method, which is called from the constructor
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut regexp) = this.as_regexp_mut(activation.context.gc_context) {
-            let source: AvmString<'gc> = match args.get(0) {
-                Some(Value::Undefined) => "".into(),
-                Some(Value::Object(Object::RegExpObject(o))) => {
-                    if !matches!(args.get(1), Some(Value::Undefined)) {
-                        return Err(Error::AvmError(type_error(
-                            activation,
-                            "Error #1100: Cannot supply flags when constructing one RegExp from another.",
-                            1100,
-                        )?));
-                    }
-                    let other = o.as_regexp().unwrap();
-                    regexp.set_source(other.source());
-                    regexp.set_flags(other.flags());
-                    return Ok(Value::Undefined);
+    if let Some(mut regexp) = this.as_regexp_mut(activation.context.gc_context) {
+        let source: AvmString<'gc> = match args.get(0) {
+            Some(Value::Undefined) => "".into(),
+            Some(Value::Object(Object::RegExpObject(o))) => {
+                if !matches!(args.get(1), Some(Value::Undefined)) {
+                    return Err(Error::AvmError(type_error(
+                        activation,
+                        "Error #1100: Cannot supply flags when constructing one RegExp from another.",
+                        1100,
+                    )?));
                 }
-                arg => arg
-                    .unwrap_or(&Value::String("".into()))
-                    .coerce_to_string(activation)?,
-            };
-
-            regexp.set_source(source);
-
-            let flag_chars = match args.get(1) {
-                Some(Value::Undefined) => "".into(),
-                arg => arg
-                    .unwrap_or(&Value::String("".into()))
-                    .coerce_to_string(activation)?,
-            };
-
-            let mut flags = RegExpFlags::empty();
-            for c in &flag_chars {
-                flags |= match u8::try_from(c) {
-                    Ok(b's') => RegExpFlags::DOTALL,
-                    Ok(b'x') => RegExpFlags::EXTENDED,
-                    Ok(b'g') => RegExpFlags::GLOBAL,
-                    Ok(b'i') => RegExpFlags::IGNORE_CASE,
-                    Ok(b'm') => RegExpFlags::MULTILINE,
-                    _ => continue,
-                };
+                let other = o.as_regexp().unwrap();
+                regexp.set_source(other.source());
+                regexp.set_flags(other.flags());
+                return Ok(Value::Undefined);
             }
+            arg => arg
+                .unwrap_or(&Value::String("".into()))
+                .coerce_to_string(activation)?,
+        };
 
-            regexp.set_flags(flags);
+        regexp.set_source(source);
+
+        let flag_chars = match args.get(1) {
+            Some(Value::Undefined) => "".into(),
+            arg => arg
+                .unwrap_or(&Value::String("".into()))
+                .coerce_to_string(activation)?,
+        };
+
+        let mut flags = RegExpFlags::empty();
+        for c in &flag_chars {
+            flags |= match u8::try_from(c) {
+                Ok(b's') => RegExpFlags::DOTALL,
+                Ok(b'x') => RegExpFlags::EXTENDED,
+                Ok(b'g') => RegExpFlags::GLOBAL,
+                Ok(b'i') => RegExpFlags::IGNORE_CASE,
+                Ok(b'm') => RegExpFlags::MULTILINE,
+                _ => continue,
+            };
         }
+
+        regexp.set_flags(flags);
     }
 
     Ok(Value::Undefined)
@@ -68,7 +66,7 @@ pub fn init<'gc>(
 
 pub fn call_handler<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this_class = activation.subclass_object().unwrap();
@@ -85,13 +83,11 @@ pub fn call_handler<'gc>(
 /// Implements `RegExp.dotall`
 pub fn get_dotall<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(regexp) = this.as_regexp() {
-            return Ok(regexp.flags().contains(RegExpFlags::DOTALL).into());
-        }
+    if let Some(regexp) = this.as_regexp() {
+        return Ok(regexp.flags().contains(RegExpFlags::DOTALL).into());
     }
 
     Ok(Value::Undefined)
@@ -100,13 +96,11 @@ pub fn get_dotall<'gc>(
 /// Implements `RegExp.extended`
 pub fn get_extended<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(regexp) = this.as_regexp() {
-            return Ok(regexp.flags().contains(RegExpFlags::EXTENDED).into());
-        }
+    if let Some(regexp) = this.as_regexp() {
+        return Ok(regexp.flags().contains(RegExpFlags::EXTENDED).into());
     }
 
     Ok(Value::Undefined)
@@ -115,13 +109,11 @@ pub fn get_extended<'gc>(
 /// Implements `RegExp.global`
 pub fn get_global<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(regexp) = this.as_regexp() {
-            return Ok(regexp.flags().contains(RegExpFlags::GLOBAL).into());
-        }
+    if let Some(regexp) = this.as_regexp() {
+        return Ok(regexp.flags().contains(RegExpFlags::GLOBAL).into());
     }
 
     Ok(Value::Undefined)
@@ -130,13 +122,11 @@ pub fn get_global<'gc>(
 /// Implements `RegExp.ignoreCase`
 pub fn get_ignore_case<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(regexp) = this.as_regexp() {
-            return Ok(regexp.flags().contains(RegExpFlags::IGNORE_CASE).into());
-        }
+    if let Some(regexp) = this.as_regexp() {
+        return Ok(regexp.flags().contains(RegExpFlags::IGNORE_CASE).into());
     }
 
     Ok(Value::Undefined)
@@ -145,13 +135,11 @@ pub fn get_ignore_case<'gc>(
 /// Implements `RegExp.multiline`
 pub fn get_multiline<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(regexp) = this.as_regexp() {
-            return Ok(regexp.flags().contains(RegExpFlags::MULTILINE).into());
-        }
+    if let Some(regexp) = this.as_regexp() {
+        return Ok(regexp.flags().contains(RegExpFlags::MULTILINE).into());
     }
 
     Ok(Value::Undefined)
@@ -160,13 +148,11 @@ pub fn get_multiline<'gc>(
 /// Implements `RegExp.lastIndex`'s getter
 pub fn get_last_index<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(re) = this.as_regexp() {
-            return Ok(re.last_index().into());
-        }
+    if let Some(re) = this.as_regexp() {
+        return Ok(re.last_index().into());
     }
 
     Ok(Value::Undefined)
@@ -175,17 +161,15 @@ pub fn get_last_index<'gc>(
 /// Implements `RegExp.lastIndex`'s setter
 pub fn set_last_index<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
-            let i = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_u32(activation)?;
-            re.set_last_index(i as usize);
-        }
+    if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
+        let i = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_u32(activation)?;
+        re.set_last_index(i as usize);
     }
 
     Ok(Value::Undefined)
@@ -194,13 +178,11 @@ pub fn set_last_index<'gc>(
 /// Implements `RegExp.source`
 pub fn get_source<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(re) = this.as_regexp() {
-            return Ok(re.source().into());
-        }
+    if let Some(re) = this.as_regexp() {
+        return Ok(re.source().into());
     }
 
     Ok(Value::Undefined)
@@ -209,40 +191,38 @@ pub fn get_source<'gc>(
 /// Implements `RegExp.exec`
 pub fn exec<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
-            let text = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_string(activation)?;
+    if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
+        let text = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_string(activation)?;
 
-            let (storage, index) = match re.exec(text) {
-                Some(matched) => {
-                    let substrings = matched
-                        .groups()
-                        .map(|range| range.map(|r| WString::from(&text[r])));
+        let (storage, index) = match re.exec(text) {
+            Some(matched) => {
+                let substrings = matched
+                    .groups()
+                    .map(|range| range.map(|r| WString::from(&text[r])));
 
-                    let storage = ArrayStorage::from_iter(substrings.map(|s| match s {
-                        None => Value::Undefined,
-                        Some(s) => AvmString::new(activation.context.gc_context, s).into(),
-                    }));
+                let storage = ArrayStorage::from_iter(substrings.map(|s| match s {
+                    None => Value::Undefined,
+                    Some(s) => AvmString::new(activation.context.gc_context, s).into(),
+                }));
 
-                    (storage, matched.start())
-                }
-                None => return Ok(Value::Null),
-            };
+                (storage, matched.start())
+            }
+            None => return Ok(Value::Null),
+        };
 
-            let object = ArrayObject::from_storage(activation, storage)?;
+        let object = ArrayObject::from_storage(activation, storage)?;
 
-            object.set_string_property_local("index", Value::Number(index as f64), activation)?;
+        object.set_string_property_local("index", Value::Number(index as f64), activation)?;
 
-            object.set_string_property_local("input", text.into(), activation)?;
+        object.set_string_property_local("input", text.into(), activation)?;
 
-            return Ok(object.into());
-        }
+        return Ok(object.into());
     }
 
     Ok(Value::Undefined)
@@ -251,17 +231,15 @@ pub fn exec<'gc>(
 /// Implements `RegExp.test`
 pub fn test<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
-            let text = args
-                .get(0)
-                .unwrap_or(&Value::Undefined)
-                .coerce_to_string(activation)?;
-            return Ok(re.test(text).into());
-        }
+    if let Some(mut re) = this.as_regexp_mut(activation.context.gc_context) {
+        let text = args
+            .get(0)
+            .unwrap_or(&Value::Undefined)
+            .coerce_to_string(activation)?;
+        return Ok(re.test(text).into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -41,20 +41,18 @@ const PUBLIC_INSTANCE_AND_PROTO_METHODS: &[(&str, NativeMethodImpl)] = &[
 /// Implements `String`'s instance initializer.
 pub fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
+    activation.super_init(this, &[])?;
 
-        if let Some(mut value) = this.as_primitive_mut(activation.context.gc_context) {
-            if !matches!(*value, Value::String(_)) {
-                *value = args
-                    .get(0)
-                    .unwrap_or(&Value::String("".into()))
-                    .coerce_to_string(activation)?
-                    .into();
-            }
+    if let Some(mut value) = this.as_primitive_mut(activation.context.gc_context) {
+        if !matches!(*value, Value::String(_)) {
+            *value = args
+                .get(0)
+                .unwrap_or(&Value::String("".into()))
+                .coerce_to_string(activation)?
+                .into();
         }
     }
 
@@ -64,37 +62,35 @@ pub fn instance_init<'gc>(
 /// Implements `String`'s class initializer.
 pub fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let scope = activation.create_scopechain();
-        let gc_context = activation.context.gc_context;
-        let this_class = this.as_class_object().unwrap();
-        let proto = this_class.prototype();
+    let scope = activation.create_scopechain();
+    let gc_context = activation.context.gc_context;
+    let this_class = this.as_class_object().unwrap();
+    let proto = this_class.prototype();
 
-        for (name, method) in PUBLIC_INSTANCE_AND_PROTO_METHODS {
-            proto.set_string_property_local(
-                *name,
-                FunctionObject::from_method(
-                    activation,
-                    Method::from_builtin(*method, name, gc_context),
-                    scope,
-                    None,
-                    Some(this_class),
-                )
-                .into(),
+    for (name, method) in PUBLIC_INSTANCE_AND_PROTO_METHODS {
+        proto.set_string_property_local(
+            *name,
+            FunctionObject::from_method(
                 activation,
-            )?;
-            proto.set_local_property_is_enumerable(gc_context, (*name).into(), false);
-        }
+                Method::from_builtin(*method, name, gc_context),
+                scope,
+                None,
+                Some(this_class),
+            )
+            .into(),
+            activation,
+        )?;
+        proto.set_local_property_is_enumerable(gc_context, (*name).into(), false);
     }
     Ok(Value::Undefined)
 }
 
 pub fn call_handler<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(args
@@ -107,13 +103,11 @@ pub fn call_handler<'gc>(
 /// Implements `length` property's getter
 fn length<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Value::String(s) = this.value_of(activation.context.gc_context)? {
-            return Ok(s.len().into());
-        }
+    if let Value::String(s) = this.value_of(activation.context.gc_context)? {
+        return Ok(s.len().into());
     }
 
     Ok(Value::Undefined)
@@ -122,28 +116,26 @@ fn length<'gc>(
 /// Implements `String.charAt`
 fn char_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Value::String(s) = this.value_of(activation.context.gc_context)? {
-            // This function takes Number, so if we use coerce_to_i32 instead of coerce_to_number, the value may overflow.
-            let n = args
-                .get(0)
-                .unwrap_or(&Value::Number(0.0))
-                .coerce_to_number(activation)?;
-            if n < 0.0 {
-                return Ok("".into());
-            }
-
-            let index = if !n.is_nan() { n as usize } else { 0 };
-            let ret = s
-                .get(index)
-                .map(WString::from_unit)
-                .map(|s| AvmString::new(activation.context.gc_context, s))
-                .unwrap_or_default();
-            return Ok(ret.into());
+    if let Value::String(s) = this.value_of(activation.context.gc_context)? {
+        // This function takes Number, so if we use coerce_to_i32 instead of coerce_to_number, the value may overflow.
+        let n = args
+            .get(0)
+            .unwrap_or(&Value::Number(0.0))
+            .coerce_to_number(activation)?;
+        if n < 0.0 {
+            return Ok("".into());
         }
+
+        let index = if !n.is_nan() { n as usize } else { 0 };
+        let ret = s
+            .get(index)
+            .map(WString::from_unit)
+            .map(|s| AvmString::new(activation.context.gc_context, s))
+            .unwrap_or_default();
+        return Ok(ret.into());
     }
 
     Ok(Value::Undefined)
@@ -152,24 +144,22 @@ fn char_at<'gc>(
 /// Implements `String.charCodeAt`
 fn char_code_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Value::String(s) = this.value_of(activation.context.gc_context)? {
-            // This function takes Number, so if we use coerce_to_i32 instead of coerce_to_number, the value may overflow.
-            let n = args
-                .get(0)
-                .unwrap_or(&Value::Number(0.0))
-                .coerce_to_number(activation)?;
-            if n < 0.0 {
-                return Ok(f64::NAN.into());
-            }
-
-            let index = if !n.is_nan() { n as usize } else { 0 };
-            let ret = s.get(index).map(f64::from).unwrap_or(f64::NAN);
-            return Ok(ret.into());
+    if let Value::String(s) = this.value_of(activation.context.gc_context)? {
+        // This function takes Number, so if we use coerce_to_i32 instead of coerce_to_number, the value may overflow.
+        let n = args
+            .get(0)
+            .unwrap_or(&Value::Number(0.0))
+            .coerce_to_number(activation)?;
+        if n < 0.0 {
+            return Ok(f64::NAN.into());
         }
+
+        let index = if !n.is_nan() { n as usize } else { 0 };
+        let ret = s.get(index).map(f64::from).unwrap_or(f64::NAN);
+        return Ok(ret.into());
     }
 
     Ok(Value::Undefined)
@@ -178,25 +168,22 @@ fn char_code_at<'gc>(
 /// Implements `String.concat`
 fn concat<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let mut ret = WString::from(Value::from(this).coerce_to_string(activation)?.as_wstr());
-        for arg in args {
-            let s = arg.coerce_to_string(activation)?;
-            ret.push_str(&s);
-        }
-        return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    let mut ret = WString::from(Value::from(this).coerce_to_string(activation)?.as_wstr());
+    for arg in args {
+        let s = arg.coerce_to_string(activation)?;
+        ret.push_str(&s);
     }
 
-    Ok(Value::Undefined)
+    Ok(AvmString::new(activation.context.gc_context, ret).into())
 }
 
 /// Implements `String.fromCharCode`
 fn from_char_code<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let mut out = WString::with_capacity(args.len(), false);
@@ -214,159 +201,145 @@ fn from_char_code<'gc>(
 /// Implements `String.indexOf`
 fn index_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this = Value::from(this).coerce_to_string(activation)?;
-        let pattern = match args.get(0) {
-            None => return Ok(Value::Undefined),
-            Some(s) => s.clone().coerce_to_string(activation)?,
-        };
+    let this = Value::from(this).coerce_to_string(activation)?;
+    let pattern = match args.get(0) {
+        None => return Ok(Value::Undefined),
+        Some(s) => s.clone().coerce_to_string(activation)?,
+    };
 
-        let start_index = match args.get(1) {
-            None | Some(Value::Undefined) => 0,
-            Some(n) => n.coerce_to_i32(activation)?.max(0) as usize,
-        };
+    let start_index = match args.get(1) {
+        None | Some(Value::Undefined) => 0,
+        Some(n) => n.coerce_to_i32(activation)?.max(0) as usize,
+    };
 
-        return this
-            .slice(start_index..)
-            .and_then(|s| s.find(&pattern))
-            .map(|i| Ok((i + start_index).into()))
-            .unwrap_or_else(|| Ok((-1).into())); // Out of range or not found
-    }
-
-    Ok(Value::Undefined)
+    return this
+        .slice(start_index..)
+        .and_then(|s| s.find(&pattern))
+        .map(|i| Ok((i + start_index).into()))
+        .unwrap_or_else(|| Ok((-1).into())); // Out of range or not found
 }
 
 /// Implements `String.lastIndexOf`
 fn last_index_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this = Value::from(this).coerce_to_string(activation)?;
-        let pattern = match args.get(0) {
-            None => return Ok(Value::Undefined),
-            Some(s) => s.clone().coerce_to_string(activation)?,
-        };
+    let this = Value::from(this).coerce_to_string(activation)?;
+    let pattern = match args.get(0) {
+        None => return Ok(Value::Undefined),
+        Some(s) => s.clone().coerce_to_string(activation)?,
+    };
 
-        let start_index = match args.get(1) {
-            None | Some(Value::Undefined) => this.len(),
-            Some(n) => match usize::try_from(n.coerce_to_i32(activation)?) {
-                Ok(n) => n + pattern.len(),
-                Err(_) => return Ok((-1).into()), // Bail out on negative indices.
-            },
-        };
+    let start_index = match args.get(1) {
+        None | Some(Value::Undefined) => this.len(),
+        Some(n) => match usize::try_from(n.coerce_to_i32(activation)?) {
+            Ok(n) => n + pattern.len(),
+            Err(_) => return Ok((-1).into()), // Bail out on negative indices.
+        },
+    };
 
-        return this
-            .slice(..start_index)
-            .unwrap_or(&this)
-            .rfind(&pattern)
-            .map(|i| Ok(i.into()))
-            .unwrap_or_else(|| Ok((-1).into())); // Not found
-    }
-
-    Ok(Value::Undefined)
+    return this
+        .slice(..start_index)
+        .unwrap_or(&this)
+        .rfind(&pattern)
+        .map(|i| Ok(i.into()))
+        .unwrap_or_else(|| Ok((-1).into())); // Not found
 }
 
 /// Implements String.localeCompare
 /// NOTE: Despite the declaration of this function in the documentation, FP does not support multiple strings in comparison
 fn locale_compare<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this = Value::from(this).coerce_to_string(activation)?;
-        let other = match args.get(0) {
-            None => Value::Undefined.coerce_to_string(activation)?,
-            Some(s) => s.clone().coerce_to_string(activation)?,
-        };
+    let this = Value::from(this).coerce_to_string(activation)?;
+    let other = match args.get(0) {
+        None => Value::Undefined.coerce_to_string(activation)?,
+        Some(s) => s.clone().coerce_to_string(activation)?,
+    };
 
-        for (tc, oc) in this.iter().zip(other.iter()) {
-            let res = (tc as i32) - (oc as i32);
-            if res != 0 {
-                return Ok(Value::Integer(res));
-            }
+    for (tc, oc) in this.iter().zip(other.iter()) {
+        let res = (tc as i32) - (oc as i32);
+        if res != 0 {
+            return Ok(Value::Integer(res));
         }
-
-        if this.len() < other.len() {
-            return Ok(Value::Integer(-1));
-        }
-
-        if this.len() > other.len() {
-            return Ok(Value::Integer(1));
-        }
-
-        return Ok(Value::Integer(0));
     }
 
-    Ok(Value::Undefined)
+    if this.len() < other.len() {
+        return Ok(Value::Integer(-1));
+    }
+
+    if this.len() > other.len() {
+        return Ok(Value::Integer(1));
+    }
+
+    return Ok(Value::Integer(0));
 }
 
 /// Implements `String.match`
 fn match_s<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let (Some(this), pattern) = (this, args.get(0).unwrap_or(&Value::Undefined)) {
-        let this = Value::from(this).coerce_to_string(activation)?;
+    let pattern = args.get(0).unwrap_or(&Value::Undefined);
+    let this = Value::from(this).coerce_to_string(activation)?;
 
-        let regexp_class = activation.avm2().classes().regexp;
-        let pattern = if !pattern.is_of_type(activation, regexp_class) {
-            let string = pattern.coerce_to_string(activation)?;
-            regexp_class.construct(activation, &[Value::String(string)])?
+    let regexp_class = activation.avm2().classes().regexp;
+    let pattern = if !pattern.is_of_type(activation, regexp_class) {
+        let string = pattern.coerce_to_string(activation)?;
+        regexp_class.construct(activation, &[Value::String(string)])?
+    } else {
+        pattern.coerce_to_object(activation)?
+    };
+
+    if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc_context) {
+        let mut storage = ArrayStorage::new(0);
+        if regexp.flags().contains(RegExpFlags::GLOBAL) {
+            let mut last = regexp.last_index();
+            let old_last_index = regexp.last_index();
+            regexp.set_last_index(0);
+            while let Some(result) = regexp.exec(this) {
+                if regexp.last_index() == last {
+                    break;
+                }
+                storage.push(
+                    AvmString::new(activation.context.gc_context, &this[result.range()]).into(),
+                );
+                last = regexp.last_index();
+            }
+            regexp.set_last_index(0);
+            if old_last_index == regexp.last_index() {
+                regexp.set_last_index(1);
+            }
+            return Ok(ArrayObject::from_storage(activation, storage)
+                .unwrap()
+                .into());
         } else {
-            pattern.coerce_to_object(activation)?
-        };
+            let old = regexp.last_index();
+            regexp.set_last_index(0);
+            if let Some(result) = regexp.exec(this) {
+                let substrings = result.groups().map(|range| &this[range.unwrap_or(0..0)]);
 
-        if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc_context) {
-            let mut storage = ArrayStorage::new(0);
-            if regexp.flags().contains(RegExpFlags::GLOBAL) {
-                let mut last = regexp.last_index();
-                let old_last_index = regexp.last_index();
-                regexp.set_last_index(0);
-                while let Some(result) = regexp.exec(this) {
-                    if regexp.last_index() == last {
-                        break;
-                    }
-                    storage.push(
-                        AvmString::new(activation.context.gc_context, &this[result.range()]).into(),
-                    );
-                    last = regexp.last_index();
+                let mut storage = ArrayStorage::new(0);
+                for substring in substrings {
+                    storage.push(AvmString::new(activation.context.gc_context, substring).into());
                 }
-                regexp.set_last_index(0);
-                if old_last_index == regexp.last_index() {
-                    regexp.set_last_index(1);
-                }
+                regexp.set_last_index(old);
                 return Ok(ArrayObject::from_storage(activation, storage)
                     .unwrap()
                     .into());
             } else {
-                let old = regexp.last_index();
-                regexp.set_last_index(0);
-                if let Some(result) = regexp.exec(this) {
-                    let substrings = result.groups().map(|range| &this[range.unwrap_or(0..0)]);
-
-                    let mut storage = ArrayStorage::new(0);
-                    for substring in substrings {
-                        storage
-                            .push(AvmString::new(activation.context.gc_context, substring).into());
-                    }
-                    regexp.set_last_index(old);
-                    return Ok(ArrayObject::from_storage(activation, storage)
-                        .unwrap()
-                        .into());
-                } else {
-                    regexp.set_last_index(old);
-                    // If the pattern parameter is a String or a non-global regular expression
-                    // and no match is found, the method returns null
-                    return Ok(Value::Null);
-                }
-            };
+                regexp.set_last_index(old);
+                // If the pattern parameter is a String or a non-global regular expression
+                // and no match is found, the method returns null
+                return Ok(Value::Null);
+            }
         };
     }
 
@@ -376,82 +349,79 @@ fn match_s<'gc>(
 /// Implements `String.replace`
 fn replace<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this = Value::from(this).coerce_to_string(activation)?;
-        let pattern = args.get(0).unwrap_or(&Value::Undefined);
-        let replacement = args.get(1).unwrap_or(&Value::Undefined);
-        // Handles regex patterns.
-        if let Some(mut regexp) = pattern
-            .as_object()
-            .as_ref()
-            .and_then(|o| o.as_regexp_mut(activation.context.gc_context))
-        {
-            // Replacement is either a function or treatable as string.
-            if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
-                return Ok(regexp.replace_fn(activation, this, &f)?.into());
-            } else {
-                let replacement = replacement.coerce_to_string(activation)?;
-                return Ok(regexp.replace_string(activation, this, replacement)?.into());
-            }
-        }
-        // Handles patterns which are treatable as string.
-        let pattern = pattern.coerce_to_string(activation)?;
-        if let Some(position) = this.find(&pattern) {
-            let mut ret = WString::from(&this[..position]);
-            // Replacement is either a function or treatable as string.
-            if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
-                let args = [pattern.into(), position.into(), this.into()];
-                let v = f.call(Value::Null, &args, activation)?;
-                ret.push_str(v.coerce_to_string(activation)?.as_wstr());
-            } else {
-                let replacement = replacement.coerce_to_string(activation)?;
-                ret.push_str(&replacement);
-            }
-            ret.push_str(&this[position + pattern.len()..]);
-            return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    let this = Value::from(this).coerce_to_string(activation)?;
+    let pattern = args.get(0).unwrap_or(&Value::Undefined);
+    let replacement = args.get(1).unwrap_or(&Value::Undefined);
+    // Handles regex patterns.
+    if let Some(mut regexp) = pattern
+        .as_object()
+        .as_ref()
+        .and_then(|o| o.as_regexp_mut(activation.context.gc_context))
+    {
+        // Replacement is either a function or treatable as string.
+        if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
+            return Ok(regexp.replace_fn(activation, this, &f)?.into());
         } else {
-            return Ok(this.into());
+            let replacement = replacement.coerce_to_string(activation)?;
+            return Ok(regexp.replace_string(activation, this, replacement)?.into());
         }
     }
 
-    Ok(Value::Undefined)
+    // Handles patterns which are treatable as string.
+    let pattern = pattern.coerce_to_string(activation)?;
+    if let Some(position) = this.find(&pattern) {
+        let mut ret = WString::from(&this[..position]);
+        // Replacement is either a function or treatable as string.
+        if let Some(f) = replacement.as_object().and_then(|o| o.as_function_object()) {
+            let args = [pattern.into(), position.into(), this.into()];
+            let v = f.call(Value::Null, &args, activation)?;
+            ret.push_str(v.coerce_to_string(activation)?.as_wstr());
+        } else {
+            let replacement = replacement.coerce_to_string(activation)?;
+            ret.push_str(&replacement);
+        }
+        ret.push_str(&this[position + pattern.len()..]);
+
+        Ok(AvmString::new(activation.context.gc_context, ret).into())
+    } else {
+        Ok(this.into())
+    }
 }
 
 /// Implements `String.search`
 fn search<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let (Some(this), pattern) = (this, args.get(0).unwrap_or(&Value::Undefined)) {
-        let this = Value::from(this).coerce_to_string(activation)?;
+    let pattern = args.get(0).unwrap_or(&Value::Undefined);
+    let this = Value::from(this).coerce_to_string(activation)?;
 
-        let regexp_class = activation.avm2().classes().regexp;
-        let pattern = if !pattern.is_of_type(activation, regexp_class) {
-            let string = pattern.coerce_to_string(activation)?;
-            regexp_class.construct(activation, &[Value::String(string)])?
+    let regexp_class = activation.avm2().classes().regexp;
+    let pattern = if !pattern.is_of_type(activation, regexp_class) {
+        let string = pattern.coerce_to_string(activation)?;
+        regexp_class.construct(activation, &[Value::String(string)])?
+    } else {
+        pattern.coerce_to_object(activation)?
+    };
+
+    if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc_context) {
+        let old = regexp.last_index();
+        regexp.set_last_index(0);
+        if let Some(result) = regexp.exec(this) {
+            let found_index = result.groups().flatten().next().unwrap_or_default().start as i32;
+
+            regexp.set_last_index(old);
+            return Ok(Value::Integer(found_index));
         } else {
-            pattern.coerce_to_object(activation)?
-        };
-
-        if let Some(mut regexp) = pattern.as_regexp_mut(activation.context.gc_context) {
-            let old = regexp.last_index();
-            regexp.set_last_index(0);
-            if let Some(result) = regexp.exec(this) {
-                let found_index = result.groups().flatten().next().unwrap_or_default().start as i32;
-
-                regexp.set_last_index(old);
-                return Ok(Value::Integer(found_index));
-            } else {
-                regexp.set_last_index(old);
-                // If the pattern parameter is a String or a non-global regular expression
-                // and no match is found, the method returns -1
-                return Ok(Value::Integer(-1));
-            }
-        };
+            regexp.set_last_index(old);
+            // If the pattern parameter is a String or a non-global regular expression
+            // and no match is found, the method returns -1
+            return Ok(Value::Integer(-1));
+        }
     }
 
     Ok(Value::Undefined)
@@ -460,249 +430,226 @@ fn search<'gc>(
 /// Implements `String.slice`
 fn slice<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this = Value::from(this).coerce_to_string(activation)?;
-        let start_index = match args.get(0) {
-            None => 0,
-            Some(n) => {
-                let n = n.coerce_to_number(activation)?;
-                string_wrapping_index(n, this.len())
-            }
-        };
-        let end_index = match args.get(1) {
-            None => this.len(),
-            Some(n) => {
-                let n = n.coerce_to_number(activation)?;
-                string_wrapping_index(n, this.len())
-            }
-        };
-        return if start_index < end_index {
-            let ret = WString::from(&this[start_index..end_index]);
-            Ok(AvmString::new(activation.context.gc_context, ret).into())
-        } else {
-            Ok("".into())
-        };
+    let this = Value::from(this).coerce_to_string(activation)?;
+    let start_index = match args.get(0) {
+        None => 0,
+        Some(n) => {
+            let n = n.coerce_to_number(activation)?;
+            string_wrapping_index(n, this.len())
+        }
+    };
+    let end_index = match args.get(1) {
+        None => this.len(),
+        Some(n) => {
+            let n = n.coerce_to_number(activation)?;
+            string_wrapping_index(n, this.len())
+        }
+    };
+
+    if start_index < end_index {
+        let ret = WString::from(&this[start_index..end_index]);
+        Ok(AvmString::new(activation.context.gc_context, ret).into())
+    } else {
+        Ok("".into())
     }
-    Ok(Value::Undefined)
 }
 
 /// Implements `String.split`
 fn split<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let delimiter = args.get(0).unwrap_or(&Value::Undefined);
-        if matches!(delimiter, Value::Undefined) {
-            let this = Value::from(this);
-            return Ok(
-                ArrayObject::from_storage(activation, iter::once(this).collect())
-                    .unwrap()
-                    .into(),
-            );
-        }
-
-        let this = Value::from(this).coerce_to_string(activation)?;
-        let limit = match args.get(1).unwrap_or(&Value::Undefined) {
-            Value::Undefined => usize::MAX,
-            limit => limit.coerce_to_i32(activation)?.max(0) as usize,
-        };
-
-        if let Some(mut regexp) = delimiter
-            .as_object()
-            .as_ref()
-            .and_then(|o| o.as_regexp_mut(activation.context.gc_context))
-        {
-            return Ok(regexp.split(activation, this, limit)?.into());
-        }
-
-        let delimiter = delimiter.coerce_to_string(activation)?;
-
-        let storage = if delimiter.is_empty() {
-            // When using an empty delimiter, Str::split adds an extra beginning and trailing item, but Flash does not.
-            // e.g., split("foo", "") returns ["", "f", "o", "o", ""] in Rust but ["f, "o", "o"] in Flash.
-            // Special case this to match Flash's behavior.
-            this.iter()
-                .take(limit)
-                .map(|c| {
-                    Value::from(AvmString::new(
-                        activation.context.gc_context,
-                        WString::from_unit(c),
-                    ))
-                })
-                .collect()
-        } else {
-            this.split(&delimiter)
-                .take(limit)
-                .map(|c| Value::from(AvmString::new(activation.context.gc_context, c)))
-                .collect()
-        };
-
-        return Ok(ArrayObject::from_storage(activation, storage)
-            .unwrap()
-            .into());
+    let delimiter = args.get(0).unwrap_or(&Value::Undefined);
+    if matches!(delimiter, Value::Undefined) {
+        let this = Value::from(this);
+        return Ok(
+            ArrayObject::from_storage(activation, iter::once(this).collect())
+                .unwrap()
+                .into(),
+        );
     }
-    Ok(Value::Undefined)
+
+    let this = Value::from(this).coerce_to_string(activation)?;
+    let limit = match args.get(1).unwrap_or(&Value::Undefined) {
+        Value::Undefined => usize::MAX,
+        limit => limit.coerce_to_i32(activation)?.max(0) as usize,
+    };
+
+    if let Some(mut regexp) = delimiter
+        .as_object()
+        .as_ref()
+        .and_then(|o| o.as_regexp_mut(activation.context.gc_context))
+    {
+        return Ok(regexp.split(activation, this, limit)?.into());
+    }
+
+    let delimiter = delimiter.coerce_to_string(activation)?;
+
+    let storage = if delimiter.is_empty() {
+        // When using an empty delimiter, Str::split adds an extra beginning and trailing item, but Flash does not.
+        // e.g., split("foo", "") returns ["", "f", "o", "o", ""] in Rust but ["f, "o", "o"] in Flash.
+        // Special case this to match Flash's behavior.
+        this.iter()
+            .take(limit)
+            .map(|c| {
+                Value::from(AvmString::new(
+                    activation.context.gc_context,
+                    WString::from_unit(c),
+                ))
+            })
+            .collect()
+    } else {
+        this.split(&delimiter)
+            .take(limit)
+            .map(|c| Value::from(AvmString::new(activation.context.gc_context, c)))
+            .collect()
+    };
+
+    return Ok(ArrayObject::from_storage(activation, storage)
+        .unwrap()
+        .into());
 }
 
 /// Implements `String.substr`
 fn substr<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this_val = Value::from(this);
-        let this = this_val.coerce_to_string(activation)?;
+    let this_val = Value::from(this);
+    let this = this_val.coerce_to_string(activation)?;
 
-        if args.is_empty() {
-            return Ok(Value::from(this));
-        }
-
-        let start_index = string_wrapping_index(
-            args.get(0)
-                .unwrap_or(&Value::Number(0.))
-                .coerce_to_number(activation)?,
-            this.len(),
-        );
-
-        let len = args
-            .get(1)
-            .unwrap_or(&Value::Number(0x7fffffff as f64))
-            .coerce_to_number(activation)?;
-
-        let len = if len < 0. {
-            if len.is_infinite() {
-                0.
-            } else {
-                let wrapped_around = this.len() as f64 + len;
-                if wrapped_around as usize + start_index >= this.len() {
-                    return Ok("".into());
-                };
-                wrapped_around
-            }
-        } else {
-            len
-        };
-
-        let end_index = if len == f64::INFINITY {
-            this.len()
-        } else {
-            this.len().min(start_index + len as usize)
-        };
-
-        let ret = WString::from(&this[start_index..end_index]);
-        return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    if args.is_empty() {
+        return Ok(Value::from(this));
     }
 
-    Ok(Value::Undefined)
+    let start_index = string_wrapping_index(
+        args.get(0)
+            .unwrap_or(&Value::Number(0.))
+            .coerce_to_number(activation)?,
+        this.len(),
+    );
+
+    let len = args
+        .get(1)
+        .unwrap_or(&Value::Number(0x7fffffff as f64))
+        .coerce_to_number(activation)?;
+
+    let len = if len < 0. {
+        if len.is_infinite() {
+            0.
+        } else {
+            let wrapped_around = this.len() as f64 + len;
+            if wrapped_around as usize + start_index >= this.len() {
+                return Ok("".into());
+            };
+            wrapped_around
+        }
+    } else {
+        len
+    };
+
+    let end_index = if len == f64::INFINITY {
+        this.len()
+    } else {
+        this.len().min(start_index + len as usize)
+    };
+
+    let ret = WString::from(&this[start_index..end_index]);
+    return Ok(AvmString::new(activation.context.gc_context, ret).into());
 }
 
 /// Implements `String.substring`
 fn substring<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this_val = Value::from(this);
-        let this = this_val.coerce_to_string(activation)?;
+    let this_val = Value::from(this);
+    let this = this_val.coerce_to_string(activation)?;
 
-        if args.is_empty() {
-            return Ok(Value::from(this));
-        }
-
-        let mut start_index = string_index(
-            args.get(0)
-                .unwrap_or(&Value::Number(0.))
-                .coerce_to_number(activation)?,
-            this.len(),
-        );
-
-        let mut end_index = string_index(
-            args.get(1)
-                .unwrap_or(&Value::Number(0x7fffffff as f64))
-                .coerce_to_number(activation)?,
-            this.len(),
-        );
-
-        if end_index < start_index {
-            std::mem::swap(&mut end_index, &mut start_index);
-        }
-
-        let ret = WString::from(&this[start_index..end_index]);
-        return Ok(AvmString::new(activation.context.gc_context, ret).into());
+    if args.is_empty() {
+        return Ok(Value::from(this));
     }
 
-    Ok(Value::Undefined)
+    let mut start_index = string_index(
+        args.get(0)
+            .unwrap_or(&Value::Number(0.))
+            .coerce_to_number(activation)?,
+        this.len(),
+    );
+
+    let mut end_index = string_index(
+        args.get(1)
+            .unwrap_or(&Value::Number(0x7fffffff as f64))
+            .coerce_to_number(activation)?,
+        this.len(),
+    );
+
+    if end_index < start_index {
+        std::mem::swap(&mut end_index, &mut start_index);
+    }
+
+    let ret = WString::from(&this[start_index..end_index]);
+    return Ok(AvmString::new(activation.context.gc_context, ret).into());
 }
 
 /// Implements `String.toLowerCase`
 fn to_lower_case<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this_val = Value::from(this);
-        let this = this_val.coerce_to_string(activation)?;
-        return Ok(AvmString::new(
-            activation.context.gc_context,
-            this.iter()
-                .map(crate::string::utils::swf_to_lowercase)
-                .collect::<WString>(),
-        )
-        .into());
-    }
-    Ok(Value::Undefined)
+    let this_val = Value::from(this);
+    let this = this_val.coerce_to_string(activation)?;
+
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        this.iter()
+            .map(crate::string::utils::swf_to_lowercase)
+            .collect::<WString>(),
+    )
+    .into())
 }
 
 /// Implements `String.toString`
 fn to_string<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        return Ok(Value::from(this));
-    }
-    Ok(Value::Undefined)
+    Ok(Value::from(this))
 }
 
 /// Implements `String.valueOf`
 fn value_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        return this.value_of(activation.context.gc_context);
-    }
-    Ok(Value::Undefined)
+    this.value_of(activation.context.gc_context)
 }
 
 /// Implements `String.toUpperCase`
 fn to_upper_case<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let this_val = Value::from(this);
-        let this = this_val.coerce_to_string(activation)?;
-        return Ok(AvmString::new(
-            activation.context.gc_context,
-            this.iter()
-                .map(crate::string::utils::swf_to_uppercase)
-                .collect::<WString>(),
-        )
-        .into());
-    }
-    Ok(Value::Undefined)
+    let this_val = Value::from(this);
+    let this = this_val.coerce_to_string(activation)?;
+
+    Ok(AvmString::new(
+        activation.context.gc_context,
+        this.iter()
+            .map(crate::string::utils::swf_to_uppercase)
+            .collect::<WString>(),
+    )
+    .into())
 }
 
 /// Construct `String`'s class.

--- a/core/src/avm2/globals/toplevel.rs
+++ b/core/src/avm2/globals/toplevel.rs
@@ -15,7 +15,7 @@ use std::fmt::Write;
 
 pub fn trace<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args {
@@ -39,7 +39,7 @@ pub fn trace<'gc>(
 
 pub fn log_warn<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args {
@@ -63,7 +63,7 @@ pub fn log_warn<'gc>(
 
 pub fn stub_method<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args {
@@ -100,7 +100,7 @@ pub fn stub_method<'gc>(
 
 pub fn stub_getter<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args {
@@ -123,7 +123,7 @@ pub fn stub_getter<'gc>(
 
 pub fn stub_setter<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args {
@@ -146,7 +146,7 @@ pub fn stub_setter<'gc>(
 
 pub fn stub_constructor<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     match args {
@@ -179,7 +179,7 @@ pub fn stub_constructor<'gc>(
 
 pub fn is_finite<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(val) = args.get(0) {
@@ -191,7 +191,7 @@ pub fn is_finite<'gc>(
 
 pub fn is_nan<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(val) = args.get(0) {
@@ -203,7 +203,7 @@ pub fn is_nan<'gc>(
 
 pub fn parse_int<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let string = match args.get(0).unwrap_or(&Value::Undefined) {
@@ -222,7 +222,7 @@ pub fn parse_int<'gc>(
 
 pub fn parse_float<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(value) = args.get(0) {
@@ -238,7 +238,7 @@ pub fn parse_float<'gc>(
 
 pub fn is_xml_name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     avm2_stub_method!(activation, "", "isXMLName");
@@ -247,7 +247,7 @@ pub fn is_xml_name<'gc>(
 
 pub fn escape<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = match args.first() {
@@ -280,7 +280,7 @@ pub fn escape<'gc>(
 
 pub fn unescape<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let value = match args.first() {
@@ -327,7 +327,7 @@ pub fn unescape<'gc>(
 
 pub fn encode_uri<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     encode_utf8_with_exclusions(
@@ -340,7 +340,7 @@ pub fn encode_uri<'gc>(
 
 pub fn encode_uri_component<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     encode_utf8_with_exclusions(
@@ -392,7 +392,7 @@ fn encode_utf8_with_exclusions<'gc>(
 
 pub fn decode_uri<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     decode(
@@ -406,7 +406,7 @@ pub fn decode_uri<'gc>(
 
 pub fn decode_uri_component<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     decode(activation, args, "", "decodeURIComponent")

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -14,19 +14,17 @@ use gc_arena::GcCell;
 /// Implements `uint`'s instance initializer.
 fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
-            if matches!(*prim, Value::Undefined | Value::Null) {
-                *prim = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Undefined)
-                    .coerce_to_u32(activation)?
-                    .into();
-            }
+    if let Some(mut prim) = this.as_primitive_mut(activation.context.gc_context) {
+        if matches!(*prim, Value::Undefined | Value::Null) {
+            *prim = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Undefined)
+                .coerce_to_u32(activation)?
+                .into();
         }
     }
 
@@ -36,12 +34,10 @@ fn instance_init<'gc>(
 /// Implements `uint`'s native instance initializer.
 fn native_instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, args)?;
-    }
+    activation.super_init(this, args)?;
 
     Ok(Value::Undefined)
 }
@@ -49,81 +45,79 @@ fn native_instance_init<'gc>(
 /// Implements `uint`'s class initializer.
 fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let scope = activation.create_scopechain();
-        let gc_context = activation.context.gc_context;
-        let this_class = this.as_class_object().unwrap();
-        let uint_proto = this_class.prototype();
+    let scope = activation.create_scopechain();
+    let gc_context = activation.context.gc_context;
+    let this_class = this.as_class_object().unwrap();
+    let uint_proto = this_class.prototype();
 
-        uint_proto.set_string_property_local(
-            "toExponential",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_exponential, "toExponential", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+    uint_proto.set_string_property_local(
+        "toExponential",
+        FunctionObject::from_method(
             activation,
-        )?;
-        uint_proto.set_string_property_local(
-            "toFixed",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_fixed, "toFixed", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_exponential, "toExponential", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    uint_proto.set_string_property_local(
+        "toFixed",
+        FunctionObject::from_method(
             activation,
-        )?;
-        uint_proto.set_string_property_local(
-            "toPrecision",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_precision, "toPrecision", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_fixed, "toFixed", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    uint_proto.set_string_property_local(
+        "toPrecision",
+        FunctionObject::from_method(
             activation,
-        )?;
-        uint_proto.set_string_property_local(
-            "toString",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(to_string, "toString", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_precision, "toPrecision", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    uint_proto.set_string_property_local(
+        "toString",
+        FunctionObject::from_method(
             activation,
-        )?;
-        uint_proto.set_string_property_local(
-            "valueOf",
-            FunctionObject::from_method(
-                activation,
-                Method::from_builtin(value_of, "valueOf", gc_context),
-                scope,
-                None,
-                Some(this_class),
-            )
-            .into(),
+            Method::from_builtin(to_string, "toString", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    uint_proto.set_string_property_local(
+        "valueOf",
+        FunctionObject::from_method(
             activation,
-        )?;
-        uint_proto.set_local_property_is_enumerable(gc_context, "toExponential".into(), false);
-        uint_proto.set_local_property_is_enumerable(gc_context, "toFixed".into(), false);
-        uint_proto.set_local_property_is_enumerable(gc_context, "toPrecision".into(), false);
-        uint_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
-        uint_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
-    }
+            Method::from_builtin(value_of, "valueOf", gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    uint_proto.set_local_property_is_enumerable(gc_context, "toExponential".into(), false);
+    uint_proto.set_local_property_is_enumerable(gc_context, "toFixed".into(), false);
+    uint_proto.set_local_property_is_enumerable(gc_context, "toPrecision".into(), false);
+    uint_proto.set_local_property_is_enumerable(gc_context, "toString".into(), false);
+    uint_proto.set_local_property_is_enumerable(gc_context, "valueOf".into(), false);
 
     Ok(Value::Undefined)
 }
@@ -131,31 +125,29 @@ fn class_init<'gc>(
 /// Implements `uint.toExponential`
 fn to_exponential<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if digits > 20 {
-                    return Err("toExponential can only print with 0 through 20 digits.".into());
-                }
-
-                return Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("{number:.digits$e}")
-                        .replace('e', "e+")
-                        .replace("e+-", "e-")
-                        .replace("e+0", ""),
-                )
-                .into());
+            if digits > 20 {
+                return Err("toExponential can only print with 0 through 20 digits.".into());
             }
+
+            return Ok(AvmString::new_utf8(
+                activation.context.gc_context,
+                format!("{number:.digits$e}")
+                    .replace('e', "e+")
+                    .replace("e+-", "e-")
+                    .replace("e+0", ""),
+            )
+            .into());
         }
     }
 
@@ -165,28 +157,26 @@ fn to_exponential<'gc>(
 /// Implements `uint.toFixed`
 fn to_fixed<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if digits > 20 {
-                    return Err("toFixed can only print with 0 through 20 digits.".into());
-                }
-
-                return Ok(AvmString::new_utf8(
-                    activation.context.gc_context,
-                    format!("{0:.1$}", number as f64, digits),
-                )
-                .into());
+            if digits > 20 {
+                return Err("toFixed can only print with 0 through 20 digits.".into());
             }
+
+            return Ok(AvmString::new_utf8(
+                activation.context.gc_context,
+                format!("{0:.1$}", number as f64, digits),
+            )
+            .into());
         }
     }
 
@@ -196,24 +186,22 @@ fn to_fixed<'gc>(
 /// Implements `uint.toPrecision`
 fn to_precision<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let wanted_digits = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(0))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let wanted_digits = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(0))
+                .coerce_to_u32(activation)? as usize;
 
-                if wanted_digits < 1 || wanted_digits > 21 {
-                    return Err("toPrecision can only print with 1 through 21 digits.".into());
-                }
-
-                return Ok(print_with_precision(activation, number as f64, wanted_digits)?.into());
+            if wanted_digits < 1 || wanted_digits > 21 {
+                return Err("toPrecision can only print with 1 through 21 digits.".into());
             }
+
+            return Ok(print_with_precision(activation, number as f64, wanted_digits)?.into());
         }
     }
 
@@ -223,24 +211,22 @@ fn to_precision<'gc>(
 /// Implements `uint.toString`
 fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            if let Value::Integer(number) = *this {
-                let radix = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or(Value::Integer(10))
-                    .coerce_to_u32(activation)? as usize;
+    if let Some(this) = this.as_primitive() {
+        if let Value::Integer(number) = *this {
+            let radix = args
+                .get(0)
+                .cloned()
+                .unwrap_or(Value::Integer(10))
+                .coerce_to_u32(activation)? as usize;
 
-                if radix < 2 || radix > 36 {
-                    return Err("toString can only print in bases 2 thru 36.".into());
-                }
-
-                return Ok(print_with_radix(activation, number as f64, radix)?.into());
+            if radix < 2 || radix > 36 {
+                return Err("toString can only print in bases 2 thru 36.".into());
             }
+
+            return Ok(print_with_radix(activation, number as f64, radix)?.into());
         }
     }
 
@@ -250,13 +236,11 @@ fn to_string<'gc>(
 /// Implements `uint.valueOf`
 fn value_of<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(this) = this.as_primitive() {
-            return Ok(*this);
-        }
+    if let Some(this) = this.as_primitive() {
+        return Ok(*this);
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -20,27 +20,25 @@ use std::cmp::{max, min, Ordering};
 /// Implements `Vector`'s instance constructor.
 pub fn instance_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        activation.super_init(this, &[])?;
+    activation.super_init(this, &[])?;
 
-        if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let length = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Integer(0))
-                .coerce_to_u32(activation)? as usize;
-            let is_fixed = args
-                .get(1)
-                .cloned()
-                .unwrap_or_else(|| false.into())
-                .coerce_to_boolean();
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let length = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Integer(0))
+            .coerce_to_u32(activation)? as usize;
+        let is_fixed = args
+            .get(1)
+            .cloned()
+            .unwrap_or_else(|| false.into())
+            .coerce_to_boolean();
 
-            vector.resize(length, activation)?;
-            vector.set_is_fixed(is_fixed);
-        }
+        vector.resize(length, activation)?;
+        vector.set_is_fixed(is_fixed);
     }
 
     Ok(Value::Undefined)
@@ -48,7 +46,7 @@ pub fn instance_init<'gc>(
 
 fn class_call<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if args.len() != 1 {
@@ -89,89 +87,87 @@ fn class_call<'gc>(
 /// Implements `Vector`'s class constructor.
 pub fn class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let mut globals = activation.global_scope().unwrap();
-        let mut domain = activation.domain();
+    let mut globals = activation.global_scope().unwrap();
+    let mut domain = activation.domain();
 
-        let vector_internal_namespace = activation.avm2().vector_internal_namespace;
+    let vector_internal_namespace = activation.avm2().vector_internal_namespace;
 
-        //We have to grab Object's defining script instead of our own, because
-        //at this point Vector hasn't actually been defined yet. It doesn't
-        //matter because we only have one script for our globals.
-        let (_, script) = domain
-            .get_defining_script(&Multiname::new(
-                activation.avm2().public_namespace,
-                "Object",
-            ))?
-            .unwrap();
+    //We have to grab Object's defining script instead of our own, because
+    //at this point Vector hasn't actually been defined yet. It doesn't
+    //matter because we only have one script for our globals.
+    let (_, script) = domain
+        .get_defining_script(&Multiname::new(
+            activation.avm2().public_namespace,
+            "Object",
+        ))?
+        .unwrap();
 
-        let class_class = activation.avm2().classes().class;
-        let int_class = activation.avm2().classes().int;
-        let int_vector_class = this.apply(activation, int_class.into())?;
-        let int_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$int");
+    let class_class = activation.avm2().classes().class;
+    let int_class = activation.avm2().classes().int;
+    let int_vector_class = this.apply(activation, int_class.into())?;
+    let int_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$int");
 
-        globals.install_const_late(
-            activation.context.gc_context,
-            int_vector_name_legacy,
-            int_vector_class.into(),
-            class_class,
-        );
-        domain.export_definition(
-            int_vector_name_legacy,
-            script,
-            activation.context.gc_context,
-        );
+    globals.install_const_late(
+        activation.context.gc_context,
+        int_vector_name_legacy,
+        int_vector_class.into(),
+        class_class,
+    );
+    domain.export_definition(
+        int_vector_name_legacy,
+        script,
+        activation.context.gc_context,
+    );
 
-        let uint_class = activation.avm2().classes().uint;
-        let uint_vector_class = this.apply(activation, uint_class.into())?;
-        let uint_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$uint");
+    let uint_class = activation.avm2().classes().uint;
+    let uint_vector_class = this.apply(activation, uint_class.into())?;
+    let uint_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$uint");
 
-        globals.install_const_late(
-            activation.context.gc_context,
-            uint_vector_name_legacy,
-            uint_vector_class.into(),
-            class_class,
-        );
-        domain.export_definition(
-            uint_vector_name_legacy,
-            script,
-            activation.context.gc_context,
-        );
+    globals.install_const_late(
+        activation.context.gc_context,
+        uint_vector_name_legacy,
+        uint_vector_class.into(),
+        class_class,
+    );
+    domain.export_definition(
+        uint_vector_name_legacy,
+        script,
+        activation.context.gc_context,
+    );
 
-        let number_class = activation.avm2().classes().number;
-        let number_vector_class = this.apply(activation, number_class.into())?;
-        let number_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$double");
+    let number_class = activation.avm2().classes().number;
+    let number_vector_class = this.apply(activation, number_class.into())?;
+    let number_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$double");
 
-        globals.install_const_late(
-            activation.context.gc_context,
-            number_vector_name_legacy,
-            number_vector_class.into(),
-            class_class,
-        );
-        domain.export_definition(
-            number_vector_name_legacy,
-            script,
-            activation.context.gc_context,
-        );
+    globals.install_const_late(
+        activation.context.gc_context,
+        number_vector_name_legacy,
+        number_vector_class.into(),
+        class_class,
+    );
+    domain.export_definition(
+        number_vector_name_legacy,
+        script,
+        activation.context.gc_context,
+    );
 
-        let plain_vector_class = this.apply(activation, Value::Null)?;
-        let object_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$object");
+    let plain_vector_class = this.apply(activation, Value::Null)?;
+    let object_vector_name_legacy = QName::new(vector_internal_namespace, "Vector$object");
 
-        globals.install_const_late(
-            activation.context.gc_context,
-            object_vector_name_legacy,
-            plain_vector_class.into(),
-            class_class,
-        );
-        domain.export_definition(
-            object_vector_name_legacy,
-            script,
-            activation.context.gc_context,
-        );
-    }
+    globals.install_const_late(
+        activation.context.gc_context,
+        object_vector_name_legacy,
+        plain_vector_class.into(),
+        class_class,
+    );
+    domain.export_definition(
+        object_vector_name_legacy,
+        script,
+        activation.context.gc_context,
+    );
 
     Ok(Value::Undefined)
 }
@@ -179,59 +175,57 @@ pub fn class_init<'gc>(
 /// Implements `Vector`'s specialized-class constructor.
 pub fn specialized_class_init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let proto = this
-            .get_public_property("prototype", activation)?
-            .as_object()
-            .ok_or_else(|| {
-                format!(
-                    "Specialization {} has a prototype of null or undefined",
-                    this.instance_of_class_name(activation.context.gc_context)
-                )
-            })?;
-        let scope = activation.create_scopechain();
+    let proto = this
+        .get_public_property("prototype", activation)?
+        .as_object()
+        .ok_or_else(|| {
+            format!(
+                "Specialization {} has a prototype of null or undefined",
+                this.instance_of_class_name(activation.context.gc_context)
+            )
+        })?;
+    let scope = activation.create_scopechain();
 
-        const PUBLIC_PROTOTYPE_METHODS: &[(&str, NativeMethodImpl)] = &[
-            ("concat", concat),
-            ("join", join),
-            ("toString", to_string),
-            ("toLocaleString", to_locale_string),
-            ("every", every),
-            ("some", some),
-            ("forEach", for_each),
-            ("filter", filter),
-            ("indexOf", index_of),
-            ("lastIndexOf", last_index_of),
-            ("map", map),
-            ("pop", pop),
-            ("push", push),
-            ("shift", shift),
-            ("unshift", unshift),
-            ("reverse", reverse),
-            ("slice", slice),
-            ("sort", sort),
-            ("splice", splice),
-        ];
-        for (pubname, func) in PUBLIC_PROTOTYPE_METHODS {
-            proto.set_string_property_local(
-                *pubname,
-                FunctionObject::from_function(
-                    activation,
-                    Method::from_builtin(*func, pubname, activation.context.gc_context),
-                    scope,
-                )?
-                .into(),
+    const PUBLIC_PROTOTYPE_METHODS: &[(&str, NativeMethodImpl)] = &[
+        ("concat", concat),
+        ("join", join),
+        ("toString", to_string),
+        ("toLocaleString", to_locale_string),
+        ("every", every),
+        ("some", some),
+        ("forEach", for_each),
+        ("filter", filter),
+        ("indexOf", index_of),
+        ("lastIndexOf", last_index_of),
+        ("map", map),
+        ("pop", pop),
+        ("push", push),
+        ("shift", shift),
+        ("unshift", unshift),
+        ("reverse", reverse),
+        ("slice", slice),
+        ("sort", sort),
+        ("splice", splice),
+    ];
+    for (pubname, func) in PUBLIC_PROTOTYPE_METHODS {
+        proto.set_string_property_local(
+            *pubname,
+            FunctionObject::from_function(
                 activation,
-            )?;
-            proto.set_local_property_is_enumerable(
-                activation.context.gc_context,
-                (*pubname).into(),
-                false,
-            );
-        }
+                Method::from_builtin(*func, pubname, activation.context.gc_context),
+                scope,
+            )?
+            .into(),
+            activation,
+        )?;
+        proto.set_local_property_is_enumerable(
+            activation.context.gc_context,
+            (*pubname).into(),
+            false,
+        );
     }
 
     Ok(Value::Undefined)
@@ -240,13 +234,11 @@ pub fn specialized_class_init<'gc>(
 /// `Vector.length` getter
 pub fn length<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(vector) = this.as_vector_storage() {
-            return Ok(vector.length().into());
-        }
+    if let Some(vector) = this.as_vector_storage() {
+        return Ok(vector.length().into());
     }
 
     Ok(Value::Undefined)
@@ -255,19 +247,17 @@ pub fn length<'gc>(
 /// `Vector.length` setter
 pub fn set_length<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let new_length = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Integer(0))
-                .coerce_to_u32(activation)? as usize;
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let new_length = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Integer(0))
+            .coerce_to_u32(activation)? as usize;
 
-            vector.resize(new_length, activation)?;
-        }
+        vector.resize(new_length, activation)?;
     }
 
     Ok(Value::Undefined)
@@ -276,13 +266,11 @@ pub fn set_length<'gc>(
 /// `Vector.fixed` getter
 pub fn fixed<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(vector) = this.as_vector_storage() {
-            return Ok(vector.is_fixed().into());
-        }
+    if let Some(vector) = this.as_vector_storage() {
+        return Ok(vector.is_fixed().into());
     }
 
     Ok(Value::Undefined)
@@ -291,19 +279,17 @@ pub fn fixed<'gc>(
 /// `Vector.fixed` setter
 pub fn set_fixed<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let new_fixed = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Bool(false))
-                .coerce_to_boolean();
+    if let Some(mut vector) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let new_fixed = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Bool(false))
+            .coerce_to_boolean();
 
-            vector.set_is_fixed(new_fixed);
-        }
+        vector.set_is_fixed(new_fixed);
     }
 
     Ok(Value::Undefined)
@@ -312,73 +298,69 @@ pub fn set_fixed<'gc>(
 /// `Vector.concat` impl
 pub fn concat<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let mut new_vector_storage = if let Some(vector) = this.as_vector_storage() {
-            vector.clone()
-        } else {
-            return Err("Not a vector-structured object".into());
-        };
+    let mut new_vector_storage = if let Some(vector) = this.as_vector_storage() {
+        vector.clone()
+    } else {
+        return Err("Not a vector-structured object".into());
+    };
 
-        let my_class = this
-            .instance_of()
-            .ok_or("TypeError: Tried to concat into a bare object")?;
-        let val_class = new_vector_storage.value_type();
+    let my_class = this
+        .instance_of()
+        .ok_or("TypeError: Tried to concat into a bare object")?;
+    let val_class = new_vector_storage.value_type();
 
-        for arg in args {
-            let arg_obj = arg
-                .as_object()
-                .ok_or("Cannot concat Vector with null or undefined")?;
-            let arg_class = arg_obj
-                .instance_of_class_definition()
-                .ok_or("TypeError: Tried to concat from a bare object")?;
-            if !arg.is_of_type(activation, my_class) {
-                return Err(format!(
-                    "TypeError: Cannot coerce argument of type {:?} to argument of type {:?}",
-                    arg_class.read().name(),
-                    my_class.inner_class_definition().read().name()
-                )
-                .into());
-            }
-
-            let old_vec = arg_obj.as_vector_storage();
-            let old_vec: Vec<Value<'gc>> = if let Some(old_vec) = old_vec {
-                old_vec.iter().collect()
-            } else {
-                continue;
-            };
-
-            for val in old_vec {
-                if let Ok(val_obj) = val.coerce_to_object(activation) {
-                    if !val.is_of_type(activation, val_class) {
-                        let other_val_class = val_obj
-                            .instance_of_class_definition()
-                            .ok_or("TypeError: Tried to concat a bare object into a Vector")?;
-                        return Err(format!(
-                            "TypeError: Cannot coerce Vector value of type {:?} to type {:?}",
-                            other_val_class.read().name(),
-                            val_class.inner_class_definition().read().name()
-                        )
-                        .into());
-                    }
-                }
-
-                let coerced_val = val.coerce_to_type(activation, val_class)?;
-                new_vector_storage.push(coerced_val, activation)?;
-            }
+    for arg in args {
+        let arg_obj = arg
+            .as_object()
+            .ok_or("Cannot concat Vector with null or undefined")?;
+        let arg_class = arg_obj
+            .instance_of_class_definition()
+            .ok_or("TypeError: Tried to concat from a bare object")?;
+        if !arg.is_of_type(activation, my_class) {
+            return Err(format!(
+                "TypeError: Cannot coerce argument of type {:?} to argument of type {:?}",
+                arg_class.read().name(),
+                my_class.inner_class_definition().read().name()
+            )
+            .into());
         }
 
-        return Ok(VectorObject::from_vector(new_vector_storage, activation)?.into());
+        let old_vec = arg_obj.as_vector_storage();
+        let old_vec: Vec<Value<'gc>> = if let Some(old_vec) = old_vec {
+            old_vec.iter().collect()
+        } else {
+            continue;
+        };
+
+        for val in old_vec {
+            if let Ok(val_obj) = val.coerce_to_object(activation) {
+                if !val.is_of_type(activation, val_class) {
+                    let other_val_class = val_obj
+                        .instance_of_class_definition()
+                        .ok_or("TypeError: Tried to concat a bare object into a Vector")?;
+                    return Err(format!(
+                        "TypeError: Cannot coerce Vector value of type {:?} to type {:?}",
+                        other_val_class.read().name(),
+                        val_class.inner_class_definition().read().name()
+                    )
+                    .into());
+                }
+            }
+
+            let coerced_val = val.coerce_to_type(activation, val_class)?;
+            new_vector_storage.push(coerced_val, activation)?;
+        }
     }
 
-    Ok(Value::Undefined)
+    Ok(VectorObject::from_vector(new_vector_storage, activation)?.into())
 }
 
 fn join_inner<'gc, 'a, 'ctxt, C>(
     activation: &mut Activation<'a, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
     mut conv: C,
 ) -> Result<Value<'gc>, Error<'gc>>
@@ -390,25 +372,23 @@ where
         separator = ",".into();
     }
 
-    if let Some(this) = this {
-        if let Some(vector) = this.as_vector_storage() {
-            let string_separator = separator.coerce_to_string(activation)?;
-            let mut accum = Vec::with_capacity(vector.length());
+    if let Some(vector) = this.as_vector_storage() {
+        let string_separator = separator.coerce_to_string(activation)?;
+        let mut accum = Vec::with_capacity(vector.length());
 
-            for (_, item) in vector.iter().enumerate() {
-                if matches!(item, Value::Undefined) || matches!(item, Value::Null) {
-                    accum.push("".into());
-                } else {
-                    accum.push(conv(item, activation)?.coerce_to_string(activation)?);
-                }
+        for (_, item) in vector.iter().enumerate() {
+            if matches!(item, Value::Undefined) || matches!(item, Value::Null) {
+                accum.push("".into());
+            } else {
+                accum.push(conv(item, activation)?.coerce_to_string(activation)?);
             }
-
-            return Ok(AvmString::new(
-                activation.context.gc_context,
-                crate::string::join(&accum, &string_separator),
-            )
-            .into());
         }
+
+        return Ok(AvmString::new(
+            activation.context.gc_context,
+            crate::string::join(&accum, &string_separator),
+        )
+        .into());
     }
 
     Ok(Value::Undefined)
@@ -417,7 +397,7 @@ where
 /// Implements `Vector.join`
 pub fn join<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     join_inner(activation, this, args, |v, _act| Ok(v))
@@ -426,7 +406,7 @@ pub fn join<'gc>(
 /// Implements `Vector.toString`
 pub fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     join_inner(activation, this, &[",".into()], |v, _act| Ok(v))
@@ -435,7 +415,7 @@ pub fn to_string<'gc>(
 /// Implements `Vector.toLocaleString`
 pub fn to_locale_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     join_inner(activation, this, &[",".into()], |v, act| {
@@ -450,130 +430,116 @@ pub fn to_locale_string<'gc>(
 /// Implements `Vector.every`
 pub fn every<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            let result = callback
-                .call(receiver, &[item, i.into(), this.into()], activation)?
-                .coerce_to_boolean();
+        let result = callback
+            .call(receiver, &[item, i.into(), this.into()], activation)?
+            .coerce_to_boolean();
 
-            if !result {
-                return Ok(false.into());
-            }
+        if !result {
+            return Ok(false.into());
         }
-
-        return Ok(true.into());
     }
 
-    Ok(Value::Undefined)
+    Ok(true.into())
 }
 
 /// Implements `Vector.some`
 pub fn some<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            let result = callback
-                .call(receiver, &[item, i.into(), this.into()], activation)?
-                .coerce_to_boolean();
+        let result = callback
+            .call(receiver, &[item, i.into(), this.into()], activation)?
+            .coerce_to_boolean();
 
-            if result {
-                return Ok(true.into());
-            }
+        if result {
+            return Ok(true.into());
         }
-
-        return Ok(false.into());
     }
 
-    Ok(Value::Undefined)
+    Ok(false.into())
 }
 
 /// Implements `Vector.filter`
 pub fn filter<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
 
-        let value_type = this
-            .instance_of()
-            .unwrap()
-            .as_class_params()
-            .ok_or("Cannot filter unparameterized vector")?
-            .unwrap_or(activation.avm2().classes().object);
-        let mut new_storage = VectorStorage::new(0, false, value_type, activation);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let value_type = this
+        .instance_of()
+        .unwrap()
+        .as_class_params()
+        .ok_or("Cannot filter unparameterized vector")?
+        .unwrap_or(activation.avm2().classes().object);
+    let mut new_storage = VectorStorage::new(0, false, value_type, activation);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            let result = callback
-                .call(receiver, &[item, i.into(), this.into()], activation)?
-                .coerce_to_boolean();
+        let result = callback
+            .call(receiver, &[item, i.into(), this.into()], activation)?
+            .coerce_to_boolean();
 
-            if result {
-                new_storage.push(item, activation)?;
-            }
+        if result {
+            new_storage.push(item, activation)?;
         }
-
-        return Ok(VectorObject::from_vector(new_storage, activation)?.into());
     }
 
-    Ok(Value::Undefined)
+    Ok(VectorObject::from_vector(new_storage, activation)?.into())
 }
 
 /// Implements `Vector.forEach`
 pub fn for_each<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            callback.call(receiver, &[item, i.into(), this.into()], activation)?;
-        }
+        callback.call(receiver, &[item, i.into(), this.into()], activation)?;
     }
 
     Ok(Value::Undefined)
@@ -582,34 +548,32 @@ pub fn for_each<'gc>(
 /// Implements `Vector.indexOf`
 pub fn index_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let search_for = args.get(0).cloned().unwrap_or(Value::Undefined);
-        let from_index = args
-            .get(1)
-            .cloned()
-            .unwrap_or_else(|| 0.into())
+    let search_for = args.get(0).cloned().unwrap_or(Value::Undefined);
+    let from_index = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| 0.into())
+        .coerce_to_i32(activation)?;
+
+    let from_index = if from_index < 0 {
+        let length = this
+            .get_public_property("length", activation)?
             .coerce_to_i32(activation)?;
+        max(length + from_index, 0) as u32
+    } else {
+        from_index as u32
+    };
 
-        let from_index = if from_index < 0 {
-            let length = this
-                .get_public_property("length", activation)?
-                .coerce_to_i32(activation)?;
-            max(length + from_index, 0) as u32
-        } else {
-            from_index as u32
-        };
+    let mut iter = ArrayIter::with_bounds(activation, this, from_index, u32::MAX)?;
 
-        let mut iter = ArrayIter::with_bounds(activation, this, from_index, u32::MAX)?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
-
-            if item == search_for {
-                return Ok(i.into());
-            }
+        if item == search_for {
+            return Ok(i.into());
         }
     }
 
@@ -619,34 +583,32 @@ pub fn index_of<'gc>(
 /// Implements `Vector.lastIndexOf`
 pub fn last_index_of<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let search_for = args.get(0).cloned().unwrap_or(Value::Undefined);
-        let from_index = args
-            .get(1)
-            .cloned()
-            .unwrap_or_else(|| i32::MAX.into())
+    let search_for = args.get(0).cloned().unwrap_or(Value::Undefined);
+    let from_index = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| i32::MAX.into())
+        .coerce_to_i32(activation)?;
+
+    let from_index = if from_index < 0 {
+        let length = this
+            .get_public_property("length", activation)?
             .coerce_to_i32(activation)?;
+        max(length + from_index, 0) as u32
+    } else {
+        from_index as u32
+    };
 
-        let from_index = if from_index < 0 {
-            let length = this
-                .get_public_property("length", activation)?
-                .coerce_to_i32(activation)?;
-            max(length + from_index, 0) as u32
-        } else {
-            from_index as u32
-        };
+    let mut iter = ArrayIter::with_bounds(activation, this, 0, from_index)?;
 
-        let mut iter = ArrayIter::with_bounds(activation, this, 0, from_index)?;
+    while let Some(r) = iter.next_back(activation) {
+        let (i, item) = r?;
 
-        while let Some(r) = iter.next_back(activation) {
-            let (i, item) = r?;
-
-            if item == search_for {
-                return Ok(i.into());
-            }
+        if item == search_for {
+            return Ok(i.into());
         }
     }
 
@@ -656,51 +618,45 @@ pub fn last_index_of<'gc>(
 /// Implements `Vector.map`
 pub fn map<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        let callback = args
-            .get(0)
-            .cloned()
-            .unwrap_or(Value::Undefined)
-            .as_callable(activation, None, None)?;
-        let receiver = args.get(1).cloned().unwrap_or(Value::Null);
+    let callback = args
+        .get(0)
+        .cloned()
+        .unwrap_or(Value::Undefined)
+        .as_callable(activation, None, None)?;
+    let receiver = args.get(1).cloned().unwrap_or(Value::Null);
 
-        let value_type = this
-            .instance_of()
-            .unwrap()
-            .as_class_params()
-            .ok_or("Cannot filter unparameterized vector")?
-            .unwrap_or(activation.avm2().classes().object);
-        let mut new_storage = VectorStorage::new(0, false, value_type, activation);
-        let mut iter = ArrayIter::new(activation, this)?;
+    let value_type = this
+        .instance_of()
+        .unwrap()
+        .as_class_params()
+        .ok_or("Cannot filter unparameterized vector")?
+        .unwrap_or(activation.avm2().classes().object);
+    let mut new_storage = VectorStorage::new(0, false, value_type, activation);
+    let mut iter = ArrayIter::new(activation, this)?;
 
-        while let Some(r) = iter.next(activation) {
-            let (i, item) = r?;
+    while let Some(r) = iter.next(activation) {
+        let (i, item) = r?;
 
-            let new_item = callback.call(receiver, &[item, i.into(), this.into()], activation)?;
-            let coerced_item = new_item.coerce_to_type(activation, value_type)?;
+        let new_item = callback.call(receiver, &[item, i.into(), this.into()], activation)?;
+        let coerced_item = new_item.coerce_to_type(activation, value_type)?;
 
-            new_storage.push(coerced_item, activation)?;
-        }
-
-        return Ok(VectorObject::from_vector(new_storage, activation)?.into());
+        new_storage.push(coerced_item, activation)?;
     }
 
-    Ok(Value::Undefined)
+    Ok(VectorObject::from_vector(new_storage, activation)?.into())
 }
 
 /// Implements `Vector.pop`
 pub fn pop<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            return vs.pop(activation);
-        }
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        return vs.pop(activation);
     }
 
     Ok(Value::Undefined)
@@ -709,21 +665,19 @@ pub fn pop<'gc>(
 /// Implements `Vector.push`
 pub fn push<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let value_type = vs.value_type();
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let value_type = vs.value_type();
 
-            for arg in args {
-                let coerced_arg = arg.coerce_to_type(activation, value_type)?;
+        for arg in args {
+            let coerced_arg = arg.coerce_to_type(activation, value_type)?;
 
-                vs.push(coerced_arg, activation)?;
-            }
-
-            return Ok(vs.length().into());
+            vs.push(coerced_arg, activation)?;
         }
+
+        return Ok(vs.length().into());
     }
 
     Ok(Value::Undefined)
@@ -732,13 +686,11 @@ pub fn push<'gc>(
 /// Implements `Vector.shift`
 pub fn shift<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            return vs.shift(activation);
-        }
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        return vs.shift(activation);
     }
 
     Ok(Value::Undefined)
@@ -747,21 +699,19 @@ pub fn shift<'gc>(
 /// Implements `Vector.unshift`
 pub fn unshift<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let value_type = vs.value_type();
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let value_type = vs.value_type();
 
-            for arg in args.iter().rev() {
-                let coerced_arg = arg.coerce_to_type(activation, value_type)?;
+        for arg in args.iter().rev() {
+            let coerced_arg = arg.coerce_to_type(activation, value_type)?;
 
-                vs.unshift(coerced_arg, activation)?;
-            }
-
-            return Ok(vs.length().into());
+            vs.unshift(coerced_arg, activation)?;
         }
+
+        return Ok(vs.length().into());
     }
 
     Ok(Value::Undefined)
@@ -770,25 +720,23 @@ pub fn unshift<'gc>(
 /// Implements `Vector.insertAt`
 pub fn insert_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let index = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_i32(activation)?;
-            let value_type = vs.value_type();
-            let value = args
-                .get(1)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_type(activation, value_type)?;
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let index = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)?;
+        let value_type = vs.value_type();
+        let value = args
+            .get(1)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_type(activation, value_type)?;
 
-            vs.insert(index, value, activation)?;
-        }
+        vs.insert(index, value, activation)?;
     }
 
     Ok(Value::Undefined)
@@ -797,19 +745,17 @@ pub fn insert_at<'gc>(
 /// Implements `Vector.removeAt`
 pub fn remove_at<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let index = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_i32(activation)?;
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let index = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)?;
 
-            return vs.remove(index, activation);
-        }
+        return vs.remove(index, activation);
     }
 
     Ok(Value::Undefined)
@@ -818,15 +764,13 @@ pub fn remove_at<'gc>(
 /// Implements `Vector.reverse`
 pub fn reverse<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            vs.reverse();
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        vs.reverse();
 
-            return Ok(this.into());
-        }
+        return Ok(this.into());
     }
 
     Ok(Value::Undefined)
@@ -835,38 +779,36 @@ pub fn reverse<'gc>(
 /// Implements `Vector.slice`
 pub fn slice<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let from = args
-                .get(0)
-                .cloned()
-                .unwrap_or_else(|| 0.into())
-                .coerce_to_i32(activation)?;
-            let to = args
-                .get(1)
-                .cloned()
-                .unwrap_or_else(|| 16777215.into())
-                .coerce_to_i32(activation)?;
-            let value_type = vs.value_type();
+    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let from = args
+            .get(0)
+            .cloned()
+            .unwrap_or_else(|| 0.into())
+            .coerce_to_i32(activation)?;
+        let to = args
+            .get(1)
+            .cloned()
+            .unwrap_or_else(|| 16777215.into())
+            .coerce_to_i32(activation)?;
+        let value_type = vs.value_type();
 
-            let from = vs.clamp_parameter_index(from);
-            let to = vs.clamp_parameter_index(to);
+        let from = vs.clamp_parameter_index(from);
+        let to = vs.clamp_parameter_index(to);
 
-            let mut new_vs = VectorStorage::new(0, false, value_type, activation);
+        let mut new_vs = VectorStorage::new(0, false, value_type, activation);
 
-            if to > from {
-                for value in vs.iter().skip(from).take(to - from) {
-                    new_vs.push(value, activation)?;
-                }
+        if to > from {
+            for value in vs.iter().skip(from).take(to - from) {
+                new_vs.push(value, activation)?;
             }
-
-            let new_vector = VectorObject::from_vector(new_vs, activation)?;
-
-            return Ok(new_vector.into());
         }
+
+        let new_vector = VectorObject::from_vector(new_vs, activation)?;
+
+        return Ok(new_vector.into());
     }
 
     Ok(Value::Undefined)
@@ -875,85 +817,80 @@ pub fn slice<'gc>(
 /// Implements `Vector.sort`
 pub fn sort<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let fn_or_options = args.get(0).cloned().unwrap_or(Value::Undefined);
+    if let Some(vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let fn_or_options = args.get(0).cloned().unwrap_or(Value::Undefined);
 
-            let (compare_fnc, options) = if fn_or_options
-                .as_callable(activation, None, None)
-                .is_ok()
-            {
-                (
-                    Some(fn_or_options.as_object().unwrap()),
-                    SortOptions::empty(),
-                )
-            } else {
-                (
-                    None,
-                    SortOptions::from_bits_truncate(fn_or_options.coerce_to_u32(activation)? as u8),
-                )
-            };
+        let (compare_fnc, options) = if fn_or_options.as_callable(activation, None, None).is_ok() {
+            (
+                Some(fn_or_options.as_object().unwrap()),
+                SortOptions::empty(),
+            )
+        } else {
+            (
+                None,
+                SortOptions::from_bits_truncate(fn_or_options.coerce_to_u32(activation)? as u8),
+            )
+        };
 
-            let compare = move |activation: &mut Activation<'_, 'gc>, a, b| {
-                if let Some(compare_fnc) = compare_fnc {
-                    let order = compare_fnc
-                        .call(this.into(), &[a, b], activation)?
-                        .coerce_to_number(activation)?;
+        let compare = move |activation: &mut Activation<'_, 'gc>, a, b| {
+            if let Some(compare_fnc) = compare_fnc {
+                let order = compare_fnc
+                    .call(this.into(), &[a, b], activation)?
+                    .coerce_to_number(activation)?;
 
-                    if order > 0.0 {
-                        Ok(Ordering::Greater)
-                    } else if order < 0.0 {
-                        Ok(Ordering::Less)
-                    } else {
-                        Ok(Ordering::Equal)
-                    }
-                } else if options.contains(SortOptions::NUMERIC) {
-                    compare_numeric(activation, a, b)
-                } else if options.contains(SortOptions::CASE_INSENSITIVE) {
-                    compare_string_case_insensitive(activation, a, b)
+                if order > 0.0 {
+                    Ok(Ordering::Greater)
+                } else if order < 0.0 {
+                    Ok(Ordering::Less)
                 } else {
-                    compare_string_case_sensitive(activation, a, b)
+                    Ok(Ordering::Equal)
                 }
-            };
-
-            let mut values: Vec<_> = vs.iter().collect();
-            drop(vs);
-
-            let mut unique_sort_satisfied = true;
-            let mut error_signal = Ok(());
-            values.sort_unstable_by(|a, b| match compare(activation, *a, *b) {
-                Ok(Ordering::Equal) => {
-                    unique_sort_satisfied = false;
-                    Ordering::Equal
-                }
-                Ok(v) if options.contains(SortOptions::DESCENDING) => v.reverse(),
-                Ok(v) => v,
-                Err(e) => {
-                    error_signal = Err(e);
-                    Ordering::Less
-                }
-            });
-
-            error_signal?;
-
-            //NOTE: RETURNINDEXEDARRAY does NOT actually return anything useful.
-            //The actual sorting still happens, but the results are discarded.
-            if options.contains(SortOptions::RETURN_INDEXED_ARRAY) {
-                return Ok(this.into());
+            } else if options.contains(SortOptions::NUMERIC) {
+                compare_numeric(activation, a, b)
+            } else if options.contains(SortOptions::CASE_INSENSITIVE) {
+                compare_string_case_insensitive(activation, a, b)
+            } else {
+                compare_string_case_sensitive(activation, a, b)
             }
+        };
 
-            if !options.contains(SortOptions::UNIQUE_SORT) || unique_sort_satisfied {
-                let mut vs = this
-                    .as_vector_storage_mut(activation.context.gc_context)
-                    .unwrap();
-                vs.replace_storage(values.into_iter().collect());
+        let mut values: Vec<_> = vs.iter().collect();
+        drop(vs);
+
+        let mut unique_sort_satisfied = true;
+        let mut error_signal = Ok(());
+        values.sort_unstable_by(|a, b| match compare(activation, *a, *b) {
+            Ok(Ordering::Equal) => {
+                unique_sort_satisfied = false;
+                Ordering::Equal
             }
+            Ok(v) if options.contains(SortOptions::DESCENDING) => v.reverse(),
+            Ok(v) => v,
+            Err(e) => {
+                error_signal = Err(e);
+                Ordering::Less
+            }
+        });
 
+        error_signal?;
+
+        //NOTE: RETURNINDEXEDARRAY does NOT actually return anything useful.
+        //The actual sorting still happens, but the results are discarded.
+        if options.contains(SortOptions::RETURN_INDEXED_ARRAY) {
             return Ok(this.into());
         }
+
+        if !options.contains(SortOptions::UNIQUE_SORT) || unique_sort_satisfied {
+            let mut vs = this
+                .as_vector_storage_mut(activation.context.gc_context)
+                .unwrap();
+            vs.replace_storage(values.into_iter().collect());
+        }
+
+        return Ok(this.into());
     }
 
     Ok(Value::Undefined)
@@ -962,47 +899,45 @@ pub fn sort<'gc>(
 /// Implements `Vector.splice`
 pub fn splice<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(this) = this {
-        if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
-            let start_len = args
-                .get(0)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_i32(activation)?;
-            let delete_len = args
-                .get(1)
-                .cloned()
-                .unwrap_or(Value::Undefined)
-                .coerce_to_i32(activation)?;
-            let value_type = vs.value_type();
+    if let Some(mut vs) = this.as_vector_storage_mut(activation.context.gc_context) {
+        let start_len = args
+            .get(0)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)?;
+        let delete_len = args
+            .get(1)
+            .cloned()
+            .unwrap_or(Value::Undefined)
+            .coerce_to_i32(activation)?;
+        let value_type = vs.value_type();
 
-            let start = vs.clamp_parameter_index(start_len);
-            let end = max(
-                start,
-                min(
-                    if delete_len < 0 {
-                        vs.clamp_parameter_index(delete_len)
-                    } else {
-                        start + delete_len as usize
-                    },
-                    vs.length(),
-                ),
-            );
-            let mut to_coerce = Vec::new();
+        let start = vs.clamp_parameter_index(start_len);
+        let end = max(
+            start,
+            min(
+                if delete_len < 0 {
+                    vs.clamp_parameter_index(delete_len)
+                } else {
+                    start + delete_len as usize
+                },
+                vs.length(),
+            ),
+        );
+        let mut to_coerce = Vec::new();
 
-            for value in args[2..].iter() {
-                to_coerce.push(value.coerce_to_type(activation, value_type)?);
-            }
-
-            let new_vs =
-                VectorStorage::from_values(vs.splice(start..end, to_coerce)?, false, value_type);
-            let new_vector = VectorObject::from_vector(new_vs, activation)?;
-
-            return Ok(new_vector.into());
+        for value in args[2..].iter() {
+            to_coerce.push(value.coerce_to_type(activation, value_type)?);
         }
+
+        let new_vs =
+            VectorStorage::from_values(vs.splice(start..end, to_coerce)?, false, value_type);
+        let new_vector = VectorObject::from_vector(new_vs, activation)?;
+
+        return Ok(new_vector.into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -23,10 +23,10 @@ fn ill_formed_markup_err<'gc>(
 
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap().as_xml_object().unwrap();
+    let this = this.as_xml_object().unwrap();
     let value = args[0];
 
     if let Some(obj) = value.as_object() {
@@ -58,10 +58,10 @@ pub fn init<'gc>(
 
 pub fn name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let node = this.unwrap().as_xml_object().unwrap();
+    let node = this.as_xml_object().unwrap();
     if let Some(local_name) = node.local_name() {
         avm2_stub_method!(activation, "XML", "name", "namespaces");
         // FIXME - use namespace
@@ -74,7 +74,7 @@ pub fn name<'gc>(
 
 pub fn namespace<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // FIXME: Implement namespace support (including prefix)
@@ -85,39 +85,39 @@ pub fn namespace<'gc>(
 
 pub fn local_name<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let node = this.unwrap().as_xml_object().unwrap();
+    let node = this.as_xml_object().unwrap();
     Ok(node.local_name().map_or(Value::Null, Value::String))
 }
 
 pub fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let node = xml.node();
     Ok(Value::String(node.xml_to_string(activation)?))
 }
 
 pub fn to_xml_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let node = xml.node();
     Ok(Value::String(node.xml_to_xml_string(activation)?))
 }
 
 pub fn child<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let multiname = name_to_multiname(activation, &args[0], false)?;
     // FIXME: Support numerical indexes.
     let children = if let E4XNodeKind::Element { children, .. } = &*xml.node().kind() {
@@ -135,10 +135,10 @@ pub fn child<'gc>(
 
 pub fn child_index<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let node = xml.node();
 
     let parent = if let Some(parent) = node.parent() {
@@ -164,10 +164,10 @@ pub fn child_index<'gc>(
 
 pub fn children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let children = if let E4XNodeKind::Element { children, .. } = &*xml.node().kind() {
         children.iter().map(|node| E4XOrXml::E4X(*node)).collect()
     } else {
@@ -179,20 +179,20 @@ pub fn children<'gc>(
 
 pub fn copy<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let node = xml.node();
     Ok(XmlObject::new(node.deep_copy(activation.context.gc_context), activation).into())
 }
 
 pub fn parent<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let node = xml.node();
     Ok(node.parent().map_or(Value::Undefined, |parent| {
         XmlObject::new(parent, activation).into()
@@ -201,10 +201,10 @@ pub fn parent<'gc>(
 
 pub fn elements<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let multiname = if args[0] == Value::Undefined {
         Multiname::any(activation.context.gc_context)
     } else {
@@ -228,10 +228,9 @@ pub fn elements<'gc>(
 
 pub fn attributes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let xml = this.as_xml_object().unwrap();
     let attributes = if let E4XNodeKind::Element { attributes, .. } = &*xml.node().kind() {
         attributes.iter().map(|node| E4XOrXml::E4X(*node)).collect()
@@ -244,10 +243,9 @@ pub fn attributes<'gc>(
 
 pub fn attribute<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let xml = this.as_xml_object().unwrap();
     let multiname = name_to_multiname(activation, &args[0], true)?;
     let attributes = if let E4XNodeKind::Element { attributes, .. } = &*xml.node().kind() {
@@ -265,7 +263,7 @@ pub fn attribute<'gc>(
 
 pub fn call_handler<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(obj) = args.try_get_object(activation, 0) {
@@ -294,10 +292,9 @@ pub fn call_handler<'gc>(
 
 pub fn node_kind<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let xml = this.as_xml_object().unwrap();
     let name = match &*xml.node().kind() {
         E4XNodeKind::Text(_) => "text",
@@ -312,10 +309,9 @@ pub fn node_kind<'gc>(
 
 pub fn append_child<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let xml = this.as_xml_object().unwrap();
 
     let child = args.get_object(activation, 0, "child")?;
@@ -338,10 +334,10 @@ pub fn append_child<'gc>(
 
 pub fn descendants<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let multiname = name_to_multiname(activation, &args[0], false)?;
     let mut descendants = Vec::new();
     xml.node().descendants(&multiname, &mut descendants);
@@ -350,10 +346,10 @@ pub fn descendants<'gc>(
 
 pub fn text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml = this.unwrap().as_xml_object().unwrap();
+    let xml = this.as_xml_object().unwrap();
     let nodes = if let E4XNodeKind::Element { children, .. } = &*xml.node().kind() {
         children
             .iter()
@@ -368,7 +364,7 @@ pub fn text<'gc>(
 
 pub fn length<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     Ok(Value::Integer(1))
@@ -376,20 +372,20 @@ pub fn length<'gc>(
 
 pub fn has_complex_content<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml_obj = this.unwrap().as_xml_object().unwrap();
+    let xml_obj = this.as_xml_object().unwrap();
     let result = xml_obj.node().has_complex_content();
     Ok(result.into())
 }
 
 pub fn has_simple_content<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml_obj = this.unwrap().as_xml_object().unwrap();
+    let xml_obj = this.as_xml_object().unwrap();
     let result = xml_obj.node().has_simple_content();
     Ok(result.into())
 }

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -34,10 +34,10 @@ fn has_simple_content_inner(children: &[E4XOrXml<'_>]) -> bool {
 
 pub fn init<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap().as_xml_list_object().unwrap();
+    let this = this.as_xml_list_object().unwrap();
     let value = args[0];
 
     if let Some(obj) = value.as_object() {
@@ -70,7 +70,7 @@ pub fn init<'gc>(
 
 pub fn call_handler<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    _this: Option<Object<'gc>>,
+    _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     // We do *not* create a new object when AS does 'XMLList(someXMLList)'
@@ -89,30 +89,30 @@ pub fn call_handler<'gc>(
 
 pub fn has_complex_content<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list.children();
     Ok(has_complex_content_inner(&children).into())
 }
 
 pub fn has_simple_content<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list.children();
     Ok(has_simple_content_inner(&children).into())
 }
 
 pub fn to_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list.children();
     if has_simple_content_inner(&children) {
         Ok(simple_content_to_string(children.iter().cloned(), activation)?.into())
@@ -123,10 +123,10 @@ pub fn to_string<'gc>(
 
 pub fn to_xml_string<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list.children();
     let mut out = WString::new();
     for (i, child) in children.iter().enumerate() {
@@ -140,20 +140,20 @@ pub fn to_xml_string<'gc>(
 
 pub fn length<'gc>(
     _activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list.children();
     Ok(children.len().into())
 }
 
 pub fn child<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let multiname = name_to_multiname(activation, &args[0], false)?;
     let children = list.children();
     let mut sub_children = Vec::new();
@@ -172,10 +172,10 @@ pub fn child<'gc>(
 
 pub fn children<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list.children();
     let mut sub_children = Vec::new();
     for child in &*children {
@@ -188,10 +188,10 @@ pub fn children<'gc>(
 
 pub fn copy<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let list = this.unwrap().as_xml_list_object().unwrap();
+    let list = this.as_xml_list_object().unwrap();
     let children = list
         .children()
         .iter()
@@ -202,10 +202,9 @@ pub fn copy<'gc>(
 
 pub fn attribute<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let list = this.as_xml_list_object().unwrap();
 
     let name = args[0];
@@ -229,10 +228,9 @@ pub fn attribute<'gc>(
 
 pub fn attributes<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let list = this.as_xml_list_object().unwrap();
 
     let mut child_attrs = Vec::new();
@@ -247,10 +245,9 @@ pub fn attributes<'gc>(
 
 pub fn name<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let this = this.unwrap();
     let list = this.as_xml_list_object().unwrap();
 
     let mut children = list.children_mut(activation.context.gc_context);
@@ -270,10 +267,10 @@ pub fn name<'gc>(
 
 pub fn descendants<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml_list = this.unwrap().as_xml_list_object().unwrap();
+    let xml_list = this.as_xml_list_object().unwrap();
     let multiname = name_to_multiname(activation, &args[0], false)?;
     let mut descendants = Vec::new();
     for child in xml_list.children().iter() {
@@ -284,10 +281,10 @@ pub fn descendants<'gc>(
 
 pub fn text<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    this: Option<Object<'gc>>,
+    this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    let xml_list = this.unwrap().as_xml_list_object().unwrap();
+    let xml_list = this.as_xml_list_object().unwrap();
     let mut nodes = Vec::new();
     for child in xml_list.children().iter() {
         if let E4XNodeKind::Element { ref children, .. } = &*child.node().kind() {

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -21,18 +21,13 @@ use swf::avm2::types::{
 /// Parameters are as follows:
 ///
 ///  * The AVM2 runtime
-///  * The action context
 ///  * The current `this` object
 ///  * The arguments this function was called with
 ///
-/// Native functions are allowed to return a value or `None`. `None` indicates
-/// that the given value will not be returned on the stack and instead will
-/// resolve on the AVM stack, as if you had called a non-native function. If
-/// your function yields `None`, you must ensure that the top-most activation
-/// in the AVM1 runtime will return with the value of this function.
+/// Native functions are allowed to return a Value or an Error.
 pub type NativeMethodImpl = for<'gc> fn(
     &mut Activation<'_, 'gc>,
-    Option<Object<'gc>>,
+    Object<'gc>,
     &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>>;
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1929,7 +1929,7 @@ impl Player {
             for so in avm2_activation.context.avm2_shared_objects.clone().values() {
                 if let Err(e) = crate::avm2::globals::flash::net::shared_object::flush(
                     &mut avm2_activation,
-                    Some(*so),
+                    *so,
                     &[],
                 ) {
                     tracing::error!("Error flushing AVM2 shared object `{:?}`: {:?}", so, e);


### PR DESCRIPTION
RIP `Option<Object<'gc>>`, a0ab978bed8f0b2c1281a837d701308266b0fa21-[d64ae83](https://github.com/ruffle-rs/ruffle/commit/d64ae83a207eb96f5b9fb7c95c4a711b186935db).
Also RIP my computer trying to render the diff.