### PR TITLE
avm2: Add API versioning to DisplayObjectContainer

### DIFF
--- a/core/src/avm2/globals/flash/display/DisplayObjectContainer.as
+++ b/core/src/avm2/globals/flash/display/DisplayObjectContainer.as
@@ -29,10 +29,15 @@ package flash.display {
         public native function getChildIndex(child:DisplayObject):int;
         public native function removeChild(child:DisplayObject):DisplayObject;
         public native function removeChildAt(index:int):DisplayObject;
+
+        [API("674")] // AIR 3.0, FP 11, SWF 13
         public native function removeChildren(beginIndex:int = 0, endIndex:int = 0x7fffffff):void;
+
         public native function setChildIndex(child:DisplayObject, index:int):void;
         public native function swapChildren(child1:DisplayObject, child2:DisplayObject):void;
         public native function swapChildrenAt(index1:int, index2:int):void;
+
+        [API("690")] // AIR 3.8, FP 11.8, SWF 21
         public native function stopAllMovieClips():void;
 
         public native function getObjectsUnderPoint(point:Point):Array;


### PR DESCRIPTION
Reference: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/DisplayObjectContainer.html

I only found these two methods with a version higher than FP 9.

API versions determined according to `avm2/globals/README.md`.

This is supposed to fix #14704 according to @Lord-McSweeney (https://github.com/ruffle-rs/ruffle/issues/14704#issuecomment-1888113744), but haven't tested it, as I don't know how.