### PR TITLE
web: Add allowFullScreen embed/object option (part of #4258)

### DIFF
--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -103,6 +103,9 @@ pub struct StageData<'gc> {
     /// Whether to prevent movies from the changing the stage alignment
     forced_align: bool,
 
+    /// Whether to allow the stage's displayState to be changed.
+    allow_full_screen: bool,
+
     /// Whether or not a RENDER event should be dispatched on the next render
     invalidated: bool,
 
@@ -174,6 +177,7 @@ impl<'gc> Stage<'gc> {
                 invalidated: false,
                 align: Default::default(),
                 forced_align: false,
+                allow_full_screen: true,
                 use_bitmap_downsampling: false,
                 view_bounds: Default::default(),
                 window_mode: Default::default(),
@@ -331,6 +335,16 @@ impl<'gc> Stage<'gc> {
         self.0.write(context.gc_context).forced_scale_mode = force;
     }
 
+    /// Get whether the Stage's display state can be changed.
+    pub fn allow_full_screen(self) -> bool {
+        self.0.read().allow_full_screen
+    }
+
+    /// Set whether the Stage's display state can be changed.
+    pub fn set_allow_full_screen(self, context: &mut UpdateContext<'_, 'gc>, allow: bool) {
+        self.0.write(context.gc_context).allow_full_screen = allow;
+    }
+
     fn is_fullscreen_state(display_state: StageDisplayState) -> bool {
         display_state == StageDisplayState::FullScreen
             || display_state == StageDisplayState::FullScreenInteractive
@@ -365,6 +379,7 @@ impl<'gc> Stage<'gc> {
     ) {
         if display_state == self.display_state()
             || (Self::is_fullscreen_state(display_state) && self.is_fullscreen())
+            || !self.allow_full_screen()
         {
             return;
         }

--- a/core/src/display_object/stage.rs
+++ b/core/src/display_object/stage.rs
@@ -104,7 +104,7 @@ pub struct StageData<'gc> {
     forced_align: bool,
 
     /// Whether to allow the stage's displayState to be changed.
-    allow_full_screen: bool,
+    allow_fullscreen: bool,
 
     /// Whether or not a RENDER event should be dispatched on the next render
     invalidated: bool,
@@ -177,7 +177,7 @@ impl<'gc> Stage<'gc> {
                 invalidated: false,
                 align: Default::default(),
                 forced_align: false,
-                allow_full_screen: true,
+                allow_fullscreen: true,
                 use_bitmap_downsampling: false,
                 view_bounds: Default::default(),
                 window_mode: Default::default(),
@@ -336,13 +336,13 @@ impl<'gc> Stage<'gc> {
     }
 
     /// Get whether the Stage's display state can be changed.
-    pub fn allow_full_screen(self) -> bool {
-        self.0.read().allow_full_screen
+    pub fn allow_fullscreen(self) -> bool {
+        self.0.read().allow_fullscreen
     }
 
     /// Set whether the Stage's display state can be changed.
-    pub fn set_allow_full_screen(self, context: &mut UpdateContext<'_, 'gc>, allow: bool) {
-        self.0.write(context.gc_context).allow_full_screen = allow;
+    pub fn set_allow_fullscreen(self, context: &mut UpdateContext<'_, 'gc>, allow: bool) {
+        self.0.write(context.gc_context).allow_fullscreen = allow;
     }
 
     fn is_fullscreen_state(display_state: StageDisplayState) -> bool {
@@ -379,7 +379,7 @@ impl<'gc> Stage<'gc> {
     ) {
         if display_state == self.display_state()
             || (Self::is_fullscreen_state(display_state) && self.is_fullscreen())
-            || !self.allow_full_screen()
+            || !self.allow_fullscreen()
         {
             return;
         }

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -813,6 +813,14 @@ impl Player {
         })
     }
 
+    /// Set whether the Stage's display state can be changed.
+    pub fn set_allow_full_screen(&mut self, allow_full_screen: bool) {
+        self.mutate_with_update_context(|context| {
+            let stage = context.stage;
+            stage.set_allow_full_screen(context, allow_full_screen);
+        })
+    }
+
     pub fn set_quality(&mut self, quality: StageQuality) {
         self.mutate_with_update_context(|context| {
             context.stage.set_quality(context, quality);
@@ -2095,6 +2103,7 @@ pub struct PlayerBuilder {
     forced_align: bool,
     scale_mode: StageScaleMode,
     forced_scale_mode: bool,
+    allow_full_screen: bool,
     fullscreen: bool,
     letterbox: Letterbox,
     max_execution_duration: Duration,
@@ -2137,6 +2146,7 @@ impl PlayerBuilder {
             forced_align: false,
             scale_mode: StageScaleMode::default(),
             forced_scale_mode: false,
+            allow_full_screen: true,
             fullscreen: false,
             // Disable script timeout in debug builds by default.
             letterbox: Letterbox::Fullscreen,
@@ -2535,6 +2545,7 @@ impl PlayerBuilder {
             stage.set_forced_align(context, self.forced_align);
             stage.set_scale_mode(context, self.scale_mode);
             stage.set_forced_scale_mode(context, self.forced_scale_mode);
+            stage.set_allow_full_screen(context, self.allow_full_screen);
             stage.post_instantiation(context, None, Instantiator::Movie, false);
             stage.build_matrices(context);
         });

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -814,10 +814,10 @@ impl Player {
     }
 
     /// Set whether the Stage's display state can be changed.
-    pub fn set_allow_full_screen(&mut self, allow_full_screen: bool) {
+    pub fn set_allow_fullscreen(&mut self, allow_fullscreen: bool) {
         self.mutate_with_update_context(|context| {
             let stage = context.stage;
-            stage.set_allow_full_screen(context, allow_full_screen);
+            stage.set_allow_fullscreen(context, allow_fullscreen);
         })
     }
 
@@ -2103,7 +2103,7 @@ pub struct PlayerBuilder {
     forced_align: bool,
     scale_mode: StageScaleMode,
     forced_scale_mode: bool,
-    allow_full_screen: bool,
+    allow_fullscreen: bool,
     fullscreen: bool,
     letterbox: Letterbox,
     max_execution_duration: Duration,
@@ -2146,7 +2146,7 @@ impl PlayerBuilder {
             forced_align: false,
             scale_mode: StageScaleMode::default(),
             forced_scale_mode: false,
-            allow_full_screen: true,
+            allow_fullscreen: true,
             fullscreen: false,
             // Disable script timeout in debug builds by default.
             letterbox: Letterbox::Fullscreen,
@@ -2545,7 +2545,7 @@ impl PlayerBuilder {
             stage.set_forced_align(context, self.forced_align);
             stage.set_scale_mode(context, self.scale_mode);
             stage.set_forced_scale_mode(context, self.forced_scale_mode);
-            stage.set_allow_full_screen(context, self.allow_full_screen);
+            stage.set_allow_fullscreen(context, self.allow_fullscreen);
             stage.post_instantiation(context, None, Instantiator::Movie, false);
             stage.build_matrices(context);
         });

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -31,6 +31,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     maxExecutionDuration: 15,
     base: null,
     menu: true,
+    allowFullScreen: false,
     salign: "",
     forceAlign: false,
     quality: "high",

--- a/web/packages/core/src/config.ts
+++ b/web/packages/core/src/config.ts
@@ -31,7 +31,7 @@ export const DEFAULT_CONFIG: Required<BaseLoadOptions> = {
     maxExecutionDuration: 15,
     base: null,
     menu: true,
-    allowFullScreen: false,
+    allowFullscreen: false,
     salign: "",
     forceAlign: false,
     quality: "high",

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -521,6 +521,13 @@ export interface BaseLoadOptions {
     forceScale?: boolean;
 
     /**
+     * If set to true, the Stage's displayState can be changed
+     *
+     * @default false
+     */
+    allowFullScreen?: boolean;
+
+    /**
      * Sets and locks the player's frame rate, overriding the movie's frame rate.
      *
      * @default null

--- a/web/packages/core/src/load-options.ts
+++ b/web/packages/core/src/load-options.ts
@@ -525,7 +525,7 @@ export interface BaseLoadOptions {
      *
      * @default false
      */
-    allowFullScreen?: boolean;
+    allowFullscreen?: boolean;
 
     /**
      * Sets and locks the player's frame rate, overriding the movie's frame rate.

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1482,12 +1482,12 @@ export class RufflePlayer extends HTMLElement {
             if (this.isFullscreen) {
                 items.push({
                     text: text("context-menu-exit-fullscreen"),
-                    onClick: () => this.instance?.set_fullscreen(false),
+                    onClick: () => this.setFullscreen(false),
                 });
             } else {
                 items.push({
                     text: text("context-menu-enter-fullscreen"),
-                    onClick: () => this.instance?.set_fullscreen(true),
+                    onClick: () => this.setFullscreen(true),
                 });
             }
         }
@@ -2499,6 +2499,10 @@ export function getPolyfillOptions(
     const menu = parseBoolean(getOptionString("menu"));
     if (menu !== null) {
         options.menu = menu;
+    }
+    const allowFullScreen = parseBoolean(getOptionString("allowFullScreen"));
+    if (allowFullScreen !== null) {
+        options.allowFullScreen = allowFullScreen;
     }
     const parameters = getOptionString("flashvars");
     if (parameters !== null) {

--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -2500,9 +2500,9 @@ export function getPolyfillOptions(
     if (menu !== null) {
         options.menu = menu;
     }
-    const allowFullScreen = parseBoolean(getOptionString("allowFullScreen"));
-    if (allowFullScreen !== null) {
-        options.allowFullScreen = allowFullScreen;
+    const allowFullscreen = parseBoolean(getOptionString("allowFullScreen"));
+    if (allowFullscreen !== null) {
+        options.allowFullscreen = allowFullscreen;
     }
     const parameters = getOptionString("flashvars");
     if (parameters !== null) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -281,7 +281,7 @@ struct Config {
     #[serde(rename = "menu")]
     show_menu: bool,
 
-    allow_full_screen: bool,
+    allow_fullscreen: bool,
 
     salign: Option<String>,
 
@@ -710,7 +710,7 @@ impl Ruffle {
             // Set config parameters.
             core.set_background_color(config.background_color);
             core.set_show_menu(config.show_menu);
-            core.set_allow_full_screen(config.allow_full_screen);
+            core.set_allow_fullscreen(config.allow_fullscreen);
             core.set_window_mode(config.wmode.as_deref().unwrap_or("window"));
             callstack = Some(core.callstack());
         }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -281,6 +281,8 @@ struct Config {
     #[serde(rename = "menu")]
     show_menu: bool,
 
+    allow_full_screen: bool,
+
     salign: Option<String>,
 
     force_align: bool,
@@ -708,6 +710,7 @@ impl Ruffle {
             // Set config parameters.
             core.set_background_color(config.background_color);
             core.set_show_menu(config.show_menu);
+            core.set_allow_full_screen(config.allow_full_screen);
             core.set_window_mode(config.wmode.as_deref().unwrap_or("window"));
             callstack = Some(core.callstack());
         }


### PR DESCRIPTION
Note 1:

I realized on `fullscreenchange`, `this.instance?.set_fullscreen` is called (this was to fix escape key behavior IIRC):
https://github.com/ruffle-rs/ruffle/blob/e0f5b8906dc1893416d9d836fd4458c8acc2817b/web/packages/core/src/ruffle-player.ts#L1140-L1142
That same function got called by clicking the context menu item "Enter/Exit Fullscreen", but with my change in `set_display_state` that Rust function doesn't actually full screen the content when `allowFullScreen` is false. So I switched "Enter/Exit Fullscreen" to use the pure JavaScript `setFullscreen` function, which will subsequently trigger a `fullscreenchange` event to call `this.instance?.set_fullscreen` to do the Rust portion of the logic. That way full-screening the content with the context menu always works, but only changes the `displayState` if `allowFullScreen` is true.

Note 2:

I'm not actually throwing the `SecurityError` that is supposed to be thrown when the `displayState` doesn't change in AS3, but that can be a future TODO.