### PR TITLE
avm2: Implement flash.system.Security pageDomain

### DIFF
--- a/core/src/avm2/globals/flash/system/Security.as
+++ b/core/src/avm2/globals/flash/system/Security.as
@@ -1,6 +1,8 @@
 package flash.system {
 	public final class Security {
+		public static native function get pageDomain():String;
 		public static native function get sandboxType():String;
+
 		public static native function allowDomain(... domains):void;
 		public static native function allowInsecureDomain(... domains):void;
 		public static native function loadPolicyFile(url: String):void;

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -164,6 +164,8 @@ pub struct UpdateContext<'a, 'gc> {
     /// The system properties
     pub system: &'a mut SystemProperties,
 
+    pub page_url: &'a mut Option<String>,
+
     /// The current instance ID. Used to generate default `instanceN` names.
     pub instance_counter: &'a mut i32,
 
@@ -377,6 +379,7 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
             player: self.player.clone(),
             load_manager: self.load_manager,
             system: self.system,
+            page_url: self.page_url,
             instance_counter: self.instance_counter,
             avm1_shared_objects: self.avm1_shared_objects,
             avm2_shared_objects: self.avm2_shared_objects,

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -298,6 +298,8 @@ pub struct Player {
 
     system: SystemProperties,
 
+    page_url: Option<String>,
+
     /// The current instance ID. Used to generate default `instanceN` names.
     instance_counter: i32,
 
@@ -1927,6 +1929,7 @@ impl Player {
                 player: self.self_reference.clone(),
                 load_manager,
                 system: &mut self.system,
+                page_url: &mut self.page_url,
                 instance_counter: &mut self.instance_counter,
                 storage: self.storage.deref_mut(),
                 log: self.log.deref_mut(),
@@ -2184,6 +2187,7 @@ pub struct PlayerBuilder {
     player_version: Option<u8>,
     quality: StageQuality,
     sandbox_type: SandboxType,
+    page_url: Option<String>,
     frame_rate: Option<f64>,
     external_interface_providers: Vec<Box<dyn ExternalInterfaceProvider>>,
     fs_command_provider: Box<dyn FsCommandProvider>,
@@ -2229,6 +2233,7 @@ impl PlayerBuilder {
             player_version: None,
             quality: StageQuality::High,
             sandbox_type: SandboxType::LocalTrusted,
+            page_url: None,
             frame_rate: None,
             external_interface_providers: vec![],
             fs_command_provider: Box::new(NullFsCommandProvider),
@@ -2391,6 +2396,12 @@ impl PlayerBuilder {
         self
     }
 
+    // Configure the embedding page's URL (if applicable)
+    pub fn with_page_url(mut self, page_url: Option<String>) -> Self {
+        self.page_url = page_url;
+        self
+    }
+
     /// Sets and locks the player's frame rate. If None is provided, this has no effect.
     pub fn with_frame_rate(mut self, frame_rate: Option<f64>) -> Self {
         self.frame_rate = frame_rate;
@@ -2532,6 +2543,7 @@ impl PlayerBuilder {
                 // Misc. state
                 rng: SmallRng::seed_from_u64(get_current_date_time().timestamp_millis() as u64),
                 system: SystemProperties::new(self.sandbox_type),
+                page_url: self.page_url.clone(),
                 transform_stack: TransformStack::new(),
                 instance_counter: 0,
                 player_version,

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -156,6 +156,7 @@ impl ActivePlayer {
             .with_fullscreen(opt.fullscreen)
             .with_load_behavior(opt.load_behavior)
             .with_spoofed_url(opt.spoof_url.clone().map(|url| url.to_string()))
+            .with_page_url(opt.spoof_url.clone().map(|url| url.to_string()))
             .with_player_version(Some(opt.player_version))
             .with_frame_rate(opt.frame_rate);
         let player = builder.build();

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -674,6 +674,7 @@ impl Ruffle {
             .with_frame_rate(config.frame_rate)
             // FIXME - should this be configurable?
             .with_sandbox_type(SandboxType::Remote)
+            .with_page_url(window.location().href().ok())
             .build();
 
         let mut callstack = None;


### PR DESCRIPTION
Improves #14028. 

I don't have a good way to test real Flash in a browser, so it would be interesting to know what `Security.pageDomain` returns exactly. The documentation mentions `http://www.example.com` so without a trailing slash.