### PR TITLE
avm2: Log an error when a symbol class lookup fails

### DIFF
--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -917,7 +917,7 @@ impl<'gc> MovieClip<'gc> {
                         }
                     }
                 }
-                Err(e) => tracing::warn!(
+                Err(e) => tracing::error!(
                     "Got AVM2 error {:?} when attempting to assign symbol class {}",
                     e,
                     class_name


### PR DESCRIPTION
This is almost guaranteed to cause problems, so it shouldn't be a warning.