### PR TITLE
github: Generate AVM2 report as part of nightly release

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -264,6 +264,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-stub-report:
+    name: Build AVM2 stub repository
+    needs: create-nightly-release
+    if: needs.create-nightly-release.outputs.is_active == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone Ruffle repo
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Generate report
+        run: ./stub-report/generate-report.sh
+
+      - name: Upload report
+        run: gh release upload "${{ needs.create-nightly-release.outputs.tag_name }}" avm2_report.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-web:
     name: Build web${{ matrix.demo && ' demo' || '' }}
     needs: create-nightly-release

--- a/stub-report/generate-report.sh
+++ b/stub-report/generate-report.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Generates the AVM2 report and writes it to 'avm2_report.json'
+
+set -euxo pipefail
+
+rm -rf /tmp/ruffle-website-update
+mkdir /tmp/ruffle-website-update
+
+cargo run --locked --package stub-report /tmp/ruffle-website-update/implementation.json
+
+git clone https://github.com/ruffle-rs/api-report /tmp/ruffle-website-update/api-report
+cargo run --manifest-path /tmp/ruffle-website-update/api-report/Cargo.toml  -- -s /tmp/ruffle-website-update/api-report/avm2_specification.json -i /tmp/ruffle-website-update/implementation.json -o avm2_report.json


### PR DESCRIPTION
We upload it to the release as a file named 'avm2_report.json' The website will use this to automatically display the latest report