### PR TITLE
avm1: Correctly mark unloaded movies as unloaded instead of relying on clip depth

### DIFF
--- a/core/src/display_object/container.rs
+++ b/core/src/display_object/container.rs
@@ -1018,6 +1018,7 @@ impl<'gc> ChildContainer<'gc> {
         let cur_depth = child.depth();
         // Note that the depth returned by AS will be offset by the `AVM_DEPTH_BIAS`, so this is really `-(cur_depth+1+AVM_DEPTH_BIAS)`
         child.set_depth(context.gc_context, -cur_depth - 1);
+        child.set_avm1_pending_removal(context.gc_context, true);
 
         if let Some(mc) = child.as_movie_clip() {
             // Clip events should still fire


### PR DESCRIPTION
Fixes #9522 and fixes #10633. I'm pretty sure that this will also f​ix #9886 and #13876, but I haven't created test SWFs for those.

Logic is from [Toad06's branch](https://github.com/ruffle-rs/ruffle/compare/master...Toad06:ruffle:unload_test), mentioned in #10633.

When merged, #14276 should include enough test coverage.