### PR TITLE
web: Rename extension to 'Ruffle - Flash Emulator'

### DIFF
--- a/web/packages/extension/manifest_firefox.json5
+++ b/web/packages/extension/manifest_firefox.json5
@@ -1,6 +1,6 @@
 {
     "manifest_version": 2,
-    "name": "Ruffle",
+    "name": "Ruffle - Flash Emulator",
     "version": null, // Filled by Webpack.
     "default_locale": "en",
     "description": "__MSG_description__",

--- a/web/packages/extension/manifest_other.json5
+++ b/web/packages/extension/manifest_other.json5
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "name": "Ruffle",
+    "name": "Ruffle - Flash Emulator",
     "version": null, // Filled by Webpack.
     "default_locale": "en",
     "description": "__MSG_description__",


### PR DESCRIPTION
Searching for "Flash" doesn't really bring Ruffle up, especially not with a dozen "Flash Player" extensions that is ironically usually just an outdated ruffle + analytics/ads.

This helps alienate that a lot. It also helps teach people what Ruffle is, just seeing "Ruffle" doesn't explain to a random person what it is :D