### PR TITLE
avm2: Make MouseEvent isRelatedPropertyInaccessible a getter/setter

### DIFF
--- a/core/src/avm2/globals/flash/events/MouseEvent.as
+++ b/core/src/avm2/globals/flash/events/MouseEvent.as
@@ -33,7 +33,7 @@ package flash.events
         public var shiftKey: Boolean;
         public var buttonDown: Boolean;
         public var delta: int;
-        public var isRelatedObjectInaccessible: Boolean;
+        private var _isRelatedObjectInaccessible: Boolean;
 
         public var movementX: Number;
         public var movementY: Number;
@@ -59,7 +59,6 @@ package flash.events
             this.shiftKey = shiftKey;
             this.buttonDown = buttonDown;
             this.delta = delta;
-            this.isRelatedObjectInaccessible = false; // unimplemented
 
             this.movementX = 0.0; // unimplemented
             this.movementY = 0.0; // unimplemented
@@ -74,6 +73,14 @@ package flash.events
         override public function toString() : String
         {
             return this.formatToString("MouseEvent","type","bubbles","cancelable","eventPhase","localX","localY","stageX","stageY","relatedObject","ctrlKey","altKey","shiftKey","buttonDown","delta");
+        }
+
+        public function get isRelatedObjectInaccessible():Boolean {
+            return _isRelatedObjectInaccessible;
+        }
+
+        public function set isRelatedObjectInaccessible(value:Boolean):void {
+            _isRelatedObjectInaccessible = value;
         }
 
         public native function updateAfterEvent():void;


### PR DESCRIPTION
Slightly progresses #10173 after #14037. Without this PR but with #14037, the error that appears when clicking anywhere on the animation (which full-screens the content in Ruffle but not in browser Flash) is about writing to the read-only property isRelatedPropertyInaccessible. With this PR, it's instead TLF/FTE related.