### PR TITLE
avm2: Re-use same AMFValue for the same Object ptr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "flash-lso"
 version = "0.6.0"
-source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=450234ad4225facff08226c31468fb7cf9fb8197#450234ad4225facff08226c31468fb7cf9fb8197"
+source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=2f976fb15b30aa4c5cb398710dc5e31a21004e57#2f976fb15b30aa4c5cb398710dc5e31a21004e57"
 dependencies = [
  "cookie-factory",
  "enumset",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.190", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a33521c29a918950df8ae9fe07e527ac65553f5", optional = true }
 regress = "0.7"
-flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "450234ad4225facff08226c31468fb7cf9fb8197" }
+flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "2f976fb15b30aa4c5cb398710dc5e31a21004e57" }
 lzma-rs = {version = "0.3.0", optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.3", default-features = false, features = ["mp3"], optional = true }

--- a/core/src/avm2/globals/flash/net/shared_object.rs
+++ b/core/src/avm2/globals/flash/net/shared_object.rs
@@ -17,7 +17,14 @@ fn new_lso<'gc>(
     data: Object<'gc>,
 ) -> Result<Lso, Error<'gc>> {
     let mut elements = Vec::new();
-    crate::avm2::amf::recursive_serialize(activation, data, &mut elements, None, AMFVersion::AMF3)?;
+    crate::avm2::amf::recursive_serialize(
+        activation,
+        data,
+        &mut elements,
+        None,
+        AMFVersion::AMF3,
+        &mut Default::default(),
+    )?;
     Ok(Lso::new(
         elements,
         name.split('/')

--- a/core/src/avm2/globals/flash/net/socket.rs
+++ b/core/src/avm2/globals/flash/net/socket.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::avm2::bytearray::{Endian, ObjectEncoding};
 use crate::avm2::error::{io_error, make_error_2008, security_error};
 pub use crate::avm2::object::socket_allocator;
@@ -644,8 +646,10 @@ pub fn write_object<'gc>(
             ObjectEncoding::Amf0 => AMFVersion::AMF0,
             ObjectEncoding::Amf3 => AMFVersion::AMF3,
         };
-        if let Some(amf) = crate::avm2::amf::serialize_value(activation, obj, amf_version) {
-            let element = Element::new("", amf);
+        if let Some(amf) =
+            crate::avm2::amf::serialize_value(activation, obj, amf_version, &mut Default::default())
+        {
+            let element = Element::new("", Rc::new(amf));
             let mut lso = flash_lso::types::Lso::new(vec![element], "", amf_version);
             let bytes = flash_lso::write::write_to_bytes(&mut lso)
                 .map_err(|_| "Failed to serialize object")?;

--- a/core/src/avm2/globals/flash/utils/byte_array.rs
+++ b/core/src/avm2/globals/flash/utils/byte_array.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::avm2::activation::Activation;
 use crate::avm2::bytearray::{Endian, ObjectEncoding};
 use crate::avm2::error::make_error_2008;
@@ -797,8 +799,10 @@ pub fn write_object<'gc>(
             ObjectEncoding::Amf0 => AMFVersion::AMF0,
             ObjectEncoding::Amf3 => AMFVersion::AMF3,
         };
-        if let Some(amf) = crate::avm2::amf::serialize_value(activation, obj, amf_version) {
-            let element = Element::new("", amf);
+        if let Some(amf) =
+            crate::avm2::amf::serialize_value(activation, obj, amf_version, &mut Default::default())
+        {
+            let element = Element::new("", Rc::new(amf));
             let mut lso = flash_lso::types::Lso::new(vec![element], "", amf_version);
             let bytes = flash_lso::write::write_to_bytes(&mut lso)
                 .map_err(|_| "Failed to serialize object")?;


### PR DESCRIPTION
This preserves object identity across a serialization round-trip. Unfortunately, we don't currently implement this correctly in flash_lso, so I've added a stub message.

Once flash_lso is fixed, this code will start working. For now, it just allows us to detect (via the stub) if this is actually used by an SWF.