### PR TITLE
web: Add width, height, and type to RufflePlayer (fix #13176)

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -454,6 +454,66 @@ export class RufflePlayer extends HTMLElement {
     }
 
     /**
+     * Polyfill of height getter for HTMLEmbedElement and HTMLObjectElement
+     *
+     * @ignore
+     * @internal
+     */
+    get height(): string {
+        return this.getAttribute("height") || "";
+    }
+
+    /**
+     * Polyfill of height setter for HTMLEmbedElement and HTMLObjectElement
+     *
+     * @ignore
+     * @internal
+     */
+    set height(height: string) {
+        this.setAttribute("height", height);
+    }
+
+    /**
+     * Polyfill of width getter for HTMLEmbedElement and HTMLObjectElement
+     *
+     * @ignore
+     * @internal
+     */
+    get width(): string {
+        return this.getAttribute("width") || "";
+    }
+
+    /**
+     * Polyfill of width setter for HTMLEmbedElement and HTMLObjectElement
+     *
+     * @ignore
+     * @internal
+     */
+    set width(widthVal: string) {
+        this.setAttribute("width", widthVal);
+    }
+
+    /**
+     * Polyfill of type getter for HTMLEmbedElement and HTMLObjectElement
+     *
+     * @ignore
+     * @internal
+     */
+    get type(): string {
+        return this.getAttribute("type") || "";
+    }
+
+    /**
+     * Polyfill of type setter for HTMLEmbedElement and HTMLObjectElement
+     *
+     * @ignore
+     * @internal
+     */
+    set type(typeVal: string) {
+        this.setAttribute("type", typeVal);
+    }
+
+    /**
      * @ignore
      * @internal
      */


### PR DESCRIPTION
There are still unsupported properties listed on https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement and https://developer.mozilla.org/en-US/docs/Web/API/HTMLEmbedElement but these are the most common ones.