### PR TITLE
core: Convert two unused doc comments to normal comments

### DIFF
--- a/core/src/avm1/globals/xml_socket.rs
+++ b/core/src/avm1/globals/xml_socket.rs
@@ -235,7 +235,7 @@ pub fn constructor<'gc>(
         activation.gc(),
         XmlSocketData {
             handle: Cell::new(None),
-            /// Default timeout is 20_000 milliseconds (20 seconds)
+            // Default timeout is 20_000 milliseconds (20 seconds)
             timeout: Cell::new(20000),
             read_buffer: RefCell::new(Vec::new()),
         },

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -155,8 +155,8 @@ impl<'gc> Font<'gc> {
                 glyphs,
                 code_point_to_glyph,
 
-                /// DefineFont3 stores coordinates at 20x the scale of DefineFont1/2.
-                /// (SWF19 p.164)
+                // DefineFont3 stores coordinates at 20x the scale of DefineFont1/2.
+                // (SWF19 p.164)
                 scale: if tag.version >= 3 { 20480.0 } else { 1024.0 },
                 kerning_pairs,
                 ascent,


### PR DESCRIPTION
This fixes Nightly warnings