### PR TITLE
desktop: Track wgpu stats in Tracy

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -3,8 +3,8 @@ use crate::custom_event::RuffleEvent;
 use crate::gui::{GuiController, MENU_HEIGHT};
 use crate::player::{PlayerController, PlayerOptions};
 use crate::util::{
-    get_screen_size, parse_url, pick_file, winit_key_to_char, winit_to_ruffle_key_code,
-    winit_to_ruffle_text_control,
+    get_screen_size, parse_url, pick_file, plot_stats_in_tracy, winit_key_to_char,
+    winit_to_ruffle_key_code, winit_to_ruffle_text_control,
 };
 use anyhow::{Context, Error};
 use ruffle_core::{PlayerEvent, StageDisplayState};
@@ -136,10 +136,7 @@ impl App {
                         } else {
                             self.gui.borrow_mut().render(None);
                         }
-                        #[cfg(feature = "tracy")]
-                        tracing_tracy::client::Client::running()
-                            .expect("tracy client must be running")
-                            .frame_mark();
+                        plot_stats_in_tracy(&self.gui.borrow().descriptors().wgpu_instance);
                     }
                 }
 

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -83,7 +83,7 @@ impl GuiController {
                 view_formats: Default::default(),
             },
         );
-        let descriptors = Descriptors::new(adapter, device, queue);
+        let descriptors = Descriptors::new(instance, adapter, device, queue);
         let egui_ctx = Context::default();
         if let Some(Theme::Light) = window.theme() {
             egui_ctx.set_visuals(egui::Visuals::light());

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -58,7 +58,7 @@ impl GuiController {
         let surface = unsafe { instance.create_surface(window.as_ref()) }?;
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             backend,
-            instance,
+            &instance,
             Some(&surface),
             opt.power.into(),
             opt.trace_path(),

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -414,7 +414,7 @@ fn main() -> Result<()> {
     ))
     .map_err(|e| anyhow!(e.to_string()))?;
 
-    let descriptors = Arc::new(Descriptors::new(adapter, device, queue));
+    let descriptors = Arc::new(Descriptors::new(instance, adapter, device, queue));
 
     if opt.swf.is_file() {
         capture_single_swf(descriptors, &opt)?;

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -407,7 +407,7 @@ fn main() -> Result<()> {
     });
     let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
         opt.graphics.into(),
-        instance,
+        &instance,
         None,
         opt.power.into(),
         trace_path(&opt),

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -67,7 +67,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
         let surface = instance.create_surface_from_canvas(canvas)?;
         let (adapter, device, queue) = request_adapter_and_device(
             wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
-            instance,
+            &instance,
             Some(&surface),
             wgpu::PowerPreference::HighPerformance,
             None,
@@ -102,7 +102,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
         let surface = unsafe { instance.create_surface(window) }?;
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             backend,
-            instance,
+            &instance,
             Some(&surface),
             power_preference,
             trace_path,
@@ -133,7 +133,7 @@ impl WgpuRenderBackend<crate::target::TextureTarget> {
         });
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             backend,
-            instance,
+            &instance,
             None,
             power_preference,
             trace_path,
@@ -1031,7 +1031,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 
 pub async fn request_adapter_and_device(
     backend: wgpu::Backends,
-    instance: wgpu::Instance,
+    instance: &wgpu::Instance,
     surface: Option<&wgpu::Surface>,
     power_preference: wgpu::PowerPreference,
     trace_path: Option<&Path>,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -73,7 +73,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
             None,
         )
         .await?;
-        let descriptors = Descriptors::new(adapter, device, queue);
+        let descriptors = Descriptors::new(instance, adapter, device, queue);
         let target =
             SwapChainTarget::new(surface, &descriptors.adapter, (1, 1), &descriptors.device);
         Self::new(Arc::new(descriptors), target)
@@ -107,7 +107,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
             power_preference,
             trace_path,
         ))?;
-        let descriptors = Descriptors::new(adapter, device, queue);
+        let descriptors = Descriptors::new(instance, adapter, device, queue);
         let target = SwapChainTarget::new(surface, &descriptors.adapter, size, &descriptors.device);
         Self::new(Arc::new(descriptors), target)
     }
@@ -138,7 +138,7 @@ impl WgpuRenderBackend<crate::target::TextureTarget> {
             power_preference,
             trace_path,
         ))?;
-        let descriptors = Descriptors::new(adapter, device, queue);
+        let descriptors = Descriptors::new(instance, adapter, device, queue);
         let target = crate::target::TextureTarget::new(&descriptors.device, size)?;
         Self::new(Arc::new(descriptors), target)
     }

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -12,6 +12,7 @@ use std::mem;
 use std::sync::{Arc, Mutex};
 
 pub struct Descriptors {
+    pub wgpu_instance: wgpu::Instance,
     pub adapter: wgpu::Adapter,
     pub device: wgpu::Device,
     pub limits: wgpu::Limits,
@@ -34,7 +35,12 @@ impl Debug for Descriptors {
 }
 
 impl Descriptors {
-    pub fn new(adapter: wgpu::Adapter, device: wgpu::Device, queue: wgpu::Queue) -> Self {
+    pub fn new(
+        instance: wgpu::Instance,
+        adapter: wgpu::Adapter,
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+    ) -> Self {
         let limits = device.limits();
         let bind_layouts = BindLayouts::new(&device);
         let bitmap_samplers = BitmapSamplers::new(&device);
@@ -57,6 +63,7 @@ impl Descriptors {
         let filters = Filters::new(&device);
 
         Self {
+            wgpu_instance: instance,
             adapter,
             device,
             limits,

--- a/tests/tests/util/environment.rs
+++ b/tests/tests/util/environment.rs
@@ -15,20 +15,22 @@ use std::sync::{Arc, OnceLock};
    but for `cargo nextest run` it's a big cost per test if it's not going to use it.
 */
 
-fn create_wgpu_device() -> Option<(wgpu::Adapter, wgpu::Device, wgpu::Queue)> {
+fn create_wgpu_device() -> Option<(wgpu::Instance, wgpu::Adapter, wgpu::Device, wgpu::Queue)> {
+    let instance = wgpu::Instance::new(Default::default());
     futures::executor::block_on(request_adapter_and_device(
         wgpu::Backends::all(),
-        &wgpu::Instance::new(Default::default()),
+        &instance,
         None,
         Default::default(),
         None,
     ))
     .ok()
+    .map(|(adapter, device, queue)| (instance, adapter, device, queue))
 }
 
 fn build_wgpu_descriptors() -> Option<Arc<Descriptors>> {
-    if let Some((adapter, device, queue)) = create_wgpu_device() {
-        Some(Arc::new(Descriptors::new(adapter, device, queue)))
+    if let Some((instance, adapter, device, queue)) = create_wgpu_device() {
+        Some(Arc::new(Descriptors::new(instance, adapter, device, queue)))
     } else {
         None
     }

--- a/tests/tests/util/environment.rs
+++ b/tests/tests/util/environment.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, OnceLock};
 fn create_wgpu_device() -> Option<(wgpu::Adapter, wgpu::Device, wgpu::Queue)> {
     futures::executor::block_on(request_adapter_and_device(
         wgpu::Backends::all(),
-        wgpu::Instance::new(Default::default()),
+        &wgpu::Instance::new(Default::default()),
         None,
         Default::default(),
         None,


### PR DESCRIPTION
This lets us track gpu resource usage.

![image](https://github.com/ruffle-rs/ruffle/assets/317625/f49c3e27-a098-490c-ac1f-b2c03e7a056a)
