### PR TITLE
ci: Run cargo-nextest with `-j 6`

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -77,13 +77,13 @@ jobs:
         if: runner.os != 'macOS'
         # TODO: Disallow retries in general once we can allow only after SIGABRT.
         # See: https://github.com/nextest-rs/nextest/issues/1172
-        run: cargo nextest run --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
+        run: cargo nextest run --workspace --locked --no-fail-fast --retries 2 -j 6 --features imgtests,lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Run tests without image tests
         if: runner.os == 'macOS'
-        run: cargo nextest run --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
+        run: cargo nextest run --workspace --locked --no-fail-fast -j 6 --features lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 


### PR DESCRIPTION
Now that the hosted runners are upgraded to have 4 cores, this should hopefully further improve runtime on Windows, by pipelining CPU load and IO latency.