### PR TITLE
avm2: Implement JS->AS3 Object deserialization

### DIFF
--- a/core/src/external.rs
+++ b/core/src/external.rs
@@ -225,9 +225,19 @@ impl Value {
             Value::String(value) => {
                 Avm2Value::String(AvmString::new_utf8(activation.context.gc_context, value))
             }
-            Value::Object(_values) => {
-                tracing::warn!("into_avm2 needs to be implemented for Value::Object");
-                Avm2Value::Undefined
+            Value::Object(values) => {
+                let obj = activation
+                    .avm2()
+                    .classes()
+                    .object
+                    .construct(activation, &[])
+                    .unwrap();
+                for (key, value) in values.into_iter() {
+                    let key = AvmString::new_utf8(activation.context.gc_context, key);
+                    let value = value.into_avm2(activation);
+                    obj.set_public_property(key, value, activation).unwrap();
+                }
+                Avm2Value::Object(obj)
             }
             Value::List(values) => {
                 let storage = values


### PR DESCRIPTION
I only tested it on
```
document.querySelector('ruffle-player').purchaseItem({
    itemId: 123,
    itemHash: "hash"
});
```
which seemed to deserialize correctly. Should be enough to fix https://github.com/ruffle-rs/ruffle/issues/15221 (but note that I didn't directly test that either).

The `unwrap()`s are unfortunate, as we don't return Result from there; but these spots also aren't likely to throw any AS exceptions. It's up to reviewers :D whether this should be better handled.