### PR TITLE
Renovate config migration, un-ignore `tests`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
+    // un-ignoring "tests" after ":ignoreModulesAndTests" via
+    // "config:recommended" - we have utilities in there
+    "ignorePaths": [
+        "**/node_modules/**"
+    ],
     // Package rules are matched such that later rules override earlier ones.
     "packageRules": [
         {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,13 +9,13 @@
     // Package rules are matched such that later rules override earlier ones.
     "packageRules": [
         {
-            "matchLanguages": ["rust"],
+            "matchCategories": ["rust"],
             "groupName": "Rust dependencies",
             "rangeStrategy": "bump",
             "extends": ["schedule:weekly"],
         },
         {
-            "matchLanguages": ["rust"],
+            "matchCategories": ["rust"],
             "matchPackageNames": ["wgpu", "naga", "naga_oil", "egui-wgpu"],
             "groupName": "Rust dependencies related to wgpu",
             "rangeStrategy": "bump",
@@ -31,7 +31,7 @@
             "enabled": false,
         },
         {
-            "matchLanguages": ["js"],
+            "matchCategories": ["js"],
             "groupName": "Node.js dependencies",
             "rangeStrategy": "bump",
             "extends": ["schedule:monthly"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:base"],
+    "extends": ["config:recommended"],
     // Package rules are matched such that later rules override earlier ones.
     "packageRules": [
         {


### PR DESCRIPTION
Two commits are just keeping up with the times.
One was a base config rename: https://github.com/renovatebot/renovate/commit/f9e3e80e0c9c6a972d847f8740de5016a2bf698a
The other was recommended by the validator: https://docs.renovatebot.com/config-validation/

And the third one is to resolve `mocket`, `input-format` and `socket-format` (among others) not being updated.
See: https://github.com/renovatebot/renovate/discussions/23952