### PR TITLE
avm2: Add target_dirty flag and use it to reevaluate target object

### DIFF
--- a/core/src/avm2/globals/xml.rs
+++ b/core/src/avm2/globals/xml.rs
@@ -216,29 +216,9 @@ pub fn child<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     let xml = this.as_xml_object().unwrap();
     let multiname = name_to_multiname(activation, &args[0], false)?;
-    let children = if let E4XNodeKind::Element { children, .. } = &*xml.node().kind() {
-        if let Some(local_name) = multiname.local_name() {
-            if let Ok(index) = local_name.parse::<usize>() {
-                let children = if let Some(node) = children.get(index) {
-                    vec![E4XOrXml::E4X(*node)]
-                } else {
-                    Vec::new()
-                };
-                return Ok(XmlListObject::new(activation, children, None, None).into());
-            }
-        }
 
-        children
-            .iter()
-            .filter(|node| node.matches_name(&multiname))
-            .map(|node| E4XOrXml::E4X(*node))
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    // FIXME: If name is not a number index, then we should call [[Get]] (get_property_local) with the name.
-    Ok(XmlListObject::new(activation, children, Some(xml.into()), Some(multiname)).into())
+    let list = xml.child(&multiname, activation);
+    Ok(list.into())
 }
 
 pub fn child_index<'gc>(

--- a/core/src/avm2/globals/xml_list.rs
+++ b/core/src/avm2/globals/xml_list.rs
@@ -197,7 +197,7 @@ pub fn children<'gc>(
         }
     }
     // FIXME: This method should just call get_property_local with "*".
-    Ok(XmlListObject::new(
+    Ok(XmlListObject::new_with_children(
         activation,
         sub_children,
         Some(list.into()),
@@ -240,7 +240,13 @@ pub fn attribute<'gc>(
     }
 
     // FIXME: This should just use get_property_local with an attribute Multiname.
-    Ok(XmlListObject::new(activation, sub_children, Some(list.into()), Some(multiname)).into())
+    Ok(XmlListObject::new_with_children(
+        activation,
+        sub_children,
+        Some(list.into()),
+        Some(multiname),
+    )
+    .into())
 }
 
 pub fn attributes<'gc>(
@@ -258,7 +264,7 @@ pub fn attributes<'gc>(
     }
 
     // FIXME: This should just use get_property_local with an any attribute Multiname.
-    Ok(XmlListObject::new(
+    Ok(XmlListObject::new_with_children(
         activation,
         child_attrs,
         Some(list.into()),
@@ -319,7 +325,9 @@ pub fn text<'gc>(
             );
         }
     }
-    Ok(XmlListObject::new(activation, nodes, Some(xml_list.into()), None).into())
+    // FIXME: This should call XmlObject's text() and concat everything together
+    //        (Necessary for correct target object/property and dirty flag).
+    Ok(XmlListObject::new_with_children(activation, nodes, Some(xml_list.into()), None).into())
 }
 
 pub fn comments<'gc>(
@@ -339,7 +347,10 @@ pub fn comments<'gc>(
             );
         }
     }
-    Ok(XmlListObject::new(activation, nodes, Some(xml_list.into()), None).into())
+
+    // FIXME: This should call XmlObject's comments() and concat everything together
+    //        (Necessary for correct target object/property and dirty flag).
+    Ok(XmlListObject::new_with_children(activation, nodes, Some(xml_list.into()), None).into())
 }
 
 // ECMA-357 13.5.4.17 XMLList.prototype.parent ( )
@@ -401,5 +412,7 @@ pub fn processing_instructions<'gc>(
         }
     }
 
-    Ok(XmlListObject::new(activation, nodes, Some(xml_list.into()), None).into())
+    // FIXME: This should call XmlObject's processing_instructions() and concat everything together
+    //        (Necessary for correct target object/property and dirty flag).
+    Ok(XmlListObject::new_with_children(activation, nodes, Some(xml_list.into()), None).into())
 }

--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -160,8 +160,8 @@ impl<'gc> XmlListObject<'gc> {
     }
 
     // ECMA-357 9.2.1.6 [[Append]] (V)
-    pub fn append(&self, value: Value<'gc>, activation: &mut Activation<'_, 'gc>) {
-        let mut write = self.0.write(activation.gc());
+    pub fn append(&self, value: Value<'gc>, mc: &Mutation<'gc>) {
+        let mut write = self.0.write(mc);
 
         // 3. If Type(V) is XMLList,
         if let Some(list) = value.as_object().and_then(|x| x.as_xml_list_object()) {
@@ -750,7 +750,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                         }
 
                         // 2.c.ix. Call the [[Append]] method of x with argument y
-                        self.append(XmlObject::new(y, activation).into(), activation);
+                        self.append(XmlObject::new(y, activation).into(), activation.gc());
                     }
 
                     // 2.d. If (Type(V) ∉ {XML, XMLList}) or (V.[[Class]] ∈ {"text", "attribute"}), let V = ToString(V)
@@ -941,7 +941,7 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
                 }
 
                 // 3.a.iii. Call the [[Append]] method of x with argument r
-                self.append(r.as_object().into(), activation);
+                self.append(r.as_object().into(), activation.gc());
             }
 
             let mut write = self.0.write(activation.gc());

--- a/tests/tests/swfs/from_avmplus/e4x/XMLList/e13_5_4_4/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/XMLList/e13_5_4_4/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This behavior is required by #13677.

This is not mentioned in E4X specification and seems to be an `avmplus` quirk.
Unfortunately, this requires looking through all uses of XmlListObject::new, which use a Vec to set the children and make them use [[Append]] where mentioned in E4X specification.