### PR TITLE
desktop: Allow specifying WGPU instance flags from environment

### DIFF
--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -55,6 +55,7 @@ impl GuiController {
         }
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: backend,
+            flags: wgpu::InstanceFlags::default().with_env(),
             ..Default::default()
         });
         let surface = unsafe {


### PR DESCRIPTION
This is mainly useful to allow forcing usage of Vulkan on non-compliant drivers, such as Mesa's driver for Intel Haswell IGPUs, using the `WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER` environment variable. Currently, wgpu will always reject adapters with non-compliant drivers, even though they will often still work fine.