### PR TITLE
chore: Update libz-sys to 1.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,9 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e6ab01971eb092ffe6a7d42f49f9ff42662f17604681e2843ad65077ba47dc"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
I need this to be able to run clippy again 😅 (https://github.com/rust-lang/libz-sys/issues/143)