### PR TITLE
avm2: Correctly set `caller_movie` in `Activation::from_script`

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -239,7 +239,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             local_registers,
             outer: ScopeChain::new(domain),
             caller_domain: Some(domain),
-            caller_movie: None,
+            caller_movie: script.translation_unit().map(|t| t.movie()),
             subclass_object: None,
             activation_class: None,
             stack_depth: context.avm2.stack.len(),


### PR DESCRIPTION
I'd like to get this merged quickly so correct behavior can be implemented in #13756. If that PR adds a test that checks if `appendChild`/`prependChild`/etc do in fact use the current movie and not the root movie, there shouldn't be any need to add a test to this PR.

This should fix a case where `MC.gotoAndPlay/Stop` is used in a script initializer- before this PR, that would panic.