### PR TITLE
desktop: Introduce generic gamepad remapping support

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -115,7 +115,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev
+          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev libudev-dev
 
       - name: Cargo build
         run: cargo build --locked --package ruffle_desktop --release ${{matrix.DESKTOP_FEATURES && '--features' }} ${{matrix.DESKTOP_FEATURES}} ${{ matrix.target && '--target' }} ${{ matrix.target }}

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev
+          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
 
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
@@ -124,7 +124,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev
+          sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev libudev-dev
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "gilrs"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b2e57a9cb946b5d04ae8638c5f554abb5a9f82c4c950fd5b1fee6d119592fb"
+dependencies = [
+ "fnv",
+ "gilrs-core",
+ "log",
+ "uuid",
+ "vec_map",
+]
+
+[[package]]
+name = "gilrs-core"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af1827b7dd2f36d740ae804c1b3ea0d64c12533fb61ff91883005143a0e8c5a"
+dependencies = [
+ "core-foundation",
+ "inotify",
+ "io-kit-sys",
+ "js-sys",
+ "libc",
+ "libudev-sys",
+ "log",
+ "nix 0.27.1",
+ "uuid",
+ "vec_map",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,6 +2768,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,6 +2826,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
 dependencies = [
  "unic-langid",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
 ]
 
 [[package]]
@@ -3038,6 +3102,16 @@ dependencies = [
  "escape8259",
  "termcolor",
  "threadpool",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3496,6 +3570,17 @@ dependencies = [
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4467,6 +4552,7 @@ dependencies = [
  "futures",
  "futures-lite 2.2.0",
  "generational-arena",
+ "gilrs",
  "image",
  "isahc",
  "macro_rules_attribute",
@@ -5901,6 +5987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5911,6 +6003,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you are building for a Linux platform, the following are typical dependencies
 * libxcb-xfixes0-dev
 * libgtk-3-dev
 * libssl-dev
+* libudev-dev
 * libxcb-xinput-dev
 * libxcb-xkb-dev
 * libxcb-cursor-dev

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -30,6 +30,12 @@ pub enum PlayerEvent {
     MouseWheel {
         delta: MouseWheelDelta,
     },
+    GamepadButtonDown {
+        button: GamepadButton,
+    },
+    GamepadButtonUp {
+        button: GamepadButton,
+    },
     TextInput {
         codepoint: char,
     },
@@ -381,6 +387,7 @@ impl TextControlCode {
 }
 
 /// Flash virtual keycode.
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, FromPrimitive)]
 pub enum KeyCode {
     Unknown = 0,
@@ -673,4 +680,23 @@ pub fn key_code_to_button_key_code(key_code: KeyCode) -> Option<ButtonKeyCode> {
         _ => return None,
     };
     Some(out)
+}
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+pub enum GamepadButton {
+    South,
+    East,
+    North,
+    West,
+    LeftTrigger,
+    LeftTrigger2,
+    RightTrigger,
+    RightTrigger2,
+    Select,
+    Start,
+    DPadUp,
+    DPadDown,
+    DPadLeft,
+    DPadRight,
 }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -46,6 +46,7 @@ futures-lite = "2.2.0"
 async-io = "2.3.1"
 async-net = "2.0.0"
 async-channel = "2.2.0"
+gilrs = "0.10"
 
 # Deliberately held back to match tracy client used by profiling crate
 tracing-tracy = { version = "=0.10.4", optional = true }

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -10,6 +10,7 @@ use crate::{CALLSTACK, RENDER_INFO, SWF_INFO};
 use anyhow::anyhow;
 use ruffle_core::backend::navigator::{OpenURLMode, SocketMode};
 use ruffle_core::config::Letterbox;
+use ruffle_core::events::{GamepadButton, KeyCode};
 use ruffle_core::{
     DefaultFont, LoadBehavior, Player, PlayerBuilder, PlayerEvent, PlayerRuntime, StageAlign,
     StageScaleMode,
@@ -18,7 +19,7 @@ use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
 use ruffle_render_wgpu::descriptors::Descriptors;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
@@ -52,6 +53,7 @@ pub struct PlayerOptions {
     pub frame_rate: Option<f64>,
     pub open_url_mode: OpenURLMode,
     pub dummy_external_interface: bool,
+    pub gamepad_button_mapping: HashMap<GamepadButton, KeyCode>,
 }
 
 impl From<&Opt> for PlayerOptions {
@@ -79,6 +81,7 @@ impl From<&Opt> for PlayerOptions {
             dummy_external_interface: value.dummy_external_interface,
             socket_allowed: HashSet::from_iter(value.socket_allow.iter().cloned()),
             tcp_connections: value.tcp_connections,
+            gamepad_button_mapping: HashMap::from_iter(value.gamepad_button.iter().cloned()),
         }
     }
 }
@@ -143,6 +146,10 @@ impl ActivePlayer {
         } else {
             Duration::from_secs_f64(opt.max_execution_duration)
         };
+
+        if !opt.gamepad_button_mapping.is_empty() {
+            builder = builder.with_gamepad_button_mapping(opt.gamepad_button_mapping.clone());
+        }
 
         builder = builder
             .with_navigator(navigator)

--- a/desktop/src/util.rs
+++ b/desktop/src/util.rs
@@ -1,7 +1,8 @@
 use crate::custom_event::RuffleEvent;
 use anyhow::{anyhow, Error};
+use gilrs::Button;
 use rfd::FileDialog;
-use ruffle_core::events::{KeyCode, TextControlCode};
+use ruffle_core::events::{GamepadButton, KeyCode, TextControlCode};
 use std::path::{Path, PathBuf};
 use url::Url;
 use winit::dpi::PhysicalSize;
@@ -168,6 +169,28 @@ pub fn winit_to_ruffle_key_code(event: &KeyEvent) -> KeyCode {
         Key::Named(NamedKey::F23) => KeyCode::F23,
         Key::Named(NamedKey::F24) => KeyCode::F24,
         _ => KeyCode::Unknown,
+    }
+}
+
+pub fn gilrs_button_to_gamepad_button(button: Button) -> Option<GamepadButton> {
+    match button {
+        Button::South => Some(GamepadButton::South),
+        Button::East => Some(GamepadButton::East),
+        Button::North => Some(GamepadButton::North),
+        Button::West => Some(GamepadButton::West),
+        Button::LeftTrigger => Some(GamepadButton::LeftTrigger),
+        Button::LeftTrigger2 => Some(GamepadButton::LeftTrigger2),
+        Button::RightTrigger => Some(GamepadButton::RightTrigger),
+        Button::RightTrigger2 => Some(GamepadButton::RightTrigger2),
+        Button::Select => Some(GamepadButton::Select),
+        Button::Start => Some(GamepadButton::Start),
+        Button::DPadUp => Some(GamepadButton::DPadUp),
+        Button::DPadDown => Some(GamepadButton::DPadDown),
+        Button::DPadLeft => Some(GamepadButton::DPadLeft),
+        Button::DPadRight => Some(GamepadButton::DPadRight),
+        // GilRs has some more buttons that are seemingly not supported anywhere
+        // like C or Z.
+        _ => None,
     }
 }
 


### PR DESCRIPTION
This is mostly a proof-of-concept, because I totally fail at playing Super Mario without a gamepad. We probably need to do some kind of per-game/swf remapping logic to actually make this useful, considering how peculiar some of those keybinds are. 