### PR TITLE
tests/avm2: Exclude PixelBender and Scene3D visual tests on WARP

### DIFF
--- a/tests/tests/swfs/avm2/pixelbender_effect_BlurredFocus/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_BlurredFocus/test.toml
@@ -6,4 +6,4 @@ max_outliers = 1003
 
 [player_options]
 viewport_dimensions = { width = 600, height = 700, scale_factor = 1 }
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/pixelbender_effect_glassDisplace_shaderfilter/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_glassDisplace_shaderfilter/test.toml
@@ -5,4 +5,4 @@ tolerance = 3
 max_outliers = 380
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/pixelbender_effect_smudge/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_smudge/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/pixelbender_effect_tintype/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_tintype/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/pixelbender_effect_twirl/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_twirl/test.toml
@@ -6,4 +6,4 @@ max_outliers = 1003
 
 [player_options]
 viewport_dimensions = { width = 600, height = 700, scale_factor = 1 }
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/pixelbender_images/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_images/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/pixelbender_shaderdata/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_shaderdata/test.toml
@@ -1,4 +1,4 @@
 num_frames = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_agal_cross_product/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_agal_cross_product/test.toml
@@ -5,4 +5,4 @@ tolerance = 2
 max_outliers = 10
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_bitmap/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_bitmap/test.toml
@@ -6,4 +6,4 @@ num_frames = 50
 tolerance = 2
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_blend/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_blend/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 2
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_errors/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_errors/test.toml
@@ -1,4 +1,4 @@
 num_frames = 10
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_errors_swf_29/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_errors_swf_29/test.toml
@@ -1,4 +1,4 @@
 num_frames = 10
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_fractal/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_fractal/test.toml
@@ -6,4 +6,4 @@ max_outliers = 25
 
 [player_options]
 max_execution_duration = { secs = 1000, nanos = 0 }
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
@@ -4,4 +4,4 @@ num_frames = 40
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1 }
+with_renderer = { optional = true, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_sampler/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_sampler/test.toml
@@ -5,4 +5,4 @@ tolerance = 1
 max_outliers = 782
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1 }
+with_renderer = { optional = true, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_texture/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture/test.toml
@@ -9,4 +9,4 @@ tolerance = 2
 max_outliers = 117
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_texture_bytearray/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture_bytearray/test.toml
@@ -4,7 +4,7 @@ num_frames = 1
 tolerance = 2
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1 }
+with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
 
 [required_features]
 jpegxr = true

--- a/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_alpha/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_alpha/test.toml
@@ -5,7 +5,7 @@ tolerance = 2
 max_outliers = 66
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1 }
+with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
 
 [required_features]
 jpegxr = true

--- a/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_raw_alpha/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_raw_alpha/test.toml
@@ -5,7 +5,7 @@ tolerance = 2
 max_outliers = 66
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
 
 [required_features]
 jpegxr = true

--- a/tests/tests/swfs/avm2/stage3d_triangle/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1 }
+with_renderer = { optional = true, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_triangle_bytes4/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle_bytes4/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1 }
+with_renderer = { optional = true, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_triangle_float1/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle_float1/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/avm2/stage3d_triangle_index_upload/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle_index_upload/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/stage3d/sampler_odd_size/test.toml
+++ b/tests/tests/swfs/stage3d/sampler_odd_size/test.toml
@@ -5,4 +5,4 @@ max_outliers = 782
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/stage3d/scissor_rectangle/test.toml
+++ b/tests/tests/swfs/stage3d/scissor_rectangle/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }

--- a/tests/tests/swfs/stage3d/scissor_rectangle_invalid/test.toml
+++ b/tests/tests/swfs/stage3d/scissor_rectangle_invalid/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1 }
+with_renderer = { optional = false, sample_count = 1, exclude_warp = true }


### PR DESCRIPTION
As they are a prime suspects for causing hangs on CI.