### PR TITLE
build: Reduce disk use of reproducible docker builds

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -7,21 +7,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y 
 RUN apt-get -y full-upgrade
 RUN apt-get install -y apt-utils
-RUN apt-get install -y wget git openssl libssl-dev gcc gzip tar default-jdk default-jre pkg-config
+RUN apt-get install -y wget git openssl libssl-dev gcc gzip tar default-jre-headless pkg-config
 RUN wget 'https://deb.nodesource.com/setup_lts.x' --quiet -O- | bash
 RUN apt-get install -y nodejs
 RUN wget 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh';
 RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda;
 ENV PATH="/miniconda/bin:$PATH"
 RUN conda install -y -c conda-forge binaryen
-RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y
+RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
 # RUN source "$HOME/.cargo/env"
 # source to modify env doesn't work with docker it seems :( so add cargo to PATH manually:
 ENV PATH="/root/.cargo/bin:$PATH"
-RUN rustup update
-RUN rustup target add wasm32-unknown-unknown
 RUN cargo install wasm-bindgen-cli --version 0.2.87
 COPY . ruffle
 WORKDIR ruffle/web
-RUN npm install
+RUN npm install --omit=optional
 RUN npm run build:repro

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
         "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
-        "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_VERSION_SEAL=true npm run build",
+        "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_CARGO_CLEAN=true ENABLE_VERSION_SEAL=true npm run build",
         "demo": "npm start --workspace ruffle-demo",
         "test": "npm test --workspaces --if-present",
         "docs": "npm run docs --workspaces --if-present",

--- a/web/packages/core/tools/build_wasm.js
+++ b/web/packages/core/tools/build_wasm.js
@@ -59,6 +59,11 @@ function cargoBuild({ profile, features, rustFlags }) {
         stdio: "inherit",
     });
 }
+function cargoClean() {
+    execFileSync("cargo", ["clean"], {
+        stdio: "inherit",
+    });
+}
 function buildWasm(profile, filename, optimise, extensions) {
     const rustFlags = ["--cfg=web_sys_unstable_apis", "-Aunknown_lints"];
     const wasmBindgenFlags = [];
@@ -84,6 +89,10 @@ function buildWasm(profile, filename, optimise, extensions) {
         dir: "dist",
         flags: wasmBindgenFlags,
     });
+    if (process.env["ENABLE_CARGO_CLEAN"]) {
+        console.log(`Running cargo clean...`);
+        cargoClean();
+    }
     if (optimise) {
         console.log(`Running wasm-opt on ${flavor}...`);
         runWasmOpt({


### PR DESCRIPTION
- JRE is now headless (and no JDK at all)
- use a minimal profile in rustup (as in: no docs/clippy)
- no `RUN rustup update` (anyone knows why it was there? Surely rustup installs recent version by default?)
- run `cargo clean` after the built artifact is moved to `dist/`

Result:
- ~0.7GB smaller image before we start building Ruffle
- ~1.1GB of space regained between vanilla and non-vanilla wasm builds (plus another 1.1GB at the end, but that shouldn't matter)

The next big thing would have been removing `miniconda` and pulling recent `binaryen` another way, that's another almost 1GB saved.

Would still like @kmeisthax to review and make sure it still reproduces with it (whether before or after merge).