### PR TITLE
core,avm1,avm2: Cache what player events a `DisplayObject` has

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -921,27 +921,23 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         );
 
         if let Some(name) = name {
-            self.base_clip().update_clip_events(self.context.gc_context, name.to_string().as_str());
+            self.base_clip()
+                .update_clip_events(self.context.gc_context, name.to_string().as_str());
             self.define_local(name, func_obj.into())?;
         } else {
-            match self.context.avm1.peek(0) {
-                Value::String(name) => {
-                    let mut clip = match self.context.avm1.peek(1) {
-                        Value::MovieClip(movie_clip) => {
-                            if let Some((_, _, clip)) = movie_clip.resolve_reference(self) {
-                                clip
-                            } else {
-                                self.base_clip()
-                            }
-                        },
-                        _ => {
+            if let Value::String(name) = self.context.avm1.peek(0) {
+                let mut clip = match self.context.avm1.peek(1) {
+                    Value::MovieClip(movie_clip) => {
+                        if let Some((_, _, clip)) = movie_clip.resolve_reference(self) {
+                            clip
+                        } else {
                             self.base_clip()
-                        },
-                    };
-                    clip.update_clip_events(self.context.gc_context, name.to_string().as_str());
-                },
-                _ => {},
-            };
+                        }
+                    }
+                    _ => self.base_clip(),
+                };
+                clip.update_clip_events(self.context.gc_context, name.to_string().as_str());
+            }
             self.context.avm1.push(func_obj.into());
         }
 

--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -919,9 +919,29 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             self.context.avm1.prototypes().function,
             prototype,
         );
+
         if let Some(name) = name {
+            self.base_clip().update_clip_events(self.context.gc_context, name.to_string().as_str());
             self.define_local(name, func_obj.into())?;
         } else {
+            match self.context.avm1.peek(0) {
+                Value::String(name) => {
+                    let mut clip = match self.context.avm1.peek(1) {
+                        Value::MovieClip(movie_clip) => {
+                            if let Some((_, _, clip)) = movie_clip.resolve_reference(self) {
+                                clip
+                            } else {
+                                self.base_clip()
+                            }
+                        },
+                        _ => {
+                            self.base_clip()
+                        },
+                    };
+                    clip.update_clip_events(self.context.gc_context, name.to_string().as_str());
+                },
+                _ => {},
+            };
             self.context.avm1.push(func_obj.into());
         }
 

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -342,6 +342,20 @@ impl<'gc> Avm1<'gc> {
         self.stack.push(value);
     }
 
+    pub fn peek(&self, n: usize) -> Value<'gc> {
+        if n < self.stack.len() {
+            let value = self.stack.get(self.stack.len() - n - 1).copied().unwrap_or_else(|| {
+                tracing::warn!("Avm1::peek: Stack underflow");
+                Value::Undefined
+            });
+
+            avm_debug!(self, "Stack peek {}: {value:?}", self.stack.len());
+            value
+        } else {
+            Value::Undefined
+        }
+    }
+
     #[allow(clippy::let_and_return)]
     pub fn pop(&mut self) -> Value<'gc> {
         let value = self.stack.pop().unwrap_or_else(|| {

--- a/core/src/avm1/runtime.rs
+++ b/core/src/avm1/runtime.rs
@@ -344,10 +344,14 @@ impl<'gc> Avm1<'gc> {
 
     pub fn peek(&self, n: usize) -> Value<'gc> {
         if n < self.stack.len() {
-            let value = self.stack.get(self.stack.len() - n - 1).copied().unwrap_or_else(|| {
-                tracing::warn!("Avm1::peek: Stack underflow");
-                Value::Undefined
-            });
+            let value = self
+                .stack
+                .get(self.stack.len() - n - 1)
+                .copied()
+                .unwrap_or_else(|| {
+                    tracing::warn!("Avm1::peek: Stack underflow");
+                    Value::Undefined
+                });
 
             avm_debug!(self, "Stack peek {}: {value:?}", self.stack.len());
             value

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -563,9 +563,9 @@ impl<'gc> DisplayObjectBase<'gc> {
     }
 
     fn set_propagate_to_children(&mut self, propagate: bool) {
-        self.flags.set(DisplayObjectFlags::PROPAGATE_TO_CHILDREN, propagate);
+        self.flags
+            .set(DisplayObjectFlags::PROPAGATE_TO_CHILDREN, propagate);
     }
-
 
     fn set_avm1_removed(&mut self, value: bool) {
         self.flags.set(DisplayObjectFlags::AVM1_REMOVED, value);
@@ -1589,9 +1589,12 @@ pub trait TDisplayObject<'gc>:
 
     /// Sets whether we should propagate `ClipEvent`s down to our children.
     fn set_propagate_to_children(&mut self, gc_context: MutationContext<'gc, '_>, propagate: bool) {
-        self.base_mut(gc_context).set_propagate_to_children(propagate);
+        self.base_mut(gc_context)
+            .set_propagate_to_children(propagate);
         if let Some(parent) = self.parent() {
-            parent.base_mut(gc_context).set_propagate_to_children(propagate);
+            parent
+                .base_mut(gc_context)
+                .set_propagate_to_children(propagate);
         }
     }
 
@@ -1689,12 +1692,15 @@ pub trait TDisplayObject<'gc>:
         if let Some(flag) = event.flag() {
             return self.clip_events().contains(flag.into());
         }
-        return false;
+        false
     }
 
     fn update_clip_events(&mut self, gc_context: MutationContext<'gc, '_>, name: &str) {
         if let Some(event) = crate::events::method_name_to_clip_event(name) {
-            self.set_clip_events(gc_context, self.clip_events() | event.flag().unwrap().into());
+            self.set_clip_events(
+                gc_context,
+                self.clip_events() | event.flag().unwrap().into(),
+            );
             if let Some(mut parent) = self.parent() {
                 if event.propagates() && !parent.should_propagate_to_children() {
                     parent.set_propagate_to_children(gc_context, true);

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -639,6 +639,10 @@ impl<'gc> DisplayObjectBase<'gc> {
         self.clip_events = value;
     }
 
+    pub fn set_clip_events_inplace(&mut self, value: swf::ClipEventFlag) {
+        self.clip_events |= value;
+    }
+
     fn has_clip_event(&self, event: crate::events::ClipEvent<'gc>) -> bool {
         if let Some(flag) = event.flag() {
             return self.clip_events().contains(flag);
@@ -1670,16 +1674,17 @@ pub trait TDisplayObject<'gc>:
         self.base_mut(gc_context).set_clip_events(value);
     }
 
+    fn set_clip_events_inplace(&mut self, gc_context: MutationContext<'gc, '_>, value: swf::ClipEventFlag) {
+        self.base_mut(gc_context).set_clip_events_inplace(value);
+    }
+
     fn has_clip_event(&self, event: crate::events::ClipEvent<'gc>) -> bool {
         self.base().has_clip_event(event)
     }
 
     fn update_clip_events(&mut self, gc_context: MutationContext<'gc, '_>, name: &str) {
         if let Some(event) = crate::events::method_name_to_clip_event(name) {
-            self.set_clip_events(
-                gc_context,
-                self.clip_events() | event.flag().unwrap(),
-            );
+            self.set_clip_events_inplace(gc_context, event.flag().unwrap());
         }
     }
 

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -73,7 +73,7 @@ impl<'gc> Avm1Button<'gc> {
             over_to_up_sound: None,
         };
 
-        Avm1Button(GcCell::new(
+        let result = Avm1Button(GcCell::new(
             gc_context,
             Avm1ButtonData {
                 base: Default::default(),
@@ -90,7 +90,11 @@ impl<'gc> Avm1Button<'gc> {
                 },
                 has_focus: false,
             },
-        ))
+        ));
+        result
+            .base_mut(gc_context)
+            .add_button_actions_to_clip_events(button.clone());
+        result
     }
 
     pub fn set_sounds(self, gc_context: MutationContext<'gc, '_>, sounds: swf::ButtonSounds) {

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -110,7 +110,7 @@ impl<'gc> Avm2Button<'gc> {
             over_to_up_sound: None,
         };
 
-        Avm2Button(GcCell::new(
+        let result = Avm2Button(GcCell::new(
             context.gc_context,
             Avm2ButtonData {
                 base: Default::default(),
@@ -134,7 +134,11 @@ impl<'gc> Avm2Button<'gc> {
                 use_hand_cursor: true,
                 skip_current_frame: false,
             },
-        ))
+        ));
+        result
+            .base_mut(context.gc_context)
+            .add_button_actions_to_clip_events(button.clone());
+        result
     }
 
     pub fn empty_button(context: &mut UpdateContext<'_, 'gc>) -> Self {

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -461,7 +461,7 @@ pub trait TInteractiveObject<'gc>:
             return ClipEventResult::Handled;
         }
 
-        if !event.has_method_name() || self.as_displayobject().has_clip_event(event) {
+        if event.flag().is_none() || self.as_displayobject().has_clip_event(event) {
             self.event_dispatch(context, event)
         } else {
             ClipEventResult::NotHandled

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -183,7 +183,10 @@ pub trait TInteractiveObject<'gc>:
         context: &mut UpdateContext<'_, 'gc>,
         event: ClipEvent<'gc>,
     ) -> ClipEventResult {
-        if event.propagates() && (matches!(event, ClipEvent::KeyPress {..}) || self.as_displayobject().should_propagate_to_children()) {
+        if event.propagates()
+            && (matches!(event, ClipEvent::KeyPress { .. })
+                || self.as_displayobject().should_propagate_to_children())
+        {
             if let Some(container) = self.as_displayobject().as_container() {
                 for child in container.iter_render_list() {
                     if let Some(interactive) = child.as_interactive() {
@@ -461,10 +464,13 @@ pub trait TInteractiveObject<'gc>:
             return ClipEventResult::Handled;
         }
 
-        if !event.propagates() || matches!(event, ClipEvent::KeyPress {..}) || self.as_displayobject().has_clip_event(event) {
+        if !event.propagates()
+            || matches!(event, ClipEvent::KeyPress { .. })
+            || self.as_displayobject().has_clip_event(event)
+        {
             self.event_dispatch(context, event)
         } else {
-            return ClipEventResult::NotHandled;
+            ClipEventResult::NotHandled
         }
     }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -183,7 +183,7 @@ pub trait TInteractiveObject<'gc>:
         context: &mut UpdateContext<'_, 'gc>,
         event: ClipEvent<'gc>,
     ) -> ClipEventResult {
-        if event.propagates() {
+        if event.propagates() && (matches!(event, ClipEvent::KeyPress {..}) || self.as_displayobject().should_propagate_to_children()) {
             if let Some(container) = self.as_displayobject().as_container() {
                 for child in container.iter_render_list() {
                     if let Some(interactive) = child.as_interactive() {
@@ -461,7 +461,11 @@ pub trait TInteractiveObject<'gc>:
             return ClipEventResult::Handled;
         }
 
-        self.event_dispatch(context, event)
+        if !event.propagates() || matches!(event, ClipEvent::KeyPress {..}) || self.as_displayobject().has_clip_event(event) {
+            self.event_dispatch(context, event)
+        } else {
+            return ClipEventResult::NotHandled;
+        }
     }
 
     /// Determine the bottom-most interactive display object under the given

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -461,7 +461,10 @@ pub trait TInteractiveObject<'gc>:
             return ClipEventResult::Handled;
         }
 
-        if event.flag().is_none() || self.as_displayobject().has_clip_event(event) {
+        if event.flag().is_none()
+            || self.as_displayobject().has_clip_event(event)
+            || context.is_action_script_3()
+        {
             self.event_dispatch(context, event)
         } else {
             ClipEventResult::NotHandled

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -464,10 +464,7 @@ pub trait TInteractiveObject<'gc>:
             return ClipEventResult::Handled;
         }
 
-        if !event.propagates()
-            || matches!(event, ClipEvent::KeyPress { .. })
-            || self.as_displayobject().has_clip_event(event)
-        {
+        if !event.has_method_name() || self.as_displayobject().has_clip_event(event) {
             self.event_dispatch(context, event)
         } else {
             ClipEventResult::NotHandled

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -183,10 +183,7 @@ pub trait TInteractiveObject<'gc>:
         context: &mut UpdateContext<'_, 'gc>,
         event: ClipEvent<'gc>,
     ) -> ClipEventResult {
-        if event.propagates()
-            && (matches!(event, ClipEvent::KeyPress { .. })
-                || self.as_displayobject().should_propagate_to_children())
-        {
+        if event.propagates() {
             if let Some(container) = self.as_displayobject().as_container() {
                 for child in container.iter_render_list() {
                     if let Some(interactive) = child.as_interactive() {

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3371,6 +3371,7 @@ impl<'gc> MovieClipData<'gc> {
         for handler in &event_handlers {
             all_event_flags |= handler.events;
         }
+        self.base.base.set_clip_events_inplace(all_event_flags);
         self.clip_event_flags = all_event_flags;
         self.clip_event_handlers = event_handlers;
     }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -335,24 +335,24 @@ impl<'gc> ClipEvent<'gc> {
 }
 
 pub fn method_name_to_clip_event(name: &str) -> Option<ClipEvent<'static>> {
-        match name {
-            "onDragOut" => Some(ClipEvent::DragOut { to: None }),
-            "onDragOver" => Some(ClipEvent::DragOver { from: None }),
-            "onEnterFrame" => Some(ClipEvent::EnterFrame),
-            "onKeyDown" => Some(ClipEvent::KeyDown),
-            "onKeyUp" => Some(ClipEvent::KeyUp),
-            "onLoad" => Some(ClipEvent::Load),
-            "onMouseDown" => Some(ClipEvent::MouseDown),
-            "onMouseMove" => Some(ClipEvent::MouseMove),
-            "onMouseUp" => Some(ClipEvent::MouseUp),
-            "onPress" => Some(ClipEvent::Press),
-            "onRollOut" => Some(ClipEvent::RollOut { to: None }),
-            "onRollOver" => Some(ClipEvent::RollOver { from: None }),
-            "onRelease" => Some(ClipEvent::Release),
-            "onReleaseOutside" => Some(ClipEvent::ReleaseOutside),
-            "onUnload" => Some(ClipEvent::Unload),
-            _ => None,
-        }
+    match name {
+        "onDragOut" => Some(ClipEvent::DragOut { to: None }),
+        "onDragOver" => Some(ClipEvent::DragOver { from: None }),
+        "onEnterFrame" => Some(ClipEvent::EnterFrame),
+        "onKeyDown" => Some(ClipEvent::KeyDown),
+        "onKeyUp" => Some(ClipEvent::KeyUp),
+        "onLoad" => Some(ClipEvent::Load),
+        "onMouseDown" => Some(ClipEvent::MouseDown),
+        "onMouseMove" => Some(ClipEvent::MouseMove),
+        "onMouseUp" => Some(ClipEvent::MouseUp),
+        "onPress" => Some(ClipEvent::Press),
+        "onRollOut" => Some(ClipEvent::RollOut { to: None }),
+        "onRollOver" => Some(ClipEvent::RollOver { from: None }),
+        "onRelease" => Some(ClipEvent::Release),
+        "onReleaseOutside" => Some(ClipEvent::ReleaseOutside),
+        "onUnload" => Some(ClipEvent::Unload),
+        _ => None,
+    }
 }
 
 /// Control inputs to a text field

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -332,6 +332,26 @@ impl<'gc> ClipEvent<'gc> {
             | ClipEvent::MouseUpInside => None,
         }
     }
+    pub const fn has_method_name(self) -> bool {
+        matches!(
+            self,
+            ClipEvent::DragOut { .. }
+                | ClipEvent::DragOver { .. }
+                | ClipEvent::EnterFrame
+                | ClipEvent::KeyDown
+                | ClipEvent::KeyUp
+                | ClipEvent::Load
+                | ClipEvent::MouseDown
+                | ClipEvent::MouseMove
+                | ClipEvent::MouseUp
+                | ClipEvent::Press
+                | ClipEvent::RollOut { .. }
+                | ClipEvent::RollOver { .. }
+                | ClipEvent::Release
+                | ClipEvent::ReleaseOutside
+                | ClipEvent::Unload
+        )
+    }
 }
 
 pub fn method_name_to_clip_event(name: &str) -> Option<ClipEvent<'static>> {

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -334,6 +334,27 @@ impl<'gc> ClipEvent<'gc> {
     }
 }
 
+pub fn method_name_to_clip_event(name: &str) -> Option<ClipEvent<'static>> {
+        match name {
+            "onDragOut" => Some(ClipEvent::DragOut { to: None }),
+            "onDragOver" => Some(ClipEvent::DragOver { from: None }),
+            "onEnterFrame" => Some(ClipEvent::EnterFrame),
+            "onKeyDown" => Some(ClipEvent::KeyDown),
+            "onKeyUp" => Some(ClipEvent::KeyUp),
+            "onLoad" => Some(ClipEvent::Load),
+            "onMouseDown" => Some(ClipEvent::MouseDown),
+            "onMouseMove" => Some(ClipEvent::MouseMove),
+            "onMouseUp" => Some(ClipEvent::MouseUp),
+            "onPress" => Some(ClipEvent::Press),
+            "onRollOut" => Some(ClipEvent::RollOut { to: None }),
+            "onRollOver" => Some(ClipEvent::RollOver { from: None }),
+            "onRelease" => Some(ClipEvent::Release),
+            "onReleaseOutside" => Some(ClipEvent::ReleaseOutside),
+            "onUnload" => Some(ClipEvent::Unload),
+            _ => None,
+        }
+}
+
 /// Control inputs to a text field
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 pub enum TextControlCode {


### PR DESCRIPTION
This allows us to skip pushing unnecessary player events onto the action queue.

This definitely improves performance in clip, and/or button heavy scenes, when doing
something like moving the mouse around.

There's definitely room for improvement, but I feel it's a good start. :)

btw, the only reason this is marked as avm2 is because this technically also works for `Avm2Button`s.