### PR TITLE
Use supported_sample_count for Context3D sample count

### DIFF
--- a/render/wgpu/src/context3d/mod.rs
+++ b/render/wgpu/src/context3d/mod.rs
@@ -17,6 +17,7 @@ use wgpu::{CommandEncoder, Extent3d, RenderPass};
 
 use crate::context3d::current_pipeline::{BoundTextureData, AGAL_FLOATS_PER_REGISTER};
 use crate::descriptors::Descriptors;
+use crate::utils::supported_sample_count;
 use crate::Texture;
 
 use std::num::NonZeroU64;
@@ -547,6 +548,8 @@ impl Context3D for WgpuContext3D {
                 wants_best_resolution: _,
                 wants_best_resolution_on_browser_zoom: _,
             } => {
+                let format = wgpu::TextureFormat::Rgba8Unorm;
+
                 let mut sample_count = anti_alias;
                 if sample_count == 0 {
                     sample_count = 1;
@@ -556,9 +559,10 @@ impl Context3D for WgpuContext3D {
                     // Round down to nearest power of 2
                     sample_count = next_pot / 2;
                 }
+                sample_count =
+                    supported_sample_count(&self.descriptors.adapter, sample_count, format);
 
                 let texture_label = create_debug_label!("Render target texture");
-                let format = wgpu::TextureFormat::Rgba8Unorm;
 
                 let make_it = || {
                     // TODO - see if we can deduplicate this with the code in `CommandTarget`

--- a/render/wgpu/src/surface.rs
+++ b/render/wgpu/src/surface.rs
@@ -48,8 +48,11 @@ impl Surface {
         };
         let frame_buffer_format = remove_srgb(surface_format);
 
-        let sample_count =
-            supported_sample_count(&descriptors.adapter, quality, frame_buffer_format);
+        let sample_count = supported_sample_count(
+            &descriptors.adapter,
+            quality.sample_count(),
+            frame_buffer_format,
+        );
         let pipelines = descriptors.pipelines(sample_count, frame_buffer_format);
         Self {
             size,

--- a/render/wgpu/src/utils.rs
+++ b/render/wgpu/src/utils.rs
@@ -2,7 +2,6 @@ use crate::buffer_pool::BufferDescription;
 use crate::descriptors::Descriptors;
 use crate::globals::Globals;
 use crate::Transforms;
-use ruffle_render::quality::StageQuality;
 use std::borrow::Cow;
 use std::mem::size_of;
 use wgpu::util::DeviceExt;
@@ -186,10 +185,9 @@ pub fn buffer_to_image(
 
 pub fn supported_sample_count(
     adapter: &wgpu::Adapter,
-    quality: StageQuality,
+    mut sample_count: u32,
     format: wgpu::TextureFormat,
 ) -> u32 {
-    let mut sample_count = quality.sample_count();
     let features = adapter.get_texture_format_features(format).flags;
 
     // Keep halving the sample count until we get one that's supported - or 1 (no multisampling)


### PR DESCRIPTION
This rounds the requested sample count down to a value that's supported by the device.