### PR TITLE
desktop: Add window.location.href spoofing to the fake ExternalInterface

### DIFF
--- a/desktop/src/backends/external_interface.rs
+++ b/desktop/src/backends/external_interface.rs
@@ -1,10 +1,30 @@
-use ruffle_core::external::{ExternalInterfaceMethod, ExternalInterfaceProvider};
+use ruffle_core::context::UpdateContext;
+use ruffle_core::external::{
+    ExternalInterfaceMethod, ExternalInterfaceProvider, Value as ExternalValue,
+};
+use url::Url;
 
-#[derive(Default)]
-pub struct DesktopExternalInterfaceProvider;
+pub struct DesktopExternalInterfaceProvider {
+    pub spoof_url: Option<Url>,
+}
+
+struct FakeWindowLocationHrefToString(Url);
+
+impl ExternalInterfaceMethod for FakeWindowLocationHrefToString {
+    fn call(&self, _context: &mut UpdateContext<'_, '_>, _args: &[ExternalValue]) -> ExternalValue {
+        ExternalValue::String(self.0.to_string())
+    }
+}
 
 impl ExternalInterfaceProvider for DesktopExternalInterfaceProvider {
-    fn get_method(&self, _name: &str) -> Option<Box<dyn ExternalInterfaceMethod>> {
+    fn get_method(&self, name: &str) -> Option<Box<dyn ExternalInterfaceMethod>> {
+        if let Some(ref url) = self.spoof_url {
+            if name == "window.location.href.toString" {
+                return Some(Box::new(FakeWindowLocationHrefToString(url.clone())));
+            }
+        }
+
+        tracing::warn!("Trying to call unknown ExternalInterface method: {name}");
         None
     }
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -128,8 +128,9 @@ impl ActivePlayer {
         RENDER_INFO.with(|i| *i.borrow_mut() = Some(renderer.debug_info().to_string()));
 
         if opt.dummy_external_interface {
-            builder =
-                builder.with_external_interface(Box::<DesktopExternalInterfaceProvider>::default());
+            builder = builder.with_external_interface(Box::new(DesktopExternalInterfaceProvider {
+                spoof_url: opt.spoof_url.clone(),
+            }));
         }
 
         let max_execution_duration = if opt.max_execution_duration == f64::INFINITY {


### PR DESCRIPTION
From what I can tell this `ExternalInterface.call("window.location.href.toString")` is probably the most common usage of the ExternalInterace API, for example in #12054, #8330 and others that I can't remember. I re-used the already existing `--spoof-url` parameter for this.