### PR TITLE
chore: Update flash-lso

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "flash-lso"
 version = "0.6.0"
-source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=949ffefaf7c16c829bf0be267011b138b95d935f#949ffefaf7c16c829bf0be267011b138b95d935f"
+source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=f9526ea0e7e22cf5704972aa43c5b0f9e8896773#f9526ea0e7e22cf5704972aa43c5b0f9e8896773"
 dependencies = [
  "cookie-factory",
  "enumset",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.190", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a33521c29a918950df8ae9fe07e527ac65553f5", optional = true }
 regress = "0.7"
-flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "949ffefaf7c16c829bf0be267011b138b95d935f" }
+flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "f9526ea0e7e22cf5704972aa43c5b0f9e8896773" }
 lzma-rs = {version = "0.3.0", optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.3", default-features = false, features = ["mp3"], optional = true }


### PR DESCRIPTION
Update to https://github.com/ruffle-rs/rust-flash-lso/commit/f9526ea0e7e22cf5704972aa43c5b0f9e8896773