### PR TITLE
desktop: Handle cookies and Content-Type for HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2420,7 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "http",
+ "httpdate",
  "log",
  "mime",
  "once_cell",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -26,7 +26,7 @@ webbrowser = "0.8.11"
 url = "2.4.1"
 arboard = "3.2.1"
 dirs = "5.0"
-isahc = "1.7.2"
+isahc = { version = "1.7.2", features = ["cookies"] }
 rfd = "0.12.0"
 anyhow = "1.0"
 bytemuck = "1.14.0"


### PR DESCRIPTION
Both of these are handled automatically by the browser in the web backend. This makes the desktop client store cookies between requests (though they are discarded when the desktop player is closed), and set the "Content-Type" header based on the mime-type supplied in the URLRequest.