### PR TITLE
avm2: Implement `Error.prototype.toString`

### DIFF
--- a/core/src/avm2/globals/Error.as
+++ b/core/src/avm2/globals/Error.as
@@ -20,5 +20,10 @@ package {
 		public native function getStackTrace():String;
 
 		public static const length:int = 1;
+
+		prototype.toString = function():String {
+			var self:Error = this;
+			return self.message.length == 0 ? self.name : self.name + ": " + self.message;
+		};
 	}
 }

--- a/core/src/avm2/object/error_object.rs
+++ b/core/src/avm2/object/error_object.rs
@@ -4,7 +4,6 @@ use crate::avm2::activation::Activation;
 use crate::avm2::call_stack::CallStack;
 use crate::avm2::object::script_object::ScriptObjectData;
 use crate::avm2::object::{ClassObject, Object, ObjectPtr, TObject};
-use crate::avm2::string::AvmString;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::string::WString;
@@ -137,10 +136,6 @@ impl<'gc> TObject<'gc> for ErrorObject<'gc> {
 
     fn value_of(&self, _mc: &Mutation<'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(Value::Object(Object::from(*self)))
-    }
-
-    fn to_string(&self, activation: &mut Activation<'_, 'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok(AvmString::new(activation.context.gc_context, self.display()?).into())
     }
 
     fn as_error_object(&self) -> Option<ErrorObject<'gc>> {

--- a/tests/tests/swfs/from_avmplus/ecma3/ErrorObject/e15_11_2_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/ErrorObject/e15_11_2_1/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/class_003/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/class_003/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/regress_72773_rt/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/regress_72773_rt/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
And remove `ErrorObject::to_string` implementation. This fixes a few avmplus tests.