### PR TITLE
tests: Exclude WARP from running the acid_gradient_1 visual test ported from Shumway

### DIFF
--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_gradient_1/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_gradient_1/test.toml
@@ -6,4 +6,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }


### PR DESCRIPTION
Keeping on fighting the little fires around Windows CI.