### PR TITLE
 avm2: Boolean.valueOf and Boolean.toString default to false 

### DIFF
--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -96,7 +96,7 @@ fn to_string<'gc>(
         };
     }
 
-    Err("Boolean.prototype.toString has been called on an incompatible object".into())
+    Ok("false".into())
 }
 
 /// Implements `Boolean.valueOf`
@@ -109,7 +109,7 @@ fn value_of<'gc>(
         return Ok(*this);
     }
 
-    Ok(Value::Undefined)
+    Ok(false.into())
 }
 
 /// Construct `Boolean`'s class.

--- a/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_3_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_3_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_3_1_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_3_1_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_4/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_4/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_4__1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Boolean/e15_6_4__1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/ecall_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/ecall_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Makes tests `e15_6_3_1`, `e15_6_3_1_3`, `e15_6_4`, `e15_6_4__1` and `ecall_1` pass.