### PR TITLE
avm2: Optimize the interpreter loop

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -590,10 +590,16 @@ impl<'gc> Avm2<'gc> {
         self.call_stack
     }
 
+    #[cold]
+    fn stack_overflow(&self) {
+        tracing::warn!("Avm2::push: Stack overflow");
+    }
+
     /// Push a value onto the operand stack.
+    #[inline(always)]
     fn push(&mut self, value: impl Into<Value<'gc>>, depth: usize, max: usize) {
         if self.stack.len() - depth > max {
-            tracing::warn!("Avm2::push: Stack overflow");
+            self.stack_overflow();
             return;
         }
         let mut value = value.into();
@@ -610,11 +616,17 @@ impl<'gc> Avm2<'gc> {
         self.stack.push(value);
     }
 
+    #[cold]
+    fn stack_underflow(&self) {
+        tracing::warn!("Avm2::pop: Stack underflow");
+    }
+
     /// Retrieve the top-most value on the operand stack.
     #[allow(clippy::let_and_return)]
+    #[inline(always)]
     fn pop(&mut self, depth: usize) -> Value<'gc> {
         let value = if self.stack.len() <= depth {
-            tracing::warn!("Avm2::pop: Stack underflow");
+            self.stack_underflow();
             Value::Undefined
         } else {
             self.stack.pop().unwrap_or(Value::Undefined)

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -921,6 +921,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     }
 
     /// Run a single action from a given action reader.
+    #[inline(always)]
     fn do_next_opcode<'b>(
         &mut self,
         method: Gc<'gc, BytecodeMethod<'gc>>,


### PR DESCRIPTION
**Edit: Most of the changes described below have been abandoned in favor of https://github.com/ruffle-rs/ruffle/pull/14563**

Currently the very hot code in `do_next_opcode` is basically split into two parts:
- Reading/decoding the opcode via `Reader::read_op`
- Dispatching based on the decoded data

This doesn't seem to produce very good code. Most interpreters that I know fuse decoding and dispatching. In this proof of concept the compiler seems to generate jump tables for at least a subset of opcodes. 

I am not sure if I trust the numbers, but the time spent in a very tight loop like this seems to be reduced by 25%

```actionscript
var foo: int = 0xFFFFFFFF;
for (var i: int = 0; i < 100000; i++) {
    for (var j: int = 8; j >= 0; j--) {
        var bar: int = -(foo & 1);
        foo = (foo >> 1) ^ (0xEDB88320 & bar);
    }
}
```
