### PR TITLE
avm2: Add `Activation::caller_movie_or_root` to default to root movie

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -604,6 +604,12 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         self.caller_movie.clone()
     }
 
+    /// Like `caller_movie()`, but returns the root movie if `caller_movie`
+    /// is `None`. This matches what FP does in most cases.
+    pub fn caller_movie_or_root(&self) -> Arc<SwfMovie> {
+        self.caller_movie().unwrap_or(self.context.swf.clone())
+    }
+
     /// Returns the global scope of this activation.
     ///
     /// The global scope refers to scope at the bottom of the

--- a/core/src/avm2/e4x.rs
+++ b/core/src/avm2/e4x.rs
@@ -1342,7 +1342,7 @@ pub fn maybe_escape_child<'gc>(
         }
     }
 
-    if activation.caller_movie().unwrap().version() >= 21 {
+    if activation.caller_movie_or_root().version() >= 21 {
         if let Some(xml) = child.as_object().and_then(|x| x.as_xml_object()) {
             let node = xml.node();
             let parent = node.parent();

--- a/core/src/avm2/globals/flash/display/movie_clip.rs
+++ b/core/src/avm2/globals/flash/display/movie_clip.rs
@@ -393,12 +393,7 @@ pub fn goto_frame<'gc>(
 
                 let frame = mc.frame_label_to_number(&frame_or_label, &activation.context);
 
-                if activation
-                    .caller_movie()
-                    .expect("Caller SWF should exist")
-                    .version()
-                    >= 11
-                {
+                if activation.caller_movie_or_root().version() >= 11 {
                     frame.ok_or(
                         // TODO: Also include the scene in the error message, as done above
                         Error::AvmError(argument_error(

--- a/core/src/avm2/globals/flash/text/font.rs
+++ b/core/src/avm2/globals/flash/text/font.rs
@@ -104,7 +104,7 @@ pub fn enumerate_fonts<'gc>(
     if let Some(library) = activation
         .context
         .library
-        .library_for_movie(activation.caller_movie().unwrap())
+        .library_for_movie(activation.caller_movie_or_root())
     {
         for font in library.embedded_fonts() {
             // TODO: EmbeddedCFF isn't supposed to show until it's been used (some kind of internal initialization method?)


### PR DESCRIPTION
Supersedes #13492.

Fixes #14041 and fixes #13490.