### PR TITLE
web: Fix extension vs selfhost loading conflicts

### DIFF
--- a/web/packages/core/src/polyfills.ts
+++ b/web/packages/core/src/polyfills.ts
@@ -214,10 +214,7 @@ export function pluginPolyfill(): void {
  * Polyfills legacy Flash content on the page.
  */
 export function polyfill(): void {
-    const usingExtension =
-        navigator.plugins.namedItem("Ruffle Extension")?.filename ===
-        "ruffle.js";
-    if (isExtension || (!isFlashEnabledBrowser() && !usingExtension)) {
+    if (!isFlashEnabledBrowser()) {
         polyfillFlashInstances();
         polyfillFrames();
         initMutationObserver();

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -687,24 +687,6 @@ export class RufflePlayer extends HTMLElement {
         );
         return options;
     }
-    /**
-     * Gets the configuration set by the Ruffle extension
-     *
-     * @returns The configuration set by the Ruffle extension
-     */
-    getExtensionConfig(): Record<string, unknown> {
-        return window.RufflePlayer &&
-            window.RufflePlayer.conflict &&
-            (window.RufflePlayer.conflict["newestName"] === "extension" ||
-                (window.RufflePlayer as Record<string, unknown>)[
-                    "newestName"
-                ] === "extension")
-            ? (window.RufflePlayer?.conflict["config"] as Record<
-                  string,
-                  unknown
-              >)
-            : {};
-    }
 
     /**
      * Loads a specified movie into this player.
@@ -737,10 +719,8 @@ export class RufflePlayer extends HTMLElement {
         }
 
         try {
-            const extensionConfig = this.getExtensionConfig();
             this.loadedConfig = {
                 ...DEFAULT_CONFIG,
-                ...extensionConfig,
                 ...(window.RufflePlayer?.config ?? {}),
                 ...this.config,
                 ...options,

--- a/web/packages/core/src/version.ts
+++ b/web/packages/core/src/version.ts
@@ -18,7 +18,6 @@ export class Version {
         private readonly minor: number,
         private readonly patch: number,
         private readonly prIdent: string[] | null,
-        // @ts-expect-error: Property 'buildIdent' is declared but its value is never read.
         private readonly buildIdent: string[] | null,
     ) {}
 
@@ -124,6 +123,8 @@ export class Version {
 
         if (this.prIdent === null && other.prIdent !== null) {
             return true;
+        } else if (this.prIdent !== null && other.prIdent === null) {
+            return false;
         } else if (this.prIdent !== null && other.prIdent !== null) {
             const isNumeric = /^[0-9]*$/;
             for (
@@ -131,35 +132,21 @@ export class Version {
                 i < this.prIdent.length && i < other.prIdent.length;
                 i += 1
             ) {
-                if (
-                    !isNumeric.test(this.prIdent[i]!) &&
-                    isNumeric.test(other.prIdent[i]!)
-                ) {
+                const numericThis = isNumeric.test(other.prIdent[i]!);
+                const numericOther = isNumeric.test(this.prIdent[i]!);
+                if (!numericOther && numericThis) {
                     return true;
-                } else if (
-                    isNumeric.test(this.prIdent[i]!) &&
-                    isNumeric.test(other.prIdent[i]!)
-                ) {
-                    if (
-                        parseInt(this.prIdent[i]!, 10) >
-                        parseInt(other.prIdent[i]!, 10)
-                    ) {
+                } else if (numericOther && numericThis) {
+                    const intThis = parseInt(this.prIdent[i]!, 10);
+                    const intOther = parseInt(other.prIdent[i]!, 10);
+                    if (intThis > intOther) {
                         return true;
-                    } else if (
-                        parseInt(this.prIdent[i]!, 10) <
-                        parseInt(other.prIdent[i]!, 10)
-                    ) {
+                    } else if (intThis < intOther) {
                         return false;
                     }
-                } else if (
-                    isNumeric.test(this.prIdent[i]!) &&
-                    !isNumeric.test(other.prIdent[i]!)
-                ) {
+                } else if (numericOther && !numericThis) {
                     return false;
-                } else if (
-                    !isNumeric.test(this.prIdent[i]!) &&
-                    !isNumeric.test(other.prIdent[i]!)
-                ) {
+                } else if (!numericOther && !numericThis) {
                     if (this.prIdent[i]! > other.prIdent[i]!) {
                         return true;
                     } else if (this.prIdent[i]! < other.prIdent[i]!) {
@@ -168,7 +155,49 @@ export class Version {
                 }
             }
 
-            return this.prIdent.length > other.prIdent.length;
+            if (this.prIdent.length > other.prIdent.length) {
+                return true;
+            } else if (this.prIdent.length < other.prIdent.length) {
+                return false;
+            }
+        }
+
+        // Unlike prerelease, we prefer to have a build ident than to not
+        if (this.buildIdent !== null && other.buildIdent === null) {
+            return true;
+        } else if (this.buildIdent === null && other.buildIdent !== null) {
+            return false;
+        } else if (this.buildIdent !== null && other.buildIdent !== null) {
+            const isNumeric = /^[0-9]*$/;
+            for (
+                let i = 0;
+                i < this.buildIdent.length && i < other.buildIdent.length;
+                i += 1
+            ) {
+                const numricThis = isNumeric.test(this.buildIdent[i]!);
+                const numericOther = isNumeric.test(other.buildIdent[i]!);
+                if (!numricThis && numericOther) {
+                    return true;
+                } else if (numricThis && numericOther) {
+                    const intThis = parseInt(this.buildIdent[i]!, 10);
+                    const intOther = parseInt(other.buildIdent[i]!, 10);
+                    if (intThis > intOther) {
+                        return true;
+                    } else if (intThis < intOther) {
+                        return false;
+                    }
+                } else if (numricThis && !numericOther) {
+                    return false;
+                } else if (!numricThis && !numericOther) {
+                    if (this.buildIdent[i]! > other.buildIdent[i]!) {
+                        return true;
+                    } else if (this.buildIdent[i]! < other.buildIdent[i]!) {
+                        return false;
+                    }
+                }
+            }
+
+            return this.buildIdent.length > other.buildIdent.length;
         }
 
         return false;

--- a/web/packages/core/test/version.ts
+++ b/web/packages/core/test/version.ts
@@ -20,7 +20,7 @@ const testMatrix = [
         "1-alpha",
     ],
     ["0.1.2", "0.1.1-dev", "0.1"],
-    ["0.0.2", "0.0.2-dev", "0.0.2+build"],
+    ["0.0.2+build", "0.0.2+124", "0.0.2+123", "0.0.2", "0.0.2-dev"],
     ["0.0.1", "0.0.1-dev", "0.0.1-5", "0.0.1-2"],
 ];
 
@@ -107,13 +107,6 @@ describe("Version", function () {
             const tests = flatten(testMatrix);
             for (let a = 0; a < tests.length; a++) {
                 for (let b = a + 1; b < tests.length; b++) {
-                    if (
-                        tests[a]!.indexOf("+") > -1 ||
-                        tests[b]!.indexOf("+") > -1
-                    ) {
-                        // Skip "builds" for purposes of this test.
-                        continue;
-                    }
                     assert(
                         Version.fromSemver(tests[a]!).hasPrecedenceOver(
                             Version.fromSemver(tests[b]!),
@@ -127,13 +120,6 @@ describe("Version", function () {
             const tests = flatten(testMatrix).reverse();
             for (let a = 0; a < tests.length; a++) {
                 for (let b = a + 1; b < tests.length; b++) {
-                    if (
-                        tests[a]!.indexOf("+") > -1 ||
-                        tests[b]!.indexOf("+") > -1
-                    ) {
-                        // Skip "builds" for purposes of this test.
-                        continue;
-                    }
                     assert(
                         !Version.fromSemver(tests[a]!).hasPrecedenceOver(
                             Version.fromSemver(tests[b]!),

--- a/web/packages/core/tools/set_version.js
+++ b/web/packages/core/tools/set_version.js
@@ -2,9 +2,10 @@ const replace = require("replace-in-file");
 const childProcess = require("child_process");
 const fs = require("fs");
 
-let versionNumber = process.env.npm_package_version;
-let versionChannel = process.env.CFG_RELEASE_CHANNEL || "nightly";
 let buildDate = new Date().toISOString();
+let versionNumber =
+    process.env.npm_package_version + "+" + buildDate.substr(0, 10);
+let versionChannel = process.env.CFG_RELEASE_CHANNEL || "nightly";
 const firefoxExtensionId =
     process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs";
 

--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -108,6 +108,8 @@ function isXMLDocument(): boolean {
 
 (async () => {
     const options = await utils.getOptions();
+    const explicitOptions = await utils.getExplicitOptions();
+
     const pageOptout = checkPageOptout();
     const shouldLoad =
         !isXMLDocument() &&
@@ -171,7 +173,7 @@ function isXMLDocument(): boolean {
     await sendMessageToPage({
         type: "load",
         config: {
-            ...options,
+            ...explicitOptions,
             autoplay: options.autostart ? "on" : "auto",
             unmuteOverlay: options.autostart ? "hidden" : "visible",
             splashScreen: !options.autostart,

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -24,7 +24,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     player.id = "player";
     document.getElementById("main")!.append(player);
 
-    const options = await utils.getOptions();
+    const options = await utils.getExplicitOptions();
 
     player.load({
         ...options,

--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -145,3 +145,22 @@ export async function getOptions(): Promise<Options> {
     // Copy over default options if they don't exist yet.
     return { ...DEFAULT_OPTIONS, ...options };
 }
+
+/**
+ * Gets the options that are explicitly different from the defaults.
+ *
+ * In the future we should just not store options we don't want to set.
+ */
+export async function getExplicitOptions(): Promise<Options> {
+    const options = await getOptions();
+    const defaultOptions = DEFAULT_OPTIONS;
+    for (const key in defaultOptions) {
+        // @ts-expect-error: Element implicitly has an any type
+        if (key in options && defaultOptions[key] === options[key]) {
+            // @ts-expect-error: Element implicitly has an any type
+            delete options[key];
+        }
+    }
+
+    return options;
+}


### PR DESCRIPTION
Well, as best as I can.


There's a few issues at play:
1. Things loaded from different sources are different JS types, so we always saw another version of ruffle as a "conflict" and didn't consider it at all. This means that whatever loaded last would take over config, but whatever loaded first would still polyfill because nothing told it to stop.
2. Extension set every single option explicitly, which meant that selfhosted stuff would get overwritten if loaded first.
3. Identical versions (we're still `0.1.0`) compared the same so it was pretty arbitrary which one would win - I made it include the build date as a tie breaker.