### PR TITLE
core: Mouse positions reported to ActionScript should be integers

### DIFF
--- a/core/src/avm1/object/stage_object.rs
+++ b/core/src/avm1/object/stage_object.rs
@@ -799,12 +799,12 @@ fn set_quality<'gc>(
 
 fn x_mouse<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
     let local = this.mouse_to_local(*activation.context.mouse_position);
-    local.x.to_pixels().into()
+    local.x.to_pixels().round().into()
 }
 
 fn y_mouse<'gc>(activation: &mut Activation<'_, 'gc>, this: DisplayObject<'gc>) -> Value<'gc> {
     let local = this.mouse_to_local(*activation.context.mouse_position);
-    local.y.to_pixels().into()
+    local.y.to_pixels().round().into()
 }
 
 fn property_coerce_to_number<'gc>(


### PR DESCRIPTION
Flash Player always reports `_xmouse`, `_ymouse`, `stage.mouseX` and `stage.mouseY` as integers.