### PR TITLE
ci: Fix paths filter

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -15,20 +15,23 @@ jobs:
     name: Paths filter
     runs-on: ubuntu-22.04
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      should_run: ${{ steps.filter.outputs.src }}
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dorny/paths-filter@v2
+      - uses: AurorNZ/paths-filter@v3
         id: filter
         with:
           filters: |
             src:
-              - '!(web/package.json|web/package-lock.json|web/packages/**|**.md)'
+              - '!web/package.json'
+              - '!web/package-lock.json'
+              - '!web/packages/**'
+              - '!**/*.md'
 
   build:
     needs: changes
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.should_run== 'true'
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
@@ -91,7 +94,7 @@ jobs:
 
   check-required:
     needs: changes
-    if: needs.changes.outputs.src == 'false'
+    if: needs.changes.outputs.should_run == 'false'
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -15,20 +15,20 @@ jobs:
     name: Paths filter
     runs-on: ubuntu-22.04
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      should_run: ${{ steps.filter.outputs.src }}
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dorny/paths-filter@v2
+      - uses: AurorNZ/paths-filter@v3
         id: filter
         with:
           filters: |
             src:
-              - '!**.md'
+              - '!**/*.md'
 
   build:
     needs: changes
-    if: needs.changes.outputs.src == 'true'
+    if: needs.changes.outputs.should_run == 'true'
     name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.rust_version == 'nightly' }}
@@ -99,7 +99,7 @@ jobs:
 
   check-required:
     needs: changes
-    if: needs.changes.outputs.src == 'false'
+    if: needs.changes.outputs.should_run == 'false'
     name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
- The `|` glob operator does not actually work. As a workaround, switch to a fork of the paths-filter action that supports multiple exclude rules. (`dorny/paths-filter` does allow you to specify multiple exclude rules, but it matches *any* of them instead of *all* of them, which is useless for us.)
- Our exclude rule for markdown files was wrong - it only matched files in the top-level directory. Correct the rule to also match markdown files in subdirectories.

For more context, see:
- https://github.com/dorny/paths-filter/issues/135
- #5103
- #5212
- #5332