### PR TITLE
web: Remove a whole bunch of internal stuff from public API + documentation, and simplify loading a bit

### DIFF
--- a/web/packages/core/src/index.ts
+++ b/web/packages/core/src/index.ts
@@ -1,15 +1,12 @@
-export * from "./load-ruffle";
-export * from "./plugin-polyfill";
+/**
+ * This is the public API of the web version of Ruffle.
+ *
+ * Types should only be exported here if they are intended to be part of that public API, not internal.
+ */
+
 export * from "./polyfills";
 export * from "./public-api";
-export * from "./public-path";
-export * from "./register-element";
-export * from "./ruffle-embed";
-export * from "./ruffle-imports";
-export * from "./ruffle-object";
 export * from "./ruffle-player";
-export * from "./flash-identifiers";
-export * from "./shadow-template";
 export * from "./version";
 export * from "./version-range";
 export * from "./config";

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -115,7 +115,7 @@ type Ruffle =
     | (typeof import("../dist/ruffle_web"))["Ruffle"]
     | (typeof import("../dist/ruffle_web-wasm_extensions"))["Ruffle"];
 
-let lastLoaded: Promise<Ruffle> | null = null;
+let nativeConstructor: Promise<Ruffle> | null = null;
 
 /**
  * Obtain an instance of `Ruffle`.
@@ -131,9 +131,9 @@ export function loadRuffle(
     config: BaseLoadOptions,
     progressCallback?: ProgressCallback,
 ): Promise<Ruffle> {
-    if (lastLoaded === null) {
-        lastLoaded = fetchRuffle(config, progressCallback);
+    if (nativeConstructor === null) {
+        nativeConstructor = fetchRuffle(config, progressCallback);
     }
 
-    return lastLoaded;
+    return nativeConstructor;
 }

--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -11,7 +11,7 @@ import {
 } from "wasm-feature-detect";
 import { setPolyfillsOnLoad } from "./js-polyfills";
 import { publicPath } from "./public-path";
-import type { DataLoadOptions, URLLoadOptions } from "./load-options";
+import { BaseLoadOptions } from "./load-options";
 
 declare global {
     let __webpack_public_path__: string;
@@ -32,7 +32,7 @@ type ProgressCallback = (bytesLoaded: number, bytesTotal: number) => void;
  * instances.
  */
 async function fetchRuffle(
-    config: URLLoadOptions | DataLoadOptions | object,
+    config: BaseLoadOptions,
     progressCallback?: ProgressCallback,
 ): Promise<typeof Ruffle> {
     // Apply some pure JavaScript polyfills to prevent conflicts with external
@@ -128,7 +128,7 @@ let lastLoaded: Promise<Ruffle> | null = null;
  * instances.
  */
 export function loadRuffle(
-    config: URLLoadOptions | DataLoadOptions | object,
+    config: BaseLoadOptions,
     progressCallback?: ProgressCallback,
 ): Promise<Ruffle> {
     if (lastLoaded === null) {

--- a/web/packages/core/src/public-path.ts
+++ b/web/packages/core/src/public-path.ts
@@ -1,4 +1,4 @@
-import type { DataLoadOptions, URLLoadOptions } from "./load-options";
+import { BaseLoadOptions } from "./load-options";
 import { currentScriptURL, isExtension } from "./current-script";
 
 /**
@@ -18,9 +18,7 @@ import { currentScriptURL, isExtension } from "./current-script";
  * @param config The `window.RufflePlayer.config` object.
  * @returns The public path for the given source.
  */
-export function publicPath(
-    config: URLLoadOptions | DataLoadOptions | object,
-): string {
+export function publicPath(config: BaseLoadOptions): string {
     // Default to the directory where this script resides.
     let path = currentScriptURL?.href ?? "";
     if (

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -667,7 +667,9 @@ export class RufflePlayer extends HTMLElement {
                 'The configuration option contextMenu no longer takes a boolean. Use "on", "off", or "rightClickOnly".',
             );
         }
-        const ruffleConstructor = await loadRuffle(
+        this.instance = await loadRuffle(
+            this.container,
+            this,
             this.loadedConfig || {},
             this.onRuffleDownloadProgress.bind(this),
         ).catch((e) => {
@@ -709,11 +711,6 @@ export class RufflePlayer extends HTMLElement {
             throw e;
         });
 
-        this.instance = await new ruffleConstructor(
-            this.container,
-            this,
-            this.loadedConfig,
-        );
         this.instance!.set_volume(this.volumeSettings.get_volume());
 
         this.rendererDebugInfo = this.instance!.renderer_debug_info();
@@ -729,13 +726,14 @@ export class RufflePlayer extends HTMLElement {
         }
 
         const actuallyUsedRendererName = this.instance!.renderer_name();
+        const constructor = <typeof Ruffle>this.instance!.constructor;
 
         console.log(
             "%c" +
                 "New Ruffle instance created (Version: " +
                 buildInfo.versionName +
                 " | WebAssembly extensions: " +
-                (ruffleConstructor.is_wasm_simd_used() ? "ON" : "OFF") +
+                (constructor.is_wasm_simd_used() ? "ON" : "OFF") +
                 " | Used renderer: " +
                 (actuallyUsedRendererName ?? "") +
                 ")",


### PR DESCRIPTION
Originally meant to change how config was passed over to rust but rabbit holes in rabbit holes 😅