### PR TITLE
web: Don't let video modal overflow RufflePlayer

### DIFF
--- a/web/packages/core/src/shadow-template.ts
+++ b/web/packages/core/src/shadow-template.ts
@@ -394,6 +394,11 @@ export function applyStaticStyles(styleElement: HTMLStyleElement) {
             padding-top: 20px;
         }`,
 
+        `#video-holder video {
+            max-width: 100%;
+            height: calc(100% - 58px);
+        }`,
+
         `.slider-container {
             margin-top: 10px;
             display: flex;


### PR DESCRIPTION
58px is the padding-top of the video-holder (20px) plus the padding-top plus padding-bottom of the modal-area (16px each) plus the border-top plus border-bottom of the modal-area (3px each). Noticed this issue on the no longer in use webpage https://bioservers.org/ddnalc/dna_today/index.html.