### PR TITLE
avm2: Allow assigning XML objects without a name (eg. text)

### DIFF
--- a/core/src/avm2/object/xml_list_object.rs
+++ b/core/src/avm2/object/xml_list_object.rs
@@ -731,12 +731,12 @@ impl<'gc> TObject<'gc> for XmlListObject<'gc> {
 
                             // 2.c.viii.2. If Type(V) is XML, let y.[[Name]] = V.[[Name]]
                             if let Some(xml) = value.as_object().and_then(|x| x.as_xml_object()) {
-                                // FIXME: What if XML value does not have a local name?
-                                y.set_local_name(
-                                    xml.node().local_name().expect("Not validated yet"),
-                                    activation.gc(),
-                                );
-                                // FIXME: Also set the namespace.
+                                if let Some(name) = xml.node().local_name() {
+                                    y.set_local_name(name, activation.gc());
+                                }
+                                if let Some(namespace) = xml.node().namespace() {
+                                    y.set_namespace(namespace, activation.gc());
+                                }
                             }
 
                             // 2.c.viii.3. Else if Type(V) is XMLList, let y.[[Name]] = V.[[TargetProperty]]

--- a/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_4_27/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/XML/e13_4_4_27/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This should fix #13800 and #13803. Thanks to `XML.appendChild` now using the `set_property_local` path, we get test coverage for free. :tada: 