### PR TITLE
avm2: Fix ifstricteq and ifstrictne comparisons

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -2472,7 +2472,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
 
-        if value1 == value2 {
+        if value1.strict_eq(&value2) {
             reader.seek(full_data, offset);
         }
 
@@ -2488,7 +2488,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let value2 = self.pop_stack();
         let value1 = self.pop_stack();
 
-        if value1 != value2 {
+        if !value1.strict_eq(&value2) {
             reader.seek(full_data, offset);
         }
 


### PR DESCRIPTION
Unlike strict_equals they were comparing with just `==`, which is not entirely correct, since objects like XmlObjects need special cases.

Found this while debugging test `e13_5_4_16`.