### PR TITLE
web: Add support for compiling WebGPU-enabled wasm module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,6 @@ inherits = "release"
 
 [profile.web-wasm-extensions]
 inherits = "release"
+
+[profile.web-wasm-webgpu]
+inherits = "release"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -13,7 +13,7 @@ publish = false # This crate is useless alone, people should use the npm package
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["canvas", "console_error_panic_hook", "webgl", "wgpu-webgl"]
+default = ["canvas", "console_error_panic_hook", "webgl"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]

--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
         "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
+        "build:tri-webgpu": "cross-env ENABLE_WASM_WEBGPU=true ENABLE_WASM_EXTENSIONS=true npm run build",
         "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_CARGO_CLEAN=true ENABLE_VERSION_SEAL=true npm run build",
         "demo": "npm start --workspace ruffle-demo",
         "test": "npm test --workspaces --if-present",


### PR DESCRIPTION
With this PR, I've able to play 'This is the only level too' in the latest Chrome dev build using WebGPU.

This adds a third wasm module `ruffle_web-wasm_webgpu_bg.wasm`, which uses the `webgpu` backend in the `wgpu` crate. It's always built with extensions enabled (since any browser that supports WebGPU also supports the needed wasm extensions).

This backend is not built by default - you need to run `npm run build:tri-webgpu` to build it. Additionally, `load-ruffle.ts` contains the code to try to fetch this module, but enabling it requires modifiying `const ALLOW_WEBGPU: true;` locally.

The purpose of this is to add the infrastructure needed for trying out WebGPU locally. For now, it should be invisible to end users - we don't build the new wasm module as part of our release process, and we'll never attempt to fetch it.

In addition to the `const ALLOW_WEBGPU` gating and actual browser WebGPU support, this requires the experimental wasm `type-reflection` and `jspi` features. Neither of these make any changes to the wasm bytecode - instead, they allow using Javascript Promise Integration (https://v8.dev/blog/jspi). This will allow the browser to suspend the exectuion of our module when we call `GPUBuffer.mapAsync` - that is, making it appear as a synchronous call from the perspective of Rust. This will allow us to implement `BitmapData.draw` under WebGPU.

Actually getting `GPUBuffer.mapAsync` to work for us will require several other changes, both in `wasm-bindgen` (to set up the necessary JSPI integration from the Javascript side) and `wgpu` (to give us access to the underlying `GPUBuffer`, or to use JSPI for us).