### PR TITLE
avm2: Throw TypeError for null argument in TextField string property setters

### DIFF
--- a/core/src/avm2/globals/flash/text/text_field.rs
+++ b/core/src/avm2/globals/flash/text/text_field.rs
@@ -95,7 +95,7 @@ pub fn set_auto_size<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        let value = args.get_string(activation, 0)?;
+        let value = args.get_string_non_null(activation, 0, "autoSize")?;
         this.set_autosize(
             if &value == b"left" {
                 AutoSizeMode::Left
@@ -495,7 +495,7 @@ pub fn set_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        let text = args.get_string(activation, 0)?;
+        let text = args.get_string_non_null(activation, 0, "text")?;
 
         this.set_is_html(&mut activation.context, false);
         this.set_text(&text, &mut activation.context);
@@ -613,7 +613,7 @@ pub fn set_type<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        let is_editable = args.get_string(activation, 0)?;
+        let is_editable = args.get_string_non_null(activation, 0, "type")?;
 
         if &is_editable == b"input" {
             this.set_editable(true, &mut activation.context);
@@ -668,7 +668,7 @@ pub fn append_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        let new_text = args.get_string(activation, 0)?;
+        let new_text = args.get_string_non_null(activation, 0, "text")?;
         let existing_length = this.text_length();
 
         this.replace_text(
@@ -726,7 +726,7 @@ pub fn replace_selected_text<'gc>(
         .as_display_object()
         .and_then(|this| this.as_edit_text())
     {
-        let value = args.get_string(activation, 0)?;
+        let value = args.get_string_non_null(activation, 0, "text")?;
         let selection = this
             .selection()
             .unwrap_or_else(|| TextSelection::for_position(0));
@@ -761,7 +761,7 @@ pub fn replace_text<'gc>(
             .cloned()
             .unwrap_or(Value::Undefined)
             .coerce_to_u32(activation)?;
-        let value = args.get_string(activation, 2)?;
+        let value = args.get_string_non_null(activation, 2, "text")?;
 
         this.replace_text(
             begin_index as usize,
@@ -942,7 +942,7 @@ pub fn set_anti_alias_type<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         let old_settings = this.render_settings();
-        let new_type = args.get_string(activation, 0)?;
+        let new_type = args.get_string_non_null(activation, 0, "antiAliasType")?;
 
         if &new_type == b"advanced" {
             this.set_render_settings(
@@ -988,7 +988,7 @@ pub fn set_grid_fit_type<'gc>(
         .and_then(|this| this.as_edit_text())
     {
         let old_settings = this.render_settings();
-        let new_type = args.get_string(activation, 0)?;
+        let new_type = args.get_string_non_null(activation, 0, "gridFitType")?;
 
         if &new_type == b"pixel" {
             this.set_render_settings(

--- a/core/src/avm2/parameters.rs
+++ b/core/src/avm2/parameters.rs
@@ -76,6 +76,12 @@ pub trait ParametersExt<'gc> {
         activation: &mut Activation<'_, 'gc>,
         index: usize,
     ) -> Result<AvmString<'gc>, Error<'gc>>;
+    fn get_string_non_null(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        name: &'static str,
+    ) -> Result<AvmString<'gc>, Error<'gc>>;
 
     /// Gets the value at the given index and coerces it to an AvmString.
     ///
@@ -157,6 +163,18 @@ impl<'gc> ParametersExt<'gc> for &[Value<'gc>] {
         index: usize,
     ) -> Result<AvmString<'gc>, Error<'gc>> {
         self[index].coerce_to_string(activation)
+    }
+
+    fn get_string_non_null(
+        &self,
+        activation: &mut Activation<'_, 'gc>,
+        index: usize,
+        name: &'static str,
+    ) -> Result<AvmString<'gc>, Error<'gc>> {
+        match self[index] {
+            Value::Null | Value::Undefined => Err(null_parameter_error(activation, name)),
+            other => other.coerce_to_string(activation),
+        }
     }
 
     fn try_get_string(


### PR DESCRIPTION
I suspect this is an issue throughout the codebase, but I'm fixing it where I found it.