### PR TITLE
ci: Update get-current-time to v2.1.2 which uses Node 20

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -39,13 +39,13 @@ jobs:
           echo "is_active=$is_active" >> $GITHUB_OUTPUT
 
       - name: Get current time with dashes
-        uses: 1466587594/get-current-time@v2.1.1
+        uses: 1466587594/get-current-time@v2.1.2
         id: current_time_dashes
         with:
           format: YYYY-MM-DD
 
       - name: Get current time with underscores
-        uses: 1466587594/get-current-time@v2.1.1
+        uses: 1466587594/get-current-time@v2.1.2
         id: current_time_underscores
         with:
           format: YYYY_MM_DD
@@ -533,13 +533,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Get current time with dashes
-        uses: 1466587594/get-current-time@v2.1.1
+        uses: 1466587594/get-current-time@v2.1.2
         id: current_time_dashes
         with:
           format: YYYY-MM-DD
 
       - name: Get current time with dots
-        uses: 1466587594/get-current-time@v2.1.1
+        uses: 1466587594/get-current-time@v2.1.2
         id: current_time_dots
         with:
           format: YYYY.MM.DD


### PR DESCRIPTION
https://github.com/josStorer/get-current-time/releases/tag/v2.1.2