### PR TITLE
avm2: String fixes

### DIFF
--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -189,10 +189,6 @@ fn from_char_code<'gc>(
     let mut out = WString::with_capacity(args.len(), false);
     for arg in args {
         let i = arg.coerce_to_u32(activation)? as u16;
-        if i == 0 {
-            // Ignore nulls.
-            continue;
-        }
         out.push(i);
     }
     Ok(AvmString::new(activation.context.gc_context, out).into())

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -201,7 +201,7 @@ fn index_of<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let this = Value::from(this).coerce_to_string(activation)?;
     let pattern = match args.get(0) {
-        None => return Ok(Value::Undefined),
+        None => return Ok(Value::Integer(-1)),
         Some(s) => s.clone().coerce_to_string(activation)?,
     };
 

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -622,7 +622,13 @@ fn to_string<'gc>(
     this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    Ok(Value::from(this))
+    if let Some(this) = this.as_primitive() {
+        if let Value::String(v) = *this {
+            return Ok(v.into());
+        }
+    }
+
+    Ok("".into())
 }
 
 /// Implements `String.valueOf`

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -12,7 +12,6 @@ use crate::avm2::QName;
 use crate::avm2::{ArrayObject, ArrayStorage};
 use crate::string::{AvmString, WString};
 use gc_arena::GcCell;
-use std::iter;
 
 // All of these methods will be defined as both
 // AS3 instance methods and methods on the `String` class prototype.
@@ -460,14 +459,6 @@ fn split<'gc>(
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     let delimiter = args.get(0).unwrap_or(&Value::Undefined);
-    if matches!(delimiter, Value::Undefined) {
-        let this = Value::from(this);
-        return Ok(
-            ArrayObject::from_storage(activation, iter::once(this).collect())
-                .unwrap()
-                .into(),
-        );
-    }
 
     let this = Value::from(this).coerce_to_string(activation)?;
     let limit = match args.get(1).unwrap_or(&Value::Undefined) {

--- a/tests/tests/swfs/from_avmplus/ecma3/GlobalObject/e15_1_2_5_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/GlobalObject/e15_1_2_5_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_3_2_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_3_2_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_11_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_11_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_12_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_12_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_2_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_2_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_2_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_2_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_5_4/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_5_4/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_6_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_6_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_8_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/e15_5_4_8_2/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/toLocaleLowerCase/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/toLocaleLowerCase/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/String/toLocaleUpperCase5/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/String/toLocaleUpperCase5/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/TypeConversion/e9_7/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/TypeConversion/e9_7/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Makes tests `e15_5_4`, `e15_5_4_2_1`, `e15_5_4_2_rt`, `e15_1_2_5_3`, `e15_ 5_3_2_3`, `e15_5_4_11_1`, `e15_ 5_4_12_1`, `e15_5_4_5_4`, `toLocaleLowerCase`, `toLocaleUpperCase5`, `e9_7`,  `e15_5_4_8_2` and `e15_5_4_6_1` pass.