### PR TITLE
nit: Fix tool name in error message of extension build

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -33,7 +33,7 @@ function transformManifest(content, env) {
             firefoxExtensionId = versionSeal.firefox_extension_id;
         } else {
             throw new Error(
-                "Version seal requested but not found. To generate it, please run web/packages/core/tools/set_version.js using npm in the web directory, with the ENABLE_VERSION_SEAL environment variable set to true.",
+                "Version seal requested but not found. To generate it, please run web/packages/core/tools/set_version.js using node in the web directory, with the ENABLE_VERSION_SEAL environment variable set to true.",
             );
         }
     }


### PR DESCRIPTION
This is a fixup for https://github.com/ruffle-rs/ruffle/pull/13733.

I always confuse these things, and notice these minor mistakes an hour after merging. _Gosh hecking darn it!_