### PR TITLE
tests: Exclude WARP from running acid_large, and allow acid_image and acid_gradient_* again

### DIFF
--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_gradient_1/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_gradient_1/test.toml
@@ -6,4 +6,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_gradient_2/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_gradient_2/test.toml
@@ -6,4 +6,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_image/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_image/test.toml
@@ -6,4 +6,4 @@ num_frames = 10
 tolerance = 11
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_large/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_large/test.toml
@@ -6,4 +6,4 @@ num_frames = 500
 tolerance = 11
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }


### PR DESCRIPTION
The little fires around flaky Windows CI might have made a :clown_face: of us, never being where we thought they were...
This reverts #12661, #12853, and #12970.

_Also, test systems that don't flush the test case name to stdout before doing anything with it are hella mid. /s_