### PR TITLE
avm2: Fix XML/XMLList call handlers

### DIFF
--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -388,19 +388,21 @@ pub fn call_handler<'gc>(
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    if let Some(obj) = args.try_get_object(activation, 0) {
-        // We do *not* create a new object when AS does 'XML(someXML)'
-        if let Some(xml) = obj.as_xml_object() {
-            return Ok(xml.into());
-        }
-        // This re-uses the XML object stored in the list
-        if let Some(xml_list) = obj.as_xml_list_object() {
-            if xml_list.length() == 1 {
-                return Ok(xml_list.children_mut(activation.context.gc_context)[0]
-                    .get_or_create_xml(activation)
-                    .into());
+    if args.len() == 1 {
+        if let Some(obj) = args.try_get_object(activation, 0) {
+            // We do *not* create a new object when AS does 'XML(someXML)'
+            if let Some(xml) = obj.as_xml_object() {
+                return Ok(xml.into());
             }
-            return Err(Error::AvmError(ill_formed_markup_err(activation)?));
+            // This re-uses the XML object stored in the list
+            if let Some(xml_list) = obj.as_xml_list_object() {
+                if xml_list.length() == 1 {
+                    return Ok(xml_list.children_mut(activation.context.gc_context)[0]
+                        .get_or_create_xml(activation)
+                        .into());
+                }
+                return Err(Error::AvmError(ill_formed_markup_err(activation)?));
+            }
         }
     }
 

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -83,12 +83,15 @@ pub fn call_handler<'gc>(
     _this: Object<'gc>,
     args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    // We do *not* create a new object when AS does 'XMLList(someXMLList)'
-    if let Some(obj) = args.try_get_object(activation, 0) {
-        if let Some(xml_list) = obj.as_xml_list_object() {
-            return Ok(xml_list.into());
+    if args.len() == 1 {
+        // We do *not* create a new object when AS does 'XMLList(someXMLList)'
+        if let Some(obj) = args.try_get_object(activation, 0) {
+            if let Some(xml_list) = obj.as_xml_list_object() {
+                return Ok(xml_list.into());
+            }
         }
     }
+
     Ok(activation
         .avm2()
         .classes()

--- a/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Previously the call handlers would panic when given zero arguments.