### PR TITLE
Exporter: Updated the logic that gives a error message

### DIFF
--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -419,9 +419,7 @@ fn main() -> Result<()> {
     if opt.swf.is_file() {
         capture_single_swf(descriptors, &opt)?;
     } else if !opt.swf.is_dir() {
-        return Err(anyhow!(
-            "Given path is not a file or directory."
-        ));
+        return Err(anyhow!("Given path is not a file or directory."));
     } else if opt.output_path.is_some() {
         capture_multiple_swfs(descriptors, &opt)?;
     } else {

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -418,6 +418,10 @@ fn main() -> Result<()> {
 
     if opt.swf.is_file() {
         capture_single_swf(descriptors, &opt)?;
+    } else if !opt.swf.is_dir() {
+        return Err(anyhow!(
+            "Given path is not a file or directory."
+        ));
     } else if opt.output_path.is_some() {
         capture_multiple_swfs(descriptors, &opt)?;
     } else {


### PR DESCRIPTION
If you used exporter to export a frame and accidently gave a path that dis not exist it would say: Output directory is required when exporting multiple files. instead of giving the error that the path does not exist.

I found that confusing so fixed that in this little pr.