### PR TITLE
core: Switch dasp from a git revision to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
  "alsa",
  "core-foundation-sys",
  "coreaudio-rs",
- "dasp_sample 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dasp_sample",
  "jni 0.19.0",
  "js-sys",
  "libc",
@@ -1065,7 +1065,8 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 [[package]]
 name = "dasp"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7381b67da416b639690ac77c73b86a7b5e64a29e31d1f75fb3b1102301ef355a"
 dependencies = [
  "dasp_envelope",
  "dasp_frame",
@@ -1073,7 +1074,7 @@ dependencies = [
  "dasp_peak",
  "dasp_ring_buffer",
  "dasp_rms",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
  "dasp_signal",
  "dasp_slice",
  "dasp_window",
@@ -1082,55 +1083,61 @@ dependencies = [
 [[package]]
 name = "dasp_envelope"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec617ce7016f101a87fe85ed44180839744265fae73bb4aa43e7ece1b7668b6"
 dependencies = [
  "dasp_frame",
  "dasp_peak",
  "dasp_ring_buffer",
  "dasp_rms",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]
 name = "dasp_frame"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
 dependencies = [
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]
 name = "dasp_interpolate"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc975a6563bb7ca7ec0a6c784ead49983a21c24835b0bc96eea11ee407c7486"
 dependencies = [
  "dasp_frame",
  "dasp_ring_buffer",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]
 name = "dasp_peak"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf88559d79c21f3d8523d91250c397f9a15b5fc72fbb3f87fdb0a37b79915bf"
 dependencies = [
  "dasp_frame",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]
 name = "dasp_ring_buffer"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d79e19b89618a543c4adec9c5a347fe378a19041699b3278e616e387511ea1"
 
 [[package]]
 name = "dasp_rms"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c5dcb30b7e5014486e2822537ea2beae50b19722ffe2ed7549ab03774575aa"
 dependencies = [
  "dasp_frame",
  "dasp_ring_buffer",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]
@@ -1140,14 +1147,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
-name = "dasp_sample"
-version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
-
-[[package]]
 name = "dasp_signal"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1ab7d01689c6ed4eae3d38fe1cea08cba761573fbd2d592528d55b421077e7"
 dependencies = [
  "dasp_envelope",
  "dasp_frame",
@@ -1155,25 +1158,27 @@ dependencies = [
  "dasp_peak",
  "dasp_ring_buffer",
  "dasp_rms",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
  "dasp_window",
 ]
 
 [[package]]
 name = "dasp_slice"
 version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1c7335d58e7baedafa516cb361360ff38d6f4d3f9d9d5ee2a2fc8e27178fa1"
 dependencies = [
  "dasp_frame",
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]
 name = "dasp_window"
-version = "0.11.0"
-source = "git+https://github.com/RustAudio/dasp?rev=f05a703#f05a703d247bb504d7e812b51e95f3765d9c5e94"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ded7b88821d2ce4e8b842c9f1c86ac911891ab89443cc1de750cae764c5076"
 dependencies = [
- "dasp_sample 0.11.0 (git+https://github.com/RustAudio/dasp?rev=f05a703)",
+ "dasp_sample",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,7 @@ nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a3352
 regress = "0.7"
 flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "3669a352c14192d0d301e594ae6047ae99725006" }
 lzma-rs = {version = "0.3.0", optional = true }
-dasp = { git = "https://github.com/RustAudio/dasp", rev = "f05a703", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
+dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.3", default-features = false, features = ["mp3"], optional = true }
 enumset = "1.1.3"
 bytemuck = "1.14.0"


### PR DESCRIPTION
The previously referenced commit was originally part of https://github.com/RustAudio/dasp/pull/137.

The nightly compilation error it is supposed to fix (https://github.com/RustAudio/dasp/issues/136), isn't reproducible now, and it already wasn't in 2021: https://github.com/RustAudio/dasp/pull/155

This trims our dependency tree a little bit, since `dasp` `v0.11.0` is also an indirect dependency, as pointed out by #13576.