### PR TITLE
core: Add volume controls to desktop and web

### DIFF
--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -446,7 +446,8 @@ impl AudioMixer {
         };
         use std::ops::DerefMut;
 
-        let volume = volume.to_sample();
+        // Adapt the volume for logarithmic hearing.
+        let volume = ((10_f32.powf(81_f32.log10() * volume) - 1.0) / 80.0).to_sample();
 
         // For each sample, mix the samples from all active sound instances.
         for buf_frame in output_buffer

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -596,11 +596,15 @@ impl Player {
     }
 
     /// Returns the master volume of the player. 1.0 is 100% volume.
+    ///
+    /// The volume is linear and not adapted for logarithmic hearing.
     pub fn volume(&self) -> f32 {
         self.audio.volume()
     }
 
     /// Sets the master volume of the player. 1.0 is 100% volume.
+    ///
+    /// The volume should be linear and not adapted for logarithmic hearing.
     pub fn set_volume(&mut self, volume: f32) {
         self.audio.set_volume(volume)
     }

--- a/desktop/assets/texts/de-DE/main_menu.ftl
+++ b/desktop/assets/texts/de-DE/main_menu.ftl
@@ -17,6 +17,7 @@ file-menu-exit = Beenden
 controls-menu = Steuerung
 controls-menu-suspend = Aussetzen
 controls-menu-resume = Fortsetzen
+controls-menu-volume = Lautstärke
 help-menu = Hilfe
 help-menu-join-discord = Discord beitreten
 help-menu-report-a-bug = Bug melden...

--- a/desktop/assets/texts/de-DE/volume_dialog.ftl
+++ b/desktop/assets/texts/de-DE/volume_dialog.ftl
@@ -1,0 +1,3 @@
+volume-controls = Lautstärkeeinstellungen
+volume-controls-mute = Stummschalten
+volume-controls-volume = Lautstärke

--- a/desktop/assets/texts/en-US/main_menu.ftl
+++ b/desktop/assets/texts/en-US/main_menu.ftl
@@ -17,6 +17,7 @@ file-menu-exit = Exit
 controls-menu = Controls
 controls-menu-suspend = Suspend
 controls-menu-resume = Resume
+controls-menu-volume = Volume controls
 
 help-menu = Help
 help-menu-join-discord = Join Discord

--- a/desktop/assets/texts/en-US/volume_dialog.ftl
+++ b/desktop/assets/texts/en-US/volume_dialog.ftl
@@ -1,0 +1,3 @@
+volume-controls = Volume controls
+volume-controls-mute = Mute
+volume-controls-volume = Volume

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -20,6 +20,7 @@ use ruffle_core::debug_ui::Message as DebugMessage;
 use ruffle_core::Player;
 use std::collections::HashMap;
 use std::fs;
+use std::sync::MutexGuard;
 use sys_locale::get_locale;
 use unic_langid::LanguageIdentifier;
 use winit::event_loop::EventLoopProxy;
@@ -64,6 +65,8 @@ pub const MENU_HEIGHT: u32 = 24;
 pub struct RuffleGui {
     event_loop: EventLoopProxy<RuffleEvent>,
     is_about_visible: bool,
+    is_volume_visible: bool,
+    volume_controls: VolumeControls,
     is_open_dialog_visible: bool,
     context_menu: Vec<ruffle_core::ContextMenuItem>,
     open_dialog: OpenDialog,
@@ -89,6 +92,8 @@ impl RuffleGui {
 
         Self {
             is_about_visible: false,
+            is_volume_visible: false,
+            volume_controls: VolumeControls::new(false, default_player_options.volume * 100.0),
             is_open_dialog_visible: false,
             was_suspended_before_debug: false,
 
@@ -148,6 +153,10 @@ impl RuffleGui {
                     }
                 });
             }
+
+            self.volume_window(egui_ctx, Some(player));
+        } else {
+            self.volume_window(egui_ctx, None);
         }
 
         if !self.context_menu.is_empty() {
@@ -164,7 +173,12 @@ impl RuffleGui {
     }
 
     /// Notifies the GUI that a new player was created.
-    fn on_player_created(&mut self, opt: PlayerOptions, movie_url: Url) {
+    fn on_player_created(
+        &mut self,
+        opt: PlayerOptions,
+        movie_url: Url,
+        mut player: MutexGuard<Player>,
+    ) {
         self.currently_opened = Some((movie_url.clone(), opt.clone()));
 
         // Update dialog state to reflect the newly-opened movie's options.
@@ -175,6 +189,8 @@ impl RuffleGui {
             self.event_loop.clone(),
             self.locale.clone(),
         );
+
+        player.set_volume(self.volume_controls.get_real_volume());
     }
 
     /// Renders the main menu bar at the top of the window.
@@ -255,6 +271,9 @@ impl RuffleGui {
                             }
                         }
                     });
+                    if Button::new(text(&self.locale, "controls-menu-volume")).ui(ui).clicked() {
+                        self.show_volume_screen(ui);
+                    }
                 });
                 menu::menu_button(ui, text(&self.locale, "debug-menu"), |ui| {
                     ui.add_enabled_ui(player.is_some(), |ui| {
@@ -306,6 +325,7 @@ impl RuffleGui {
         });
     }
 
+    /// Renders the About Ruffle window.
     fn about_window(&mut self, egui_ctx: &egui::Context) {
         egui::Window::new(text(&self.locale, "about-ruffle"))
             .collapsible(false)
@@ -389,6 +409,40 @@ impl RuffleGui {
                         ui.shrink_width_to_current();
                     });
                 })
+            });
+    }
+
+    /// Renders the volume controls window.
+    fn volume_window(&mut self, egui_ctx: &egui::Context, player: Option<&mut Player>) {
+        egui::Window::new(text(&self.locale, "volume-controls"))
+            .collapsible(false)
+            .resizable(false)
+            .anchor(Align2::CENTER_CENTER, egui::Vec2::ZERO)
+            .open(&mut self.is_volume_visible)
+            .show(egui_ctx, |ui| {
+                let mut changed_slider = false;
+
+                let changed_checkbox = ui
+                    .checkbox(
+                        &mut self.volume_controls.is_muted,
+                        text(&self.locale, "volume-controls-mute"),
+                    )
+                    .changed();
+
+                ui.add_enabled_ui(!self.volume_controls.is_muted, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(text(&self.locale, "volume-controls-volume"));
+                        changed_slider = ui
+                            .add(Slider::new(&mut self.volume_controls.volume, 0.0..=100.0))
+                            .changed();
+                    });
+                });
+
+                if changed_checkbox || changed_slider {
+                    if let Some(player) = player {
+                        player.set_volume(self.volume_controls.get_real_volume());
+                    }
+                }
             });
     }
 
@@ -482,5 +536,36 @@ impl RuffleGui {
     fn show_about_screen(&mut self, ui: &mut egui::Ui) {
         self.is_about_visible = true;
         ui.close_menu();
+    }
+
+    fn show_volume_screen(&mut self, ui: &mut egui::Ui) {
+        self.is_volume_visible = true;
+        ui.close_menu();
+    }
+}
+
+/// The volume controls of the Ruffle GUI.
+pub struct VolumeControls {
+    is_muted: bool,
+    volume: f32,
+}
+
+impl VolumeControls {
+    fn new(is_muted: bool, volume: f32) -> Self {
+        Self { is_muted, volume }
+    }
+
+    /// Calculates the real volume (between 0 and 1) out of the entered volume
+    /// (between 0 and 100) and the mute checkbox.
+    ///
+    /// This is also necessary because human hearing is logarithmic:
+    /// What sounds like half as loud (and should be 50% on the scale) is actually
+    /// about 1/10th of the real volume.
+    pub fn get_real_volume(&self) -> f32 {
+        if !self.is_muted {
+            (10_f32.powf(81_f32.log10() * self.volume / 100.0) - 1.0) / 80.0
+        } else {
+            0.0
+        }
     }
 }

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -190,7 +190,7 @@ impl RuffleGui {
             self.locale.clone(),
         );
 
-        player.set_volume(self.volume_controls.get_real_volume());
+        player.set_volume(self.volume_controls.get_volume());
     }
 
     /// Renders the main menu bar at the top of the window.
@@ -440,7 +440,7 @@ impl RuffleGui {
 
                 if changed_checkbox || changed_slider {
                     if let Some(player) = player {
-                        player.set_volume(self.volume_controls.get_real_volume());
+                        player.set_volume(self.volume_controls.get_volume());
                     }
                 }
             });
@@ -555,15 +555,11 @@ impl VolumeControls {
         Self { is_muted, volume }
     }
 
-    /// Calculates the real volume (between 0 and 1) out of the entered volume
-    /// (between 0 and 100) and the mute checkbox.
-    ///
-    /// This is also necessary because human hearing is logarithmic:
-    /// What sounds like half as loud (and should be 50% on the scale) is actually
-    /// about 1/10th of the real volume.
-    pub fn get_real_volume(&self) -> f32 {
+    /// Returns the volume between 0 and 1 (calculated out of the
+    /// checkbox and the slider).
+    fn get_volume(&self) -> f32 {
         if !self.is_muted {
-            (10_f32.powf(81_f32.log10() * self.volume / 100.0) - 1.0) / 80.0
+            self.volume / 100.0
         } else {
             0.0
         }

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -182,7 +182,13 @@ impl GuiController {
             self.size.height,
         );
         player.create(&opt, &movie_url, movie_view);
-        self.gui.on_player_created(opt, movie_url);
+        self.gui.on_player_created(
+            opt,
+            movie_url,
+            player
+                .get()
+                .expect("Player must exist after being created."),
+        );
     }
 
     pub fn render(&mut self, mut player: Option<MutexGuard<Player>>) {

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -8,7 +8,6 @@ use crate::executor::WinitAsyncExecutor;
 use crate::gui::MovieView;
 use crate::{CALLSTACK, RENDER_INFO, SWF_INFO};
 use anyhow::anyhow;
-use ruffle_core::backend::audio::AudioBackend;
 use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
 use ruffle_core::config::Letterbox;
 use ruffle_core::{LoadBehavior, Player, PlayerBuilder, PlayerEvent, StageAlign, StageScaleMode};
@@ -98,8 +97,7 @@ impl ActivePlayer {
         let mut builder = PlayerBuilder::new();
 
         match CpalAudioBackend::new() {
-            Ok(mut audio) => {
-                audio.set_volume(opt.volume);
+            Ok(audio) => {
                 builder = builder.with_audio(audio);
             }
             Err(e) => {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -141,6 +141,7 @@ export class RufflePlayer extends HTMLElement {
     private readonly splashScreen: HTMLElement;
     private readonly virtualKeyboard: HTMLInputElement;
     private readonly saveManager: HTMLDivElement;
+    private readonly volumeControls: HTMLDivElement;
     private readonly videoModal: HTMLDivElement;
 
     private readonly contextMenuOverlay: HTMLElement;
@@ -173,6 +174,8 @@ export class RufflePlayer extends HTMLElement {
     private longPressTimer: ReturnType<typeof setTimeout> | null = null;
     private pointerDownPosition: Point | null = null;
     private pointerMoveMaxDistance = 0;
+
+    private volumeSettings: VolumeControls;
 
     /**
      * Triggered when a movie metadata has been loaded (such as movie width and height).
@@ -258,8 +261,16 @@ export class RufflePlayer extends HTMLElement {
         this.videoModal = <HTMLDivElement>(
             this.shadow.getElementById("video-modal")!
         );
+        this.volumeControls = <HTMLDivElement>(
+            this.shadow.getElementById("volume-controls-modal")
+        );
         this.addModalJavaScript(this.saveManager);
+        this.addModalJavaScript(this.volumeControls);
         this.addModalJavaScript(this.videoModal);
+
+        this.volumeSettings = new VolumeControls(false, 1.0);
+        this.addVolumeControlsJavaScript(this.volumeControls);
+
         const backupSaves = <HTMLElement>(
             this.saveManager.querySelector("#backup-saves")
         );
@@ -348,6 +359,67 @@ export class RufflePlayer extends HTMLElement {
                 }
             });
         }
+    }
+
+    /**
+     * Add the volume control texts, set the controls to the current settings and
+     * add event listeners to update the settings and controls when being changed.
+     *
+     * @param volumeControlsModal The element containing the volume controls modal.
+     */
+    private addVolumeControlsJavaScript(
+        volumeControlsModal: HTMLDivElement,
+    ): void {
+        const muteCheckbox = volumeControlsModal.querySelector(
+            "#mute-checkbox",
+        ) as HTMLInputElement;
+        const volumeSlider = volumeControlsModal.querySelector(
+            "#volume-slider",
+        ) as HTMLInputElement;
+        const volumeSliderText = volumeControlsModal.querySelector(
+            "#volume-slider-text",
+        ) as HTMLSpanElement;
+
+        const heading = volumeControlsModal.querySelector(
+            "#volume-controls-heading",
+        ) as HTMLHeadingElement;
+        const muteCheckboxLabel = volumeControlsModal.querySelector(
+            "#mute-checkbox-label",
+        ) as HTMLLabelElement;
+        const volumeSliderLabel = volumeControlsModal.querySelector(
+            "#volume-slider-label",
+        ) as HTMLLabelElement;
+
+        // Add the texts.
+        heading.textContent = text("volume-controls");
+        muteCheckboxLabel.textContent = text("volume-controls-mute");
+        volumeSliderLabel.textContent = text("volume-controls-volume");
+
+        // Set the controls to the current settings.
+        muteCheckbox.checked = this.volumeSettings.isMuted;
+        volumeSlider.disabled = muteCheckbox.checked;
+        volumeSlider.valueAsNumber = this.volumeSettings.volume;
+        volumeSliderLabel.style.color = muteCheckbox.checked ? "grey" : "black";
+        volumeSliderText.style.color = muteCheckbox.checked ? "grey" : "black";
+        volumeSliderText.textContent = String(this.volumeSettings.volume);
+
+        // Add event listeners to update the settings and controls.
+        muteCheckbox.addEventListener("change", () => {
+            volumeSlider.disabled = muteCheckbox.checked;
+            volumeSliderLabel.style.color = muteCheckbox.checked
+                ? "grey"
+                : "black";
+            volumeSliderText.style.color = muteCheckbox.checked
+                ? "grey"
+                : "black";
+            this.volumeSettings.isMuted = muteCheckbox.checked;
+            this.instance?.set_volume(this.volumeSettings.get_real_volume());
+        });
+        volumeSlider.addEventListener("input", () => {
+            volumeSliderText.textContent = volumeSlider.value;
+            this.volumeSettings.volume = volumeSlider.valueAsNumber;
+            this.instance?.set_volume(this.volumeSettings.get_real_volume());
+        });
     }
 
     /**
@@ -577,6 +649,7 @@ export class RufflePlayer extends HTMLElement {
             this,
             this.loadedConfig,
         );
+        this.instance!.set_volume(this.volumeSettings.get_real_volume());
         this.rendererDebugInfo = this.instance!.renderer_debug_info();
 
         const actuallyUsedRendererName = this.instance!.renderer_name();
@@ -1172,6 +1245,13 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
+     * Opens the volume controls.
+     */
+    private openVolumeControls(): void {
+        this.volumeControls.classList.remove("hidden");
+    }
+
+    /**
      * Fetches the loaded SWF and downloads it.
      */
     async downloadSwf(): Promise<void> {
@@ -1269,6 +1349,13 @@ export class RufflePlayer extends HTMLElement {
                 });
             }
         }
+
+        items.push({
+            text: text("context-menu-volume-controls"),
+            onClick: () => {
+                this.openVolumeControls();
+            },
+        });
 
         if (
             this.instance &&
@@ -2273,4 +2360,37 @@ export function isFallbackElement(elem: Element): boolean {
         parent = parent.parentElement;
     }
     return false;
+}
+
+/**
+ * The volume controls of the Ruffle web GUI.
+ */
+class VolumeControls {
+    isMuted: boolean;
+    volume: number;
+
+    constructor(isMuted: boolean, volume: number) {
+        this.isMuted = isMuted;
+        this.volume = volume * 100;
+    }
+
+    /**
+     * Calculates the real volume (between 0 and 1) out of the entered volume
+     * (between 0 and 100) and the mute checkbox.
+     *
+     * This is also necessary because human hearing is logarithmic:
+     * What sounds like half as loud (and should be 50% on the scale) is actually
+     * about 1/10th of the real volume.
+     *
+     * @returns The real volume.
+     */
+    public get_real_volume(): number {
+        if (!this.isMuted) {
+            return (
+                (Math.pow(10, (Math.log10(81) * this.volume) / 100) - 1) / 80
+            );
+        } else {
+            return 0;
+        }
+    }
 }

--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -390,11 +390,28 @@ export function applyStaticStyles(styleElement: HTMLStyleElement) {
         `#video-holder {
             padding-top: 20px;
         }`,
+
+        `.slider-container {
+            margin-top: 10px;
+            display: flex;
+            align-items: center;
+        }`,
+
+        `#volume-slider {
+            margin-left: 10px;
+            margin-right: 10px;
+        }`,
+
+        `#volume-slider-text {
+            text-align: right;
+            width: 28px;
+        }`,
     ];
     insertRules(styleElement.sheet, rules);
 }
 
 /**
+ * Create and return a new HTML Element with the given arguments.
  *
  * @param tag The HTML tag name of the new element.
  * @param id The id of the new element.
@@ -427,6 +444,52 @@ function createElement(
             element.setAttribute(key, attr);
         }
     }
+    return element;
+}
+
+/**
+ * Create and return a new HTMLInputElement with the given arguments.
+ *
+ * @param htmlType The type of input element.
+ * @param id The id of the input element.
+ * @param min The min of the input element.
+ * @param max The max of the input element.
+ * @param step The step of the input element.
+ *
+ * @returns The newly created HTMLInputElement
+ */
+function createInputElement(
+    htmlType: string,
+    id: string,
+    min?: string,
+    max?: string,
+    step?: string,
+): HTMLInputElement {
+    const element = createElement("input", id) as HTMLInputElement;
+    element.type = htmlType;
+    if (min) {
+        element.min = min;
+    }
+    if (max) {
+        element.max = max;
+    }
+    if (step) {
+        element.step = step;
+    }
+    return element;
+}
+
+/**
+ * Create and return a new HTMLLabelElement with the given arguments.
+ *
+ * @param id The id of the label element.
+ * @param htmlFor The for of the label element.
+ *
+ * @returns The newly created HTMLLabelElement
+ */
+function createLabelElement(id: string, htmlFor: string): HTMLLabelElement {
+    const element = createElement("label", id) as HTMLLabelElement;
+    element.htmlFor = htmlFor;
     return element;
 }
 
@@ -682,6 +745,36 @@ const generalSaveOptions = createElement(
 const backupSaves = createElement("span", "backup-saves", "save-option");
 const localSaves = createElement("table", "local-saves");
 
+// Volume control elements
+const volumeControlsModal = createElement(
+    "div",
+    "volume-controls-modal",
+    "modal hidden",
+);
+const volumeModalArea = createElement("div", undefined, "modal-area");
+const volumeModalClose = createElement("span", undefined, "close-modal");
+volumeModalClose.textContent = "\u00D7";
+const volumeControls = createElement("div", "volume-controls");
+const volumeControlsHeading = createElement("h2", "volume-controls-heading");
+const muteCheckboxLabel = createLabelElement(
+    "mute-checkbox-label",
+    "mute-checkbox",
+);
+const muteCheckbox = createInputElement("checkbox", "mute-checkbox");
+const sliderContainer = createElement("div", undefined, "slider-container");
+const volumeSliderLabel = createLabelElement(
+    "volume-slider-label",
+    "volume-slider",
+);
+const volumeSlider = createInputElement(
+    "range",
+    "volume-slider",
+    "0",
+    "100",
+    "1",
+);
+const volumeSliderText = createElement("span", "volume-slider-text");
+
 // Video modal elements
 const videoModal = createElement("div", "video-modal", "modal hidden");
 const videoModalArea = createElement("div", undefined, "modal-area");
@@ -740,6 +833,18 @@ appendElement(saveModalArea, saveModalClose);
 appendElement(saveModalArea, generalSaveOptions);
 appendElement(generalSaveOptions, backupSaves);
 appendElement(saveModalArea, localSaves);
+// Volume control append
+appendElement(ruffleShadowTemplate.content, volumeControlsModal);
+appendElement(volumeControlsModal, volumeModalArea);
+appendElement(volumeModalArea, volumeModalClose);
+appendElement(volumeModalArea, volumeControls);
+appendElement(volumeControls, volumeControlsHeading);
+appendElement(volumeControls, muteCheckboxLabel);
+appendElement(volumeControls, muteCheckbox);
+appendElement(volumeControls, sliderContainer);
+appendElement(sliderContainer, volumeSliderLabel);
+appendElement(sliderContainer, volumeSlider);
+appendElement(sliderContainer, volumeSliderText);
 // Video modal append
 appendElement(ruffleShadowTemplate.content, videoModal);
 appendElement(videoModal, videoModalArea);

--- a/web/packages/core/texts/de-DE/context_menu.ftl
+++ b/web/packages/core/texts/de-DE/context_menu.ftl
@@ -9,3 +9,4 @@ context-menu-about-ruffle =
 context-menu-hide = Menü ausblenden
 context-menu-exit-fullscreen = Vollbild verlassen
 context-menu-enter-fullscreen = Vollbildmodus aktivieren
+context-menu-volume-controls = Lautstärke einstellen

--- a/web/packages/core/texts/de-DE/volume-controls.ftl
+++ b/web/packages/core/texts/de-DE/volume-controls.ftl
@@ -1,0 +1,3 @@
+volume-controls = Lautstärkeeinstellungen
+volume-controls-mute = Stummschalten
+volume-controls-volume = Lautstärke

--- a/web/packages/core/texts/en-US/context_menu.ftl
+++ b/web/packages/core/texts/en-US/context_menu.ftl
@@ -9,3 +9,4 @@ context-menu-about-ruffle =
 context-menu-hide = Hide this menu
 context-menu-exit-fullscreen = Exit fullscreen
 context-menu-enter-fullscreen = Enter fullscreen
+context-menu-volume-controls = Volume controls

--- a/web/packages/core/texts/en-US/volume-controls.ftl
+++ b/web/packages/core/texts/en-US/volume-controls.ftl
@@ -1,0 +1,3 @@
+volume-controls = Volume controls
+volume-controls-mute = Mute
+volume-controls-volume = Volume


### PR DESCRIPTION
This pull request adds volume controls to both desktop and web.
On desktop, they can be accessed through the menu bar, on web, through the right-click menu.
The volume controls contain a mute button and a slider from 0 to 100 in each.
The volume given to the player is adapted for logarithmic hearing.

On desktop, the volume controls are available, even if no SWF file is currently being played. When starting to play an SWF file, the current GUI volume controls are used.
Since the GUI volume controls use the PlayerOptions volume value as the default, this PR also fixes the issue that the PlayerOptions volume has previously not been adapted for logarithmic hearing.

The volume controls (and the options to open them) are multilingual. In this pull request, English and German translations have been added.

This closes #1771.