### PR TITLE
avm2: Cleanup: Make `Domain::get_class` not return a `Result`

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -298,7 +298,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         name: &Multiname<'gc>,
     ) -> Result<GcCell<'gc, Class<'gc>>, Error<'gc>> {
         self.domain()
-            .get_class(name, self.context.gc_context)?
+            .get_class(name, self.context.gc_context)
             .ok_or_else(|| format!("Attempted to resolve nonexistent type {name:?}").into())
     }
 

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -402,7 +402,7 @@ impl<'gc> ClassObject<'gc> {
         mc: &Mutation<'gc>,
     ) -> Result<GcCell<'gc, Class<'gc>>, Error<'gc>> {
         domain
-            .get_class(class_name, mc)?
+            .get_class(class_name, mc)
             .ok_or_else(|| format!("Could not resolve class {class_name:?}").into())
     }
 

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -77,7 +77,7 @@ impl<'gc> PropertyClass<'gc> {
                     // so use that domain if we don't have a translation unit.
                     let domain =
                         unit.map_or(activation.avm2().playerglobals_domain, |u| u.domain());
-                    if let Some(class) = domain.get_class(name, activation.context.gc_context)? {
+                    if let Some(class) = domain.get_class(name, activation.context.gc_context) {
                         *self = PropertyClass::Class(class);
                         (Some(class), true)
                     } else {

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -1001,7 +1001,7 @@ impl<'gc> Value<'gc> {
         }
         let param_type = activation
             .domain()
-            .get_class(type_name, activation.context.gc_context)?
+            .get_class(type_name, activation.context.gc_context)
             .ok_or_else(|| {
                 Error::RustError(
                     format!("Failed to lookup class {:?} during coercion", type_name).into(),


### PR DESCRIPTION
Since it was always the `Ok` variant anyway, just sometimes with a `None` in it, not a `Some`.

Noticed by @Lord-McSweeney [on Discord](https://discord.com/channels/610531541889581066/1018988594259574845/1193255188300038245).