### PR TITLE
avm2: Use root movie when running timer/event/broadcast closures

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -437,7 +437,8 @@ impl<'gc> Avm2<'gc> {
                 .copied();
 
             if let Some(object) = object.and_then(|obj| obj.upgrade(context.gc_context)) {
-                let mut activation = Activation::from_nothing(context.reborrow());
+                let movie = context.swf.clone();
+                let mut activation = Activation::from_movie(context.reborrow(), movie);
 
                 if object.is_of_type(on_type.inner_class_definition(), &mut activation.context) {
                     if let Err(err) = events::dispatch_event(&mut activation, object, event) {

--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -346,7 +346,8 @@ impl<'gc> Avm2<'gc> {
             .map(|e| e.event_type())
             .unwrap_or_else(|| panic!("cannot dispatch non-event object: {:?}", event));
 
-        let mut activation = Activation::from_nothing(context.reborrow());
+        let movie = context.swf.clone();
+        let mut activation = Activation::from_movie(context.reborrow(), movie);
         if let Err(err) = events::dispatch_event(&mut activation, target, event) {
             tracing::error!(
                 "Encountered AVM2 error when dispatching `{}` event: {:?}",

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -207,6 +207,31 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
     }
 
+    /// Like `from_domain`, but with a specified movie.
+    /// Used when you
+    pub fn from_domain_and_movie(
+        context: UpdateContext<'a, 'gc>,
+        domain: Domain<'gc>,
+        movie: Arc<SwfMovie>,
+    ) -> Self {
+        let local_registers = RegisterSet::new(0);
+
+        Self {
+            actions_since_timeout_check: 0,
+            local_registers,
+            outer: ScopeChain::new(context.avm2.stage_domain),
+            caller_domain: Some(domain),
+            caller_movie: Some(movie),
+            subclass_object: None,
+            activation_class: None,
+            stack_depth: context.avm2.stack.len(),
+            scope_depth: context.avm2.scope_stack.len(),
+            max_stack_size: 0,
+            max_scope_size: 0,
+            context,
+        }
+    }
+
     /// Construct an activation for the execution of a particular script's
     /// initializer method.
     pub fn from_script(

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -179,6 +179,26 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
     }
 
+    /// Like `from_nothing`, but with a specified movie.
+    pub fn from_movie(context: UpdateContext<'a, 'gc>, movie: Arc<SwfMovie>) -> Self {
+        let local_registers = RegisterSet::new(0);
+
+        Self {
+            actions_since_timeout_check: 0,
+            local_registers,
+            outer: ScopeChain::new(context.avm2.stage_domain),
+            caller_domain: None,
+            caller_movie: Some(movie),
+            subclass_object: None,
+            activation_class: None,
+            stack_depth: context.avm2.stack.len(),
+            scope_depth: context.avm2.scope_stack.len(),
+            max_stack_size: 0,
+            max_scope_size: 0,
+            context,
+        }
+    }
+
     /// Like `from_nothing`, but with a specified domain.
     ///
     /// This should be used when you actually need to run AVM2 code, but
@@ -208,7 +228,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     }
 
     /// Like `from_domain`, but with a specified movie.
-    /// Used when you
     pub fn from_domain_and_movie(
         context: UpdateContext<'a, 'gc>,
         domain: Domain<'gc>,

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -150,9 +150,13 @@ impl<'gc> Timers<'gc> {
                     }
                 }
                 TimerCallback::Avm2Callback { closure, params } => {
+                    // Timer callbacks execute in the context of the root movie, so
+                    // provide the root SWF and the stage domain
+
                     let domain = context.avm2.stage_domain();
+                    let movie = context.swf.clone();
                     let mut avm2_activation =
-                        Avm2Activation::from_domain(context.reborrow(), domain);
+                        Avm2Activation::from_domain_and_movie(context.reborrow(), domain, movie);
                     match closure.call(Avm2Value::Null, &params, &mut avm2_activation) {
                         Ok(v) => v.coerce_to_boolean(),
                         Err(e) => {


### PR DESCRIPTION
Fixes #13490.

I think there's a few more places where this needs to be fixed, but it's unlikely that they will ever be called:

- FLV script data handlers
- `ExternalInterface` callback


For the future, I think a `Activation::from_context` that accepts a movie and checks the library for the AVM2 domain would be useful, but I think this is fine for now.

(I did confirm that this uses the root movie version.)