### PR TITLE
ci: Compile Rust tests in release mode

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -77,13 +77,13 @@ jobs:
         if: runner.os != 'macOS'
         # TODO: Disallow retries in general once we can allow only after SIGABRT.
         # See: https://github.com/nextest-rs/nextest/issues/1172
-        run: cargo nextest run --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
+        run: cargo nextest run --release --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Run tests without image tests
         if: runner.os == 'macOS'
-        run: cargo nextest run --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
+        run: cargo nextest run --release --workspace --locked --no-fail-fast -j 4 --features lzma,jpegxr
         env:
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 


### PR DESCRIPTION
Let's see whether this is faster now...

Afterwards, I think it would still be favorable to create a custom Rust profile for CI, where optimizations are enabled, but debug checks are not disabled.

Also note that our cargo cache is primed with debug artifacts, so it's not trivial to accurately measure this.