### PR TITLE
extension: Persist content script registration across sessions

### DIFF
--- a/web/packages/extension/src/background.ts
+++ b/web/packages/extension/src/background.ts
@@ -14,7 +14,7 @@ async function enable() {
             {
                 id: "plugin-polyfill",
                 js: ["dist/pluginPolyfill.js"],
-                persistAcrossSessions: false,
+                persistAcrossSessions: true,
                 matches: ["<all_urls>"],
                 excludeMatches: [
                     "https://sso.godaddy.com/*",


### PR DESCRIPTION
It turns out that extension service workers are inactive when Chrome starts and only wake up when they receive an event.

This fixes the plugin polyfill not running on sites after Chrome is restarted until the service worker is woken up by an event. http://www.g2conline.org/ is a good site to test this on.