### PR TITLE
core: Font kerning is in points not pixels

### DIFF
--- a/core/src/font.rs
+++ b/core/src/font.rs
@@ -252,7 +252,7 @@ impl FontFace {
                 for subtable in kern.subtables {
                     if subtable.horizontal {
                         if let Some(value) = subtable.glyphs_kerning(left_glyph, right_glyph) {
-                            return Twips::from_pixels_i32(value as i32);
+                            return Twips::new(value as i32);
                         }
                     }
                 }


### PR DESCRIPTION
Very likely fixes #14695. I don't have the Verdana font, but it fixes DejaVu Sans. I somehow missed this instance of pixels vs. points, most likely because none of the fonts I tried actually used this type of kerning.