### PR TITLE
tests: More improvements to make them runnable on web

### DIFF
--- a/tests/framework/src/backends/log.rs
+++ b/tests/framework/src/backends/log.rs
@@ -16,7 +16,7 @@ impl Default for TestLogBackend {
 }
 
 impl TestLogBackend {
-    pub fn trace_output(self) -> String {
+    pub fn trace_output(&self) -> String {
         self.trace_output.take()
     }
 }

--- a/tests/framework/src/environment.rs
+++ b/tests/framework/src/environment.rs
@@ -14,24 +14,22 @@ pub trait Environment {
         false
     }
 
-    /// Creates any amount of render backends for a new test run.
+    /// Creates a render backend for a new test run.
     ///
-    /// This method must return both a [RenderBackend] and [RenderInterface] as pairs,
-    /// and they will be treated as pairs for the purposes of this test framework.
+    /// This method must return both a [RenderBackend] and [RenderInterface] as a pair.
     ///
     /// All relevant methods in the [RenderInterface] will receive the same [RenderBackend]
     /// that was provided here with that interface.
     ///
-    /// A separate test run will be performed for each renderer returned as a result of this method.
-    /// If none are returned, a single test will be performed without any renderer.
+    /// If None is returned, a test will be performed without any renderer.
     ///
     /// If [Self::is_render_supported] returned false, this won't be attempted.
-    fn create_renderers(
+    fn create_renderer(
         &self,
         _width: u32,
         _height: u32,
-    ) -> Vec<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)> {
-        vec![]
+    ) -> Option<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)> {
+        None
     }
 }
 

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -195,11 +195,11 @@ impl PlayerOptions {
         &self,
         environment: &impl Environment,
         dimensions: ViewportDimensions,
-    ) -> Vec<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)> {
+    ) -> Option<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)> {
         if self.with_renderer.is_some() {
-            environment.create_renderers(dimensions.width, dimensions.height)
+            environment.create_renderer(dimensions.width, dimensions.height)
         } else {
-            vec![]
+            None
         }
     }
 }

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use vfs::VfsPath;
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TestOptions {
     pub num_frames: Option<u32>,
@@ -83,7 +83,7 @@ impl TestOptions {
     }
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Clone, Deserialize, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct Approximations {
     number_patterns: Vec<String>,
@@ -116,7 +116,7 @@ impl Approximations {
     }
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Clone, Deserialize, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct RequiredFeatures {
     lzma: bool,
@@ -129,7 +129,7 @@ impl RequiredFeatures {
     }
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Clone, Deserialize, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct PlayerOptions {
     max_execution_duration: Option<Duration>,
@@ -356,7 +356,7 @@ impl ImageComparison {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RenderOptions {
     optional: bool,

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -140,11 +140,16 @@ impl TestRunner {
         &self.player
     }
 
+    pub fn options(&self) -> &TestOptions {
+        &self.options
+    }
+
     pub fn next_tick_may_be_last(&self) -> bool {
         self.remaining_iterations == 1
     }
 
-    pub fn tick(&mut self) -> Result<TestStatus> {
+    /// Tick this test forward, running any actionscript and progressing the timeline by one.
+    pub fn tick(&mut self) {
         while !self
             .player
             .lock()
@@ -162,7 +167,10 @@ impl TestRunner {
         self.remaining_iterations -= 1;
         self.current_iteration += 1;
         self.executor.run();
+    }
 
+    /// After a tick, run any custom fdcommands that were queued up and perform any scheduled tests.  
+    pub fn test(&mut self) -> Result<TestStatus> {
         for command in self.fs_commands.try_iter() {
             match command {
                 FsCommand::Quit => {

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -358,7 +358,7 @@ impl TestRunner {
                         continue;
                     }
 
-                    approximations.compare(actual, expected);
+                    approximations.compare(actual, expected)?;
                 } else {
                     let mut found = false;
 
@@ -393,7 +393,7 @@ impl TestRunner {
                                     .as_str()
                                     .parse::<f64>()
                                     .expect("Failed to parse 'expected' capture group as float");
-                                approximations.compare(actual_num, expected_num);
+                                approximations.compare(actual_num, expected_num)?;
                             }
                             let modified_actual = pattern.replace_all(actual, "");
                             let modified_expected = pattern.replace_all(expected, "");

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -2,7 +2,7 @@ use crate::backends::{TestLogBackend, TestNavigatorBackend, TestUiBackend};
 use crate::environment::RenderInterface;
 use crate::fs_commands::{FsCommand, TestFsCommandProvider};
 use crate::image_trigger::ImageTrigger;
-use crate::options::ImageComparison;
+use crate::options::{ImageComparison, TestOptions};
 use crate::test::Test;
 use crate::util::{read_bytes, write_image};
 use anyhow::{anyhow, Result};
@@ -19,138 +19,157 @@ use ruffle_input_format::{
 };
 use ruffle_render::backend::{RenderBackend, ViewportDimensions};
 use ruffle_socket_format::SocketEvent;
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::sleep;
 use std::time::Duration;
 use vfs::VfsPath;
 
-/// Loads an SWF and runs it through the Ruffle core for a number of frames.
-/// Tests that the trace output matches the given expected output.
-#[allow(clippy::too_many_arguments)]
-pub fn run_swf(
-    test: &Test,
-    movie: SwfMovie,
-    mut injector: InputInjector,
-    socket_events: Option<Vec<SocketEvent>>,
-    before_start: &mut impl FnMut(Arc<Mutex<Player>>) -> Result<()>,
-    before_end: &mut impl FnMut(Arc<Mutex<Player>>) -> Result<()>,
-    renderer: Option<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)>,
-    viewport_dimensions: ViewportDimensions,
-) -> Result<String> {
-    let mut executor = NullExecutor::new();
-    let mut frame_time = 1000.0 / movie.frame_rate().to_f64();
-    if let Some(tr) = test.options.tick_rate {
-        frame_time = tr;
-    }
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum TestStatus {
+    Continue,
+    Sleep(Duration),
+    Finished,
+}
 
-    let frame_time_duration = Duration::from_millis(frame_time as u64);
+pub struct TestRunner {
+    root_path: VfsPath,
+    options: TestOptions,
+    player: Arc<Mutex<Player>>,
+    injector: InputInjector,
+    executor: NullExecutor,
+    frame_time: f64,
+    frame_time_duration: Duration,
+    log: TestLogBackend,
+    fs_commands: mpsc::Receiver<FsCommand>,
+    render_interface: Option<Box<dyn RenderInterface>>,
+    images: HashMap<String, ImageComparison>,
+    remaining_iterations: u32,
+    current_iteration: u32,
+}
 
-    let log = TestLogBackend::default();
-    let (fs_command_provider, fs_commands) = TestFsCommandProvider::new();
-    let navigator = TestNavigatorBackend::new(
-        test.root_path.clone(),
-        &executor,
-        socket_events,
-        test.options.log_fetch.then(|| log.clone()),
-    )?;
-
-    let mut builder = PlayerBuilder::new()
-        .with_log(log.clone())
-        .with_navigator(navigator)
-        .with_max_execution_duration(Duration::from_secs(300))
-        .with_fs_commands(Box::new(fs_command_provider))
-        .with_ui(TestUiBackend::new(test.fonts()?))
-        .with_viewport_dimensions(
-            viewport_dimensions.width,
-            viewport_dimensions.height,
-            viewport_dimensions.scale_factor,
-        );
-
-    let render_interface = if let Some((interface, backend)) = renderer {
-        builder = builder.with_boxed_renderer(backend);
-        Some(interface)
-    } else {
-        None
-    };
-
-    // Test player options may override anything set above
-    let player = test
-        .options
-        .player_options
-        .setup(builder)?
-        .with_movie(movie)
-        .with_autoplay(true) //.tick() requires playback
-        .build();
-
-    let mut images = test.options.image_comparisons.clone();
-
-    before_start(player.clone())?;
-
-    if test.options.num_frames.is_none() && test.options.num_ticks.is_none() {
-        return Err(anyhow!(
-            "Test {} must specify at least one of num_frames or num_ticks",
-            &test.name
-        ));
-    }
-
-    let mut remaining_iterations = test
-        .options
-        .num_frames
-        .or(test.options.num_ticks)
-        .expect("valid iteration count");
-    let mut current_iteration = 0;
-
-    while remaining_iterations > 0 {
-        // If requested, ensure that the 'expected' amount of
-        // time actually elapses between frames. This is useful for
-        // tests that call 'flash.utils.getTimer()' and use
-        // 'setInterval'/'flash.utils.Timer'
-        //
-        // Note that when Ruffle actually runs frames, we can
-        // execute frames faster than this in order to 'catch up'
-        // if we've fallen behind. However, in order to make regression
-        // tests deterministic, we always call 'update_timers' with
-        // an elapsed time of 'frame_time'. By sleeping for 'frame_time_duration',
-        // we ensure that the result of 'flash.utils.getTimer()' is consistent
-        // with timer execution (timers will see an elapsed time of *at least*
-        // the requested timer interval).
-        if test.options.sleep_to_meet_frame_rate {
-            std::thread::sleep(frame_time_duration);
+impl TestRunner {
+    pub fn new(
+        test: &Test,
+        movie: SwfMovie,
+        injector: InputInjector,
+        socket_events: Option<Vec<SocketEvent>>,
+        renderer: Option<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)>,
+        viewport_dimensions: ViewportDimensions,
+    ) -> Result<Self> {
+        if test.options.num_frames.is_none() && test.options.num_ticks.is_none() {
+            return Err(anyhow!(
+                "Test {} must specify at least one of num_frames or num_ticks",
+                &test.name
+            ));
         }
 
-        while !player
+        let executor = NullExecutor::new();
+        let mut frame_time = 1000.0 / movie.frame_rate().to_f64();
+        if let Some(tr) = test.options.tick_rate {
+            frame_time = tr;
+        }
+
+        let frame_time_duration = Duration::from_millis(frame_time as u64);
+
+        let log = TestLogBackend::default();
+        let (fs_command_provider, fs_commands) = TestFsCommandProvider::new();
+        let navigator = TestNavigatorBackend::new(
+            test.root_path.clone(),
+            &executor,
+            socket_events,
+            test.options.log_fetch.then(|| log.clone()),
+        )?;
+
+        let mut builder = PlayerBuilder::new()
+            .with_log(log.clone())
+            .with_navigator(navigator)
+            .with_max_execution_duration(Duration::from_secs(300))
+            .with_fs_commands(Box::new(fs_command_provider))
+            .with_ui(TestUiBackend::new(test.fonts()?))
+            .with_viewport_dimensions(
+                viewport_dimensions.width,
+                viewport_dimensions.height,
+                viewport_dimensions.scale_factor,
+            );
+
+        let render_interface = if let Some((interface, backend)) = renderer {
+            builder = builder.with_boxed_renderer(backend);
+            Some(interface)
+        } else {
+            None
+        };
+
+        // Test player options may override anything set above
+        let player = test
+            .options
+            .player_options
+            .setup(builder)?
+            .with_movie(movie)
+            .with_autoplay(true) //.tick() requires playback
+            .build();
+
+        let images = test.options.image_comparisons.clone();
+
+        let remaining_iterations = test
+            .options
+            .num_frames
+            .or(test.options.num_ticks)
+            .expect("valid iteration count");
+
+        Ok(Self {
+            root_path: test.root_path.clone(),
+            player,
+            injector,
+            render_interface,
+            executor,
+            frame_time,
+            frame_time_duration,
+            log,
+            fs_commands,
+            images,
+            remaining_iterations,
+            current_iteration: 0,
+            options: test.options.clone(),
+        })
+    }
+
+    pub fn tick(&mut self) -> Result<TestStatus> {
+        while !self
+            .player
             .lock()
             .unwrap()
             .preload(&mut ExecutionLimit::exhausted())
         {}
 
-        if test.options.num_ticks.is_some() {
-            player.lock().unwrap().tick(frame_time);
+        if self.options.num_ticks.is_some() {
+            self.player.lock().unwrap().tick(self.frame_time);
         } else {
-            player.lock().unwrap().run_frame();
-            player.lock().unwrap().update_timers(frame_time);
-            player.lock().unwrap().audio_mut().tick();
+            self.player.lock().unwrap().run_frame();
+            self.player.lock().unwrap().update_timers(self.frame_time);
+            self.player.lock().unwrap().audio_mut().tick();
         }
-        remaining_iterations -= 1;
-        current_iteration += 1;
-        executor.run();
+        self.remaining_iterations -= 1;
+        self.current_iteration += 1;
+        self.executor.run();
 
-        for command in fs_commands.try_iter() {
+        for command in self.fs_commands.try_iter() {
             match command {
                 FsCommand::Quit => {
-                    remaining_iterations = 0;
+                    self.remaining_iterations = 0;
                 }
                 FsCommand::CaptureImage(name) => {
-                    if let Some(image_comparison) = images.remove(&name) {
+                    if let Some(image_comparison) = self.images.remove(&name) {
                         if image_comparison.trigger != ImageTrigger::FsCommand {
                             return Err(anyhow!("Encountered fscommand to capture and compare image '{name}', but the trigger was expected to be {:?}", image_comparison.trigger));
                         }
                         capture_and_compare_image(
-                            &test.root_path,
-                            &player,
+                            &self.root_path,
+                            &self.player,
                             &name,
                             image_comparison,
-                            test.options.known_failure,
-                            render_interface.as_deref(),
+                            self.options.known_failure,
+                            self.render_interface.as_deref(),
                         )?;
                     } else {
                         return Err(anyhow!("Encountered fscommand to capture and compare image '{name}', but no [image_comparison] was set up for this."));
@@ -159,9 +178,9 @@ pub fn run_swf(
             }
         }
 
-        injector.next(|evt, _btns_down| {
+        self.injector.next(|evt, _btns_down| {
             if let AutomatedEvent::SetClipboardText { text } = evt {
-                player
+                self.player
                     .lock()
                     .unwrap()
                     .ui_mut()
@@ -169,7 +188,7 @@ pub fn run_swf(
                 return;
             }
 
-            player.lock().unwrap().handle_event(match evt {
+            self.player.lock().unwrap().handle_event(match evt {
                 AutomatedEvent::MouseDown { pos, btn } => PlayerEvent::MouseDown {
                     x: pos.0,
                     y: pos.1,
@@ -215,58 +234,119 @@ pub fn run_swf(
             });
         });
         // Rendering has side-effects (such as processing 'DisplayObject.scrollRect' updates)
-        player.lock().unwrap().render();
+        self.player.lock().unwrap().render();
 
-        if let Some(name) = images
+        if let Some(name) = self
+            .images
             .iter()
-            .find(|(_k, v)| v.trigger == ImageTrigger::SpecificIteration(current_iteration))
+            .find(|(_k, v)| v.trigger == ImageTrigger::SpecificIteration(self.current_iteration))
             .map(|(k, _v)| k.to_owned())
         {
-            let image_comparison = images
+            let image_comparison = self
+                .images
                 .remove(&name)
                 .expect("Name was just retrieved from map, should not be missing!");
             capture_and_compare_image(
-                &test.root_path,
-                &player,
+                &self.root_path,
+                &self.player,
                 &name,
                 image_comparison,
-                test.options.known_failure,
-                render_interface.as_deref(),
+                self.options.known_failure,
+                self.render_interface.as_deref(),
             )?;
+        }
+
+        if self.remaining_iterations == 0 {
+            // Last iteration, let's check everything went well
+
+            if let Some(name) = self
+                .images
+                .iter()
+                .find(|(_k, v)| v.trigger == ImageTrigger::LastFrame)
+                .map(|(k, _v)| k.to_owned())
+            {
+                let image_comparison = self
+                    .images
+                    .remove(&name)
+                    .expect("Name was just retrieved from map, should not be missing!");
+
+                capture_and_compare_image(
+                    &self.root_path,
+                    &self.player,
+                    &name,
+                    image_comparison,
+                    self.options.known_failure,
+                    self.render_interface.as_deref(),
+                )?;
+            }
+
+            if !self.images.is_empty() {
+                return Err(anyhow!(
+                    "Image comparisons didn't trigger: {:?}",
+                    self.images.keys()
+                ));
+            }
+        }
+
+        Ok(match self.remaining_iterations {
+            0 => TestStatus::Finished,
+            _ if self.options.sleep_to_meet_frame_rate => {
+                // If requested, ensure that the 'expected' amount of
+                // time actually elapses between frames. This is useful for
+                // tests that call 'flash.utils.getTimer()' and use
+                // 'setInterval'/'flash.utils.Timer'
+                //
+                // Note that when Ruffle actually runs frames, we can
+                // execute frames faster than this in order to 'catch up'
+                // if we've fallen behind. However, in order to make regression
+                // tests deterministic, we always call 'update_timers' with
+                // an elapsed time of 'frame_time'. By sleeping for 'frame_time_duration',
+                // we ensure that the result of 'flash.utils.getTimer()' is consistent
+                // with timer execution (timers will see an elapsed time of *at least*
+                // the requested timer interval).
+                TestStatus::Sleep(self.frame_time_duration)
+            }
+            _ => TestStatus::Continue,
+        })
+    }
+}
+
+/// Loads an SWF and runs it through the Ruffle core for a number of frames.
+/// Tests that the trace output matches the given expected output.
+#[allow(clippy::too_many_arguments)]
+pub fn run_swf(
+    test: &Test,
+    movie: SwfMovie,
+    injector: InputInjector,
+    socket_events: Option<Vec<SocketEvent>>,
+    before_start: &mut impl FnMut(Arc<Mutex<Player>>) -> Result<()>,
+    before_end: &mut impl FnMut(Arc<Mutex<Player>>) -> Result<()>,
+    renderer: Option<(Box<dyn RenderInterface>, Box<dyn RenderBackend>)>,
+    viewport_dimensions: ViewportDimensions,
+) -> Result<String> {
+    let mut runner = TestRunner::new(
+        test,
+        movie,
+        injector,
+        socket_events,
+        renderer,
+        viewport_dimensions,
+    )?;
+    before_start(runner.player.clone())?;
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
         }
     }
 
-    if let Some(name) = images
-        .iter()
-        .find(|(_k, v)| v.trigger == ImageTrigger::LastFrame)
-        .map(|(k, _v)| k.to_owned())
-    {
-        let image_comparison = images
-            .remove(&name)
-            .expect("Name was just retrieved from map, should not be missing!");
+    before_end(runner.player)?;
 
-        capture_and_compare_image(
-            &test.root_path,
-            &player,
-            &name,
-            image_comparison,
-            test.options.known_failure,
-            render_interface.as_deref(),
-        )?;
-    }
+    runner.executor.run();
 
-    if !images.is_empty() {
-        return Err(anyhow!(
-            "Image comparisons didn't trigger: {:?}",
-            images.keys()
-        ));
-    }
-
-    before_end(player)?;
-
-    executor.run();
-
-    let trace = log.trace_output();
+    let trace = runner.log.trace_output();
     // Null bytes are invisible, and interfere with constructing
     // the expected output.txt file. Any tests dealing with null
     // bytes should explicitly test for them in ActionScript.

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -54,38 +54,22 @@ impl Test {
     ) -> Result<()> {
         let movie = self.movie()?;
         let viewport_dimensions = self.options.player_options.viewport_dimensions(&movie);
-        let renderers = self
+        let renderer = self
             .options
             .player_options
             .create_renderer(environment, viewport_dimensions);
 
-        if renderers.is_empty() {
-            let output = run_swf(
-                self,
-                movie,
-                self.input_injector()?,
-                self.socket_events()?,
-                &mut before_start,
-                &mut before_end,
-                None,
-                viewport_dimensions,
-            )?;
-            self.compare_output(&output)?;
-        } else {
-            for renderer in renderers {
-                let output = run_swf(
-                    self,
-                    movie.clone(),
-                    self.input_injector()?,
-                    self.socket_events()?,
-                    &mut before_start,
-                    &mut before_end,
-                    Some(renderer),
-                    viewport_dimensions,
-                )?;
-                self.compare_output(&output)?;
-            }
-        }
+        let output = run_swf(
+            self,
+            movie,
+            self.input_injector()?,
+            self.socket_events()?,
+            &mut before_start,
+            &mut before_end,
+            renderer,
+            viewport_dimensions,
+        )?;
+        self.compare_output(&output)?;
 
         Ok(())
     }

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -3,7 +3,6 @@ use crate::options::TestOptions;
 use crate::runner::run_swf;
 use crate::util::read_bytes;
 use anyhow::{anyhow, Result};
-use pretty_assertions::Comparison;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::Player;
 use ruffle_input_format::InputInjector;
@@ -59,7 +58,7 @@ impl Test {
             .player_options
             .create_renderer(environment, viewport_dimensions);
 
-        let output = run_swf(
+        run_swf(
             self,
             movie,
             self.input_injector()?,
@@ -69,7 +68,6 @@ impl Test {
             renderer,
             viewport_dimensions,
         )?;
-        self.compare_output(&output)?;
 
         Ok(())
     }
@@ -123,119 +121,5 @@ impl Test {
                 .options
                 .player_options
                 .can_run(check_renderer, environment)
-    }
-
-    pub fn compare_output(&self, actual_output: &str) -> Result<()> {
-        let expected_output = self.output_path.read_to_string()?.replace("\r\n", "\n");
-
-        if let Some(approximations) = &self.options.approximations {
-            if actual_output.lines().count() != expected_output.lines().count() {
-                return Err(anyhow!(
-                    "# of lines of output didn't match (expected {} from Flash, got {} from Ruffle",
-                    expected_output.lines().count(),
-                    actual_output.lines().count()
-                ));
-            }
-
-            for (actual, expected) in actual_output.lines().zip(expected_output.lines()) {
-                // If these are numbers, compare using approx_eq.
-                if let (Ok(actual), Ok(expected)) = (actual.parse::<f64>(), expected.parse::<f64>())
-                {
-                    // NaNs should be able to pass in an approx test.
-                    if actual.is_nan() && expected.is_nan() {
-                        continue;
-                    }
-
-                    approximations.compare(actual, expected);
-                } else {
-                    let mut found = false;
-
-                    // Check each of the user-provided regexes for a match
-                    for pattern in approximations.number_patterns() {
-                        if let (Some(actual_captures), Some(expected_captures)) =
-                            (pattern.captures(actual), pattern.captures(expected))
-                        {
-                            found = true;
-                            if expected_captures.len() != actual_captures.len() {
-                                return Err(anyhow!(
-                                    "Differing numbers of regex captures (expected {}, actually {})",
-                                    expected_captures.len(),
-                                    actual_captures.len(),
-                                ));
-                            }
-
-                            // Each capture group (other than group 0, which is always the entire regex
-                            // match) represents a floating-point value
-                            for (actual_val, expected_val) in actual_captures
-                                .iter()
-                                .skip(1)
-                                .zip(expected_captures.iter().skip(1))
-                            {
-                                let actual_num = actual_val
-                                    .expect("Missing capture group value for 'actual'")
-                                    .as_str()
-                                    .parse::<f64>()
-                                    .expect("Failed to parse 'actual' capture group as float");
-                                let expected_num = expected_val
-                                    .expect("Missing capture group value for 'expected'")
-                                    .as_str()
-                                    .parse::<f64>()
-                                    .expect("Failed to parse 'expected' capture group as float");
-                                approximations.compare(actual_num, expected_num);
-                            }
-                            let modified_actual = pattern.replace_all(actual, "");
-                            let modified_expected = pattern.replace_all(expected, "");
-
-                            assert_text_matches(
-                                modified_actual.as_ref(),
-                                modified_expected.as_ref(),
-                            )?;
-                            break;
-                        }
-                    }
-
-                    if !found {
-                        assert_text_matches(actual, expected)?;
-                    }
-                }
-            }
-        } else {
-            assert_text_matches(actual_output, &expected_output)?;
-        }
-
-        Ok(())
-    }
-}
-
-/// Wrapper around string slice that makes debug output `{:?}` to print string same way as `{}`.
-/// Used in different `assert*!` macros in combination with `pretty_assertions` crate to make
-/// test failures to show nice diffs.
-/// Courtesy of https://github.com/colin-kiegel/rust-pretty-assertions/issues/24
-#[derive(PartialEq, Eq)]
-#[doc(hidden)]
-struct PrettyString<'a>(pub &'a str);
-
-/// Make diff to display string as multi-line string
-impl<'a> std::fmt::Debug for PrettyString<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(self.0)
-    }
-}
-
-fn assert_text_matches(ruffle: &str, flash: &str) -> Result<()> {
-    if flash != ruffle {
-        let left_pretty = PrettyString(ruffle);
-        let right_pretty = PrettyString(flash);
-        let comparison = Comparison::new(&left_pretty, &right_pretty);
-
-        Err(anyhow!(
-            "assertion failed: `(flash_expected == ruffle_actual)`\
-                       \n\
-                       \n{}\
-                       \n",
-            comparison
-        ))
-    } else {
-        Ok(())
     }
 }

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -52,9 +52,7 @@ impl Test {
         mut before_end: impl FnMut(Arc<Mutex<Player>>) -> Result<()>,
         environment: &impl Environment,
     ) -> Result<()> {
-        let data = read_bytes(&self.swf_path)?;
-        let movie = SwfMovie::from_data(&data, format!("file:///{}", self.swf_path.as_str()), None)
-            .map_err(|e| anyhow!(e.to_string()))?;
+        let movie = self.movie()?;
         let viewport_dimensions = self.options.player_options.viewport_dimensions(&movie);
         let renderers = self
             .options
@@ -90,6 +88,13 @@ impl Test {
         }
 
         Ok(())
+    }
+
+    pub fn movie(&self) -> Result<SwfMovie> {
+        let data = read_bytes(&self.swf_path)?;
+        let movie = SwfMovie::from_data(&data, format!("file:///{}", self.swf_path.as_str()), None)
+            .map_err(|e| anyhow!(e.to_string()))?;
+        Ok(movie)
     }
 
     fn socket_events(&self) -> Result<Option<Vec<SocketEvent>>> {

--- a/tests/tests/environment.rs
+++ b/tests/tests/environment.rs
@@ -12,17 +12,15 @@ impl Environment for NativeEnvironment {
     }
 
     #[cfg(feature = "imgtests")]
-    fn create_renderers(
+    fn create_renderer(
         &self,
         width: u32,
         height: u32,
-    ) -> Vec<(
+    ) -> Option<(
         Box<dyn ruffle_test_framework::environment::RenderInterface>,
         Box<dyn ruffle_test_framework::environment::RenderBackend>,
     )> {
         renderer::NativeRenderInterface::create_pair(width, height)
-            .into_iter()
-            .collect()
     }
 }
 

--- a/tests/tests/external_interface/tests.rs
+++ b/tests/tests/external_interface/tests.rs
@@ -2,31 +2,43 @@ use crate::external_interface::ExternalInterfaceTestProvider;
 use ruffle_core::external::Value as ExternalValue;
 use ruffle_test_framework::environment::Environment;
 use ruffle_test_framework::options::TestOptions;
+use ruffle_test_framework::runner::TestStatus;
 use ruffle_test_framework::test::Test;
 use ruffle_test_framework::vfs::{PhysicalFS, VfsPath};
 use std::collections::BTreeMap;
+use std::thread::sleep;
 
 pub fn external_interface_avm1(
     environment: &impl Environment,
 ) -> Result<(), libtest_mimic::Failed> {
-    Ok(Test::from_options(
+    let test = &Test::from_options(
         TestOptions {
-            num_frames: Some(1),
+            num_frames: Some(2),
             ..Default::default()
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm1/external_interface/")),
         "external_interface_avm1".to_string(),
-    )?
-    .run(
-        |player| {
-            player
-                .lock()
-                .unwrap()
-                .add_external_interface(Box::new(ExternalInterfaceTestProvider::new()));
-            Ok(())
-        },
-        |player| {
-            let mut player_locked = player.lock().unwrap();
+    )?;
+    let mut runner = test.create_test_runner(environment)?;
+
+    runner
+        .player()
+        .lock()
+        .unwrap()
+        .add_external_interface(Box::new(ExternalInterfaceTestProvider::new()));
+
+    let mut first = true;
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+
+        if first {
+            first = false;
+            let mut player_locked = runner.player().lock().unwrap();
 
             let parroted =
                 player_locked.call_internal_interface("parrot", vec!["Hello World!".into()]);
@@ -58,33 +70,42 @@ pub fn external_interface_avm1(
             player_locked.log_backend().avm_trace(&format!(
                 "After calling `callWith` with a complex payload: {result:?}",
             ));
-            Ok(())
-        },
-        environment,
-    )?)
+        }
+    }
+
+    Ok(())
 }
 
 pub fn external_interface_avm2(
     environment: &impl Environment,
 ) -> Result<(), libtest_mimic::Failed> {
-    Ok(Test::from_options(
+    let test = &Test::from_options(
         TestOptions {
-            num_frames: Some(1),
+            num_frames: Some(2),
             ..Default::default()
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm2/external_interface/")),
         "external_interface_avm2".to_string(),
-    )?
-    .run(
-        |player| {
-            player
-                .lock()
-                .unwrap()
-                .add_external_interface(Box::new(ExternalInterfaceTestProvider::new()));
-            Ok(())
-        },
-        |player| {
-            let mut player_locked = player.lock().unwrap();
+    )?;
+    let mut runner = test.create_test_runner(environment)?;
+    runner
+        .player()
+        .lock()
+        .unwrap()
+        .add_external_interface(Box::new(ExternalInterfaceTestProvider::new()));
+
+    let mut first = true;
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+
+        if first {
+            first = false;
+            let mut player_locked = runner.player().lock().unwrap();
 
             let parroted =
                 player_locked.call_internal_interface("parrot", vec!["Hello World!".into()]);
@@ -107,8 +128,8 @@ pub fn external_interface_avm2(
             player_locked.log_backend().avm_trace(&format!(
                 "After calling `callWith` with a complex payload: {result:?}",
             ));
-            Ok(())
-        },
-        environment,
-    )?)
+        }
+    }
+
+    Ok(())
 }

--- a/tests/tests/external_interface/tests.rs
+++ b/tests/tests/external_interface/tests.rs
@@ -30,7 +30,8 @@ pub fn external_interface_avm1(
     let mut first = true;
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,
@@ -97,7 +98,8 @@ pub fn external_interface_avm2(
     let mut first = true;
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -121,7 +121,8 @@ fn run_test(args: &Arguments, file: DirEntry, name: String) -> Trial {
             let mut runner = test.create_test_runner(&NativeEnvironment)?;
 
             loop {
-                match runner.tick()? {
+                runner.tick();
+                match runner.test()? {
                     TestStatus::Continue => {}
                     TestStatus::Sleep(duration) => sleep(duration),
                     TestStatus::Finished => break,

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -9,10 +9,12 @@ use anyhow::Context;
 use anyhow::Result;
 use libtest_mimic::{Arguments, Trial};
 use ruffle_test_framework::options::TestOptions;
+use ruffle_test_framework::runner::TestStatus;
 use ruffle_test_framework::test::Test;
 use ruffle_test_framework::vfs::{PhysicalFS, VfsPath};
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use std::path::Path;
+use std::thread::sleep;
 use walkdir::DirEntry;
 
 mod environment;
@@ -115,7 +117,19 @@ fn run_test(args: &Arguments, file: DirEntry, name: String) -> Trial {
 
     let mut trial = Trial::test(test.name.to_string(), move || {
         let test = AssertUnwindSafe(test);
-        let unwind_result = catch_unwind(|| test.run(|_| Ok(()), |_| Ok(()), &NativeEnvironment));
+        let unwind_result = catch_unwind(|| {
+            let mut runner = test.create_test_runner(&NativeEnvironment)?;
+
+            loop {
+                match runner.tick()? {
+                    TestStatus::Continue => {}
+                    TestStatus::Sleep(duration) => sleep(duration),
+                    TestStatus::Finished => break,
+                }
+            }
+
+            Result::<_>::Ok(())
+        });
         if test.options.known_failure {
             match unwind_result {
                 Ok(Ok(())) => Err(

--- a/tests/tests/shared_object/mod.rs
+++ b/tests/tests/shared_object/mod.rs
@@ -1,8 +1,10 @@
 use ruffle_core::backend::storage::{MemoryStorageBackend, StorageBackend};
 use ruffle_test_framework::environment::Environment;
 use ruffle_test_framework::options::TestOptions;
+use ruffle_test_framework::runner::TestStatus;
 use ruffle_test_framework::test::Test;
 use ruffle_test_framework::vfs::{PhysicalFS, VfsPath};
+use std::thread::sleep;
 
 pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_mimic::Failed> {
     // Test SharedObject persistence. Run an SWF that saves data
@@ -11,7 +13,7 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
         Box::<MemoryStorageBackend>::default();
 
     // Initial run; no shared object data.
-    Test::from_options(
+    let test1 = &Test::from_options(
         TestOptions {
             num_frames: Some(1),
             output_path: "output1.txt".into(),
@@ -19,17 +21,22 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm1/shared_object/")),
         "shared_object_avm1".to_string(),
-    )?
-    .run(
-        |_| Ok(()),
-        |player| {
-            // Save the storage backend for next run.
-            let mut player = player.lock().unwrap();
-            std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
-            Ok(())
-        },
-        environment,
     )?;
+    let mut runner = test1.create_test_runner(environment)?;
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+    }
+
+    // Save the storage backend for next run.
+    {
+        let mut player = runner.player().lock().unwrap();
+        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+    }
 
     // Verify that the flash cookie matches the expected one
     let expected = std::fs::read("tests/swfs/avm1/shared_object/RuffleTest.sol")?;
@@ -41,7 +48,7 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
     );
 
     // Re-run the SWF, verifying that the shared object persists.
-    Test::from_options(
+    let test2 = &Test::from_options(
         TestOptions {
             num_frames: Some(1),
             output_path: "output2.txt".into(),
@@ -49,17 +56,22 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm1/shared_object/")),
         "shared_object_avm1".to_string(),
-    )?
-    .run(
-        |player| {
-            // Swap in the previous storage backend.
-            let mut player = player.lock().unwrap();
-            std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
-            Ok(())
-        },
-        |_| Ok(()),
-        environment,
     )?;
+
+    let mut runner = test2.create_test_runner(environment)?;
+    {
+        // Swap in the previous storage backend.
+        let mut player = runner.player().lock().unwrap();
+        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+    }
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+    }
 
     Ok(())
 }
@@ -73,7 +85,7 @@ pub fn shared_object_self_ref_avm1(
         Box::<MemoryStorageBackend>::default();
 
     // Initial run; no shared object data.
-    Test::from_options(
+    let test1 = &Test::from_options(
         TestOptions {
             num_frames: Some(1),
             output_path: "output1.txt".into(),
@@ -81,17 +93,22 @@ pub fn shared_object_self_ref_avm1(
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm1/shared_object_self_ref/")),
         "shared_object_self_ref_avm1".to_string(),
-    )?
-    .run(
-        |_| Ok(()),
-        |player| {
-            // Save the storage backend for next run.
-            let mut player = player.lock().unwrap();
-            std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
-            Ok(())
-        },
-        environment,
     )?;
+    let mut runner = test1.create_test_runner(environment)?;
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+    }
+
+    {
+        // Save the storage backend for next run.
+        let mut player = runner.player().lock().unwrap();
+        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+    }
 
     // Verify that the flash cookie matches the expected one
     let expected = std::fs::read("tests/swfs/avm1/shared_object_self_ref/RuffleTestRef.sol")?;
@@ -103,7 +120,7 @@ pub fn shared_object_self_ref_avm1(
     );
 
     // Re-run the SWF, verifying that the shared object persists.
-    Test::from_options(
+    let test2 = &Test::from_options(
         TestOptions {
             num_frames: Some(1),
             output_path: "output2.txt".into(),
@@ -111,17 +128,21 @@ pub fn shared_object_self_ref_avm1(
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm1/shared_object_self_ref/")),
         "shared_object_self_ref_avm1".to_string(),
-    )?
-    .run(
-        |player| {
-            // Swap in the previous storage backend.
-            let mut player = player.lock().unwrap();
-            std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
-            Ok(())
-        },
-        |_| Ok(()),
-        environment,
     )?;
+    let mut runner = test2.create_test_runner(environment)?;
+    {
+        // Swap in the previous storage backend.
+        let mut player = runner.player().lock().unwrap();
+        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+    }
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+    }
 
     Ok(())
 }
@@ -133,7 +154,7 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
         Box::<MemoryStorageBackend>::default();
 
     // Initial run; no shared object data.
-    Test::from_options(
+    let test1 = &Test::from_options(
         TestOptions {
             num_frames: Some(1),
             output_path: "output1.txt".into(),
@@ -141,17 +162,22 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm2/shared_object/")),
         "shared_object_avm2".to_string(),
-    )?
-    .run(
-        |_player| Ok(()),
-        |player| {
-            // Save the storage backend for next run.
-            let mut player = player.lock().unwrap();
-            std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
-            Ok(())
-        },
-        environment,
     )?;
+    let mut runner = test1.create_test_runner(environment)?;
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+    }
+
+    {
+        // Save the storage backend for next run.
+        let mut player = runner.player().lock().unwrap();
+        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+    }
 
     // Verify that the flash cookie matches the expected one
     let expected = std::fs::read("tests/swfs/avm2/shared_object/RuffleTest.sol")?;
@@ -163,7 +189,7 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
     );
 
     // Re-run the SWF, verifying that the shared object persists.
-    Test::from_options(
+    let test2 = &Test::from_options(
         TestOptions {
             num_frames: Some(1),
             output_path: "output2.txt".into(),
@@ -171,17 +197,21 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
         },
         VfsPath::new(PhysicalFS::new("tests/swfs/avm2/shared_object/")),
         "shared_object_avm2".to_string(),
-    )?
-    .run(
-        |player| {
-            // Swap in the previous storage backend.
-            let mut player = player.lock().unwrap();
-            std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
-            Ok(())
-        },
-        |_player| Ok(()),
-        environment,
     )?;
+    let mut runner = test2.create_test_runner(environment)?;
+    {
+        // Swap in the previous storage backend.
+        let mut player = runner.player().lock().unwrap();
+        std::mem::swap(player.storage_mut(), &mut memory_storage_backend);
+    }
+
+    loop {
+        match runner.tick()? {
+            TestStatus::Continue => {}
+            TestStatus::Sleep(duration) => sleep(duration),
+            TestStatus::Finished => break,
+        }
+    }
 
     Ok(())
 }

--- a/tests/tests/shared_object/mod.rs
+++ b/tests/tests/shared_object/mod.rs
@@ -25,7 +25,8 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
     let mut runner = test1.create_test_runner(environment)?;
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,
@@ -66,7 +67,8 @@ pub fn shared_object_avm1(environment: &impl Environment) -> Result<(), libtest_
     }
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,
@@ -97,7 +99,8 @@ pub fn shared_object_self_ref_avm1(
     let mut runner = test1.create_test_runner(environment)?;
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,
@@ -137,7 +140,8 @@ pub fn shared_object_self_ref_avm1(
     }
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,
@@ -166,7 +170,8 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
     let mut runner = test1.create_test_runner(environment)?;
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,
@@ -206,7 +211,8 @@ pub fn shared_object_avm2(environment: &impl Environment) -> Result<(), libtest_
     }
 
     loop {
-        match runner.tick()? {
+        runner.tick();
+        match runner.test()? {
             TestStatus::Continue => {}
             TestStatus::Sleep(duration) => sleep(duration),
             TestStatus::Finished => break,


### PR DESCRIPTION
Commit log explains the changes out, the full diff is a bit messy looking I guess :D

With these changes, tests run absolutely fine (though slow) on web. That's in a pending PR though as I'm still working on the actual web UI.

Main changes are:
- Testing is no longer just "run test", now it creates a runner and tick/test/tick/test until finished. This way, wasm can run tests that need async.
- Slightly less panic happy (panics on web are sad)
- Only one renderer per environment; the application running the tests can just run them again with a new environment