### PR TITLE
avm2: Fix multiply with overflow in `string_to_f64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "linkme",
  "lzma-rs",
  "nellymoser-rs",
+ "num-bigint",
  "num-derive 0.4.1",
  "num-traits",
  "percent-encoding",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,6 +63,7 @@ jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", branch = "ruffle", optio
 image = { version = "0.24.8", default-features = false, features = ["tiff", "dxt"] }
 enum-map = "2.7.3"
 ttf-parser = "0.20"
+num-bigint = "0.4"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.30"


### PR DESCRIPTION
With more than 15 digits, avmplus uses **BigInteger** arithmetic to avoid rounding errors (fix #14426). https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/MathUtils.cpp#L1359-L1379