### PR TITLE
chore: Bump `tracing-tracy`, deny `tracy-client` duplicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,7 +3888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
 dependencies = [
  "profiling-procmacros",
- "tracy-client 0.16.4",
+ "tracy-client",
 ]
 
 [[package]]
@@ -5317,13 +5317,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-tracy"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c48ef3e655220d4e43a6be44aa84f078c3004357251cab45f9cc15551a593e"
+checksum = "fc6c7bf057d67aa107e076129a4f331aaac47ec379952d9f0775c6b1d838ee97"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
- "tracy-client 0.15.2",
+ "tracy-client",
 ]
 
 [[package]]
@@ -5339,33 +5339,13 @@ dependencies = [
 
 [[package]]
 name = "tracy-client"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608"
-dependencies = [
- "loom",
- "once_cell",
- "tracy-client-sys 0.21.2",
-]
-
-[[package]]
-name = "tracy-client"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82da0d50d9df1106619b1e5b118f39de779f7d8b9c3504485b291cb16fabd20f"
 dependencies = [
  "loom",
  "once_cell",
- "tracy-client-sys 0.22.0",
-]
-
-[[package]]
-name = "tracy-client-sys"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb915ea3af048554640d76dd6f1492589a6401a41a30d789b983c1ec280455a"
-dependencies = [
- "cc",
+ "tracy-client-sys",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,10 @@ license-files = []
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 
+# We are manually pinning `tracing-tracy` to match the version used by
+# `profiling`, but this can get stale easily.
+deny = [{ name = "tracy-client", deny-multiple-versions = true }]
+
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not
 # in the allow list is encountered

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -45,7 +45,7 @@ async-net = "2.0.0"
 async-channel = "2.1.1"
 
 # Deliberately held back to match tracy client used by profiling crate
-tracing-tracy = { version = "=0.10.2", optional = true }
+tracing-tracy = { version = "=0.10.4", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
To avoid the cryptic "span! without a running Client" runtime errors now, and hopefully keep them from reoccurring in the future.