### PR TITLE
wstr: Don't panic on 0xFF in DecodeAvmUtf8

### DIFF
--- a/wstr/src/tests.rs
+++ b/wstr/src/tests.rs
@@ -207,3 +207,9 @@ fn str_patterns() {
     test_pattern(wide, bstr!(b"aa"), &[(2, 4), (6, 8)], None);
     test_pattern(wide, wstr!('↓''a'), &[(1, 3), (5, 7)], None);
 }
+
+#[test]
+fn from_ff_byte() {
+    let s = WString::from_utf8_bytes(vec![0xff, 0xff]);
+    assert_eq!(s, wstr!(0xff 0xff));
+}

--- a/wstr/src/utils.rs
+++ b/wstr/src/utils.rs
@@ -131,7 +131,7 @@ impl<'a> Iterator for DecodeAvmUtf8<'a> {
         let ones = first.leading_ones();
         self.index += 1;
 
-        if ones <= 1 {
+        if ones <= 1 || ones == 8 {
             return Some(first as u32);
         }
 


### PR DESCRIPTION
I was running into this panic:
```
thread 'main' panicked at 'attempt to shift right with overflow', wstr/src/utils.rs:139:18
```
caused by `to_string` in `byte_array.rs`.