### PR TITLE
avm2: Small TLF fixes

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -6,7 +6,7 @@ use crate::avm2::parameters::ParametersExt;
 use crate::avm2::value::Value;
 use crate::avm2::Multiname;
 use crate::avm2_stub_method;
-use crate::display_object::EditText;
+use crate::display_object::{EditText, TDisplayObject};
 use crate::html::TextFormat;
 use crate::string::WStr;
 
@@ -150,6 +150,10 @@ fn apply_format<'gc>(
     }
 
     display_object.set_word_wrap(true, &mut activation.context);
+
+    let measured_text = display_object.measure_text(&mut activation.context);
+
+    display_object.set_height(&mut activation.context, measured_text.1.to_pixels());
 
     Ok(())
 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -789,12 +789,6 @@ impl<'gc> EditText<'gc> {
             !edit_text.flags.contains(EditTextFlag::USE_OUTLINES),
         );
 
-        if edit_text.is_tlf {
-            // Resize the TLF textfield to match the height of the text.
-            // FIXME: This should probably be done in text_block::create_text_line.
-            edit_text.bounds.set_height(intrinsic_bounds.extent_y());
-        }
-
         edit_text.line_data = get_line_data(&new_layout);
         edit_text.layout = new_layout;
         edit_text.intrinsic_bounds = intrinsic_bounds;

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -391,6 +391,7 @@ impl<'gc> EditText<'gc> {
     ) -> Self {
         let text = Self::new(context, swf_movie, x, y, width, height);
         text.set_is_tlf(context.gc_context, true);
+        text.set_selectable(false, context);
 
         text
     }


### PR DESCRIPTION
Fix some vertical cutoff by resizing the `EditText` in `text_block::create_text_line` instead of resizing it in `EditText::relayout`, and ensure that TLF `EditText`s are not selectable (previously they were stealing the focus).