### PR TITLE
desktop: load cjk fallback fonts using fontdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fontdb"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8d8cbea8f21307d7e84bca254772981296f058a1d36b461bf4d83a7499fc9e"
+dependencies = [
+ "log",
+ "memmap2 0.6.2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2742,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
 dependencies = [
  "libc",
 ]
@@ -3843,6 +3865,7 @@ dependencies = [
  "egui-winit",
  "embed-resource",
  "fluent-templates",
+ "fontdb",
  "futures",
  "generational-arena",
  "isahc",
@@ -4202,7 +4225,7 @@ checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2",
+ "memmap2 0.5.10",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -4379,7 +4402,7 @@ dependencies = [
  "dlib",
  "lazy_static",
  "log",
- "memmap2",
+ "memmap2 0.5.10",
  "nix 0.24.3",
  "pkg-config",
  "wayland-client",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -13,6 +13,7 @@ cpal = "0.15.2"
 egui = "0.22.0"
 egui-wgpu = { version = "0.22.0", features = ["winit"] }
 egui-winit = "0.22.0"
+fontdb = "0.14"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -6,6 +6,7 @@ use crate::gui::{RuffleGui, MENU_HEIGHT};
 use crate::player::{PlayerController, PlayerOptions};
 use anyhow::anyhow;
 use egui::Context;
+use fontdb::{Database, Family, Query, Source};
 use ruffle_core::Player;
 use ruffle_render_wgpu::backend::{request_adapter_and_device, WgpuRenderBackend};
 use ruffle_render_wgpu::descriptors::Descriptors;
@@ -82,7 +83,9 @@ impl GuiController {
             },
         );
         let descriptors = Descriptors::new(adapter, device, queue);
+        let system_fonts = load_system_fonts().unwrap_or_default();
         let egui_ctx = Context::default();
+        egui_ctx.set_fonts(system_fonts);
         if let Some(Theme::Light) = window.theme() {
             egui_ctx.set_visuals(egui::Visuals::light());
         }
@@ -310,4 +313,50 @@ impl GuiController {
     pub fn show_open_dialog(&mut self) {
         self.gui.open_file_advanced()
     }
+}
+
+// try to load known unicode supporting fonts to draw cjk characters in egui
+fn load_system_fonts() -> anyhow::Result<egui::FontDefinitions> {
+    let mut font_database = Database::default();
+    font_database.load_system_fonts();
+
+    let system_unicode_fonts = Query {
+        families: &[
+            Family::Name("MS UI Gothic"),     // windows
+            Family::Name("Arial Unicode MS"), // macos
+            Family::Name("Noto Sans"),        // linux
+            Family::SansSerif,
+        ],
+        ..Query::default()
+    };
+
+    let id = font_database
+        .query(&system_unicode_fonts)
+        .ok_or(anyhow!("no unicode fonts found!"))?;
+    let (name, src, index) = font_database
+        .face(id)
+        .map(|f| (f.post_script_name.clone(), f.source.clone(), f.index))
+        .expect("id not found in font database");
+
+    let mut fontdata = match src {
+        Source::File(path) => {
+            let data = std::fs::read(path)?;
+            egui::FontData::from_owned(data)
+        }
+        Source::Binary(bin) | Source::SharedFile(_, bin) => {
+            let data = bin.as_ref().as_ref().to_vec();
+            egui::FontData::from_owned(data)
+        }
+    };
+    fontdata.index = index;
+    tracing::info!("loaded cjk fallback font \"{}\"", name);
+
+    let mut fd = egui::FontDefinitions::default();
+    fd.font_data.insert(name.clone(), fontdata);
+    fd.families
+        .get_mut(&egui::FontFamily::Proportional)
+        .expect("font family not found")
+        .push(name);
+
+    Ok(fd)
 }


### PR DESCRIPTION
This is a rebase of #11370 with a commit added to fix font selection on Windows.