### PR TITLE
fix(deps): update rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "parking",
  "polling 3.3.1",
  "rustix",
@@ -318,7 +318,7 @@ checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
  "async-io",
  "blocking",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
 ]
 
 [[package]]
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bef9e74b5908bed0360844109a55b62b07cc973274c11d3a577bda8cc1cf60"
+checksum = "e445576659fd04a57b44cbd00aa37aaa815ebefa0aa3cb677a6b5e63d883074f"
 
 [[package]]
 name = "block"
@@ -502,7 +502,7 @@ dependencies = [
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "piper",
  "tracing",
 ]
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1922,14 +1922,13 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
 ]
@@ -4234,7 +4233,7 @@ dependencies = [
  "fluent-templates",
  "fontdb",
  "futures",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "generational-arena",
  "image",
  "isahc",
@@ -5405,9 +5404,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unic-langid"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398f9ad7239db44fd0f80fe068d12ff22d78354080332a5077dc6f52f14dcf2f"
+checksum = "887622f8e7b723780c5e64b04dcc0c9b8f426ada7cca6790cd3ea3bf0f08037a"
 dependencies = [
  "unic-langid-impl",
  "unic-langid-macros",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 linkme = { version = "0.3", optional = true }
 byteorder = "1.5"
-bitstream-io = "1.8.0"
+bitstream-io = "1.10.0"
 flate2 = "1.0.28"
 fnv = "1.0.7"
 gc-arena = { package = "ruffle_gc_arena", path = "../ruffle_gc_arena" }
@@ -46,7 +46,7 @@ dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "s
 symphonia = { version = "0.5.3", default-features = false, features = ["mp3"], optional = true }
 enumset = "1.1.3"
 bytemuck = "1.14.0"
-clap = { version = "4.4.8", features = ["derive"], optional=true }
+clap = { version = "4.4.11", features = ["derive"], optional=true }
 realfft = "3.3.0"
 hashbrown = { version = "0.14.3", features = ["raw"] }
 scopeguard = "1.2.0"

--- a/core/build_playerglobal/Cargo.toml
+++ b/core/build_playerglobal/Cargo.toml
@@ -12,7 +12,7 @@ convert_case = "0.6.0"
 proc-macro2 = "1.0.70"
 quote = "1.0.33"
 swf = { path = "../../swf" }
-clap = {version = "4.4.8", features = ["derive"]}
+clap = {version = "4.4.11", features = ["derive"]}
 serde = {version = "1.0.193", features = ["derive"]}
 serde-xml-rs = "0.6.0"
 colored = "2.0.4"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-clap = { version = "4.4.8", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive"] }
 cpal = "0.15.2"
 egui = { workspace = true }
 egui_extras = { version = "0.23.0", features = ["image"] }
@@ -33,13 +33,13 @@ rfd = "0.12.1"
 anyhow = "1.0"
 bytemuck = "1.14.0"
 os_info = { version = "3", default-features = false }
-unic-langid = "0.9.1"
+unic-langid = "0.9.3"
 sys-locale = "0.3.1"
 wgpu = { workspace = true }
 futures = "0.3.29"
 chrono = { version = "0.4", default-features = false, features = [] }
 fluent-templates = "0.8.0"
-futures-lite = "2.0.1"
+futures-lite = "2.1.0"
 async-io = "2.2.1"
 async-net = "2.0.0"
 async-channel = "2.1.1"

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-clap = { version = "4.4.8", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive"] }
 futures = "0.3"
 ruffle_core = { path = "../core", features = ["deterministic", "default_font"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 wasm-bindgen = { version = "=0.2.89", optional = true }
 enum-map = "2.7.3"
 serde = { version = "1.0.193", features = ["derive"] }
-clap = { version = "4.4.8", features = ["derive"], optional = true }
+clap = { version = "4.4.11", features = ["derive"], optional = true }
 h263-rs-yuv = { git = "https://github.com/ruffle-rs/h263-rs", rev = "16700664e2b3334f0a930f99af86011aebee14cc"}
 lru = "0.12.1"
 num-traits = "0.2"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -13,7 +13,7 @@ tracing = { workspace = true }
 ruffle_render = { path = "..", features = ["tessellator", "wgpu"] }
 bytemuck = { version = "1.14.0", features = ["derive"] }
 raw-window-handle = "0.5.2"
-clap = { version = "4.4.8", features = ["derive"], optional = true }
+clap = { version = "4.4.11", features = ["derive"], optional = true }
 enum-map = "2.7.3"
 fnv = "1.0.7"
 swf = { path = "../../swf" }

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-clap = { version = "4.4.8", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive"] }
 ruffle_core = { path = "../core", features = ["deterministic"] }
 log = "0.4"
 walkdir = "2.4.0"

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 
 [dependencies]
 bitflags = "2.4.1"
-bitstream-io = "1.8.0"
+bitstream-io = "1.10.0"
 byteorder = "1.5"
 encoding_rs = "0.8.33"
 num-derive = "0.4"

--- a/tests/mocket/Cargo.toml
+++ b/tests/mocket/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = "1.0.75"
-clap = { version = "4.4.8", features = ["derive"] }
+clap = { version = "4.4.11", features = ["derive"] }
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true }
 ruffle_socket_format = { path = "../socket-format" }


### PR DESCRIPTION
This is the same as https://github.com/ruffle-rs/ruffle/pull/14306, minus the `egui` bump (see #13732).