### PR TITLE
ci: Fix failing visual tests

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt-get update
-          sudo apt-get dist-upgrade
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev
 
       - name: Cache Cargo output

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -110,7 +110,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: swf_images
+          name: swf_images_${{ matrix.rust_version }}_${{ matrix.os }}
           path: |
             tests*/**/*.actual*.png
             tests*/**/*.difference*.png

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          sudo add-apt-repository ppa:kisak/kisak-mesa -y
           sudo apt-get update
+          sudo apt-get dist-upgrade
           sudo apt install -y libasound2-dev libxcb-shape0-dev libxcb-xfixes0-dev libgtk-3-dev mesa-vulkan-drivers libpango1.0-dev
 
       - name: Cache Cargo output


### PR DESCRIPTION
Two failures:
- mesa-vulkan-driver just updated from 23.0.4 to 23.2.1, which brought in a new bug that fails any test with a blur filter. Update to a newer one from PPA (reverts #8708) to see if it helps.
- Don't upload artifacts with the same name, overwriting them