### PR TITLE
avm2: Coerce value in set slot opcode

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1837,7 +1837,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value = self.pop_stack();
         let object = self.pop_stack().coerce_to_object_or_typeerror(self, None)?;
 
-        object.set_slot(index, value, self.context.gc_context)?;
+        object.set_slot(index, value, self)?;
 
         Ok(FrameControl::Continue)
     }
@@ -1858,7 +1858,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value = self.pop_stack();
 
         self.global_scope()
-            .map(|global| global.set_slot(index, value, self.context.gc_context))
+            .map(|global| global.set_slot(index, value, self))
             .transpose()?;
 
         Ok(FrameControl::Continue)

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -552,10 +552,19 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     }
 
     /// Set a slot by its index.
-    fn set_slot(self, id: u32, value: Value<'gc>, mc: &Mutation<'gc>) -> Result<(), Error<'gc>> {
-        let mut base = self.base_mut(mc);
+    fn set_slot(
+        self,
+        id: u32,
+        value: Value<'gc>,
+        activation: &mut Activation<'_, 'gc>,
+    ) -> Result<(), Error<'gc>> {
+        let value = self
+            .vtable()
+            .unwrap()
+            .coerce_trait_value(id, value, activation)?;
+        let mut base = self.base_mut(activation.gc());
 
-        base.set_slot(id, value, mc)
+        base.set_slot(id, value, activation.gc())
     }
 
     /// Initialize a slot by its index.

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversions1_23/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversions1_23/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsFalse/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsFalse/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsNaN/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsNaN/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsNeg1_23/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsNeg1_23/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsNull/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsNull/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsString/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsString/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsTrue/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsTrue/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsUndefined/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Types/Conversions/ImplicitConversionsUndefined/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This was causing a bunch of implicit conversion test failures.

This technically makes test `from_avmplus/as3/Types/Int/wraparound` pass, but only in release mode due to debug mode integer overflow checks. (Which could be fixed with a simple `wrapping_add` function call).