### PR TITLE
github: Add script and workflow to automatically update stub report

### DIFF
--- a/.github/workflows/update_website_report.yml
+++ b/.github/workflows/update_website_report.yml
@@ -1,0 +1,24 @@
+name: Update AVM2 implementation report on website
+
+on:
+  push:
+    branches: [ master ]
+  # FIXME - remove before merging
+  pull_request:
+    branches: [master]
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+
+    if: github.repository == 'ruffle-rs/ruffle'
+
+    strategy:
+      max-parallel: 1 # Should be 1 to avoid parallel builds
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run website update script
+        run: |
+          ./update-website.sh

--- a/update-website.sh
+++ b/update-website.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euxo pipefail
+
+rm -rf /tmp/ruffle-website-update
+mkdir /tmp/ruffle-website-update
+
+cargo run --package stub-report /tmp/ruffle-website-update/implementation.json
+
+cd /tmp/ruffle-website-update/
+git clone https://github.com/ruffle-rs/api-report
+cd api-report
+cargo run -- -s avm2_specification.json -i ../implementation.json -o ../report.json
+
+cd ../
+
+git clone https://github.com/ruffle-rs/ruffle-rs.github.io
+cd ruffle-rs.github.io
+
+if cmp -s "../report.json" "src/app/compatibility/avm2/report.json"; then
+	echo "Report is unchanged, exiting"
+	exit 0
+fi
+
+echo "Report is changed - pushing commit"
+cp ../report.json src/app/compatibility/avm2/report.json
+git add src/app/compatibility/avm2/report.json
+git commit -m "Update AVM2 report from https://github.com/ruffle-rs/ruffle/commit/${GITHUB_SHA}"


### PR DESCRIPTION
On every push to master, we now regenerate the stub report and check if it's changed from the one currently published on the website. If it has, we push a new commit to the website