### PR TITLE
web: Properly panic when loading invalid SWF files (fix #14665)

### DIFF
--- a/core/src/backend/ui.rs
+++ b/core/src/backend/ui.rs
@@ -81,7 +81,7 @@ pub trait UiBackend: Downcast {
     /// Displays a message about an error during root movie download.
     /// In particular, on web this can be a CORS error, which we can sidestep
     /// by providing a direct .swf link instead.
-    fn display_root_movie_download_failed_message(&self);
+    fn display_root_movie_download_failed_message(&self, _invalid_swf: bool);
 
     // Unused, but kept in case we need it later.
     fn message(&self, message: &str);
@@ -275,7 +275,7 @@ impl UiBackend for NullUiBackend {
         Ok(())
     }
 
-    fn display_root_movie_download_failed_message(&self) {}
+    fn display_root_movie_download_failed_message(&self, _invalid_swf: bool) {}
 
     fn message(&self, _message: &str) {}
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -838,7 +838,15 @@ impl<'gc> Loader<'gc> {
                 .map(|u| u.to_string())
                 .unwrap_or(swf_url);
 
-            let mut movie = SwfMovie::from_data(&response.body, spoofed_or_swf_url, None)?;
+            let mut movie =
+                SwfMovie::from_data(&response.body, spoofed_or_swf_url, None).map_err(|error| {
+                    player
+                        .lock()
+                        .unwrap()
+                        .ui()
+                        .display_root_movie_download_failed_message();
+                    error
+                })?;
             on_metadata(movie.header());
             movie.append_parameters(parameters);
             player.lock().unwrap().mutate_with_update_context(|uc| {

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -821,7 +821,7 @@ impl<'gc> Loader<'gc> {
                     .lock()
                     .unwrap()
                     .ui()
-                    .display_root_movie_download_failed_message();
+                    .display_root_movie_download_failed_message(false);
                 error.error
             })?;
 
@@ -844,7 +844,7 @@ impl<'gc> Loader<'gc> {
                         .lock()
                         .unwrap()
                         .ui()
-                        .display_root_movie_download_failed_message();
+                        .display_root_movie_download_failed_message(true);
                     error
                 })?;
             on_metadata(movie.header());

--- a/desktop/src/backends/ui.rs
+++ b/desktop/src/backends/ui.rs
@@ -196,7 +196,7 @@ impl UiBackend for DesktopUiBackend {
         Ok(())
     }
 
-    fn display_root_movie_download_failed_message(&self) {
+    fn display_root_movie_download_failed_message(&self, _invalid_swf: bool) {
         let dialog = MessageDialog::new()
             .set_level(MessageLevel::Warning)
             .set_title("Ruffle - Load failed")

--- a/tests/framework/src/backends/ui.rs
+++ b/tests/framework/src/backends/ui.rs
@@ -113,7 +113,7 @@ impl UiBackend for TestUiBackend {
         Ok(())
     }
 
-    fn display_root_movie_download_failed_message(&self) {}
+    fn display_root_movie_download_failed_message(&self, _invalid_swf: bool) {}
 
     fn message(&self, _message: &str) {}
 

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -2026,8 +2026,11 @@ export class RufflePlayer extends HTMLElement {
         let actionLink: PanicLinkInfo;
         if (!isBuildOutdated) {
             let url;
-            if (document.location.protocol.includes("extension")) {
-                url = this.swfUrl!.href;
+            if (
+                document.location.protocol.includes("extension") &&
+                this.swfUrl
+            ) {
+                url = this.swfUrl.href;
             } else {
                 url = document.location.href;
             }

--- a/web/packages/core/texts/en-US/messages.ftl
+++ b/web/packages/core/texts/en-US/messages.ftl
@@ -30,6 +30,9 @@ error-wasm-mime-type =
     Ruffle has encountered a major issue whilst trying to initialize.
     This web server is not serving ".wasm" files with the correct MIME type.
     If you are the server administrator, please consult the Ruffle wiki for help.
+error-invalid-swf =
+    Ruffle cannot parse the requested file.
+    The most likely reason is that the requested file is not a valid SWF.
 error-swf-fetch =
     Ruffle failed to load the Flash SWF file.
     The most likely reason is that the file no longer exists, so there is nothing for Ruffle to load.

--- a/web/src/ui.rs
+++ b/web/src/ui.rs
@@ -240,8 +240,9 @@ impl UiBackend for WebUiBackend {
         }
     }
 
-    fn display_root_movie_download_failed_message(&self) {
-        self.js_player.display_root_movie_download_failed_message()
+    fn display_root_movie_download_failed_message(&self, invalid_swf: bool) {
+        self.js_player
+            .display_root_movie_download_failed_message(invalid_swf)
     }
 
     fn message(&self, message: &str) {


### PR DESCRIPTION
Note: The error when loading a page which is not an SWF is the same as the error when loading an SWF that does not exist for the purpose of code simplicity. This can be changed if desired.