### PR TITLE
avm2: Reduce the size of Op on 64bit

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1102,12 +1102,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::TypeOf => self.op_type_of(),
                 Op::EscXAttr => self.op_esc_xattr(),
                 Op::EscXElem => self.op_esc_elem(),
-                Op::LookupSwitch {
-                    default_offset,
-                    case_offsets,
-                } => self.op_lookup_switch(
-                    default_offset,
-                    &case_offsets,
+                Op::LookupSwitch(ref lookup_switch) => self.op_lookup_switch(
+                    lookup_switch.default_offset,
+                    &lookup_switch.case_offsets,
                     instruction_start,
                     reader,
                     full_data,

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -754,7 +754,7 @@ impl<'a> Reader<'a> {
             OpCode::Li16 => Op::Li16,
             OpCode::Li32 => Op::Li32,
             OpCode::Li8 => Op::Li8,
-            OpCode::LookupSwitch => Op::LookupSwitch {
+            OpCode::LookupSwitch => Op::LookupSwitch(Box::new(LookupSwitch {
                 default_offset: self.read_i24()?,
                 case_offsets: {
                     let num_cases = self.read_u30()? + 1;
@@ -764,7 +764,7 @@ impl<'a> Reader<'a> {
                     }
                     case_offsets.into()
                 },
-            },
+            })),
             OpCode::LShift => Op::LShift,
             OpCode::Modulo => Op::Modulo,
             OpCode::Multiply => Op::Multiply,

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -1,5 +1,7 @@
 use bitflags::bitflags;
 use std::marker::PhantomData;
+#[cfg(target_pointer_width = "64")]
+use std::mem::size_of;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AbcFile {
@@ -247,6 +249,12 @@ pub struct Script {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct LookupSwitch {
+    pub default_offset: i32,
+    pub case_offsets: Box<[i32]>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum Op {
     Add,
     AddI,
@@ -471,10 +479,7 @@ pub enum Op {
     Li16,
     Li32,
     Li8,
-    LookupSwitch {
-        default_offset: i32,
-        case_offsets: Box<[i32]>,
-    },
+    LookupSwitch(Box<LookupSwitch>),
     LShift,
     Modulo,
     Multiply,
@@ -569,3 +574,6 @@ pub enum Op {
     Timestamp,
     URShift,
 }
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<Op>() == 16);

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -907,14 +907,11 @@ impl<W: Write> Writer<W> {
             Op::Li16 => self.write_opcode(OpCode::Li16)?,
             Op::Li32 => self.write_opcode(OpCode::Li32)?,
             Op::Li8 => self.write_opcode(OpCode::Li8)?,
-            Op::LookupSwitch {
-                default_offset,
-                ref case_offsets,
-            } => {
+            Op::LookupSwitch(ref lookup_switch) => {
                 self.write_opcode(OpCode::LookupSwitch)?;
-                self.write_i24(default_offset)?;
-                self.write_u30(case_offsets.len() as u32 - 1)?;
-                for offset in case_offsets.iter() {
+                self.write_i24(lookup_switch.default_offset)?;
+                self.write_u30(lookup_switch.case_offsets.len() as u32 - 1)?;
+                for offset in lookup_switch.case_offsets.iter() {
                     self.write_i24(*offset)?;
                 }
             }
@@ -1439,10 +1436,10 @@ pub mod tests {
         assert_eq!(write(Op::Li8), b"\x35");
 
         assert_eq!(
-            write(Op::LookupSwitch {
+            write(Op::LookupSwitch(Box::new(LookupSwitch {
                 default_offset: 1,
                 case_offsets: Box::new([3, 4, 5])
-            }),
+            }))),
             b"\x1B\x01\x00\x00\x02\x03\x00\x00\x04\x00\x00\x05\x00\x00"
         );
 


### PR DESCRIPTION
This reduces the size of `Op` from 24 to 16 bytes, at the cost of `LookupSwitch` having a bit more overhead. This is useful for #14563, because it would reduce the total bytecode size by 1/3.