### PR TITLE
web: Simplify the `TS_NODE_COMPILER_OPTIONS` value for mocha in core test

### DIFF
--- a/web/packages/core/package.json
+++ b/web/packages/core/package.json
@@ -14,7 +14,7 @@
         "build": "tsc --build --force",
         "postbuild": "node tools/set_version.js && node tools/bundle_texts.js",
         "docs": "typedoc",
-        "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\",\\\"verbatimModuleSyntax\\\":false} mocha"
+        "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} mocha"
     },
     "dependencies": {
         "jszip": "^3.10.1",


### PR DESCRIPTION
While `npm test` in `web` works on CI, for some reason, on my local machine, I get this error:
`✖ ERROR: SyntaxError: Unexpected token 'v', "verbatimModuleSyntax" is not valid JSON`

Perhaps the `,` in that string confuses something. With this patch, I can test the `core` package successfully.

The removed option looks like a backward compatibility thing, that we're only trying to disable, but this _(leans on Chesterton's fence)_ doesn't seem necessary (anymore), and maybe it's not even enabled by default.