### PR TITLE
Fix BitmapData.clone accidentally re-using GPU texture

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -393,7 +393,7 @@ fn clone<'gc>(
             return Ok(new_bitmap_data(
                 activation.context.gc_context,
                 this.get_local_stored("__proto__", activation, false),
-                operations::clone(bitmap_data),
+                bitmap_data.clone_data(),
             )
             .into());
         }

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -1124,7 +1124,7 @@ pub fn clone<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let Some(bitmap_data) = this.as_bitmap_data() {
         if !bitmap_data.disposed() {
-            let new_bitmap_data = operations::clone(bitmap_data);
+            let new_bitmap_data = bitmap_data.clone_data();
 
             let class = activation.avm2().classes().bitmapdata;
             let new_bitmap_data_object = BitmapDataObject::from_bitmap_data_internal(

--- a/core/src/bitmap/operations.rs
+++ b/core/src/bitmap/operations.rs
@@ -122,14 +122,6 @@ pub fn get_pixel(target: BitmapDataWrapper, x: u32, y: u32) -> u32 {
         .with_alpha(0x0)
         .into()
 }
-
-pub fn clone(original: BitmapDataWrapper) -> BitmapData {
-    // Sync now to bring everything to cpu so we don't force multiple syncs to happen later
-    let original = original.sync();
-    let read = original.read();
-    read.clone()
-}
-
 pub fn flood_fill<'gc>(
     mc: &Mutation<'gc>,
     target: BitmapDataWrapper<'gc>,


### PR DESCRIPTION
This caused the clone to be linked to the original, instead of being a completely independent BitmapData object.

Fixes https://github.com/ruffle-rs/ruffle/issues/13360