### PR TITLE
FLV audio +Buffer refactor

### DIFF
--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -65,6 +65,7 @@ macro_rules! mc_setter {
 }
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
+    "attachAudio" => method(mc_method!(attach_audio); DONT_ENUM | DONT_DELETE | VERSION_6);
     "attachBitmap" => method(mc_method!(attach_bitmap); DONT_ENUM | DONT_DELETE | VERSION_8);
     "attachMovie" => method(mc_method!(attach_movie); DONT_ENUM | DONT_DELETE);
     "beginFill" => method(mc_method!(begin_fill); DONT_ENUM | DONT_DELETE | VERSION_6);
@@ -281,6 +282,22 @@ fn attach_bitmap<'gc>(
                 );
             }
         }
+    }
+
+    Ok(Value::Undefined)
+}
+
+fn attach_audio<'gc>(
+    movie_clip: MovieClip<'gc>,
+    activation: &mut Activation<'_, 'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    if let [Value::Object(netstream_obj), ..] = args {
+        if let NativeObject::NetStream(netstream) = netstream_obj.native() {
+            movie_clip.attach_audio(&mut activation.context, Some(netstream));
+        }
+    } else if let [Value::Bool(false), ..] = args {
+        movie_clip.attach_audio(&mut activation.context, None);
     }
 
     Ok(Value::Undefined)

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -26,7 +26,10 @@ pub use mixer::*;
 #[cfg(not(feature = "audio"))]
 mod decoders {
     #[derive(Debug, thiserror::Error)]
-    pub enum Error {}
+    pub enum Error {
+        #[error("Too many sounds are playing")]
+        TooManySounds,
+    }
 }
 
 use instant::Duration;

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -192,7 +192,7 @@ pub trait AudioBackend: Downcast {
 
     /// Determine if a sound is still playing.
     fn is_sound_playing(&self, instance: SoundInstanceHandle) -> bool {
-        self.get_sound_duration(instance).is_some()
+        self.get_sound_position(instance).is_some()
     }
 }
 

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -528,6 +528,32 @@ impl<'gc> AudioManager<'gc> {
         }
     }
 
+    pub fn start_substream(
+        &mut self,
+        audio: &mut dyn AudioBackend,
+        stream_data: Substream,
+        movie_clip: MovieClip<'gc>,
+        stream_info: &swf::SoundStreamHead,
+    ) -> Option<SoundInstanceHandle> {
+        if self.sounds.len() < Self::MAX_SOUNDS {
+            let handle = audio.start_substream(stream_data, stream_info).ok()?;
+            let instance = SoundInstance {
+                sound: None,
+                instance: handle,
+                display_object: Some(movie_clip.into()),
+                transform: display_object::SoundTransform::default(),
+                avm1_object: None,
+                avm2_object: None,
+                stream_start_frame: None,
+            };
+            audio.set_sound_transform(handle, self.transform_for_sound(&instance));
+            self.sounds.push(instance);
+            Some(handle)
+        } else {
+            None
+        }
+    }
+
     /// Returns the difference in seconds between the primary audio stream's time and the player's time.
     pub fn audio_skew_time(&mut self, audio: &mut dyn AudioBackend, offset_ms: f64) -> f64 {
         // Consider the first playing "stream" sound to be the primary audio track.

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -534,9 +534,9 @@ impl<'gc> AudioManager<'gc> {
         stream_data: Substream,
         movie_clip: MovieClip<'gc>,
         stream_info: &swf::SoundStreamHead,
-    ) -> Option<SoundInstanceHandle> {
+    ) -> Result<SoundInstanceHandle, DecodeError> {
         if self.sounds.len() < Self::MAX_SOUNDS {
-            let handle = audio.start_substream(stream_data, stream_info).ok()?;
+            let handle = audio.start_substream(stream_data, stream_info)?;
             let instance = SoundInstance {
                 sound: None,
                 instance: handle,
@@ -548,9 +548,9 @@ impl<'gc> AudioManager<'gc> {
             };
             audio.set_sound_transform(handle, self.transform_for_sound(&instance));
             self.sounds.push(instance);
-            Some(handle)
+            Ok(handle)
         } else {
-            None
+            Err(DecodeError::TooManySounds)
         }
     }
 

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -31,6 +31,9 @@ pub enum Error {
 
     #[error("Unhandled compression {0:?}")]
     UnhandledCompression(AudioCompression),
+
+    #[error("Too many sounds are playing")]
+    TooManySounds,
 }
 
 /// An audio decoder. Can be used as an `Iterator` to return stero sample frames.

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -472,7 +472,7 @@ impl Read for SubstreamTagReader {
         buf[..len].copy_from_slice(&data[..len]);
 
         drop(data);
-        *chunk = chunk.to_start_and_end(chunk.start() + len, chunk.end());
+        *chunk = chunk.to_start_and_end(len, 0);
 
         if chunk.is_empty() {
             self.current_audio_data = None;

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -14,6 +14,7 @@ pub use mp3::{mp3_metadata, Mp3Decoder};
 pub use nellymoser::NellymoserDecoder;
 pub use pcm::PcmDecoder;
 
+use crate::buffer::{Slice, SliceCursor, Substream, SubstreamChunksIter};
 use crate::tag_utils::{ControlFlow, SwfSlice};
 use std::io::{Cursor, Read};
 use swf::{AudioCompression, SoundFormat, TagCode};
@@ -238,9 +239,6 @@ pub trait SeekableDecoder: Decoder {
 /// `StreamTagReader` reads through the SWF tag data of a `MovieClip`, extracting
 /// audio data from the `SoundStreamBlock` tags. It can be used as an `Iterator` that
 /// will return consecutive slices of the underlying audio data.
-/// `StreamTagReader` reads through the SWF tag data of a `MovieClip`, extracting
-/// audio data from the `SoundStreamBlock` tags. It can be used as an `Iterator` that
-/// will return consecutive slices of the underlying audio data.
 struct StreamTagReader {
     /// The tag data of the `MovieClip` that contains the streaming audio track.
     swf_data: SwfSlice,
@@ -369,4 +367,225 @@ impl Read for StreamTagReader {
 pub struct Mp3Metadata {
     pub sample_rate: u16,
     pub num_sample_frames: u32,
+}
+
+/// `SubstreamTagReader` reads through the data chunks of a `Substream` with
+/// audio data in it. Data is assumed to have already been extracted from its
+/// container.
+///
+/// MP3 data will be further joined into properly-sized chunks.
+struct SubstreamTagReader {
+    /// The tag data of the `MovieClip` that contains the streaming audio track.
+    data_stream: SubstreamChunksIter,
+
+    /// The compressed audio data in the most recent `SoundStreamBlock` we've seen, returned by `Iterator::next`.
+    current_audio_data: Option<Slice>,
+
+    /// The compression used by the audio data.
+    compression: AudioCompression,
+
+    /// The number of audio samples for use in future animation frames.
+    ///
+    /// Only used in MP3 encoding to properly handle gaps in the audio track.
+    mp3_samples_buffered: i32,
+
+    /// The ideal number of audio samples in each animation frame, i.e. the sample rate divided by frame rate.
+    ///
+    /// Only used in MP3 encoding to properly handle gaps in the audio track.
+    _mp3_samples_per_block: u16,
+}
+
+impl SubstreamTagReader {
+    /// Builds a new `SubstreamTagReader` from the given `Substream`.
+    ///
+    /// `Substream` should reference audio data.
+    fn new(stream_info: &swf::SoundStreamHead, data_stream: Substream) -> Self {
+        Self {
+            data_stream: data_stream.iter_chunks(),
+            compression: stream_info.stream_format.compression,
+            current_audio_data: None,
+            mp3_samples_buffered: 0,
+            _mp3_samples_per_block: stream_info.num_samples_per_block,
+        }
+    }
+}
+
+impl Iterator for SubstreamTagReader {
+    type Item = Slice;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let compression = self.compression;
+        let next_chunk = self.data_stream.next()?;
+        let data = next_chunk.data();
+
+        let mut audio_block = &data[..];
+        if compression == AudioCompression::Mp3 && next_chunk.len() >= 4 {
+            // MP3s deliver audio in frames of 576 samples, which means we may have SoundStreamBlocks with
+            // lots of extra samples, followed by a block with 0 samples. Worse, there may be frames without
+            // blocks at all despite SWF19 saying this shouldn't happen. This may or may not indicate a gap
+            // in the audio depending on the number of empty frames.
+            // Keep a tally of the # of samples we've seen compared to the number of samples that will be
+            // played in each timeline frame. Only stop an MP3 sound if we've exhausted all of the samples.
+            // RESEARCHME: How does Flash Player actually determine when there is an audio gap or not?
+            // If an MP3 audio track has gaps, Flash Player will often play it out of sync (too early).
+            // Seems closely related to `stream_info.num_samples_per_block`.
+            let num_samples =
+                u16::from_le_bytes(audio_block[..2].try_into().expect("2 bytes fit into a u16"));
+            self.mp3_samples_buffered += i32::from(num_samples);
+            audio_block = &audio_block[4..];
+        }
+        self.current_audio_data = Some(next_chunk.to_subslice(audio_block));
+
+        // TODO: per-frame sample tracking. `Substream` does not have a notion
+        // of a 'frame'. However, SWF audio streams end if there's no audio
+        // data in a frame, EXCEPT for MP3 which is allowed to straddle frames,
+        // have empty frames, etc. Non-MP3 stops at the first chunk.
+        self.current_audio_data.clone()
+    }
+}
+
+/// Returns an `Reader` that reads through SWF tags and returns slices of any
+/// audio stream data for `SoundStreamBlock` tags.
+impl Read for SubstreamTagReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.current_audio_data.is_none() && self.next().is_none() {
+            //next() fills current_audio_data
+            return Ok(0);
+        }
+
+        let chunk = self.current_audio_data.as_mut().unwrap();
+        let data = chunk.data();
+
+        //At this point, current_audio_data should be full
+        let len = std::cmp::min(buf.len(), data.len());
+        buf[..len].copy_from_slice(&data[..len]);
+
+        drop(data);
+        *chunk = chunk.to_start_and_end(chunk.start() + len, chunk.end());
+
+        if chunk.is_empty() {
+            self.current_audio_data = None;
+        }
+        Ok(len)
+    }
+}
+
+/// Create a new decoder that reads data from a shared `Substream` instance.
+/// This works similarly to `make_stream_decoder` but using the new buffer
+/// infrastructure that will eventually replace SWF-specific streaming.
+///
+/// The substream is shared in order to allow appending additional data into
+/// the stream.
+pub fn make_substream_decoder(
+    stream_info: &swf::SoundStreamHead,
+    data_stream: Substream,
+) -> Result<Box<dyn Decoder + Send>, Error> {
+    let decoder: Box<dyn Decoder + Send> =
+        if stream_info.stream_format.compression == AudioCompression::Adpcm {
+            Box::new(AdpcmSubstreamDecoder::new(stream_info, data_stream)?)
+        } else {
+            Box::new(StandardSubstreamDecoder::new(stream_info, data_stream)?)
+        };
+    Ok(decoder)
+}
+
+/// The `StandardSubstreamDecoder` takes care of reading the audio data from
+/// the chunks of a `Substream` and feeding it to the decoder.
+struct StandardSubstreamDecoder {
+    /// The underlying decoder. The decoder will get its data from a `Substream`.
+    decoder: Box<dyn Decoder>,
+}
+
+impl StandardSubstreamDecoder {
+    /// Constructs a new `StandardSubstreamDecoder`.
+    /// `swf_data` should be the tag data of the MovieClip that contains the stream.
+    fn new(stream_info: &swf::SoundStreamHead, data_stream: Substream) -> Result<Self, Error> {
+        // Create a tag reader to get the audio data from SoundStreamBlock tags.
+        let tag_reader = SubstreamTagReader::new(stream_info, data_stream);
+        // Wrap the tag reader in the decoder.
+        let decoder = make_decoder(&stream_info.stream_format, tag_reader)?;
+        Ok(Self { decoder })
+    }
+}
+
+impl Decoder for StandardSubstreamDecoder {
+    fn num_channels(&self) -> u8 {
+        self.decoder.num_channels()
+    }
+    fn sample_rate(&self) -> u16 {
+        self.decoder.sample_rate()
+    }
+}
+
+impl Iterator for StandardSubstreamDecoder {
+    type Item = [i16; 2];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.decoder.next()
+    }
+}
+
+/// Stream sounds encoded with ADPCM have an ADPCM header in each `SoundStreamBlock` tag, unlike
+/// other compression formats that remain the same as if they were a single sound clip.
+/// Therefore, we must recreate the decoder with each `SoundStreamBlock` to parse the additional
+/// headers.
+pub struct AdpcmSubstreamDecoder {
+    format: SoundFormat,
+    tag_reader: SubstreamTagReader,
+    decoder: AdpcmDecoder<SliceCursor>,
+}
+
+impl AdpcmSubstreamDecoder {
+    fn new(stream_info: &swf::SoundStreamHead, data_stream: Substream) -> Result<Self, Error> {
+        let empty_buffer = data_stream.buffer().to_empty_slice();
+        let mut tag_reader = SubstreamTagReader::new(stream_info, data_stream);
+        let audio_data = tag_reader.next().unwrap_or(empty_buffer);
+        let decoder = AdpcmDecoder::new(
+            audio_data.as_cursor(),
+            stream_info.stream_format.is_stereo,
+            stream_info.stream_format.sample_rate,
+        )?;
+        Ok(Self {
+            format: stream_info.stream_format.clone(),
+            tag_reader,
+            decoder,
+        })
+    }
+}
+
+impl Decoder for AdpcmSubstreamDecoder {
+    fn num_channels(&self) -> u8 {
+        self.decoder.num_channels()
+    }
+    fn sample_rate(&self) -> u16 {
+        self.decoder.sample_rate()
+    }
+}
+
+impl Iterator for AdpcmSubstreamDecoder {
+    type Item = [i16; 2];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(sample_frame) = self.decoder.next() {
+            // Return sample frames until the decoder has exhausted
+            // the SoundStreamBlock tag.
+            Some(sample_frame)
+        } else if let Some(audio_data) = self.tag_reader.next() {
+            // We've reached the end of the sound stream block tag, so
+            // read the next one and recreate the decoder.
+            // `AdpcmDecoder` read the ADPCM header when it is created.
+            self.decoder = AdpcmDecoder::new(
+                audio_data.as_cursor(),
+                self.format.is_stereo,
+                self.format.sample_rate,
+            )
+            .ok()?;
+            self.decoder.next()
+        } else {
+            // No more SoundStreamBlock tags.
+            None
+        }
+    }
 }

--- a/core/src/backend/audio/decoders.rs
+++ b/core/src/backend/audio/decoders.rs
@@ -472,7 +472,7 @@ impl Read for SubstreamTagReader {
         buf[..len].copy_from_slice(&data[..len]);
 
         drop(data);
-        *chunk = chunk.to_start_and_end(len, 0);
+        *chunk = chunk.to_start_and_end(len, chunk.len());
 
         if chunk.is_empty() {
             self.current_audio_data = None;

--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -1,5 +1,5 @@
 use super::decoders::{self, AdpcmDecoder, Decoder, PcmDecoder, SeekableDecoder};
-use super::{SoundHandle, SoundInstanceHandle, SoundTransform};
+use super::{SoundHandle, SoundInstanceHandle, SoundStreamInfo, SoundTransform};
 use crate::backend::audio::{DecodeError, RegisterError};
 use crate::buffer::Substream;
 use crate::tag_utils::SwfSlice;
@@ -412,7 +412,7 @@ impl AudioMixer {
 
     fn make_stream_from_buffer_substream(
         &self,
-        stream_info: &swf::SoundStreamHead,
+        stream_info: &SoundStreamInfo,
         data_stream: Substream,
     ) -> Result<Box<dyn Stream>, DecodeError> {
         // Instantiate a decoder for the compression that the sound data uses.
@@ -608,7 +608,7 @@ impl AudioMixer {
     pub fn start_substream(
         &mut self,
         stream_data: Substream,
-        stream_info: &swf::SoundStreamHead,
+        stream_info: &SoundStreamInfo,
     ) -> Result<SoundInstanceHandle, DecodeError> {
         // The audio data for substream sounds is already de-multiplexed by the
         // caller. The substream tag reader will feed the decoder audio data
@@ -1111,7 +1111,7 @@ macro_rules! impl_audio_mixer_backend {
         fn start_substream(
             &mut self,
             stream_data: ruffle_core::buffer::Substream,
-            stream_info: &swf::SoundStreamHead,
+            stream_info: &SoundStreamInfo,
         ) -> Result<SoundInstanceHandle, DecodeError> {
             self.$mixer.start_substream(stream_data, stream_info)
         }

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -608,6 +608,40 @@ mod test {
     }
 
     #[test]
+    fn slice_cursor_read() {
+        let buf = Buffer::from(vec![
+            38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
+        ]);
+        let slice = buf.to_full_slice();
+        let mut cursor = slice.as_cursor();
+        let refdata = slice.data();
+
+        let mut data = vec![0; 1];
+
+        for byte in &refdata[..] {
+            let result = cursor.read(&mut data);
+            assert_eq!(result.unwrap(), 1);
+            assert_eq!(data[0], *byte);
+        }
+    }
+
+    #[test]
+    fn slice_cursor_read_all() {
+        let buf = Buffer::from(vec![
+            38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
+        ]);
+        let slice = buf.to_full_slice();
+        let mut cursor = slice.as_cursor();
+        let refdata = slice.data();
+
+        let mut data = vec![0; slice.len() + 32];
+
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), slice.len());
+        assert_eq!(&data[..slice.len()], &refdata[..]);
+    }
+
+    #[test]
     fn substream_cursor_read_inside() {
         let buf = Buffer::from(vec![
             38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -1,7 +1,10 @@
 //! Shared-ownership buffer types
 
 use gc_arena::Collect;
+use std::cmp::min;
 use std::fmt::Debug;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult};
+use std::iter::Iterator;
 use std::ops::{Bound, Deref, RangeBounds};
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
@@ -88,8 +91,8 @@ impl Buffer {
         if start <= s.len() && end <= s.len() && start <= end {
             Some(Slice {
                 buf: Self(self.0.clone()),
-                start: start,
-                end: end,
+                start,
+                end,
             })
         } else {
             None
@@ -105,9 +108,21 @@ impl Buffer {
     }
 }
 
+impl Default for Buffer {
+    fn default() -> Self {
+        Buffer::new()
+    }
+}
+
 impl From<Vec<u8>> for Buffer {
     fn from(val: Vec<u8>) -> Self {
         Self(Arc::new(RwLock::new(val)))
+    }
+}
+
+impl PartialEq for Buffer {
+    fn eq(&self, other: &Buffer) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 
@@ -242,6 +257,167 @@ impl Slice {
     }
 }
 
+/// A list of multiple slices of the same buffer.
+///
+/// `Substream` represents a substream of the underlying buffer. Slices can be
+/// appended to the chunks list
+#[derive(Clone, Debug)]
+pub struct Substream {
+    buf: Option<Buffer>,
+    chunks: Vec<(usize, usize)>,
+}
+
+impl Substream {
+    pub fn new() -> Self {
+        Self {
+            buf: None,
+            chunks: vec![],
+        }
+    }
+
+    pub fn append(&mut self, slice: Slice) -> Result<(), ()> {
+        if self.buf.is_none() {
+            self.buf = Some(slice.buf);
+            self.chunks.push((slice.start, slice.end));
+
+            Ok(())
+        } else if self.buf == Some(slice.buf) {
+            self.chunks.push((slice.start, slice.end));
+
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn num_chunks(&self) -> usize {
+        self.chunks.len()
+    }
+
+    pub fn as_cursor(&self) -> SubstreamCursor {
+        SubstreamCursor {
+            substream: self.clone(),
+            chunk_pos: 0,
+            bytes_pos: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        let mut tally = 0;
+        for (chunk_start, chunk_end) in &self.chunks {
+            tally += chunk_end - chunk_start;
+        }
+
+        tally
+    }
+
+    pub fn iter_chunks(&self) -> SubstreamChunksIter {
+        SubstreamChunksIter {
+            substream: self.clone(),
+            next_buf: 0,
+        }
+    }
+}
+
+impl From<Buffer> for Substream {
+    fn from(buf: Buffer) -> Self {
+        Self {
+            buf: Some(buf),
+            chunks: vec![],
+        }
+    }
+}
+
+impl From<Slice> for Substream {
+    fn from(slice: Slice) -> Self {
+        Self {
+            buf: Some(slice.buf),
+            chunks: vec![(slice.start, slice.end)],
+        }
+    }
+}
+
+/// A readable cursor into a buffer substream.
+///
+/// Reads from the cursor (via `Read` etc) will be filled as if the substream
+/// referred to in the chunks list is a single contiguous stream of bytes with
+/// no other data in between. Code using a `SubstreamCursor` can thus work with
+/// both multiplexed and unmultiplexed data in the same way.
+pub struct SubstreamCursor {
+    substream: Substream,
+    chunk_pos: usize,
+    bytes_pos: usize,
+}
+
+impl Read for SubstreamCursor {
+    fn read(&mut self, data: &mut [u8]) -> IoResult<usize> {
+        let mut out_count = 0;
+        if self.substream.buf.is_none() {
+            return Ok(out_count);
+        }
+
+        let buf_owned = self.substream.buf.clone().expect("buffer");
+        let buf = buf_owned.0.read().map_err(|_| {
+            IoError::new(
+                IoErrorKind::Other,
+                "the underlying substream is locked by a panicked process",
+            )
+        })?;
+
+        while out_count < data.len() {
+            let cur_chunk = self.substream.chunks.get(self.chunk_pos);
+            if cur_chunk.is_none() {
+                return Ok(out_count);
+            }
+
+            let cur_chunk = cur_chunk.expect("cur_chunk should never be None");
+
+            let chunk_len = cur_chunk.1 - cur_chunk.0;
+            let copy_count = min(data.len() - out_count, chunk_len - self.bytes_pos);
+
+            data[out_count..out_count + copy_count].copy_from_slice(
+                buf.get(cur_chunk.0..cur_chunk.0 + copy_count)
+                    .expect("Slice offsets are always valid"),
+            );
+            self.bytes_pos += copy_count;
+            if self.bytes_pos < chunk_len {
+                break;
+            }
+
+            out_count += copy_count;
+
+            self.chunk_pos += 1;
+            self.bytes_pos = 0;
+        }
+
+        Ok(out_count)
+    }
+}
+
+/// Iterator for substream chunks
+pub struct SubstreamChunksIter {
+    substream: Substream,
+    next_buf: usize,
+}
+
+impl Iterator for SubstreamChunksIter {
+    type Item = Slice;
+
+    fn next(&mut self) -> Option<Slice> {
+        if let Some((start, end)) = self.substream.chunks.get(self.next_buf) {
+            if let Some(buf) = &self.substream.buf {
+                return Some(Slice {
+                    buf: buf.clone(),
+                    start: *start,
+                    end: *end,
+                });
+            }
+        }
+
+        None
+    }
+}
+
 #[derive(Debug)]
 pub struct SliceRef<'a> {
     guard: RwLockReadGuard<'a, Vec<u8>>,
@@ -267,7 +443,8 @@ impl PartialEq for SliceRef<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::buffer::Buffer;
+    use crate::buffer::{Buffer, Substream};
+    use std::io::Read;
 
     #[test]
     fn buf_slice() {
@@ -287,5 +464,42 @@ mod test {
         buf.append(&mut vec![6, 7, 8, 9]);
 
         assert_eq!(&*slice.data(), &[2, 3]);
+    }
+
+    #[test]
+    fn substream_cursor_read_inside() {
+        let buf = Buffer::from(vec![
+            38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
+        ]);
+        let mut substream = Substream::new();
+
+        substream.append(buf.get(3..7).unwrap()).unwrap();
+        substream.append(buf.get(10..12).unwrap()).unwrap();
+        substream.append(buf.get(14..15).unwrap()).unwrap();
+
+        let mut cursor = substream.as_cursor();
+        let mut data = vec![0; 7];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(data, vec![1; 7]);
+    }
+
+    #[test]
+    fn substream_cursor_read_outside() {
+        let buf = Buffer::from(vec![
+            38, 26, 99, 1, 1, 1, 1, 38, 12, 14, 1, 1, 93, 86, 1, 88,
+        ]);
+        let mut substream = Substream::new();
+
+        substream.append(buf.get(0..3).unwrap()).unwrap();
+        substream.append(buf.get(7..10).unwrap()).unwrap();
+        substream.append(buf.get(12..14).unwrap()).unwrap();
+        substream.append(buf.get(15..).unwrap()).unwrap();
+
+        let mut cursor = substream.as_cursor();
+        let mut data = vec![0; 7];
+        let result = cursor.read(&mut data);
+        assert_eq!(result.unwrap(), 7);
+        assert_eq!(data, vec![38, 26, 99, 38, 12, 14, 93, 86, 88]);
     }
 }

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -403,6 +403,30 @@ impl Substream {
     pub fn buffer(&self) -> &Buffer {
         &self.buf
     }
+
+    pub fn first_chunk(&self) -> Option<Slice> {
+        if let Some((start, end)) = self.chunks.read().unwrap().first() {
+            Some(Slice {
+                buf: self.buf.clone(),
+                start: *start,
+                end: *end,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn last_chunk(&self) -> Option<Slice> {
+        if let Some((start, end)) = self.chunks.read().unwrap().last() {
+            Some(Slice {
+                buf: self.buf.clone(),
+                start: *start,
+                end: *end,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl From<Buffer> for Substream {

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -265,6 +265,10 @@ impl Slice {
         }
     }
 
+    pub fn buffer(&self) -> &Buffer {
+        &self.buf
+    }
+
     /// Create a readable cursor into the `Slice`.
     pub fn as_cursor(&self) -> SliceCursor {
         SliceCursor {

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -493,6 +493,7 @@ impl Iterator for SubstreamChunksIter {
 
     fn next(&mut self) -> Option<Slice> {
         if let Some((start, end)) = self.substream.chunks.read().unwrap().get(self.next_buf) {
+            self.next_buf += 1;
             return Some(Slice {
                 buf: self.substream.buf.clone(),
                 start: *start,

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -2,7 +2,7 @@
 
 use gc_arena::Collect;
 use std::cmp::min;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter, LowerHex, UpperHex};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult};
 use std::iter::Iterator;
 use std::ops::{Bound, Deref, RangeBounds};
@@ -278,6 +278,18 @@ impl Slice {
     }
 }
 
+impl LowerHex for Slice {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        LowerHex::fmt(&self.data(), f)
+    }
+}
+
+impl UpperHex for Slice {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        UpperHex::fmt(&self.data(), f)
+    }
+}
+
 /// A readable cursor into a buffer slice.
 pub struct SliceCursor {
     slice: Slice,
@@ -512,6 +524,36 @@ impl PartialEq for SliceRef<'_> {
         self.guard.as_ptr() == other.guard.as_ptr()
             && self.start == other.start
             && self.end == other.end
+    }
+}
+
+impl LowerHex for SliceRef<'_> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (index, byte) in self[..].iter().enumerate() {
+            if index > 0 {
+                write!(f, " ")?;
+            }
+            LowerHex::fmt(byte, f)?;
+        }
+        write!(f, "]")?;
+
+        Ok(())
+    }
+}
+
+impl UpperHex for SliceRef<'_> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (index, byte) in self[..].iter().enumerate() {
+            if index > 0 {
+                write!(f, " ")?;
+            }
+            UpperHex::fmt(byte, f)?;
+        }
+        write!(f, "]")?;
+
+        Ok(())
     }
 }
 

--- a/core/src/buffer.rs
+++ b/core/src/buffer.rs
@@ -1,0 +1,291 @@
+//! Shared-ownership buffer types
+
+use gc_arena::Collect;
+use std::fmt::Debug;
+use std::ops::{Bound, Deref, RangeBounds};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
+
+/// A shared data buffer.
+///
+/// `Buffer` is intended to mirror the API of a `Vec<u8>`, but with shared
+/// ownership. Mutability is partially supported: you may append data to the
+/// end of the buffer, but not change or remove bytes already added to the
+/// buffer.
+///
+/// Buffer data may also be sliced to yield references to the underlying data.
+/// See `Slice` for more info.
+#[derive(Clone, Debug, Collect)]
+#[collect(require_static)]
+pub struct Buffer(Arc<RwLock<Vec<u8>>>);
+
+impl Buffer {
+    pub fn new() -> Self {
+        Buffer(Arc::new(RwLock::new(Vec::new())))
+    }
+
+    pub fn with_capacity(cap: usize) -> Self {
+        Buffer(Arc::new(RwLock::new(Vec::with_capacity(cap))))
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.0.read().expect("unlock read").capacity()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.read().expect("unlock read").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.read().expect("unlock read").is_empty()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.write().expect("unlock write").reserve(additional)
+    }
+
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.0
+            .write()
+            .expect("unlock write")
+            .reserve_exact(additional)
+    }
+
+    pub fn as_slice(&self) -> Slice {
+        let end = self.0.read().expect("unlock read").len();
+        Slice {
+            buf: self.clone(),
+            start: 0,
+            end,
+        }
+    }
+
+    pub fn append(&mut self, other: &mut Vec<u8>) {
+        self.0.write().expect("unlock write").append(other)
+    }
+
+    pub fn extend_from_slice(&mut self, other: &[u8]) {
+        self.0
+            .write()
+            .expect("unlock write")
+            .extend_from_slice(other)
+    }
+
+    pub fn get<T: RangeBounds<usize>>(&self, range: T) -> Option<Slice> {
+        let s = self.0.read().expect("unlock read");
+
+        let start = match range.start_bound() {
+            Bound::Included(u) => *u,
+            Bound::Excluded(u) => *u + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(u) => *u + 1,
+            Bound::Excluded(u) => *u,
+            Bound::Unbounded => s.len(),
+        };
+
+        if start <= s.len() && end <= s.len() && start <= end {
+            Some(Slice {
+                buf: Self(self.0.clone()),
+                start: start,
+                end: end,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn to_full_slice(&self) -> Slice {
+        self.get(0..).expect("full slices are always valid")
+    }
+
+    pub fn to_empty_slice(&self) -> Slice {
+        self.get(0..0).expect("empty slices are always valid")
+    }
+}
+
+impl From<Vec<u8>> for Buffer {
+    fn from(val: Vec<u8>) -> Self {
+        Self(Arc::new(RwLock::new(val)))
+    }
+}
+
+/// A reference into a shared data buffer.
+///
+/// `Slice` is intended to mirror the API of a `&[u8]`, but without retaining
+/// a borrow. Ownership of a `Slice` keeps the underlying buffer data alive,
+/// and you can read the buffer data at any time.
+///
+/// Slice bounds are interpreted as a [start..end] pair, i.e. inclusive on the
+/// start bound and exclusive on the end.
+#[derive(Clone, Debug)]
+pub struct Slice {
+    buf: Buffer,
+    start: usize,
+    end: usize,
+}
+
+impl Slice {
+    /// Create a subslice of this buffer slice.
+    ///
+    /// The parameter `slice` must be derived from the same buffer this slice
+    /// was, and must also be within bounds of this slice. If not, then the
+    /// returned slice will be empty.
+    pub fn to_subslice(&self, slice: &[u8]) -> Self {
+        let self_guard = self.buf.0.read().expect("unlock read");
+        let self_pval = self_guard.as_ptr() as usize;
+        let slice_pval = slice.as_ptr() as usize;
+
+        if (self_pval + self.start) <= slice_pval && slice_pval < (self_pval + self.end) {
+            Self {
+                buf: self.buf.clone(),
+                start: slice_pval - self_pval,
+                end: (slice_pval - self_pval) + slice.len(),
+            }
+        } else {
+            self.buf.to_empty_slice()
+        }
+    }
+
+    /// Create a subslice of this buffer slice, without bounds checking.
+    ///
+    /// The parameter `slice` must be derived from the same buffer this slice
+    /// was, otherwise the returned slice will be empty
+    ///
+    /// This emulates "unbounded reads" in file formats that don't bounds-check
+    /// things properly.
+    pub fn to_unbounded_subslice(&self, slice: &[u8]) -> Self {
+        let self_guard = self.buf.0.read().expect("unlock read");
+        let self_pval = self_guard.as_ptr() as usize;
+        let self_len = self.buf.len();
+        let slice_pval = slice.as_ptr() as usize;
+
+        if self_pval <= slice_pval && slice_pval < (self_pval + self_len) {
+            Slice {
+                buf: self.buf.clone(),
+                start: slice_pval - self_pval,
+                end: (slice_pval - self_pval) + slice.len(),
+            }
+        } else {
+            self.buf.to_empty_slice()
+        }
+    }
+
+    /// Construct a new Slice from a start and an end.
+    ///
+    /// The start and end values will be relative to the current slice.
+    /// Furthermore, this function will yield an empty slice if the calculated
+    /// slice would be invalid (e.g. negative length) or would extend past the
+    /// end of the current slice.
+    pub fn to_start_and_end(&self, start: usize, end: usize) -> Self {
+        let new_start = self.start + start;
+        let new_end = self.start + end;
+
+        if new_start <= new_end && new_end < self.end {
+            if let Some(result) = self.buf.get(new_start..new_end) {
+                result
+            } else {
+                self.buf.to_empty_slice()
+            }
+        } else {
+            self.buf.to_empty_slice()
+        }
+    }
+
+    /// Get a subslice of this slice.
+    ///
+    /// Normal subslicing bounds rules will be respected. If you want to get a
+    /// slice outside the bounds of this one, use `to_unbounded_subslice`.
+    pub fn get<T: RangeBounds<usize>>(&self, range: T) -> Option<Slice> {
+        let s = self.buf.0.read().expect("unlock read");
+
+        let start = match range.start_bound() {
+            Bound::Included(u) => *u,
+            Bound::Excluded(u) => *u + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(u) => *u + 1,
+            Bound::Excluded(u) => *u,
+            Bound::Unbounded => s.len(),
+        };
+
+        if start <= s.len() && end <= s.len() && start <= end {
+            Some(Slice {
+                buf: self.buf.clone(),
+                start: self.start + start,
+                end: self.start + end,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Checks if this slice is empty
+    pub fn is_empty(&self) -> bool {
+        self.end == self.start
+    }
+
+    /// Get the length of the Slice.
+    pub fn len(&self) -> usize {
+        self.end - self.start
+    }
+
+    pub fn data(&self) -> SliceRef {
+        SliceRef {
+            guard: self.buf.0.read().expect("unlock read"),
+            start: self.start,
+            end: self.end,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SliceRef<'a> {
+    guard: RwLockReadGuard<'a, Vec<u8>>,
+    start: usize,
+    end: usize,
+}
+
+impl Deref for SliceRef<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard[self.start..self.end]
+    }
+}
+
+impl PartialEq for SliceRef<'_> {
+    fn eq(&self, other: &SliceRef<'_>) -> bool {
+        self.guard.as_ptr() == other.guard.as_ptr()
+            && self.start == other.start
+            && self.end == other.end
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::buffer::Buffer;
+
+    #[test]
+    fn buf_slice() {
+        let buf = Buffer::from(vec![0, 1, 2, 3, 4, 5]);
+        let slice = buf.get(2..4).expect("valid slice");
+
+        assert_eq!(&*slice.data(), &[2, 3]);
+    }
+
+    #[test]
+    fn buf_slice_append() {
+        let mut buf = Buffer::from(vec![0, 1, 2, 3, 4, 5]);
+        let slice = buf.get(2..4).expect("valid slice");
+
+        assert_eq!(&*slice.data(), &[2, 3]);
+
+        buf.append(&mut vec![6, 7, 8, 9]);
+
+        assert_eq!(&*slice.data(), &[2, 3]);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,7 +22,7 @@ mod avm1;
 mod avm2;
 mod binary_data;
 pub mod bitmap;
-mod buffer;
+pub mod buffer;
 mod character;
 pub mod context;
 pub mod context_menu;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -22,6 +22,7 @@ mod avm1;
 mod avm2;
 mod binary_data;
 pub mod bitmap;
+mod buffer;
 mod character;
 pub mod context;
 pub mod context_menu;

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1392,6 +1392,7 @@ impl<'gc> Loader<'gc> {
 
                 match response {
                     Ok(mut response) => {
+                        stream.init_buffer(uc);
                         stream.load_buffer(uc, &mut response.body);
                     }
                     Err(response) => {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1392,7 +1392,7 @@ impl<'gc> Loader<'gc> {
 
                 match response {
                     Ok(mut response) => {
-                        stream.init_buffer(uc);
+                        stream.reset_buffer(uc);
                         stream.load_buffer(uc, &mut response.body);
                     }
                     Err(response) => {

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -239,7 +239,7 @@ pub struct NetStreamData<'gc> {
 impl<'gc> NetStream<'gc> {
     pub fn new(gc_context: &Mutation<'gc>, avm_object: Option<AvmObject<'gc>>) -> Self {
         // IMPORTANT: When adding new fields consider if they need to be
-        // initialized in `init_buffer` as well.
+        // initialized in `reset_buffer` as well.
         Self(GcCell::new(
             gc_context,
             NetStreamData {
@@ -271,15 +271,15 @@ impl<'gc> NetStream<'gc> {
         self.0.write(gc_context).avm_object = Some(avm_object);
     }
 
-    /// Initialize the `NetStream` buffer to accept new source data.
+    /// Reset the `NetStream` buffer to accept new source data.
     ///
     /// This must be done once per source change and should ideally be done
     /// immediately before the first `load_buffer` call for a particular source
     /// file.
     ///
-    /// Externally visible AVM state must not be initialized here - i.e. the
+    /// Externally visible AVM state must not be reinitialized here - i.e. the
     /// AS3 `client` doesn't go away because you played a new video file.
-    pub fn init_buffer(self, context: &mut UpdateContext<'_, 'gc>) {
+    pub fn reset_buffer(self, context: &mut UpdateContext<'_, 'gc>) {
         let mut write = self.0.write(context.gc_context);
 
         if let Some(instance) = write.sound_instance {

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -517,7 +517,7 @@ impl<'gc> NetStream<'gc> {
     ///
     /// Intended to be called at the start of tag processing, before any new
     /// audio data has been streamed.
-    fn collect_sound_stream(
+    fn cleanup_sound_stream(
         self,
         context: &mut UpdateContext<'_, 'gc>,
         write: &mut NetStreamData<'gc>,
@@ -801,7 +801,7 @@ impl<'gc> NetStream<'gc> {
         #![allow(clippy::explicit_auto_deref)] //Erroneous lint
         let mut write = self.0.write(context.gc_context);
 
-        self.collect_sound_stream(context, &mut write);
+        self.cleanup_sound_stream(context, &mut write);
         let slice = write.buffer.to_full_slice();
         let buffer = slice.data();
 

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -14,6 +14,7 @@ use crate::backend::audio::{DecodeError, SoundInstanceHandle};
 use crate::backend::navigator::Request;
 use crate::buffer::{Buffer, Substream};
 use crate::context::UpdateContext;
+use crate::display_object::MovieClip;
 use crate::loader::Error;
 use crate::string::AvmString;
 use crate::vminterface::AvmObject;
@@ -31,7 +32,30 @@ use ruffle_video::VideoStreamHandle;
 use std::cmp::max;
 use std::io::Seek;
 use swf::{AudioCompression, SoundFormat, SoundStreamHead, VideoCodec, VideoDeblocking};
+use thiserror::Error;
 use url::Url;
+
+#[derive(Debug, Error)]
+enum NetstreamError {
+    #[error("Decoding failed because {0}")]
+    DecodeError(DecodeError),
+
+    #[error("Could not play back audio and no error was given")]
+    NoPlayback,
+
+    #[error("Unknown codec")]
+    UnknownCodec,
+
+    #[error("AVM1 NetStream not attached to MovieClip")]
+    NotAttached,
+}
+
+impl From<DecodeError> for NetstreamError {
+    fn from(err: DecodeError) -> NetstreamError {
+        NetstreamError::DecodeError(err)
+    }
+}
+
 /// Manager for all media streams.
 ///
 /// This does *not* handle data transport; which is delegated to `LoadManager`.
@@ -147,10 +171,6 @@ pub enum NetStreamType {
         /// onto a table of data buffers like `Video` does, so we must maintain
         /// frame IDs ourselves for various API related purposes.
         frame_id: u32,
-
-        /// The currently playing audio track's `Substream` and associated
-        /// audio instance.
-        audio_stream: Option<(Substream, SoundInstanceHandle)>,
     },
 }
 
@@ -197,6 +217,14 @@ pub struct NetStreamData<'gc> {
 
     /// The URL of the requested FLV if one exists.
     url: Option<String>,
+
+    /// The currently playing audio track's `Substream` and associated
+    /// audio instance.
+    #[collect(require_static)]
+    audio_stream: Option<(Substream, SoundInstanceHandle)>,
+
+    /// The MovieClip this `NetStream` is attached to.
+    attached_to: Option<MovieClip<'gc>>,
 }
 
 impl<'gc> NetStream<'gc> {
@@ -213,6 +241,8 @@ impl<'gc> NetStream<'gc> {
                 avm_object,
                 avm2_client: None,
                 url: None,
+                audio_stream: None,
+                attached_to: None,
             },
         ))
     }
@@ -298,6 +328,38 @@ impl<'gc> NetStream<'gc> {
         StreamManager::toggle_paused(context, self);
     }
 
+    /// Indicates that this `NetStream`'s audio was detached from a `MovieClip` (AVM1)
+    pub fn was_detached(self, context: &mut UpdateContext<'_, 'gc>) {
+        let mut write = self.0.write(context.gc_context);
+
+        if let Some((_substream, sound_instance)) = &write.audio_stream {
+            context
+                .audio_manager
+                .stop_sound(context.audio, *sound_instance);
+        }
+
+        write.audio_stream = None;
+        write.attached_to = None;
+    }
+
+    /// Indicates that this `NetStream`'s audio was attached to a `MovieClip` (AVM1)
+    pub fn was_attached(self, context: &mut UpdateContext<'_, 'gc>, clip: MovieClip<'gc>) {
+        let mut write = self.0.write(context.gc_context);
+
+        // A `NetStream` cannot be attached to two `MovieClip`s at once.
+        // Stop the old sound; the new one will stream at the next tag read.
+        // TODO: Change this to have `audio_manager` just switch the sound
+        // transforms around
+        if let Some((_substream, sound_instance)) = &write.audio_stream {
+            context
+                .audio_manager
+                .stop_sound(context.audio, *sound_instance);
+        }
+
+        write.audio_stream = None;
+        write.attached_to = Some(clip);
+    }
+
     pub fn tick(self, context: &mut UpdateContext<'_, 'gc>, dt: f64) {
         #![allow(clippy::explicit_auto_deref)] //Erroneous lint
         let mut write = self.0.write(context.gc_context);
@@ -324,7 +386,6 @@ impl<'gc> NetStream<'gc> {
                                 header,
                                 video_stream: None,
                                 frame_id: 0,
-                                audio_stream: None,
                             });
                         }
                         Err(FlvError::EndOfData) => return,
@@ -409,17 +470,15 @@ impl<'gc> NetStream<'gc> {
                         sound_type,
                         data,
                     }) => {
-                        let mut substream = match &mut write.stream_type {
-                            Some(NetStreamType::Flv {
-                                audio_stream: Some((substream, audio_handle)),
-                                ..
-                            }) if context.audio.is_sound_playing(*audio_handle) => {
+                        let attached_to = write.attached_to;
+                        let mut substream = match &mut write.audio_stream {
+                            Some((substream, audio_handle))
+                                if context.audio.is_sound_playing(*audio_handle) =>
+                            {
                                 substream.clone()
                             }
-                            Some(NetStreamType::Flv {
-                                audio_stream, //None or not playing
-                                ..
-                            }) => {
+                            audio_stream => {
+                                //None or not playing
                                 let substream = Substream::new(slice.buffer().clone());
                                 let audio_handle = (|| {
                                     let swf_format = SoundFormat {
@@ -442,26 +501,18 @@ impl<'gc> NetStream<'gc> {
                                                 AudioCompression::Nellymoser
                                             }
                                             FlvSoundFormat::G711ALawPCM => {
-                                                return Err(DecodeError::UnhandledCompression(
-                                                    AudioCompression::Uncompressed,
-                                                ))
+                                                return Err(NetstreamError::UnknownCodec)
                                             }
                                             FlvSoundFormat::G711MuLawPCM => {
-                                                return Err(DecodeError::UnhandledCompression(
-                                                    AudioCompression::Uncompressed,
-                                                ))
+                                                return Err(NetstreamError::UnknownCodec)
                                             }
                                             FlvSoundFormat::Aac => {
-                                                return Err(DecodeError::UnhandledCompression(
-                                                    AudioCompression::Uncompressed,
-                                                ))
+                                                return Err(NetstreamError::UnknownCodec)
                                             }
                                             FlvSoundFormat::Speex => AudioCompression::Speex,
                                             FlvSoundFormat::MP38kHz => AudioCompression::Mp3,
                                             FlvSoundFormat::DeviceSpecific => {
-                                                return Err(DecodeError::UnhandledCompression(
-                                                    AudioCompression::Uncompressed,
-                                                ))
+                                                return Err(NetstreamError::UnknownCodec)
                                             }
                                         },
                                         sample_rate: match (format, rate) {
@@ -480,19 +531,36 @@ impl<'gc> NetStream<'gc> {
                                             FlvSoundSize::Bits16 => true,
                                         },
                                     };
-                                    context.audio.start_substream(
-                                        substream.clone(),
-                                        &SoundStreamHead {
-                                            stream_format: swf_format.clone(),
-                                            playback_format: swf_format,
-                                            num_samples_per_block: 0,
-                                            latency_seek: 0,
-                                        },
-                                    )
+
+                                    let sound_stream_head = SoundStreamHead {
+                                        stream_format: swf_format.clone(),
+                                        playback_format: swf_format,
+                                        num_samples_per_block: 0,
+                                        latency_seek: 0,
+                                    };
+
+                                    if context.is_action_script_3() {
+                                        Ok(context.audio.start_substream(
+                                            substream.clone(),
+                                            &sound_stream_head,
+                                        )?)
+                                    } else if let Some(mc) = attached_to {
+                                        context
+                                            .audio_manager
+                                            .start_substream(
+                                                context.audio,
+                                                substream.clone(),
+                                                mc,
+                                                &sound_stream_head,
+                                            )
+                                            .ok_or(NetstreamError::NoPlayback)
+                                    } else {
+                                        return Err(NetstreamError::NotAttached);
+                                    }
                                 })();
 
                                 if let Err(e) = audio_handle {
-                                    tracing::error!("Error encountered appending substream: {}", e);
+                                    tracing::error!("Error encountered starting stream: {}", e);
                                 } else {
                                     *audio_stream =
                                         Some((substream.clone(), audio_handle.unwrap()));
@@ -500,7 +568,6 @@ impl<'gc> NetStream<'gc> {
 
                                 substream
                             }
-                            _ => unreachable!(),
                         };
 
                         let result = match data {

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -40,9 +40,6 @@ enum NetstreamError {
     #[error("Decoding failed because {0}")]
     DecodeError(DecodeError),
 
-    #[error("Could not play back audio and no error was given")]
-    NoPlayback,
-
     #[error("Unknown codec")]
     UnknownCodec,
 
@@ -545,15 +542,12 @@ impl<'gc> NetStream<'gc> {
                                             &sound_stream_head,
                                         )?)
                                     } else if let Some(mc) = attached_to {
-                                        context
-                                            .audio_manager
-                                            .start_substream(
-                                                context.audio,
-                                                substream.clone(),
-                                                mc,
-                                                &sound_stream_head,
-                                            )
-                                            .ok_or(NetstreamError::NoPlayback)
+                                        Ok(context.audio_manager.start_substream(
+                                            context.audio,
+                                            substream.clone(),
+                                            mc,
+                                            &sound_stream_head,
+                                        )?)
                                     } else {
                                         return Err(NetstreamError::NotAttached);
                                     }

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -719,11 +719,12 @@ impl<'gc> NetStream<'gc> {
                     _ => tracing::error!("Invalid FLV metadata tag!"),
                 }
             }
+            let avm_object = write.avm_object;
             drop(write);
             // This is necessary because the script callback functions can call back into
             // these methods, (e.g. NetStream::play), so we need to avoid holding a borrow
             // while the script data is being handled.
-            let _ = self.handle_script_data(self.0.read().avm_object, context, var.name, var.data); // Any errors while trying to lookup or call AVM2 properties are silently swallowed.
+            let _ = self.handle_script_data(avm_object, context, var.name, var.data); // Any errors while trying to lookup or call AVM2 properties are silently swallowed.
             write = self.0.write(context.gc_context);
         }
 

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -10,7 +10,9 @@ use crate::avm2::{
     Activation as Avm2Activation, Avm2, Error as Avm2Error, EventObject as Avm2EventObject,
     FlvValueAvm2Ext, Object as Avm2Object,
 };
-use crate::backend::audio::{DecodeError, SoundInstanceHandle};
+use crate::backend::audio::{
+    DecodeError, SoundInstanceHandle, SoundStreamInfo, SoundStreamWrapping,
+};
 use crate::backend::navigator::Request;
 use crate::buffer::{Buffer, Substream, SubstreamError};
 use crate::context::UpdateContext;
@@ -31,7 +33,7 @@ use ruffle_video::frame::EncodedFrame;
 use ruffle_video::VideoStreamHandle;
 use std::cmp::max;
 use std::io::Seek;
-use swf::{AudioCompression, SoundFormat, SoundStreamHead, VideoCodec, VideoDeblocking};
+use swf::{AudioCompression, SoundFormat, VideoCodec, VideoDeblocking};
 use thiserror::Error;
 use url::Url;
 
@@ -548,9 +550,9 @@ impl<'gc> NetStream<'gc> {
                                         },
                                     };
 
-                                    let sound_stream_head = SoundStreamHead {
-                                        stream_format: swf_format.clone(),
-                                        playback_format: swf_format,
+                                    let sound_stream_head = SoundStreamInfo {
+                                        wrapping: SoundStreamWrapping::Unwrapped,
+                                        stream_format: swf_format,
                                         num_samples_per_block: 0,
                                         latency_seek: 0,
                                     };

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -47,9 +47,6 @@ enum NetstreamError {
 
     #[error("Unknown codec")]
     UnknownCodec,
-
-    #[error("AVM1 NetStream not attached to MovieClip")]
-    NotAttached,
 }
 
 impl From<DecodeError> for NetstreamError {
@@ -506,13 +503,7 @@ impl<'gc> NetStream<'gc> {
             if let Some((substream, sound_stream_head)) = &mut write.audio_stream {
                 let attached_to = write.attached_to;
 
-                if context.is_action_script_3() {
-                    write.sound_instance = Some(
-                        context
-                            .audio
-                            .start_substream(substream.clone(), sound_stream_head)?,
-                    );
-                } else if let Some(mc) = attached_to {
+                if let Some(mc) = attached_to {
                     write.sound_instance = Some(context.audio_manager.start_substream(
                         context.audio,
                         substream.clone(),
@@ -520,8 +511,12 @@ impl<'gc> NetStream<'gc> {
                         sound_stream_head,
                     )?);
                 } else {
-                    return Err(NetstreamError::NotAttached);
-                };
+                    write.sound_instance = Some(
+                        context
+                            .audio
+                            .start_substream(substream.clone(), sound_stream_head)?,
+                    );
+                }
             }
         }
 

--- a/desktop/src/backends/audio.rs
+++ b/desktop/src/backends/audio.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Error};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ruffle_core::backend::audio::{
     swf, AudioBackend, AudioMixer, DecodeError, RegisterError, SoundHandle, SoundInstanceHandle,
-    SoundTransform,
+    SoundStreamInfo, SoundTransform,
 };
 use ruffle_core::impl_audio_mixer_backend;
 

--- a/tests/tests/util/runner.rs
+++ b/tests/tests/util/runner.rs
@@ -6,7 +6,7 @@ use crate::util::test::Test;
 use anyhow::{anyhow, Result};
 use ruffle_core::backend::audio::{
     swf, AudioBackend, AudioMixer, DecodeError, RegisterError, SoundHandle, SoundInstanceHandle,
-    SoundTransform,
+    SoundStreamInfo, SoundTransform,
 };
 use ruffle_core::backend::log::LogBackend;
 use ruffle_core::backend::navigator::NullExecutor;

--- a/web/src/audio.rs
+++ b/web/src/audio.rs
@@ -1,6 +1,6 @@
 use ruffle_core::backend::audio::{
     swf, AudioBackend, AudioMixer, AudioMixerProxy, DecodeError, RegisterError, SoundHandle,
-    SoundInstanceHandle, SoundTransform,
+    SoundInstanceHandle, SoundStreamInfo, SoundTransform,
 };
 use ruffle_core::impl_audio_mixer_backend;
 use ruffle_web_common::JsResult;


### PR DESCRIPTION
This PR adds a new set of types for managing data buffers in use by Ruffle's various backends:

 * `Buffer` stores the whole of a given data stream, whether that be a SWF file, FLV file, MP3 file, and so on. Data ownership is shared. Mutability is limited to appending data to the end of the buffer.
 * A `Slice` can be constructed from a range on the `Buffer`. Slices are guaranteed to always refer to the same data.
   * The `Slice` can be indexed as a `[u8]` by turning it into a `SliceRef<'_>`. This is equivalent to holding a `&[u8]`.
   * Data can be read from the `Slice` by turning it into a `SliceCursor` which implements `Read`.
 * Multiple `Slice`s can be appended to a single `Substream`, which represents a single embedded data stream in a `Buffer`. The slice list in the `Substream` is also shared and can be appended to.
   * A `Substream` can be iterated as a sequence of `Slice`s by turning it into a `SubstreamChunksIter`.
   * A `Substream` can be read from as a file by turning it into a `SubstreamCursor` which implements `Read`.

This mirrors the existing hierarchy of `SwfMovie` and `SwfSlice`, which will eventually be changed to use `Buffer` and `Slice` under the hood. The purpose of that is to enable progressive downloading of SWF files (eventually, pending implementation of streaming decompressors, etc). This switch has not been done yet of course.

The current motivation is to support FLV audio. Currently, the audio backend can only stream data from an SWF tagstream, because the stream reader logic is buried deep into the audio decoder. This PR actually clones all that logic; the intent is to replace the existing streaming sounds pipeline entirely with the `Substream` based pipeline.

The new audio API for all of this is actually super-simple: just a single `start_substream` method. `Substream` itself has an internally mutable chunks list, so appending to it will make playback happen as long as the sound is still playing. If it's been stopped, you can check for that with `is_sound_playing` and restart the stream if so.

This PR successfully plays the audio on https://www.nothingtodo.co.uk/view/3136/who-needs-a-glove.html without issue. Note that the transport controls will still not work since we don't support seeking.