### PR TITLE
web: Add defaultFonts and fontSources config options

### DIFF
--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -45,4 +45,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     allowNetworking: NetworkingAccessMode.All,
     openInNewTab: null,
     socketProxy: [],
+    fontSources: [],
 };

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -46,4 +46,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     openInNewTab: null,
     socketProxy: [],
     fontSources: [],
+    defaultFonts: {},
 };

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -268,6 +268,30 @@ export interface SocketProxy {
 }
 
 /**
+ * Defines the names of the fonts to use for each "default" Flash device font.
+ *
+ * The name of each font provided will be used, in priority order.
+ *
+ * For example, defining `sans: ["Helvetica", "Arial"]` would use Helvetica if present, before trying Arial.
+ */
+export interface DefaultFonts {
+    /**
+     * `_sans`, a Sans-Serif font (similar to Helvetica or Arial)
+     */
+    sans?: Array<string>;
+
+    /**
+     * `_serif`, a Serif font (similar to Times Roman)
+     */
+    serif?: Array<string>;
+
+    /**
+     * `_typewriter`, a Monospace font (similar to Courier)
+     */
+    typewriter?: Array<string>;
+}
+
+/**
  * Any options used for loading a movie.
  */
 export interface BaseLoadOptions {
@@ -574,6 +598,13 @@ export interface BaseLoadOptions {
      * @default []
      */
     fontSources?: Array<string>;
+
+    /**
+     * The font names to use for each "default" Flash device font.
+     *
+     * @default {}
+     */
+    defaultFonts?: DefaultFonts;
 }
 
 /**

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -561,6 +561,19 @@ export interface BaseLoadOptions {
      * @default []
      */
     socketProxy?: Array<SocketProxy>;
+
+    /**
+     * An array of font URLs to eagerly load and provide to Ruffle.
+     *
+     * These will be fetched by the browser as part of the loading of Flash content, which may slow down load times.
+     *
+     * Currently only SWFs are supported, and each font embedded within that SWF will be used as device font by Flash content.
+     *
+     * If any URL fails to load (either it's an invalid file, or a network error occurs), Ruffle will log an error but continue without it.
+     *
+     * @default []
+     */
+    fontSources?: Array<string>;
 }
 
 /**

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -731,6 +731,25 @@ export class RufflePlayer extends HTMLElement {
             }
         }
 
+        if (this.loadedConfig?.defaultFonts?.sans) {
+            this.instance!.set_default_font(
+                "sans",
+                this.loadedConfig?.defaultFonts.sans,
+            );
+        }
+        if (this.loadedConfig?.defaultFonts?.serif) {
+            this.instance!.set_default_font(
+                "serif",
+                this.loadedConfig?.defaultFonts.serif,
+            );
+        }
+        if (this.loadedConfig?.defaultFonts?.typewriter) {
+            this.instance!.set_default_font(
+                "typewriter",
+                this.loadedConfig?.defaultFonts.typewriter,
+            );
+        }
+
         this.instance!.set_volume(this.volumeSettings.get_volume());
 
         this.rendererDebugInfo = this.instance!.renderer_debug_info();

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -714,6 +714,23 @@ export class RufflePlayer extends HTMLElement {
             throw e;
         });
 
+        if (this.loadedConfig?.fontSources) {
+            for (const url of this.loadedConfig.fontSources) {
+                try {
+                    const response = await fetch(url);
+                    this.instance!.add_font(
+                        url,
+                        new Uint8Array(await response.arrayBuffer()),
+                    );
+                } catch (error) {
+                    console.warn(
+                        `Couldn't download font source from ${url}`,
+                        error,
+                    );
+                }
+            }
+        }
+
         this.instance!.set_volume(this.volumeSettings.get_volume());
 
         this.rendererDebugInfo = this.instance!.renderer_debug_info();

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -19,8 +19,8 @@ use ruffle_core::external::{
     ExternalInterfaceMethod, ExternalInterfaceProvider, FsCommandProvider, Value as ExternalValue,
     Value,
 };
-use ruffle_core::swf;
 use ruffle_core::tag_utils::SwfMovie;
+use ruffle_core::{swf, DefaultFont};
 use ruffle_core::{
     Color, Player, PlayerBuilder, PlayerEvent, SandboxType, StageAlign, StageScaleMode,
     StaticCallstack, ViewportDimensions,
@@ -491,6 +491,27 @@ impl Ruffle {
             }
 
             tracing::warn!("Font source {font_name} was not recognised (not a valid SWF?)");
+        });
+    }
+
+    pub fn set_default_font(&mut self, default_name: &str, fonts: Vec<JsValue>) {
+        let _ = self.with_core_mut(|core| {
+            let default = match default_name {
+                "sans" => DefaultFont::Sans,
+                "serif" => DefaultFont::Serif,
+                "typewriter" => DefaultFont::Typewriter,
+                name => {
+                    tracing::error!("Unknown default font name '{name}'");
+                    return;
+                }
+            };
+            core.set_default_font(
+                default,
+                fonts
+                    .into_iter()
+                    .flat_map(|value| value.as_string())
+                    .collect(),
+            );
         });
     }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -10,6 +10,7 @@ mod ui;
 use generational_arena::{Arena, Index};
 use js_sys::{Array, Error as JsError, Function, Object, Promise, Uint8Array};
 use ruffle_core::backend::navigator::OpenURLMode;
+use ruffle_core::backend::ui::FontDefinition;
 use ruffle_core::compatibility_rules::CompatibilityRules;
 use ruffle_core::config::{Letterbox, NetworkingAccessMode};
 use ruffle_core::context::UpdateContext;
@@ -18,6 +19,7 @@ use ruffle_core::external::{
     ExternalInterfaceMethod, ExternalInterfaceProvider, FsCommandProvider, Value as ExternalValue,
     Value,
 };
+use ruffle_core::swf;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::{
     Color, Player, PlayerBuilder, PlayerEvent, SandboxType, StageAlign, StageScaleMode,
@@ -458,6 +460,38 @@ impl Ruffle {
         // Remove instance from the active list.
         let _ = self.remove_instance();
         // Instance is dropped at this point.
+    }
+
+    pub fn add_font(&mut self, font_name: &str, data: Uint8Array) {
+        let _ = self.with_core_mut(|core| {
+            let bytes: Vec<u8> = data.to_vec();
+            if let Ok(swf_stream) = swf::decompress_swf(&bytes[..]) {
+                if let Ok(swf) = swf::parse_swf(&swf_stream) {
+                    let encoding = swf::SwfStr::encoding_for_version(swf.header.version());
+                    for tag in swf.tags {
+                        match tag {
+                            swf::Tag::DefineFont(_font) => {
+                                tracing::warn!("DefineFont1 tag is not yet supported by Ruffle, inside font swf {font_name}");
+                            }
+                            swf::Tag::DefineFont2(font) => {
+                                tracing::debug!(
+                                    "Loaded font {} from font swf {font_name}",
+                                    font.name.to_str_lossy(encoding)
+                                );
+                                core.register_device_font(FontDefinition::SwfTag(*font, encoding));
+                            }
+                            swf::Tag::DefineFont4(_font) => {
+                                tracing::warn!("DefineFont4 tag is not yet supported by Ruffle, inside font swf {font_name}");
+                            }
+                            _ => {}
+                        }
+                    }
+                    return;
+                }
+            }
+
+            tracing::warn!("Font source {font_name} was not recognised (not a valid SWF?)");
+        });
     }
 
     #[allow(clippy::boxed_local)] // for js_bind

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -145,5 +145,8 @@ impl UiBackend for WebUiBackend {
         self.js_player.display_unsupported_video(url.as_str());
     }
 
-    fn load_device_font(&self, _name: &str, _register: &dyn FnMut(FontDefinition)) {}
+    fn load_device_font(&self, _name: &str, _register: &dyn FnMut(FontDefinition)) {
+        // Because fonts must be loaded instantly (no async),
+        // we actually just provide them all upfront at time of Player creation.
+    }
 }


### PR DESCRIPTION
# Font sources
![image](https://github.com/ruffle-rs/ruffle/assets/317625/3669b3a7-3642-444b-9fc1-6e4caea04207)

Each URL provided to this config option will *try* to eagerly load as a font source.
If the URL cannot load, it will be ignored (but a warning will print).
If the URL cannot parse into a valid font, it will be ignored (but a warning will print).

Right now it only supports fonts embeded inside SWFs. Any number of fonts can be inside a single SWF, but they need to be embedded with DefineFont2 and you need to make sure it's actually inside the swf (not stripped out by not being used).
A future PR will enable TTF/OTF support.

## How to make a font SWF
### 1. Create a new document in Flash Pro or Animate, make sure it's ActionScript 3.
![image](https://github.com/ruffle-rs/ruffle/assets/317625/94a0cbf1-1ba4-4492-a3e3-f9c0ec718418)

### 2. On the right hand side, click the Library tab and right click somewhere in the big empty space, and hit New Font
![image](https://github.com/ruffle-rs/ruffle/assets/317625/98bd0c2a-64c7-4fd3-bb5a-06f003489efc)

### 3. Set the name, pick the font and style from the list, and then choose which characters you want to embed. Only these characters will be available to use from this font.
![image](https://github.com/ruffle-rs/ruffle/assets/317625/9f2a09b3-bdf6-42d6-8ea9-7c9d5e22c3b0)

### 4.  In the ActionScript tab, check "Export for ActionScript" to make sure it stays inside the swf, and make sure it's "DF3" not "DF4".
![image](https://github.com/ruffle-rs/ruffle/assets/317625/36a07d8f-c5ff-4ac4-b923-d3d6b683a578)

### 5. Export the SWF. Make sure you export it as a SWF
![image](https://github.com/ruffle-rs/ruffle/assets/317625/095e0de5-6b88-41a4-90b7-d115967e4177)
![image](https://github.com/ruffle-rs/ruffle/assets/317625/3041462a-504d-4a10-910b-2a7827e072f5)

### 6. Configure Ruffle to load that SWF as a font source.
```js
window.RufflePlayer.config = {
    fontSources: ["my-big-fonts.swf"]
}
```

# Default fonts
![image](https://github.com/ruffle-rs/ruffle/assets/317625/0dbcee57-a89c-4227-940b-79e43d21d427)

There are 3 "default" device fonts in Flash. `_sans`, `_serif`, `_typewriter`. In Ruffle they are our Noto Sans fallback unless configured otherwise.

To change that, set:
```js
window.RufflePlayer.config = {
    defaultFonts: {
        sans: ["Caveat"]
    }
}
```

The font in question needs to be loaded with fontSources or it won't be found.
