### PR TITLE
web: Use CustomEvent instead of Event for load events so MooTools works

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -2356,9 +2356,9 @@ export class RufflePlayer extends HTMLElement {
         // TODO: Switch this to ReadyState.Loading when we have streaming support.
         this._readyState = ReadyState.Loaded;
         this.hideSplashScreen();
-        this.dispatchEvent(new Event(RufflePlayer.LOADED_METADATA));
+        this.dispatchEvent(new CustomEvent(RufflePlayer.LOADED_METADATA));
         // TODO: Move this to whatever function changes the ReadyState to Loaded when we have streaming support.
-        this.dispatchEvent(new Event(RufflePlayer.LOADED_DATA));
+        this.dispatchEvent(new CustomEvent(RufflePlayer.LOADED_DATA));
     }
 }
 


### PR DESCRIPTION
This seems like it fixes #14133 and makes #8348 load (though the content doesn't work properly). Likely fixes other MooTools issues too, but many of the reported issues are to do with content which has since been removed (including #6065, #2567, and #2463).

#9517 is not fixed. It uses a newer version of MooTools which likely has different issues. #8619 is not fixed; it doesn't seem to use MooTools at all anymore but it requests mixed content without proper CORS headers on the HTTPS page and on the HTTP page the SWF files can't be read either for some reason.