### PR TITLE
extension: Bail if postMessage event has no data

### DIFF
--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -158,7 +158,7 @@ function isXMLDocument(): boolean {
 
     window.addEventListener("message", (event) => {
         // We only accept messages from ourselves.
-        if (event.source !== window) {
+        if (event.source !== window || !event.data) {
             return;
         }
 

--- a/web/packages/extension/src/ruffle.ts
+++ b/web/packages/extension/src/ruffle.ts
@@ -51,7 +51,7 @@ function openInNewTab(swf: URL): void {
 if (ID) {
     window.addEventListener("message", (event) => {
         // We only accept messages from ourselves.
-        if (event.source !== window) {
+        if (event.source !== window || !event.data) {
             return;
         }
 


### PR DESCRIPTION
Fixes #14486