### PR TITLE
ci: Set up cargo-deny

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -76,6 +76,10 @@ jobs:
         # Don't fail the build for clippy on nightly, since we get a lot of false-positives
         run: cargo clippy --all --all-features --tests ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
 
+      - name: Check licensing and duplicates in used crates
+        if: ${{ runner.os == 'Linux' && matrix.rust_version == 'stable' }}
+        uses: EmbarkStudios/cargo-deny-action@v1
+
       - name: Check documentation
         run: cargo doc --no-deps --all-features
         env:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,72 @@
+
+# If true, metadata will be collected with `--all-features`.
+all-features = true
+
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+
+# List of explicitly allowed licenses
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Zlib",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "MPL-2.0",
+    "BSL-1.0",
+    "CC0-1.0",
+    "OFL-1.1",
+    "LicenseRef-UFL-1.0",
+]
+
+# List of explicitly disallowed licenses
+deny = [
+    "GPL-1.0",
+    "GPL-2.0",
+    "GPL-3.0",
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information.
+
+# Some parts of NihAV were kindly relicenced for us under MIT by the author.
+# See: https://codecs.multimedia.cx/nihav-relicensed-code/
+[[licenses.clarify]]
+name = "nihav_core"
+expression = "MIT"
+license-files = []
+
+[[licenses.clarify]]
+name = "nihav_duck"
+expression = "MIT"
+license-files = []
+
+[[licenses.clarify]]
+name = "nihav_codec_support"
+expression = "MIT"
+license-files = []
+
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+
+[sources.allow-org]
+#  github.com organizations to allow git sources for
+github = [
+    "ruffle-rs",
+    "kyren",
+    "gfx-rs",
+]


### PR DESCRIPTION
I'd like to get verification that the allowed/denied licenses are actually correct.
Also I haven't dared to deny duplicate crates, as there are a lot of them.