### PR TITLE
core: Fix BG music not stopping in Samorost (close #963)

### DIFF
--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -768,6 +768,7 @@ impl<'gc> Loader<'gc> {
                 if let Some(mut mc) = clip.as_movie_clip() {
                     if !uc.is_action_script_3() {
                         mc.avm1_unload(uc);
+                        uc.stop_all_sounds();
                     }
 
                     // Before the actual SWF is loaded, an initial loading state is entered.


### PR DESCRIPTION
`MovieClip avm1_unload()` was already stopping the current stream at https://github.com/ruffle-rs/ruffle/blob/5bebebddbe3c39362ba520cb0c9c28b3cb7f72a3/core/src/display_object/movie_clip.rs#L2924C18-L2924C18 in Samorost, the BG music that keeps playing after switching SWFs in ruffle is not a stream but a sound.

I don't know how to make it stop only the sound that's currently playing, so here's a "fix" that just stops them all.