### PR TITLE
web: Clean up nonsensical feature setup of the ruffle_core dependency

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -56,8 +56,7 @@ gloo-net =  { version = "0.4.0", default-features = false, features = ["websocke
 
 [dependencies.ruffle_core]
 path = "../core"
-default-features = false
-features = ["audio", "mp3", "nellymoser", "wasm-bindgen", "default", "default_compatibility_rules", "default_font"]
+features = ["audio", "mp3", "nellymoser", "wasm-bindgen", "default_compatibility_rules", "default_font"]
 
 [dependencies.web-sys]
 version = "0.3.64"


### PR DESCRIPTION
If we disable the default features on one line, why re-enable it manually on the next line...
And the default feature list of core is empty anyway, so it makes no difference anyway.