### PR TITLE
swf: avm1: Ignore bad ActionTry opcodes and bad ConstantPool strings

### DIFF
--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -207,7 +207,10 @@ impl<'a> Reader<'a> {
         let count = self.read_u16()?;
         let mut strings = Vec::with_capacity(count as usize);
         for _ in 0..count {
-            strings.push(self.read_str()?);
+            let string = self.read_str();
+            if let Ok(string) = string {
+                strings.push(string);
+            }
         }
         Ok(ConstantPool { strings })
     }

--- a/swf/src/avm1/read.rs
+++ b/swf/src/avm1/read.rs
@@ -350,6 +350,15 @@ impl<'a> Reader<'a> {
     }
 
     fn read_try(&mut self, length: &mut usize) -> Result<Try<'a>> {
+        // All Try opcodes must be at least 7 bytes long. If it's shorter, it's a bogus opcode; return an empty Try.
+        if *length < 7 {
+            return Ok(Try {
+                try_body: &[],
+                catch_body: None,
+                finally_body: None,
+            });
+        }
+
         let flags = TryFlags::from_bits_truncate(self.read_u8()?);
         let try_size: usize = self.read_u16()?.into();
         let catch_size: usize = self.read_u16()?.into();


### PR DESCRIPTION
Fixes #2717, fixes #9785 (both issues described).

I'm not sure how to write a test for this, apart from creating a SWF and manually hex-editing Action data.