### PR TITLE
 avm2: has_property should do proto.has_property instead of has_own_property

### DIFF
--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -647,7 +647,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         if self.has_own_property(name) {
             true
         } else if let Some(proto) = self.proto() {
-            proto.has_own_property(name)
+            proto.has_property(name)
         } else {
             false
         }


### PR DESCRIPTION
I noticed this while reviewing #15119. Need to test this though.