### PR TITLE
debug_ui: Indent non-expandable items object- and display trees

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -583,7 +583,18 @@ impl DisplayObjectWindow {
                     }
                 });
         } else {
-            open_display_object_button(ui, context, messages, object, &mut self.hovered_debug_rect);
+            // This item is not expandable, but we want to keep
+            // the space empty where the expand button would be,
+            // so it doesn't look like a sibling of the parent.
+            ui.indent(ui.id().with(object.as_ptr()), |ui| {
+                open_display_object_button(
+                    ui,
+                    context,
+                    messages,
+                    object,
+                    &mut self.hovered_debug_rect,
+                );
+            });
         }
     }
 }

--- a/core/src/debug_ui/display_object/search.rs
+++ b/core/src/debug_ui/display_object/search.rs
@@ -171,7 +171,11 @@ fn show_object_tree(
     hovered_debug_rect: &mut Option<DisplayObjectHandle>,
 ) {
     if tree.children.is_empty() {
-        show_item(ui, context, tree, messages, hovered_debug_rect);
+        // This item is not expandable, but we want to keep the space empty where the
+        // expand button would be, so it doesn't look like a sibling of the parent.
+        ui.indent(ui.id().with(tree.handle.as_ptr()), |ui| {
+            show_item(ui, context, tree, messages, hovered_debug_rect);
+        });
     } else {
         CollapsingState::load_with_default_open(ui.ctx(), ui.id().with(tree.handle.as_ptr()), true)
             .show_header(ui, |ui| {


### PR DESCRIPTION
This confused me terribly.

Before (single item, `instance2`, collapsed/expanded):

![image](https://github.com/ruffle-rs/ruffle/assets/288816/a5d12481-d926-475f-87a5-8523771979a1) ![image](https://github.com/ruffle-rs/ruffle/assets/288816/f511fb42-511d-412a-850b-54989177b8c9)

After (same item collapsed/expanded):

![image](https://github.com/ruffle-rs/ruffle/assets/288816/036e16b9-bf95-4550-aba9-0fe2d1f070a9) ![image](https://github.com/ruffle-rs/ruffle/assets/288816/f3613cde-ab1d-484a-9b81-197bcbd13739)
