### PR TITLE
web: Support for Sockets with WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-net"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "pin-project",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glow"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,8 +4247,10 @@ dependencies = [
  "base64",
  "chrono",
  "console_error_panic_hook",
+ "futures-util",
  "generational-arena",
  "getrandom",
+ "gloo-net",
  "js-sys",
  "ruffle_core",
  "ruffle_render",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -64,5 +64,5 @@ features = [
     "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element", "Event",
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
-    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window",
+    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ProgressEvent", "WebSocket", "MessageEvent", "BinaryType", "ErrorEvent", "CloseEvent",
 ]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -50,6 +50,8 @@ serde = { version = "1.0.188", features = ["derive"] }
 thiserror = "1.0"
 base64 = "0.21.4"
 async-channel = "1.9.0"
+futures-util = { version = "0.3.28", features = ["sink"] }
+gloo-net =  { version = "0.4.0", default-features = false, features = ["websocket"] }
 
 [dependencies.ruffle_core]
 path = "../core"
@@ -64,5 +66,5 @@ features = [
     "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element", "Event",
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
-    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ProgressEvent", "WebSocket", "MessageEvent", "BinaryType", "ErrorEvent", "CloseEvent",
+    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window",
 ]

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -44,5 +44,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     openUrlMode: OpenURLMode.Allow,
     allowNetworking: NetworkingAccessMode.All,
     openInNewTab: null,
-    wsProxy: [],
+    socketProxy: [],
 };

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -44,4 +44,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     openUrlMode: OpenURLMode.Allow,
     allowNetworking: NetworkingAccessMode.All,
     openInNewTab: null,
+    wsProxy: [],
 };

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -248,7 +248,7 @@ export const enum NetworkingAccessMode {
     None = "none",
 }
 
-export interface WebSocketProxy {
+export interface SocketProxy {
     host: string;
     port: number;
 
@@ -536,7 +536,7 @@ export interface BaseLoadOptions {
      */
     openInNewTab?: ((swf: URL) => void) | null;
 
-    wsProxy?: Array<WebSocketProxy>;
+    socketProxy?: Array<SocketProxy>;
 }
 
 /**

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -248,10 +248,22 @@ export const enum NetworkingAccessMode {
     None = "none",
 }
 
+/**
+ * Represents a host, port and proxyUrl. Used when a SWF file tries to use a Socket.
+ */
 export interface SocketProxy {
+    /**
+     * Host used by the SWF.
+     */
     host: string;
+    /**
+     * Port used by the SWF.
+     */
     port: number;
 
+    /**
+     * The proxy URL to use when SWF file tries to connect to the specified host and port.
+     */
     proxyUrl: string;
 }
 
@@ -536,6 +548,18 @@ export interface BaseLoadOptions {
      */
     openInNewTab?: ((swf: URL) => void) | null;
 
+    /**
+     * An array of SocketProxy objects.
+     *
+     * When a SWF tries to establish a Socket connection, Ruffle will search for
+     * a matching SocketProxy object in this array and use it to establish a WebSocket connection,
+     * through which all communication is tunneled through.
+     *
+     * When none are found, Ruffle will fail the connection gracefully.
+     * When multiple matching SocketProxy objects exist, the first one is used.
+     *
+     * @default []
+     */
     socketProxy?: Array<SocketProxy>;
 }
 

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -248,6 +248,13 @@ export const enum NetworkingAccessMode {
     None = "none",
 }
 
+export interface WebSocketProxy {
+    host: string;
+    port: number;
+
+    proxyUrl: string;
+}
+
 /**
  * Any options used for loading a movie.
  */
@@ -528,6 +535,8 @@ export interface BaseLoadOptions {
      * @default null
      */
     openInNewTab?: ((swf: URL) => void) | null;
+
+    wsProxy?: Array<WebSocketProxy>;
 }
 
 /**

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -244,7 +244,7 @@ where
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct WebSocketProxy {
+pub struct SocketProxy {
     host: String,
     port: u16,
 
@@ -299,7 +299,7 @@ struct Config {
 
     allow_networking: NetworkingAccessMode,
 
-    ws_proxy: Vec<WebSocketProxy>,
+    socket_proxy: Vec<SocketProxy>,
 }
 
 /// Metadata about the playing SWF file to be passed back to JavaScript.
@@ -553,7 +553,7 @@ impl Ruffle {
             config.base_url,
             log_subscriber.clone(),
             config.open_url_mode,
-            config.ws_proxy,
+            config.socket_proxy,
         ));
 
         match window.local_storage() {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -244,6 +244,15 @@ where
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct WebSocketProxy {
+    host: String,
+    port: u16,
+
+    proxy_url: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Config {
     allow_script_access: bool,
 
@@ -289,6 +298,8 @@ struct Config {
     open_url_mode: OpenURLMode,
 
     allow_networking: NetworkingAccessMode,
+
+    ws_proxy: Vec<WebSocketProxy>,
 }
 
 /// Metadata about the playing SWF file to be passed back to JavaScript.
@@ -542,6 +553,7 @@ impl Ruffle {
             config.base_url,
             log_subscriber.clone(),
             config.open_url_mode,
+            config.ws_proxy,
         ));
 
         match window.local_storage() {

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -1,5 +1,5 @@
 //! Navigator backend for web
-use crate::WebSocketProxy;
+use crate::SocketProxy;
 use async_channel::Receiver;
 use futures_util::{SinkExt, StreamExt};
 use gloo_net::websocket::{futures::WebSocket, Message};
@@ -33,7 +33,7 @@ pub struct WebNavigatorBackend {
     upgrade_to_https: bool,
     base_url: Option<Url>,
     open_url_mode: OpenURLMode,
-    websocket_proxies: Vec<WebSocketProxy>,
+    socket_proxies: Vec<SocketProxy>,
 }
 
 impl WebNavigatorBackend {
@@ -44,7 +44,7 @@ impl WebNavigatorBackend {
         base_url: Option<String>,
         log_subscriber: Arc<Layered<WASMLayer, Registry>>,
         open_url_mode: OpenURLMode,
-        websocket_proxies: Vec<WebSocketProxy>,
+        socket_proxies: Vec<SocketProxy>,
     ) -> Self {
         let window = web_sys::window().expect("window()");
 
@@ -86,7 +86,7 @@ impl WebNavigatorBackend {
             base_url,
             log_subscriber,
             open_url_mode,
-            websocket_proxies,
+            socket_proxies,
         }
     }
 }
@@ -369,7 +369,6 @@ impl NavigatorBackend for WebNavigatorBackend {
     fn connect_socket(
         &mut self,
         host: String,
-
         port: u16,
         // NOTE: WebSocket does not allow specifying a timeout, so this goes unused.
         _timeout: Duration,
@@ -378,7 +377,7 @@ impl NavigatorBackend for WebNavigatorBackend {
         sender: Sender<SocketAction>,
     ) {
         let Some(proxy) = self
-            .websocket_proxies
+            .socket_proxies
             .iter()
             .find(|x| x.host == host && x.port == port)
         else {

--- a/web/src/navigator.rs
+++ b/web/src/navigator.rs
@@ -435,6 +435,11 @@ impl NavigatorBackend for WebNavigatorBackend {
                 }
             }
 
+            // Close WebSocket as the sender was dropped.
+            if let Err(e) = ws.close() {
+                tracing::error!("Failed to close WebSocket connection {:?}", e);
+            }
+
             Ok(())
         }));
     }


### PR DESCRIPTION
As WebSocket is not a normal TCP socket, it requires extra software like [`websockify`](https://github.com/novnc/websockify) on the server.

Unresolved questions:

- [ ] Make a interface so a custom socket connection method could be used (like integrated server running in web browser), but `ExternalInterface` exists so that kinda invalidates this point.
- [x] How do we determine if we use `wss` (HTTPS for WebSockets) or `ws` protocol?
- [x] An API to intercept to modify host, port, or cancel connection entirely?