### PR TITLE
avm2: More lenient SWF version check for invalid frame label behavior

### DIFF
--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -392,7 +392,8 @@ pub fn goto_frame<'gc>(
                 }
 
                 let frame = mc.frame_label_to_number(&frame_or_label, &activation.context);
-                if mc.movie().version() >= 11 {
+                // TODO: This should use the SWF version of the current DoAbc(2) tag. Until then, let's be lenient
+                if mc.movie().version() >= 11 && activation.context.swf.version() >= 11 {
                     frame.ok_or(
                         // TODO: Also include the scene in the error message, as done above
                         Error::AvmError(argument_error(


### PR DESCRIPTION
This is needed because we don't have a way of checking the SWF version of the currently executing bytecode, only of the current clip, which can be different. AVM2's version-dependent behavior should depend on the SWF containing the current DoAbc(2) tag. This distinction matters for Nightflies since it executes code on an SWFv11 clip from SWFv10.

Fixes #11987.