### PR TITLE
wgpu: Bail out early when trying to set empty program constants

### DIFF
--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -925,6 +925,9 @@ impl Context3D for WgpuContext3D {
                 first_register,
                 matrix_raw_data_column_major,
             } => {
+                if matrix_raw_data_column_major.is_empty() {
+                    return;
+                }
                 let buffer = match program_type {
                     ProgramType::Vertex => &self.current_pipeline.vertex_shader_uniforms,
                     ProgramType::Fragment => &self.current_pipeline.fragment_shader_uniforms,


### PR DESCRIPTION
There's nothing to do in this case, and we want to avoid trying to construct a `NonZeroU64` for the size.

Progresses https://github.com/ruffle-rs/ruffle/issues/12364