### PR TITLE
Update vite to 5.0.12 in `package.json`

### DIFF
--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -26,6 +26,6 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
         "typescript": "^5.3.3",
-        "vite": "^5.0.10"
+        "vite": "^5.0.12"
     }
 }


### PR DESCRIPTION
Renovate PR to update `vite` to 5.0.12 (https://github.com/ruffle-rs/ruffle/pull/14851) updated only `package-lock.json`, but not `package.json`

This causes `vite`  inside `package-lock.json` to roll back to 5.0.10 after `npm install`. This PR fixes that :)