### PR TITLE
renovate: Merge patch and major-minor Rust update rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,15 +5,7 @@
     "packageRules": [
         {
             "matchLanguages": ["rust"],
-            "matchUpdateTypes": "patch",
-            "groupName": "Rust dependency patches",
-            "rangeStrategy": "bump",
-            "extends": ["schedule:weekly"],
-        },
-        {
-            "matchLanguages": ["rust"],
             "groupName": "Rust dependencies",
-            "matchUpdateTypes": ["major", "minor"],
             "rangeStrategy": "bump",
             "extends": ["schedule:weekly"],
         },


### PR DESCRIPTION
The bot disabled itself due to #12522:

> There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.
> 
> Location: .github/renovate.json5
> Error type: The renovate configuration file contains some invalid settings
> Message: `packageRules[0]: packageRules cannot combine both matchUpdateTypes and rangeStrategy. Rule: {"matchCategories":["rust"],"matchUpdateTypes":["patch"],"groupName":"Rust dependency patches","rangeStrategy":"bump","extends":["schedule:weekly"]}, packageRules[1]: packageRules cannot combine both matchUpdateTypes and rangeStrategy. Rule: {"matchCategories":["rust"],"groupName":"Rust dependencies","matchUpdateTypes":["major","minor"],"rangeStrategy":"bump","extends":["schedule:weekly"]}`