### PR TITLE
avm2: Don't add ClassDefinition to AMF0 objects

### DIFF
--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -126,11 +126,15 @@ pub fn serialize_value<'gc>(
                     recursive_serialize(activation, o, &mut object_body, amf_version).unwrap();
                     Some(AmfValue::Object(
                         object_body,
-                        Some(ClassDefinition {
-                            name: "".to_string(),
-                            attributes: EnumSet::only(Attribute::Dynamic),
-                            static_properties: Vec::new(),
-                        }),
+                        if amf_version == AMFVersion::AMF3 {
+                            Some(ClassDefinition {
+                                name: "".to_string(),
+                                attributes: EnumSet::only(Attribute::Dynamic),
+                                static_properties: Vec::new(),
+                            })
+                        } else {
+                            None
+                        },
                     ))
                 } else {
                     tracing::warn!(

--- a/tests/tests/swfs/avm2/socket_read_write_object/test.toml
+++ b/tests/tests/swfs/avm2/socket_read_write_object/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 10
-known_failure = true # Flash serializes AMF0 Object as object, but ruffle as typed object


### PR DESCRIPTION
This fixes #12383

We should probably include it when doing not-objects later, maybe? But this spot is specifically `new Object()` which should have no type info included.