### PR TITLE
core,avm1,avm2: Stub 9-slice scaling (`scale9Grid`)

### DIFF
--- a/core/src/avm1/globals/button.rs
+++ b/core/src/avm1/globals/button.rs
@@ -3,9 +3,11 @@
 use crate::avm1::activation::Activation;
 use crate::avm1::error::Error;
 use crate::avm1::globals::bitmap_filter;
+use crate::avm1::globals::movie_clip::{new_rectangle, object_to_rectangle};
 use crate::avm1::property_decl::{define_properties_on, Declaration};
 use crate::avm1::ArrayObject;
 use crate::avm1::{globals, Object, ScriptObject, TObject, Value};
+use crate::avm1_stub;
 use crate::context::GcContext;
 use crate::display_object::{Avm1Button, TDisplayObject};
 use crate::string::AvmString;
@@ -42,6 +44,7 @@ const PROTO_DECLS: &[Declaration] = declare_properties! {
     "useHandCursor" => bool(true);
     "getDepth" => method(globals::get_depth; DONT_DELETE | READ_ONLY | VERSION_6);
     "blendMode" => property(button_getter!(blend_mode), button_setter!(set_blend_mode); DONT_DELETE | VERSION_8);
+    "scale9Grid" => property(button_getter!(scale_9_grid), button_setter!(set_scale_9_grid); DONT_DELETE | DONT_ENUM | VERSION_8);
     "filters" => property(button_getter!(filters), button_setter!(set_filters); DONT_DELETE | DONT_ENUM | VERSION_8);
     "cacheAsBitmap" => property(button_getter!(cache_as_bitmap), button_setter!(set_cache_as_bitmap); DONT_DELETE | DONT_ENUM | VERSION_8);
 };
@@ -139,5 +142,34 @@ fn set_cache_as_bitmap<'gc>(
         activation.context.gc_context,
         value.as_bool(activation.swf_version()),
     );
+    Ok(())
+}
+
+fn scale_9_grid<'gc>(
+    this: Avm1Button<'gc>,
+    activation: &mut Activation<'_, 'gc>,
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm1_stub!(activation, "Button", "scale9Grid");
+    let rect = this.scaling_grid();
+    if rect.is_valid() {
+        new_rectangle(activation, rect)
+    } else {
+        Ok(Value::Undefined)
+    }
+}
+
+fn set_scale_9_grid<'gc>(
+    this: Avm1Button<'gc>,
+    activation: &mut Activation<'_, 'gc>,
+    value: Value<'gc>,
+) -> Result<(), Error<'gc>> {
+    avm1_stub!(activation, "Button", "scale9Grid");
+    if let Value::Object(object) = value {
+        if let Some(rectangle) = object_to_rectangle(activation, object)? {
+            this.set_scaling_grid(activation.context.gc_context, rectangle);
+        }
+    } else {
+        this.set_scaling_grid(activation.context.gc_context, Default::default());
+    };
     Ok(())
 }

--- a/core/src/avm2/globals/flash/display/DisplayObject.as
+++ b/core/src/avm2/globals/flash/display/DisplayObject.as
@@ -72,14 +72,9 @@ package flash.display {
 
         public native function get scaleZ():Number;
         public native function set scaleZ(value:Number):void;
-        
-        public function get scale9Grid():Rectangle {
-            stub_getter("flash.display.DisplayObject", "scale9Grid");
-            return null;
-        }
-        public function set scale9Grid(value:Rectangle):void {
-            stub_setter("flash.display.DisplayObject", "scale9Grid");
-        }
+
+        public native function get scale9Grid():Rectangle;
+        public native function set scale9Grid(value:Rectangle):void;
 
         public native function get name():String;
         public native function set name(value:String):void;

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -138,6 +138,44 @@ pub fn set_height<'gc>(
     Ok(Value::Undefined)
 }
 
+/// Implements `scale9Grid`'s getter.
+pub fn get_scale9grid<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_getter!(activation, "flash.display.DisplayObject", "scale9Grid");
+    if let Some(dobj) = this.as_display_object() {
+        let rect = dobj.scaling_grid();
+        return if rect.is_valid() {
+            let rect = new_rectangle(activation, rect)?;
+            Ok(rect.into())
+        } else {
+            Ok(Value::Null)
+        };
+    }
+
+    Ok(Value::Undefined)
+}
+
+/// Implements `scale9Grid`'s setter.
+pub fn set_scale9grid<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    this: Object<'gc>,
+    args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    avm2_stub_setter!(activation, "flash.display.DisplayObject", "scale9Grid");
+    if let Some(dobj) = this.as_display_object() {
+        let rect = match args.try_get_object(activation, 0) {
+            None => Rectangle::default(),
+            Some(rect) => object_to_rectangle(activation, rect)?,
+        };
+        dobj.set_scaling_grid(activation.context.gc_context, rect);
+    }
+
+    Ok(Value::Undefined)
+}
+
 /// Implements `scaleY`'s getter.
 pub fn get_scale_y<'gc>(
     activation: &mut Activation<'_, 'gc>,

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -252,6 +252,10 @@ pub struct DisplayObjectBase<'gc> {
     #[collect(require_static)]
     next_scroll_rect: Rectangle<Twips>,
 
+    /// Rectangle used for 9-slice scaling (`DislayObject.scale9grid`).
+    #[collect(require_static)]
+    scaling_grid: Rectangle<Twips>,
+
     /// If this Display Object should cacheAsBitmap - and if so, the cache itself.
     /// None means not cached, Some means cached.
     #[collect(require_static)]
@@ -282,6 +286,7 @@ impl<'gc> Default for DisplayObjectBase<'gc> {
             flags: DisplayObjectFlags::VISIBLE,
             scroll_rect: None,
             next_scroll_rect: Default::default(),
+            scaling_grid: Default::default(),
             cache: None,
         }
     }
@@ -1614,6 +1619,14 @@ pub trait TDisplayObject<'gc>:
         if let Some(parent) = self.parent() {
             parent.invalidate_cached_bitmap(gc_context);
         }
+    }
+
+    fn scaling_grid(&self) -> Rectangle<Twips> {
+        self.base().scaling_grid.clone()
+    }
+
+    fn set_scaling_grid(&self, gc_context: &Mutation<'gc>, rect: Rectangle<Twips>) {
+        self.base_mut(gc_context).scaling_grid = rect;
     }
 
     /// Whether this object has been removed. Only applies to AVM1.

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -598,6 +598,10 @@ impl<'gc> MovieClip<'gc> {
                     .0
                     .write(context.gc_context)
                     .define_morph_shape(context, reader, 2),
+                TagCode::DefineScalingGrid => self
+                    .0
+                    .write(context.gc_context)
+                    .define_scaling_grid(context, reader),
                 TagCode::DefineShape => self
                     .0
                     .write(context.gc_context)
@@ -3470,6 +3474,25 @@ impl<'gc, 'a> MovieClipData<'gc> {
             .library
             .library_for_movie_mut(self.movie())
             .register_character(define_bits_lossless.id, Character::Bitmap(bitmap));
+        Ok(())
+    }
+
+    #[inline]
+    fn define_scaling_grid(
+        &mut self,
+        context: &mut UpdateContext<'_, 'gc>,
+        reader: &mut SwfStream<'a>,
+    ) -> Result<(), Error> {
+        let id = reader.read_u16()?;
+        let rect = reader.read_rectangle()?;
+        let library = context.library.library_for_movie_mut(self.movie());
+        if let Some(character) = library.character_by_id(id) {
+            if let Character::MovieClip(clip) = character {
+                clip.set_scaling_grid(context.gc_context, rect);
+            } else {
+                tracing::warn!("DefineScalingGrid for invalid ID {}", id);
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This is a rebased version of the core, avm1, and avm2 parts of #10611, minus rendering.

~~This is a rebased version of #10611. Only minor changes done, like a typo fix, removing some back-and-forth changes, and turning the added visual test into an actually runnable test.~~

~~I'm not sure if `render_with_scaling_grid` is still needed with our current (caching, blending, filtering, masking, scrolling, etc.) renderer setup, or if only some part of it should be thrown out, or if it's even called from the right place.~~

~~Fixes #3302.~~
~~Improves, but does not fix, #13688.~~
~~Also related: #9829~~