### PR TITLE
avm2: Always serialize as ECMAArray, which produces an AMF0 MixedArray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "flash-lso"
 version = "0.6.0"
-source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=2f976fb15b30aa4c5cb398710dc5e31a21004e57#2f976fb15b30aa4c5cb398710dc5e31a21004e57"
+source = "git+https://github.com/ruffle-rs/rust-flash-lso?rev=2f770555ea49c6db49c57c1dd46c7cc686e8dacc#2f770555ea49c6db49c57c1dd46c7cc686e8dacc"
 dependencies = [
  "cookie-factory",
  "enumset",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.196", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 nellymoser-rs = { git = "https://github.com/ruffle-rs/nellymoser", rev = "4a33521c29a918950df8ae9fe07e527ac65553f5", optional = true }
 regress = "0.8"
-flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "2f976fb15b30aa4c5cb398710dc5e31a21004e57" }
+flash-lso = { git = "https://github.com/ruffle-rs/rust-flash-lso", rev = "2f770555ea49c6db49c57c1dd46c7cc686e8dacc" }
 lzma-rs = {version = "0.3.0", optional = true }
 dasp = { version = "0.11.0", features = ["interpolate", "interpolate-linear", "signal"], optional = true }
 symphonia = { version = "0.5.3", default-features = false, features = ["mp3"], optional = true }

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -69,12 +69,8 @@ pub fn serialize_value<'gc>(
                     }
                 }
 
-                if sparse.is_empty() {
-                    Some(AmfValue::StrictArray(dense))
-                } else {
-                    let len = sparse.len() as u32;
-                    Some(AmfValue::ECMAArray(dense, sparse, len))
-                }
+                let len = o.as_array_storage().unwrap().length() as u32;
+                Some(AmfValue::ECMAArray(dense, sparse, len))
             } else if let Some(vec) = o.as_vector_storage() {
                 let val_type = vec.value_type();
                 if val_type == Some(activation.avm2().classes().int) {

--- a/tests/tests/swfs/from_shumway/encoding_1/test.toml
+++ b/tests/tests/swfs/from_shumway/encoding_1/test.toml
@@ -1,2 +1,1 @@
 num_frames = 1
-known_failure = true


### PR DESCRIPTION
Depends on https://github.com/ruffle-rs/rust-flash-lso/pull/55