### PR TITLE
chore: Deny unknown crate sources

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -62,10 +62,10 @@ deny = [{ name = "tracy-client", deny-multiple-versions = true }]
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not
 # in the allow list is encountered
-unknown-registry = "warn"
+unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "warn"
+unknown-git = "deny"
 
 [sources.allow-org]
 #  github.com organizations to allow git sources for

--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,5 @@ unknown-git = "deny"
 #  github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    "kyren",
     "gfx-rs",
 ]


### PR DESCRIPTION
Deny unknown crate registry and git repository sources, plus disallow "kyren" as GitHub organization as crate source, since we have switched to the published `gc-arena` 0.5.0 release in #14616.