### PR TITLE
avm2: Use 'has_own_property' to check for prop in 'resolve_definition'

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -284,11 +284,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         } else if let Some(result) = outer_scope.resolve(name, self)? {
             Ok(Some(result))
         } else if let Some(global) = self.global_scope() {
-            let prop = global.base().get_property_local(name, self)?;
-            if prop == Value::Undefined {
+            if !global.base().has_own_property(name) {
                 return Ok(None);
             }
-            Ok(Some(prop))
+            return Ok(Some(global.base().get_property_local(name, self)?));
         } else {
             Ok(None)
         }

--- a/tests/tests/swfs/from_avmplus/ecma3/Statements/eswitch_004/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Statements/eswitch_004/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Statements/ewhile_002/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Statements/ewhile_002/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
If Actionscript explicitly sets the property to 'undefined', we should still succeed.