### PR TITLE
avm2: Throw ArgumentError when trying to construct `new Worker()`

### DIFF
--- a/core/src/avm2/globals/flash/system/Worker.as
+++ b/core/src/avm2/globals/flash/system/Worker.as
@@ -1,7 +1,9 @@
 package flash.system {
     public final class Worker {
-        public function Worker() {}
-        
+        public function Worker() {
+            throw new ArgumentError("Error #2012: Worker$ class cannot be instantiated.", 2012);
+        }
+
         public static function get isSupported():Boolean {
             return false;
         }


### PR DESCRIPTION
I noticed a subtle inconsistency in stack traces across Ruffle and FP.

FP:
```
ArgumentError: Error #2012: Worker$ class cannot be instantiated.
	at Tests()
```

Ruffle:
```
ArgumentError: Error #2012: Worker$ class cannot be instantiated.
	at flash.system::Worker()
	at Tests()
```
<s>I believe FP has some sort of metadata on the class which throws the error where the class gets constructed, instead of actually running the constructor code. Note that this _does not_ apply to `TextJustifier` and `ContentElement`, which throw `Error #2012` when, for example, `new ContentElement(...)` is constructed instead of constructing a class that extends `ContentElement`.</s>

Nevermind, Adrian stated on Discord that the error logic should be in the instance allocator instead of running in the instance initializer.