### PR TITLE
Ignore bad version mark (sometimes used by obfuscators) (close #15006)

### DIFF
--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -46,7 +46,9 @@ fn strip_version_mark(url: &WStr, is_playerglobals: bool) -> Option<(&WStr, ApiV
                 // Always return None for non-playerglobals to fall back to root api version as avmplus does
                 // https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/AbcParser.cpp#L1510
                 // Warn just for non-playerglobals with version marks
-                tracing::warn!("Ignoring url {url:?} with version mark in non-playerglobals domain");
+                tracing::warn!(
+                    "Ignoring url {url:?} with version mark in non-playerglobals domain"
+                );
                 return None;
             }
 

--- a/core/src/avm2/namespace.rs
+++ b/core/src/avm2/namespace.rs
@@ -7,7 +7,6 @@ use num_traits::FromPrimitive;
 use ruffle_wstr::WStr;
 use std::fmt::Debug;
 use swf::avm2::types::{Index, Namespace as AbcNamespace};
-use tracing::warn;
 
 use super::api_version::ApiVersion;
 
@@ -47,7 +46,7 @@ fn strip_version_mark(url: &WStr, is_playerglobals: bool) -> Option<(&WStr, ApiV
                 // Always return None for non-playerglobals to fall back to root api version as avmplus does
                 // https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/AbcParser.cpp#L1510
                 // Warn just for non-playerglobals with version marks
-                warn!("Ignoring url {url:?} with version mark in non-playerglobals domain");
+                tracing::warn!("Ignoring url {url:?} with version mark in non-playerglobals domain");
                 return None;
             }
 


### PR DESCRIPTION
Some obfuscators use random mark on all the object. Ignore them as avmplus does otherwise some things won't run.
Example #15006