### PR TITLE
github: Use full version for the `mnao305/chrome-extension-upload` action

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -407,7 +407,7 @@ jobs:
         continue-on-error: true
         env:
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
-        uses: mnao305/chrome-extension-upload@v5
+        uses: mnao305/chrome-extension-upload@v5.0.0
         with:
           extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
           client-id: ${{ secrets.CHROME_CLIENT_ID }}


### PR DESCRIPTION
This regressed in #15094.

I wasn't paying enough attention, and/or haven't verified the change myself, and/or hoped that there is a semver-like fuzzy matching of these versions.
Looks like there isn't.