### PR TITLE
Use VM_INTERNAL api version in helper methods

### DIFF
--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -301,7 +301,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         value: Value<'gc>,
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
-        let name = Multiname::new(activation.avm2().public_namespace_base_version, name);
+        let name = Multiname::new(activation.avm2().public_namespace_vm_internal, name);
         self.set_property_local(&name, value, activation)
     }
 
@@ -368,7 +368,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<(), Error<'gc>> {
         self.set_property(
-            &Multiname::new(activation.avm2().public_namespace_base_version, name),
+            &Multiname::new(activation.avm2().public_namespace_vm_internal, name),
             value,
             activation,
         )


### PR DESCRIPTION
This is a better default than using the lowest possible version, as it allows things like AMF deserialization to see all properties on the target object.

This only affects explicit Ruffle-side property setting - interpreted code will continue to use the namespace version determined by the SWF version.