### PR TITLE
avm2: flash.system.Capabilities#playerType should return "Desktop" when the current runtime is AIR runtime(unless the swf is loaded by an HTML page)

### DIFF
--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -27,7 +27,6 @@ pub fn get_player_type<'gc>(
     let player_type = if cfg!(target_family = "wasm") {
         "PlugIn"
     } else {
-        //See: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/system/Capabilities.html#playerType
         match activation.context.avm2.player_runtime {
             PlayerRuntime::FlashPlayer => "StandAlone",
             PlayerRuntime::AIR => "Desktop",

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -1,6 +1,7 @@
 //! `flash.display.Capabilities` native methods
 
 use crate::avm2::{Activation, AvmString, Error, Object, Value};
+use crate::player::PlayerRuntime;
 
 /// Implements `flash.system.Capabilities.version`
 pub fn get_version<'gc>(
@@ -26,7 +27,11 @@ pub fn get_player_type<'gc>(
     let player_type = if cfg!(target_family = "wasm") {
         "PlugIn"
     } else {
-        "StandAlone"
+        //See: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/system/Capabilities.html#playerType
+        match activation.context.avm2.player_runtime {
+            PlayerRuntime::FlashPlayer => "StandAlone",
+            PlayerRuntime::AIR => "Desktop",
+        }
     };
 
     Ok(AvmString::new_utf8(activation.context.gc_context, player_type).into())


### PR DESCRIPTION
See: https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/system/Capabilities.html#playerType
