### PR TITLE
core: fix lerp_twips sometimes being off-by-one due to FP error

### DIFF
--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -415,7 +415,7 @@ fn lerp_color(start: &Color, end: &Color, a: f32, b: f32) -> Color {
 }
 
 fn lerp_twips(start: Twips, end: Twips, a: f32, b: f32) -> Twips {
-    Twips::new((start.get() as f32 * a + end.get() as f32 * b) as i32)
+    Twips::new((start.get() as f32 * a + end.get() as f32 * b).round() as i32)
 }
 
 fn lerp_fill(start: &swf::FillStyle, end: &swf::FillStyle, a: f32, b: f32) -> swf::FillStyle {
@@ -598,5 +598,23 @@ fn lerp_gradient(start: &swf::Gradient, end: &swf::Gradient, a: f32, b: f32) -> 
         spread: start.spread,
         interpolation: start.interpolation,
         records,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Regression test for #14074
+    #[test]
+    fn test_lerp_rounding() {
+        let ratio: u16 = 17246;
+        let b = f32::from(ratio) / 65535.0;
+        let a = 1.0 - b;
+
+        assert_eq!(
+            lerp_twips(Twips::new(-7), Twips::new(-7), a, b),
+            Twips::new(-7)
+        );
     }
 }


### PR DESCRIPTION
The issue:

* Morphing is done by lerping control points between a start and end shape.
* Control points are specified in twips, so lerp_twips is used.
* Twips are integers.
* lerp_twips converts the start and end twips to floats, does its math, and converts them back to integers.
* When converting the lerped float back to an integer, it uses "float as i32"
* This performs round-towards-zero.
* So if, due to FP inaccuracy, the result was -6.9999999, this would round to -6, not -7, which is a whole twip out.
* Sometimes this could cause lerp_twips(x, x, ...) != x
* There are only 20 twips to a pixel so this error compounds fast in complex paths.

The fix:

Use `.round() as i32` instead of `as i32`.

Example failure case:

```rust

let ratio: u16 = 17246;
let b = f32::from(ratio) / 65535.0;
let a = 1.0 - b;

println!(
    "{}",
    lerp_twips(
        Twips::new(-7),
        Twips::new(-7),
        a,
        b
    )
);
// Prints -6

```

Example affected SWF:

https://foon.uk/farcade/jig08/

This bug is causing the campfire on the right to glitch out.

