### PR TITLE
naga-agal: Stub anisotropic filters in opcodes

### DIFF
--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -1172,6 +1172,21 @@ impl<'a> NagaBuilder<'a> {
                     (Filter::Nearest, Wrapping::RepeatUClampV) => {
                         texture_samplers.repeat_u_clamp_v_nearest
                     }
+                    (
+                        Filter::Anisotropic2x
+                        | Filter::Anisotropic4x
+                        | Filter::Anisotropic8x
+                        | Filter::Anisotropic16x,
+                        _,
+                    ) => {
+                        // FIXME - implement anisotropic filters with wgpu
+                        match wrapping {
+                            Wrapping::Clamp => texture_samplers.clamp_linear,
+                            Wrapping::Repeat => texture_samplers.repeat_linear,
+                            Wrapping::ClampURepeatV => texture_samplers.clamp_u_repeat_v_linear,
+                            Wrapping::RepeatUClampV => texture_samplers.repeat_u_clamp_v_linear,
+                        }
+                    }
                 };
 
                 let coord = self.emit_source_field_load(source1, false)?;

--- a/render/naga-agal/src/types.rs
+++ b/render/naga-agal/src/types.rs
@@ -131,6 +131,10 @@ impl SourceField {
 pub enum Filter {
     Nearest = 0,
     Linear = 1,
+    Anisotropic2x = 2,
+    Anisotropic4x = 3,
+    Anisotropic8x = 4,
+    Anisotropic16x = 5,
 }
 
 #[derive(FromPrimitive, Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
We had already stubbed these when set from ActionScript, but were were panicking when they were selected directly in the AGAL bytecode.