### PR TITLE
github: Also exclude `.git` and `tests/tests/swfs` from `reproducible-source.zip`

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -322,7 +322,9 @@ jobs:
       - name: Produce reproducible source archive
         if: ${{ !matrix.demo }}
         shell: bash -l {0}
-        run: zip -r reproducible-source.zip . -x /web/node_modules/**/* -x /web/**/node_modules/**/* && cp reproducible-source.zip "${{ needs.create-nightly-release.outputs.package_prefix }}-reproducible-source.zip"
+        run: |
+          zip -r reproducible-source.zip . -x '/web/node_modules/*' -x '/web/*/node_modules/*' -x '/.git/*' -x '/tests/tests/swfs/*'
+          cp reproducible-source.zip "${{ needs.create-nightly-release.outputs.package_prefix }}-reproducible-source.zip"
 
       - name: Upload reproducible source archive
         if: ${{ !matrix.demo }}


### PR DESCRIPTION
This should reduce the unzipped(?) size from ~216 MB down to ~15MB, hopefully allowing the submission of it to AMO to not fail.

Also leave the `*` wildcard expansion up to `zip` instead of doing it in the invoking shell.

Plus a (now) much needed line wrap for bonus.