### PR TITLE
README.md: Avoid _ showing between image links at the top of the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,12 @@
   <a href="https://ruffle.rs"><img alt="Ruffle" src="https://ruffle.rs/assets/logo.svg" /></a>
 </p>
 <p align="center">
-  <a href="https://github.com/ruffle-rs/ruffle/actions">
-    <img alt="Rust Build Status" src="https://img.shields.io/github/actions/workflow/status/ruffle-rs/ruffle/test_rust.yml?label=Rust%20Build&logo=github&branch=master" />
-    <img alt="Web Build Status" src="https://img.shields.io/github/actions/workflow/status/ruffle-rs/ruffle/test_web.yml?label=Web%20Build&logo=github&branch=master" />
-  </a>
-  <a href="https://www.npmjs.com/package/@ruffle-rs/ruffle">
-    <img alt="Ruffle npm" src="https://img.shields.io/npm/v/@ruffle-rs/ruffle?color=007acc&logo=npm" />
-  </a>
-  <a href="https://aur.archlinux.org/packages/ruffle-nightly-bin">
-    <img alt="Ruffle AUR" src="https://img.shields.io/aur/version/ruffle-nightly-bin?logo=archlinux" />
-  </a>
-  <a href="https://discord.gg/ruffle">
-    <img alt="Ruffle Discord" src="https://img.shields.io/discord/610531541889581066?label=&color=7389d8&labelColor=6a7ec2&logoColor=ffffff&logo=discord" />
-  </a>
-  <a href="https://crowdin.com/project/ruffle">
-    <img alt="Ruffle translations" src="https://badges.crowdin.net/ruffle/localized.svg" />
-  </a>
+  <a href="https://github.com/ruffle-rs/ruffle/actions"><img alt="Rust Build Status" src="https://img.shields.io/github/actions/workflow/status/ruffle-rs/ruffle/test_rust.yml?label=Rust%20Build&logo=github&branch=master" /></a>
+  <a href="https://github.com/ruffle-rs/ruffle/actions/workflows/test_web.yml"><img alt="Web Build Status" src="https://img.shields.io/github/actions/workflow/status/ruffle-rs/ruffle/test_web.yml?label=Web%20Build&logo=github&branch=master" /></a>
+  <a href="https://www.npmjs.com/package/@ruffle-rs/ruffle"><img alt="Ruffle npm" src="https://img.shields.io/npm/v/@ruffle-rs/ruffle?color=007acc&logo=npm" /></a>
+  <a href="https://aur.archlinux.org/packages/ruffle-nightly-bin"><img alt="Ruffle AUR" src="https://img.shields.io/aur/version/ruffle-nightly-bin?logo=archlinux" /></a>
+  <a href="https://discord.gg/ruffle"><img alt="Ruffle Discord" src="https://img.shields.io/discord/610531541889581066?label=&color=7389d8&labelColor=6a7ec2&logoColor=ffffff&logo=discord" /></a>
+  <a href="https://crowdin.com/project/ruffle"><img alt="Ruffle translations" src="https://badges.crowdin.net/ruffle/localized.svg" /></a>
   <br />
   <strong><a href="https://ruffle.rs">website</a> | <a href="https://ruffle.rs/demo">demo</a> | <a href="https://github.com/ruffle-rs/ruffle/releases">nightly builds</a> | <a href="https://github.com/ruffle-rs/ruffle/wiki">wiki</a></strong>
 </p>


### PR DESCRIPTION
This PR edits the HTML of the badges at the top of the README.

Also, this now links to the Web Test GitHub Actions workflow page for that specific link.