### PR TITLE
avm2: Special case Number.toString for Infinity and NaN

### DIFF
--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -260,6 +260,18 @@ pub fn print_with_radix<'gc>(
         return Value::from(number).coerce_to_string(activation);
     }
 
+    if number.is_nan() {
+        return Ok("NaN".into());
+    }
+
+    if number.is_infinite() {
+        if number < 0.0 {
+            return Ok("-Infinity".into());
+        } else if number > 0.0 {
+            return Ok("Infinity".into());
+        }
+    }
+
     let mut digits = vec![];
     let sign = number.signum();
     number = number.abs();

--- a/tests/tests/swfs/avm2/from_avmplus/e4x/Global/e13_1_2_1/test.toml
+++ b/tests/tests/swfs/avm2/from_avmplus/e4x/Global/e13_1_2_1/test.toml
@@ -1,3 +1,2 @@
 num_ticks = 1
-ignore = true # infinite loop?
 known_failure = true # https://github.com/ruffle-rs/ruffle/issues/12354


### PR DESCRIPTION
This avoids getting into an infinite loop for some of the avmplus tests.