### PR TITLE
avm2: Always run loadCompressedTextureFromByteArray synchronously

### DIFF
--- a/core/src/avm2/globals/flash/display3D/textures/Texture.as
+++ b/core/src/avm2/globals/flash/display3D/textures/Texture.as
@@ -10,8 +10,10 @@ package flash.display3D.textures {
         public function uploadCompressedTextureFromByteArray(data:ByteArray, byteArrayOffset:uint, async:Boolean = false):void {
             if (async) {
                 var self = this;
+                // FIXME - actually run this in the background, with a copy of 'data'
+                self.uploadCompressedTextureFromByteArrayInternal(data, byteArrayOffset);
+
                 setTimeout(function() {
-                    self.uploadCompressedTextureFromByteArrayInternal(data, byteArrayOffset);
                     self.dispatchEvent(new Event("textureReady"));
                 }, 0);
             } else {


### PR DESCRIPTION
The caller might modify the ByteArray immediately after the call. Since we don't have a simple way of copying it from ActionScript, let's perform the actual upload synchronously, but still fire the event during the next tick.

Fixes https://github.com/ruffle-rs/ruffle/issues/13990