### PR TITLE
wgpu: Disable Context3D.setRenderToTexture MSAA on web

### DIFF
--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -751,6 +751,18 @@ impl Context3D for WgpuContext3D {
                 if sample_count == 0 {
                     sample_count = 1;
                 }
+                #[cfg(target_family = "wasm")]
+                {
+                    if sample_count > 1
+                        && matches!(
+                            self.descriptors.adapter.get_info().backend,
+                            wgpu::Backend::Gl
+                        )
+                    {
+                        tracing::warn!("Context.setRenderToTexture with antiAlias > 1 is not yet supported on WebGL");
+                        sample_count = 1;
+                    }
+                }
 
                 let texture_wrapper = texture.as_any().downcast_ref::<TextureWrapper>().unwrap();
                 self.current_texture_size = Some(Extent3d {


### PR DESCRIPTION
This is not supported under webgl, and results in a panic "Tex storage 2D multisample is not supported" if we try to do it.