### PR TITLE
extension: Fix check for scripting permission

### DIFF
--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -147,7 +147,8 @@ function isXMLDocument(): boolean {
     // NOTE: The script code injected here is the compiled form of
     // plugin-polyfill.ts. It is injected by tools/inject_plugin_polyfill.js
     // which just search-and-replaces for this particular string.
-    if (!chrome?.scripting) {
+    const permissions = (chrome || browser).runtime.getManifest().permissions;
+    if (!permissions?.includes("scripting")) {
         // Chrome does this differently, by injecting it straight into the main world.
         // This isn't as fast, oh well.
         injectScriptRaw("%PLUGIN_POLYFILL_SOURCE%");


### PR DESCRIPTION
The content script doesn't have access to the `scripting` API, but it does have the ability to get the extension's manifest: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#webextension_apis