### PR TITLE
web/extension: Raise minimum Firefox version on Android to 121

### DIFF
--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -60,12 +60,11 @@ async function sign(
         )}/versions/${encodeURIComponent(version)}/`,
         json: {
             compatibility: {
-                android: {
-                    min: "84",
-                    // "max" is undefined, so the manifest max or default will be used.
-                },
                 firefox: {
                     min: "84",
+                },
+                android: {
+                    min: "121",
                 },
             },
             approval_notes: `This version was derived from the source code available at https://github.com/ruffle-rs/ruffle/releases/tag/${sourceTag} - a ZIP file from this Git tag has been attached. If you download it yourself instead of using the ZIP file provided, make sure to grab the reproducible version of the ZIP, as it contains versioning information that will not be present on the main source download.\n\


### PR DESCRIPTION
A follow-up for https://github.com/ruffle-rs/ruffle/pull/14233.

Reason: https://github.com/ruffle-rs/ruffle/actions/runs/7067394881/job/19240696121#step:7:200