### PR TITLE
core: Implement ToXMLString for Attribute and Comment node kind

### DIFF
--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -713,10 +713,18 @@ fn to_xml_string_inner<'gc>(xml: E4XOrXml<'gc>, buf: &mut WString) -> Result<(),
             buf.push_str(&escape_element_value(*text));
             return Ok(());
         }
-        E4XNodeKind::Attribute(_)
-        | E4XNodeKind::Comment(_)
-        | E4XNodeKind::ProcessingInstruction(_) => {
+        E4XNodeKind::ProcessingInstruction(_) => {
             return Err(format!("ToXMLString: Not yet implemented node {:?}", node_kind).into())
+        }
+        E4XNodeKind::Comment(data) => {
+            buf.push_utf8("<!--");
+            buf.push_str(data);
+            buf.push_utf8("-->");
+            return Ok(());
+        }
+        E4XNodeKind::Attribute(data) => {
+            buf.push_str(&escape_attribute_value(*data));
+            return Ok(());
         }
         E4XNodeKind::CData(data) => {
             buf.push_utf8("<![CDATA[");


### PR DESCRIPTION
Attempts to fix #12064. The comment node kind isn't required to fix the issue, but I've implemented it as well, since it's basically the same as CData, according to avmplus:

https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/XMLObject.cpp#L1176-L1192