### PR TITLE
core: Remove unsupported content warning

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -24,10 +24,6 @@ pub trait UiBackend: Downcast {
 
     fn set_fullscreen(&mut self, is_full: bool) -> Result<(), FullscreenError>;
 
-    /// Displays a warning about unsupported content in Ruffle.
-    /// The user can still click an "OK" or "run anyway" message to dismiss the warning.
-    fn display_unsupported_message(&self);
-
     /// Displays a message about an error during root movie download.
     /// In particular, on web this can be a CORS error, which we can sidestep
     /// by providing a direct .swf link instead.
@@ -169,8 +165,6 @@ impl UiBackend for NullUiBackend {
     fn set_fullscreen(&mut self, _is_full: bool) -> Result<(), FullscreenError> {
         Ok(())
     }
-
-    fn display_unsupported_message(&self) {}
 
     fn display_root_movie_download_failed_message(&self) {}
 

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -236,8 +236,6 @@ pub struct Player {
 
     swf: Arc<SwfMovie>,
 
-    warn_on_unsupported_content: bool,
-
     is_playing: bool,
     needs_render: bool,
 
@@ -453,10 +451,6 @@ impl Player {
             let stage = activation.context.stage;
             stage.build_matrices(&mut activation.context);
         });
-
-        if self.swf.is_action_script_3() && self.warn_on_unsupported_content {
-            self.ui.display_unsupported_message();
-        }
 
         self.audio.set_frame_rate(self.frame_rate);
     }
@@ -2093,7 +2087,6 @@ pub struct PlayerBuilder {
     viewport_width: u32,
     viewport_height: u32,
     viewport_scale_factor: f64,
-    warn_on_unsupported_content: bool,
     load_behavior: LoadBehavior,
     spoofed_url: Option<String>,
     compatibility_rules: CompatibilityRules,
@@ -2138,7 +2131,6 @@ impl PlayerBuilder {
             viewport_width: 550,
             viewport_height: 400,
             viewport_scale_factor: 1.0,
-            warn_on_unsupported_content: true,
             load_behavior: LoadBehavior::Streaming,
             spoofed_url: None,
             compatibility_rules: CompatibilityRules::default(),
@@ -2232,13 +2224,6 @@ impl PlayerBuilder {
     #[inline]
     pub fn with_max_execution_duration(mut self, duration: Duration) -> Self {
         self.max_execution_duration = duration;
-        self
-    }
-
-    /// Configures the player to warn if unsupported content is detected (ActionScript 3.0).
-    #[inline]
-    pub fn with_warn_on_unsupported_content(mut self, value: bool) -> Self {
-        self.warn_on_unsupported_content = value;
         self
     }
 
@@ -2440,7 +2425,6 @@ impl PlayerBuilder {
                 player_version,
                 is_playing: self.autoplay,
                 needs_render: true,
-                warn_on_unsupported_content: self.warn_on_unsupported_content,
                 self_reference: self_ref.clone(),
                 load_behavior: self.load_behavior,
                 spoofed_url: self.spoofed_url.clone(),

--- a/desktop/assets/texts/en-US/settings.ftl
+++ b/desktop/assets/texts/en-US/settings.ftl
@@ -58,9 +58,6 @@ scale-mode-noscale = No Scale
 scale-mode-showall = Show All
 scale-mode-force = Force
 
-warn-if-unsupported = Warn if Unsupported
-warn-if-unsupported-check = Warn
-
 player-version = Player Version
 
 custom-framerate = Custom Framerate

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -432,10 +432,6 @@ impl App {
                         .create_movie(&mut self.player, *options, url);
                 }
 
-                winit::event::Event::UserEvent(RuffleEvent::DisplayUnsupportedMessage) => {
-                    self.gui.borrow_mut().display_unsupported_message();
-                }
-
                 winit::event::Event::UserEvent(RuffleEvent::CloseFile) => {
                     self.player.destroy();
                 }

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -1,4 +1,3 @@
-use crate::custom_event::RuffleEvent;
 use anyhow::{Context, Error};
 use arboard::Clipboard;
 use rfd::{MessageButtons, MessageDialog, MessageLevel};
@@ -8,11 +7,9 @@ use ruffle_core::backend::ui::{
 use std::rc::Rc;
 use sys_locale::get_locale;
 use tracing::error;
-use winit::event_loop::EventLoopProxy;
 use winit::window::{Fullscreen, Window};
 
 pub struct DesktopUiBackend {
-    event_loop: EventLoopProxy<RuffleEvent>,
     window: Rc<Window>,
     cursor_visible: bool,
     clipboard: Clipboard,
@@ -21,13 +18,12 @@ pub struct DesktopUiBackend {
 }
 
 impl DesktopUiBackend {
-    pub fn new(event_loop: EventLoopProxy<RuffleEvent>, window: Rc<Window>) -> Result<Self, Error> {
+    pub fn new(window: Rc<Window>) -> Result<Self, Error> {
         let preferred_language = get_locale();
         let language = preferred_language
             .and_then(|l| l.parse().ok())
             .unwrap_or_else(|| US_ENGLISH.clone());
         Ok(Self {
-            event_loop,
             window,
             cursor_visible: true,
             clipboard: Clipboard::new().context("Couldn't get platform clipboard")?,
@@ -82,12 +78,6 @@ impl UiBackend for DesktopUiBackend {
             None
         });
         Ok(())
-    }
-
-    fn display_unsupported_message(&self) {
-        let _ = self
-            .event_loop
-            .send_event(RuffleEvent::DisplayUnsupportedMessage);
     }
 
     fn display_root_movie_download_failed_message(&self) {

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -96,10 +96,6 @@ pub struct Opt {
     #[clap(long, action)]
     pub timedemo: bool,
 
-    /// Start application without ActionScript 3 warning.
-    #[clap(long, action)]
-    pub dont_warn_on_unsupported_content: bool,
-
     #[clap(long, default_value = "streaming")]
     pub load_behavior: LoadBehavior,
 

--- a/desktop/src/custom_event.rs
+++ b/desktop/src/custom_event.rs
@@ -24,6 +24,4 @@ pub enum RuffleEvent {
 
     /// The user selected an item in the right-click context menu.
     ContextMenuItemClicked(usize),
-
-    DisplayUnsupportedMessage,
 }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -64,7 +64,6 @@ pub const MENU_HEIGHT: u32 = 24;
 pub struct RuffleGui {
     event_loop: EventLoopProxy<RuffleEvent>,
     is_about_visible: bool,
-    is_as3_warning_visible: bool,
     is_open_dialog_visible: bool,
     context_menu: Vec<ruffle_core::ContextMenuItem>,
     open_dialog: OpenDialog,
@@ -90,7 +89,6 @@ impl RuffleGui {
 
         Self {
             is_about_visible: false,
-            is_as3_warning_visible: false,
             is_open_dialog_visible: false,
             was_suspended_before_debug: false,
 
@@ -123,8 +121,6 @@ impl RuffleGui {
 
         self.about_window(egui_ctx);
         self.open_dialog(egui_ctx);
-
-        self.as3_warning(egui_ctx);
 
         if let Some(player) = player {
             let was_suspended = player.debug_ui().should_suspend_player();
@@ -165,10 +161,6 @@ impl RuffleGui {
 
     pub fn is_context_menu_visible(&self) -> bool {
         !self.context_menu.is_empty()
-    }
-
-    pub fn display_unsupported_message(&mut self) {
-        self.is_as3_warning_visible = true;
     }
 
     /// Notifies the GUI that a new player was created.
@@ -312,35 +304,6 @@ impl RuffleGui {
                 });
             });
         });
-    }
-
-    fn as3_warning(&mut self, egui_ctx: &egui::Context) {
-        let mut keep_open = true;
-        egui::Window::new("AS3 warning")
-            .collapsible(false)
-            .resizable(false)
-            .title_bar(false)
-            .anchor(Align2::CENTER_TOP, (0.0, 50.0))
-            .open(&mut self.is_as3_warning_visible)
-            .show(egui_ctx, |ui| {
-                ui.set_min_width(400.0);
-                ui.label("The Ruffle emulator may not yet fully support all of ActionScript 3 used by this content.");
-                ui.label("Some parts of the content may not work as expected.");
-
-                ui.label("See the following link for more info:");
-                ui.hyperlink_to(
-                    "https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users",
-                    "https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users",
-                );
-                ui.label("(click anywhere to continue)");
-
-                if ui.input(|i| i.key_pressed(Key::Escape) || i.pointer.any_click()) {
-                    keep_open = false;
-                }
-            });
-        if !keep_open {
-            self.is_as3_warning_visible = false;
-        }
     }
 
     fn about_window(&mut self, egui_ctx: &egui::Context) {

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -182,10 +182,6 @@ impl GuiController {
         self.gui.on_player_created(opt, movie_url);
     }
 
-    pub fn display_unsupported_message(&mut self) {
-        self.gui.display_unsupported_message();
-    }
-
     pub fn render(&mut self, mut player: Option<MutexGuard<Player>>) {
         let surface_texture = self
             .surface

--- a/desktop/src/gui/open_dialog.rs
+++ b/desktop/src/gui/open_dialog.rs
@@ -430,14 +430,6 @@ impl OpenDialog {
                 );
                 ui.end_row();
 
-                // TODO: This should probably be a global setting somewhere, not per load
-                ui.label(text(&self.locale, "warn-if-unsupported"));
-                ui.checkbox(
-                    &mut self.options.warn_on_unsupported_content,
-                    text(&self.locale, "warn-if-unsupported-check"),
-                );
-                ui.end_row();
-
                 ui.label(text(&self.locale, "player-version"));
                 DragValue::new(&mut self.options.player_version)
                     .clamp_range(1..=32)

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -39,7 +39,6 @@ pub struct PlayerOptions {
     pub proxy: Option<Url>,
     pub upgrade_to_https: bool,
     pub fullscreen: bool,
-    pub warn_on_unsupported_content: bool,
     pub load_behavior: LoadBehavior,
     pub letterbox: Letterbox,
     pub spoof_url: Option<Url>,
@@ -64,7 +63,6 @@ impl From<&Opt> for PlayerOptions {
             proxy: value.proxy.clone(),
             upgrade_to_https: value.upgrade_to_https,
             fullscreen: value.fullscreen,
-            warn_on_unsupported_content: !value.dont_warn_on_unsupported_content,
             load_behavior: value.load_behavior,
             letterbox: value.letterbox,
             spoof_url: value.spoof_url.clone(),
@@ -139,15 +137,11 @@ impl ActivePlayer {
             .with_navigator(navigator)
             .with_renderer(renderer)
             .with_storage(DiskStorageBackend::new().expect("Couldn't create storage backend"))
-            .with_ui(
-                DesktopUiBackend::new(event_loop.clone(), window.clone())
-                    .expect("Couldn't create ui backend"),
-            )
+            .with_ui(DesktopUiBackend::new(window.clone()).expect("Couldn't create ui backend"))
             .with_autoplay(true)
             .with_letterbox(opt.letterbox)
             .with_max_execution_duration(max_execution_duration)
             .with_quality(opt.quality)
-            .with_warn_on_unsupported_content(opt.warn_on_unsupported_content)
             .with_align(opt.align, opt.force_align)
             .with_scale_mode(opt.scale, opt.force_scale)
             .with_fullscreen(opt.fullscreen)

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -20,7 +20,6 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     upgradeToHttps: true,
     compatibilityRules: true,
     favorFlash: true,
-    warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
     showSwfDownload: false,
     contextMenu: ContextMenu.On,

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -20,6 +20,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     upgradeToHttps: true,
     compatibilityRules: true,
     favorFlash: true,
+    warnOnUnsupportedContent: true,
     logLevel: LogLevel.Error,
     showSwfDownload: false,
     contextMenu: ContextMenu.On,

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -338,14 +338,6 @@ export interface BaseLoadOptions {
     favorFlash?: boolean;
 
     /**
-     * Whether or not to display an overlay with a warning when
-     * loading a movie with unsupported content.
-     *
-     * @default true
-     */
-    warnOnUnsupportedContent?: boolean;
-
-    /**
      * Console logging level.
      *
      * @default LogLevel.Error

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -338,6 +338,19 @@ export interface BaseLoadOptions {
     favorFlash?: boolean;
 
     /**
+     * This is no longer used and does not affect anything.
+     * It is only kept for backwards compatibility.
+     *
+     * Previously:
+     * "Whether or not to display an overlay with a warning when
+     * loading a movie with unsupported content."
+     *
+     * @default true
+     * @deprecated
+     */
+    warnOnUnsupportedContent?: boolean;
+
+    /**
      * Console logging level.
      *
      * @default LogLevel.Error

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -2002,27 +2002,6 @@ export class RufflePlayer extends HTMLElement {
         }
     }
 
-    protected displayUnsupportedMessage(): void {
-        const div = document.createElement("div");
-        div.id = "message_overlay";
-        // TODO: Change link to https://ruffle.rs/faq or similar
-        // TODO: Pause content until message is dismissed
-        div.innerHTML = `<div class="message">
-            ${textAsParagraphs("message-unsupported-avm2")}
-            <div>
-                <a target="_blank" class="more-info-link" href="https://github.com/ruffle-rs/ruffle/wiki/Frequently-Asked-Questions-For-Users">${text(
-                    "more-info",
-                )}</a>
-                <button id="run-anyway-btn">${text("run-anyway")}</button>
-            </div>
-        </div>`;
-        this.container.prepend(div);
-        const button = <HTMLButtonElement>div.querySelector("#run-anyway-btn");
-        button.onclick = () => {
-            div.parentNode!.removeChild(div);
-        };
-    }
-
     /**
      * Show a dismissible message in front of the player.
      *

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -1,6 +1,3 @@
-message-unsupported-avm2 =
-    The Ruffle emulator may not yet fully support all of ActionScript 3 used by this content.
-    Some parts of the content may not work as expected.
 message-cant-embed =
     Ruffle wasn't able to run the Flash embedded in this page.
     You can try to open the file in a separate tab, to sidestep this issue.

--- a/web/packages/extension/assets/_locales/en/messages.json
+++ b/web/packages/extension/assets/_locales/en/messages.json
@@ -11,9 +11,6 @@
     "settings_autostart": {
         "message": "Play automatically without splash screen (then click to unmute)"
     },
-    "settings_warn_on_unsupported_content": {
-        "message": "Warn on unsupported content"
-    },
     "settings_log_level": {
         "message": "Log level"
     },

--- a/web/packages/extension/assets/options.html
+++ b/web/packages/extension/assets/options.html
@@ -32,10 +32,6 @@
                 <input type="checkbox" id="autostart" />
                 <label for="autostart">Play automatically without splash screen (then click to unmute)</label>
             </div>
-            <div class="option checkbox">
-                <input type="checkbox" id="warn_on_unsupported_content" />
-                <label for="warn_on_unsupported_content">Warn on unsupported content</label>
-            </div>
             <details>
                 <summary id="advanced_options">Advanced Options</summary>
                 <div class="options">

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -101,9 +101,6 @@ extern "C" {
     #[wasm_bindgen(method)]
     fn panic(this: &JavascriptPlayer, error: &JsError);
 
-    #[wasm_bindgen(method, js_name = "displayUnsupportedMessage")]
-    fn display_unsupported_message(this: &JavascriptPlayer);
-
     #[wasm_bindgen(method, js_name = "displayRootMovieDownloadFailedMessage")]
     fn display_root_movie_download_failed_message(this: &JavascriptPlayer);
 
@@ -273,8 +270,6 @@ struct Config {
     frame_rate: Option<f64>,
 
     wmode: Option<String>,
-
-    warn_on_unsupported_content: bool,
 
     #[serde(deserialize_with = "deserialize_log_level")]
     log_level: tracing::Level,
@@ -573,7 +568,6 @@ impl Ruffle {
             .with_video(SoftwareVideoBackend::new())
             .with_letterbox(config.letterbox)
             .with_max_execution_duration(config.max_execution_duration)
-            .with_warn_on_unsupported_content(config.warn_on_unsupported_content)
             .with_player_version(config.player_version)
             .with_compatibility_rules(if config.compatibility_rules {
                 CompatibilityRules::default()

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -124,10 +124,6 @@ impl UiBackend for WebUiBackend {
         }
     }
 
-    fn display_unsupported_message(&self) {
-        self.js_player.display_unsupported_message()
-    }
-
     fn display_root_movie_download_failed_message(&self) {
         self.js_player.display_root_movie_download_failed_message()
     }


### PR DESCRIPTION
We support more of AVM2 today than we did AVM1 back when it was added. I think it's time.

I thought about keeping the option there "just in case", being unused... but realistically the effort to detect and add new localized warnings feels too high.