### PR TITLE
core: Remove lots of uses of derive(Collect)

### DIFF
--- a/core/src/avm1/property.rs
+++ b/core/src/avm1/property.rs
@@ -8,8 +8,7 @@ use gc_arena::Collect;
 bitflags! {
     /// Attributes of properties in the AVM runtime.
     /// The values are significant and should match the order used by `object::as_set_prop_flags`.
-    #[derive(Clone, Collect, Copy, Debug)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy, Debug)]
     pub struct Attribute: u16 {
         const DONT_ENUM     = 1 << 0;
         const DONT_DELETE   = 1 << 1;
@@ -49,6 +48,7 @@ pub struct Property<'gc> {
     data: Value<'gc>,
     getter: Option<Object<'gc>>,
     setter: Option<Object<'gc>>,
+    #[collect(require_static)]
     attributes: Attribute,
 }
 

--- a/core/src/avm1/scope.rs
+++ b/core/src/avm1/scope.rs
@@ -10,8 +10,7 @@ use crate::string::AvmString;
 use gc_arena::{Collect, Gc, MutationContext};
 
 /// Indicates what kind of scope a scope is.
-#[derive(Clone, Collect, Copy, Debug, Eq, PartialEq)]
-#[collect(require_static)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ScopeClass {
     /// Scope represents global scope.
     Global,
@@ -34,6 +33,7 @@ pub enum ScopeClass {
 #[collect(no_drop)]
 pub struct Scope<'gc> {
     parent: Option<Gc<'gc, Scope<'gc>>>,
+    #[collect(require_static)]
     class: ScopeClass,
     values: Object<'gc>,
 }

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -58,8 +58,7 @@ bitflags! {
 pub type AllocatorFn =
     for<'gc> fn(ClassObject<'gc>, &mut Activation<'_, 'gc>) -> Result<Object<'gc>, Error<'gc>>;
 
-#[derive(Clone, Collect)]
-#[collect(require_static)]
+#[derive(Clone, Copy)]
 pub struct Allocator(pub AllocatorFn);
 
 impl fmt::Debug for Allocator {
@@ -99,6 +98,7 @@ pub struct Class<'gc> {
     /// If `None`, then instances of this object will be allocated the same way
     /// as the superclass specifies; or if there is no superclass, it will be
     /// allocated as a `ScriptObject`.
+    #[collect(require_static)]
     instance_allocator: Option<Allocator>,
 
     /// The instance initializer for this class.

--- a/core/src/avm2/events.rs
+++ b/core/src/avm2/events.rs
@@ -13,8 +13,7 @@ use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
 /// Which phase of event dispatch is currently occurring.
-#[derive(Copy, Clone, Collect, Debug, PartialEq, Eq)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum EventPhase {
     /// The event has yet to be fired on the target and is descending the
     /// ancestors of the event target.
@@ -29,8 +28,7 @@ pub enum EventPhase {
 }
 
 /// How this event is allowed to propagate.
-#[derive(Copy, Clone, Collect, Debug, PartialEq, Eq)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PropagationMode {
     /// Propagate events normally.
     Allow,
@@ -59,12 +57,14 @@ pub struct Event<'gc> {
     cancelled: bool,
 
     /// Whether or not event propagation has stopped.
+    #[collect(require_static)]
     propagation: PropagationMode,
 
     /// The object currently having it's event handlers invoked.
     current_target: Option<Object<'gc>>,
 
     /// The current event phase.
+    #[collect(require_static)]
     event_phase: EventPhase,
 
     /// The object this event was dispatched on.

--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -50,8 +50,7 @@ impl<'gc> NamespaceSet<'gc> {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, Default, Collect)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct MultinameFlags: u8 {
         /// Whether the namespace needs to be read at runtime before use.
         /// This should only be set when lazy-initialized in Activation.
@@ -85,6 +84,7 @@ pub struct Multiname<'gc> {
     /// this multiname is satisfied by any type parameter or no type parameter
     param: Option<Gc<'gc, Multiname<'gc>>>,
 
+    #[collect(require_static)]
     flags: MultinameFlags,
 }
 

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -59,6 +59,7 @@ pub struct ClassObjectData<'gc> {
     superclass_object: Option<ClassObject<'gc>>,
 
     /// The instance allocator for this class.
+    #[collect(require_static)]
     instance_allocator: Allocator,
 
     /// The instance constructor function

--- a/core/src/avm2/object/soundchannel_object.rs
+++ b/core/src/avm2/object/soundchannel_object.rs
@@ -63,8 +63,6 @@ pub struct SoundChannelObjectData<'gc> {
     position: f64,
 }
 
-#[derive(Collect)]
-#[collect(require_static)]
 pub enum SoundChannelData {
     NotLoaded {
         sound_transform: Option<SoundTransform>,

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -49,6 +49,7 @@ pub struct TextFormatObjectData<'gc> {
     /// Base script object
     base: ScriptObjectData<'gc>,
 
+    #[collect(require_static)]
     text_format: TextFormat,
 }
 

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -16,6 +16,7 @@ use gc_arena::Collect;
 #[collect(no_drop)]
 pub struct RegExp<'gc> {
     source: AvmString<'gc>,
+    #[collect(require_static)]
     flags: RegExpFlags,
     last_index: usize,
 
@@ -37,8 +38,7 @@ impl<'gc> Clone for RegExp<'gc> {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Collect, Debug)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy, Debug)]
     pub struct RegExpFlags: u8 {
         const GLOBAL       = 1 << 0;
         const IGNORE_CASE  = 1 << 1;

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -273,6 +273,7 @@ pub struct AudioManager<'gc> {
     sounds: Vec<SoundInstance<'gc>>,
 
     /// The global sound transform applied to all sounds.
+    #[collect(require_static)]
     global_sound_transform: display_object::SoundTransform,
 
     /// The number of seconds that a timeline audio stream should buffer before playing.
@@ -654,6 +655,7 @@ pub struct SoundInstance<'gc> {
     /// Only AVM2 sounds have a local sound transform. In AVM1, sound instances
     /// instead get the sound transform of the display object they're
     /// associated with.
+    #[collect(require_static)]
     transform: display_object::SoundTransform,
 
     /// The AVM1 `Sound` object associated with this sound, if any.
@@ -668,8 +670,7 @@ pub struct SoundInstance<'gc> {
 /// A sound transform for a playing sound, for use by audio backends.
 /// This differs from `display_object::SoundTransform` by being
 /// already converted to `f32` and having `volume` baked in.
-#[derive(Debug, PartialEq, Clone, Collect)]
-#[collect(require_static)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct SoundTransform {
     pub left_to_left: f32,
     pub left_to_right: f32,

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,4 +1,3 @@
-use gc_arena::Collect;
 use serde::{Deserialize, Serialize};
 
 /// Controls whether the content is letterboxed or pillarboxed when the
@@ -7,8 +6,7 @@ use serde::{Deserialize, Serialize};
 /// When letterboxed, black bars will be rendered around the exterior
 /// margins of the content.
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Collect, Serialize, Deserialize)]
-#[collect(require_static)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename = "letterbox")]
 pub enum Letterbox {
     /// The content will never be letterboxed.

--- a/core/src/context_menu.rs
+++ b/core/src/context_menu.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 #[derive(Collect, Default)]
 #[collect(no_drop)]
 pub struct ContextMenuState<'gc> {
+    #[collect(require_static)]
     info: Vec<ContextMenuItem>,
     callbacks: Vec<ContextMenuCallback<'gc>>,
 }
@@ -122,8 +123,7 @@ impl<'gc> ContextMenuState<'gc> {
     }
 }
 
-#[derive(Collect, Clone, Serialize)]
-#[collect(require_static)]
+#[derive(Clone, Serialize)]
 pub struct ContextMenuItem {
     pub enabled: bool,
     #[serde(rename = "separatorBefore")]

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -212,6 +212,7 @@ pub struct DisplayObjectBase<'gc> {
     next_avm1_clip: Option<DisplayObject<'gc>>,
 
     /// The sound transform of sounds playing via this display object.
+    #[collect(require_static)]
     sound_transform: SoundTransform,
 
     /// The display object that we are being masked by.
@@ -236,6 +237,7 @@ pub struct DisplayObjectBase<'gc> {
     opaque_background: Option<Color>,
 
     /// Bit flags for various display object properties.
+    #[collect(require_static)]
     flags: DisplayObjectFlags,
 
     /// The 'internal' scroll rect used for rendering and methods like 'localToGlobal'.
@@ -2290,8 +2292,7 @@ impl<'gc> DisplayObject<'gc> {
 
 bitflags! {
     /// Bit flags used by `DisplayObject`.
-    #[derive(Clone, Collect, Copy)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy)]
     struct DisplayObjectFlags: u16 {
         /// Whether this object has been removed from the display list.
         /// Necessary in AVM1 to throw away queued actions from removed movie clips.
@@ -2367,8 +2368,7 @@ bitflags! {
 /// Every value is a percentage (0-100), but out of range values are allowed.
 /// In AVM1, this is returned by `Sound.getTransform`.
 /// In AVM2, this is returned by `Sprite.soundTransform`.
-#[derive(Debug, PartialEq, Eq, Clone, Collect)]
-#[collect(require_static)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SoundTransform {
     pub volume: i32,
     pub left_to_left: i32,

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -40,6 +40,8 @@ pub struct Avm1ButtonData<'gc> {
     state: ButtonState,
     hit_area: BTreeMap<Depth, DisplayObject<'gc>>,
     container: ChildContainer<'gc>,
+    #[allow(dead_code)]
+    #[collect(require_static)]
     tracking: ButtonTracking,
     object: Option<Object<'gc>>,
     initialized: bool,
@@ -681,8 +683,7 @@ struct ButtonAction {
     key_code: Option<ButtonKeyCode>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ButtonTracking {
     Push,
     Menu,

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -59,6 +59,7 @@ pub struct Avm2ButtonData<'gc> {
     hit_area: Option<DisplayObject<'gc>>,
 
     /// The current tracking mode of this button.
+    #[collect(require_static)]
     tracking: ButtonTracking,
 
     /// The class of this button.

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -85,6 +85,7 @@ pub struct EditTextData<'gc> {
     ///
     /// It is lowered further into layout boxes, which are used for actual
     /// rendering.
+    #[collect(require_static)]
     text_spans: FormatSpans,
 
     /// The color of the background fill. Only applied when has_border and has_background.
@@ -96,6 +97,7 @@ pub struct EditTextData<'gc> {
     border_color: Color,
 
     /// The current border drawing.
+    #[collect(require_static)]
     drawing: Drawing,
 
     /// Whether or not the width of the field should change in response to text
@@ -107,6 +109,7 @@ pub struct EditTextData<'gc> {
     layout: Vec<LayoutBox<'gc>>,
 
     /// The intrinsic bounds of the laid-out text.
+    #[collect(require_static)]
     intrinsic_bounds: BoxBounds<Twips>,
 
     /// The current intrinsic bounds of the text field.
@@ -129,15 +132,18 @@ pub struct EditTextData<'gc> {
     /// In AVM2, every text field has its own mandatory selection.
     /// In Ruffle, every text field has its own optional selection. This hybrid approach means manually maintaining
     /// the invariants that selection is always None for an unfocused AVM1 field, and never None for an AVM2 field.
+    #[collect(require_static)]
     selection: Option<TextSelection>,
 
     /// Which rendering engine this text field will use.
+    #[collect(require_static)]
     render_settings: TextRenderSettings,
 
     /// How many pixels right the text is offset by. 0-based index.
     hscroll: f64,
 
     /// Information about the layout's current lines. Used by scroll properties.
+    #[collect(require_static)]
     line_data: Vec<LineData>,
 
     /// How many lines down the text is offset by. 1-based index.
@@ -148,6 +154,7 @@ pub struct EditTextData<'gc> {
     max_chars: i32,
 
     /// Flags indicating the text field's settings.
+    #[collect(require_static)]
     flags: EditTextFlag,
 }
 
@@ -1998,8 +2005,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
 }
 
 bitflags::bitflags! {
-    #[derive(Clone, Copy, Collect)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy)]
     struct EditTextFlag: u16 {
         const FIRING_VARIABLE_BINDING = 1 << 0;
         const HAS_BACKGROUND = 1 << 1;
@@ -2031,16 +2037,14 @@ struct EditTextStatic {
     initial_text: Option<WString>,
 }
 
-#[derive(Copy, Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug)]
 pub struct TextSelection {
     from: usize,
     to: usize,
 }
 
 /// Information about the start and end y-coordinates of a given line of text
-#[derive(Copy, Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug)]
 pub struct LineData {
     index: usize,
     /// How many twips down the highest point of the line is

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -34,6 +34,7 @@ pub struct GraphicData<'gc> {
     base: DisplayObjectBase<'gc>,
     static_data: gc_arena::Gc<'gc, GraphicStatic>,
     avm2_object: Option<Avm2Object<'gc>>,
+    #[collect(require_static)]
     drawing: Option<Drawing>,
 }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -64,8 +64,7 @@ fn lowest_common_ancestor<'gc>(
 
 bitflags! {
     /// Boolean state flags used by `InteractiveObject`.
-    #[derive(Clone, Copy, Collect)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy)]
     struct InteractiveObjectFlags: u8 {
         /// Whether this `InteractiveObject` accepts mouse and other user
         /// events.
@@ -80,6 +79,7 @@ bitflags! {
 #[collect(no_drop)]
 pub struct InteractiveObjectBase<'gc> {
     pub base: DisplayObjectBase<'gc>,
+    #[collect(require_static)]
     flags: InteractiveObjectFlags,
     context_menu: Avm2Value<'gc>,
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -150,12 +150,15 @@ pub struct MovieClipData<'gc> {
     audio_stream: Option<SoundInstanceHandle>,
     container: ChildContainer<'gc>,
     object: Option<AvmObject<'gc>>,
+    #[collect(require_static)]
     clip_event_handlers: Vec<ClipEventHandler>,
     #[collect(require_static)]
     clip_event_flags: ClipEventFlag,
     frame_scripts: Vec<Option<Avm2Object<'gc>>>,
+    #[collect(require_static)]
     flags: MovieClipFlags,
     avm2_class: Option<Avm2ClassObject<'gc>>,
+    #[collect(require_static)]
     drawing: Drawing,
     has_focus: bool,
     avm2_enabled: bool,
@@ -179,6 +182,7 @@ pub struct MovieClipData<'gc> {
     tag_frame_boundaries: HashMap<FrameNumber, (u64, u64)>,
 
     /// List of tags queued up for the current frame.
+    #[collect(require_static)]
     queued_tags: HashMap<Depth, QueuedTagList>,
 }
 
@@ -4560,8 +4564,7 @@ impl<'a> GotoPlaceObject<'a> {
 ///
 /// Any other configuration in the SWF tag stream is normalized to one of
 /// these patterns.
-#[derive(Default, Debug, Eq, PartialEq, Clone, Copy, Collect)]
-#[collect(require_static)]
+#[derive(Default, Debug, Eq, PartialEq, Clone, Copy)]
 pub enum QueuedTagList {
     #[default]
     None,
@@ -4628,8 +4631,7 @@ impl QueuedTagList {
 /// A single tag we encountered this frame that we intend to process on a queue.
 ///
 /// No more than one queued action is allowed to be processed on-queue.
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Collect)]
-#[collect(require_static)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub struct QueuedTag {
     pub tag_type: QueuedTagAction,
     pub tag_start: u64,
@@ -4638,8 +4640,7 @@ pub struct QueuedTag {
 /// The type of queued tag.
 ///
 /// The u8 parameter is the tag version.
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Collect)]
-#[collect(require_static)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum QueuedTagAction {
     Place(u8),
     Remove(u8),
@@ -4647,8 +4648,7 @@ pub enum QueuedTagAction {
 
 bitflags! {
     /// Boolean state flags used by `MovieClip`.
-    #[derive(Clone, Copy, Collect)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy)]
     struct MovieClipFlags: u8 {
         /// Whether this `MovieClip` has run its initial frame.
         const INITIALIZED             = 1 << 0;
@@ -4677,8 +4677,7 @@ bitflags! {
 
 /// Actions that are attached to a `MovieClip` event in
 /// an `onClipEvent`/`on` handler.
-#[derive(Debug, Clone, Collect)]
-#[collect(require_static)]
+#[derive(Debug, Clone)]
 pub struct ClipEventHandler {
     /// The events that triggers this handler.
     events: ClipEventFlag,

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -70,6 +70,7 @@ pub struct StageData<'gc> {
     background_color: Option<Color>,
 
     /// Determines how player content is resized to fit the stage.
+    #[collect(require_static)]
     letterbox: Letterbox,
 
     /// The dimensions of the SWF file.
@@ -85,15 +86,18 @@ pub struct StageData<'gc> {
     stage_size: (u32, u32),
 
     /// The scale mode of the stage.
+    #[collect(require_static)]
     scale_mode: StageScaleMode,
 
     /// Whether to prevent movies from changing the stage scale mode.
     forced_scale_mode: bool,
 
     /// The display state of the stage.
+    #[collect(require_static)]
     display_state: StageDisplayState,
 
     /// The alignment of the stage.
+    #[collect(require_static)]
     align: StageAlign,
 
     /// Whether to prevent movies from the changing the stage alignment
@@ -116,6 +120,7 @@ pub struct StageData<'gc> {
     /// The window mode of the viewport.
     ///
     /// Only used on web to control how the Flash content layers with other content on the page.
+    #[collect(require_static)]
     window_mode: WindowMode,
 
     /// Whether or not objects display a glowing border when they have focus.
@@ -918,8 +923,7 @@ pub struct ParseEnumError;
 /// The scale mode of a stage.
 /// This controls the behavior when the player viewport size differs from the SWF size.
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Collect)]
-#[collect(require_static)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StageScaleMode {
     /// The movie will be stretched to fit the container.
     ExactFit,
@@ -986,8 +990,7 @@ impl FromWStr for StageScaleMode {
 
 /// The scale mode of a stage.
 /// This controls the behavior when the player viewport size differs from the SWF size.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Collect)]
-#[collect(require_static)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StageDisplayState {
     /// Sets AIR application or content in Flash Player to expand the stage over the user's entire screen.
     /// Keyboard input is disabled, with the exception of a limited set of non-printing keys.
@@ -1051,8 +1054,7 @@ bitflags! {
     ///
     /// This is a bitflags instead of an enum to mimic Flash Player behavior.
     /// You can theoretically have both TOP and BOTTOM bits set, for example.
-    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Collect)]
-    #[collect(require_static)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub struct StageAlign: u8 {
         /// Align to the top of the viewport.
         const TOP    = 1 << 0;
@@ -1114,8 +1116,7 @@ impl FromWStr for StageAlign {
 /// the page. This setting is only used on web.
 ///
 /// [Apply OBJECT and EMBED tag attributes in Adobe Flash Professional](https://helpx.adobe.com/flash/kb/flash-object-embed-tag-attributes.html)
-#[derive(Default, Clone, Collect, Copy, Debug, Eq, PartialEq)]
-#[collect(require_static)]
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WindowMode {
     /// The Flash content is rendered in its own window and layering is done with the browser's
     /// default behavior.

--- a/core/src/display_object/text.rs
+++ b/core/src/display_object/text.rs
@@ -31,6 +31,7 @@ impl fmt::Debug for Text<'_> {
 pub struct TextData<'gc> {
     base: DisplayObjectBase<'gc>,
     static_data: gc_arena::Gc<'gc, TextStatic>,
+    #[collect(require_static)]
     render_settings: TextRenderSettings,
     avm2_object: Option<Avm2Object<'gc>>,
 }

--- a/core/src/display_object/video.rs
+++ b/core/src/display_object/video.rs
@@ -52,6 +52,7 @@ pub struct VideoData<'gc> {
     source: GcCell<'gc, VideoSource<'gc>>,
 
     /// The decoder stream that this video source is associated to.
+    #[collect(require_static)]
     stream: VideoStream,
 
     /// AVM representation of this video player.
@@ -79,8 +80,7 @@ pub struct VideoData<'gc> {
 }
 
 /// An optionally-instantiated video stream.
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Clone, Debug)]
 pub enum VideoStream {
     /// An uninstantiated video stream.
     ///

--- a/core/src/drawing.rs
+++ b/core/src/drawing.rs
@@ -1,5 +1,4 @@
 use crate::context::RenderContext;
-use gc_arena::Collect;
 use ruffle_render::backend::{RenderBackend, ShapeHandle};
 use ruffle_render::bitmap::{BitmapHandle, BitmapInfo, BitmapSize, BitmapSource};
 use ruffle_render::commands::CommandHandler;
@@ -9,8 +8,7 @@ use ruffle_render::shape_utils::{
 use std::cell::{Cell, RefCell};
 use swf::{FillStyle, LineStyle, Point, Rectangle, Twips};
 
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Clone, Debug)]
 pub struct Drawing {
     render_handle: RefCell<Option<ShapeHandle>>,
     shape_bounds: Rectangle<Twips>,

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -16,8 +16,7 @@ pub fn round_down_to_pixel(t: Twips) -> Twips {
 }
 
 /// Parameters necessary to evaluate a font.
-#[derive(Copy, Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug)]
 pub struct EvalParameters {
     /// The height of each glyph, equivalent to a font size.
     height: Twips,
@@ -97,6 +96,7 @@ struct FontData {
     leading: i16,
 
     /// The identity of the font.
+    #[collect(require_static)]
     descriptor: FontDescriptor,
 }
 
@@ -508,8 +508,7 @@ impl FontDescriptor {
 /// This is controlled by the "Anti-alias" setting in the Flash IDE.
 /// Using "Anti-alias for readibility" switches to the "Advanced" text
 /// rendering engine.
-#[derive(Debug, PartialEq, Clone, Collect)]
-#[collect(require_static)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TextRenderSettings {
     /// This text should render with the standard rendering engine.
     /// Set via "Anti-alias for animation" in the Flash IDE.

--- a/core/src/html/dimensions.rs
+++ b/core/src/html/dimensions.rs
@@ -1,12 +1,10 @@
 //! CSS dimension types
-use gc_arena::Collect;
 use std::cmp::{max, min, Ord};
 use std::ops::{Add, AddAssign, Sub};
 use swf::{Rectangle, Twips};
 
 /// A type which represents the top-left position of a layout box.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Position<T> {
     x: T,
     y: T,
@@ -81,8 +79,7 @@ where
 }
 
 /// A type which represents the size of a layout box.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Size<T> {
     width: T,
     height: T,
@@ -133,8 +130,7 @@ impl<T> From<Position<T>> for Size<T> {
 }
 
 /// A type which represents the offset and size of a text box.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct BoxBounds<T> {
     offset_x: T,
     extent_x: T,

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -636,6 +636,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 #[collect(no_drop)]
 pub struct LayoutBox<'gc> {
     /// The rectangle corresponding to the outer boundaries of the content box.
+    #[collect(require_static)]
     bounds: BoxBounds<Twips>,
 
     /// What content is contained by the content box.
@@ -660,6 +661,7 @@ pub enum LayoutContent<'gc> {
         end: usize,
 
         /// The formatting options for the text box.
+        #[collect(require_static)]
         text_format: TextFormat,
 
         /// The font that was resolved at the time of layout for this text.
@@ -667,6 +669,7 @@ pub enum LayoutContent<'gc> {
 
         /// All parameters used to evaluate the font at the time of layout for
         /// this text.
+        #[collect(require_static)]
         params: EvalParameters,
 
         /// The color to render the font with.
@@ -680,6 +683,7 @@ pub enum LayoutContent<'gc> {
     /// to be U+2022.
     Bullet {
         /// The formatting options for the text box.
+        #[collect(require_static)]
         text_format: TextFormat,
 
         /// The font that was resolved at the time of layout for this text.
@@ -687,6 +691,7 @@ pub enum LayoutContent<'gc> {
 
         /// All parameters used to evaluate the font at the time of layout for
         /// this text.
+        #[collect(require_static)]
         params: EvalParameters,
 
         /// The color to render the font with.
@@ -699,7 +704,7 @@ pub enum LayoutContent<'gc> {
     /// The drawing will be rendered with its origin at the position of the
     /// layout box's bounds. The size of those bounds do not affect the
     /// rendering of the drawing.
-    Drawing(Drawing),
+    Drawing(#[collect(require_static)] Drawing),
 }
 
 impl<'gc> LayoutBox<'gc> {

--- a/core/src/html/text_format.rs
+++ b/core/src/html/text_format.rs
@@ -313,8 +313,7 @@ impl TextFormat {
 ///
 /// This struct also contains a resolved version of the `TextFormat` structure
 /// listed above.
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Clone, Debug)]
 pub struct TextSpan {
     /// How many characters are subsumed by this text span.
     ///
@@ -516,8 +515,7 @@ impl TextSpan {
 }
 
 /// Struct which contains text formatted by `TextSpan`s.
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Clone, Debug)]
 pub struct FormatSpans {
     text: WString,
     displayed_text: WString,

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -460,8 +460,7 @@ impl<'gc> Default for LoadManager<'gc> {
 }
 
 /// The completion status of a `Loader` loading a movie.
-#[derive(Clone, Collect, Copy, Debug, Eq, PartialEq)]
-#[collect(require_static)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LoaderStatus {
     /// The movie hasn't been loaded yet.
     Pending,
@@ -521,6 +520,7 @@ pub enum Loader<'gc> {
         /// the movie has been replaced (and thus Load events can be trusted)
         /// or an error has occurred (in which case we don't care about the
         /// loader anymore).
+        #[collect(require_static)]
         loader_status: LoaderStatus,
 
         /// The SWF being loaded.

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -129,8 +129,7 @@ impl<'gc> PartialEq for NetStream<'gc> {
 impl<'gc> Eq for NetStream<'gc> {}
 
 /// The current type of the data in the stream buffer.
-#[derive(Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Clone, Debug)]
 pub enum NetStreamType {
     /// The stream is an FLV.
     Flv {
@@ -172,6 +171,7 @@ pub struct NetStreamData<'gc> {
     preload_offset: usize,
 
     /// The current stream type, if known.
+    #[collect(require_static)]
     stream_type: Option<NetStreamType>,
 
     /// The current seek offset in the stream.

--- a/core/src/vminterface.rs
+++ b/core/src/vminterface.rs
@@ -14,8 +14,7 @@ use gc_arena::Collect;
 /// A secondary purpose of this type is to flag which VM is creating an object,
 /// which can be used to ensure the object is instantiated as tied to the
 /// correct VM.
-#[derive(Copy, Clone, Debug, Collect)]
-#[collect(require_static)]
+#[derive(Copy, Clone, Debug)]
 pub enum Instantiator {
     /// This object was instantiated by a tag in a given SWF movie, or by a VM
     /// action which does not implicitly instantiate a given object. Acceptable


### PR DESCRIPTION
IMO we should try to go this way whenever possible.
It's also friendlier to compile times c: