### PR TITLE
core: Fix `mouseWheel` event not being dispatched in AVM2

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1235,11 +1235,14 @@ impl Player {
                         || !over_object.as_displayobject().avm1_removed()
                     {
                         over_object.handle_clip_event(context, ClipEvent::MouseWheel { delta });
+
+                        over_object
+                            .event_dispatch_to_avm2(context, ClipEvent::MouseWheel { delta });
                     }
                 } else {
                     context
                         .stage
-                        .handle_clip_event(context, ClipEvent::MouseWheel { delta });
+                        .event_dispatch_to_avm2(context, ClipEvent::MouseWheel { delta });
                 }
             });
         }


### PR DESCRIPTION
I still need to add a test for this.

I'm not sure why, but the wheel event being dispatched is jittery for me. I'd appreciate manual testing with games that use the mouse wheel (e.g. Scratch 2). Additionally, kmeisthax's comment on #5767 seems relevant- at least I can reproduce it:
> Flash Player appears to report a delta of 3/-3 on my machine when Ruffle reports 1/-1

If anyone else can reproduce that Ruffle scrolls less than Flash, I can make the change to multiply the reported delta by 3.