### PR TITLE
extension: Use internal player page for spl files too

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -52,7 +52,7 @@ async function enable() {
                     redirect: { regexSubstitution: playerPage + "#\\0" },
                 },
                 condition: {
-                    regexFilter: "^.*\\.swf(\\?.*|#.*|)$",
+                    regexFilter: "^.*\\.s(?:wf|pl)(\\?.*|#.*|)$",
                     resourceTypes: [
                         chrome.declarativeNetRequest.ResourceType.MAIN_FRAME,
                     ],


### PR DESCRIPTION
Unfortunately, https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest/RuleCondition has no condition to allow matching the headers like https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived allows.