### PR TITLE
Progressive download of video files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,6 +4576,7 @@ dependencies = [
  "base64",
  "chrono",
  "console_error_panic_hook",
+ "futures",
  "futures-util",
  "generational-arena",
  "getrandom",
@@ -4599,6 +4600,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -5820,6 +5822,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wayland-backend"

--- a/core/src/avm1/globals/netstream.rs
+++ b/core/src/avm1/globals/netstream.rs
@@ -46,7 +46,7 @@ fn get_bytes_total<'gc>(
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
     if let NativeObject::NetStream(ns) = this.native() {
-        return Ok(ns.bytes_loaded().into());
+        return Ok(ns.bytes_total().into());
     }
 
     Ok(Value::Undefined)

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -206,6 +206,15 @@ pub enum Error {
     // the GC arena). We're losing info here. How do we fix that?
     #[error("Error running avm2 script: {0}")]
     Avm2Error(String),
+
+    #[error("System I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Cannot parse integer value: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+
+    #[error("Header value is not a valid UTF-8 string.")]
+    InvalidHeaderValue,
 }
 
 impl From<crate::avm1::Error<'_>> for Error {

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -343,6 +343,8 @@ impl<'gc> NetStream<'gc> {
     pub fn load_buffer(self, context: &mut UpdateContext<'_, 'gc>, data: &mut Vec<u8>) {
         self.0.write(context.gc_context).buffer.append(data);
 
+        StreamManager::activate(context, self);
+
         // NOTE: The onMetaData event triggers before this event in Flash due to its streaming behavior.
         self.trigger_status_event(
             context,

--- a/tests/framework/src/backends/navigator.rs
+++ b/tests/framework/src/backends/navigator.rs
@@ -11,10 +11,36 @@ use ruffle_core::indexmap::IndexMap;
 use ruffle_core::loader::Error;
 use ruffle_core::socket::{ConnectionState, SocketAction, SocketHandle};
 use ruffle_socket_format::SocketEvent;
+use std::borrow::Cow;
 use std::sync::mpsc::Sender;
 use std::time::Duration;
 use url::{ParseError, Url};
 use vfs::VfsPath;
+
+struct TestResponse {
+    url: String,
+    body: Vec<u8>,
+    status: u16,
+    redirected: bool,
+}
+
+impl SuccessResponse for TestResponse {
+    fn url(&self) -> Cow<str> {
+        Cow::Borrowed(&self.url)
+    }
+
+    fn body(self: Box<Self>) -> OwnedFuture<Vec<u8>, Error> {
+        Box::pin(async move { Ok(self.body) })
+    }
+
+    fn status(&self) -> u16 {
+        self.status
+    }
+
+    fn redirected(&self) -> bool {
+        self.redirected
+    }
+}
 
 /// A `NavigatorBackend` used by tests that supports logging fetch requests.
 ///
@@ -71,15 +97,17 @@ impl NavigatorBackend for TestNavigatorBackend {
         }
     }
 
-    fn fetch(&self, request: Request) -> OwnedFuture<SuccessResponse, ErrorResponse> {
+    fn fetch(&self, request: Request) -> OwnedFuture<Box<dyn SuccessResponse>, ErrorResponse> {
         if request.url().contains("?debug-success") {
             return Box::pin(async move {
-                Ok(SuccessResponse {
+                let response: Box<dyn SuccessResponse> = Box::new(TestResponse {
                     url: request.url().to_string(),
                     body: b"Hello, World!".to_vec(),
                     status: 200,
                     redirected: false,
-                })
+                });
+
+                Ok(response)
             });
         }
 
@@ -184,12 +212,15 @@ impl NavigatorBackend for TestNavigatorBackend {
                 url: url.to_string(),
                 error: Error::FetchError(error.to_string()),
             })?;
-            Ok(SuccessResponse {
+
+            let response: Box<dyn SuccessResponse> = Box::new(TestResponse {
                 url: url.to_string(),
                 body,
                 status: 0,
                 redirected: false,
-            })
+            });
+
+            Ok(response)
         })
     }
 

--- a/tests/framework/src/backends/navigator.rs
+++ b/tests/framework/src/backends/navigator.rs
@@ -51,6 +51,10 @@ impl SuccessResponse for TestResponse {
     fn redirected(&self) -> bool {
         self.redirected
     }
+
+    fn expected_length(&self) -> Result<Option<u64>, Error> {
+        Ok(Some(self.body.len() as u64))
+    }
 }
 
 /// A `NavigatorBackend` used by tests that supports logging fetch requests.

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -57,6 +57,8 @@ async-channel = "2.1.1"
 futures-util = { version = "0.3.30", features = ["sink"] }
 gloo-net =  { version = "0.5.0", default-features = false, features = ["websocket"] }
 rfd = { version = "0.13.0", features = ["file-handle-inner"] }
+wasm-streams = "0.3.0"
+futures = "0.3.0"
 
 [dependencies.ruffle_core]
 path = "../core"
@@ -70,5 +72,5 @@ features = [
     "ChannelMergerNode", "ChannelSplitterNode", "ClipboardEvent", "DataTransfer", "Element", "Event",
     "EventTarget", "GainNode", "Headers", "HtmlCanvasElement", "HtmlDocument", "HtmlElement", "HtmlFormElement",
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
-    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "RequestCredentials"
+    "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials"
 ]


### PR DESCRIPTION
Adds the ability to stream fetched data instead of an all-at-once download. Also adds the ability to get estimated download size. Most of `NetStream` was already built in anticipation of streaming download, so we're applying these new backend capabilities to it first.

This also reserves buffer capacity and sets `bytesTotal` based on the estimated file size length.

This does *not* add SWF progressive download capability. While we already have well tested implementations of *simulated* streaming download (specifically to hide shape processing latency), we need streaming-aware zlib/LZMA decompressors before we can actually download SWFs in chunks.

~~This PR is a draft because I haven't actually tested it in a browser yet.~~ I have been able to successfully do streaming playback on at least one video player (specifically old YouTube via Internet Archive).