### PR TITLE
web: Don't store the full semver version as the version name, just construct it when needed

### DIFF
--- a/web/packages/core/src/source-api.ts
+++ b/web/packages/core/src/source-api.ts
@@ -15,7 +15,8 @@ export const SourceAPI = {
     /**
      * The version of this particular API, as a string in a semver compatible format.
      */
-    version: buildInfo.versionNumber,
+    version:
+        buildInfo.versionNumber + "+" + buildInfo.buildDate.substring(0, 10),
 
     /**
      * Start up the polyfills.

--- a/web/packages/core/tools/set_version.js
+++ b/web/packages/core/tools/set_version.js
@@ -3,8 +3,7 @@ const childProcess = require("child_process");
 const fs = require("fs");
 
 let buildDate = new Date().toISOString();
-let versionNumber =
-    process.env.npm_package_version + "+" + buildDate.substr(0, 10);
+let versionNumber = process.env.npm_package_version;
 let versionChannel = process.env.CFG_RELEASE_CHANNEL || "nightly";
 const firefoxExtensionId =
     process.env.FIREFOX_EXTENSION_ID || "ruffle@ruffle.rs";


### PR DESCRIPTION
Should fix submission of extension to the stores