### PR TITLE
ci: Switch to `cargo-nextest` for running Rust tests

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -68,6 +68,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Check formatting
+        if: runner.os == 'Linux'
         run: cargo fmt --all -- --check
 
       - name: Check clippy
@@ -81,6 +82,7 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v1
 
       - name: Check documentation
+        if: runner.os == 'Linux'
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Run tests with image tests
         if: runner.os != 'macOS'
-        run: cargo nextest run --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
+        # TODO: Disallow retries in general once we can allow only after SIGABRT.
+        # See: https://github.com/nextest-rs/nextest/issues/1172
+        run: cargo nextest run --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -85,15 +85,20 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+      - name: Install cargo nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Run tests with image tests
         if: runner.os != 'macOS'
-        run: cargo test --all --locked --features imgtests,lzma,jpegxr
+        run: cargo nextest run --workspace --locked --no-fail-fast -j 4 --features imgtests,lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Run tests without image tests
         if: runner.os == 'macOS'
-        run: cargo test --all --locked --features lzma,jpegxr
+        run: cargo nextest run --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 

--- a/tests/tests/swfs/avm2/pixelbender_effect_BlurredFocus/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_BlurredFocus/test.toml
@@ -6,4 +6,4 @@ max_outliers = 1003
 
 [player_options]
 viewport_dimensions = { width = 600, height = 700, scale_factor = 1 }
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/pixelbender_effect_glassDisplace_shaderfilter/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_glassDisplace_shaderfilter/test.toml
@@ -5,4 +5,4 @@ tolerance = 3
 max_outliers = 380
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/pixelbender_effect_smudge/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_smudge/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/pixelbender_effect_tintype/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_tintype/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/pixelbender_effect_twirl/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_effect_twirl/test.toml
@@ -6,4 +6,4 @@ max_outliers = 1003
 
 [player_options]
 viewport_dimensions = { width = 600, height = 700, scale_factor = 1 }
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/pixelbender_images/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_images/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/pixelbender_shaderdata/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_shaderdata/test.toml
@@ -1,4 +1,4 @@
 num_frames = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_agal_cross_product/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_agal_cross_product/test.toml
@@ -5,4 +5,4 @@ tolerance = 2
 max_outliers = 10
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_bitmap/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_bitmap/test.toml
@@ -6,4 +6,4 @@ num_frames = 50
 tolerance = 2
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_blend/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_blend/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 2
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_errors/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_errors/test.toml
@@ -1,4 +1,4 @@
 num_frames = 10
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_errors_swf_29/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_errors_swf_29/test.toml
@@ -1,4 +1,4 @@
 num_frames = 10
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_fractal/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_fractal/test.toml
@@ -6,4 +6,4 @@ max_outliers = 25
 
 [player_options]
 max_execution_duration = { secs = 1000, nanos = 0 }
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
@@ -4,4 +4,4 @@ num_frames = 40
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = true, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_sampler/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_sampler/test.toml
@@ -5,4 +5,4 @@ tolerance = 1
 max_outliers = 782
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = true, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_texture/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture/test.toml
@@ -9,4 +9,4 @@ tolerance = 2
 max_outliers = 117
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_texture_bytearray/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture_bytearray/test.toml
@@ -4,7 +4,7 @@ num_frames = 1
 tolerance = 2
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = true, sample_count = 1 }
 
 [required_features]
 jpegxr = true

--- a/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_alpha/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_alpha/test.toml
@@ -5,7 +5,7 @@ tolerance = 2
 max_outliers = 66
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = true, sample_count = 1 }
 
 [required_features]
 jpegxr = true

--- a/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_raw_alpha/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_texture_bytearray_compressed_raw_alpha/test.toml
@@ -5,7 +5,7 @@ tolerance = 2
 max_outliers = 66
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }
 
 [required_features]
 jpegxr = true

--- a/tests/tests/swfs/avm2/stage3d_triangle/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = true, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_triangle_bytes4/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle_bytes4/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = true, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = true, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_triangle_float1/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle_float1/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/avm2/stage3d_triangle_index_upload/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_triangle_index_upload/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/stage3d/sampler_odd_size/test.toml
+++ b/tests/tests/swfs/stage3d/sampler_odd_size/test.toml
@@ -5,4 +5,4 @@ max_outliers = 782
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/stage3d/scissor_rectangle/test.toml
+++ b/tests/tests/swfs/stage3d/scissor_rectangle/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/stage3d/scissor_rectangle_invalid/test.toml
+++ b/tests/tests/swfs/stage3d/scissor_rectangle_invalid/test.toml
@@ -4,4 +4,4 @@ num_frames = 1
 tolerance = 1
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_large/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_large/test.toml
@@ -6,4 +6,4 @@ num_frames = 500
 tolerance = 11
 
 [player_options]
-with_renderer = { optional = false, sample_count = 1, exclude_warp = true }
+with_renderer = { optional = false, sample_count = 1 }


### PR DESCRIPTION
This is supposed to avoid https://github.com/gfx-rs/wgpu/issues/4885, as `nextest` runs every test in its own process.
Supposedly for the same reason, WARP is a lot less delicate, therefore #14393 is mostly reverted.
There still seem to be some sort of random driver [de]initialization issue on Ubuntu, but with allowing a few retries, this should hopefully not actually cause failures often. EDIT: Allowed retrying test because of this.
It's also nicer to debug failures, because it's always obvious exactly which test case failed.
Run on 4 threads at once, to overlap CPU-bound and IO-bound work.

I have considered adding a file in `.config` instead of the 3-4 command line arguments, but I think this is still fine as is.