### PR TITLE
tests: Don't set logger in test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,7 +4558,6 @@ dependencies = [
  "approx",
  "async-channel 2.1.1",
  "chrono",
- "env_logger",
  "futures",
  "image",
  "percent-encoding",
@@ -4571,8 +4570,6 @@ dependencies = [
  "ruffle_video_software",
  "serde",
  "toml",
- "tracing",
- "tracing-subscriber",
  "url",
  "vfs",
 ]
@@ -5244,12 +5241,15 @@ name = "tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "env_logger",
  "futures",
  "image",
  "libtest-mimic",
  "ruffle_core",
  "ruffle_render_wgpu",
  "ruffle_test_framework",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,6 +29,9 @@ walkdir = "2.4.0"
 anyhow = "1.0.79"
 image = { version = "0.24.8", default-features = false, features  = ["png"] }
 futures = "0.3.30"
+env_logger = "0.10.1"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [[test]]
 name = "tests"

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -23,9 +23,6 @@ url = "2.5.0"
 chrono = "0.4.31"
 approx = "0.5.1"
 pretty_assertions = "1.4.0"
-env_logger = "0.10.1"
-tracing = { workspace = true}
-tracing-subscriber = { workspace = true }
 serde = "1.0.195"
 toml = "0.8.8"
 anyhow = "1.0.79"

--- a/tests/framework/src/lib.rs
+++ b/tests/framework/src/lib.rs
@@ -9,18 +9,3 @@ pub use vfs;
 
 mod backends;
 mod util;
-
-pub fn set_logger() {
-    let _ = env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("info,wgpu_core=warn,wgpu_hal=warn"),
-    )
-    .format_timestamp(None)
-    .is_test(true)
-    .try_init();
-
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .finish();
-    // Ignore error if it's already been set
-    let _ = tracing::subscriber::set_global_default(subscriber);
-}

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -1,7 +1,6 @@
 use crate::environment::Environment;
 use crate::options::TestOptions;
 use crate::runner::run_swf;
-use crate::set_logger;
 use crate::util::read_bytes;
 use anyhow::{anyhow, Result};
 use pretty_assertions::Comparison;
@@ -53,8 +52,6 @@ impl Test {
         mut before_end: impl FnMut(Arc<Mutex<Player>>) -> Result<()>,
         environment: &impl Environment,
     ) -> Result<()> {
-        set_logger();
-
         let data = read_bytes(&self.swf_path)?;
         let movie = SwfMovie::from_data(&data, format!("file:///{}", self.swf_path.as_str()), None)
             .map_err(|e| anyhow!(e.to_string()))?;

--- a/tests/tests/external_interface/tests.rs
+++ b/tests/tests/external_interface/tests.rs
@@ -2,7 +2,6 @@ use crate::external_interface::ExternalInterfaceTestProvider;
 use ruffle_core::external::Value as ExternalValue;
 use ruffle_test_framework::environment::Environment;
 use ruffle_test_framework::options::TestOptions;
-use ruffle_test_framework::set_logger;
 use ruffle_test_framework::test::Test;
 use ruffle_test_framework::vfs::{PhysicalFS, VfsPath};
 use std::collections::BTreeMap;
@@ -10,7 +9,6 @@ use std::collections::BTreeMap;
 pub fn external_interface_avm1(
     environment: &impl Environment,
 ) -> Result<(), libtest_mimic::Failed> {
-    set_logger();
     Ok(Test::from_options(
         TestOptions {
             num_frames: Some(1),
@@ -69,7 +67,6 @@ pub fn external_interface_avm1(
 pub fn external_interface_avm2(
     environment: &impl Environment,
 ) -> Result<(), libtest_mimic::Failed> {
-    set_logger();
     Ok(Test::from_options(
         TestOptions {
             num_frames: Some(1),

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -42,6 +42,19 @@ fn is_candidate(args: &Arguments, test_name: &str) -> bool {
 fn main() {
     let args = Arguments::from_args();
 
+    let _ = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or("info,wgpu_core=warn,wgpu_hal=warn"),
+    )
+    .format_timestamp(None)
+    .is_test(true)
+    .try_init();
+
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .finish();
+    // Ignore error if it's already been set
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
     let root = Path::new("tests/swfs");
     let mut tests: Vec<Trial> = walkdir::WalkDir::new(root)
         .into_iter()

--- a/tests/tests/shared_object/mod.rs
+++ b/tests/tests/shared_object/mod.rs
@@ -1,12 +1,10 @@
 use ruffle_core::backend::storage::{MemoryStorageBackend, StorageBackend};
 use ruffle_test_framework::environment::Environment;
 use ruffle_test_framework::options::TestOptions;
-use ruffle_test_framework::set_logger;
 use ruffle_test_framework::test::Test;
 use ruffle_test_framework::vfs::{PhysicalFS, VfsPath};
 
 pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_mimic::Failed> {
-    set_logger();
     // Test SharedObject persistence. Run an SWF that saves data
     // to a shared object twice and verify that the data is saved.
     let mut memory_storage_backend: Box<dyn StorageBackend> =
@@ -69,7 +67,6 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
 pub fn shared_object_self_ref_avm1(
     environment: &impl Environment,
 ) -> Result<(), libtest_mimic::Failed> {
-    set_logger();
     // Test SharedObject persistence. Run an SWF that saves data
     // to a shared object twice and verify that the data is saved.
     let mut memory_storage_backend: Box<dyn StorageBackend> =
@@ -130,7 +127,6 @@ pub fn shared_object_self_ref_avm1(
 }
 
 pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_mimic::Failed> {
-    set_logger();
     // Test SharedObject persistence. Run an SWF that saves data
     // to a shared object twice and verify that the data is saved.
     let mut memory_storage_backend: Box<dyn StorageBackend> =


### PR DESCRIPTION
It's the responsibility of the caller to do it how they want