### PR TITLE
web: Mark the Firefox extension as compatible with Android upon AMO submission

### DIFF
--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -59,6 +59,15 @@ async function sign(
             extensionId,
         )}/versions/${encodeURIComponent(version)}/`,
         json: {
+            compatibility: {
+                android: {
+                    min: "84",
+                    // "max" is undefined, so the manifest max or default will be used.
+                },
+                firefox: {
+                    min: "84",
+                },
+            },
             approval_notes: `This version was derived from the source code available at https://github.com/ruffle-rs/ruffle/releases/tag/${sourceTag} - a ZIP file from this Git tag has been attached. If you download it yourself instead of using the ZIP file provided, make sure to grab the reproducible version of the ZIP, as it contains versioning information that will not be present on the main source download.\n\
 \n\
 We highly recommend using the Docker build workflow. You can invoke it using the following three commands:\n\


### PR DESCRIPTION
See for reference:
https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#version-create
https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#version-compatibility-examples

The minimum version is from: https://github.com/ruffle-rs/ruffle/wiki#web