### PR TITLE
render/wgpu: Add WgpuRenderBackend<SwapChainTarget>::recreate_surface().

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -111,6 +111,21 @@ impl WgpuRenderBackend<SwapChainTarget> {
         let target = SwapChainTarget::new(surface, &descriptors.adapter, size, &descriptors.device);
         Self::new(Arc::new(descriptors), target)
     }
+
+    #[cfg(not(target_family = "wasm"))]
+    pub fn recreate_surface<
+        W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRawDisplayHandle,
+    >(
+        &mut self,
+        window: &W,
+        size: (u32, u32),
+    ) -> Result<(), Error> {
+        let descriptors = &self.descriptors;
+        let surface = unsafe { descriptors.wgpu_instance.create_surface(window) }?;
+        self.target =
+            SwapChainTarget::new(surface, &descriptors.adapter, size, &descriptors.device);
+        Ok(())
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
This is needed for the Android app (shameless plug: https://github.com/torokati44/ruffle-android :wink:) to remain functional after switching away from the app and back (i.e. activity suspend-resume).
See: https://github.com/gfx-rs/wgpu/issues/2302