### PR TITLE
desktop: Add Letterbox option to Open Advanced dialog

### DIFF
--- a/desktop/assets/texts/en-US/open_dialog.ftl
+++ b/desktop/assets/texts/en-US/open_dialog.ftl
@@ -3,5 +3,5 @@ open-dialog = Open File or URL
 open-dialog-path = File or URL
 
 open-dialog-add-parameter = Add
-open-dialog-delete-parameter = Delete
-open-dialog-clear-parameters = Clear all
+open-dialog-remove-parameter = Remove
+open-dialog-remove-parameters = Remove all

--- a/desktop/assets/texts/en-US/settings.ftl
+++ b/desktop/assets/texts/en-US/settings.ftl
@@ -34,6 +34,11 @@ quality-high8x8linear = High (8x8) Linear
 quality-high16x16 = High (16x16)
 quality-high16x16linear = High (16x16) Linear
 
+letterbox = Letterbox
+letterbox-on = On
+letterbox-fullscreen = Fullscreen Only
+letterbox-off = Off
+
 align = Stage Alignment
 align-center = Center
 align-left = Left

--- a/desktop/src/gui/open_dialog.rs
+++ b/desktop/src/gui/open_dialog.rs
@@ -474,7 +474,7 @@ impl OpenDialog {
             if ui
                 .add_enabled(
                     !self.options.parameters.is_empty(),
-                    Button::new(text(&self.locale, "open-dialog-clear-parameters")),
+                    Button::new(text(&self.locale, "open-dialog-remove-parameters")),
                 )
                 .clicked()
             {
@@ -495,7 +495,7 @@ impl OpenDialog {
                         ui.text_edit_singleline(value);
                         if ui
                             .button("x")
-                            .on_hover_text(text(&self.locale, "open-dialog-delete-parameter"))
+                            .on_hover_text(text(&self.locale, "open-dialog-remove-parameter"))
                             .clicked()
                         {
                             keep = false;

--- a/desktop/src/gui/open_dialog.rs
+++ b/desktop/src/gui/open_dialog.rs
@@ -6,6 +6,7 @@ use egui::{
     Align2, Button, Checkbox, ComboBox, DragValue, Grid, Slider, TextEdit, Ui, Widget, Window,
 };
 use ruffle_core::backend::navigator::OpenURLMode;
+use ruffle_core::config::Letterbox;
 use ruffle_core::{LoadBehavior, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;
 use std::path::Path;
@@ -277,6 +278,32 @@ impl OpenDialog {
                             &mut self.options.quality,
                             StageQuality::High16x16Linear,
                             text(&self.locale, "quality-high16x16linear"),
+                        );
+                    });
+                ui.end_row();
+
+                ui.label(text(&self.locale, "letterbox"));
+                ComboBox::from_id_source("open-file-advanced-options-letterbox")
+                    .selected_text(match self.options.letterbox {
+                        Letterbox::On => text(&self.locale, "letterbox-on"),
+                        Letterbox::Fullscreen => text(&self.locale, "letterbox-fullscreen"),
+                        Letterbox::Off => text(&self.locale, "letterbox-off"),
+                    })
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(
+                            &mut self.options.letterbox,
+                            Letterbox::On,
+                            text(&self.locale, "letterbox-on"),
+                        );
+                        ui.selectable_value(
+                            &mut self.options.letterbox,
+                            Letterbox::Fullscreen,
+                            text(&self.locale, "letterbox-fullscreen"),
+                        );
+                        ui.selectable_value(
+                            &mut self.options.letterbox,
+                            Letterbox::Off,
+                            text(&self.locale, "letterbox-off"),
                         );
                     });
                 ui.end_row();


### PR DESCRIPTION
I guess we missed this one before. Addresses #11967.

I also made a minor change to make the wording for removing movie parameters more consistent.