### PR TITLE
avm2: Correctly fire `textureReady` event for async Texture uploads

### DIFF
--- a/core/src/avm2/globals/flash/display3D/textures/Texture.as
+++ b/core/src/avm2/globals/flash/display3D/textures/Texture.as
@@ -1,11 +1,24 @@
 package flash.display3D.textures {	
     import flash.display.BitmapData;
+    import flash.events.Event;
     import flash.utils.ByteArray;
-    import __ruffle__.stub_method;
+    import flash.utils.setTimeout;
     
     public final class Texture extends TextureBase {
         public native function uploadFromBitmapData(source:BitmapData, miplevel:uint = 0):void;
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:uint, miplevel:uint = 0):void;
-        public native function uploadCompressedTextureFromByteArray(data:ByteArray, byteArrayOffset:uint, async:Boolean = false):void;
+        public function uploadCompressedTextureFromByteArray(data:ByteArray, byteArrayOffset:uint, async:Boolean = false):void {
+            if (async) {
+                var self = this;
+                setTimeout(function() {
+                    self.uploadCompressedTextureFromByteArrayInternal(data, byteArrayOffset);
+                    self.dispatchEvent(new Event("textureReady"));
+                }, 0);
+            } else {
+                this.uploadCompressedTextureFromByteArrayInternal(data, byteArrayOffset);
+            }
+        }
+
+        private native function uploadCompressedTextureFromByteArrayInternal(data:ByteArray, byteArrayOffset:uint):void
     }
 }

--- a/core/src/avm2/globals/flash/display3D/textures/texture.rs
+++ b/core/src/avm2/globals/flash/display3D/textures/texture.rs
@@ -160,7 +160,7 @@ pub(super) fn do_compressed_upload<'gc>(
     Ok(())
 }
 
-pub fn upload_compressed_texture_from_byte_array<'gc>(
+pub fn upload_compressed_texture_from_byte_array_internal<'gc>(
     activation: &mut Activation<'_, 'gc>,
     this: Object<'gc>,
     args: &[Value<'gc>],
@@ -168,15 +168,6 @@ pub fn upload_compressed_texture_from_byte_array<'gc>(
     let texture = this.as_texture().unwrap();
     let data = args.get_object(activation, 0, "data")?;
     let byte_array_offset = args.get_u32(activation, 1)? as usize;
-    let async_ = args.get_bool(2);
-    if async_ {
-        avm2_stub_method!(
-            activation,
-            "flash.display3D.textures.Texture",
-            "uploadCompressedTextureFromByteArray",
-            "with async"
-        );
-    }
 
     if !matches!(texture.original_format(), Context3DTextureFormat::Bgra) {
         avm2_stub_method!(


### PR DESCRIPTION
The Starling Benchmark was waiting for an event that never came.