### PR TITLE
ci: Test that the Dockerfile in web is able to build the browser extensions

### DIFF
--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -1,0 +1,45 @@
+name: Test extension builder Dockerfile
+
+on:
+  #Run weekly every Thursday (one day before AMO submission)
+  schedule:
+   - cron: "0 2 * * 5"
+
+  #Allow for manual tests if needed
+  workflow_dispatch:
+
+jobs:
+  test-dockerfile:
+    name: Test the Dockerfile
+    runs-on: ubuntu-22.04
+
+    if: github.repository == 'ruffle-rs/ruffle'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate version seal
+        env:
+          ENABLE_VERSION_SEAL: true
+        working-directory: ./web
+        run: |
+          npm install
+          node packages/core/tools/set_version.js
+
+      - name: Build Docker image with Ruffle in it
+        run: docker build --tag ruffle-web-docker -f web/docker/Dockerfile .
+
+      - name: Copy extensions out of Docker image
+        run: docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages
+
+      - name: Check that the Firefox extension was built
+        run: test -f web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi
+
+      - name: Notify Discord
+        uses: th0th/notify-discord@v0.4.1
+        if: ${{ always() }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_JOB_NAME: "Build extension via Dockerfile"
+          GITHUB_JOB_STATUS: ${{ job.status }}


### PR DESCRIPTION
This should check weekly that https://github.com/ruffle-rs/ruffle/pull/13733 didn't regress, and the Firefox extension is buildable by the Dockerfile.

The question is, who is going to notice if this fails, and in what way?
Also, should we try passing in the environment variables containing the relevant repo secrets, so the signing step is also checked?

See for an example invocation: https://github.com/torokati44/ruffle/actions/runs/6661108191/job/18103430036