### PR TITLE
core: Fix filters being cut off when nested inside another cacheAsBitmap

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -794,7 +794,7 @@ pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_
                 for filter in &mut filters {
                     // Scaling is done by *stage view matrix* only, nothing in-between
                     filter.scale(stage_matrix.a, stage_matrix.d);
-                    filter_rect = context.renderer.calculate_dest_rect(filter, filter_rect);
+                    filter_rect = filter.calculate_dest_rect(filter_rect);
                 }
                 let draw_offset = Point::new(filter_rect.x_min, filter_rect.y_min);
                 if cache.is_dirty(&base_transform.matrix, width, height) {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -785,10 +785,10 @@ pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_
                 let width = width as u16;
                 let height = height as u16;
                 let mut filter_rect = Rectangle {
-                    x_min: 0,
-                    x_max: width as i32,
-                    y_min: 0,
-                    y_max: height as i32,
+                    x_min: Twips::ZERO,
+                    x_max: Twips::from_pixels_i32(width as i32),
+                    y_min: Twips::ZERO,
+                    y_max: Twips::from_pixels_i32(height as i32),
                 };
                 let stage_matrix = context.stage.view_matrix();
                 for filter in &mut filters {
@@ -796,6 +796,12 @@ pub fn render_base<'gc>(this: DisplayObject<'gc>, context: &mut RenderContext<'_
                     filter.scale(stage_matrix.a, stage_matrix.d);
                     filter_rect = filter.calculate_dest_rect(filter_rect);
                 }
+                let filter_rect = Rectangle {
+                    x_min: filter_rect.x_min.to_pixels().floor() as i32,
+                    x_max: filter_rect.x_max.to_pixels().ceil() as i32,
+                    y_min: filter_rect.y_min.to_pixels().floor() as i32,
+                    y_max: filter_rect.y_max.to_pixels().ceil() as i32,
+                };
                 let draw_offset = Point::new(filter_rect.x_min, filter_rect.y_min);
                 if cache.is_dirty(&base_transform.matrix, width, height) {
                     cache.update(

--- a/render/src/backend.rs
+++ b/render/src/backend.rs
@@ -61,11 +61,6 @@ pub trait RenderBackend: Downcast {
         None
     }
 
-    /// Calculates the destination rect needed to hold a filter upon a source of the given area.
-    fn calculate_dest_rect(&self, _filter: &Filter, source_rect: Rectangle<i32>) -> Rectangle<i32> {
-        source_rect
-    }
-
     fn is_filter_supported(&self, _filter: &Filter) -> bool {
         false
     }

--- a/render/src/filters.rs
+++ b/render/src/filters.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use downcast_rs::{impl_downcast, Downcast};
 use std::fmt::Debug;
-use swf::Color;
+use swf::{Color, Rectangle};
 
 #[derive(Debug, Clone)]
 pub enum Filter {
@@ -57,6 +57,17 @@ impl Filter {
             Filter::GradientGlowFilter(filter) => filter.scale(x, y),
             Filter::DisplacementMapFilter(filter) => filter.scale(x, y),
             _ => {}
+        }
+    }
+
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+        match self {
+            Filter::BlurFilter(filter) => filter.calculate_dest_rect(source_rect),
+            Filter::GlowFilter(filter) => filter.calculate_dest_rect(source_rect),
+            Filter::DropShadowFilter(filter) => filter.calculate_dest_rect(source_rect),
+            Filter::BevelFilter(filter) => filter.calculate_dest_rect(source_rect),
+            Filter::DisplacementMapFilter(filter) => filter.calculate_dest_rect(source_rect),
+            _ => source_rect,
         }
     }
 
@@ -139,6 +150,24 @@ impl DisplacementMapFilter {
     pub fn scale(&mut self, x: f32, y: f32) {
         self.viewscale_x *= x;
         self.viewscale_y *= y;
+    }
+
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+        source_rect
+        // [NA] TODO: This *appears* to be correct, but I'm not entirely sure why Flash does this.
+        // This is commented out for now because Flash actually might need us to resize the texture *after* we make it,
+        // which is unsupported in our current architecture as of time of writing.
+
+        // if filter.mode == DisplacementMapFilterMode::Color {
+        //     Rectangle {
+        //         x_min: source_rect.x_min - ((filter.scale_x / 2.0).floor() as i32),
+        //         x_max: source_rect.x_max + (filter.scale_x.floor() as i32),
+        //         y_min: source_rect.y_min - ((filter.scale_y / 2.0).floor() as i32),
+        //         y_max: source_rect.y_max + (filter.scale_y.floor() as i32),
+        //     }
+        // } else {
+        //     source_rect
+        // }
     }
 }
 

--- a/render/src/filters.rs
+++ b/render/src/filters.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use downcast_rs::{impl_downcast, Downcast};
 use std::fmt::Debug;
-use swf::{Color, Rectangle};
+use swf::{Color, Rectangle, Twips};
 
 #[derive(Debug, Clone)]
 pub enum Filter {
@@ -60,7 +60,7 @@ impl Filter {
         }
     }
 
-    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         match self {
             Filter::BlurFilter(filter) => filter.calculate_dest_rect(source_rect),
             Filter::GlowFilter(filter) => filter.calculate_dest_rect(source_rect),
@@ -152,7 +152,7 @@ impl DisplacementMapFilter {
         self.viewscale_y *= y;
     }
 
-    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         source_rect
         // [NA] TODO: This *appears* to be correct, but I'm not entirely sure why Flash does this.
         // This is commented out for now because Flash actually might need us to resize the texture *after* we make it,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -33,7 +33,7 @@ use std::cell::Cell;
 use std::mem;
 use std::path::Path;
 use std::sync::Arc;
-use swf::{Color, Rectangle};
+use swf::Color;
 use tracing::instrument;
 use wgpu::SubmissionIndex;
 
@@ -923,12 +923,6 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
         );
 
         Some(self.make_queue_sync_handle(target, index, destination, copy_area))
-    }
-
-    fn calculate_dest_rect(&self, filter: &Filter, source_rect: Rectangle<i32>) -> Rectangle<i32> {
-        self.descriptors
-            .filters
-            .calculate_dest_rect(filter, source_rect)
     }
 
     fn compile_pixelbender_shader(

--- a/render/wgpu/src/filters.rs
+++ b/render/wgpu/src/filters.rs
@@ -21,7 +21,6 @@ use crate::filters::shader::ShaderFilter;
 use crate::surface::target::CommandTarget;
 use bytemuck::{Pod, Zeroable};
 use ruffle_render::filters::Filter;
-use swf::Rectangle;
 use wgpu::util::DeviceExt;
 use wgpu::vertex_attr_array;
 
@@ -221,31 +220,6 @@ impl Filters {
             glow: GlowFilter::new(device),
             bevel: BevelFilter::new(device),
             displacement_map: DisplacementMapFilter::new(device),
-        }
-    }
-
-    pub fn calculate_dest_rect(
-        &self,
-        filter: &Filter,
-        source_rect: Rectangle<i32>,
-    ) -> Rectangle<i32> {
-        match filter {
-            Filter::BlurFilter(filter) => self.blur.calculate_dest_rect(filter, source_rect),
-            Filter::GlowFilter(filter) => {
-                self.glow
-                    .calculate_dest_rect(filter, source_rect, &self.blur)
-            }
-            Filter::DropShadowFilter(filter) => {
-                DropShadowFilter::calculate_dest_rect(filter, source_rect, &self.blur, &self.glow)
-            }
-            Filter::BevelFilter(filter) => {
-                self.bevel
-                    .calculate_dest_rect(filter, source_rect, &self.blur)
-            }
-            Filter::DisplacementMapFilter(filter) => self
-                .displacement_map
-                .calculate_dest_rect(filter, source_rect),
-            _ => source_rect,
         }
     }
 

--- a/render/wgpu/src/filters/bevel.rs
+++ b/render/wgpu/src/filters/bevel.rs
@@ -7,7 +7,7 @@ use crate::surface::target::CommandTarget;
 use crate::utils::SampleCountMap;
 use bytemuck::{Pod, Zeroable};
 use std::sync::OnceLock;
-use swf::{BevelFilter as BevelFilterArgs, Rectangle};
+use swf::BevelFilter as BevelFilterArgs;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -122,34 +122,6 @@ impl BevelFilter {
                     multiview: None,
                 })
         })
-    }
-
-    pub fn calculate_dest_rect(
-        &self,
-        filter: &BevelFilterArgs,
-        source_rect: Rectangle<i32>,
-        blur_filter: &BlurFilter,
-    ) -> Rectangle<i32> {
-        let mut result = blur_filter.calculate_dest_rect(&filter.inner_blur_filter(), source_rect);
-        let distance = filter.distance.to_f32();
-        let angle = filter.angle.to_f32();
-        let x = (angle.cos() * distance).ceil() as i32;
-        let y = (angle.sin() * distance).ceil() as i32;
-        if x < 0 {
-            result.x_min += x;
-            result.x_max -= x;
-        } else {
-            result.x_max += x;
-            result.x_min -= x;
-        }
-        if y < 0 {
-            result.y_min += y;
-            result.y_max -= y;
-        } else {
-            result.y_max += y;
-            result.y_min -= y;
-        }
-        result
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/render/wgpu/src/filters/displacement_map.rs
+++ b/render/wgpu/src/filters/displacement_map.rs
@@ -10,7 +10,6 @@ use ruffle_render::filters::{
     DisplacementMapFilter as DisplacementMapFilterArgs, DisplacementMapFilterMode,
 };
 use std::sync::OnceLock;
-use swf::Rectangle;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -138,28 +137,6 @@ impl DisplacementMapFilter {
                     multiview: None,
                 })
         })
-    }
-
-    pub fn calculate_dest_rect(
-        &self,
-        _filter: &DisplacementMapFilterArgs,
-        source_rect: Rectangle<i32>,
-    ) -> Rectangle<i32> {
-        source_rect
-        // [NA] TODO: This *appears* to be correct, but I'm not entirely sure why Flash does this.
-        // This is commented out for now because Flash actually might need us to resize the texture *after* we make it,
-        // which is unsupported in our current architecture as of time of writing.
-
-        // if filter.mode == DisplacementMapFilterMode::Color {
-        //     Rectangle {
-        //         x_min: source_rect.x_min - ((filter.scale_x / 2.0).floor() as i32),
-        //         x_max: source_rect.x_max + (filter.scale_x.floor() as i32),
-        //         y_min: source_rect.y_min - ((filter.scale_y / 2.0).floor() as i32),
-        //         y_max: source_rect.y_max + (filter.scale_y.floor() as i32),
-        //     }
-        // } else {
-        //     source_rect
-        // }
     }
 
     pub fn apply(

--- a/render/wgpu/src/filters/drop_shadow.rs
+++ b/render/wgpu/src/filters/drop_shadow.rs
@@ -4,7 +4,7 @@ use crate::filters::blur::BlurFilter;
 use crate::filters::glow::GlowFilter;
 use crate::filters::FilterSource;
 use crate::surface::target::CommandTarget;
-use swf::{DropShadowFilter as DropShadowFilterArgs, Rectangle};
+use swf::DropShadowFilter as DropShadowFilterArgs;
 
 /// Drop shadow is just Glow with an offset.
 /// None of this strictly needs to be a struct,
@@ -12,31 +12,6 @@ use swf::{DropShadowFilter as DropShadowFilterArgs, Rectangle};
 pub struct DropShadowFilter;
 
 impl DropShadowFilter {
-    pub fn calculate_dest_rect(
-        filter: &DropShadowFilterArgs,
-        source_rect: Rectangle<i32>,
-        blur_filter: &BlurFilter,
-        glow_filter: &GlowFilter,
-    ) -> Rectangle<i32> {
-        let mut result =
-            glow_filter.calculate_dest_rect(&filter.inner_glow_filter(), source_rect, blur_filter);
-        let distance = filter.distance.to_f32();
-        let angle = filter.angle.to_f32();
-        let x = (angle.cos() * distance).ceil() as i32;
-        let y = (angle.sin() * distance).ceil() as i32;
-        if x < 0 {
-            result.x_min += x;
-        } else {
-            result.x_max += x;
-        }
-        if y < 0 {
-            result.y_min += y;
-        } else {
-            result.y_max += y;
-        }
-        result
-    }
-
     pub fn apply(
         descriptors: &Descriptors,
         texture_pool: &mut TexturePool,

--- a/render/wgpu/src/filters/glow.rs
+++ b/render/wgpu/src/filters/glow.rs
@@ -7,7 +7,7 @@ use crate::surface::target::CommandTarget;
 use crate::utils::SampleCountMap;
 use bytemuck::{Pod, Zeroable};
 use std::sync::OnceLock;
-use swf::{GlowFilter as GlowFilterArgs, Rectangle};
+use swf::GlowFilter as GlowFilterArgs;
 use wgpu::util::DeviceExt;
 
 #[repr(C)]
@@ -121,16 +121,6 @@ impl GlowFilter {
                     multiview: None,
                 })
         })
-    }
-
-    pub fn calculate_dest_rect(
-        &self,
-        filter: &GlowFilterArgs,
-        source_rect: Rectangle<i32>,
-        blur_filter: &BlurFilter,
-    ) -> Rectangle<i32> {
-        // TODO: Inner might not need this. Docs suggest it doesn't care about source rect, but rather source *size*?
-        blur_filter.calculate_dest_rect(&filter.inner_blur_filter(), source_rect)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/swf/src/types/bevel_filter.rs
+++ b/swf/src/types/bevel_filter.rs
@@ -1,4 +1,4 @@
-use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8};
+use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, Rectangle};
 use bitflags::bitflags;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -46,6 +46,29 @@ impl BevelFilter {
             blur_y: self.blur_y,
             flags: BlurFilterFlags::from_passes(self.num_passes()),
         }
+    }
+
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+        let mut result = self.inner_blur_filter().calculate_dest_rect(source_rect);
+        let distance = self.distance.to_f32();
+        let angle = self.angle.to_f32();
+        let x = (angle.cos() * distance).ceil() as i32;
+        let y = (angle.sin() * distance).ceil() as i32;
+        if x < 0 {
+            result.x_min += x;
+            result.x_max -= x;
+        } else {
+            result.x_max += x;
+            result.x_min -= x;
+        }
+        if y < 0 {
+            result.y_min += y;
+            result.y_max -= y;
+        } else {
+            result.y_max += y;
+            result.y_min -= y;
+        }
+        result
     }
 }
 

--- a/swf/src/types/bevel_filter.rs
+++ b/swf/src/types/bevel_filter.rs
@@ -1,4 +1,4 @@
-use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, Rectangle};
+use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, Rectangle, Twips};
 use bitflags::bitflags;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -48,20 +48,20 @@ impl BevelFilter {
         }
     }
 
-    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         let mut result = self.inner_blur_filter().calculate_dest_rect(source_rect);
-        let distance = self.distance.to_f32();
-        let angle = self.angle.to_f32();
-        let x = (angle.cos() * distance).ceil() as i32;
-        let y = (angle.sin() * distance).ceil() as i32;
-        if x < 0 {
+        let distance = self.distance.to_f64();
+        let angle = self.angle.to_f64();
+        let x = Twips::from_pixels(angle.cos() * distance);
+        let y = Twips::from_pixels(angle.sin() * distance);
+        if x < Twips::ZERO {
             result.x_min += x;
             result.x_max -= x;
         } else {
             result.x_max += x;
             result.x_min -= x;
         }
-        if y < 0 {
+        if y < Twips::ZERO {
             result.y_min += y;
             result.y_max -= y;
         } else {

--- a/swf/src/types/blur_filter.rs
+++ b/swf/src/types/blur_filter.rs
@@ -1,11 +1,11 @@
-use crate::{Fixed16, Rectangle};
+use crate::{Fixed16, Rectangle, Twips};
 use bitflags::bitflags;
 
 /// How much each pass should multiply the requested blur size by - accumulative.
 /// These are very approximate to Flash, and not 100% exact.
 /// Pass 1 would be 100%, but pass 2 would be 110%.
 /// This is accumulative so you can calculate the size upfront for how many passes you'll need to perform.
-const PASS_SCALES: [f32; 15] = [
+const PASS_SCALES: [f64; 15] = [
     1.0, 2.1, 2.7, 3.1, 3.5, 3.8, 4.0, 4.2, 4.4, 4.6, 5.0, 6.0, 6.0, 7.0, 7.0,
 ];
 
@@ -31,10 +31,10 @@ impl BlurFilter {
         self.num_passes() == 0 || (self.blur_x <= Fixed16::ONE && self.blur_y <= Fixed16::ONE)
     }
 
-    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         let scale = PASS_SCALES[self.num_passes().clamp(1, 15) as usize - 1];
-        let x = (scale * self.blur_x.to_f32()).ceil().max(0.0) as i32;
-        let y = (scale * self.blur_y.to_f32()).ceil().max(0.0) as i32;
+        let x = Twips::from_pixels(scale * self.blur_x.to_f64());
+        let y = Twips::from_pixels(scale * self.blur_y.to_f64());
         Rectangle {
             x_min: source_rect.x_min - x,
             x_max: source_rect.x_max + x,

--- a/swf/src/types/blur_filter.rs
+++ b/swf/src/types/blur_filter.rs
@@ -33,8 +33,8 @@ impl BlurFilter {
 
     pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         let scale = PASS_SCALES[self.num_passes().clamp(1, 15) as usize - 1];
-        let x = Twips::from_pixels(scale * self.blur_x.to_f64());
-        let y = Twips::from_pixels(scale * self.blur_y.to_f64());
+        let x = Twips::from_pixels((scale * self.blur_x.to_f64()).max(0.0));
+        let y = Twips::from_pixels((scale * self.blur_y.to_f64()).max(0.0));
         Rectangle {
             x_min: source_rect.x_min - x,
             x_max: source_rect.x_max + x,

--- a/swf/src/types/blur_filter.rs
+++ b/swf/src/types/blur_filter.rs
@@ -1,5 +1,13 @@
-use crate::Fixed16;
+use crate::{Fixed16, Rectangle};
 use bitflags::bitflags;
+
+/// How much each pass should multiply the requested blur size by - accumulative.
+/// These are very approximate to Flash, and not 100% exact.
+/// Pass 1 would be 100%, but pass 2 would be 110%.
+/// This is accumulative so you can calculate the size upfront for how many passes you'll need to perform.
+const PASS_SCALES: [f32; 15] = [
+    1.0, 2.1, 2.7, 3.1, 3.5, 3.8, 4.0, 4.2, 4.4, 4.6, 5.0, 6.0, 6.0, 7.0, 7.0,
+];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BlurFilter {
@@ -21,6 +29,18 @@ impl BlurFilter {
 
     pub fn impotent(&self) -> bool {
         self.num_passes() == 0 || (self.blur_x <= Fixed16::ONE && self.blur_y <= Fixed16::ONE)
+    }
+
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+        let scale = PASS_SCALES[self.num_passes().clamp(1, 15) as usize - 1];
+        let x = (scale * self.blur_x.to_f32()).ceil().max(0.0) as i32;
+        let y = (scale * self.blur_y.to_f32()).ceil().max(0.0) as i32;
+        Rectangle {
+            x_min: source_rect.x_min - x,
+            x_max: source_rect.x_max + x,
+            y_min: source_rect.y_min - y,
+            y_max: source_rect.y_max + y,
+        }
     }
 }
 

--- a/swf/src/types/drop_shadow_filter.rs
+++ b/swf/src/types/drop_shadow_filter.rs
@@ -1,5 +1,6 @@
 use crate::{
     BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, GlowFilter, GlowFilterFlags, Rectangle,
+    Twips,
 };
 use bitflags::bitflags;
 
@@ -63,18 +64,18 @@ impl DropShadowFilter {
         }
     }
 
-    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         let mut result = self.inner_glow_filter().calculate_dest_rect(source_rect);
-        let distance = self.distance.to_f32();
-        let angle = self.angle.to_f32();
-        let x = (angle.cos() * distance).ceil() as i32;
-        let y = (angle.sin() * distance).ceil() as i32;
-        if x < 0 {
+        let distance = self.distance.to_f64();
+        let angle = self.angle.to_f64();
+        let x = Twips::from_pixels(angle.cos() * distance);
+        let y = Twips::from_pixels(angle.sin() * distance);
+        if x < Twips::ZERO {
             result.x_min += x;
         } else {
             result.x_max += x;
         }
-        if y < 0 {
+        if y < Twips::ZERO {
             result.y_min += y;
         } else {
             result.y_max += y;

--- a/swf/src/types/drop_shadow_filter.rs
+++ b/swf/src/types/drop_shadow_filter.rs
@@ -1,4 +1,6 @@
-use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, GlowFilter, GlowFilterFlags};
+use crate::{
+    BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, GlowFilter, GlowFilterFlags, Rectangle,
+};
 use bitflags::bitflags;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -59,6 +61,25 @@ impl DropShadowFilter {
             strength: self.strength,
             flags,
         }
+    }
+
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+        let mut result = self.inner_glow_filter().calculate_dest_rect(source_rect);
+        let distance = self.distance.to_f32();
+        let angle = self.angle.to_f32();
+        let x = (angle.cos() * distance).ceil() as i32;
+        let y = (angle.sin() * distance).ceil() as i32;
+        if x < 0 {
+            result.x_min += x;
+        } else {
+            result.x_max += x;
+        }
+        if y < 0 {
+            result.y_min += y;
+        } else {
+            result.y_max += y;
+        }
+        result
     }
 }
 

--- a/swf/src/types/glow_filter.rs
+++ b/swf/src/types/glow_filter.rs
@@ -1,4 +1,4 @@
-use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, Rectangle};
+use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, Rectangle, Twips};
 use bitflags::bitflags;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -36,7 +36,7 @@ impl GlowFilter {
         self.blur_y *= Fixed16::from_f32(y);
     }
 
-    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<Twips>) -> Rectangle<Twips> {
         // TODO: Inner might not need this. Docs suggest it doesn't care about source rect, but rather source *size*?
         self.inner_blur_filter().calculate_dest_rect(source_rect)
     }

--- a/swf/src/types/glow_filter.rs
+++ b/swf/src/types/glow_filter.rs
@@ -1,4 +1,4 @@
-use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8};
+use crate::{BlurFilter, BlurFilterFlags, Color, Fixed16, Fixed8, Rectangle};
 use bitflags::bitflags;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -34,6 +34,11 @@ impl GlowFilter {
     pub fn scale(&mut self, x: f32, y: f32) {
         self.blur_x *= Fixed16::from_f32(x);
         self.blur_y *= Fixed16::from_f32(y);
+    }
+
+    pub fn calculate_dest_rect(&self, source_rect: Rectangle<i32>) -> Rectangle<i32> {
+        // TODO: Inner might not need this. Docs suggest it doesn't care about source rect, but rather source *size*?
+        self.inner_blur_filter().calculate_dest_rect(source_rect)
     }
 
     pub fn inner_blur_filter(&self) -> BlurFilter {

--- a/tests/tests/swfs/visual/cache_as_bitmap/contains_grown_filter/test.toml
+++ b/tests/tests/swfs/visual/cache_as_bitmap/contains_grown_filter/test.toml
@@ -1,5 +1,4 @@
 num_frames = 1
-known_failure = true
 
 [image_comparisons.output]
 tolerance = 5


### PR DESCRIPTION
This should fix any remaining filter-cutoff issue, such as the glow in #11729 (https://github.com/ruffle-rs/ruffle/issues/11729#issuecomment-1632913648).