### PR TITLE
debug_ui: Show ClassObject when clicking on domain class

### DIFF
--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -158,6 +158,12 @@ pub struct Class<'gc> {
     /// System defined classes are allowed to have illegal trait configurations
     /// without throwing a VerifyError.
     is_system: bool,
+
+    /// The ClassObjects for this class.
+    /// In almost all cases, this will either be empty or have a single object.
+    /// However, a swf can run `newclass` multiple times on the same class
+    /// to create multiple `ClassObjects`.
+    class_objects: Vec<ClassObject<'gc>>,
 }
 
 /// Allows using a `GcCell<'gc, Class<'gc>>` as a HashMap key,
@@ -218,6 +224,7 @@ impl<'gc> Class<'gc> {
                 traits_loaded: true,
                 is_system: true,
                 applications: FnvHashMap::default(),
+                class_objects: Vec::new(),
             },
         )
     }
@@ -278,6 +285,14 @@ impl<'gc> Class<'gc> {
     /// Set the attributes of the class (sealed/final/interface status).
     pub fn set_attributes(&mut self, attributes: ClassAttributes) {
         self.attributes = attributes;
+    }
+
+    pub fn add_class_object(&mut self, class_object: ClassObject<'gc>) {
+        self.class_objects.push(class_object);
+    }
+
+    pub fn class_objects(&self) -> &[ClassObject<'gc>] {
+        &self.class_objects
     }
 
     /// Construct a class from a `TranslationUnit` and its class index.
@@ -399,6 +414,7 @@ impl<'gc> Class<'gc> {
                 traits_loaded: false,
                 is_system: false,
                 applications: Default::default(),
+                class_objects: Vec::new(),
             },
         ))
     }
@@ -569,6 +585,7 @@ impl<'gc> Class<'gc> {
                 traits_loaded: true,
                 is_system: false,
                 applications: Default::default(),
+                class_objects: Vec::new(),
             },
         ))
     }

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -232,6 +232,10 @@ impl<'gc> ClassObject<'gc> {
             .write(activation.context.gc_context)
             .instance_scope = instance_scope;
 
+        class
+            .write(activation.context.gc_context)
+            .add_class_object(class_object);
+
         Ok(class_object)
     }
 

--- a/core/src/debug_ui/domain.rs
+++ b/core/src/debug_ui/domain.rs
@@ -1,8 +1,11 @@
-use egui::{collapsing_header::CollapsingState, TextEdit, Ui, Window};
+use egui::{collapsing_header::CollapsingState, CollapsingHeader, TextEdit, Ui, Window};
 
 use crate::{avm2::Domain, context::UpdateContext};
 
-use super::{handle::DomainHandle, Message};
+use super::{
+    handle::{AVM2ObjectHandle, DomainHandle},
+    Message,
+};
 
 #[derive(Debug, Default)]
 pub struct DomainListWindow {
@@ -58,10 +61,20 @@ impl DomainListWindow {
                     if !class_name.to_string().to_ascii_lowercase().contains(search) {
                         continue;
                     }
-                    let response = ui.button(format!("Class {class_name}"));
-                    if response.clicked() {
-                        // TODO - display some kind of class info window
-                    }
+
+                    CollapsingHeader::new(format!("Class {class_name}"))
+                        .id_source(ui.id().with(class.as_ptr()))
+                        .show(ui, |ui| {
+                            for class_obj in class.read().class_objects() {
+                                let button = ui.button(format!("{class_obj:?}"));
+                                if button.clicked() {
+                                    messages.push(Message::TrackAVM2Object(AVM2ObjectHandle::new(
+                                        context,
+                                        (*class_obj).into(),
+                                    )));
+                                }
+                            }
+                        });
                 }
                 drop(class_props);
 


### PR DESCRIPTION
This re-uses our existing infrastructure for displaying AVM2 Class objector. One minor limitation of this approach is the inability to view a `Class` that hasn't yet had its `ClassObject` created - however, this should be rare in practice.