### PR TITLE
avm2: Stub Accelerometer.isSupported

### DIFF
--- a/core/src/avm2/globals/flash/sensors/Accelerometer.as
+++ b/core/src/avm2/globals/flash/sensors/Accelerometer.as
@@ -1,0 +1,8 @@
+package flash.sensors {
+    [API("667")]
+    public class Accelerometer {
+        public static function get isSupported():Boolean {
+            return false;
+        }
+    }
+}

--- a/core/src/avm2/globals/globals.as
+++ b/core/src/avm2/globals/globals.as
@@ -304,6 +304,8 @@ include "flash/security/CertificateStatus.as"
 include "flash/security/X509Certificate.as"
 include "flash/security/X500DistinguishedName.as"
 
+include "flash/sensors/Accelerometer.as"
+
 include "flash/system.as"
 include "flash/system/ApplicationDomain.as"
 include "flash/system/Capabilities.as"


### PR DESCRIPTION
This fixes Asterius from showing "undefined" as intro text (Fixes #12463).