### PR TITLE
[WIP] avm2: Store resolved function param types

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -227,7 +227,12 @@ impl<'gc> Avm2<'gc> {
             Method::Native(method) => {
                 //This exists purely to check if the builtin is OK with being called with
                 //no parameters.
-                init_activation.resolve_parameters(method.name, &[], &method.signature)?;
+
+                let signature = method.resolved_signature(&mut init_activation);
+                let signature = signature.read();
+                let signature = &*signature;
+                init_activation.resolve_parameters(method.name, &[], signature)?;
+
                 init_activation
                     .context
                     .avm2

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -185,6 +185,12 @@ impl Hash for ClassKey<'_> {
     }
 }
 
+impl<'gc> fmt::Debug for Class<'gc> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Class").field("name", &self.name).finish()
+    }
+}
+
 impl<'gc> Class<'gc> {
     /// Create a new class.
     ///

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -143,10 +143,13 @@ impl<'gc> Executable<'gc> {
                     .into());
                 }
 
+                let signature = bm.method.resolved_signature(&mut activation);
+                let signature = signature.read();
+
                 let arguments = activation.resolve_parameters(
                     bm.method.name,
                     arguments,
-                    &bm.method.signature,
+                    &signature,
                 )?;
                 activation
                     .context

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -10,7 +10,7 @@ use crate::avm2::value::Value;
 use crate::avm2::{Error, Multiname};
 use core::fmt;
 use gc_arena::{Collect, Gc, GcCell, GcWeakCell, MutationContext};
-use std::cell::{Ref, RefMut};
+use std::cell::{Cell, Ref, RefMut};
 
 /// A class instance allocator that allocates Function objects.
 /// This is only used when ActionScript manually calls 'new Function()',
@@ -32,6 +32,8 @@ pub fn function_allocator<'gc>(
             name: "<Empty Function>",
             signature: vec![],
             return_type: Multiname::any(activation.context.gc_context),
+            has_resolved_signature: Cell::new(false),
+            resolved_signature: GcCell::allocate(activation.context.gc_context, vec![]),
             is_variadic: true,
         },
     );


### PR DESCRIPTION
It's an ugly WIP-POC-prototype thing. `ResolvedParamConfig` feels silly, maybe new gc-arena's Cell-like apis would help clean it up.
(I also wish the signature stuff was unified/shared between native and bytecode method types.)
Now that `has_class_in_chain` PR is merged, this passes all tests c:

This removes all runtime parameter type name lookups from function calls. In my microbenchmarks, for `function f(a: int, b: int, c: int, d: int, e: int)`, this speeds up calls by ~30%.

The remaining overhead is
- mostly: `UpdateContext` cloning
- secondly: copying the arguments vec (twice!)
- other than that: general push/pop overhead