### PR TITLE
core: Font refactoring to allow backends to provide device fonts

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -79,6 +79,7 @@ known_stubs = ["linkme"]
 default_compatibility_rules = []
 egui = ["dep:egui", "dep:egui_extras", "png"]
 jpegxr = ["dep:jpegxr"]
+default_font = []
 
 [build-dependencies]
 build_playerglobal = { path = "build_playerglobal" }

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -790,11 +790,12 @@ impl Default for TextRenderSettings {
 #[cfg(test)]
 mod tests {
     use crate::font::{EvalParameters, Font};
-    use crate::player::FALLBACK_DEVICE_FONT_TAG;
     use crate::string::WStr;
     use gc_arena::{rootless_arena, Mutation};
     use ruffle_render::backend::{null::NullRenderer, ViewportDimensions};
     use swf::Twips;
+
+    const DEVICE_FONT_TAG: &[u8] = include_bytes!("../assets/noto-sans-definefont3.bin");
 
     fn with_device_font<F>(callback: F)
     where
@@ -806,7 +807,7 @@ mod tests {
                 height: 0,
                 scale_factor: 1.0,
             });
-            let mut reader = swf::read::Reader::new(FALLBACK_DEVICE_FONT_TAG, 8);
+            let mut reader = swf::read::Reader::new(DEVICE_FONT_TAG, 8);
             let device_font = Font::from_swf_tag(
                 mc,
                 &mut renderer,

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -778,7 +778,7 @@ impl Default for TextRenderSettings {
 #[cfg(test)]
 mod tests {
     use crate::font::{EvalParameters, Font};
-    use crate::player::Player;
+    use crate::player::FALLBACK_DEVICE_FONT_TAG;
     use crate::string::WStr;
     use gc_arena::{rootless_arena, Mutation};
     use ruffle_render::backend::{null::NullRenderer, ViewportDimensions};
@@ -794,7 +794,15 @@ mod tests {
                 height: 0,
                 scale_factor: 1.0,
             });
-            let device_font = Player::load_device_font(mc, &mut renderer);
+            let mut reader = swf::read::Reader::new(FALLBACK_DEVICE_FONT_TAG, 8);
+            let device_font = Font::from_swf_tag(
+                mc,
+                &mut renderer,
+                reader
+                    .read_define_font_2(3)
+                    .expect("Built-in font should compile"),
+                reader.encoding(),
+            );
 
             callback(mc, device_font);
         })

--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -10,6 +10,18 @@ use std::cmp::max;
 
 pub use swf::TextGridFit;
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum DefaultFont {
+    /// `_sans`, a Sans-Serif font (similar to Helvetica or Arial)
+    Sans,
+
+    /// `_serif`, a Serif font (similar to Times Roman)
+    Serif,
+
+    /// `_typewriter`, a Monospace font (similar to Courier)
+    Typewriter,
+}
+
 /// Certain Flash routines measure text by rounding down to the nearest whole pixel.
 pub fn round_down_to_pixel(t: Twips) -> Twips {
     Twips::from_pixels(t.to_pixels().floor())

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -477,7 +477,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             }
         }
 
-        if let Some(font) = context.library.load_device_font(
+        if let Some(font) = context.library.get_or_load_device_font(
             &font_name,
             context.ui,
             context.renderer,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,6 +62,7 @@ pub mod stub;
 pub use avm1::globals::system::SandboxType;
 pub use context_menu::ContextMenuItem;
 pub use events::PlayerEvent;
+pub use font::DefaultFont;
 pub use indexmap;
 pub use loader::LoadBehavior;
 pub use player::{Player, PlayerBuilder, StaticCallstack};

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -468,7 +468,7 @@ impl<'gc> Library<'gc> {
 
         let mut result = vec![];
         for name in self.default_font_names.entry(name).or_default().clone() {
-            if let Some(font) = self.load_device_font(&name, ui, renderer, gc_context) {
+            if let Some(font) = self.get_or_load_device_font(&name, ui, renderer, gc_context) {
                 result.push(font);
             }
         }
@@ -478,7 +478,7 @@ impl<'gc> Library<'gc> {
     }
 
     /// Returns the device font for use when a font is unavailable.
-    pub fn load_device_font(
+    pub fn get_or_load_device_font(
         &mut self,
         name: &str,
         ui: &dyn UiBackend,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -68,6 +68,8 @@ use tracing::{info, instrument};
 /// `player_version`.
 pub const NEWEST_PLAYER_VERSION: u8 = 32;
 
+pub const FALLBACK_DEVICE_FONT_TAG: &[u8] = include_bytes!("../assets/noto-sans-definefont3.bin");
+
 #[derive(Collect)]
 #[collect(no_drop)]
 struct GcRoot<'gc> {
@@ -1977,8 +1979,7 @@ impl Player {
         gc_context: &'gc gc_arena::Mutation<'gc>,
         renderer: &mut dyn RenderBackend,
     ) -> Font<'gc> {
-        const DEVICE_FONT_TAG: &[u8] = include_bytes!("../assets/noto-sans-definefont3.bin");
-        let mut reader = swf::read::Reader::new(DEVICE_FONT_TAG, 8);
+        let mut reader = swf::read::Reader::new(FALLBACK_DEVICE_FONT_TAG, 8);
         Font::from_swf_tag(
             gc_context,
             renderer,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -69,6 +69,7 @@ use tracing::{info, instrument};
 /// `player_version`.
 pub const NEWEST_PLAYER_VERSION: u8 = 32;
 
+#[cfg(feature = "default_font")]
 pub const FALLBACK_DEVICE_FONT_TAG: &[u8] = include_bytes!("../assets/noto-sans-definefont3.bin");
 
 #[derive(Collect)]
@@ -2531,15 +2532,18 @@ impl PlayerBuilder {
         // Finalize configuration and load the movie.
         let mut player_lock = player.lock().unwrap();
 
-        // TODO: This should be done by the frontend... probably?
-        let mut font_reader = swf::read::Reader::new(FALLBACK_DEVICE_FONT_TAG, 8);
-        let font_tag = font_reader
-            .read_define_font_2(3)
-            .expect("Built-in font should compile");
-        player_lock.register_device_font(FontDefinition::SwfTag(font_tag, font_reader.encoding()));
-        player_lock.set_default_font(DefaultFont::Sans, vec!["Noto Sans".to_string()]);
-        player_lock.set_default_font(DefaultFont::Serif, vec!["Noto Sans".to_string()]);
-        player_lock.set_default_font(DefaultFont::Typewriter, vec!["Noto Sans".to_string()]);
+        #[cfg(feature = "default_font")]
+        {
+            let mut font_reader = swf::read::Reader::new(FALLBACK_DEVICE_FONT_TAG, 8);
+            let font_tag = font_reader
+                .read_define_font_2(3)
+                .expect("Built-in font should compile");
+            player_lock
+                .register_device_font(FontDefinition::SwfTag(font_tag, font_reader.encoding()));
+            player_lock.set_default_font(DefaultFont::Sans, vec!["Noto Sans".to_string()]);
+            player_lock.set_default_font(DefaultFont::Serif, vec!["Noto Sans".to_string()]);
+            player_lock.set_default_font(DefaultFont::Typewriter, vec!["Noto Sans".to_string()]);
+        }
 
         player_lock.mutate_with_update_context(|context| {
             Avm2::load_player_globals(context).expect("Unable to load AVM2 globals");

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,7 +14,7 @@ egui = { workspace = true }
 egui-wgpu = { version = "0.23.0", features = ["winit"] }
 egui-winit = "0.23.0"
 fontdb = "0.15"
-ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
+ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui", "default_font"] }
 ruffle_render = { path = "../render", features = ["clap"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -3,7 +3,7 @@ use arboard::Clipboard;
 use rfd::{MessageButtons, MessageDialog, MessageDialogResult, MessageLevel};
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::backend::ui::{
-    FullscreenError, LanguageIdentifier, MouseCursor, UiBackend, US_ENGLISH,
+    FontDefinition, FullscreenError, LanguageIdentifier, MouseCursor, UiBackend, US_ENGLISH,
 };
 use std::rc::Rc;
 use sys_locale::get_locale;
@@ -141,6 +141,8 @@ impl UiBackend for DesktopUiBackend {
             Err(e) => tracing::error!("Could not open URL {}: {}", url, e),
         };
     }
+
+    fn load_device_font(&self, _name: &str, _register: &dyn FnMut(FontDefinition)) {}
 
     // Unused on desktop
     fn open_virtual_keyboard(&self) {}

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 futures = "0.3"
-ruffle_core = { path = "../core", features = ["deterministic"] }
+ruffle_core = { path = "../core", features = ["deterministic", "default_font"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 image = { version = "0.24.7", default-features = false, features = ["png"] }
 log = "0.4"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 futures = "0.3.28"
-ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3"] }
+ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font"] }
 ruffle_render_wgpu = { path = "../render/wgpu" }
 ruffle_render = { path = "../render" }
 ruffle_input_format = { path = "input-format" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -56,7 +56,7 @@ gloo-net =  { version = "0.4.0", default-features = false, features = ["websocke
 [dependencies.ruffle_core]
 path = "../core"
 default-features = false
-features = ["audio", "mp3", "nellymoser", "wasm-bindgen", "default", "default_compatibility_rules"]
+features = ["audio", "mp3", "nellymoser", "wasm-bindgen", "default", "default_compatibility_rules", "default_font"]
 
 [dependencies.web-sys]
 version = "0.3.64"

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -1,6 +1,6 @@
 use super::JavascriptPlayer;
 use ruffle_core::backend::ui::{
-    FullscreenError, LanguageIdentifier, MouseCursor, UiBackend, US_ENGLISH,
+    FontDefinition, FullscreenError, LanguageIdentifier, MouseCursor, UiBackend, US_ENGLISH,
 };
 use ruffle_web_common::JsResult;
 use std::borrow::Cow;
@@ -144,4 +144,6 @@ impl UiBackend for WebUiBackend {
     fn display_unsupported_video(&self, url: Url) {
         self.js_player.display_unsupported_video(url.as_str());
     }
+
+    fn load_device_font(&self, _name: &str, _register: &dyn FnMut(FontDefinition)) {}
 }


### PR DESCRIPTION
Peeled this out of my big font WIP.

The notable changes here are:
- There's an enum representing the "default" device fonts in Flash, ie `_sans` is `DefaultFont::Sans`.
- Each default font has a list of implementation font names, which currently is just `["Noto Sans"]` for each.
- Whenever a font is requested which doesn't already exist, it's treated as a device font and the UI backend is requested to load it
- The UI backend has a callback to register new fonts when prompted, and Player also has a method to register new fonts

I did a lot of back and forth on the designs of things before settling on this, and I fell down so many different rabbit holes. I'm brain dumping a bit below so that at least relevant research notes can be preserved before I inevitably try to forget the word "Font" and all its associated trauma.

## UI Backend callback vs return value
This totally *should* be a return value, ideally `Vec<FontDefinition>`. Unfortunately `swf::Font` has a lifetime, so... callback is easier.

## Font lookup should be Vec, not Option?
Yeah so here's a fun fact: nothing requires font names to be unique. If you request, say, Helvetica... well you may have Helvetica, Helvetica Bold, Helvetica Light, maybe a fancy version of Helvetica that has extra glyphs for CJK?

Now, that sounds like these are *variations* of a font... and that's true. But it doesn't have to be, that's just the most common scenario. Ultimately, they're named Helvetica and so they all need to be considered when we're looking for Helvetica.

## Font lookup
I wrote a todo for this in the code, I have no intention of fixing it right now because it's a bit of an invasive change and I'm already deep in it.

Due to the above point, when we look for fonts we need to look at **all** fonts to see if they match the one we're looking for.

We need to consider:
- Does this font have the glyphs we need for this text?
- Is this font capable of the style that we want to use it for, or do we need to emulate that style? (prefer ones that support it, but fallback to ones that don't)
- Is one of the names of this font, somewhat similar to the one we're looking for?

## Font names
Yeah so that one is a bit of a gotcha. Fonts have multiple names. Or they can have zero names! Their names can depend on your language, or your operating system!

We've seen a hint of this before with DefineFont tags having two names and this has caused a bit of confusion before.

I did some experimenting in Flash Player and found that:
- If the so called "full name" (name ID 4) of a font **starts with** the requested font name (case insensitive), that font is used
- If the so called "family name" (name ID 1) of a font **equals** (case insensitive) the requested font name, that font is used

We don't support anything like this yet. We currently store a single `FontIdentifier` inside a `Font`, but it should instead be that we ask each font "do you match this request".

## FontDefinition enum vs swf::Font directly
Right now it's a single variant enum, but it'll get at least 2 more variants when ttf support lands. Something like:
`FontCollection { bytes: Vec<u8>, index: u32 }` - used for `.ttc` font collections, index is the font within the collection
`FontFile { bytes: Vec<u8> }` for regular `.ttf`, `.otf` etc

And maybe for good measure:
`Swf(SwfMovie)` to allow multiple fonts packaged together, whilst benefiting from the compression of a swf over a straight up font tag.

On that note...

## DefineFont is amazing at compressing fonts.
It's a shame it's so lossy though.

NotoSans-Regular.ttf is 543 KB
The DefineFont3 tag for the same font is 356 KB
The SWF containing that tag is 211 KB.

Of course, if you limit it to just latin as we do today, then it's 107 KB tag / 72 KB SWF.

The lossy part, is that there's way more information in a font which isn't expressible through the SWF format. Most notably:
- GPOS is the modern day kerning, which has way more control over glyph placements. Newer fonts use it and not traditional kerning tables, so they'd just look weird in SWF format.
- GSUB makes things like ligatures work, and is required for some languages to be readable at all. No idea if it's possible to embed an arabic font, for example.

Honorable mention to variable fonts, which in theory could be much smaller by virtue of a single font for all style variations, instead of embedding a Regular, an Italic, a Bold, a Bold Italic, etc. Noto Sans TC (traditional chinese) is 64 MB across 9 variations... or a single 11MB variable font!

## Speaking of font styles
It's broken today. We don't emulate styles if there's no explicit matching font for them. We should fix that, but I'm leaving that for future us. Screw future us, what did they ever do for us?

## Speaking of our noto sans default
We should switch it to embed the swf rather than the tag. The swf is 44KB vs the tags 73KB. That's swf default speedy compression, too.

## Default fonts
Flash gives (in theory) 3 so called "default fonts". They're `_sans`, `_serif` and `_typewriter`.

I suspect there's more undocumented ones. I'm fairly sure I've seen a translation of `_typewriter` recently... and that apparently worked.

We currently just default everything over to NotoSans today, and I've preserved that in this PR by defining the implementation of each default font as "just noto sans", but this will change in the future:

- Desktop will default each to something appropriate to the OS
- Web will likely have a config to allow changing the implementations of each default

Note that it's a list of font implementations, not a single font. Maybe we can't actually find that font, or maybe we need to provide a latin font, a chinese font, a japanese font... etc.

## Multiple fonts per... font...
Oh god the word font has no meaning anymore. I'm aware I'm using it wrong in some places too, but whatever.

If a textbox has a mixture of latin and chinese text on the same line, it's very unlikely that a single font has both sets of glyphs. Fonts can only have a small amount of glyphs each, after all.

We need to change how we do text layouts to account for changing font per glyph - even if the font name is the same - so that we can handle this correctly. Today we'd just pick one and hope for the best. It's wrong before this PR, it's wrong after this PR. Future us can fix it. I believe in them.

## Fonts must exist on demand
So the way it works now is that when we need a font that doesn't exist to Ruffle, we ask the UIBackend for it. The font either must exist before the end of that call, or we're going to assume it doesn't exist ever. It sucks, it's going to mean more work on Web, but that's just how it is.

There can be actionscript code that makes a text box, puts some text in it, assigns a font, and then uses the width of the text to center it on the screen. It can only do that if the font existed right there and then, and so whatever font we end up using **must** exist at the time that we request it.

## Web config?
A future PR will make fonts configurable on web. It won't require any core changes to do so, this PR lays all the foundation for that.

Most likely it'll be something like two config sections:
- Default fonts implementations: a list of font names per default. A webmaster could change `_sans` to `["Comic Sans"]` if they wanted. (or realistically, add CJK fonts)
- A list of fonts sources (URL or blobs) to load

Because fonts must exist right away, web will have to resolve and download any URLs before starting playback of the movie. It'll then add it to the player through `player.register_device_font()`, and the UIBackend method just goes unimplemented here.

Maybe one day that theoretical low level font api on web browsers could be implemented, then we'd switch to the UIBackend method instead. Maybe. Doubt it.

## Default fonts default fonts feature
What even are words?

In the future, desktop won't use the NotoSans default that we use today. Web will, exporter probably will, android app may move away from it too one day.

It's a waste to bundle that font in executables that won't use it, but it's also kind of a waste to have every *other* executable need to copy it and the set up code for it.

As a compromise, it's a feature. It's on everywhere right now, and desktop can just turn it off later. We can revisit this later if we care.