### PR TITLE
wgpu: Fix crash when not using push constants

### DIFF
--- a/render/wgpu/src/layouts.rs
+++ b/render/wgpu/src/layouts.rs
@@ -33,7 +33,7 @@ impl BindLayouts {
         let color_transforms = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             entries: &[wgpu::BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStages::FRAGMENT,
+                visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
                 ty: wgpu::BindingType::Buffer {
                     ty: wgpu::BufferBindingType::Uniform,
                     has_dynamic_offset: true,


### PR DESCRIPTION
This is required for webgpu support. We must have broken this some time ago and didn't realize, because push constants are on most devices 