### PR TITLE
core: Refactor away some `GcCell`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,8 +1828,8 @@ dependencies = [
 
 [[package]]
 name = "gc-arena"
-version = "0.3.1"
-source = "git+https://github.com/kyren/gc-arena?rev=ad3e24f89c78d8bb94db18383987290f88e4edcb#ad3e24f89c78d8bb94db18383987290f88e4edcb"
+version = "0.3.3"
+source = "git+https://github.com/kyren/gc-arena?rev=efd89fc683c6bb456af3e226c33763cb822645e9#efd89fc683c6bb456af3e226c33763cb822645e9"
 dependencies = [
  "gc-arena-derive",
  "sptr",
@@ -1837,8 +1837,8 @@ dependencies = [
 
 [[package]]
 name = "gc-arena-derive"
-version = "0.3.1"
-source = "git+https://github.com/kyren/gc-arena?rev=ad3e24f89c78d8bb94db18383987290f88e4edcb#ad3e24f89c78d8bb94db18383987290f88e4edcb"
+version = "0.3.3"
+source = "git+https://github.com/kyren/gc-arena?rev=efd89fc683c6bb456af3e226c33763cb822645e9#efd89fc683c6bb456af3e226c33763cb822645e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ repository = "https://github.com/ruffle-rs/ruffle"
 version = "0.1.0"
 
 [workspace.dependencies]
-# gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "ad3e24f89c78d8bb94db18383987290f88e4edcb" }
+# gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "efd89fc683c6bb456af3e226c33763cb822645e9" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 naga = { version = "0.12.3", features = ["validate", "wgsl-out"] }

--- a/core/src/avm1/globals/shared_object.rs
+++ b/core/src/avm1/globals/shared_object.rs
@@ -107,7 +107,7 @@ fn recursive_serialize<'gc>(
                             .expect("Failed to convert xml to string in SharedObject");
                         writer.xml(name.as_ref(), string.to_utf8_lossy().as_ref(), true)
                     } else if let NativeObject::Date(date) = o.native() {
-                        writer.date(name.as_ref(), date.read().time(), None)
+                        writer.date(name.as_ref(), date.get().time(), None)
                     } else {
                         let (ow, token) = writer.object(CacheKey::from_ptr(o.as_ptr()));
 

--- a/core/src/avm1/globals/text_field.rs
+++ b/core/src/avm1/globals/text_field.rs
@@ -9,7 +9,7 @@ use crate::display_object::{AutoSizeMode, EditText, TDisplayObject, TextSelectio
 use crate::font::round_down_to_pixel;
 use crate::html::TextFormat;
 use crate::string::{AvmString, WStr};
-use gc_arena::GcCell;
+use gc_arena::Gc;
 use swf::Color;
 
 macro_rules! tf_method {
@@ -137,7 +137,7 @@ fn new_text_format<'gc>(
     let object = ScriptObject::new(activation.context.gc_context, Some(proto));
     object.set_native(
         activation.context.gc_context,
-        NativeObject::TextFormat(GcCell::new(activation.context.gc_context, text_format)),
+        NativeObject::TextFormat(Gc::new(activation.context.gc_context, text_format.into())),
     );
     object
 }
@@ -158,7 +158,7 @@ fn set_new_text_format<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let [Value::Object(text_format), ..] = args {
         if let NativeObject::TextFormat(text_format) = text_format.native() {
-            text_field.set_new_text_format(text_format.read().clone(), &mut activation.context);
+            text_field.set_new_text_format(text_format.borrow().clone(), &mut activation.context);
         }
     }
 
@@ -221,7 +221,7 @@ fn set_text_format<'gc>(
             text_field.set_text_format(
                 begin_index,
                 end_index,
-                text_format.read().clone(),
+                text_format.borrow().clone(),
                 &mut activation.context,
             );
         }

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -26,8 +26,9 @@ use crate::html::TextFormat;
 use crate::streams::NetStream;
 use crate::string::AvmString;
 use crate::xml::XmlNode;
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::{Collect, Gc, GcCell, Mutation};
 use ruffle_macros::enum_trait_object;
+use std::cell::Cell;
 use std::fmt::Debug;
 
 pub mod array_object;
@@ -42,7 +43,7 @@ pub mod value_object;
 #[collect(no_drop)]
 pub enum NativeObject<'gc> {
     None,
-    Date(GcCell<'gc, Date>),
+    Date(Gc<'gc, Cell<Date>>),
     BlurFilter(BlurFilter<'gc>),
     BevelFilter(BevelFilter<'gc>),
     GlowFilter(GlowFilter<'gc>),

--- a/core/src/avm1/object.rs
+++ b/core/src/avm1/object.rs
@@ -28,7 +28,7 @@ use crate::string::AvmString;
 use crate::xml::XmlNode;
 use gc_arena::{Collect, Gc, GcCell, Mutation};
 use ruffle_macros::enum_trait_object;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::fmt::Debug;
 
 pub mod array_object;
@@ -55,7 +55,7 @@ pub enum NativeObject<'gc> {
     GradientGlowFilter(GradientFilter<'gc>),
     ColorTransform(GcCell<'gc, ColorTransformObject>),
     Transform(TransformObject<'gc>),
-    TextFormat(GcCell<'gc, TextFormat>),
+    TextFormat(Gc<'gc, RefCell<TextFormat>>),
     NetStream(NetStream<'gc>),
     BitmapData(BitmapDataWrapper<'gc>),
     Xml(Xml<'gc>),

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -400,12 +400,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             RegisterSet::new(num_locals + num_declared_arguments + arg_register + 1);
         *local_registers.get_mut(0).unwrap() = this.into();
 
-        let activation_class = if let Some(class_cache) = method.activation_class {
-            let cached_cls = class_cache.read();
-            let activation_class = if let Some(cls) = *cached_cls {
-                cls
-            } else {
-                drop(cached_cls);
+        let activation_class =
+            BytecodeMethod::get_or_init_activation_class(method, context.gc_context, || {
                 let translation_unit = method.translation_unit();
                 let abc_method = method.method();
                 let mut dummy_activation =
@@ -417,18 +413,8 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                     abc_method,
                     body,
                 )?;
-                let activation_class_object =
-                    ClassObject::from_class(&mut dummy_activation, activation_class, None)?;
-                drop(dummy_activation);
-
-                *class_cache.write(context.gc_context) = Some(activation_class_object);
-                activation_class_object
-            };
-
-            Some(activation_class)
-        } else {
-            None
-        };
+                ClassObject::from_class(&mut dummy_activation, activation_class, None)
+            })?;
 
         let mut activation = Self {
             actions_since_timeout_check: 0,

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -220,7 +220,7 @@ impl<'builder, 'activation_a, 'gc, T: TimeZone> DateAdjustment<'builder, 'activa
         } else {
             None
         };
-        object.set_date_time(self.activation.context.gc_context, date);
+        object.set_date_time(date);
         if let Some(date) = date {
             date.timestamp_millis() as f64
         } else {
@@ -243,16 +243,13 @@ pub fn instance_init<'gc>(
                 let timezone = get_timezone();
 
                 // We need a starting value to adjust from.
-                date.set_date_time(
-                    activation.context.gc_context,
-                    Some(
-                        timezone
-                            .with_ymd_and_hms(0, 1, 1, 0, 0, 0)
-                            .single()
-                            .expect("Found ambiguous epoch time when constructing Date")
-                            .into(),
-                    ),
-                );
+                date.set_date_time(Some(
+                    timezone
+                        .with_ymd_and_hms(0, 1, 1, 0, 0, 0)
+                        .single()
+                        .expect("Found ambiguous epoch time when constructing Date")
+                        .into(),
+                ));
 
                 DateAdjustment::new(activation, &timezone)
                     .year(args.get(0))?
@@ -272,12 +269,12 @@ pub fn instance_init<'gc>(
                 };
                 if timestamp.is_finite() {
                     if let LocalResult::Single(time) = Utc.timestamp_millis_opt(timestamp as i64) {
-                        date.set_date_time(activation.context.gc_context, Some(time))
+                        date.set_date_time(Some(time))
                     }
                 }
             }
         } else {
-            date.set_date_time(activation.context.gc_context, Some(get_current_date_time()))
+            date.set_date_time(Some(get_current_date_time()))
         }
     }
 
@@ -355,10 +352,10 @@ pub fn set_time<'gc>(
                 .timestamp_millis_opt(new_time as i64)
                 .single()
                 .expect("Found ambiguous timestamp for current time zone");
-            this.set_date_time(activation.context.gc_context, Some(time));
+            this.set_date_time(Some(time));
             return Ok((time.timestamp_millis() as f64).into());
         } else {
-            this.set_date_time(activation.context.gc_context, None);
+            this.set_date_time(None);
             return Ok(f64::NAN.into());
         }
     }
@@ -612,16 +609,13 @@ pub fn set_full_year<'gc>(
     if let Some(this) = this.as_date_object() {
         let timezone = get_timezone();
         if this.date_time().is_none() {
-            this.set_date_time(
-                activation.context.gc_context,
-                Some(
-                    timezone
-                        .with_ymd_and_hms(0, 1, 1, 0, 0, 0)
-                        .single()
-                        .expect("Found ambiguous epoch time when constructing Date")
-                        .into(),
-                ),
-            );
+            this.set_date_time(Some(
+                timezone
+                    .with_ymd_and_hms(0, 1, 1, 0, 0, 0)
+                    .single()
+                    .expect("Found ambiguous epoch time when constructing Date")
+                    .into(),
+            ));
         }
         let timestamp = DateAdjustment::new(activation, &timezone)
             .year(args.get(0))?
@@ -877,14 +871,11 @@ pub fn set_full_year_utc<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(this) = this.as_date_object() {
         if this.date_time().is_none() {
-            this.set_date_time(
-                activation.context.gc_context,
-                Some(
-                    Utc.with_ymd_and_hms(0, 1, 1, 0, 0, 0)
-                        .single()
-                        .expect("Found ambiguous epoch time when constructing Date"),
-                ),
-            );
+            this.set_date_time(Some(
+                Utc.with_ymd_and_hms(0, 1, 1, 0, 0, 0)
+                    .single()
+                    .expect("Found ambiguous epoch time when constructing Date"),
+            ));
         }
         let timestamp = DateAdjustment::new(activation, &Utc)
             .year(args.get(0))?

--- a/core/src/avm2/globals/flash/text/text_format.rs
+++ b/core/src/avm2/globals/flash/text/text_format.rs
@@ -34,7 +34,7 @@ pub fn set_align<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         let value = match value {
             Value::Undefined | Value::Null => {
@@ -80,7 +80,7 @@ pub fn set_block_indent<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.block_indent = match value {
             Value::Undefined | Value::Null => None,
@@ -107,11 +107,11 @@ pub fn get_bold<'gc>(
 }
 
 pub fn set_bold<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.bold = match value {
             Value::Undefined | Value::Null => None,
@@ -138,11 +138,11 @@ pub fn get_bullet<'gc>(
 }
 
 pub fn set_bullet<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.bullet = match value {
             Value::Undefined | Value::Null => None,
@@ -173,7 +173,7 @@ pub fn set_color<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.color = match value {
             Value::Undefined | Value::Null => None,
@@ -221,7 +221,7 @@ pub fn set_font<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.font = match value {
             Value::Undefined | Value::Null => None,
@@ -252,7 +252,7 @@ pub fn set_indent<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.indent = match value {
             Value::Undefined | Value::Null => None,
@@ -279,11 +279,11 @@ pub fn get_italic<'gc>(
 }
 
 pub fn set_italic<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.italic = match value {
             Value::Undefined | Value::Null => None,
@@ -310,11 +310,11 @@ pub fn get_kerning<'gc>(
 }
 
 pub fn set_kerning<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.kerning = match value {
             Value::Undefined | Value::Null => None,
@@ -345,7 +345,7 @@ pub fn set_leading<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.leading = match value {
             Value::Undefined | Value::Null => None,
@@ -376,7 +376,7 @@ pub fn set_left_margin<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.left_margin = match value {
             Value::Undefined | Value::Null => None,
@@ -407,7 +407,7 @@ pub fn set_letter_spacing<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.letter_spacing = match value {
             Value::Undefined | Value::Null => None,
@@ -438,7 +438,7 @@ pub fn set_right_margin<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.right_margin = match value {
             Value::Undefined | Value::Null => None,
@@ -469,7 +469,7 @@ pub fn set_size<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.size = match value {
             Value::Undefined | Value::Null => None,
@@ -503,7 +503,7 @@ pub fn set_tab_stops<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.tab_stops = match value {
             Value::Undefined | Value::Null => None,
@@ -547,7 +547,7 @@ pub fn set_target<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.target = match value {
             Value::Undefined | Value::Null => None,
@@ -574,11 +574,11 @@ pub fn get_underline<'gc>(
 }
 
 pub fn set_underline<'gc>(
-    activation: &mut Activation<'_, 'gc>,
+    _activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.underline = match value {
             Value::Undefined | Value::Null => None,
@@ -608,7 +608,7 @@ pub fn set_url<'gc>(
     this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(mut text_format) = this.as_text_format_mut(activation.context.gc_context) {
+    if let Some(mut text_format) = this.as_text_format_mut() {
         let value = args.get(0).unwrap_or(&Value::Undefined);
         text_format.url = match value {
             Value::Undefined | Value::Null => None,

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -1401,7 +1401,7 @@ impl<'gc> Object<'gc> {
             Self::SoundObject(o) => WeakObject::SoundObject(SoundObjectWeak(GcCell::downgrade(o.0))),
             Self::SoundChannelObject(o) => WeakObject::SoundChannelObject(SoundChannelObjectWeak(GcCell::downgrade(o.0))),
             Self::BitmapDataObject(o) => WeakObject::BitmapDataObject(BitmapDataObjectWeak(GcCell::downgrade(o.0))),
-            Self::DateObject(o) => WeakObject::DateObject(DateObjectWeak(GcCell::downgrade(o.0))),
+            Self::DateObject(o) => WeakObject::DateObject(DateObjectWeak(Gc::downgrade(o.0))),
             Self::DictionaryObject(o) => WeakObject::DictionaryObject(DictionaryObjectWeak(GcCell::downgrade(o.0))),
             Self::QNameObject(o) => WeakObject::QNameObject(QNameObjectWeak(GcCell::downgrade(o.0))),
             Self::TextFormatObject(o) => WeakObject::TextFormatObject(TextFormatObjectWeak(GcCell::downgrade(o.0))),

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -1314,7 +1314,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     }
 
     /// Unwrap this object as a mutable text format.
-    fn as_text_format_mut(&self, _mc: &Mutation<'gc>) -> Option<RefMut<TextFormat>> {
+    fn as_text_format_mut(&self) -> Option<RefMut<TextFormat>> {
         None
     }
 
@@ -1404,7 +1404,7 @@ impl<'gc> Object<'gc> {
             Self::DateObject(o) => WeakObject::DateObject(DateObjectWeak(Gc::downgrade(o.0))),
             Self::DictionaryObject(o) => WeakObject::DictionaryObject(DictionaryObjectWeak(GcCell::downgrade(o.0))),
             Self::QNameObject(o) => WeakObject::QNameObject(QNameObjectWeak(GcCell::downgrade(o.0))),
-            Self::TextFormatObject(o) => WeakObject::TextFormatObject(TextFormatObjectWeak(GcCell::downgrade(o.0))),
+            Self::TextFormatObject(o) => WeakObject::TextFormatObject(TextFormatObjectWeak(Gc::downgrade(o.0))),
             Self::ProxyObject(o) => WeakObject::ProxyObject(ProxyObjectWeak(GcCell::downgrade(o.0))),
             Self::ErrorObject(o) => WeakObject::ErrorObject(ErrorObjectWeak(GcCell::downgrade(o.0))),
             Self::Stage3DObject(o) => WeakObject::Stage3DObject(Stage3DObjectWeak(Gc::downgrade(o.0))),

--- a/core/src/avm2/object/date_object.rs
+++ b/core/src/avm2/object/date_object.rs
@@ -5,48 +5,48 @@ use crate::avm2::value::{Hint, Value};
 use crate::avm2::Error;
 use chrono::{DateTime, Utc};
 use core::fmt;
-use gc_arena::{Collect, GcCell, GcWeakCell, Mutation};
-use std::cell::{Ref, RefMut};
+use gc_arena::barrier::unlock;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use std::cell::{Cell, Ref, RefMut};
 
 /// A class instance allocator that allocates Date objects.
 pub fn date_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class);
-
-    Ok(DateObject(GcCell::new(
-        activation.context.gc_context,
+    Ok(DateObject(Gc::new(
+        activation.gc(),
         DateObjectData {
-            base,
-            date_time: None,
+            base: RefLock::new(ScriptObjectData::new(class)),
+            date_time: Cell::new(None),
         },
     ))
     .into())
 }
 #[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
-pub struct DateObject<'gc>(pub GcCell<'gc, DateObjectData<'gc>>);
+pub struct DateObject<'gc>(pub Gc<'gc, DateObjectData<'gc>>);
 
 #[derive(Clone, Collect, Copy, Debug)]
 #[collect(no_drop)]
-pub struct DateObjectWeak<'gc>(pub GcWeakCell<'gc, DateObjectData<'gc>>);
+pub struct DateObjectWeak<'gc>(pub GcWeak<'gc, DateObjectData<'gc>>);
 
 impl fmt::Debug for DateObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DateObject")
-            .field("ptr", &self.0.as_ptr())
+            .field("ptr", &Gc::as_ptr(self.0))
             .finish()
     }
 }
 
 impl<'gc> DateObject<'gc> {
     pub fn date_time(self) -> Option<DateTime<Utc>> {
-        self.0.read().date_time
+        self.0.date_time.get()
     }
 
-    pub fn set_date_time(self, gc_context: &Mutation<'gc>, date_time: Option<DateTime<Utc>>) {
-        self.0.write(gc_context).date_time = date_time;
+    pub fn set_date_time(self, date_time: Option<DateTime<Utc>>) {
+        self.0.date_time.set(date_time);
     }
 }
 
@@ -54,23 +54,22 @@ impl<'gc> DateObject<'gc> {
 #[collect(no_drop)]
 pub struct DateObjectData<'gc> {
     /// Base script object
-    base: ScriptObjectData<'gc>,
+    base: RefLock<ScriptObjectData<'gc>>,
 
-    #[collect(require_static)]
-    date_time: Option<DateTime<Utc>>,
+    date_time: Cell<Option<DateTime<Utc>>>,
 }
 
 impl<'gc> TObject<'gc> for DateObject<'gc> {
     fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        Ref::map(self.0.read(), |read| &read.base)
+        self.0.base.borrow()
     }
 
     fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        RefMut::map(self.0.write(mc), |write| &mut write.base)
+        unlock!(Gc::write(mc, self.0), DateObjectData, base).borrow_mut()
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {
-        self.0.as_ptr() as *const ObjectPtr
+        Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
     fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {

--- a/core/src/avm2/object/textformat_object.rs
+++ b/core/src/avm2/object/textformat_object.rs
@@ -7,20 +7,20 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::html::TextFormat;
 use core::fmt;
-use gc_arena::{Collect, GcCell, GcWeakCell, Mutation};
-use std::cell::{Ref, RefMut};
+use gc_arena::barrier::unlock;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Gc, GcWeak, Mutation};
+use std::cell::{Ref, RefCell, RefMut};
 
 /// A class instance allocator that allocates TextFormat objects.
 pub fn textformat_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let base = ScriptObjectData::new(class);
-
-    Ok(TextFormatObject(GcCell::new(
-        activation.context.gc_context,
+    Ok(TextFormatObject(Gc::new(
+        activation.gc(),
         TextFormatObjectData {
-            base,
+            base: RefLock::new(ScriptObjectData::new(class)),
             text_format: Default::default(),
         },
     ))
@@ -29,16 +29,16 @@ pub fn textformat_allocator<'gc>(
 
 #[derive(Clone, Collect, Copy)]
 #[collect(no_drop)]
-pub struct TextFormatObject<'gc>(pub GcCell<'gc, TextFormatObjectData<'gc>>);
+pub struct TextFormatObject<'gc>(pub Gc<'gc, TextFormatObjectData<'gc>>);
 
 #[derive(Clone, Collect, Copy, Debug)]
 #[collect(no_drop)]
-pub struct TextFormatObjectWeak<'gc>(pub GcWeakCell<'gc, TextFormatObjectData<'gc>>);
+pub struct TextFormatObjectWeak<'gc>(pub GcWeak<'gc, TextFormatObjectData<'gc>>);
 
 impl fmt::Debug for TextFormatObject<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TextFormatObject")
-            .field("ptr", &self.0.as_ptr())
+            .field("ptr", &Gc::as_ptr(self.0))
             .finish()
     }
 }
@@ -47,10 +47,9 @@ impl fmt::Debug for TextFormatObject<'_> {
 #[collect(no_drop)]
 pub struct TextFormatObjectData<'gc> {
     /// Base script object
-    base: ScriptObjectData<'gc>,
+    base: RefLock<ScriptObjectData<'gc>>,
 
-    #[collect(require_static)]
-    text_format: TextFormat,
+    text_format: RefCell<TextFormat>,
 }
 
 impl<'gc> TextFormatObject<'gc> {
@@ -59,14 +58,16 @@ impl<'gc> TextFormatObject<'gc> {
         text_format: TextFormat,
     ) -> Result<Object<'gc>, Error<'gc>> {
         let class = activation.avm2().classes().textformat;
-        let base = ScriptObjectData::new(class);
 
-        let mut this: Object<'gc> = Self(GcCell::new(
-            activation.context.gc_context,
-            TextFormatObjectData { base, text_format },
+        let mut this: Object<'gc> = Self(Gc::new(
+            activation.gc(),
+            TextFormatObjectData {
+                base: RefLock::new(ScriptObjectData::new(class)),
+                text_format: RefCell::new(text_format),
+            },
         ))
         .into();
-        this.install_instance_slots(activation.context.gc_context);
+        this.install_instance_slots(activation.gc());
 
         Ok(this)
     }
@@ -74,15 +75,15 @@ impl<'gc> TextFormatObject<'gc> {
 
 impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
     fn base(&self) -> Ref<ScriptObjectData<'gc>> {
-        Ref::map(self.0.read(), |read| &read.base)
+        self.0.base.borrow()
     }
 
     fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
-        RefMut::map(self.0.write(mc), |write| &mut write.base)
+        unlock!(Gc::write(mc, self.0), TextFormatObjectData, base).borrow_mut()
     }
 
     fn as_ptr(&self) -> *const ObjectPtr {
-        self.0.as_ptr() as *const ObjectPtr
+        Gc::as_ptr(self.0) as *const ObjectPtr
     }
 
     fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
@@ -91,11 +92,11 @@ impl<'gc> TObject<'gc> for TextFormatObject<'gc> {
 
     /// Unwrap this object as a text format.
     fn as_text_format(&self) -> Option<Ref<TextFormat>> {
-        Some(Ref::map(self.0.read(), |d| &d.text_format))
+        Some(self.0.text_format.borrow())
     }
 
     /// Unwrap this object as a mutable text format.
-    fn as_text_format_mut(&self, mc: &Mutation<'gc>) -> Option<RefMut<TextFormat>> {
-        Some(RefMut::map(self.0.write(mc), |d| &mut d.text_format))
+    fn as_text_format_mut(&self) -> Option<RefMut<TextFormat>> {
+        Some(self.0.text_format.borrow_mut())
     }
 }

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -7,7 +7,9 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::{Multiname, Namespace};
 use core::fmt;
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::barrier::field;
+use gc_arena::lock::RefLock;
+use gc_arena::{Collect, Gc, Mutation};
 
 use super::property_map::PropertyMap;
 
@@ -57,12 +59,12 @@ struct ScopeContainer<'gc> {
 
     /// The cache of this ScopeChain. A value of None indicates that caching is disabled
     /// for this ScopeChain.
-    cache: Option<PropertyMap<'gc, Object<'gc>>>,
+    cache: Option<RefLock<PropertyMap<'gc, Object<'gc>>>>,
 }
 
 impl<'gc> ScopeContainer<'gc> {
     fn new(scopes: Vec<Scope<'gc>>) -> Self {
-        let cache = (!scopes.iter().any(|scope| scope.with)).then(PropertyMap::default);
+        let cache = (!scopes.iter().any(|scope| scope.with)).then(RefLock::default);
         Self { scopes, cache }
     }
 
@@ -91,7 +93,7 @@ impl<'gc> ScopeContainer<'gc> {
 #[derive(Collect, Clone, Copy)]
 #[collect(no_drop)]
 pub struct ScopeChain<'gc> {
-    container: Option<GcCell<'gc, ScopeContainer<'gc>>>,
+    container: Option<Gc<'gc, ScopeContainer<'gc>>>,
     domain: Domain<'gc>,
 }
 
@@ -123,10 +125,10 @@ impl<'gc> ScopeChain<'gc> {
             Some(container) => {
                 // The new ScopeChain is created by cloning the scopes of this ScopeChain,
                 // and pushing the new scopes on top of that.
-                let mut cloned = container.read().scopes.clone();
+                let mut cloned = container.scopes.clone();
                 cloned.extend_from_slice(new_scopes);
                 Self {
-                    container: Some(GcCell::new(mc, ScopeContainer::new(cloned))),
+                    container: Some(Gc::new(mc, ScopeContainer::new(cloned))),
                     domain: self.domain,
                 }
             }
@@ -134,7 +136,7 @@ impl<'gc> ScopeChain<'gc> {
                 // We are chaining on top of an empty ScopeChain, so we don't actually
                 // need to chain anything.
                 Self {
-                    container: Some(GcCell::new(mc, ScopeContainer::new(new_scopes.to_vec()))),
+                    container: Some(Gc::new(mc, ScopeContainer::new(new_scopes.to_vec()))),
                     domain: self.domain,
                 }
             }
@@ -142,13 +144,12 @@ impl<'gc> ScopeChain<'gc> {
     }
 
     pub fn get(&self, index: usize) -> Option<Scope<'gc>> {
-        self.container
-            .and_then(|container| container.read().get(index))
+        self.container.and_then(|container| container.get(index))
     }
 
     pub fn is_empty(&self) -> bool {
         self.container
-            .map(|container| container.read().is_empty())
+            .map(|container| container.is_empty())
             .unwrap_or(true)
     }
 
@@ -164,7 +165,7 @@ impl<'gc> ScopeChain<'gc> {
     ) -> Result<Option<(Option<Namespace<'gc>>, Object<'gc>)>, Error<'gc>> {
         if let Some(container) = self.container {
             // We skip the scope at depth 0 (the global scope). The global scope will be checked in a different phase.
-            for scope in container.read().scopes.iter().skip(1).rev() {
+            for scope in container.scopes.iter().skip(1).rev() {
                 // NOTE: We are manually searching the vtable's traits so we can figure out which namespace the trait
                 // belongs to.
                 let values = scope.values();
@@ -199,25 +200,24 @@ impl<'gc> ScopeChain<'gc> {
     ) -> Result<Option<Object<'gc>>, Error<'gc>> {
         // First we check the cache of our container
         if let Some(container) = self.container {
-            if let Some(cache) = &container.read().cache {
-                let cached = cache.get_for_multiname(multiname);
-                if cached.is_some() {
-                    return Ok(cached.cloned());
+            if let Some(cache) = &container.cache {
+                if let Some(cached) = cache.borrow().get_for_multiname(multiname) {
+                    return Ok(Some(*cached));
                 }
             }
         }
         let found = self.find_internal(multiname, activation)?;
         if let (Some((Some(ns), obj)), Some(container)) = (found, self.container) {
             // We found a value that hasn't been cached yet, so let's try to cache it now
-            let mut write = container.write(activation.context.gc_context);
-            if let Some(ref mut cache) = write.cache {
-                cache.insert_with_namespace(
-                    ns,
-                    multiname
-                        .local_name()
-                        .expect("Resolvable multinames should always have a local name"),
-                    obj,
-                );
+            let cache = field!(Gc::write(activation.gc(), container), ScopeContainer, cache);
+            if let Some(cache) = cache.as_write() {
+                let name = multiname
+                    .local_name()
+                    .expect("Resolvable multinames should always have a local name");
+                cache
+                    .unlock()
+                    .borrow_mut()
+                    .insert_with_namespace(ns, name, obj);
             }
         }
         Ok(found.map(|o| o.1))

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -4,19 +4,20 @@ use crate::context::UpdateContext;
 pub use crate::display_object::{
     DisplayObject, TDisplayObject, TDisplayObjectContainer, TextSelection,
 };
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::lock::GcLock;
+use gc_arena::{Collect, Mutation};
 
 #[derive(Clone, Copy, Collect)]
 #[collect(no_drop)]
-pub struct FocusTracker<'gc>(GcCell<'gc, Option<DisplayObject<'gc>>>);
+pub struct FocusTracker<'gc>(GcLock<'gc, Option<DisplayObject<'gc>>>);
 
 impl<'gc> FocusTracker<'gc> {
-    pub fn new(gc_context: &Mutation<'gc>) -> Self {
-        Self(GcCell::new(gc_context, None))
+    pub fn new(mc: &Mutation<'gc>) -> Self {
+        Self(GcLock::new(mc, None.into()))
     }
 
     pub fn get(&self) -> Option<DisplayObject<'gc>> {
-        *self.0.read()
+        self.0.get()
     }
 
     pub fn set(
@@ -24,20 +25,17 @@ impl<'gc> FocusTracker<'gc> {
         focused_element: Option<DisplayObject<'gc>>,
         context: &mut UpdateContext<'_, 'gc>,
     ) {
-        let old = std::mem::replace(&mut *self.0.write(context.gc_context), focused_element);
+        let old = self.0.get();
 
-        if old.is_none() && focused_element.is_none() {
-            // We didn't have anything, we still don't, no change.
-            return;
-        }
-        if !(old.is_some() == focused_element.is_some()
-            && old.unwrap().as_ptr() == focused_element.unwrap().as_ptr())
-        {
+        // Check if the focused element changed.
+        if old.map(|o| o.as_ptr()) != focused_element.map(|o| o.as_ptr()) {
+            self.0.set(context.gc(), focused_element);
+
             if let Some(old) = old {
-                old.on_focus_changed(context.gc_context, false);
+                old.on_focus_changed(context.gc(), false);
             }
             if let Some(new) = focused_element {
-                new.on_focus_changed(context.gc_context, true);
+                new.on_focus_changed(context.gc(), true);
             }
 
             tracing::info!("Focus is now on {:?}", focused_element);
@@ -61,10 +59,8 @@ impl<'gc> FocusTracker<'gc> {
             if text_field.is_editable() {
                 if !text_field.movie().is_action_script_3() {
                     let length = text_field.text_length();
-                    text_field.set_selection(
-                        Some(TextSelection::for_range(0, length)),
-                        context.gc_context,
-                    );
+                    text_field
+                        .set_selection(Some(TextSelection::for_range(0, length)), context.gc());
                 }
                 context.ui.open_virtual_keyboard();
             }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -47,7 +47,7 @@ use crate::stub::StubCollection;
 use crate::tag_utils::SwfMovie;
 use crate::timer::Timers;
 use crate::vminterface::Instantiator;
-use gc_arena::{ArenaParameters, Collect, DynamicRootSet, GcCell, Rootable};
+use gc_arena::{Collect, DynamicRootSet, GcCell, Rootable};
 use instant::Instant;
 use rand::{rngs::SmallRng, SeedableRng};
 use ruffle_render::backend::{null::NullRenderer, RenderBackend, ViewportDimensions};
@@ -2513,19 +2513,16 @@ impl PlayerBuilder {
                 debug_ui: Default::default(),
 
                 // GC data
-                gc_arena: Rc::new(RefCell::new(GcArena::new(
-                    ArenaParameters::default(),
-                    |gc_context| {
-                        Self::create_gc_root(
-                            gc_context,
-                            player_version,
-                            self.fullscreen,
-                            fake_movie.clone(),
-                            self.external_interface_providers,
-                            self.fs_command_provider,
-                        )
-                    },
-                ))),
+                gc_arena: Rc::new(RefCell::new(GcArena::new(|gc_context| {
+                    Self::create_gc_root(
+                        gc_context,
+                        player_version,
+                        self.fullscreen,
+                        fake_movie.clone(),
+                        self.external_interface_providers,
+                        self.fs_command_provider,
+                    )
+                }))),
             })
         });
 

--- a/ruffle_gc_arena/Cargo.toml
+++ b/ruffle_gc_arena/Cargo.toml
@@ -9,4 +9,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "ad3e24f89c78d8bb94db18383987290f88e4edcb" }
+gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "efd89fc683c6bb456af3e226c33763cb822645e9" }


### PR DESCRIPTION
Some progress towards fully getting rid of the `GcCell` shim (and the `ruffle_gc_arena` façade crate).

Every commit is independent and could be split into its own separate PR, but the changes are straightforward enough that I don't think this is necessary.