### PR TITLE
web: Don't try to enter fullscreen if already in fullscreen & vice versa

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -875,7 +875,7 @@ export class RufflePlayer extends HTMLElement {
      * @param isFull Whether to set to fullscreen or return to normal.
      */
     setFullscreen(isFull: boolean): void {
-        if (this.fullscreenEnabled) {
+        if (this.fullscreenEnabled && isFull !== this.isFullscreen) {
             if (isFull) {
                 this.enterFullscreen();
             } else {


### PR DESCRIPTION
Fixes #9615. Thanks to @Toad06 for suggesting the fix.

This problem was getting annoying when testing the web demo locally.