### PR TITLE
core: Add PlayerMode::{FlashPlayer, AIR} for Adobe AIR support

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,7 +69,7 @@ pub use events::PlayerEvent;
 pub use font::DefaultFont;
 pub use indexmap;
 pub use loader::LoadBehavior;
-pub use player::{Player, PlayerBuilder, StaticCallstack};
+pub use player::{Player, PlayerBuilder, PlayerRuntime, StaticCallstack};
 pub use ruffle_render::backend::ViewportDimensions;
 pub use swf;
 pub use swf::Color;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -250,6 +250,11 @@ pub struct Player {
     ///   Player can be enabled by setting a particular player version.
     player_version: u8,
 
+    /// The runtime we're emulating (Flash Player or Adobe AIR).
+    /// In Adobe AIR mode, additional classes are available
+    #[allow(unused)]
+    player_runtime: PlayerRuntime,
+
     swf: Arc<SwfMovie>,
 
     is_playing: bool,
@@ -2185,6 +2190,7 @@ pub struct PlayerBuilder {
     spoofed_url: Option<String>,
     compatibility_rules: CompatibilityRules,
     player_version: Option<u8>,
+    player_runtime: PlayerRuntime,
     quality: StageQuality,
     sandbox_type: SandboxType,
     page_url: Option<String>,
@@ -2231,6 +2237,7 @@ impl PlayerBuilder {
             spoofed_url: None,
             compatibility_rules: CompatibilityRules::default(),
             player_version: None,
+            player_runtime: PlayerRuntime::default(),
             quality: StageQuality::High,
             sandbox_type: SandboxType::LocalTrusted,
             page_url: None,
@@ -2387,6 +2394,12 @@ impl PlayerBuilder {
     /// Configures the target player version.
     pub fn with_player_version(mut self, version: Option<u8>) -> Self {
         self.player_version = version;
+        self
+    }
+
+    /// Configures the player runtime (default is `PlayerRuntime::FlashPlayer`)
+    pub fn with_player_runtime(mut self, runtime: PlayerRuntime) -> Self {
+        self.player_runtime = runtime;
         self
     }
 
@@ -2547,6 +2560,7 @@ impl PlayerBuilder {
                 transform_stack: TransformStack::new(),
                 instance_counter: 0,
                 player_version,
+                player_runtime: self.player_runtime,
                 is_playing: self.autoplay,
                 needs_render: true,
                 self_reference: self_ref.clone(),
@@ -2668,4 +2682,12 @@ fn run_mouse_pick<'gc>(
             }
         })
     })
+}
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PlayerRuntime {
+    #[default]
+    FlashPlayer,
+    AIR,
 }

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -3,7 +3,7 @@ use anyhow::Error;
 use clap::Parser;
 use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
 use ruffle_core::config::Letterbox;
-use ruffle_core::{LoadBehavior, StageAlign, StageScaleMode};
+use ruffle_core::{LoadBehavior, PlayerRuntime, StageAlign, StageScaleMode};
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use std::path::Path;
@@ -118,6 +118,10 @@ pub struct Opt {
     /// The version of the player to emulate
     #[clap(long)]
     pub player_version: Option<u8>,
+
+    /// The runtime to emulate (Flash Player or Adobe AIR)
+    #[clap(long, default_value = "flash-player")]
+    pub player_runtime: PlayerRuntime,
 
     /// Set and lock the player's frame rate, overriding the movie's frame rate.
     #[clap(long)]

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -10,7 +10,9 @@ use crate::{CALLSTACK, RENDER_INFO, SWF_INFO};
 use anyhow::anyhow;
 use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
 use ruffle_core::config::Letterbox;
-use ruffle_core::{LoadBehavior, Player, PlayerBuilder, PlayerEvent, StageAlign, StageScaleMode};
+use ruffle_core::{
+    LoadBehavior, Player, PlayerBuilder, PlayerEvent, PlayerRuntime, StageAlign, StageScaleMode,
+};
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
@@ -45,6 +47,7 @@ pub struct PlayerOptions {
     pub letterbox: Letterbox,
     pub spoof_url: Option<Url>,
     pub player_version: u8,
+    pub player_runtime: PlayerRuntime,
     pub frame_rate: Option<f64>,
     pub open_url_mode: OpenURLMode,
     pub dummy_external_interface: bool,
@@ -69,6 +72,7 @@ impl From<&Opt> for PlayerOptions {
             letterbox: value.letterbox,
             spoof_url: value.spoof_url.clone(),
             player_version: value.player_version.unwrap_or(32),
+            player_runtime: value.player_runtime,
             frame_rate: value.frame_rate,
             open_url_mode: value.open_url_mode,
             dummy_external_interface: value.dummy_external_interface,


### PR DESCRIPTION
We've now had two different bug reports involving Adobe AIR SWFs, so I'm going to go ahead and start adding a framework for AIR support.

This commit just adds a command-line option
`--player-mode <flash-player|air>` (defaulting to `flash-player`), and passes it along to the `Player`. The actual value is currently unused - in a follow-up PR, I'm going to implement namespace versioning for AIR.