### PR TITLE
core: Remove LoaderHandle when load is done

### DIFF
--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -24,6 +24,12 @@ use super::Avm2;
 #[collect(no_drop)]
 pub struct Domain<'gc>(GcCell<'gc, DomainData<'gc>>);
 
+impl std::fmt::Debug for Domain<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Domain({:p})", self.0.as_ptr())
+    }
+}
+
 #[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
 pub struct DomainWeak<'gc>(GcWeakCell<'gc, DomainData<'gc>>);


### PR DESCRIPTION
In almost all cases, we were letting completed LoaderHandles accumulate, leaking memory and wasting time in `preload_tick`