### PR TITLE
renovate: Include winit, egui-winit, and raw-window-handle in the wgpu dep group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,8 +16,8 @@
         },
         {
             "matchCategories": ["rust"],
-            "matchPackageNames": ["wgpu", "naga", "naga_oil", "egui-wgpu"],
-            "groupName": "Rust dependencies related to wgpu",
+            "matchPackageNames": ["winit", "wgpu", "naga", "naga_oil", "egui-winit", "egui-wgpu", "raw-window-handle"],
+            "groupName": "Rust dependencies related to winit and wgpu",
             "rangeStrategy": "bump",
             "extends": ["schedule:weekly"],
         },


### PR DESCRIPTION
So I can finally stop being the best bot:tm: (https://github.com/ruffle-rs/ruffle/pull/13487#issuecomment-1753976182).