### PR TITLE
web: Fix the Firefox extension builder Dockerfile

### DIFF
--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -13,8 +13,6 @@ jobs:
     name: Test the Dockerfile
     runs-on: ubuntu-22.04
 
-    if: github.repository == 'ruffle-rs/ruffle'
-
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +35,7 @@ jobs:
 
       - name: Notify Discord
         uses: th0th/notify-discord@v0.4.1
-        if: ${{ always() }}
+        if: ${{ always() && github.repository == 'ruffle-rs/ruffle' }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_UPDATES }}
           GITHUB_ACTOR: ${{ github.actor }}

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -30,5 +30,5 @@ RUN cargo install wasm-bindgen-cli --version 0.2.89
 COPY . ruffle
 WORKDIR ruffle/web
 ENV CARGO_FEATURES=jpegxr
-RUN npm install --omit=optional
+RUN npm install
 RUN npm run build:repro


### PR DESCRIPTION
After some experimentation in the wrong direction (thanks for the ideas anyway @Dinnerbone!), the solution was right here: https://github.com/torokati44/ruffle/actions/runs/7064760895/job/19233434777

That `${{ always() && github.repository == 'ruffle-rs/ruffle' }}` looks weird, but I _hope_ it does what I mean.