### PR TITLE
avm2: Support enumeration for XML objects

### DIFF
--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -590,6 +590,41 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
         Ok(())
     }
 
+    fn get_next_enumerant(
+        self,
+        last_index: u32,
+        _activation: &mut Activation<'_, 'gc>,
+    ) -> Result<Option<u32>, Error<'gc>> {
+        Ok(Some(if last_index == 0 { 1 } else { 0 }))
+    }
+
+    fn get_enumerant_value(
+        self,
+        index: u32,
+        _activation: &mut Activation<'_, 'gc>,
+    ) -> Result<Value<'gc>, Error<'gc>> {
+        if index == 1 {
+            Ok(self.into())
+        } else {
+            Ok(Value::Undefined)
+        }
+    }
+
+    fn get_enumerant_name(
+        self,
+        index: u32,
+        _activation: &mut Activation<'_, 'gc>,
+    ) -> Result<Value<'gc>, Error<'gc>> {
+        if index == 1 {
+            Ok(index
+                .checked_sub(1)
+                .map(|index| index.into())
+                .unwrap_or(Value::Undefined))
+        } else {
+            Ok(Value::Undefined)
+        }
+    }
+
     fn delete_property_local(
         self,
         activation: &mut Activation<'_, 'gc>,

--- a/tests/tests/swfs/from_avmplus/e4x/Expressions/e11_2_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/Expressions/e11_2_2/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true # https://github.com/ruffle-rs/ruffle/issues/12351


### PR DESCRIPTION
Previously, iterating the XML object would iterate the prototype. This broke filtering expressions on XML objects, which should work.