### PR TITLE
web: Remove npm version requirement

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -37,9 +37,6 @@
                 "webpack": "^5.90.1",
                 "webpack-cli": "^5.1.4"
             },
-            "engines": {
-                "npm": ">=10.4.0"
-            },
             "optionalDependencies": {
                 "chromedriver": "^119.0.1"
             }

--- a/web/package.json
+++ b/web/package.json
@@ -7,9 +7,6 @@
     "workspaces": [
         "./packages/*"
     ],
-    "engines": {
-        "npm": ">=10.4.0"
-    },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.20.0",
         "@typescript-eslint/parser": "^6.20.0",


### PR DESCRIPTION
It was only needed to be 7 back in 2022, and the bot just kept updating it. We're long past 7 now.