### PR TITLE
web: Fix 100% height when that equals 0

### DIFF
--- a/web/packages/selfhosted/test/polyfill/percent-height-when-zero/expected.html
+++ b/web/packages/selfhosted/test/polyfill/percent-height-when-zero/expected.html
@@ -1,0 +1,1 @@
+<div id="result_1">200</div><div id="result_2">0</div><div id="result_3">50</div><div id="result_4">200</div><div id="result_5">50</div><div id="result_6">0</div>

--- a/web/packages/selfhosted/test/polyfill/percent-height-when-zero/index.html
+++ b/web/packages/selfhosted/test/polyfill/percent-height-when-zero/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PERCENT-BASED-HEIGHT</title>
+</head>
+<body>
+  <div style="height: 0px;">
+    <div>
+      <embed id="content_1" width="100%" height="100%" src="/test_assets/example.swf"></embed>
+    </div>
+  </div>
+  <div style="height: 0px;">
+    <embed id="content_2" width="100%" height="100%" src="/test_assets/example.swf"></embed>
+  </div>
+  <div style="height: 50px;">
+    <embed id="content_3" width="100%" height="100%" src="/test_assets/example.swf"></embed>
+  </div>
+  <embed id="content_4" width="100%" height="100%" src="/test_assets/example.swf"></embed>
+  <embed id="content_5" width="100%" height="50px" src="/test_assets/example.swf"></embed>
+  <embed id="content_6" width="100%" height="0px" src="/test_assets/example.swf"></embed>
+  <div id="result"></div>
+  <script>
+  function writeResult(res, index) {
+    const resultDiv = document.createElement("div");
+    resultDiv.textContent = res;
+    resultDiv.id = "result_" + index;
+    const result = document.getElementById("result");
+    for (let i = index + 1; i <= 6; i++) {
+      const nextResult = document.getElementById("result_" + i);
+      if (nextResult) {
+        result.insertBefore(resultDiv, nextResult);
+        return;
+      }
+    }
+    result.appendChild(resultDiv);
+  }
+  function checkClientHeight(content) {
+    const index = parseInt(content.id.replace(/^\D+/g, ''));
+    setTimeout(() => writeResult(content.clientHeight, index), 1000);
+  }
+  document.addEventListener("DOMContentLoaded", () => {
+    const observer = new MutationObserver(function (mutationsList) {
+      for (const mutation of mutationsList) {
+        if (mutation && mutation.addedNodes && mutation.addedNodes.length > 0) {
+          const node = mutation.addedNodes[0];
+          if (node && node.nodeName === "RUFFLE-EMBED") {
+            node.addEventListener("loadeddata", () => checkClientHeight(node));
+          }
+        }
+      }
+    });
+    observer.observe(document, { childList: true, subtree: true });
+  });
+  </script>
+</body>
+</html>

--- a/web/packages/selfhosted/test/polyfill/percent-height-when-zero/test.js
+++ b/web/packages/selfhosted/test/polyfill/percent-height-when-zero/test.js
@@ -1,0 +1,25 @@
+const { openTest, injectRuffleAndWait } = require("../../utils");
+const { expect, use } = require("chai");
+const chaiHtml = require("chai-html");
+const fs = require("fs");
+
+use(chaiHtml);
+
+describe("Get correct sizes for Flash embeds with percent-based heights", () => {
+    it("loads the test", async () => {
+        await openTest(browser, __dirname);
+    });
+
+    it("is the correct height", async () => {
+        await injectRuffleAndWait(browser);
+        await browser.$("#result_1").waitForExist();
+        await browser.$("#result_2").waitForExist();
+        await browser.$("#result_3").waitForExist();
+        await browser.$("#result_4").waitForExist();
+        await browser.$("#result_5").waitForExist();
+        await browser.$("#result_6").waitForExist();
+        const actual = await browser.$("#result").getHTML(false);
+        const expected = fs.readFileSync(`${__dirname}/expected.html`, "utf8");
+        expect(actual).html.to.equal(expected);
+    });
+});


### PR DESCRIPTION
`200px` is what it is on Pale Moon. Other browsers may vary.

Main Test (200px height) :
```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <title>Ruffle</title>
</head>
<body>
  <embed width="100%" height="100%" src="https://cdn.jsdelivr.net/gh/ruffle-rs/demo/logo-anim.swf"></embed>
</body>
</html>
```

Other tests:

50px height:
```html
<embed width="100%" height="50px" src="https://cdn.jsdelivr.net/gh/ruffle-rs/demo/logo-anim.swf"></embed>
```
0px height:
```html
<embed width="100%" height="0px" src="https://cdn.jsdelivr.net/gh/ruffle-rs/demo/logo-anim.swf"></embed>
```
0px height:
```html
<body style="height: 0px">
  <embed width="100%" height="100%" src="https://cdn.jsdelivr.net/gh/ruffle-rs/demo/logo-anim.swf"></embed>
</body>
```
50px height:
```html
<body style="height: 50px">
  <embed width="100%" height="100%" src="https://cdn.jsdelivr.net/gh/ruffle-rs/demo/logo-anim.swf"></embed>
</body>
```
200px height:
```html
<body style="height: 0px">
  <div>
    <embed width="100%" height="100%" src="https://cdn.jsdelivr.net/gh/ruffle-rs/demo/logo-anim.swf"></embed>
  </div>
</body>
```

Test on Flash browser

[Screencast from 2023-09-08 15-54-25.webm](https://github.com/ruffle-rs/ruffle/assets/29206584/b85ba861-ba6c-48b6-b33e-098a45d6affd)

Test using this PR:

[Screencast from 2023-09-08 15-55-28.webm](https://github.com/ruffle-rs/ruffle/assets/29206584/57eb64de-9238-4edd-8a6a-826a634a7081)

