### PR TITLE
avm2: Remove ArrayObject `to_string` impl

### DIFF
--- a/core/src/avm2/object/array_object.rs
+++ b/core/src/avm2/object/array_object.rs
@@ -262,10 +262,6 @@ impl<'gc> TObject<'gc> for ArrayObject<'gc> {
             || self.base().property_is_enumerable(name)
     }
 
-    fn to_string(&self, _activation: &mut Activation<'_, 'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(Value::Object(Object::from(*self)))
-    }
-
     fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(Value::Object(Object::from(*self)))
     }

--- a/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_1_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_1_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_1_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_1_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_2_1_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_2_1_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_2_1_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_2_1_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_2_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Array/e15_4_2_3/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_1_4/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_1_4/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
This was causing the `Object.prototype.toString` to throw error 1050, instead of returning `[object Array]`, which was causing quite a few avmplus test failures.