### PR TITLE
avm2: Replace Activation.resolve_type by domain lookup

### DIFF
--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -7,7 +7,6 @@ use crate::avm2::scope::{Scope, ScopeChain};
 use crate::avm2::script::Script;
 use crate::avm2::Avm2;
 use crate::avm2::Error;
-use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::string::AvmString;
@@ -630,8 +629,9 @@ fn load_playerglobal<'gc>(
             let activation = $activation;
             $(
                 let ns = Namespace::package($package, &mut activation.borrow_gc());
-                let name = Multiname::new(ns, $class_name);
-                let class_object = activation.resolve_class(&name)?;
+                let name = QName::new(ns, $class_name);
+                let class_object = activation.domain().get_defined_value(activation, name)?;
+                let class_object = class_object.as_object().unwrap().as_class_object().unwrap();
                 let sc = activation.avm2().system_classes.as_mut().unwrap();
                 sc.$field = class_object;
             )*

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -6,10 +6,9 @@ use crate::avm2::filters::FilterAvm2Ext;
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
-use crate::avm2::Namespace;
+use crate::avm2::StageObject;
 use crate::avm2::{ArrayObject, ArrayStorage};
 use crate::avm2::{ClassObject, Error};
-use crate::avm2::{Multiname, StageObject};
 use crate::display_object::{DisplayObject, HitTestOptions, TDisplayObject};
 use crate::ecma_conversions::round_to_even;
 use crate::prelude::*;
@@ -260,13 +259,8 @@ pub fn set_filters<'gc>(
         if let Some(new_filters) = new_filters {
             if let Some(filters_array) = new_filters.as_array_object() {
                 if let Some(filters_storage) = filters_array.as_array_storage() {
-                    let filters_namespace =
-                        Namespace::package("flash.filters", &mut activation.borrow_gc());
-                    let filter_class = Multiname::new(filters_namespace, "BitmapFilter");
-
-                    let filter_class_object = activation
-                        .resolve_class(&filter_class)?
-                        .inner_class_definition();
+                    let filter_class_object = activation.avm2().classes().bitmapfilter;
+                    let filter_class = filter_class_object.inner_class_definition();
                     let mut filter_vec = Vec::with_capacity(filters_storage.length());
 
                     for filter in filters_storage.iter().flatten() {
@@ -275,9 +269,7 @@ pub fn set_filters<'gc>(
                         } else {
                             let filter_object = filter.coerce_to_object(activation)?;
 
-                            if !filter_object
-                                .is_of_type(filter_class_object, &mut activation.context)
-                            {
+                            if !filter_object.is_of_type(filter_class, &mut activation.context) {
                                 return build_argument_type_error(activation);
                             }
 


### PR DESCRIPTION
Another followup for https://github.com/ruffle-rs/ruffle/pull/11494 .

Converts some more code - `astype`/`istype` opcodes and exception type check - to use the domain instead of scoped lookups. This way we can kill old `resolve_class/type`.

The one remaining case is `resolve_definition(sc_name)` in `globals.rs`, but I unfortunately this is currently needed as we need a `ClassObject` there.

BTW, I think we forgot to mention that the original PR should have sped up a bunch of lookups, like for parameter types. This one also does this for these new opcodes - I tested that an `astype "XML"` microbenchmark speeds up by almost 2x with this change.