### PR TITLE
web: Add special case for base="."

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -2472,7 +2472,14 @@ export function getPolyfillOptions(
     }
     const base = getOptionString("base");
     if (base !== null) {
-        options.base = base;
+        // "." tells Flash Player to load relative URLs from the SWF's directory
+        // All other base values are evaluated relative to the page URL
+        if (base === ".") {
+            const swfUrl = new URL(url, document.baseURI);
+            options.base = new URL(base, swfUrl).href;
+        } else {
+            options.base = base;
+        }
     }
     const menu = parseBoolean(getOptionString("menu"));
     if (menu !== null) {


### PR DESCRIPTION
Flash Player seems to treat `base="."` (in object and embed tags) as a magic value meaning 'the main SWF's directory'. As far as I can tell, it treats every other base value as relative to the page URL, not the SWF URL. Since this behavior is confusing and undocumented, I implemented it only for Ruffle's polyfill logic, not its JS API.

This fixes the content on http://mywww.caihongtang.com/games/16334.htm . With this PR, it successfully loads `minguowangshi-data.swf`, as it does with the Flash plugin. (This problem was originally reported by a user on Discord)