### PR TITLE
avm2: Use the current SWF version instead of root SWF version in MovieClip.gotoAndPlay

### DIFF
--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -392,7 +392,7 @@ pub fn goto_frame<'gc>(
                 }
 
                 let frame = mc.frame_label_to_number(&frame_or_label, &activation.context);
-                if activation.context.swf.version() >= 11 {
+                if mc.movie().version() >= 11 {
                     frame.ok_or(
                         // TODO: Also include the scene in the error message, as done above
                         Error::AvmError(argument_error(


### PR DESCRIPTION
Fixes #11927