### PR TITLE
Update to wgpu 0.18, naga 0.14, naga_oil 0.11, egui 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eb1adf08c5bcaa8490b9851fd53cca27fa9880076f178ea9d29f05196728a8"
+checksum = "ca8410747ed85a17c4a1e9ed3f5a74d3e7bdcc876cf9a18ff40ae21d645997b2"
 dependencies = [
  "enumn",
  "serde",
@@ -1343,9 +1343,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ecolor"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf4e52dbbb615cfd30cf5a5265335c217b5fd8d669593cea74a517d9c605af"
+checksum = "4b7637fc2e74d17e52931bac90ff4fc061ac776ada9c7fa272f24cdca5991972"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd69fed5fcf4fbb8225b24e80ea6193b61e17a625db105ef0c4d71dde6eb8b7"
+checksum = "c55bcb864b764eb889515a38b8924757657a250738ad15126637ee2df291ee6b"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1367,11 +1367,12 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d4c9ab93d9528c184ef1d695c8c99b2e6d50833696ec3f513063efeee0fe77"
+checksum = "2d8ea73b329649be625fac2c9b190a2a8f9a66f98610c4b09124b596c6695053"
 dependencies = [
  "bytemuck",
+ "egui",
  "epaint",
  "log",
  "thiserror",
@@ -1382,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15479a96d9fadccf5dac690bdc6373b97b8e1c0dd28367058f25a5298da0195"
+checksum = "3b673606b6606b12b95e3a3194d7882bf5cff302db36a520b8144c7c342e4e84"
 dependencies = [
  "arboard",
  "egui",
@@ -1398,15 +1399,15 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ffe3fe5c00295f91c2a61a74ee271c32f74049c94ba0b1cea8f26eb478bc07"
+checksum = "4b880044250106e673610c9a15d62692ef8af396593058f334be6f2a4d9544a5"
 dependencies = [
  "egui",
  "enum-map",
  "image",
  "log",
- "mime_guess",
+ "mime_guess2",
  "serde",
 ]
 
@@ -1418,9 +1419,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "emath"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef2b29de53074e575c18b694167ccbe6e5191f7b25fe65175a0d905a32eeec0"
+checksum = "a045c6c0b44b35e98513fc1e9d183ab42881ac27caccb9fa345465601f56cce4"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1522,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58067b840d009143934d91d8dcb8ded054d8301d7c11a517ace0a99bb1e1595e"
+checksum = "7d1b9e000d21bab9b535ce78f9f7745be28b3f777f6c7223936561c5c7fefab8"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1795,6 +1796,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
  "spin",
 ]
 
@@ -2139,6 +2143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,14 +2214,23 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728"
+checksum = "886c2a30b160c4c6fec8f987430c26b526b7988ca71f664e6a699ddf6f9601e4"
 dependencies = [
  "js-sys",
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -2241,15 +2265,16 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
+checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
 dependencies = [
  "backtrace",
  "log",
+ "presser",
  "thiserror",
  "winapi",
- "windows 0.44.0",
+ "windows 0.51.1",
 ]
 
 [[package]]
@@ -2327,12 +2352,6 @@ checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
 dependencies = [
  "crunchy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2494,23 +2513,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2714,14 +2723,20 @@ dependencies = [
 
 [[package]]
 name = "khronos-egl"
-version = "4.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "pkg-config",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -3064,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
 dependencies = [
  "bitflags 2.4.1",
  "block",
@@ -3084,10 +3099,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
+name = "mime_guess2"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "25a3333bb1609500601edc766a39b4c1772874a4ce26022f4d866854dc020c41"
 dependencies = [
  "mime",
  "unicase",
@@ -3134,15 +3149,14 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
+version = "0.14.1"
+source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#e16f7b4083dd6b89597fa2d4c3272331193b3515"
 dependencies = [
  "bit-set",
  "bitflags 2.4.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 1.9.3",
+ "indexmap",
  "log",
  "num-traits",
  "pp-rs",
@@ -3179,22 +3193,31 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5e64da99d79501b244fb645154cd17d0f726b572cb7b029942fb8aa0c48823"
+checksum = "fff3f369dd665ee365daeab786466a6f70ff53e4a95a76117363b1077e1b0492"
 dependencies = [
  "bit-set",
  "codespan-reporting",
  "data-encoding",
- "indexmap 1.9.3",
+ "indexmap",
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "rustc-hash",
  "thiserror",
  "tracing",
  "unicode-ident",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -3853,6 +3876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4155,12 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
@@ -4238,7 +4273,7 @@ dependencies = [
  "generational-arena",
  "hashbrown 0.14.3",
  "image",
- "indexmap 2.1.0",
+ "indexmap",
  "jpegxr",
  "linkme",
  "lzma-rs",
@@ -4412,7 +4447,7 @@ dependencies = [
  "fnv",
  "futures",
  "image",
- "indexmap 2.1.0",
+ "indexmap",
  "lru",
  "naga",
  "naga-agal",
@@ -4757,7 +4792,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -5296,7 +5331,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -5307,7 +5342,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5948,11 +5983,12 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.17.2"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.17#fb4f9c53f7110766de381273168644a1eaec9323"
+version = "0.18.0"
+source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#e16f7b4083dd6b89597fa2d4c3272331193b3515"
 dependencies = [
  "arrayvec",
  "cfg-if",
+ "flume 0.11.0",
  "js-sys",
  "log",
  "naga",
@@ -5972,8 +6008,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.17.1"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.17#fb4f9c53f7110766de381273168644a1eaec9323"
+version = "0.18.1"
+source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#e16f7b4083dd6b89597fa2d4c3272331193b3515"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -5996,8 +6032,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.17.2"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.17#fb4f9c53f7110766de381273168644a1eaec9323"
+version = "0.18.1"
+source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#e16f7b4083dd6b89597fa2d4c3272331193b3515"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6008,6 +6044,7 @@ dependencies = [
  "core-graphics-types",
  "d3d12",
  "glow",
+ "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -6020,6 +6057,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
+ "once_cell",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -6036,8 +6074,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.17.0"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.17#fb4f9c53f7110766de381273168644a1eaec9323"
+version = "0.18.0"
+source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#e16f7b4083dd6b89597fa2d4c3272331193b3515"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",
@@ -6115,15 +6153,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
@@ -6137,6 +6166,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core",
  "windows-targets 0.48.5",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ version = "0.1.0"
 # gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "efd89fc683c6bb456af3e226c33763cb822645e9" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-naga = { version = "0.13.0", features = ["validate", "wgsl-out"] }
-naga_oil = "0.9.0"
-wgpu = "0.17.1"
-egui = "0.23.0"
+naga = { version = "0.14.1", features = ["validate", "wgsl-out"] }
+naga_oil = "0.11.0"
+wgpu = "0.18.0"
+egui = "0.24.1"
 
 # Don't optimize build scripts and macros.
 [profile.release.build-override]
@@ -84,10 +84,8 @@ inherits = "release"
 [profile.web-wasm-extensions]
 inherits = "release"
 
-# The `v0.17` branch is a single backport commit ahead of the `v0.17.2` release,
-# which we need. FIXME: Remove when wgpu `v0.18` is released and we can switch to it.
 [patch.crates-io]
-wgpu = { git = "https://github.com/gfx-rs/wgpu", branch = "v0.17" }
-
-[patch.'https://github.com/gfx-rs/naga']
-naga = "0.13.0"
+# These are needed because https://github.com/gfx-rs/wgpu/pull/4778
+# is not yet in the latest wgpu release. TODO: Remove when it is.
+wgpu = { git = "https://github.com/gfx-rs/wgpu", branch = "v0.18" }
+naga = { git = "https://github.com/gfx-rs/wgpu", branch = "v0.18" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ hashbrown = { version = "0.14.3", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.8.0"
 egui = { workspace = true, optional = true }
-egui_extras = { version = "0.23.0", optional = true }
+egui_extras = { version = "0.24.1", optional = true }
 png = { version = "0.17.10", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = "2.1.1"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -11,10 +11,10 @@ version.workspace = true
 clap = { version = "4.4.11", features = ["derive"] }
 cpal = "0.15.2"
 egui = { workspace = true }
-egui_extras = { version = "0.23.0", features = ["image"] }
-egui-wgpu = { version = "0.23.0", features = ["winit"] }
+egui_extras = { version = "0.24.1", features = ["image"] }
+egui-wgpu = { version = "0.24.1", features = ["winit"] }
 image = { version = "0.24", features = ["png"] }
-egui-winit = "0.23.0"
+egui-winit = "0.24.1"
 fontdb = "0.16"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui", "default_font"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -403,7 +403,7 @@ fn main() -> Result<()> {
     let opt: Opt = Opt::parse();
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: opt.graphics.into(),
-        dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+        ..Default::default()
     });
     let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
         opt.graphics.into(),

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -479,6 +479,7 @@ impl<'a> NagaBuilder<'a> {
                             location: 0,
                             interpolation: None,
                             sampling: None,
+                            second_blend_source: false,
                         }),
                         offset: 0,
                     }],
@@ -501,6 +502,7 @@ impl<'a> NagaBuilder<'a> {
                         location: 0,
                         interpolation: None,
                         sampling: None,
+                        second_blend_source: false,
                     }),
                 });
             }
@@ -653,6 +655,7 @@ impl<'a> NagaBuilder<'a> {
                     location: index as u32,
                     interpolation: None,
                     sampling: None,
+                    second_blend_source: false,
                 }),
             });
 

--- a/render/naga-agal/src/varying.rs
+++ b/render/naga-agal/src/varying.rs
@@ -60,6 +60,7 @@ impl<'a> NagaBuilder<'a> {
                                     location: index as u32,
                                     interpolation: Some(naga::Interpolation::Perspective),
                                     sampling: None,
+                                    second_blend_source: false,
                                 }),
                                 offset: 0,
                             });
@@ -85,6 +86,7 @@ impl<'a> NagaBuilder<'a> {
                             location: index as u32,
                             interpolation: Some(Interpolation::Perspective),
                             sampling: None,
+                            second_blend_source: false,
                         }),
                     });
                     let arg_index = self.func.arguments.len() - 1;

--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -259,6 +259,7 @@ impl<'a> ShaderBuilder<'a> {
                 location: 0,
                 interpolation: Some(naga::Interpolation::Perspective),
                 sampling: Some(naga::Sampling::Center),
+                second_blend_source: false,
             }),
         });
 
@@ -268,6 +269,7 @@ impl<'a> ShaderBuilder<'a> {
                 location: 0,
                 interpolation: None,
                 sampling: None,
+                second_blend_source: false,
             }),
         });
 

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -62,7 +62,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
     pub async fn for_canvas(canvas: web_sys::HtmlCanvasElement) -> Result<Self, Error> {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
-            dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+            ..Default::default()
         });
         let surface = instance.create_surface_from_canvas(canvas)?;
         let (adapter, device, queue) = request_adapter_and_device(
@@ -97,7 +97,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
         }
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: backend,
-            dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+            ..Default::default()
         });
         let surface = unsafe { instance.create_surface(window) }?;
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
@@ -144,7 +144,7 @@ impl WgpuRenderBackend<crate::target::TextureTarget> {
         }
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: backend,
-            dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+            ..Default::default()
         });
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             backend,
@@ -981,7 +981,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    store: true,
+                    store: wgpu::StoreOp::Store,
                 },
             }),
             1,

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -265,11 +265,11 @@ impl WgpuContext3D {
                 view: depth_view,
                 depth_ops: Some(wgpu::Operations {
                     load: depth_load,
-                    store: true,
+                    store: wgpu::StoreOp::Store,
                 }),
                 stencil_ops: Some(wgpu::Operations {
                     load: stencil_load,
-                    store: true,
+                    store: wgpu::StoreOp::Store,
                 }),
             })
         } else {
@@ -283,10 +283,11 @@ impl WgpuContext3D {
                 resolve_target: self.current_texture_resolve_view.as_deref(),
                 ops: wgpu::Operations {
                     load: color_load,
-                    store: true,
+                    store: wgpu::StoreOp::Store,
                 },
             })],
             depth_stencil_attachment,
+            ..Default::default()
         });
         pass.set_bind_group(0, self.bind_group.as_ref().unwrap(), &[]);
         pass.set_pipeline(

--- a/render/wgpu/src/filters/bevel.rs
+++ b/render/wgpu/src/filters/bevel.rs
@@ -237,7 +237,7 @@ impl BevelFilter {
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Bevel filter").as_deref(),
             color_attachments: &[target.color_attachments()],
-            depth_stencil_attachment: None,
+            ..Default::default()
         });
         render_pass.set_pipeline(pipeline);
 

--- a/render/wgpu/src/filters/blur.rs
+++ b/render/wgpu/src/filters/blur.rs
@@ -317,7 +317,7 @@ impl BlurFilter {
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Blur filter").as_deref(),
             color_attachments: &[destination.color_attachments()],
-            depth_stencil_attachment: None,
+            ..Default::default()
         });
         render_pass.set_pipeline(pipeline);
 
@@ -381,7 +381,7 @@ impl BlurFilter {
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Blur filter").as_deref(),
             color_attachments: &[destination.color_attachments()],
-            depth_stencil_attachment: None,
+            ..Default::default()
         });
         render_pass.set_pipeline(pipeline);
 

--- a/render/wgpu/src/filters/color_matrix.rs
+++ b/render/wgpu/src/filters/color_matrix.rs
@@ -160,7 +160,7 @@ impl ColorMatrixFilter {
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Color matrix filter").as_deref(),
             color_attachments: &[target.color_attachments()],
-            depth_stencil_attachment: None,
+            ..Default::default()
         });
         render_pass.set_pipeline(pipeline);
 

--- a/render/wgpu/src/filters/displacement_map.rs
+++ b/render/wgpu/src/filters/displacement_map.rs
@@ -235,7 +235,7 @@ impl DisplacementMapFilter {
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Displacement map filter").as_deref(),
             color_attachments: &[target.color_attachments()],
-            depth_stencil_attachment: None,
+            ..Default::default()
         });
         render_pass.set_pipeline(pipeline);
 

--- a/render/wgpu/src/filters/glow.rs
+++ b/render/wgpu/src/filters/glow.rs
@@ -214,7 +214,7 @@ impl GlowFilter {
         let mut render_pass = draw_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: create_debug_label!("Glow filter").as_deref(),
             color_attachments: &[target.color_attachments()],
-            depth_stencil_attachment: None,
+            ..Default::default()
         });
         render_pass.set_pipeline(pipeline);
 

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -16,7 +16,7 @@ use ruffle_render::{
 use wgpu::util::StagingBelt;
 use wgpu::{
     BindGroupEntry, BindingResource, BlendComponent, BufferDescriptor, BufferUsages,
-    ColorTargetState, ColorWrites, CommandEncoder, FrontFace, ImageCopyTexture, PipelineLayout,
+    ColorTargetState, ColorWrites, CommandEncoder, ImageCopyTexture, PipelineLayout,
     RenderPipeline, RenderPipelineDescriptor, SamplerBindingType, ShaderModuleDescriptor,
     TextureDescriptor, TextureFormat, TextureView, VertexState,
 };
@@ -71,11 +71,7 @@ impl PixelBenderWgpuShader {
                             write_mask: ColorWrites::all(),
                         })],
                     }),
-                    primitive: wgpu::PrimitiveState {
-                        front_face: FrontFace::Ccw,
-                        cull_mode: None,
-                        ..Default::default()
-                    },
+                    primitive: Default::default(),
                     depth_stencil: None,
                     multisample: wgpu::MultisampleState {
                         count: samples,
@@ -558,6 +554,7 @@ pub(super) fn run_pixelbender_shader_impl(
         label: Some("PixelBender render pass"),
         color_attachments: &[color_attachment],
         depth_stencil_attachment: None,
+        ..Default::default()
     });
     render_pass.set_bind_group(0, &bind_group, &[]);
     render_pass.set_pipeline(pipeline);

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -169,6 +169,7 @@ impl Surface {
                             } else {
                                 None
                             },
+                            ..Default::default()
                         });
                     render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
                     let mut renderer = CommandRenderer::new(
@@ -298,6 +299,7 @@ impl Surface {
                             } else {
                                 None
                             },
+                            ..Default::default()
                         });
                     render_pass.set_bind_group(0, target.globals().bind_group(), &[]);
 

--- a/render/wgpu/src/surface/target.rs
+++ b/render/wgpu/src/surface/target.rs
@@ -338,7 +338,7 @@ impl CommandTarget {
             encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: create_debug_label!("Clearing command target").as_deref(),
                 color_attachments: &[self.color_attachments()],
-                depth_stencil_attachment: None,
+                ..Default::default()
             });
         }
     }
@@ -367,7 +367,10 @@ impl CommandTarget {
         Some(wgpu::RenderPassColorAttachment {
             view: self.frame_buffer.view(),
             resolve_target: self.resolve_buffer.as_ref().map(|b| b.view()),
-            ops: wgpu::Operations { load, store: true },
+            ops: wgpu::Operations {
+                load,
+                store: wgpu::StoreOp::Store,
+            },
         })
     }
 
@@ -393,7 +396,7 @@ impl CommandTarget {
                 } else {
                     wgpu::LoadOp::Load
                 },
-                store: true,
+                store: wgpu::StoreOp::Store,
             }),
         })
     }

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -248,13 +248,16 @@ pub fn run_copy_pipeline(
     let load = wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT);
 
     let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: create_debug_label!("Copy back to render target").as_deref(),
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
             view: frame_view,
-            ops: wgpu::Operations { load, store: true },
+            ops: wgpu::Operations {
+                load,
+                store: wgpu::StoreOp::Store,
+            },
             resolve_target: None,
         })],
-        depth_stencil_attachment: None,
-        label: create_debug_label!("Copy back to render target").as_deref(),
+        ..Default::default()
     });
 
     render_pass.set_pipeline(&pipeline);


### PR DESCRIPTION
~~Currently blocked by, and~~ mostly based on: https://github.com/emilk/egui/pull/3505
~~EDIT: This is now merged, waiting for a new release.~~
EDIT: egui 0.24 is now out.
 
~~Also blocked by https://github.com/bevyengine/naga_oil/pull/63, which is in turn, by https://github.com/gfx-rs/wgpu/issues/4569~~.
~~EDIT: The latter is now merged, also waiting for a new release.~~
~~EDIT: A backport of the  latter is in v0.18: https://github.com/gfx-rs/wgpu/pull/4693~~
EDIT: naga_oil 0.11.0 and wgpu-core 0.18.1 are now out with these fixes.

Feel free to force-push this branch if any of you continue working on this!