### PR TITLE
ci: Track merged PRs in a project

### DIFF
--- a/.github/workflows/track_merged_prs.yml
+++ b/.github/workflows/track_merged_prs.yml
@@ -1,0 +1,17 @@
+name: Track merged pull requests
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  add-to-project:
+    if: github.event.pull_request.merged == true
+    name: Add pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/ruffle-rs/projects/7
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tested in a private repo and works!

https://github.com/orgs/ruffle-rs/projects/7

> All merged PRs to Ruffle will automatically land in the No Category column of this project.
> 
> Maintainers should occasionally go through and roughly categorize them according to the PRs topic.
> 
> If the PR isn't worth calling out because (it's meta, dependencies, or such a small change it has little to no impact on actual content), move it to N/A.
> If there's no matching category and it's a minor change, put it in the Minor column.
> If there's no matching category and it's a major change that we definitely want to call out, make a new category for it.
> If the Minor column has a bunch of similar topics already, make a new category for those and move them out.