### PR TITLE
avm2: Support more ElementFormat font options in TextBlock

### DIFF
--- a/core/src/avm2/globals/flash/text/engine/text_block.rs
+++ b/core/src/avm2/globals/flash/text/engine/text_block.rs
@@ -139,9 +139,40 @@ fn apply_format<'gc>(
             .get_public_property("fontSize", activation)?
             .coerce_to_number(activation)?;
 
+        let (font, bold, italic) = if let Value::Object(font_description) =
+            element_format.get_public_property("fontDescription", activation)?
+        {
+            (
+                Some(
+                    font_description
+                        .get_public_property("fontName", activation)?
+                        .coerce_to_string(activation)?
+                        .as_wstr()
+                        .into(),
+                ),
+                Some(
+                    &font_description
+                        .get_public_property("fontWeight", activation)?
+                        .coerce_to_string(activation)?
+                        == b"bold",
+                ),
+                Some(
+                    &font_description
+                        .get_public_property("fontPosture", activation)?
+                        .coerce_to_string(activation)?
+                        == b"italic",
+                ),
+            )
+        } else {
+            (None, None, None)
+        };
+
         let format = TextFormat {
             color: Some(swf::Color::from_rgb(color, 0xFF)),
             size: Some(size),
+            font,
+            bold,
+            italic,
             ..TextFormat::default()
         };
 

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -392,6 +392,7 @@ impl<'gc> EditText<'gc> {
         let text = Self::new(context, swf_movie, x, y, width, height);
         text.set_is_tlf(context.gc_context, true);
         text.set_selectable(false, context);
+        text.set_is_device_font(context, true);
 
         text
     }


### PR DESCRIPTION
TLF also seems to support device fonts, so I enabled that flag. (I am testing this with device font support)