### PR TITLE
ci: Don't upload the Safari extension as artifact when building the web demo

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -382,6 +382,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Safari build artifact
+        if: ${{ !matrix.demo }}
         uses: actions/upload-artifact@v4
         with:
           name: macos-safari


### PR DESCRIPTION
#15031 broke this night's release workflow run: https://github.com/ruffle-rs/ruffle/actions/runs/7719064767/job/21041617006

This is because `actions/upload-artifact@v4` no longer allows uploading the same artifact twice: https://github.com/actions/upload-artifact/issues/478

Hopefully this will fix it.

I see no reason why we would need to upload the safari extension from the web demo builder job as well (it has nothing to do with it), when we are already uploading it from the regular web builder job. (Because the universal macOS binary needs it for some reason...?)