### PR TITLE
web/extension: Lower minimum Firefox version on Android to 120

### DIFF
--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -64,7 +64,7 @@ async function sign(
                     min: "84",
                 },
                 android: {
-                    min: "121",
+                    min: "120",
                 },
             },
             approval_notes: `This version was derived from the source code available at https://github.com/ruffle-rs/ruffle/releases/tag/${sourceTag} - a ZIP file from this Git tag has been attached. If you download it yourself instead of using the ZIP file provided, make sure to grab the reproducible version of the ZIP, as it contains versioning information that will not be present on the main source download.\n\


### PR DESCRIPTION
This basically reverts https://github.com/ruffle-rs/ruffle/pull/14278.

As pointed out by @danielhjacobs, yesterday's AMO submission still returned an error: "Unknown min app version specified"

This is because:
> Once extensions are generally available on Android on December 14, 2023, AMO will update the compatible version number for extension currently set to 121.0a1 to 120.0 in order to make these extensions available on Stable.

> AMO is using version 121.0a1 to temporarily limit the extension to only be available to Firefox Nightly releases on Android. 

From: https://discourse.mozilla.org/t/min-browser-version-for-android-extension/125091/3

So, 120 _should_ work fine next week.