### PR TITLE
naga-pixelbender: Stub out Opcode::Loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,6 +2901,7 @@ dependencies = [
  "naga",
  "naga_oil",
  "ruffle_render",
+ "tracing",
 ]
 
 [[package]]

--- a/render/naga-pixelbender/Cargo.toml
+++ b/render/naga-pixelbender/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 ruffle_render = { path = "../" }
 naga = { workspace = true }
 naga_oil = { workspace = true }
+tracing = { workspace = true }
 anyhow = "1.0.75"
 bitflags = "2.4.0"
 

--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -1484,7 +1484,10 @@ impl<'a> ShaderBuilder<'a> {
                         }
                     }
                 }
-                _ => unimplemented!("Operation {op:?} not yet implemented"),
+                Operation::Loop { unknown } => {
+                    tracing::warn!("Unimplemented Loop opcode with data: {unknown:?}")
+                }
+                Operation::Nop => {}
             }
         }
         Ok(())

--- a/render/src/pixel_bender.rs
+++ b/render/src/pixel_bender.rs
@@ -244,6 +244,9 @@ pub enum Operation {
     },
     Else,
     EndIf,
+    Loop {
+        unknown: Box<[u8]>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -563,6 +566,13 @@ fn read_op<R: Read>(
                 }),
                 _ => unreachable!(),
             }
+        }
+        Opcode::Loop => {
+            let mut unknown = vec![0u8; 23];
+            data.read_exact(&mut unknown)?;
+            shader.operations.push(Operation::Loop {
+                unknown: unknown.into(),
+            });
         }
         _ => {
             let dst = data.read_u16::<LittleEndian>()?;


### PR DESCRIPTION
Some experimentation with Pixel Bender Studio shows that Opcode::Loop has a 23-byte payload. I haven't tried to figure out how to interpet the payload yet, but we can now skip over the opcode instead of bailing out entirely.