### PR TITLE
extension: Close `popup.html` when clicking "Open SWF Player" in Firefox

### DIFF
--- a/web/packages/extension/src/utils.ts
+++ b/web/packages/extension/src/utils.ts
@@ -131,8 +131,8 @@ if (typeof chrome !== "undefined") {
             chrome.tabs.create({ url: "/options.html" }, cb),
         );
     openPlayerPage = () =>
-        promisify((_cb: () => void) =>
-            chrome.tabs.create({ url: "/player.html" }),
+        promisify((cb: () => void) =>
+            chrome.tabs.create({ url: "/player.html" }, cb),
         );
 } else if (typeof browser !== "undefined") {
     i18n = browser.i18n;
@@ -141,8 +141,8 @@ if (typeof chrome !== "undefined") {
     runtime = browser.runtime;
     openOptionsPage = () => browser.runtime.openOptionsPage();
     openPlayerPage = () =>
-        promisify((_cb: () => void) =>
-            browser.tabs.create({ url: "/player.html" }),
+        promisify((cb: () => void) =>
+            browser.tabs.create({ url: "/player.html" }).then(cb),
         );
 } else {
     throw new Error("Extension API not found.");


### PR DESCRIPTION
It appears that the promise in the following code was never fulfilled, so `window.close()` was never called:
https://github.com/ruffle-rs/ruffle/blob/f0ed5c7211c22eda87425456e04e4d665068fa21/web/packages/extension/src/popup.ts#L176-L179

The same issue also occurred in Chrome, but it wasn't noticeable as this browser seems to close the popup by itself after calling `chrome.tabs.create`.