### PR TITLE
avm2: Default to receiver MC's movie if caller movie doesn't exist

### DIFF
--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -393,12 +393,7 @@ pub fn goto_frame<'gc>(
 
                 let frame = mc.frame_label_to_number(&frame_or_label, &activation.context);
 
-                if activation
-                    .caller_movie()
-                    .expect("Caller SWF should exist")
-                    .version()
-                    >= 11
-                {
+                if activation.caller_movie().unwrap_or(mc.movie()).version() >= 11 {
                     frame.ok_or(
                         // TODO: Also include the scene in the error message, as done above
                         Error::AvmError(argument_error(


### PR DESCRIPTION
I _think_ this fixes #13490.

<s>
Unfortunately I was unable to reproduce the issue. I checked the code through FFDEC- I don't think there are any places where `gotoAndStop` is used in an unusual way. The weirdest usage I got was the following:

`_timeouts.push(setTimeout(_handFront.gotoAndStop,500,"open"));`

I tested this alone and it didn't trigger a panic.
</s>

Ignore this, I found a way to reproduce the error. Turns out it uses root SWF version.