### PR TITLE
Add more specific CJK font families for Linux

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -333,10 +333,20 @@ fn load_system_fonts(locale: LanguageIdentifier) -> anyhow::Result<egui::FontDef
     } {
         families.push(windows_font);
     }
+    if let Some(linux_font) = match locale.language.as_str() {
+        "ja" => Some(Family::Name("Noto Sans CJK JP")),
+        "zh" => Some(match locale.to_string().as_str() {
+            "zh-CN" => Family::Name("Noto Sans CJK SC"),
+            _ => Family::Name("Noto Sans CJK TC"),
+        }),
+        "ko" => Some(Family::Name("Noto Sans CJK KR")),
+        _ => Some(Family::Name("Noto Sans")),
+    } {
+        families.push(linux_font);
+    }
     families.extend(
         [
             Family::Name("Arial Unicode MS"), // macos
-            Family::Name("Noto Sans"),        // linux
             Family::SansSerif,
         ]
         .iter(),


### PR DESCRIPTION
I don't know if anyone tested CJK fonts on Linux, but it wasn't working for me without this change. Now all the following are working:
- LANG=ca_ES.UTF-8 cargo run --release --package=ruffle_desktop
- **LANG=zh_CN.UTF-8 cargo run --release --package=ruffle_desktop**
- **LANG=zh_TW.UTF-8 cargo run --release --package=ruffle_desktop**
- LANG=cs_CZ.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=nl_NL.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=fr_FR.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=de_DE.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=hu_HU.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=id_ID.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=it_IT.UTF-8 cargo run --release --package=ruffle_desktop
- **LANG=ja_JP.UTF-8 cargo run --release --package=ruffle_desktop**
- **LANG=ko_KR.UTF-8 cargo run --release --package=ruffle_desktop**
- LANG=pt_PT.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=pt_BR.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=ro_RO.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=ru_RU.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=sk_SK.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=es_ES.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=sv_SE.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=tr_TR.UTF-8 cargo run --release --package=ruffle_desktop

The two things that are still not working are:
- LANG=ar_SA.UTF-8 cargo run --release --package=ruffle_desktop
- LANG=he_IL.UTF-8 cargo run --release --package=ruffle_desktop

Fix #11960.