### PR TITLE
debug_ui: Do not render container as collapsible if it has no children

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -628,7 +628,7 @@ impl DisplayObjectWindow {
         if !matches_search(object, search) {
             return;
         }
-        if let Some(ctr) = object.as_container() {
+        if let Some(ctr) = object.as_container().filter(|x| x.num_children() > 0) {
             CollapsingState::load_with_default_open(ui.ctx(), ui.id().with(object.as_ptr()), false)
                 .show_header(ui, |ui| {
                     open_display_object_button(


### PR DESCRIPTION
Before:
![before](https://github.com/ruffle-rs/ruffle/assets/131554884/4ec95141-3206-4860-b658-89e4255d7f41)


After:
![after](https://github.com/ruffle-rs/ruffle/assets/131554884/37e61d71-0b2c-4f84-bd09-3b23d95158eb)
