### PR TITLE
CI: Lighter ci on windows and mac

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -65,6 +65,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "desktop"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -71,6 +71,8 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Check clippy
+        # not critical on other platforms, and slows down Windows
+        if: runner.os == 'Linux'
         # Don't fail the build for clippy on nightly, since we get a lot of false-positives
         run: cargo clippy --all --all-features --tests ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
 

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -59,6 +59,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "web"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.


### PR DESCRIPTION
Should hopefully save us a couple minutes.

But yeah, we really should run less redundant tests on multiple platforms :/