### PR TITLE
text: Advanced horizontal text controls for EditText

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "ttf-parser",
+ "unic-segment",
  "url",
  "wasm-bindgen-futures",
  "weak-table",
@@ -5511,6 +5512,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
 name = "unic-langid"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5551,6 +5573,35 @@ dependencies = [
  "quote",
  "syn 2.0.48",
  "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
+dependencies = [
+ "unic-ucd-segment",
+]
+
+[[package]]
+name = "unic-ucd-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -64,6 +64,7 @@ image = { version = "0.24.8", default-features = false, features = ["tiff", "dxt
 enum-map = "2.7.3"
 ttf-parser = "0.20"
 num-bigint = "0.4"
+unic-segment = "0.9.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies.futures]
 version = "0.3.30"

--- a/core/src/avm2/regexp.rs
+++ b/core/src/avm2/regexp.rs
@@ -373,6 +373,7 @@ struct CachedText<'gc> {
     // Cached values of the last `{utf8, utf16}_index` call,
     // to avoid unnecessary recomputation when calling these methods
     // with increasing indices.
+    // TODO WStrToUtf8 implements UTF-8/UTF-16 index mapping, merge it if possible
     cur_utf8_index: usize,
     cur_utf16_index: usize,
 }

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -337,18 +337,31 @@ impl<'gc> ClipEvent<'gc> {
 /// Control inputs to a text field
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
 pub enum TextControlCode {
-    // TODO: Add control codes for Ctrl+Arrows and Home/End keys
     MoveLeft,
+    MoveLeftWord,
+    MoveLeftLine,
+    MoveLeftDocument,
     MoveRight,
+    MoveRightWord,
+    MoveRightLine,
+    MoveRightDocument,
     SelectLeft,
+    SelectLeftWord,
+    SelectLeftLine,
+    SelectLeftDocument,
     SelectRight,
+    SelectRightWord,
+    SelectRightLine,
+    SelectRightDocument,
     SelectAll,
     Copy,
     Paste,
     Cut,
     Backspace,
+    BackspaceWord,
     Enter,
     Delete,
+    DeleteWord,
 }
 
 impl TextControlCode {
@@ -356,7 +369,13 @@ impl TextControlCode {
     pub fn is_edit_input(self) -> bool {
         matches!(
             self,
-            Self::Paste | Self::Cut | Self::Backspace | Self::Enter | Self::Delete
+            Self::Paste
+                | Self::Cut
+                | Self::Enter
+                | Self::Backspace
+                | Self::BackspaceWord
+                | Self::Delete
+                | Self::DeleteWord
         )
     }
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1934,7 +1934,6 @@ fn web_key_to_codepoint(key: &str) -> Option<char> {
 
 /// Convert a web `KeyboardEvent.key` value to a Ruffle `TextControlCode`,
 /// given the states of the modifier keys. Return `None` if there is no match.
-/// TODO: Handle Ctrl+Arrows and Home/End keys
 pub fn web_to_ruffle_text_control(
     key: &str,
     ctrl_key: bool,
@@ -1957,22 +1956,26 @@ pub fn web_to_ruffle_text_control(
         }
     } else {
         match key {
+            "Delete" if ctrl_key => Some(TextControlCode::DeleteWord),
             "Delete" => Some(TextControlCode::Delete),
+            "Backspace" if ctrl_key => Some(TextControlCode::BackspaceWord),
             "Backspace" => Some(TextControlCode::Backspace),
-            "ArrowLeft" => {
-                if shift_key {
-                    Some(TextControlCode::SelectLeft)
-                } else {
-                    Some(TextControlCode::MoveLeft)
-                }
-            }
-            "ArrowRight" => {
-                if shift_key {
-                    Some(TextControlCode::SelectRight)
-                } else {
-                    Some(TextControlCode::MoveRight)
-                }
-            }
+            "ArrowLeft" if ctrl_key && shift_key => Some(TextControlCode::SelectLeftWord),
+            "ArrowLeft" if ctrl_key => Some(TextControlCode::MoveLeftWord),
+            "ArrowLeft" if shift_key => Some(TextControlCode::SelectLeft),
+            "ArrowLeft" => Some(TextControlCode::MoveLeft),
+            "ArrowRight" if ctrl_key && shift_key => Some(TextControlCode::SelectRightWord),
+            "ArrowRight" if ctrl_key => Some(TextControlCode::MoveRightWord),
+            "ArrowRight" if shift_key => Some(TextControlCode::SelectRight),
+            "ArrowRight" => Some(TextControlCode::MoveRight),
+            "Home" if ctrl_key && shift_key => Some(TextControlCode::SelectLeftDocument),
+            "Home" if ctrl_key => Some(TextControlCode::MoveLeftDocument),
+            "Home" if shift_key => Some(TextControlCode::SelectLeftLine),
+            "Home" => Some(TextControlCode::MoveLeftLine),
+            "End" if ctrl_key && shift_key => Some(TextControlCode::SelectRightDocument),
+            "End" if ctrl_key => Some(TextControlCode::MoveRightDocument),
+            "End" if shift_key => Some(TextControlCode::SelectRightLine),
+            "End" => Some(TextControlCode::MoveRightLine),
             _ => None,
         }
     }

--- a/wstr/src/common.rs
+++ b/wstr/src/common.rs
@@ -320,7 +320,7 @@ impl WStr {
 
     /// Returns `true` is the string contains only LATIN1 characters.
     ///
-    /// Note that this doesn't necessarily means that `self.is_wide()` is `false`.
+    /// Note that this doesn't necessarily mean that `self.is_wide()` is `false`.
     #[inline]
     pub fn is_latin1(&self) -> bool {
         super::ops::str_is_latin1(self)

--- a/wstr/src/tests.rs
+++ b/wstr/src/tests.rs
@@ -214,3 +214,140 @@ fn split_ascii_prefix() {
     assert_eq!(utils::split_ascii_prefix("abc"), (&b"abc"[..], ""));
     assert_eq!(utils::split_ascii_prefix("abcd€fg"), (&b"abcd"[..], "€fg"));
 }
+
+#[test]
+fn char_boundary() {
+    // bytes
+    let bytes = bstr!(b"abcdefgh");
+    assert_eq!(utils::next_char_boundary(bytes, 8), 8);
+    assert_eq!(utils::prev_char_boundary(bytes, 8), 7);
+    assert_eq!(utils::next_char_boundary(bytes, 7), 8);
+    assert_eq!(utils::prev_char_boundary(bytes, 4), 3);
+    assert_eq!(utils::next_char_boundary(bytes, 3), 4);
+    assert_eq!(utils::prev_char_boundary(bytes, 1), 0);
+    assert_eq!(utils::next_char_boundary(bytes, 0), 1);
+    assert_eq!(utils::prev_char_boundary(bytes, 0), 0);
+
+    // wide
+    let wide = wstr!('↓''↑''a''b''c');
+    assert_eq!(utils::next_char_boundary(wide, 5), 5);
+    assert_eq!(utils::prev_char_boundary(wide, 5), 4);
+    assert_eq!(utils::next_char_boundary(wide, 4), 5);
+    assert_eq!(utils::prev_char_boundary(wide, 3), 2);
+    assert_eq!(utils::next_char_boundary(wide, 2), 3);
+    assert_eq!(utils::prev_char_boundary(wide, 1), 0);
+    assert_eq!(utils::next_char_boundary(wide, 0), 1);
+    assert_eq!(utils::prev_char_boundary(wide, 0), 0);
+
+    // surrogate pairs
+    #[rustfmt::skip]
+    let sp = WStr::from_units(&[
+        '↓' as u16,
+        0xd83d, 0xdf01, // 🜁
+        'a' as u16,
+        0xd83d, 0xdf03, // 🜃
+        '↓' as u16,
+    ]);
+    assert_eq!(utils::next_char_boundary(sp, 7), 7);
+    assert_eq!(utils::prev_char_boundary(sp, 7), 6);
+    assert_eq!(utils::next_char_boundary(sp, 6), 7);
+    assert_eq!(utils::prev_char_boundary(sp, 6), 4);
+    assert_eq!(utils::next_char_boundary(sp, 4), 6);
+    assert_eq!(utils::prev_char_boundary(sp, 4), 3);
+    assert_eq!(utils::next_char_boundary(sp, 3), 4);
+    assert_eq!(utils::prev_char_boundary(sp, 3), 1);
+    assert_eq!(utils::next_char_boundary(sp, 1), 3);
+    assert_eq!(utils::prev_char_boundary(sp, 1), 0);
+    assert_eq!(utils::next_char_boundary(sp, 0), 1);
+    assert_eq!(utils::prev_char_boundary(sp, 0), 0);
+}
+
+#[test]
+fn utf8_index_mapping() {
+    #[rustfmt::skip]
+    let utf16 = WStr::from_units(&[
+        'a' as u16,
+        'b' as u16,
+        'c' as u16,
+        '↓' as u16,
+        'a' as u16,
+        'b' as u16,
+        0xd83d, 0xdf01, // 🜁
+        'a' as u16,
+        'ł' as u16,
+        0xd83d, 0xdf03, // 🜃
+        '↓' as u16,
+        'a' as u16,
+        'b' as u16,
+        'c' as u16,
+    ]);
+
+    // utf16 indices
+    // a    | b    | c    | ↓    | a    | b    | 🜁         | a    | ł    | 🜃         | ↓    | a    | b    | c
+    // 0061 | 0062 | 0063 | 2193 | 0061 | 0062 | d83d df01 | 0061 | 0142 | d83d df03 | 2193 | 0061 | 0062 | 0063
+    // 0    | 1    | 2    | 3    | 4    | 5    | 6    7    | 8    | 9    | 10   11   | 12   | 13   | 14   | 15
+
+    // utf8 indices
+    // a  | b  | c  | ↓        | a  | b  | 🜁           | a  | ł     | 🜃           | ↓        | a  | b  | c
+    // 61 | 62 | 63 | e2 86 93 | 61 | 62 | f0 9f 9c 81 | 61 | c5 82 | f0 9f 9c 83 | e2 86 93 | 61 | 62 | 63
+    // 0  | 1  | 2  | 3  4  5  | 6  | 7  | 8  9  10 11 | 12 | 13 14 | 15 16 17 18 | 19 20 21 | 22 | 23 | 24
+
+    let to_utf8 = WStrToUtf8::new(utf16);
+    let utf8 = to_utf8.to_utf8_lossy();
+
+    assert_eq!(utf8, "abc↓ab🜁ał🜃↓abc");
+    assert_eq!(utf8.len(), 25);
+    assert_eq!(utf16.len(), 16);
+
+    assert_eq!(to_utf8.utf16_index(0), Some(0));
+    assert_eq!(to_utf8.utf16_index(2), Some(2));
+    assert_eq!(to_utf8.utf16_index(3), Some(3));
+    assert_eq!(to_utf8.utf16_index(6), Some(4));
+    assert_eq!(to_utf8.utf16_index(7), Some(5));
+    assert_eq!(to_utf8.utf16_index(8), Some(6));
+    assert_eq!(to_utf8.utf16_index(13), Some(9));
+    assert_eq!(to_utf8.utf16_index(15), Some(10));
+    assert_eq!(to_utf8.utf16_index(22), Some(13));
+    assert_eq!(to_utf8.utf16_index(24), Some(15));
+
+    assert_eq!(to_utf8.utf8_index(0), Some(0));
+    assert_eq!(to_utf8.utf8_index(2), Some(2));
+    assert_eq!(to_utf8.utf8_index(3), Some(3));
+    assert_eq!(to_utf8.utf8_index(4), Some(6));
+    assert_eq!(to_utf8.utf8_index(5), Some(7));
+    assert_eq!(to_utf8.utf8_index(6), Some(8));
+    assert_eq!(to_utf8.utf8_index(9), Some(13));
+    assert_eq!(to_utf8.utf8_index(10), Some(15));
+    assert_eq!(to_utf8.utf8_index(13), Some(22));
+    assert_eq!(to_utf8.utf8_index(15), Some(24));
+
+    // last (potential) position
+    assert_eq!(to_utf8.utf16_index(25), Some(16));
+    assert_eq!(to_utf8.utf8_index(16), Some(25));
+
+    // out of bounds
+    assert_eq!(to_utf8.utf16_index(26), None);
+    assert_eq!(to_utf8.utf8_index(17), None);
+
+    // indices outside of character boundary
+    assert_eq!(to_utf8.utf16_index(4), Some(4));
+    assert_eq!(to_utf8.utf16_index(5), Some(4));
+    assert_eq!(to_utf8.utf16_index(9), Some(8));
+    assert_eq!(to_utf8.utf16_index(10), Some(8));
+    assert_eq!(to_utf8.utf8_index(7), Some(12));
+    assert_eq!(to_utf8.utf8_index(11), Some(19));
+}
+
+#[test]
+fn utf8_index_mapping_empty() {
+    let utf16 = WStr::empty();
+
+    let to_utf8 = WStrToUtf8::new(utf16);
+    let utf8 = to_utf8.to_utf8_lossy();
+
+    assert_eq!(utf8.len(), 0);
+    assert_eq!(utf16.len(), 0);
+
+    assert_eq!(to_utf8.utf16_index(0), Some(0));
+    assert_eq!(to_utf8.utf16_index(1), None);
+}


### PR DESCRIPTION
This PR implements the following controls:
* <kbd>Ctrl</kbd> + <kbd>Delete</kbd> &mdash; delete a word to the right,
* <kbd>Ctrl</kbd> + <kbd>Backspace</kbd> &mdash; delete a word to the left,
* <kbd>Ctrl</kbd> + <kbd>→</kbd> &mdash; move a word to the right,
* <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>→</kbd> &mdash; select a word to the right,
* <kbd>Ctrl</kbd> + <kbd>←</kbd> &mdash; move a word to the left,
* <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>←</kbd> &mdash; select a word to the left,
* <kbd>Home</kbd> &mdash; move left to the beginning of the line,
* <kbd>Shift</kbd> + <kbd>Home</kbd> &mdash; select left till the beginning of the line,
* <kbd>Ctrl</kbd> + <kbd>Home</kbd> &mdash; move left to the beginning of the document,
* <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Home</kbd> &mdash; select left till the beginning of the document,
* <kbd>End</kbd> &mdash; move right to the end of the line,
* <kbd>Shift</kbd> + <kbd>End</kbd> &mdash; select right till the end of the line,
* <kbd>Ctrl</kbd> + <kbd>End</kbd> &mdash; move right to the end of the document,
* <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>End</kbd> &mdash; select right till the end of the document.

Related to #14999. Note that this PR implements horizontal controls only. Vertical controls (arrows up/down page up/down) require more work, as we need to measure widths of characters and be aware of the text layout.