### PR TITLE
chore: Add `--locked` to all `cargo build` invocations

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -118,7 +118,7 @@ jobs:
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev
 
       - name: Cargo build
-        run: cargo build --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
+        run: cargo build --locked --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Build Safari Web Extension stub binary
         if: runner.os == 'macOS'
-        run: cargo build --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
+        run: cargo build --locked --package ruffle_web_safari --release ${{ matrix.target && '--target' }} ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -81,7 +81,7 @@ jobs:
         env:
           RUSTFLAGS: -D warnings
           # Verify that all features build.
-          CARGO_FLAGS: --locked --all-features
+          CARGO_FLAGS: --all-features
         working-directory: web
         shell: bash -l {0}
         run: |

--- a/web/packages/core/tools/build_wasm.js
+++ b/web/packages/core/tools/build_wasm.js
@@ -29,7 +29,7 @@ function runWasmBindgen({ path, outName, flags, dir }) {
     });
 }
 function cargoBuild({ profile, features, rustFlags }) {
-    let args = ["build", "--target", "wasm32-unknown-unknown"];
+    let args = ["build", "--locked", "--target", "wasm32-unknown-unknown"];
     if (profile) {
         args.push("--profile", profile);
     }


### PR DESCRIPTION
We should do it this way according to @Dinnerbone.