### PR TITLE
wstr: return correct result for `split_ascii_prefix_bytes(<ascii str>)`

### DIFF
--- a/wstr/src/tests.rs
+++ b/wstr/src/tests.rs
@@ -207,3 +207,10 @@ fn str_patterns() {
     test_pattern(wide, bstr!(b"aa"), &[(2, 4), (6, 8)], None);
     test_pattern(wide, wstr!('↓''a'), &[(1, 3), (5, 7)], None);
 }
+
+#[test]
+fn split_ascii_prefix() {
+    assert_eq!(utils::split_ascii_prefix(""), (&b""[..], ""));
+    assert_eq!(utils::split_ascii_prefix("abc"), (&b"abc"[..], ""));
+    assert_eq!(utils::split_ascii_prefix("abcd€fg"), (&b"abcd"[..], "€fg"));
+}

--- a/wstr/src/utils.rs
+++ b/wstr/src/utils.rs
@@ -53,7 +53,7 @@ pub fn swf_is_whitespace(c: u16) -> bool {
 /// and returns it as an UTF8 string, together with the remaining tail.
 pub fn split_ascii_prefix_bytes(slice: &[u8]) -> (&str, &[u8]) {
     let first_non_ascii = slice.iter().position(|c| *c >= 0x80);
-    let (head, tail) = slice.split_at(first_non_ascii.unwrap_or(0));
+    let (head, tail) = slice.split_at(first_non_ascii.unwrap_or(slice.len()));
     // SAFETY: `head` only contains ASCII.
     let head = unsafe { core::str::from_utf8_unchecked(head) };
     (head, tail)


### PR DESCRIPTION
`split_ascii_prefix_bytes(b"abc")` should return `("abc", b"")`, not `("", b"abc")`

This doesn't affect correctness, but should increase performance of ASCII `String` -> `WString` conversions.

Kudos to @Adrian17 for catching this!