### PR TITLE
core: Make `Player::mutate_with_update_context` public

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1784,7 +1784,7 @@ impl Player {
 
     /// Runs the closure `f` with an `UpdateContext`.
     /// This takes cares of populating the `UpdateContext` struct, avoiding borrow issues.
-    pub(crate) fn mutate_with_update_context<F, R>(&mut self, f: F) -> R
+    pub fn mutate_with_update_context<F, R>(&mut self, f: F) -> R
     where
         F: for<'a, 'gc> FnOnce(&mut UpdateContext<'a, 'gc>) -> R,
     {


### PR DESCRIPTION
After https://github.com/ruffle-rs/ruffle/pull/14671, there's no `Player::set_root_movie`, which I used to use in the Android app.

The way to go now is through `Player::mutate_with_update_context`, but that is only available within the same crate. Let's change that.