### PR TITLE
wgpu: Correctly set format when rendering to Stage3D texture

### DIFF
--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -80,6 +80,8 @@ pub struct CurrentPipeline {
 
     sample_count: u32,
 
+    target_format: TextureFormat,
+
     dirty: Cell<bool>,
 
     sampler_override: [Option<SamplerOverride>; 8],
@@ -155,6 +157,8 @@ impl CurrentPipeline {
             alpha_component: wgpu::BlendComponent::REPLACE,
             sample_count: 1,
 
+            target_format: TextureFormat::Rgba8Unorm,
+
             sampler_override: [None; 8],
         }
     }
@@ -214,6 +218,13 @@ impl CurrentPipeline {
         if self.sample_count != sample_count {
             self.dirty.set(true);
             self.sample_count = sample_count;
+        }
+    }
+
+    pub fn update_target_format(&mut self, format: TextureFormat) {
+        if self.target_format != format {
+            self.dirty.set(true);
+            self.target_format = format;
         }
     }
 
@@ -464,7 +475,7 @@ impl CurrentPipeline {
                     module: &compiled_shaders.fragment_module,
                     entry_point: naga_agal::SHADER_ENTRY_POINT,
                     targets: &[Some(ColorTargetState {
-                        format: TextureFormat::Rgba8Unorm,
+                        format: self.target_format,
                         blend: Some(wgpu::BlendState {
                             color: self.color_component,
                             alpha: self.alpha_component,

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -210,6 +210,8 @@ impl WgpuContext3D {
             .update_has_depth_texture(self.current_depth_texture_view.is_some());
         self.current_pipeline
             .update_sample_count(self.back_buffer_sample_count);
+        self.current_pipeline
+            .update_target_format(TextureFormat::Rgba8Unorm);
     }
 
     pub(crate) fn present(&mut self) {
@@ -828,6 +830,8 @@ impl Context3D for WgpuContext3D {
                     .update_has_depth_texture(enable_depth_and_stencil);
                 self.current_pipeline.remove_texture(&texture);
                 self.current_pipeline.update_sample_count(sample_count);
+                self.current_pipeline
+                    .update_target_format(texture_wrapper.texture.format());
             }
 
             Context3DCommand::SetRenderToBackBuffer => {


### PR DESCRIPTION
This fixes a panic when trying to render a texture with a type other than `TextureFormat::Rgba8Unorm`