### PR TITLE
avm2: Fix setting frontAndBack culling

### DIFF
--- a/core/src/avm2/globals/flash/display3D/context_3d.rs
+++ b/core/src/avm2/globals/flash/display3D/context_3d.rs
@@ -243,7 +243,7 @@ pub fn set_culling<'gc>(
             Context3DTriangleFace::Back
         } else if &*culling == b"front" {
             Context3DTriangleFace::Front
-        } else if &*culling == b"front_and_back" {
+        } else if &*culling == b"frontAndBack" {
             Context3DTriangleFace::FrontAndBack
         } else {
             tracing::error!("Unknown culling {:?}", culling);


### PR DESCRIPTION
The name uses camel case, not snake case.