### PR TITLE
avm2: Add a bunch more constants

### DIFF
--- a/core/src/avm2/globals/flash/desktop/ClipboardFormats.as
+++ b/core/src/avm2/globals/flash/desktop/ClipboardFormats.as
@@ -6,8 +6,20 @@
 package flash.desktop
 {
 
+    // The AS3 docs specify various API versions for the different members,
+    // as also indicated by their comments. The docs, however, are lying.
+    [API("662")]
     public class ClipboardFormats
     {
+        // Image data (AIR only).
+        public static const BITMAP_FORMAT:String = "air:bitmap";
+
+        // An array of files (AIR only).
+        public static const FILE_LIST_FORMAT:String = "air:file list";
+
+        // File promise list (AIR only).
+        public static const FILE_PROMISE_LIST_FORMAT:String = "air:file promise list";
+
         // HTML data.
         public static const HTML_FORMAT:String = "air:html";
 
@@ -16,6 +28,9 @@ package flash.desktop
 
         // String data.
         public static const TEXT_FORMAT:String = "air:text";
+
+        // A URL string (AIR only).
+        public static const URL_FORMAT:String = "air:url";
 
     }
 }

--- a/core/src/avm2/globals/flash/events/ActivityEvent.as
+++ b/core/src/avm2/globals/flash/events/ActivityEvent.as
@@ -1,5 +1,8 @@
 package flash.events {
 	public class ActivityEvent extends Event {
+
+		public static const ACTIVITY:String = "activity";
+
 		public var activating:Boolean;
 
 		public function ActivityEvent(type:String, bubbles:Boolean = false, cancelable:Boolean = false, activating:Boolean = false) {

--- a/core/src/avm2/globals/flash/events/IOErrorEvent.as
+++ b/core/src/avm2/globals/flash/events/IOErrorEvent.as
@@ -3,6 +3,11 @@ package flash.events {
         // Defines the value of the `type` property of an `ioError` event object.
         public static const IO_ERROR:String = "ioError";
 
+        // These next three are undocumented.
+        public static const NETWORK_ERROR:String = "networkError";
+        public static const DISK_ERROR:String = "diskError";
+        public static const VERIFY_ERROR:String = "verifyError";
+
         // The standardErrorIoError event is dispatched when an error occurs while
         // reading data from the standardError stream of a NativeProcess object.
         [API("668")]

--- a/core/src/avm2/globals/flash/events/IOErrorEvent.as
+++ b/core/src/avm2/globals/flash/events/IOErrorEvent.as
@@ -1,6 +1,22 @@
 package flash.events {
     public class IOErrorEvent extends ErrorEvent {
+        // Defines the value of the `type` property of an `ioError` event object.
         public static const IO_ERROR:String = "ioError";
+
+        // The standardErrorIoError event is dispatched when an error occurs while
+        // reading data from the standardError stream of a NativeProcess object.
+        [API("668")]
+        public static const STANDARD_ERROR_IO_ERROR:String = "standardErrorIoError";
+
+        // The standardInputIoError event is dispatched when an error occurs while
+        // writing data to the standardInput of a NativeProcess object.
+        [API("668")]
+        public static const STANDARD_INPUT_IO_ERROR:String = "standardInputIoError";
+
+        //The standardOutputIoError event is dispatched when an error occurs while
+        // reading data from the standardOutput stream of a NativeProcess object.
+        [API("668")]
+        public static const STANDARD_OUTPUT_IO_ERROR:String = "standardOutputIoError";
 
 
         public function IOErrorEvent(type:String, bubbles:Boolean = false, cancelable:Boolean = false, text:String = "", id:int = 0)

--- a/core/src/avm2/globals/flash/events/StageVideoEvent.as
+++ b/core/src/avm2/globals/flash/events/StageVideoEvent.as
@@ -5,11 +5,29 @@
 package flash.events
 {
     
+    // According to the AS3 docs, this class is only available starting with Flash Player 10.2,
+    // and some members of it are AIR-only. This is yet another case of misdocumentation.
+    [API("667")]
     public class StageVideoEvent extends Event
     {
-        public const codecInfo:String; 
-        public static const RENDER_STATE:String = "renderState"; // The StageVideoEvent.RENDER_STATE constant defines the value of the type property of a renderState event object.
-        
+        // The StageVideoEvent.RENDER_STATE constant defines the value of the type property of a renderState event object.
+        public static const RENDER_STATE:String = "renderState";
+
+        // Indicates that hardware is decoding and displaying the video.
+        // Deprecated since Flash Player 10.2, AIR 3: Please Use flash.media.VideoStatus.ACCELERATED
+        public static const RENDER_STATUS_ACCELERATED : String = "accelerated";
+
+        // Indicates that software is decoding and displaying the video.
+        // Deprecated since Flash Player 10.2, AIR 3: Please Use flash.media.VideoStatus.SOFTWARE
+        public static const RENDER_STATUS_SOFTWARE : String = "software";
+
+        // Indicates that displaying the video using the StageVideo object is not possible.
+        // Deprecated since Flash Player 10.2, AIR 3: Please Use flash.media.VideoStatus.UNAVAILABLE
+        public static const RENDER_STATUS_UNAVAILABLE : String = "unavailable";
+
+
+        public const codecInfo:String;
+
         private var _status: String; // The status of the StageVideo object.
         private var _colorSpace: String; // The color space used by the video being displayed in the StageVideo object.
 

--- a/core/src/avm2/globals/flash/ui/GameInputDevice.as
+++ b/core/src/avm2/globals/flash/ui/GameInputDevice.as
@@ -1,4 +1,11 @@
 package flash.ui {
+    // The AS3 docs say this is only available in AIR 3.7.
+    // That was determined to be a lie.
+    [API("688")]
     public final class GameInputDevice {
+        // Specifies the maximum size for the buffer used to cache sampled
+        // control values. If `startCachingSamples` returns samples that
+        // require more memory than you specify, it throws a memory error.
+        public static const MAX_BUFFER_SIZE:int = 32000;
     }
 }

--- a/core/src/avm2/globals/flash/ui/KeyLocation.as
+++ b/core/src/avm2/globals/flash/ui/KeyLocation.as
@@ -8,6 +8,11 @@ package flash.ui
 
     public final class KeyLocation
     {
+        // Indicates the key activation originated on a directional pad of input device.
+        // Example: The trackball on a mobile device or the left arrow on a remote control.
+        [API("669")]
+        public static const D_PAD:uint = 4;
+
         // Indicates the key activated is in the left key location (there is more than one possible location for this key).
         public static const LEFT:uint = 1;
 


### PR DESCRIPTION
Browsing https://ruffle.rs/compatibility/avm2, these stood out as random missing pieces.
Easy wins for our API percentage.
_Goodhart's law has not been broken during the making of this PR._