### PR TITLE
avm2: Improve E4XNode::matches_name

### DIFF
--- a/core/src/avm2/multiname.rs
+++ b/core/src/avm2/multiname.rs
@@ -364,6 +364,13 @@ impl<'gc> Multiname<'gc> {
         }
     }
 
+    pub fn has_nonempty_namespace(&self) -> bool {
+        match self.ns {
+            NamespaceSet::Single(ns) => !ns.is_public(),
+            NamespaceSet::Multiple(_) => true,
+        }
+    }
+
     pub fn explict_namespace(&self) -> Option<AvmString<'gc>> {
         match self.ns {
             NamespaceSet::Single(ns) if ns.is_namespace() && !ns.is_public() => Some(ns.as_uri()),

--- a/core/src/avm2/object/xml_object.rs
+++ b/core/src/avm2/object/xml_object.rs
@@ -275,7 +275,7 @@ impl<'gc> TObject<'gc> for XmlObject<'gc> {
         }
 
         // Special case to handle code like: xml["@attr"]
-        let multiname = if !name.has_explicit_namespace()
+        let multiname = if !name.has_nonempty_namespace()
             && !name.is_attribute()
             && !name.is_any_name()
             && !name.is_any_namespace()

--- a/tests/tests/swfs/from_avmplus/e4x/Regress/regress-263935/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/Regress/regress-263935/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Avmplus constructs a full `QName`, and uses the normal Multiname matching logic. This would be a large refactor, so I've just modified the existing method to properly handle multiple namespaces.

I've also included a closely related fix - we should only treat a multiname with the literal local name "@foo" as an attribute when the namespace is the empty public namespace. We were incorrectly reparsing multinames that contained multiple namespaces.