### PR TITLE
web: Fix Ruffle configuration not working properly for Polyfill elements and in the extension player

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -36,7 +36,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     scale: "showAll",
     forceScale: false,
     frameRate: null,
-    wmode: WindowMode.Opaque,
+    wmode: WindowMode.Window,
     publicPath: null,
     polyfills: true,
     playerVersion: null,

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -1,12 +1,10 @@
 import {
-    isBuiltInContextMenuVisible,
+    getPolyfillOptions,
     isFallbackElement,
-    isScriptAccessAllowed,
     isYoutubeFlashSource,
     RufflePlayer,
     workaroundYoutubeMixedContent,
 } from "./ruffle-player";
-import { NetworkingAccessMode, WindowMode } from "./load-options";
 import { registerElement } from "./register-element";
 import { isSwf } from "./swf-utils";
 
@@ -37,37 +35,13 @@ export class RuffleEmbed extends RufflePlayer {
         super.connectedCallback();
         const src = this.attributes.getNamedItem("src");
         if (src) {
-            const allowScriptAccess =
-                this.attributes.getNamedItem("allowScriptAccess")?.value ??
-                null;
-            const menu = this.attributes.getNamedItem("menu")?.value ?? null;
+            // Get the configuration options that have been overwritten for this movie.
+            const getOptionString = (optionName: string) =>
+                this.attributes.getNamedItem(optionName)?.value ?? null;
+            const options = getPolyfillOptions(src.value, getOptionString);
 
             // Kick off the SWF download.
-            this.load({
-                url: src.value,
-                allowScriptAccess: isScriptAccessAllowed(
-                    allowScriptAccess,
-                    src.value,
-                ),
-                parameters:
-                    this.attributes.getNamedItem("flashvars")?.value ?? null,
-                backgroundColor:
-                    this.attributes.getNamedItem("bgcolor")?.value ?? null,
-                base: this.attributes.getNamedItem("base")?.value ?? null,
-                menu: isBuiltInContextMenuVisible(menu),
-                salign: this.attributes.getNamedItem("salign")?.value ?? "",
-                quality:
-                    this.attributes.getNamedItem("quality")?.value ?? "high",
-                scale:
-                    this.attributes.getNamedItem("scale")?.value ?? "showAll",
-                wmode:
-                    (this.attributes.getNamedItem("wmode")
-                        ?.value as WindowMode) ?? WindowMode.Window,
-                allowNetworking:
-                    (this.attributes.getNamedItem("allowNetworking")
-                        ?.value as NetworkingAccessMode) ??
-                    NetworkingAccessMode.All,
-            });
+            this.load(options);
         }
     }
 
@@ -118,13 +92,10 @@ export class RuffleEmbed extends RufflePlayer {
         if (this.isConnected && name === "src") {
             const src = this.attributes.getNamedItem("src");
             if (src) {
-                this.load({
-                    url: src.value,
-                    parameters:
-                        this.attributes.getNamedItem("flashvars")?.value ??
-                        null,
-                    base: this.attributes.getNamedItem("base")?.value ?? null,
-                });
+                const getOptionString = (optionName: string) =>
+                    this.attributes.getNamedItem(optionName)?.value ?? null;
+                const options = getPolyfillOptions(src.value, getOptionString);
+                this.load(options);
             }
         }
     }

--- a/web/packages/core/src/ruffle-embed.ts
+++ b/web/packages/core/src/ruffle-embed.ts
@@ -41,7 +41,7 @@ export class RuffleEmbed extends RufflePlayer {
             const options = getPolyfillOptions(src.value, getOptionString);
 
             // Kick off the SWF download.
-            this.load(options);
+            this.load(options, true);
         }
     }
 
@@ -95,7 +95,7 @@ export class RuffleEmbed extends RufflePlayer {
                 const getOptionString = (optionName: string) =>
                     this.attributes.getNamedItem(optionName)?.value ?? null;
                 const options = getPolyfillOptions(src.value, getOptionString);
-                this.load(options);
+                this.load(options, true);
             }
         }
     }

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -111,7 +111,7 @@ export class RuffleObject extends RufflePlayer {
             const options = getPolyfillOptions(url, getOptionString);
 
             // Kick off the SWF download.
-            this.load(options);
+            this.load(options, true);
         }
     }
 

--- a/web/packages/core/src/ruffle-object.ts
+++ b/web/packages/core/src/ruffle-object.ts
@@ -1,17 +1,14 @@
 import {
-    isBuiltInContextMenuVisible,
     isFallbackElement,
-    isScriptAccessAllowed,
     isYoutubeFlashSource,
     workaroundYoutubeMixedContent,
     RufflePlayer,
+    getPolyfillOptions,
 } from "./ruffle-player";
 import { FLASH_ACTIVEX_CLASSID } from "./flash-identifiers";
 import { registerElement } from "./register-element";
-import type { URLLoadOptions, WindowMode } from "./load-options";
 import { RuffleEmbed } from "./ruffle-embed";
 import { isSwf } from "./swf-utils";
-import { NetworkingAccessMode } from "./load-options";
 
 /**
  * Find and return the first value in obj with the given key.
@@ -95,74 +92,23 @@ export class RuffleObject extends RufflePlayer {
             url = this.params["movie"];
         }
 
-        const allowScriptAccess = findCaseInsensitive(
-            this.params,
-            "allowScriptAccess",
-            null,
-        );
-
-        const parameters = findCaseInsensitive(
-            this.params,
-            "flashvars",
-            this.getAttribute("flashvars"),
-        );
-
-        const backgroundColor = findCaseInsensitive(
-            this.params,
-            "bgcolor",
-            this.getAttribute("bgcolor"),
-        );
-
-        const allowNetworking = findCaseInsensitive(
-            this.params,
-            "allowNetworking",
-            this.getAttribute("allowNetworking"),
-        );
-
-        const base = findCaseInsensitive(
-            this.params,
-            "base",
-            this.getAttribute("base"),
-        );
-
-        const menu = findCaseInsensitive(this.params, "menu", null);
-        const salign = findCaseInsensitive(this.params, "salign", "");
-        const quality = findCaseInsensitive(this.params, "quality", "high");
-        const scale = findCaseInsensitive(this.params, "scale", "showAll");
-        const wmode = findCaseInsensitive(this.params, "wmode", "window");
-
         if (url) {
-            const options: URLLoadOptions = { url };
-            options.allowScriptAccess = isScriptAccessAllowed(
-                allowScriptAccess,
-                url,
-            );
-            if (parameters) {
-                options.parameters = parameters;
-            }
-            if (backgroundColor) {
-                options.backgroundColor = backgroundColor;
-            }
-            if (base) {
-                options.base = base;
-            }
-            options.menu = isBuiltInContextMenuVisible(menu);
-            if (salign) {
-                options.salign = salign;
-            }
-            if (quality) {
-                options.quality = quality;
-            }
-            if (scale) {
-                options.scale = scale;
-            }
-            if (wmode) {
-                options.wmode = wmode as WindowMode;
-            }
-            if (allowNetworking) {
-                options.allowNetworking =
-                    allowNetworking as NetworkingAccessMode;
-            }
+            // Get the configuration options that have been overwritten for this movie.
+            const attributeCheckOptions = [
+                "allowNetworking",
+                "base",
+                "bgcolor",
+                "flashvars",
+            ];
+            const getOptionString = (optionName: string) =>
+                findCaseInsensitive(
+                    this.params,
+                    optionName,
+                    attributeCheckOptions.includes(optionName)
+                        ? this.getAttribute(optionName)
+                        : null,
+                );
+            const options = getPolyfillOptions(url, getOptionString);
 
             // Kick off the SWF download.
             this.load(options);

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -935,12 +935,15 @@ export class RufflePlayer extends HTMLElement {
      * The options, if provided, must only contain values provided for this specific movie.
      * They must not contain any default values, since those would overwrite other configuration
      * settings with a lower priority (e.g. the general RufflePlayer config).
+     * @param isPolyfillElement Whether the element is a polyfilled Flash element or not.
+     * This is used to determine a default value of the configuration.
      *
      * The options will be defaulted by the [[config]] field, which itself
      * is defaulted by a global `window.RufflePlayer.config`.
      */
     async load(
         options: string | URLLoadOptions | DataLoadOptions,
+        isPolyfillElement: boolean = false,
     ): Promise<void> {
         options = this.checkOptions(options);
 
@@ -959,6 +962,15 @@ export class RufflePlayer extends HTMLElement {
         try {
             this.loadedConfig = {
                 ...DEFAULT_CONFIG,
+                // The default allowScriptAccess value for polyfilled elements is samedomain.
+                ...(isPolyfillElement && "url" in options
+                    ? {
+                          allowScriptAccess: parseAllowScriptAccess(
+                              "samedomain",
+                              options.url,
+                          )!,
+                      }
+                    : {}),
                 ...(window.RufflePlayer?.config ?? {}),
                 ...this.config,
                 ...options,

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -98,7 +98,7 @@ function load(options) {
     player = ruffle.createPlayer();
     player.id = "player";
     main.append(player);
-    player.load(options);
+    player.load(options, false);
     player.addEventListener("loadedmetadata", function () {
         if (this.metadata) {
             for (const [key, value] of Object.entries(this.metadata)) {

--- a/web/packages/demo/www/index.js
+++ b/web/packages/demo/www/index.js
@@ -27,8 +27,10 @@ const optionGroups = {
     "Game": document.getElementById("games-optgroup"),
 };
 
-// Default config used by the player.
-const defaultConfig = {
+// This is the base config used by the demo player (except for specific SWF files
+// with their own base config).
+// It has the highest priority and its options cannot be overwritten.
+const baseDemoConfig = {
     letterbox: "on",
     logLevel: "warn",
     forceScale: true,
@@ -147,7 +149,7 @@ async function loadFile(file) {
     }
     hideSample();
     const data = await new Response(file).arrayBuffer();
-    load({ data: data, swfFileName: file.name, ...defaultConfig });
+    load({ data: data, swfFileName: file.name, ...baseDemoConfig });
 }
 
 function loadSample() {
@@ -155,7 +157,7 @@ function loadSample() {
     localFileName.textContent = "No file selected.";
     if (swfData) {
         showSample(swfData);
-        const config = swfData.config || defaultConfig;
+        const config = swfData.config || baseDemoConfig;
         load({ url: swfData.location, ...config });
     } else {
         hideSample();

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -24,8 +24,9 @@ const infoContainer = document.getElementById("info-container")!;
 const webFormSubmit = document.getElementById("web-form-submit")!;
 const webURL = document.getElementById("web-url")! as HTMLInputElement;
 
-// Default config used by the player.
-const defaultConfig = {
+// This is the base config always used by the extension player.
+// It has the highest priority and its options cannot be overwritten.
+const baseExtensionConfig = {
     letterbox: "on" as Letterbox,
     forceScale: true,
     forceAlign: true,
@@ -131,7 +132,7 @@ async function loadFile(file: File | undefined) {
         localFileName.textContent = file.name;
     }
     const data = await new Response(file).arrayBuffer();
-    load({ data: data, swfFileName: file.name, ...defaultConfig });
+    load({ data: data, swfFileName: file.name, ...baseExtensionConfig });
     history.pushState("", document.title, window.location.pathname);
 }
 
@@ -231,7 +232,7 @@ async function loadSwf(swfUrl: string) {
         ...options,
         url: swfUrl,
         base: swfUrl.substring(0, swfUrl.lastIndexOf("/") + 1),
-        ...defaultConfig,
+        ...baseExtensionConfig,
     });
 }
 

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -132,7 +132,13 @@ async function loadFile(file: File | undefined) {
         localFileName.textContent = file.name;
     }
     const data = await new Response(file).arrayBuffer();
-    load({ data: data, swfFileName: file.name, ...baseExtensionConfig });
+    const options = await utils.getExplicitOptions();
+    load({
+        ...options,
+        data: data,
+        swfFileName: file.name,
+        ...baseExtensionConfig,
+    });
     history.pushState("", document.title, window.location.pathname);
 }
 

--- a/web/packages/extension/src/player.ts
+++ b/web/packages/extension/src/player.ts
@@ -94,7 +94,7 @@ function load(options: string | DataLoadOptions | URLLoadOptions) {
     player = ruffle.createPlayer();
     player.id = "player";
     playerContainer.append(player);
-    player.load(options);
+    player.load(options, false);
     player.addEventListener("loadedmetadata", () => {
         if (player.metadata) {
             for (const [key, value] of Object.entries(player.metadata)) {


### PR DESCRIPTION
The Ruffle configuration options are currently not working properly for polyfilled elements. This pull request fixes that.

A polyfilled element can have specific configuration options which overwrite the more general Ruffle configuration settings (e.g. the general Ruffle config).
There are several places (`RuffleEmbed::connectedCallback`, `RuffleEmbed::attributeChangedCallback` and `RuffleObject::connectedCallback`) which handle the config options given to a polyfilled element and load an SWF file each.
A new `getPolyfillOptions` function has been created and returns a `URLLoadOptions` object, containing only the options that have been set for the respective element. It is now used in all of these places, reducing duplicated code between these methods.
This fixes the following bugs:

- **`RuffleEmbed::connectedCallback`**
All properties that can be set for a specific element are currently set to default values if they aren't provided, therefore overwriting the more general configuration settings.
This essentially means that **the general Ruffle configuration has no effect on polyfilled elements loaded this way**, since all options have already been set to a provided or a default value in the element config, overwriting the general configuration.
Even worse, while for most of the options, the default value the element options are set to equals the (documented) configuration default value, it diverges for `allowScriptAccess`. The documented main configuration default value is `false`, but `RuffleEmbed::connectedCallback` currently sets it to `true` if the SWF file has the same domain as the player website.
This means that **polyfilled SWF files loaded this way can access JavaScript code on the website, even if this is explicitely prohibited in the main Ruffle configuration**. This might cause potential security vulnerabilities.
- **`RuffleEmbed::attributeChangedCallback`**
Currently, `RuffleEmbed::attributeChangedCallback` is loading SWF files only with the parameters and base options. All other options given to a polyfilled element are ignored and not set in the player.
Similarly to `RuffleEmbed::connectedCallback`, those options are also set to a default value if they're not provided, making the general Ruffle config not apply in this case.
- **`RuffleObject::connectedCallback`**
As in `RuffleEmbed::connectedCallback`, the properties `quality`, `scale`, `wmode`, `menu` and `allowScriptAccess` are currently set to default values if they aren't provided. Again, this causes the general Ruffle configuration to have no effect on these options on polyfilled elements loaded this way.
Like in `RuffleEmbed::connectedCallback`, the default value `allowScriptAccess` is set to in the element config in this case is `true` if the SWF file has the same domain as the player website, also causing the same potential security vulnerabilities if the SWF file is loaded like this.
Additionally, if an option is set to `""` for a polyfilled element loaded this way, it's ignored in most cases (to be specific for the options `parameters`, `backgroundColor`, `base`, `salign`, `quality`, `scale`, `wmode` and `allowNetworking`).
This is especially relevant for `salign` because `""` is a valid configuration setting. So if the configuration element is set to something different in the general Ruffle config but overwritten to `""` for a specific polyfilled element, that element config setting is ignored.

Documentation has been added to clarify that these element configuration options must not contain any default values, since those would overwrite other configuration settings with a lower priority.


Other changes by this pull request:
- The Ruffle extension player is currently not using the extension configuration settings when loading local SWF files. This pull request fixes that.
- This pull request sets the default `WindowMode` value of the default Ruffle web config to `Window` (as it is in the desktop version and according to the documentation). It is currently set to `Opaque` (which causes the same functionality).
- The extension and demo code has been changed to clarify that no default values are contained in the element configuration options.

~~Note that this changes the default behaviour in one way: As described, `allowScriptAccess` is currently set to `true` for all polyfilled elements if the respective SWF file has the same domain as the player website. This is different to how `allowScriptAccess` is documented and how it will be with this pull request: The default value for `allowScriptAccess` being `false` if not overwritten in any configuration. While the current behaviour is different to the documentation, changing it might break websites which depend on script access but haven't overwritten the config option.~~
Edit: The default value of `allowScriptAccess` for all polyfilled elements is now samedomain (meaning `true` if the SWF file and the player page have the same domain and `false` otherwise). As this is currently not documented, I'll edit the Using Ruffle wiki entry to clarify this after this pull request gets merged.