### PR TITLE
Update the Dockerfile for building the browser extensions

### DIFF
--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -1,24 +1,32 @@
-# run this file from ruffle root dir (not the docker dir) like 
+# Run this file from ruffle root dir (not the docker dir) like this:
 # rm -rf web/docker/docker_builds/*
 # docker build --tag ruffle-web-docker -f web/docker/Dockerfile .
 # docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages
 FROM ubuntu:22.04
-ENV DEBIAN_FRONTEND=noninteractive 
-RUN apt-get update -y 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y
 RUN apt-get -y full-upgrade
+# Installing dependencies:
 RUN apt-get install -y apt-utils
-RUN apt-get install -y wget git openssl libssl-dev gcc gzip tar default-jre-headless pkg-config
-RUN wget 'https://deb.nodesource.com/setup_lts.x' --quiet -O- | bash
+RUN apt-get install -y wget git openssl libssl-dev gcc clang gzip tar default-jre-headless pkg-config
+# Installing Node.js from the nodesource repo according to their instructions:
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=20
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update -y
 RUN apt-get install -y nodejs
-RUN wget 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh';
-RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda;
+# Getting Miniconda from their website:
+RUN wget 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh'
+RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda
 ENV PATH="/miniconda/bin:$PATH"
 RUN conda install -y -c conda-forge binaryen
+# Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
-# RUN source "$HOME/.cargo/env"
-# source to modify env doesn't work with docker it seems :( so add cargo to PATH manually:
 ENV PATH="/root/.cargo/bin:$PATH"
 RUN cargo install wasm-bindgen-cli --version 0.2.87
+# Building Ruffle:
 COPY . ruffle
 WORKDIR ruffle/web
 ENV CARGO_FEATURES=jpegxr

--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -33,7 +33,7 @@ function transformManifest(content, env) {
             firefoxExtensionId = versionSeal.firefox_extension_id;
         } else {
             throw new Error(
-                "Version seal requested but not found. Please run web/packages/core/tools/set_version.js with ENABLE_VERSION_SEAL to generate it.",
+                "Version seal requested but not found. To generate it, please run web/packages/core/tools/set_version.js using npm in the web directory, with the ENABLE_VERSION_SEAL environment variable set to true.",
             );
         }
     }


### PR DESCRIPTION
This should unblock the automatic Firefox add-on updates. Also remove an intentional 60 second delay from their build attempts.

Summary of changes:

- Add clang to the dependencies
- Migrate Node.js installation to their new recommended method
- Add some comments for each logical step
- Remove a redundant comment
- Remove some unnecessary semicolons

As for why the Node.js installation method was changed, see: https://github.com/nodesource/distributions#new-update-%EF%B8%8F