### PR TITLE
avm2/core: Partially implement `LocalConnection`

### DIFF
--- a/core/src/avm2/globals/flash/net/LocalConnection.as
+++ b/core/src/avm2/globals/flash/net/LocalConnection.as
@@ -1,10 +1,11 @@
 package flash.net {
     import flash.events.EventDispatcher;
+    import flash.events.StatusEvent;
+    import flash.utils.setTimeout;
     import __ruffle__.stub_method;
     import __ruffle__.stub_getter;
 
-    // NOTE: this entire class is a stub.
-    // Thankfully (hopefully) a lot of code like Mochicrypt doesn't actually require this to... well do anything.
+    [Ruffle(InstanceAllocator)]
     public class LocalConnection extends EventDispatcher {
 
         public var client: Object;
@@ -13,17 +14,32 @@ package flash.net {
             this.client = this;
         }
 
+        [API("667")]
+        public static function get isSupported():Boolean {
+            return true;
+        }
+
         public native function get domain():String;
 
-        public function close(): void {
-            stub_method("flash.net.LocalConnection", "close");
+        public native function close():void;
+
+        public native function connect(connectionName:String):void;
+
+        public function send(connectionName: String, methodName: String, ... arguments):void {
+            if (connectionName === null) {
+                throw new TypeError("Error #2007: Parameter connectionName must be non-null.", 2007);
+            }
+            if (methodName === null) {
+                throw new TypeError("Error #2007: Parameter methodName must be non-null.", 2007);
+            }
+
+            var self = this;
+            setTimeout(function() {
+                self.send_internal(connectionName, methodName, arguments);
+            }, 0);
         }
 
-        public function connect(connectionName:String): void {
-            stub_method("flash.net.LocalConnection", "connect");
-        }
-
-        public native function send(connectionName: String, methodName: String, ... arguments);
+        private native function send_internal(connectionName: String, methodName: String, args: Array):void;
 
         public function allowDomain(... domains): void {
             stub_method("flash.net.LocalConnection", "allowDomain");

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -44,6 +44,7 @@ mod font_object;
 mod function_object;
 mod index_buffer_3d_object;
 mod loaderinfo_object;
+mod local_connection_object;
 mod namespace_object;
 mod net_connection_object;
 mod netstream_object;
@@ -95,6 +96,9 @@ pub use crate::avm2::object::index_buffer_3d_object::{
 };
 pub use crate::avm2::object::loaderinfo_object::{
     loader_info_allocator, LoaderInfoObject, LoaderInfoObjectWeak, LoaderStream,
+};
+pub use crate::avm2::object::local_connection_object::{
+    local_connection_allocator, LocalConnectionObject, LocalConnectionObjectWeak,
 };
 pub use crate::avm2::object::namespace_object::{
     namespace_allocator, NamespaceObject, NamespaceObjectWeak,
@@ -187,7 +191,8 @@ use crate::font::Font;
         ResponderObject(ResponderObject<'gc>),
         ShaderDataObject(ShaderDataObject<'gc>),
         SocketObject(SocketObject<'gc>),
-        FontObject(FontObject<'gc>)
+        FontObject(FontObject<'gc>),
+        LocalConnectionObject(LocalConnectionObject<'gc>)
     }
 )]
 pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy {
@@ -1405,6 +1410,10 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     fn as_socket(&self) -> Option<SocketObject<'gc>> {
         None
     }
+
+    fn as_local_connection_object(&self) -> Option<LocalConnectionObject<'gc>> {
+        None
+    }
 }
 
 pub enum ObjectPtr {}
@@ -1454,6 +1463,7 @@ impl<'gc> Object<'gc> {
             Self::ShaderDataObject(o) => WeakObject::ShaderDataObject(ShaderDataObjectWeak(Gc::downgrade(o.0))),
             Self::SocketObject(o) => WeakObject::SocketObject(SocketObjectWeak(Gc::downgrade(o.0))),
             Self::FontObject(o) => WeakObject::FontObject(FontObjectWeak(GcCell::downgrade(o.0))),
+            Self::LocalConnectionObject(o) => WeakObject::LocalConnectionObject(LocalConnectionObjectWeak(GcCell::downgrade(o.0))),
         }
     }
 }
@@ -1513,6 +1523,7 @@ pub enum WeakObject<'gc> {
     ShaderDataObject(ShaderDataObjectWeak<'gc>),
     SocketObject(SocketObjectWeak<'gc>),
     FontObject(FontObjectWeak<'gc>),
+    LocalConnectionObject(LocalConnectionObjectWeak<'gc>),
 }
 
 impl<'gc> WeakObject<'gc> {
@@ -1555,6 +1566,7 @@ impl<'gc> WeakObject<'gc> {
             Self::ShaderDataObject(o) => ShaderDataObject(o.0.upgrade(mc)?).into(),
             Self::SocketObject(o) => SocketObject(o.0.upgrade(mc)?).into(),
             Self::FontObject(o) => FontObject(o.0.upgrade(mc)?).into(),
+            Self::LocalConnectionObject(o) => LocalConnectionObject(o.0.upgrade(mc)?).into(),
         })
     }
 }

--- a/core/src/avm2/object/local_connection_object.rs
+++ b/core/src/avm2/object/local_connection_object.rs
@@ -1,0 +1,107 @@
+use crate::avm2::activation::Activation;
+use crate::avm2::object::script_object::ScriptObjectData;
+use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
+use crate::avm2::value::Value;
+use crate::avm2::Error;
+use crate::local_connection::{LocalConnection, LocalConnectionHandle};
+use crate::string::AvmString;
+use core::fmt;
+use gc_arena::{Collect, GcCell, GcWeakCell, Mutation};
+use std::cell::{Ref, RefMut};
+
+/// A class instance allocator that allocates LocalConnection objects.
+pub fn local_connection_allocator<'gc>(
+    class: ClassObject<'gc>,
+    activation: &mut Activation<'_, 'gc>,
+) -> Result<Object<'gc>, Error<'gc>> {
+    let base = ScriptObjectData::new(class);
+
+    Ok(LocalConnectionObject(GcCell::new(
+        activation.context.gc_context,
+        LocalConnectionObjectData {
+            base,
+            connection_handle: None,
+        },
+    ))
+    .into())
+}
+
+#[derive(Clone, Collect, Copy)]
+#[collect(no_drop)]
+pub struct LocalConnectionObject<'gc>(pub GcCell<'gc, LocalConnectionObjectData<'gc>>);
+
+#[derive(Clone, Collect, Copy, Debug)]
+#[collect(no_drop)]
+pub struct LocalConnectionObjectWeak<'gc>(pub GcWeakCell<'gc, LocalConnectionObjectData<'gc>>);
+
+impl fmt::Debug for LocalConnectionObject<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalConnectionObject")
+            .field("ptr", &self.0.as_ptr())
+            .finish()
+    }
+}
+
+#[derive(Clone, Collect)]
+#[collect(no_drop)]
+pub struct LocalConnectionObjectData<'gc> {
+    /// Base script object
+    base: ScriptObjectData<'gc>,
+
+    #[collect(require_static)]
+    connection_handle: Option<LocalConnectionHandle>,
+}
+
+impl<'gc> LocalConnectionObject<'gc> {
+    pub fn is_connected(&self) -> bool {
+        self.0.read().connection_handle.is_some()
+    }
+
+    pub fn connection_handle(&self) -> Option<LocalConnectionHandle> {
+        self.0.read().connection_handle
+    }
+
+    pub fn connect(&self, activation: &mut Activation<'_, 'gc>, name: AvmString<'gc>) {
+        assert!(!self.is_connected());
+
+        let connection_handle = activation
+            .context
+            .local_connections
+            .insert(LocalConnection::new(*self, name));
+        self.0
+            .write(activation.context.gc_context)
+            .connection_handle = Some(connection_handle);
+    }
+
+    pub fn disconnect(&self, activation: &mut Activation<'_, 'gc>) {
+        if let Some(conn_handle) = self.0.read().connection_handle {
+            activation.context.local_connections.remove(conn_handle);
+        }
+
+        self.0
+            .write(activation.context.gc_context)
+            .connection_handle = None;
+    }
+}
+
+impl<'gc> TObject<'gc> for LocalConnectionObject<'gc> {
+    fn base(&self) -> Ref<ScriptObjectData<'gc>> {
+        Ref::map(self.0.read(), |read| &read.base)
+    }
+
+    fn base_mut(&self, mc: &Mutation<'gc>) -> RefMut<ScriptObjectData<'gc>> {
+        RefMut::map(self.0.write(mc), |write| &mut write.base)
+    }
+
+    fn as_ptr(&self) -> *const ObjectPtr {
+        self.0.as_ptr() as *const ObjectPtr
+    }
+
+    fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
+        Ok(Value::Object((*self).into()))
+    }
+
+    fn as_local_connection_object(&self) -> Option<LocalConnectionObject<'gc>> {
+        Some(*self)
+    }
+}

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -18,6 +18,7 @@ use crate::focus_tracker::FocusTracker;
 use crate::frame_lifecycle::FramePhase;
 use crate::library::Library;
 use crate::loader::LoadManager;
+use crate::local_connection::LocalConnections;
 use crate::net_connection::NetConnections;
 use crate::player::Player;
 use crate::prelude::*;
@@ -233,6 +234,8 @@ pub struct UpdateContext<'a, 'gc> {
     /// List of active NetConnection instances.
     pub net_connections: &'a mut NetConnections<'gc>,
 
+    pub local_connections: &'a mut LocalConnections<'gc>,
+
     /// Dynamic root for allowing handles to GC objects to exist outside of the GC.
     pub dynamic_root: gc_arena::DynamicRootSet<'gc>,
 }
@@ -395,6 +398,7 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
             stream_manager: self.stream_manager,
             sockets: self.sockets,
             net_connections: self.net_connections,
+            local_connections: self.local_connections,
             dynamic_root: self.dynamic_root,
         }
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,6 +40,7 @@ mod html;
 mod library;
 pub mod limits;
 pub mod loader;
+mod local_connection;
 mod locale;
 mod net_connection;
 pub mod pixel_bender;

--- a/core/src/local_connection.rs
+++ b/core/src/local_connection.rs
@@ -1,0 +1,80 @@
+use crate::avm1::Object as Avm1Object;
+use crate::avm2::object::LocalConnectionObject;
+use crate::string::AvmString;
+use gc_arena::Collect;
+use generational_arena::{Arena, Index};
+
+pub type LocalConnectionHandle = Index;
+
+#[derive(Collect)]
+#[collect(no_drop)]
+pub enum LocalConnectionKind<'gc> {
+    Avm2(LocalConnectionObject<'gc>),
+    Avm1(Avm1Object<'gc>),
+}
+
+impl<'gc> From<LocalConnectionObject<'gc>> for LocalConnectionKind<'gc> {
+    fn from(obj: LocalConnectionObject<'gc>) -> Self {
+        Self::Avm2(obj)
+    }
+}
+
+#[derive(Collect)]
+#[collect(no_drop)]
+pub struct LocalConnection<'gc> {
+    object: LocalConnectionKind<'gc>,
+
+    connection_name: AvmString<'gc>,
+}
+
+impl<'gc> LocalConnection<'gc> {
+    pub fn new(
+        object: impl Into<LocalConnectionKind<'gc>>,
+        connection_name: AvmString<'gc>,
+    ) -> Self {
+        Self {
+            object: object.into(),
+            connection_name,
+        }
+    }
+}
+
+/// Manages the collection of local connections.
+pub struct LocalConnections<'gc> {
+    connections: Arena<LocalConnection<'gc>>,
+}
+
+unsafe impl<'gc> Collect for LocalConnections<'gc> {
+    fn trace(&self, cc: &gc_arena::Collection) {
+        for (_, connection) in self.connections.iter() {
+            connection.trace(cc)
+        }
+    }
+}
+
+impl<'gc> LocalConnections<'gc> {
+    pub fn empty() -> Self {
+        Self {
+            connections: Arena::new(),
+        }
+    }
+
+    pub fn insert(&mut self, connection: LocalConnection<'gc>) -> LocalConnectionHandle {
+        self.connections.insert(connection)
+    }
+
+    pub fn remove(&mut self, handle: LocalConnectionHandle) {
+        self.connections.remove(handle);
+    }
+
+    pub fn all_by_name(&self, requested_name: AvmString<'gc>) -> Vec<&LocalConnection<'gc>> {
+        let mut conns = Vec::new();
+        for (_, connection) in self.connections.iter() {
+            if connection.connection_name == requested_name {
+                conns.push(connection);
+            }
+        }
+
+        conns
+    }
+}

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -39,6 +39,7 @@ use crate::frame_lifecycle::{run_all_phases_avm2, FramePhase};
 use crate::library::Library;
 use crate::limits::ExecutionLimit;
 use crate::loader::{LoadBehavior, LoadManager};
+use crate::local_connection::LocalConnections;
 use crate::locale::get_current_date_time;
 use crate::net_connection::NetConnections;
 use crate::prelude::*;
@@ -173,6 +174,8 @@ struct GcRootData<'gc> {
     /// List of active NetConnection objects.
     net_connections: NetConnections<'gc>,
 
+    local_connections: LocalConnections<'gc>,
+
     /// Dynamic root for allowing handles to GC objects to exist outside of the GC.
     dynamic_root: DynamicRootSet<'gc>,
 }
@@ -202,6 +205,7 @@ impl<'gc> GcRootData<'gc> {
         &mut StreamManager<'gc>,
         &mut Sockets<'gc>,
         &mut NetConnections<'gc>,
+        &mut LocalConnections<'gc>,
         DynamicRootSet<'gc>,
     ) {
         (
@@ -223,6 +227,7 @@ impl<'gc> GcRootData<'gc> {
             &mut self.stream_manager,
             &mut self.sockets,
             &mut self.net_connections,
+            &mut self.local_connections,
             self.dynamic_root,
         )
     }
@@ -1910,6 +1915,7 @@ impl Player {
                 stream_manager,
                 sockets,
                 net_connections,
+                local_connections,
                 dynamic_root,
             ) = root_data.update_context_params();
 
@@ -1963,6 +1969,7 @@ impl Player {
                 stream_manager,
                 sockets,
                 net_connections,
+                local_connections,
                 dynamic_root,
             };
 
@@ -2478,6 +2485,7 @@ impl PlayerBuilder {
                     stream_manager: StreamManager::new(),
                     sockets: Sockets::empty(),
                     net_connections: NetConnections::default(),
+                    local_connections: LocalConnections::empty(),
                     dynamic_root,
                 },
             ),


### PR DESCRIPTION
This is an initial implementation of `LocalConnection` that only considers connections local to the specific SWF file. It adds a `LocalConnections` struct to `UpdateContext`, and implements the `LocalConnection` APIs for AVM2.

I also changed `LocalConnection.send` to not immediately fire the `status` event, to match Flash. #12604 is _technically_ fixed by this, but I would like to leave the issue open until AVM1/mixed AVM `LocalConnection` works (since that's what the SWF really needs).