### PR TITLE
renovate: Remove separate lockFileMaintenance schedule, set rangeStrategy to bump.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,11 +7,14 @@
             "matchLanguages": ["rust"],
             "matchUpdateTypes": "patch",
             "groupName": "Rust dependency patches",
+            "rangeStrategy": "bump",
             "extends": ["schedule:weekly"],
         },
         {
             "matchLanguages": ["rust"],
             "groupName": "Rust dependencies",
+            "matchUpdateTypes": ["major", "minor"],
+            "rangeStrategy": "bump",
             "extends": ["schedule:weekly"],
         },
         {
@@ -26,6 +29,7 @@
         {
             "matchLanguages": ["js"],
             "groupName": "Node.js dependencies",
+            "rangeStrategy": "bump",
             "extends": ["schedule:monthly"],
         },
         {
@@ -34,7 +38,4 @@
             "extends": ["schedule:monthly"],
         },
     ],
-    "lockFileMaintenance": {
-        "enabled": true
-    }
 }


### PR DESCRIPTION
This is supposed to fix the issue mentioned in https://github.com/ruffle-rs/ruffle/pull/12474#issuecomment-1660590171.

That is caused by the separate lockFileMaintenance PRs fast-forwarding the lockfiles in themselves, but not the version spec in package.json. So the lockfile will be rolled back locally. Let's try to make the lockfiles be bumped together with the version specs for both Rust and JS, with a different solution than https://github.com/ruffle-rs/ruffle/pull/9884.

The previous goal of grouping only patch updates together, and having minor and major updates be their own separate PRs per package (83f88a6f3e6757993d09b6bc97303739f86d4c30) also didn't work, as can be seen in https://github.com/ruffle-rs/ruffle/pull/12474.