### PR TITLE
chore: Move lint configuration from `.cargo/config.toml` to `Cargo.toml`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,20 +4,4 @@ rustflags = [
     # We need to specify this flag for all targets because Clippy checks all of our code against all targets
     # and our web code does not compile without this flag
     "--cfg=web_sys_unstable_apis",
-
-    # CLIPPY LINT SETTINGS
-    # This is a workaround to configure lints for the entire workspace, pending the ability to configure this via TOML.
-    # See: https://github.com/rust-lang/cargo/issues/5034
-    #      https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395
-    # TODO: Move these to the root Cargo.toml once support is merged and stable
-    # See: https://github.com/rust-lang/cargo/pull/12148
-
-    # Clippy nightly often adds new/buggy lints that we want to ignore.
-    # Don't warn about these new lints on stable.
-    "-Arenamed_and_removed_lints",
-    "-Aunknown_lints",
-
-    # LONG-TERM: These lints are unhelpful.
-    "-Aclippy::manual_map",                  # Less readable: Suggests `opt.map(..)` instsead of `if let Some(opt) { .. }`
-    "-Aclippy::manual_range_contains",       # Less readable: Suggests `(a..b).contains(n)` instead of `n >= a && n < b`
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,17 @@ naga_oil = "0.11.0"
 wgpu = "0.18.0"
 egui = "0.24.1"
 
+[workspace.lints.rust]
+# Clippy nightly often adds new/buggy lints that we want to ignore.
+# Don't warn about these new lints on stable.
+renamed_and_removed_lints = "allow"
+unknown_lints = "allow"
+
+[workspace.lints.clippy]
+# LONG-TERM: These lints are unhelpful.
+manual_map = "allow"             # Less readable: Suggests `opt.map(..)` instsead of `if let Some(opt) { .. }`
+manual_range_contains = "allow"  # Less readable: Suggests `(a..b).contains(n)` instead of `n >= a && n < b`
+
 # Don't optimize build scripts and macros.
 [profile.release.build-override]
 opt-level = 0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 linkme = { version = "0.3", optional = true }
 byteorder = "1.5"

--- a/core/build_playerglobal/Cargo.toml
+++ b/core/build_playerglobal/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 convert_case = "0.6.0"
 proc-macro2 = "1.0.73"

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.4.12", features = ["derive"] }
 cpal = "0.15.2"

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.4.12", features = ["derive"] }
 futures = "0.3"

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 ruffle_wstr = { path = "../wstr" }
 swf = { path = "../swf"}

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 js-sys = "0.3.66"
 log = "0.4"

--- a/render/naga-agal/Cargo.toml
+++ b/render/naga-agal/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bitflags = "2.4.1"
 naga = { workspace = true }

--- a/render/naga-pixelbender/Cargo.toml
+++ b/render/naga-pixelbender/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 ruffle_render = { path = "../" }
 naga = { workspace = true }

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 js-sys = "0.3.66"
 log = "0.4"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 wgpu = { workspace = true, features = ["naga"] }
 tracing = { workspace = true }

--- a/ruffle_gc_arena/Cargo.toml
+++ b/ruffle_gc_arena/Cargo.toml
@@ -8,5 +8,8 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 gc-arena = { git = "https://github.com/kyren/gc-arena", rev = "efd89fc683c6bb456af3e226c33763cb822645e9", features = ["hashbrown"] }

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.4.12", features = ["derive"] }
 ruffle_core = { path = "../core", features = ["deterministic"] }

--- a/swf/Cargo.toml
+++ b/swf/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bitflags = "2.4.1"
 bitstream-io = "2.2.0"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [features]
 # Enable running image comparison tests. This is off by default,
 # since the images we compare against are generated on CI, and may

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 futures = "0.3.30"
 ruffle_core = { path = "../../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font"] }

--- a/tests/input-format/Cargo.toml
+++ b/tests/input-format/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.109"

--- a/tests/mocket/Cargo.toml
+++ b/tests/mocket/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.78"
 clap = { version = "4.4.12", features = ["derive"] }

--- a/tests/socket-format/Cargo.toml
+++ b/tests/socket-format/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.109"

--- a/video/Cargo.toml
+++ b/video/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 swf = { path = "../swf" }
 ruffle_render = { path = "../render" }

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 ruffle_render = { path = "../../render" }
 ruffle_video = { path = ".." }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 version.workspace = true
 publish = false # This crate is useless alone, people should use the npm package
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Ruffle LLC <ruffle@ruffle.rs>"]
 edition.workspace = true
 license = "MIT OR Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 js-sys = "0.3.66"
 tracing = { workspace = true }

--- a/web/packages/extension/safari/Cargo.toml
+++ b/web/packages/extension/safari/Cargo.toml
@@ -9,5 +9,8 @@ repository.workspace = true
 version.workspace = true
 publish = false # This crate is useless unless packaged into an appex bundle
 
+[lints]
+workspace = true
+
 [dependencies]
 objc = "0.2.7"

--- a/wstr/Cargo.toml
+++ b/wstr/Cargo.toml
@@ -6,3 +6,6 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 version.workspace = true
+
+[lints]
+workspace = true


### PR DESCRIPTION
This got stabilized in Rust 1.74:
https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#lints
https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-lints-section
https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-lints-table

https://github.com/rust-lang/cargo/issues/5034 is done by https://github.com/rust-lang/cargo/issues/12115, and https://github.com/rust-lang/cargo/pull/12148 is also merged.