### PR TITLE
web: Switch click and pointer events to act on element and not window

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -298,7 +298,10 @@ export class RufflePlayer extends HTMLElement {
             "context-menu-overlay",
         )!;
         this.contextMenuElement = this.shadow.getElementById("context-menu")!;
-        window.addEventListener("pointerdown", this.checkIfTouch.bind(this));
+        document.documentElement.addEventListener(
+            "pointerdown",
+            this.checkIfTouch.bind(this),
+        );
         this.addEventListener("contextmenu", this.showContextMenu.bind(this));
         this.container.addEventListener(
             "pointerdown",
@@ -1555,11 +1558,15 @@ export class RufflePlayer extends HTMLElement {
 
         if (event.type === "contextmenu") {
             this.contextMenuSupported = true;
-            window.addEventListener("click", this.hideContextMenu.bind(this), {
-                once: true,
-            });
+            document.documentElement.addEventListener(
+                "click",
+                this.hideContextMenu.bind(this),
+                {
+                    once: true,
+                },
+            );
         } else {
-            window.addEventListener(
+            document.documentElement.addEventListener(
                 "pointerup",
                 this.hideContextMenu.bind(this),
                 { once: true },


### PR DESCRIPTION
Apparently only Elements are trusted targets for the click event: https://w3c.github.io/uievents/#event-types-list. While https://w3c.github.io/pointerevents/ doesn't specify the trusted targets for pointer events, I assume they correspond to their mouse event counterparts.

See also https://forum.palemoon.org/viewtopic.php?f=70&t=30469&p=244953#p244955