### PR TITLE
avm2: Stub Matrix3D.pointAt

### DIFF
--- a/core/src/avm2/globals/flash/geom/Matrix3D.as
+++ b/core/src/avm2/globals/flash/geom/Matrix3D.as
@@ -404,6 +404,10 @@ package flash.geom {
 			other.rawData = rawData;
 		}
 
+		public function pointAt(pos:Vector3D, at:Vector3D = null, up:Vector3D = null):void {
+			stub_method("flash.geom.Matrix3D", "pointAt");
+		}
+
 		// Based on OpenFL: https://github.com/openfl/openfl/blob/971a4c9e43b5472fd84d73920a2b7c1b3d8d9257/src/openfl/geom/Matrix3D.hx#L1437
 		public function recompose(components:Vector.<Vector3D>, orientationStyle:String = "eulerAngles"):Boolean {
 			checkOrientation(orientationStyle);


### PR DESCRIPTION
Unfortunately, the OpenFL implementation has a TODO noting that their implementation doesn't match Flash, so getting this to work will require figuring out
how Flash does things.