### PR TITLE
render: Skip unreasonably large bitmaps

### DIFF
--- a/swf/src/types/color.rs
+++ b/swf/src/types/color.rs
@@ -17,6 +17,7 @@ pub struct Color {
 }
 
 impl Color {
+    pub const TRANSPARENT: Self = Self::from_rgb(0, 0);
     pub const BLACK: Self = Self::from_rgb(0, 255);
     pub const WHITE: Self = Self::from_rgb(0xFFFFFF, 255);
     pub const RED: Self = Self::from_rgb(0xFF0000, 255);


### PR DESCRIPTION
Some SWFs report unreasonable bitmap dimensions, and trying to reserve enough capacity for them always fails. To avoid panics, skip those bitmaps.

Fixes #1191
Fixes #2759
Fixes #10701