### PR TITLE
swf: Show scaled value in `swf::FixedN`'s `Debug` implementations

### DIFF
--- a/swf/src/types/fixed.rs
+++ b/swf/src/types/fixed.rs
@@ -19,7 +19,7 @@ macro_rules! define_fixed {
         into_float($($into_type:path),*)
     ) => {
         /// A signed fixed-point value with $frac_bits bits.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
         pub struct $type_name($underlying_type);
 
         /// A signed fixed-point type.
@@ -185,7 +185,13 @@ macro_rules! define_fixed {
 
         impl std::fmt::Display for $type_name {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "{}", self.to_f64())
+                std::fmt::Display::fmt(&self.to_f64(), f)
+            }
+        }
+
+        impl std::fmt::Debug for $type_name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                std::fmt::Debug::fmt(&self.to_f64(), f)
             }
         }
 


### PR DESCRIPTION
This makes the debug output more readable, e.g. in the debug UI filter's list.

Before:
![image](https://github.com/ruffle-rs/ruffle/assets/10963458/8af4dbeb-290b-4564-af67-61ff7d9883c0)

After:
![image](https://github.com/ruffle-rs/ruffle/assets/10963458/0ed709d1-e921-472b-8bd6-dda75beea281)
