### PR TITLE
web: Add playerRuntime option to config for air or flashPlayer

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -61,6 +61,7 @@ use ruffle_video::backend::VideoBackend;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
+use std::fmt::{self, Display, Formatter};
 use std::ops::DerefMut;
 use std::rc::{Rc, Weak as RcWeak};
 use std::str::FromStr;
@@ -2701,4 +2702,25 @@ pub enum PlayerRuntime {
     #[default]
     FlashPlayer,
     AIR,
+}
+
+pub struct ParseEnumError;
+
+impl Display for ParseEnumError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Cannot parse enum.")
+    }
+}
+
+impl FromStr for PlayerRuntime {
+    type Err = ParseEnumError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let player_runtime = match s {
+            "air" => PlayerRuntime::AIR,
+            "flashPlayer" => PlayerRuntime::FlashPlayer,
+            _ => return Err(ParseEnumError),
+        };
+        Ok(player_runtime)
+    }
 }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -61,7 +61,6 @@ use ruffle_video::backend::VideoBackend;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
-use std::fmt::{self, Display, Formatter};
 use std::ops::DerefMut;
 use std::rc::{Rc, Weak as RcWeak};
 use std::str::FromStr;
@@ -2705,12 +2704,6 @@ pub enum PlayerRuntime {
 }
 
 pub struct ParseEnumError;
-
-impl Display for ParseEnumError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Cannot parse enum.")
-    }
-}
 
 impl FromStr for PlayerRuntime {
     type Err = ParseEnumError;

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -6,6 +6,7 @@ import {
     LogLevel,
     OpenURLMode,
     NetworkingAccessMode,
+    PlayerRuntime,
     UnmuteOverlay,
     WindowMode,
 } from "./load-options";
@@ -48,4 +49,5 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     fontSources: [],
     defaultFonts: {},
     credentialAllowList: [],
+    playerRuntime: PlayerRuntime.FlashPlayer,
 };

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -176,6 +176,21 @@ export enum ContextMenu {
 }
 
 /**
+ * Represents the player runtime to emulate.
+ */
+export enum PlayerRuntime {
+    /**
+     * Emulate Adobe AIR.
+     */
+    AIR = "air",
+
+    /**
+     * Emulate Adobe Flash Player.
+     */
+    FlashPlayer = "flashPlayer",
+}
+
+/**
  * Non-negative duration in seconds.
  */
 export type SecsDuration = number;
@@ -623,6 +638,13 @@ export interface BaseLoadOptions {
      * @default []
      */
     credentialAllowList?: Array<string>;
+
+    /**
+     * The player runtime to emulate
+     *
+     * This allows you to emulate Adobe AIR or Adobe Flash Player.
+     */
+    playerRuntime?: PlayerRuntime;
 }
 
 /**

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -175,9 +175,8 @@ fn deserialize_player_runtime<'de, D>(deserializer: D) -> Result<PlayerRuntime, 
 where
     D: serde::Deserializer<'de>,
 {
-    use serde::de::Error;
     let value: String = serde::Deserialize::deserialize(deserializer)?;
-    PlayerRuntime::from_str(&value).map_err(Error::custom)
+    Ok(PlayerRuntime::from_str(&value).unwrap_or_default())
 }
 
 fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>


### PR DESCRIPTION
Not super familiar with Rust, and I don't have a test for AIR. Does this look correct?

This addresses https://github.com/ruffle-rs/ruffle/pull/13077#issuecomment-1709249976 following #14166.