### PR TITLE
avm2: Copy data for async loadCompressedTextureFromByteArray

### DIFF
--- a/core/src/avm2/globals/flash/display3D/textures/Texture.as
+++ b/core/src/avm2/globals/flash/display3D/textures/Texture.as
@@ -1,24 +1,29 @@
-package flash.display3D.textures {	
+package flash.display3D.textures {
     import flash.display.BitmapData;
     import flash.events.Event;
     import flash.utils.ByteArray;
     import flash.utils.setTimeout;
-    
+
     public final class Texture extends TextureBase {
         public native function uploadFromBitmapData(source:BitmapData, miplevel:uint = 0):void;
         public native function uploadFromByteArray(data:ByteArray, byteArrayOffset:uint, miplevel:uint = 0):void;
         public function uploadCompressedTextureFromByteArray(data:ByteArray, byteArrayOffset:uint, async:Boolean = false):void {
             if (async) {
                 var self = this;
+                var copiedData = new ByteArray();
+                data.position = 0;
+                data.readBytes(copiedData);
+
                 setTimeout(function() {
-                    self.uploadCompressedTextureFromByteArrayInternal(data, byteArrayOffset);
-                    self.dispatchEvent(new Event("textureReady"));
-                }, 0);
-            } else {
+                        self.uploadCompressedTextureFromByteArrayInternal(copiedData, byteArrayOffset);
+                        self.dispatchEvent(new Event("textureReady"));
+                    }, 0);
+            }
+            else {
                 this.uploadCompressedTextureFromByteArrayInternal(data, byteArrayOffset);
             }
         }
 
-        private native function uploadCompressedTextureFromByteArrayInternal(data:ByteArray, byteArrayOffset:uint):void
+        private native function uploadCompressedTextureFromByteArrayInternal(data:ByteArray, byteArrayOffset:uint):void;
     }
 }


### PR DESCRIPTION
The caller might modify the ByteArray immediately after the call, so we need to copy the ByteArray.

Fixes https://github.com/ruffle-rs/ruffle/issues/13990