### PR TITLE
wgpu: Update wgpu and naga to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,15 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39b801912a977c3fd52d80511fe1c0c8480c6f957f21ae2ce1b92ffe970cf4b9"
 dependencies = [
  "android-properties",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cc",
  "cesu8",
  "jni 0.21.1",
@@ -150,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
+checksum = "628a8f9bd1e24b4e0db2b4bc2d000b001e7dd032d54afa60a68836aeec5aa54a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -363,21 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +365,7 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -412,7 +388,7 @@ version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c69fae65a523209d34240b60abe0c42d33d1045d445c0839d8a4894a736e2d"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -455,9 +431,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -610,7 +586,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "log",
  "polling 3.3.2",
  "rustix",
@@ -742,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.17"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80932e03c33999b9235edb8655bc9df3204adc9887c2f95b50cb1deb9fd54253"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -752,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.17"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c0db58c659eef1c73e444d298c27322a1b52f6927d2ad470c0c0f96fa7b8fa"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -824,10 +800,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "com-rs"
-version = "0.2.1"
+name = "com"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "combine"
@@ -1136,11 +1137,11 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.7.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
+checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libloading 0.8.1",
  "winapi",
 ]
@@ -1408,7 +1409,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "ecolor"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1417,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1430,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "bytemuck",
  "egui",
@@ -1445,12 +1446,12 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "arboard",
  "egui",
  "log",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "smithay-clipboard",
  "web-time",
  "webbrowser",
@@ -1460,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "egui",
  "enum-map",
@@ -1479,7 +1480,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1583,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.25.0"
-source = "git+https://github.com/ruffle-rs/egui?branch=consume_keys#bdecb2cbbc5b43e77e98b0524c3678a07a0b4e04"
+source = "git+https://github.com/emilk/egui?rev=d319489479c371b15e6419d470551dae5d647396#d319489479c371b15e6419d470551dae5d647396"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1716,9 +1717,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209098dd6dfc4445aa6111f0e98653ac323eaa4dfd212c9ca3931bf9955c31bd"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
 ]
@@ -1863,9 +1864,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
  "spin",
 ]
 
@@ -1873,7 +1871,7 @@ dependencies = [
 name = "flv-rs"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "thiserror",
 ]
 
@@ -2203,12 +2201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
 name = "gio-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886c2a30b160c4c6fec8f987430c26b526b7988ca71f664e6a699ddf6f9601e4"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2329,7 +2321,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "gpu-alloc-types",
 ]
 
@@ -2339,21 +2331,20 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
 name = "gpu-allocator"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fe17c8a05d60c38c0a4e5a3c802f2f1ceb66b76c67d96ffb34bef0475a7fad"
+checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
- "backtrace",
  "log",
  "presser",
  "thiserror",
  "winapi",
- "windows 0.51.1",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -2362,7 +2353,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "gpu-descriptor-types",
  "hashbrown 0.14.3",
 ]
@@ -2373,7 +2364,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -2399,7 +2390,7 @@ name = "h263-rs"
 version = "0.1.0"
 source = "git+https://github.com/ruffle-rs/h263-rs?rev=16700664e2b3334f0a930f99af86011aebee14cc#16700664e2b3334f0a930f99af86011aebee14cc"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "thiserror",
@@ -2453,14 +2444,14 @@ dependencies = [
 
 [[package]]
 name = "hassle-rs"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 1.3.2",
- "com-rs",
+ "bitflags 2.4.2",
+ "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.1",
  "thiserror",
  "widestring",
  "winapi",
@@ -2474,9 +2465,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hexf-parse"
@@ -2527,7 +2518,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -2923,7 +2914,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -2934,7 +2925,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -2991,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -3152,7 +3143,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -3206,11 +3197,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.14.2"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#daedf03f0617aab6b3ab7380132dc9cb07f62d32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878eb410fc90853da3908aebfe61d73d26d4437ef850b70050461f939509899"
 dependencies = [
  "bit-set",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -3229,7 +3221,7 @@ dependencies = [
 name = "naga-agal"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "insta",
  "naga",
  "num-derive 0.4.1",
@@ -3241,7 +3233,7 @@ name = "naga-pixelbender"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "naga",
  "naga_oil",
  "ruffle_render",
@@ -3250,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff3f369dd665ee365daeab786466a6f70ff53e4a95a76117363b1077e1b0492"
+checksum = "86343242cc8fe7c38de0324f0c13a789729f3d360d98de12c464a815ad52feda"
 dependencies = [
  "bit-set",
  "codespan-reporting",
@@ -3261,20 +3253,11 @@ dependencies = [
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
  "rustc-hash",
  "thiserror",
  "tracing",
  "unicode-ident",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -3297,12 +3280,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "jni-sys",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
  "num_enum 0.7.2",
- "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
  "thiserror",
 ]
@@ -3521,7 +3503,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -3601,15 +3583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
 dependencies = [
  "objc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3854,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "png"
@@ -3975,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.0",
 ]
@@ -4116,9 +4089,9 @@ checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -4126,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -4212,12 +4185,6 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
-
-[[package]]
-name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
@@ -4289,7 +4256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "serde",
  "serde_derive",
 ]
@@ -4308,7 +4275,7 @@ name = "ruffle_core"
 version = "0.1.0"
 dependencies = [
  "async-channel 2.1.1",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bitstream-io 2.2.0",
  "build_playerglobal",
  "bytemuck",
@@ -4421,7 +4388,7 @@ dependencies = [
 name = "ruffle_input_format"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "serde",
  "serde_json",
 ]
@@ -4515,7 +4482,7 @@ dependencies = [
  "naga_oil",
  "ouroboros",
  "profiling",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "ruffle_render",
  "swf",
  "tracing",
@@ -4658,12 +4625,6 @@ name = "ruffle_wstr"
 version = "0.1.0"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,7 +4669,7 @@ version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4958,7 +4919,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -5040,12 +5001,11 @@ dependencies = [
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 1.3.2",
- "num-traits",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -5088,7 +5048,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 name = "swf"
 version = "0.2.0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bitstream-io 2.2.0",
  "byteorder",
  "encoding_rs",
@@ -5656,9 +5616,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -5724,9 +5684,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.3.0"
+version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0d895592fa7710eba03fe072e614e3dc6a61ab76ae7ae10d2eb4a7ed5b00ca"
+checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -5882,7 +5842,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "nix 0.26.4",
  "wayland-backend",
  "wayland-scanner",
@@ -5894,7 +5854,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -5916,7 +5876,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5928,7 +5888,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5941,7 +5901,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -6022,18 +5982,19 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "wgpu"
-version = "0.18.0"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#daedf03f0617aab6b3ab7380132dc9cb07f62d32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b71d2ded29e2161db50ab731d6cb42c037bd7ab94864a98fa66ff36b4721a8"
 dependencies = [
  "arrayvec",
  "cfg-if",
- "flume 0.11.0",
+ "cfg_aliases",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "serde",
  "smallvec",
  "static_assertions",
@@ -6047,18 +6008,22 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.18.1"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#daedf03f0617aab6b3ab7380132dc9cb07f62d32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
+ "cfg_aliases",
  "codespan-reporting",
+ "indexmap",
  "log",
  "naga",
+ "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "ron",
  "rustc-hash",
  "serde",
@@ -6071,15 +6036,17 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.18.1"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#daedf03f0617aab6b3ab7380132dc9cb07f62d32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f259ceb56727fb097da108d92f8a5cbdb5b74a77f9e396bd43626f67299d61"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "block",
+ "cfg_aliases",
  "core-graphics-types",
  "d3d12",
  "glow",
@@ -6100,7 +6067,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
@@ -6113,10 +6080,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.18.0"
-source = "git+https://github.com/gfx-rs/wgpu?branch=v0.18#daedf03f0617aab6b3ab7380132dc9cb07f62d32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "js-sys",
  "serde",
  "web-sys",
@@ -6210,21 +6178,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.51.1"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.51.1",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-core",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -6443,7 +6402,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "bytemuck",
  "calloop",
  "cfg_aliases",
@@ -6461,7 +6420,6 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
  "redox_syscall 0.3.5",
  "rustix",
@@ -6597,7 +6555,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,11 +1138,10 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "d3d12"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
+source = "git+https://github.com/gfx-rs/wgpu?rev=e128d6c2613c7f8aecd25539c6fbc914bfda04f7#e128d6c2613c7f8aecd25539c6fbc914bfda04f7"
 dependencies = [
  "bitflags 2.4.2",
- "libloading 0.8.1",
+ "libloading 0.7.4",
  "winapi",
 ]
 
@@ -3198,9 +3197,9 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8878eb410fc90853da3908aebfe61d73d26d4437ef850b70050461f939509899"
+source = "git+https://github.com/gfx-rs/wgpu?rev=e128d6c2613c7f8aecd25539c6fbc914bfda04f7#e128d6c2613c7f8aecd25539c6fbc914bfda04f7"
 dependencies = [
+ "arrayvec",
  "bit-set",
  "bitflags 2.4.2",
  "codespan-reporting",
@@ -5983,8 +5982,7 @@ checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 [[package]]
 name = "wgpu"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b71d2ded29e2161db50ab731d6cb42c037bd7ab94864a98fa66ff36b4721a8"
+source = "git+https://github.com/gfx-rs/wgpu?rev=e128d6c2613c7f8aecd25539c6fbc914bfda04f7#e128d6c2613c7f8aecd25539c6fbc914bfda04f7"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -6009,8 +6007,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
+source = "git+https://github.com/gfx-rs/wgpu?rev=e128d6c2613c7f8aecd25539c6fbc914bfda04f7#e128d6c2613c7f8aecd25539c6fbc914bfda04f7"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -6037,8 +6034,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f259ceb56727fb097da108d92f8a5cbdb5b74a77f9e396bd43626f67299d61"
+source = "git+https://github.com/gfx-rs/wgpu?rev=e128d6c2613c7f8aecd25539c6fbc914bfda04f7#e128d6c2613c7f8aecd25539c6fbc914bfda04f7"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6058,7 +6054,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.1",
+ "libloading 0.7.4",
  "log",
  "metal",
  "naga",
@@ -6081,8 +6077,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
+source = "git+https://github.com/gfx-rs/wgpu?rev=e128d6c2613c7f8aecd25539c6fbc914bfda04f7#e128d6c2613c7f8aecd25539c6fbc914bfda04f7"
 dependencies = [
  "bitflags 2.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,7 @@ egui = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d47
 egui_extras = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}
 egui-winit = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}
 egui-wgpu = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}
+
+# TODO: Replace on new wgpu update
+wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "e128d6c2613c7f8aecd25539c6fbc914bfda04f7"}
+naga = { git = "https://github.com/gfx-rs/wgpu", rev = "e128d6c2613c7f8aecd25539c6fbc914bfda04f7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,9 @@ version = "0.1.0"
 [workspace.dependencies]
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-naga = { version = "0.14.2", features = ["validate", "wgsl-out"] }
-naga_oil = "0.11.0"
-wgpu = "0.18.0"
+naga = { version = "0.19.0", features = ["wgsl-out"] }
+naga_oil = "0.12.0"
+wgpu = "0.19.0"
 egui = "0.25.0"
 
 [workspace.lints.rust]
@@ -95,13 +95,8 @@ inherits = "release"
 inherits = "release"
 
 [patch.crates-io]
-# These are needed because https://github.com/gfx-rs/wgpu/pull/4778
-# is not yet in the latest wgpu release. TODO: Remove when it is.
-wgpu = { git = "https://github.com/gfx-rs/wgpu", branch = "v0.18" }
-naga = { git = "https://github.com/gfx-rs/wgpu", branch = "v0.18" }
-
-# https://github.com/emilk/egui/pull/3812
-egui = { git = "https://github.com/ruffle-rs/egui", branch = "consume_keys"}
-egui_extras = { git = "https://github.com/ruffle-rs/egui", branch = "consume_keys"}
-egui-winit = { git = "https://github.com/ruffle-rs/egui", branch = "consume_keys"}
-egui-wgpu = { git = "https://github.com/ruffle-rs/egui", branch = "consume_keys"}
+# TODO: Replace on new egui update
+egui = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}
+egui_extras = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}
+egui-winit = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}
+egui-wgpu = { git = "https://github.com/emilk/egui", rev = "d319489479c371b15e6419d470551dae5d647396"}

--- a/deny.toml
+++ b/deny.toml
@@ -72,4 +72,7 @@ unknown-git = "deny"
 github = [
     "ruffle-rs",
     "gfx-rs",
+
+    # TODO: Remove when egui update is released
+    "emilk",
 ]

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -29,7 +29,7 @@ pub struct GuiController {
     window: Rc<Window>,
     last_update: Instant,
     repaint_after: Duration,
-    surface: wgpu::Surface,
+    surface: wgpu::Surface<'static>,
     surface_format: wgpu::TextureFormat,
     movie_view_renderer: Arc<MovieViewRenderer>,
     // Note that `window.get_inner_size` can change at any point on x11, even between two lines of code.
@@ -57,7 +57,9 @@ impl GuiController {
             backends: backend,
             ..Default::default()
         });
-        let surface = unsafe { instance.create_surface(window.as_ref()) }?;
+        let surface = unsafe {
+            instance.create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(window.as_ref())?)
+        }?;
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             backend,
             &instance,
@@ -81,6 +83,7 @@ impl GuiController {
                 width: size.width,
                 height: size.height,
                 present_mode: Default::default(),
+                desired_maximum_frame_latency: 2,
                 alpha_mode: Default::default(),
                 view_formats: Default::default(),
             },
@@ -143,6 +146,7 @@ impl GuiController {
                         width: size.width,
                         height: size.height,
                         present_mode: Default::default(),
+                        desired_maximum_frame_latency: 2,
                         alpha_mode: Default::default(),
                         view_formats: Default::default(),
                     },

--- a/desktop/src/util.rs
+++ b/desktop/src/util.rs
@@ -248,7 +248,9 @@ pub fn plot_stats_in_tracy(instance: &wgpu::Instance) {
     const TEXTURE_VIEWS: PlotName = plot_name!("Texture Views");
 
     let tracy = Client::running().expect("tracy client must be running");
-    let report = instance.generate_report();
+    let report = instance
+        .generate_report()
+        .expect("reports should be available on desktop");
 
     #[allow(unused_mut)]
     let mut backend = None;
@@ -258,7 +260,7 @@ pub fn plot_stats_in_tracy(instance: &wgpu::Instance) {
     }
     #[cfg(windows)]
     {
-        backend = backend.or(report.dx12).or(report.dx11);
+        backend = backend.or(report.dx12);
     }
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
@@ -266,10 +268,10 @@ pub fn plot_stats_in_tracy(instance: &wgpu::Instance) {
     }
 
     if let Some(stats) = backend {
-        tracy.plot(BIND_GROUPS, stats.bind_groups.num_occupied as f64);
-        tracy.plot(BUFFERS, stats.buffers.num_occupied as f64);
-        tracy.plot(TEXTURES, stats.textures.num_occupied as f64);
-        tracy.plot(TEXTURE_VIEWS, stats.texture_views.num_occupied as f64);
+        tracy.plot(BIND_GROUPS, stats.bind_groups.num_allocated as f64);
+        tracy.plot(BUFFERS, stats.buffers.num_allocated as f64);
+        tracy.plot(TEXTURES, stats.textures.num_allocated as f64);
+        tracy.plot(TEXTURE_VIEWS, stats.texture_views.num_allocated as f64);
     }
 
     tracy.frame_mark();

--- a/render/naga-agal/Cargo.toml
+++ b/render/naga-agal/Cargo.toml
@@ -18,4 +18,4 @@ num-traits = "0.2.17"
 
 [dev-dependencies]
 insta = "1.34.0"
-naga = { workspace = true, features = ["wgsl-out", "validate"] }
+naga = { workspace = true, features = ["wgsl-out"] }

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 use naga::{
     AddressSpace, ArraySize, Block, BuiltIn, Constant, DerivativeControl, EntryPoint,
     FunctionArgument, FunctionResult, GlobalVariable, ImageClass, ImageDimension, Literal,
-    Override, ResourceBinding, ShaderStage, StructMember, SwizzleComponent, UnaryOperator,
+    Override, ResourceBinding, Scalar, ShaderStage, StructMember, SwizzleComponent, UnaryOperator,
 };
 use naga::{BinaryOperator, MathFunction};
 use naga::{
@@ -129,28 +129,25 @@ impl VertexAttributeFormat {
             return module.types.insert(
                 Type {
                     name: None,
-                    inner: TypeInner::Scalar {
-                        kind: ScalarKind::Float,
-                        width: 4,
-                    },
+                    inner: TypeInner::Scalar(Scalar::F32),
                 },
                 Span::UNDEFINED,
             );
         }
-        let (size, width, kind) = match self {
+        let (size, scalar) = match self {
             VertexAttributeFormat::Float1 => unreachable!(),
-            VertexAttributeFormat::Float2 => (VectorSize::Bi, 4, ScalarKind::Float),
-            VertexAttributeFormat::Float3 => (VectorSize::Tri, 4, ScalarKind::Float),
-            VertexAttributeFormat::Float4 => (VectorSize::Quad, 4, ScalarKind::Float),
+            VertexAttributeFormat::Float2 => (VectorSize::Bi, Scalar::F32),
+            VertexAttributeFormat::Float3 => (VectorSize::Tri, Scalar::F32),
+            VertexAttributeFormat::Float4 => (VectorSize::Quad, Scalar::F32),
             // The conversion is done by wgpu, since we specify
             // `wgpu::VertexFormat::Unorm8x4` in `CurrentPipeline::rebuild_pipeline`
-            VertexAttributeFormat::Bytes4 => (VectorSize::Quad, 4, ScalarKind::Float),
+            VertexAttributeFormat::Bytes4 => (VectorSize::Quad, Scalar::F32),
         };
 
         module.types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Vector { size, kind, width },
+                inner: TypeInner::Vector { size, scalar },
             },
             Span::UNDEFINED,
         )
@@ -412,7 +409,7 @@ impl<'a> NagaBuilder<'a> {
                 inner: TypeInner::Matrix {
                     columns: VectorSize::Tri,
                     rows: VectorSize::Tri,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -424,7 +421,7 @@ impl<'a> NagaBuilder<'a> {
                 inner: TypeInner::Matrix {
                     columns: VectorSize::Tri,
                     rows: VectorSize::Quad,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -436,7 +433,7 @@ impl<'a> NagaBuilder<'a> {
                 inner: TypeInner::Matrix {
                     columns: VectorSize::Quad,
                     rows: VectorSize::Quad,
-                    width: 4,
+                    scalar: Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -475,10 +472,7 @@ impl<'a> NagaBuilder<'a> {
         let f32_type = module.types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Float,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(Scalar::F32),
             },
             Span::UNDEFINED,
         );
@@ -486,10 +480,7 @@ impl<'a> NagaBuilder<'a> {
         let u32_type = module.types.insert(
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Uint,
-                    width: 4,
-                },
+                inner: TypeInner::Scalar(Scalar::U32),
             },
             Span::UNDEFINED,
         );
@@ -1651,10 +1642,7 @@ impl<'a> NagaBuilder<'a> {
             &mut self.return_type,
             Type {
                 name: None,
-                inner: TypeInner::Scalar {
-                    kind: ScalarKind::Float,
-                    width: 0,
-                },
+                inner: TypeInner::Scalar(Scalar::F32),
             },
         );
 

--- a/render/naga-agal/tests/snapshots/wgsl__complex_fractal.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__complex_fractal.snap
@@ -16,12 +16,12 @@ fn main(@location(0) param: vec2<f32>, @location(1) param_1: vec2<f32>) -> Verte
     var dest_temp: vec4<f32>;
     var varying_0_: vec4<f32>;
 
-    dest_temp = vec4<f32>(param.x, param.y, 0.0, 1.0);
+    dest_temp = vec4<f32>(param.x, param.y, 0f, 1f);
     let _e10: vec4<f32> = constant_registers[1u];
     let _e13: vec4<f32> = constant_registers[2u];
     let _e16: vec4<f32> = constant_registers[3u];
     let _e19: vec4<f32> = constant_registers[4u];
-    varying_0_ = (transpose(mat4x4<f32>(_e10, _e13, _e16, _e19)) * vec4<f32>(param_1.x, param_1.y, 0.0, 1.0));
+    varying_0_ = (transpose(mat4x4<f32>(_e10, _e13, _e16, _e19)) * vec4<f32>(param_1.x, param_1.y, 0f, 1f));
     let _e32: vec4<f32> = constant_registers[0u];
     let _e33: vec4<f32> = _e32.zwww;
     varying_0_.z = _e33.z;

--- a/render/naga-agal/tests/snapshots/wgsl__complex_raytrace-2.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__complex_raytrace-2.snap
@@ -97,7 +97,7 @@ fn main(@location(0) param: vec4<f32>) -> FragmentOutput {
     let _e149: vec4<f32> = constant_registers[16u];
     let _e151: vec4<f32> = temporary3_;
     let _e153: vec3<f32> = cross(_e149.xyx, _e151.xyz);
-    let _e158: vec4<f32> = vec4<f32>(_e153.x, _e153.y, _e153.z, 1.0);
+    let _e158: vec4<f32> = vec4<f32>(_e153.x, _e153.y, _e153.z, 1f);
     temporary5_.x = _e158.x;
     temporary5_.y = _e158.y;
     temporary5_.z = _e158.z;
@@ -109,7 +109,7 @@ fn main(@location(0) param: vec4<f32>) -> FragmentOutput {
     let _e176: vec4<f32> = temporary3_;
     let _e178: vec4<f32> = temporary6_;
     let _e180: vec3<f32> = cross(_e176.xyz, _e178.xyz);
-    let _e185: vec4<f32> = vec4<f32>(_e180.x, _e180.y, _e180.z, 1.0);
+    let _e185: vec4<f32> = vec4<f32>(_e180.x, _e180.y, _e180.z, 1f);
     temporary5_.x = _e185.x;
     temporary5_.y = _e185.y;
     temporary5_.z = _e185.z;

--- a/render/naga-agal/tests/snapshots/wgsl__misc_opcodes-2.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__misc_opcodes-2.snap
@@ -21,7 +21,7 @@ fn main(@location(0) param: vec4<f32>) -> FragmentOutput {
     let _e6: vec4<f32> = dpdy(_e5);
     temporary1_ = _e6;
     let _e8: vec4<f32> = temporary1_;
-    if (_e8.xxxx.x < 0.0) {
+    if (_e8.xxxx.x < 0f) {
         discard;
     }
     let _e13: vec4<f32> = temporary0_;

--- a/render/naga-agal/tests/snapshots/wgsl__misc_opcodes.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__misc_opcodes.snap
@@ -33,13 +33,13 @@ fn main(@location(0) param: vec4<f32>) -> VertexOutput {
     let _e21: vec4<f32> = temporary5_;
     let _e27: vec4<f32> = constant_registers[0u];
     let _e29: vec3<f32> = (transpose(mat3x3<f32>(_e15.xyz, _e18.xyz, _e21.xyz)) * _e27.xyz);
-    temporary4_ = vec4<f32>(_e29.x, _e29.y, _e29.z, 1.0);
+    temporary4_ = vec4<f32>(_e29.x, _e29.y, _e29.z, 1f);
     let _e35: vec4<f32> = temporary3_;
     let _e36: vec4<f32> = temporary4_;
     let _e37: vec4<f32> = temporary5_;
     let _e42: vec4<f32> = constant_registers[2u];
     let _e43: vec3<f32> = (transpose(mat3x4<f32>(_e35, _e36, _e37)) * _e42);
-    temporary5_ = vec4<f32>(_e43.x, _e43.y, _e43.z, 1.0);
+    temporary5_ = vec4<f32>(_e43.x, _e43.y, _e43.z, 1f);
     let _e49: vec4<f32> = temporary5_;
     let _e50: vec4<f32> = temporary4_;
     temporary6_ = min(_e49, _e50);

--- a/render/naga-agal/tests/snapshots/wgsl__shaders.snap
+++ b/render/naga-agal/tests/snapshots/wgsl__shaders.snap
@@ -20,8 +20,8 @@ fn main(@location(0) param: vec3<f32>, @location(1) param_1: vec3<f32>) -> Verte
     let _e7: vec4<f32> = constant_registers[1u];
     let _e10: vec4<f32> = constant_registers[2u];
     let _e13: vec4<f32> = constant_registers[3u];
-    dest_temp = (transpose(mat4x4<f32>(_e4, _e7, _e10, _e13)) * vec4<f32>(param.x, param.y, param.z, 1.0));
-    varying_0_ = vec4<f32>(param_1.x, param_1.y, param_1.z, 1.0);
+    dest_temp = (transpose(mat4x4<f32>(_e4, _e7, _e10, _e13)) * vec4<f32>(param.x, param.y, param.z, 1f));
+    varying_0_ = vec4<f32>(param_1.x, param_1.y, param_1.z, 1f);
     let _e30: vec4<f32> = dest_temp;
     let _e31: vec4<f32> = varying_0_;
     return VertexOutput(_e30, _e31);

--- a/render/naga-pixelbender/src/lib.rs
+++ b/render/naga-pixelbender/src/lib.rs
@@ -154,8 +154,7 @@ impl<'a> ShaderBuilder<'a> {
                 name: None,
                 inner: TypeInner::Vector {
                     size: naga::VectorSize::Bi,
-                    kind: ScalarKind::Float,
-                    width: 4,
+                    scalar: naga::Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -166,8 +165,8 @@ impl<'a> ShaderBuilder<'a> {
                 name: None,
                 inner: TypeInner::Vector {
                     size: naga::VectorSize::Quad,
-                    kind: ScalarKind::Float,
-                    width: 4,
+
+                    scalar: naga::Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -178,8 +177,7 @@ impl<'a> ShaderBuilder<'a> {
                 name: None,
                 inner: TypeInner::Vector {
                     size: naga::VectorSize::Quad,
-                    kind: ScalarKind::Sint,
-                    width: 4,
+                    scalar: naga::Scalar::I32,
                 },
             },
             Span::UNDEFINED,
@@ -191,7 +189,7 @@ impl<'a> ShaderBuilder<'a> {
                 inner: TypeInner::Matrix {
                     columns: naga::VectorSize::Bi,
                     rows: naga::VectorSize::Bi,
-                    width: 4,
+                    scalar: naga::Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -203,7 +201,7 @@ impl<'a> ShaderBuilder<'a> {
                 inner: TypeInner::Matrix {
                     columns: naga::VectorSize::Tri,
                     rows: naga::VectorSize::Tri,
-                    width: 4,
+                    scalar: naga::Scalar::F32,
                 },
             },
             Span::UNDEFINED,
@@ -215,7 +213,7 @@ impl<'a> ShaderBuilder<'a> {
                 inner: TypeInner::Matrix {
                     columns: naga::VectorSize::Quad,
                     rows: naga::VectorSize::Quad,
-                    width: 4,
+                    scalar: naga::Scalar::F32,
                 },
             },
             Span::UNDEFINED,

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -11,11 +11,11 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-wgpu = { workspace = true, features = ["naga"] }
+wgpu = { workspace = true, features = ["naga-ir"] }
 tracing = { workspace = true }
 ruffle_render = { path = "..", features = ["tessellator", "wgpu"] }
 bytemuck = { version = "1.14.0", features = ["derive"] }
-raw-window-handle = "0.5.2"
+raw-window-handle = "0.6.0"
 clap = { version = "4.4.17", features = ["derive"], optional = true }
 enum-map = "2.7.3"
 fnv = "1.0.7"

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -59,14 +59,22 @@ pub struct WgpuRenderBackend<T: RenderTarget> {
 
 impl WgpuRenderBackend<SwapChainTarget> {
     #[cfg(target_family = "wasm")]
-    pub async fn for_canvas(canvas: web_sys::HtmlCanvasElement) -> Result<Self, Error> {
+    pub async fn for_canvas(
+        canvas: web_sys::HtmlCanvasElement,
+        webgpu: bool,
+    ) -> Result<Self, Error> {
+        let backends = if webgpu {
+            wgpu::Backends::BROWSER_WEBGPU
+        } else {
+            wgpu::Backends::GL
+        };
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
+            backends,
             ..Default::default()
         });
         let surface = instance.create_surface(wgpu::SurfaceTarget::Canvas(canvas))?;
         let (adapter, device, queue) = request_adapter_and_device(
-            wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
+            backends,
             &instance,
             Some(&surface),
             wgpu::PowerPreference::HighPerformance,

--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -64,7 +64,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
             backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
             ..Default::default()
         });
-        let surface = instance.create_surface_from_canvas(canvas)?;
+        let surface = instance.create_surface(wgpu::SurfaceTarget::Canvas(canvas))?;
         let (adapter, device, queue) = request_adapter_and_device(
             wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
             &instance,
@@ -79,11 +79,11 @@ impl WgpuRenderBackend<SwapChainTarget> {
         Self::new(Arc::new(descriptors), target)
     }
 
+    /// # Safety
+    ///  See [`wgpu::SurfaceTargetUnsafe`] variants for safety requirements.
     #[cfg(not(target_family = "wasm"))]
-    pub fn for_window<
-        W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRawDisplayHandle,
-    >(
-        window: &W,
+    pub unsafe fn for_window_unsafe(
+        window: wgpu::SurfaceTargetUnsafe,
         size: (u32, u32),
         backend: wgpu::Backends,
         power_preference: wgpu::PowerPreference,
@@ -99,7 +99,7 @@ impl WgpuRenderBackend<SwapChainTarget> {
             backends: backend,
             ..Default::default()
         });
-        let surface = unsafe { instance.create_surface(window) }?;
+        let surface = instance.create_surface_unsafe(window)?;
         let (adapter, device, queue) = futures::executor::block_on(request_adapter_and_device(
             backend,
             &instance,
@@ -112,16 +112,16 @@ impl WgpuRenderBackend<SwapChainTarget> {
         Self::new(Arc::new(descriptors), target)
     }
 
+    /// # Safety
+    ///  See [`wgpu::SurfaceTargetUnsafe`] variants for safety requirements.
     #[cfg(not(target_family = "wasm"))]
-    pub fn recreate_surface<
-        W: raw_window_handle::HasRawWindowHandle + raw_window_handle::HasRawDisplayHandle,
-    >(
+    pub unsafe fn recreate_surface_unsafe(
         &mut self,
-        window: &W,
+        window: wgpu::SurfaceTargetUnsafe,
         size: (u32, u32),
     ) -> Result<(), Error> {
         let descriptors = &self.descriptors;
-        let surface = unsafe { descriptors.wgpu_instance.create_surface(window) }?;
+        let surface = descriptors.wgpu_instance.create_surface_unsafe(window)?;
         self.target =
             SwapChainTarget::new(surface, &descriptors.adapter, size, &descriptors.device);
         Ok(())
@@ -1055,7 +1055,7 @@ impl<T: RenderTarget + 'static> RenderBackend for WgpuRenderBackend<T> {
 pub async fn request_adapter_and_device(
     backend: wgpu::Backends,
     instance: &wgpu::Instance,
-    surface: Option<&wgpu::Surface>,
+    surface: Option<&wgpu::Surface<'static>>,
     power_preference: wgpu::PowerPreference,
     trace_path: Option<&Path>,
 ) -> Result<(wgpu::Adapter, wgpu::Device, wgpu::Queue), Error> {
@@ -1117,8 +1117,8 @@ async fn request_device(
         .request_device(
             &wgpu::DeviceDescriptor {
                 label: None,
-                features,
-                limits,
+                required_features: features,
+                required_limits: limits,
             },
             trace_path,
         )

--- a/render/wgpu/src/clap.rs
+++ b/render/wgpu/src/clap.rs
@@ -10,7 +10,7 @@ pub enum GraphicsBackend {
 impl From<GraphicsBackend> for wgpu::Backends {
     fn from(backend: GraphicsBackend) -> Self {
         match backend {
-            GraphicsBackend::Default => wgpu::Backends::PRIMARY | wgpu::Backends::DX11,
+            GraphicsBackend::Default => wgpu::Backends::PRIMARY,
             GraphicsBackend::Vulkan => wgpu::Backends::VULKAN,
             GraphicsBackend::Metal => wgpu::Backends::METAL,
             GraphicsBackend::Dx12 => wgpu::Backends::DX12,

--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -1017,7 +1017,7 @@ impl Context3D for WgpuContext3D {
                 // BitmapData's gpu texture might be modified before we actually submit
                 // `buffer_command_encoder` to the device.
                 let dest_format = dest.texture.format();
-                let mut bytes_per_row = dest_format.block_size(None).unwrap()
+                let mut bytes_per_row = dest_format.block_copy_size(None).unwrap()
                     * (dest.width() / dest_format.block_dimensions().0);
 
                 let rows_per_image = dest.height() / dest_format.block_dimensions().1;

--- a/render/wgpu/src/mesh.rs
+++ b/render/wgpu/src/mesh.rs
@@ -224,6 +224,7 @@ impl PendingDrawType {
                 usage: wgpu::TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             },
+            wgpu::util::TextureDataOrder::LayerMajor,
             &colors[..],
         );
         let view = texture.create_view(&Default::default());

--- a/render/wgpu/src/target.rs
+++ b/render/wgpu/src/target.rs
@@ -37,7 +37,7 @@ pub trait RenderTarget: Debug + 'static {
 
 #[derive(Debug)]
 pub struct SwapChainTarget {
-    window_surface: wgpu::Surface,
+    window_surface: wgpu::Surface<'static>,
     surface_config: wgpu::SurfaceConfiguration,
 }
 
@@ -59,7 +59,7 @@ impl RenderTargetFrame for SwapChainTargetFrame {
 
 impl SwapChainTarget {
     pub fn new(
-        surface: wgpu::Surface,
+        surface: wgpu::Surface<'static>,
         adapter: &wgpu::Adapter,
         (width, height): (u32, u32),
         device: &wgpu::Device,
@@ -89,6 +89,7 @@ impl SwapChainTarget {
             width,
             height,
             present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
             alpha_mode: capabilities.alpha_modes[0],
             view_formats: vec![format],
         };

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -62,9 +62,6 @@ pub fn get_backend_names(backends: wgpu::Backends) -> Vec<&'static str> {
     if backends.contains(wgpu::Backends::DX12) {
         names.push("DirectX 12");
     }
-    if backends.contains(wgpu::Backends::DX11) {
-        names.push("DirectX 11");
-    }
     if backends.contains(wgpu::Backends::METAL) {
         names.push("Metal");
     }

--- a/tests/tests/swfs/avm2/bitmapdata_applyfilter_colormatrix/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_applyfilter_colormatrix/test.toml
@@ -1,7 +1,7 @@
 num_frames = 1
 
 [image_comparisons.output]
-tolerance = 1
+tolerance = 2
 
 [player_options]
 with_renderer = { sample_count = 1 }

--- a/tests/tests/swfs/avm2/netstream_seek_flv/test.toml
+++ b/tests/tests/swfs/avm2/netstream_seek_flv/test.toml
@@ -1,7 +1,8 @@
 num_ticks=60
 
 [image_comparisons.output]
-tolerance = 1
+tolerance = 4
+max_outliers = 271
 
 [player_options]
 with_renderer = { optional = true, sample_count = 1 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["canvas", "console_error_panic_hook", "webgl", "wgpu-webgl"]
+default = ["canvas", "console_error_panic_hook", "webgl", "wgpu-webgl", "webgpu"]
 
 # core features
 avm_debug = ["ruffle_core/avm_debug"]

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1628,7 +1628,7 @@ async fn create_renderer(
 
     let _is_transparent = config.wmode.as_deref() == Some("transparent");
 
-    let mut renderer_list = vec!["webgpu", "wgpu-webgl", "webgl", "canvas"];
+    let mut renderer_list = vec!["wgpu-webgl", "webgpu", "webgl", "canvas"];
     if let Some(preferred_renderer) = &config.preferred_renderer {
         if let Some(pos) = renderer_list.iter().position(|&r| r == preferred_renderer) {
             renderer_list.remove(pos);
@@ -1660,8 +1660,11 @@ async fn create_renderer(
                         .dyn_into()
                         .map_err(|_| "Expected HtmlCanvasElement")?;
 
-                    match ruffle_render_wgpu::backend::WgpuRenderBackend::for_canvas(canvas.clone())
-                        .await
+                    match ruffle_render_wgpu::backend::WgpuRenderBackend::for_canvas(
+                        canvas.clone(),
+                        true,
+                    )
+                    .await
                     {
                         Ok(renderer) => {
                             return Ok((builder.with_renderer(renderer), canvas));
@@ -1681,8 +1684,11 @@ async fn create_renderer(
                     .dyn_into()
                     .map_err(|_| "Expected HtmlCanvasElement")?;
 
-                match ruffle_render_wgpu::backend::WgpuRenderBackend::for_canvas(canvas.clone())
-                    .await
+                match ruffle_render_wgpu::backend::WgpuRenderBackend::for_canvas(
+                    canvas.clone(),
+                    false,
+                )
+                .await
                 {
                     Ok(renderer) => {
                         return Ok((builder.with_renderer(renderer), canvas));


### PR DESCRIPTION
0.19 is out!

This depends on:
- [x] #14703  (due to egui already having updated winit)
- [x] https://github.com/emilk/egui/pull/3824
- [x] https://github.com/bevyengine/naga_oil/pull/73