### PR TITLE
core: fix center and right alignment of edit_text

### DIFF
--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -743,7 +743,7 @@ impl<'gc> EditText<'gc> {
         if autosize != AutoSizeMode::None {
             if !is_word_wrap {
                 // The edit text's bounds needs to have the padding baked in.
-                let width = intrinsic_bounds.width() + padding;
+                let width = intrinsic_bounds.extent_x() + padding;
                 let new_x = match autosize {
                     AutoSizeMode::Left => edit_text.bounds.x_min,
                     AutoSizeMode::Center => {


### PR DESCRIPTION
Fixes #1440 and its minimal reproduction #10660. I'm not really sure why this works, but it doesn't seem to break anything else