### PR TITLE
core: Invalidate cached bitmap on state change in AVM2Button

### DIFF
--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -279,6 +279,7 @@ impl<'gc> Avm2Button<'gc> {
 
     /// Change the rendered state of the button.
     pub fn set_state(self, context: &mut UpdateContext<'_, 'gc>, state: ButtonState) {
+        self.invalidate_cached_bitmap(context.gc_context);
         self.0.write(context.gc_context).state = state;
         let button = self.0.read();
         if let Some(state) = button.up_state {


### PR DESCRIPTION
Fixes #11907