### PR TITLE
web: Remove ruffle extension detection plugin

### DIFF
--- a/web/packages/core/src/plugin-polyfill.ts
+++ b/web/packages/core/src/plugin-polyfill.ts
@@ -155,15 +155,6 @@ export const FLASH_PLUGIN = new RufflePlugin(
     "ruffle.js",
 );
 
-/**
- * A fake plugin designed to allow early detection of if the Ruffle extension is in use.
- */
-export const RUFFLE_EXTENSION = new RufflePlugin(
-    "Ruffle Extension",
-    "Ruffle Extension",
-    "ruffle.js",
-);
-
 FLASH_PLUGIN.install({
     type: FUTURESPLASH_MIMETYPE,
     description: "Shockwave Flash",
@@ -187,12 +178,6 @@ FLASH_PLUGIN.install({
     description: "Shockwave Flash",
     suffixes: "swf",
     enabledPlugin: FLASH_PLUGIN,
-});
-RUFFLE_EXTENSION.install({
-    type: "",
-    description: "Ruffle Detection",
-    suffixes: "",
-    enabledPlugin: RUFFLE_EXTENSION,
 });
 
 declare global {

--- a/web/packages/extension/src/plugin-polyfill.ts
+++ b/web/packages/extension/src/plugin-polyfill.ts
@@ -3,8 +3,6 @@
 import {
     installPlugin,
     FLASH_PLUGIN,
-    RUFFLE_EXTENSION,
 } from "ruffle-core/dist/plugin-polyfill.js";
 
 installPlugin(FLASH_PLUGIN);
-installPlugin(RUFFLE_EXTENSION);


### PR DESCRIPTION
This should fix the cases where older ruffle would just stop working when it detected a newer version of the extension.

Instead of failing to work, those older versions will likely try and polyfill/etc themselves as they are incapable of version negotiation. It's better than nothing I guess. I'd still recommend people update to a version that does have functional negotiation though.