### PR TITLE
Report OS as Windows instead of Linux for now

### DIFF
--- a/core/src/avm2/globals/flash/system/Capabilities.as
+++ b/core/src/avm2/globals/flash/system/Capabilities.as
@@ -3,7 +3,7 @@ package flash.system {
     public final class Capabilities {
         public static function get os(): String {
             stub_getter("flash.system.Capabilities", "os");
-            return "Linux 5.10.49"
+            return "Windows 8"
         }
     
         public native static function get playerType(): String;
@@ -20,7 +20,7 @@ package flash.system {
         
         public static function get manufacturer(): String {
             stub_getter("flash.system.Capabilities", "manufacturer");
-            return "Adobe Linux"
+            return "Adobe Windows"
         }
         public static function get language(): String {
             stub_getter("flash.system.Capabilities", "language");

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -12,7 +12,7 @@ pub fn get_version<'gc>(
     // TODO: Report the correct OS instead of always reporting Linux
     Ok(AvmString::new_utf8(
         activation.context.gc_context,
-        format!("LNX {},0,0,0", activation.avm2().player_version),
+        format!("WIN {},0,0,0", activation.avm2().player_version),
     )
     .into())
 }

--- a/core/src/avm2/globals/flash/system/capabilities.rs
+++ b/core/src/avm2/globals/flash/system/capabilities.rs
@@ -9,7 +9,7 @@ pub fn get_version<'gc>(
     _this: Object<'gc>,
     _args: &[Value<'gc>],
 ) -> Result<Value<'gc>, Error<'gc>> {
-    // TODO: Report the correct OS instead of always reporting Linux
+    // TODO: Report the correct OS instead of always reporting Windows
     Ok(AvmString::new_utf8(
         activation.context.gc_context,
         format!("WIN {},0,0,0", activation.avm2().player_version),


### PR DESCRIPTION
`flash.system.Capabilities.manufacturer` now reports Adobe Windows and `flash.system.Capabilities.os` Windows 8