### PR TITLE
core,avm1: Dont reset fake time offset during busy loop detection

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1173,7 +1173,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.context.times_get_time_called += 1;
         // heuristic to detect busy loops used for delays and slowly progress fake time
         if self.context.times_get_time_called >= 20 && self.context.times_get_time_called % 5 == 0 {
-            *self.context.time_offset = *self.context.time_offset.max(self.context.last_time_offset);
+            *self.context.time_offset =
+                *self.context.time_offset.max(self.context.last_time_offset);
             *self.context.time_offset = self.context.time_offset.wrapping_add(1);
             *self.context.last_time_offset = *self.context.time_offset;
         }

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -1173,7 +1173,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.context.times_get_time_called += 1;
         // heuristic to detect busy loops used for delays and slowly progress fake time
         if self.context.times_get_time_called >= 20 && self.context.times_get_time_called % 5 == 0 {
-            *self.context.time_offset += 1;
+            *self.context.time_offset = *self.context.time_offset.max(self.context.last_time_offset);
+            *self.context.time_offset = self.context.time_offset.wrapping_add(1);
+            *self.context.last_time_offset = *self.context.time_offset;
         }
 
         let time = Instant::now()

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -205,6 +205,9 @@ pub struct UpdateContext<'a, 'gc> {
     /// How many times getTimer() was called so far. Used to detect busy-loops.
     pub times_get_time_called: u32,
 
+    /// The previous fake time offset since calling `getTimer()`.
+    pub last_time_offset: &'a mut u32,
+
     /// This frame's current fake time offset, used to pretend passage of time in time functions
     pub time_offset: &'a mut u32,
 
@@ -387,6 +390,7 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
             max_execution_duration: self.max_execution_duration,
             focus_tracker: self.focus_tracker,
             times_get_time_called: self.times_get_time_called,
+            last_time_offset: self.last_time_offset,
             time_offset: self.time_offset,
             frame_rate: self.frame_rate,
             forced_frame_rate: self.forced_frame_rate,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -273,6 +273,9 @@ pub struct Player {
     frame_accumulator: f64,
     recent_run_frame_timings: VecDeque<f64>,
 
+    /// The previous fake time offset since calling `getTimer()`.
+    last_time_offset: u32,
+
     /// Faked time passage for fooling hand-written busy-loop FPS limiters.
     time_offset: u32,
 
@@ -1878,6 +1881,7 @@ impl Player {
                 max_execution_duration: self.max_execution_duration,
                 focus_tracker,
                 times_get_time_called: 0,
+                last_time_offset: &mut self.last_time_offset,
                 time_offset: &mut self.time_offset,
                 audio_manager,
                 frame_rate: &mut self.frame_rate,
@@ -2421,6 +2425,7 @@ impl PlayerBuilder {
                 frame_accumulator: 0.0,
                 recent_run_frame_timings: VecDeque::with_capacity(10),
                 start_time: Instant::now(),
+                last_time_offset: 0,
                 time_offset: 0,
                 time_til_next_timer: None,
                 max_execution_duration: self.max_execution_duration,


### PR DESCRIPTION
This fixes #3386, but requires PR #9377 in order to do so.