### PR TITLE
avm2: Mark MovieClip as initialized in 'on_construction_complete'

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1902,6 +1902,7 @@ pub trait TDisplayObject<'gc>:
             if !obj.is_of_type(movieclip_class, context) && !movie.is_root() {
                 movie.stop(context);
             }
+            movie.set_initialized(context.gc_context);
         }
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -435,6 +435,10 @@ impl<'gc> MovieClip<'gc> {
         drop(mc);
     }
 
+    pub fn set_initialized(self, gc_context: &Mutation<'gc>) {
+        self.0.write(gc_context).set_initialized(true);
+    }
+
     /// Preload a chunk of the movie.
     ///
     /// A "chunk" is an implementor-chosen number of tags that are parsed
@@ -2658,10 +2662,6 @@ impl<'gc> TDisplayObject<'gc> for MovieClip<'gc> {
                     }
                     child.construct_frame(context);
                 }
-            }
-
-            if is_load_frame {
-                self.0.write(context.gc_context).set_initialized(true);
             }
         }
     }


### PR DESCRIPTION
This ensures that a re-entrant 'construct_frame' call (e.g. due to a goto or AVM2 button) does not end up marking a MovieClip as initialized too early.

This issue was causing us to run 'fire_init_and_complete_events' too early, firing Loader events before we had actually finished (and before the SWF had registered the relevant listeners).