### PR TITLE
tests: Exclude WARP from shumway_acid_tests/acid_image, it was flaky

### DIFF
--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_image/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_image/test.toml
@@ -6,4 +6,4 @@ num_frames = 10
 tolerance = 11
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }


### PR DESCRIPTION
See https://github.com/ruffle-rs/ruffle/actions/runs/5799719364/job/15720327826, https://github.com/ruffle-rs/ruffle/actions/runs/5805718377/job/15737266364, and their successful second attempts.