### PR TITLE
chore: Update wasm-bindgen version references to 0.2.90

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -291,7 +291,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in test_web.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.89
+        run: cargo install wasm-bindgen-cli --version 0.2.90
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
@@ -394,7 +394,7 @@ jobs:
           package_file="${{ needs.create-nightly-release.outputs.package_prefix }}-web-extension-firefox-unsigned.xpi"
           cp "./web/packages/extension/dist/firefox_unsigned.xpi" "$package_file"
           gh release upload "$tag_name" "$package_file"
-          rm "$package_file" 
+          rm "$package_file"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -444,7 +444,7 @@ jobs:
 
           # Copy the fresh build into this folder.
           cp -fr ../web/packages/demo/dist/* .
-          
+
           # Restore our custom swfs
           git restore swfs swfs.json
 

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -64,7 +64,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.89
+        run: cargo install wasm-bindgen-cli --version 0.2.90
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/web/README.md
+++ b/web/README.md
@@ -65,7 +65,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.89`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.90`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -y -c conda-forge binaryen
 # Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
 ENV PATH="/root/.cargo/bin:$PATH"
-RUN cargo install wasm-bindgen-cli --version 0.2.89
+RUN cargo install wasm-bindgen-cli --version 0.2.90
 # Building Ruffle:
 COPY . ruffle
 WORKDIR ruffle/web


### PR DESCRIPTION
Fixup for https://github.com/ruffle-rs/ruffle/pull/14754.