### PR TITLE
core: Support Japanese font defaults

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -25,6 +25,15 @@ pub enum DefaultFont {
 
     /// `_typewriter`, a Monospace font (similar to Courier)
     Typewriter,
+
+    /// `_ゴシック`, a Japanese Gothic font
+    JapaneseGothic,
+
+    /// `_等幅`, a Japanese Gothic Mono font
+    JapaneseGothicMono,
+
+    /// `_明朝`, a Japanese Mincho font
+    JapaneseMincho,
 }
 
 /// Certain Flash routines measure text by rounding down to the nearest whole pixel.

--- a/core/src/html/layout.rs
+++ b/core/src/html/layout.rs
@@ -491,8 +491,9 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
             "_serif" => Some(DefaultFont::Serif),
             "_sans" => Some(DefaultFont::Sans),
             "_typewriter" => Some(DefaultFont::Typewriter),
-            // [NA] I suspect that there might be undocumented more aliases.
-            // I think I've seen translated versions of these used in the wild...
+            "_ゴシック" => Some(DefaultFont::JapaneseGothic),
+            "_等幅" => Some(DefaultFont::JapaneseGothicMono),
+            "_明朝" => Some(DefaultFont::JapaneseMincho),
             _ => None,
         } {
             return context
@@ -522,7 +523,7 @@ impl<'a, 'gc> LayoutContext<'a, 'gc> {
 
         // TODO: handle multiple fonts for a definition, each covering different sets of glyphs
 
-        // At this point, the font name was neither one of the three default
+        // At this point, the font name was neither one of the default
         // fonts nor matched any device font. We explicitly handle some of the
         // well-known aliases for the default fonts for better compatibility
         // with devices that don't have those fonts installed. As a last resort

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2609,6 +2609,14 @@ impl PlayerBuilder {
             player_lock.set_default_font(DefaultFont::Sans, vec!["Noto Sans".to_string()]);
             player_lock.set_default_font(DefaultFont::Serif, vec!["Noto Sans".to_string()]);
             player_lock.set_default_font(DefaultFont::Typewriter, vec!["Noto Sans".to_string()]);
+            player_lock.set_default_font(
+                DefaultFont::JapaneseGothicMono,
+                vec!["Noto Sans".to_string()],
+            );
+            player_lock
+                .set_default_font(DefaultFont::JapaneseGothic, vec!["Noto Sans".to_string()]);
+            player_lock
+                .set_default_font(DefaultFont::JapaneseMincho, vec!["Noto Sans".to_string()]);
         }
 
         player_lock.mutate_with_update_context(|context| {

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -224,6 +224,33 @@ impl ActivePlayer {
                     "DejaVu Sans Mono".into(),
                 ],
             );
+            player_lock.set_default_font(
+                DefaultFont::JapaneseGothic,
+                vec![
+                    "ヒラギノ角ゴ Pro W3".into(), // Mac with Japanese environment
+                    "MS UI Gothic".into(),        // Windows
+                    "Noto Sans CJK JP".into(),    // Linux
+                    "Arial Unicode MS".into(),    // Mac fallback
+                ],
+            );
+            player_lock.set_default_font(
+                DefaultFont::JapaneseGothicMono,
+                vec![
+                    "Osaka－等幅".into(),      // Mac with Japanese environment
+                    "MS UI Gothic".into(),     // Windows
+                    "Noto Sans CJK JP".into(), // Linux
+                    "Arial Unicode MS".into(), // Mac fallback
+                ],
+            );
+            player_lock.set_default_font(
+                DefaultFont::JapaneseMincho,
+                vec![
+                    "ヒラギノ明朝 Pro W3".into(), // Mac with Japanese environment
+                    "MS UI Gothic".into(),        // Windows
+                    "Noto Sans CJK JP".into(),    // Linux
+                    "Arial Unicode MS".into(),    // Mac fallback
+                ],
+            );
         }
 
         Self { player, executor }

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -304,6 +304,21 @@ export interface DefaultFonts {
      * `_typewriter`, a Monospace font (similar to Courier)
      */
     typewriter?: Array<string>;
+
+    /**
+     * `_ゴシック`, a Japanese Gothic font
+     */
+    JapaneseGothic?: Array<string>;
+
+    /**
+     * `_等幅`, a Japanese Gothic Mono font
+     */
+    JapaneseGothicMono?: Array<string>;
+
+    /**
+     * `_明朝`, a Japanese Mincho font
+     */
+    JapaneseMincho?: Array<string>;
 }
 
 /**


### PR DESCRIPTION
This makes any movie using Japanese text start rendering, pretty much!

It's not flawless and we will likely adjust the matched fonts in the future.

![image](https://github.com/ruffle-rs/ruffle/assets/317625/c171fb1a-4fae-46d6-9bee-8cf55d73cd71)
![image](https://github.com/ruffle-rs/ruffle/assets/317625/564c0b73-d77a-44e4-9c98-2b4c3e643782)
