### PR TITLE
render: Bump wgpu to 0.17 and naga to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,12 +332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112ef6b3f6cb3cb6fc5b6b494ef7a848492cff1ab0ef4de10b0f7d572861c905"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +807,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -1022,12 +1016,12 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
+checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
 dependencies = [
- "bitflags 1.3.2",
- "libloading 0.7.4",
+ "bitflags 2.4.0",
+ "libloading 0.8.0",
  "winapi",
 ]
 
@@ -1275,8 +1269,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "ecolor"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e479a7fa3f23d4e794f8b2f8b3568dd4e47886ad1b12c9c095e141cb591eb63"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "bytemuck",
 ]
@@ -1284,8 +1277,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aef8ec3ae1b772f340170c65bf27d5b8c28f543a0116c844d2ac08d01123e7"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "ahash 0.8.3",
  "epaint",
@@ -1296,8 +1288,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33caaedd8283779c787298af23d8754a7e88421ff32e89ad0040c855fc0b0224"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "bytemuck",
  "epaint",
@@ -1311,8 +1302,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a49155fd4a0a4fb21224407a91de0030847972ef90fc64edb63621caea61cb2"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "arboard",
  "egui",
@@ -1327,8 +1317,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9278f4337b526f0d57e5375e5a7340a311fa6ee8f9fcc75721ac50af13face02"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "egui",
  "serde",
@@ -1343,8 +1332,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3857d743a6e0741cdd60b622a74c7a36ea75f5f8f11b793b41d905d2c9721a4b"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "bytemuck",
 ]
@@ -1434,12 +1422,10 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09333964d4d57f40a85338ba3ca5ed4716070ab184dcfed966b35491c5c64f3b"
+source = "git+https://github.com/emilk/egui?rev=98087029e020a1b2d78a4eb840d0a8505340ecad#98087029e020a1b2d78a4eb840d0a8505340ecad"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.3",
- "atomic_refcell",
  "bytemuck",
  "ecolor",
  "emath",
@@ -1698,7 +1684,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1706,6 +1713,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2008,21 +2021,21 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
 ]
 
 [[package]]
@@ -2800,16 +2813,17 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
+checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
+ "paste",
 ]
 
 [[package]]
@@ -2859,12 +2873,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcc2e0513220fd2b598e6068608d4462db20322c0e77e47f6f488dfcfc279cb"
+checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "codespan-reporting",
  "hexf-parse",
  "indexmap 1.9.3",
@@ -2904,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9c27fc9c84580434af75123d13ad98d9a56e16d033b16dcfa6940728c8c225"
+checksum = "9a5e64da99d79501b244fb645154cd17d0f726b572cb7b029942fb8aa0c48823"
 dependencies = [
  "bit-set",
  "codespan-reporting",
@@ -3400,6 +3414,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-slash"
@@ -5418,9 +5438,9 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480c965c9306872eb6255fa55e4b4953be55a8b64d57e61d7ff840d3dcc051cd"
+checksum = "7472f3b69449a8ae073f6ec41d05b6f846902d92a6c45313c50cb25857b736ce"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -5443,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
+checksum = "ecf7454d9386f602f7399225c92dd2fbdcde52c519bc8fb0bd6fbeb388075dc2"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5468,9 +5488,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb3258078e936deee14fd4e0febe1cfe9bbb5ffef165cb60218d2ee5eb4448"
+checksum = "6654a13885a17f475e8324efb46dc6986d7aaaa98353330f8de2077b153d0101"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -5480,7 +5500,6 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
  "glow",
  "gpu-alloc",
  "gpu-allocator",
@@ -5510,9 +5529,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
+checksum = "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67"
 dependencies = [
  "bitflags 2.4.0",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ version = "0.1.0"
 # gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "efd89fc683c6bb456af3e226c33763cb822645e9" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-naga = { version = "0.12.3", features = ["validate", "wgsl-out"] }
-naga_oil = "0.8.1"
-wgpu = "0.16.3"
+naga = { version = "0.13.0", features = ["validate", "wgsl-out"] }
+naga_oil = "0.9.0"
+wgpu = { version = "0.17.0" }
+egui = { git = "https://github.com/emilk/egui", rev = "98087029e020a1b2d78a4eb840d0a8505340ecad" }
 
 # Don't optimize build scripts and macros.
 [profile.release.build-override]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,8 +51,8 @@ realfft = "3.3.0"
 hashbrown = { version = "0.14.0", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.8.0"
-egui = { version = "0.22.0", optional = true }
-egui_extras = { version = "0.22.0", optional = true }
+egui = { workspace = true, optional = true }
+egui_extras = { git = "https://github.com/emilk/egui", rev = "98087029e020a1b2d78a4eb840d0a8505340ecad", optional = true }
 png = { version = "0.17.10", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = "1.9.0"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -10,9 +10,9 @@ version.workspace = true
 [dependencies]
 clap = { version = "4.4.2", features = ["derive"] }
 cpal = "0.15.2"
-egui = "0.22.0"
-egui-wgpu = { version = "0.22.0", features = ["winit"] }
-egui-winit = "0.22.0"
+egui = { workspace = true }
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "98087029e020a1b2d78a4eb840d0a8505340ecad", features = ["winit"] }
+egui-winit = { git = "https://github.com/emilk/egui", rev = "98087029e020a1b2d78a4eb840d0a8505340ecad" }
 fontdb = "0.14"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/render/naga-agal/tests/snapshots/wgsl__complex_fractal-2.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__complex_fractal-2.snap
@@ -8,7 +8,7 @@ struct FragmentOutput {
 }
 
 @group(0) @binding(1) 
-var<uniform> constant_registers: array<vec4<f32>,28u>;
+var<uniform> constant_registers: array<vec4<f32>, 28>;
 @group(0) @binding(2) 
 var sampler0_: sampler;
 @group(0) @binding(3) 

--- a/render/naga-agal/tests/snapshots/wgsl__complex_fractal.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__complex_fractal.snap
@@ -1,5 +1,6 @@
 ---
 source: render/naga-agal/tests/wgsl.rs
+assertion_line: 117
 expression: output
 ---
 struct VertexOutput {
@@ -8,7 +9,7 @@ struct VertexOutput {
 }
 
 @group(0) @binding(0) 
-var<uniform> constant_registers: array<vec4<f32>,128u>;
+var<uniform> constant_registers: array<vec4<f32>, 128>;
 
 @vertex 
 fn main(@location(0) param: vec2<f32>, @location(1) param_1: vec2<f32>) -> VertexOutput {

--- a/render/naga-agal/tests/snapshots/wgsl__complex_raytrace-2.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__complex_raytrace-2.snap
@@ -8,7 +8,7 @@ struct FragmentOutput {
 }
 
 @group(0) @binding(1) 
-var<uniform> constant_registers: array<vec4<f32>,28u>;
+var<uniform> constant_registers: array<vec4<f32>, 28>;
 @group(0) @binding(2) 
 var sampler0_: sampler;
 @group(0) @binding(3) 

--- a/render/naga-agal/tests/snapshots/wgsl__complex_raytrace.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__complex_raytrace.snap
@@ -9,7 +9,7 @@ struct VertexOutput {
 }
 
 @group(0) @binding(0) 
-var<uniform> constant_registers: array<vec4<f32>,128u>;
+var<uniform> constant_registers: array<vec4<f32>, 128>;
 
 @vertex 
 fn main(@location(0) param: vec4<f32>) -> VertexOutput {

--- a/render/naga-agal/tests/snapshots/wgsl__misc_opcodes-2.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__misc_opcodes-2.snap
@@ -1,6 +1,6 @@
 ---
 source: render/naga-agal/tests/wgsl.rs
-assertion_line: 160
+assertion_line: 195
 expression: output
 ---
 struct FragmentOutput {
@@ -8,7 +8,7 @@ struct FragmentOutput {
 }
 
 @group(0) @binding(1) 
-var<uniform> constant_registers: array<vec4<f32>,28u>;
+var<uniform> constant_registers: array<vec4<f32>, 28>;
 @group(0) @binding(2) 
 var sampler0_: sampler;
 @group(0) @binding(3) 

--- a/render/naga-agal/tests/snapshots/wgsl__misc_opcodes.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__misc_opcodes.snap
@@ -1,6 +1,6 @@
 ---
 source: render/naga-agal/tests/wgsl.rs
-assertion_line: 144
+assertion_line: 180
 expression: output
 ---
 struct VertexOutput {
@@ -8,7 +8,7 @@ struct VertexOutput {
 }
 
 @group(0) @binding(0) 
-var<uniform> constant_registers: array<vec4<f32>,128u>;
+var<uniform> constant_registers: array<vec4<f32>, 128>;
 
 @vertex 
 fn main(@location(0) param: vec4<f32>) -> VertexOutput {

--- a/render/naga-agal/tests/snapshots/wgsl__relative_load.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__relative_load.snap
@@ -1,6 +1,6 @@
 ---
 source: render/naga-agal/tests/wgsl.rs
-assertion_line: 143
+assertion_line: 146
 expression: output
 ---
 struct VertexOutput {
@@ -8,7 +8,7 @@ struct VertexOutput {
 }
 
 @group(0) @binding(0) 
-var<uniform> constant_registers: array<vec4<f32>,128u>;
+var<uniform> constant_registers: array<vec4<f32>, 128>;
 
 @vertex 
 fn main(@location(0) param: vec4<f32>, @location(1) param_1: vec4<f32>) -> VertexOutput {

--- a/render/naga-agal/tests/snapshots/wgsl__shaders-2.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__shaders-2.snap
@@ -1,6 +1,6 @@
 ---
-source: tests/wgsl.rs
-assertion_line: 53
+source: render/naga-agal/tests/wgsl.rs
+assertion_line: 54
 expression: output
 ---
 struct VertexOutput {
@@ -9,7 +9,7 @@ struct VertexOutput {
 }
 
 @group(0) @binding(0) 
-var<uniform> constant_registers: array<vec4<f32>,128u>;
+var<uniform> constant_registers: array<vec4<f32>, 128>;
 
 @vertex 
 fn main(@location(0) param: vec4<f32>, @location(1) param_1: vec4<f32>) -> VertexOutput {

--- a/render/naga-agal/tests/snapshots/wgsl__shaders-3.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__shaders-3.snap
@@ -8,7 +8,7 @@ struct FragmentOutput {
 }
 
 @group(0) @binding(1) 
-var<uniform> constant_registers: array<vec4<f32>,28u>;
+var<uniform> constant_registers: array<vec4<f32>, 28>;
 @group(0) @binding(2) 
 var sampler0_: sampler;
 @group(0) @binding(3) 

--- a/render/naga-agal/tests/snapshots/wgsl__shaders.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__shaders.snap
@@ -1,6 +1,6 @@
 ---
-source: tests/wgsl.rs
-assertion_line: 35
+source: render/naga-agal/tests/wgsl.rs
+assertion_line: 33
 expression: output
 ---
 struct VertexOutput {
@@ -9,7 +9,7 @@ struct VertexOutput {
 }
 
 @group(0) @binding(0) 
-var<uniform> constant_registers: array<vec4<f32>,128u>;
+var<uniform> constant_registers: array<vec4<f32>, 128>;
 
 @vertex 
 fn main(@location(0) param: vec3<f32>, @location(1) param_1: vec3<f32>) -> VertexOutput {


### PR DESCRIPTION
This requires forked versions of several dependencies, and egui doesn't yet compile on wasm due to the `!Send/!Sync` wgpu changes.