### PR TITLE
web: chore: Bump wasm-bindgen to 0.2.91

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -313,7 +313,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in test_web.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.90
+        run: cargo install wasm-bindgen-cli --version 0.2.91
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -61,7 +61,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.90
+        run: cargo install wasm-bindgen-cli --version 0.2.91
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5778,9 +5778,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5788,9 +5788,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -5815,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5825,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5838,9 +5838,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-streams"

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -22,7 +22,7 @@ downcast-rs = "1.2.0"
 lyon = { version = "1.0.1", optional = true }
 lyon_geom = "1.0.5"
 thiserror = "1.0"
-wasm-bindgen = { version = "=0.2.90", optional = true }
+wasm-bindgen = { version = "=0.2.91", optional = true }
 enum-map = "2.7.3"
 serde = { version = "1.0.196", features = ["derive"] }
 clap = { version = "4.4.18", features = ["derive"], optional = true }

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 js-sys = "0.3.67"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.90"
+wasm-bindgen = "=0.2.91"
 fnv = "1.0.7"
 ruffle_render = { path = "..", features = ["web"] }
 swf = { path = "../../swf" }

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -15,7 +15,7 @@ js-sys = "0.3.67"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 ruffle_render = { path = "..", features = ["tessellator", "web"] }
-wasm-bindgen = "=0.2.90"
+wasm-bindgen = "=0.2.91"
 bytemuck = { version = "1.14.1", features = ["derive"] }
 fnv = "1.0.7"
 swf = { path = "../../swf" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -45,7 +45,7 @@ ruffle_render_webgl = { path = "../render/webgl", optional = true }
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 ruffle_video_software = { path = "../video/software" }
 url = "2.5.0"
-wasm-bindgen = "=0.2.90"
+wasm-bindgen = "=0.2.91"
 wasm-bindgen-futures = "0.4.40"
 serde-wasm-bindgen = "0.6.3"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind", "clock"] }

--- a/web/README.md
+++ b/web/README.md
@@ -65,7 +65,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.90`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.91`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 js-sys = "0.3.67"
 tracing = { workspace = true }
-wasm-bindgen = "=0.2.90"
+wasm-bindgen = "=0.2.91"
 
 [dependencies.web-sys]
 version = "0.3.67"

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -y -c conda-forge binaryen
 # Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
 ENV PATH="/root/.cargo/bin:$PATH"
-RUN cargo install wasm-bindgen-cli --version 0.2.90
+RUN cargo install wasm-bindgen-cli --version 0.2.91
 # Building Ruffle:
 COPY . ruffle
 WORKDIR ruffle/web


### PR DESCRIPTION
Supersedes https://github.com/ruffle-rs/ruffle/pull/15195, as we also need to match the `wasm-bindgen-cli` version exactly in a few more places.