### PR TITLE
extension: Add exclusions for Tuxedo Computers and Taobao

### DIFF
--- a/web/packages/extension/manifest.json5
+++ b/web/packages/extension/manifest.json5
@@ -21,6 +21,8 @@
                 "https://sso.godaddy.com/*",
                 "https://authentication.td.com/*",
                 "https://*.twitch.tv/*",
+                "https://www.tuxedocomputers.com/*",
+                "https://*.taobao.com/*",
             ],
             "js": ["dist/content.js"],
             "all_frames": true,


### PR DESCRIPTION
Problems reported in #11906 and in a Chrome Web Store review