### PR TITLE
renovate: Separate wgpu-related Rust dependencies into their own group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,13 @@
             "extends": ["schedule:weekly"],
         },
         {
+            "matchLanguages": ["rust"],
+            "matchPackageNames": ["wgpu", "naga", "naga_oil", "egui-wgpu"],
+            "groupName": "Rust dependencies related to wgpu",
+            "rangeStrategy": "bump",
+            "extends": ["schedule:weekly"],
+        },
+        {
             "matchPackageNames": ["wasm-bindgen", "js-sys", "web-sys", "wasm-bindgen-futures"],
             "groupName": "wasm-bindgen",
         },


### PR DESCRIPTION
I _hope_ this will do what I want it to do...