### PR TITLE
avm2: Stub all flash.sampler methods

### DIFF
--- a/core/src/avm2/globals/flash/sampler.as
+++ b/core/src/avm2/globals/flash/sampler.as
@@ -1,26 +1,82 @@
 package flash.sampler {
     import __ruffle__.stub_method;
 
-    public function getSize(param1:*):Number {
+    public function clearSamples(): void {
+        stub_method("flash.sampler", "clearSamples");
+    }
+
+    public function getGetterInvocationCount(obj: Object, name: QName): Number {
+        stub_method("flash.sampler", "getGetterInvocationCount");
+        return -1;
+    }
+
+    public function getInvocationCount(obj: Object, name: QName): Number {
+        stub_method("flash.sampler", "getInvocationCount");
+        return -1;
+    }
+
+    public function getLexicalScopes(fun: Function): Array {
+        stub_method("flash.sampler", "getLexicalScopes");
+        return null;
+    }
+
+    public function getMasterString(str: String): String {
+        stub_method("flash.sampler", "getMasterString");
+        return null;
+    }
+
+    public function getMemberNames(obj: Object, instanceNames: Boolean = false): Object {
+        stub_method("flash.sampler", "getMemberNames");
+        return null;
+    }
+
+    public function getSampleCount(): Number {
+        stub_method("flash.sampler", "getSampleCount");
+        return 0;
+    }
+
+    public function getSamples(): Object {
+        stub_method("flash.sampler", "getSamples");
+        return {};
+    }
+
+    public function getSavedThis(fun: Function): Object {
+        stub_method("flash.sampler", "getSavedThis");
+        return undefined;
+    }
+
+    public function getSetterInvocationCount(obj: Object, name: QName): Number {
+        stub_method("flash.sampler", "getSetterInvocationCount");
+        return -1;
+    }
+
+    public function getSize(param1: *): Number {
         stub_method("flash.sampler", "getSize");
         return 0;
     }
 
-    public function clearSamples():void {
-        stub_method("flash.sampler", "clearSamples");
+    public function isGetterSetter(obj: Object, name: QName): Boolean {
+        stub_method("flash.sampler", "isGetterSetter");
+        return false;
     }
 
-    public function startSampling():void {
+    public function pauseSampling(): void {
+        stub_method("flash.sampler", "pauseSampling");
+    }
+
+    public function sampleInternalAllocs(everything: Boolean): void {
+        stub_method("flash.sampler", "sampleInternalAllocs");
+    }
+
+    public function setSamplerCallback(fun: Function): void {
+        stub_method("flash.sampler", "setSamplerCallback");
+    }
+
+    public function startSampling(): void {
         stub_method("flash.sampler", "startSampling");
     }
 
     public function stopSampling():void {
         stub_method("flash.sampler", "stopSampling");
     }
-    
-    public function getSamples():Object {
-        stub_method("flash.sampler", "getSamples");
-        return {};
-    }
 }
-


### PR DESCRIPTION
Flash output:
```
clearSamples() undefined
getGetterInvocationCount(obj, qname) -1
getInvocationCount(obj, qname) -1
getLexicalScopes(function(){}) null
getMasterString("") null
getMemberNames(obj) undefined
getSampleCount() 0
getSamples() undefined
getSavedThis(function(){}) undefined
getSetterInvocationCount(obj, qname) -1
getSize(obj) 112
isGetterSetter(obj, qname) false
pauseSampling() undefined
sampleInternalAllocs(false) undefined
setSamplerCallback(function(){}) undefined
stopSampling() undefined
startSampling() undefined
```