### PR TITLE
core: Implement lazy decoding of bitmaps

### DIFF
--- a/core/src/avm1/globals/bitmap_data.rs
+++ b/core/src/avm1/globals/bitmap_data.rs
@@ -1498,20 +1498,20 @@ fn load_bitmap<'gc>(
         .library_for_movie(movie)
         .and_then(|l| l.character_by_export_name(name));
 
-    let Some(Character::Bitmap(bitmap)) = character else {
+    let Some((_id, Character::Bitmap { compressed, .. })) = character else {
         return Ok(Value::Undefined);
     };
+    let bitmap = compressed.decode().unwrap();
 
     let transparency = true;
     let bitmap_data = BitmapData::new_with_pixels(
-        bitmap.width().into(),
-        bitmap.height().into(),
+        bitmap.width(),
+        bitmap.height(),
         transparency,
         bitmap
-            .bitmap_data(activation.context.renderer)
-            .read()
-            .pixels()
-            .to_vec(),
+            .as_colors()
+            .map(crate::bitmap::bitmap_data::Color::from)
+            .collect(),
     );
     Ok(new_bitmap_data(
         activation.context.gc_context,

--- a/core/src/avm1/globals/movie_clip.rs
+++ b/core/src/avm1/globals/movie_clip.rs
@@ -826,7 +826,7 @@ fn attach_movie<'gc>(
         .context
         .library
         .library_for_movie(movie_clip.movie())
-        .ok_or("Movie is missing!")
+        .ok_or("Movie is missing!".into())
         .and_then(|l| l.instantiate_by_export_name(export_name, activation.context.gc_context))
     {
         // Set name and attach to parent.

--- a/core/src/avm1/globals/sound.rs
+++ b/core/src/avm1/globals/sound.rs
@@ -79,7 +79,7 @@ fn attach_sound<'gc>(
             .owner()
             .unwrap_or_else(|| activation.base_clip().avm1_root())
             .movie();
-        if let Some(Character::Sound(sound)) = activation
+        if let Some((_, Character::Sound(sound))) = activation
             .context
             .library
             .library_for_movie_mut(movie)
@@ -439,7 +439,7 @@ fn stop<'gc>(
                 .owner()
                 .unwrap_or_else(|| activation.base_clip().avm1_root())
                 .movie();
-            if let Some(Character::Sound(sound)) = activation
+            if let Some((_, Character::Sound(sound))) = activation
                 .context
                 .library
                 .library_for_movie_mut(movie)

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -5,6 +5,7 @@ use crate::avm2::Activation;
 use crate::avm2::AvmString;
 use crate::avm2::Multiname;
 use crate::avm2::Value;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::mem::size_of;
 
@@ -657,6 +658,12 @@ impl<'gc> std::fmt::Display for Error<'gc> {
 
 impl<'gc, 'a> From<&'a str> for Error<'gc> {
     fn from(val: &'a str) -> Error<'gc> {
+        Error::RustError(val.into())
+    }
+}
+
+impl<'gc, 'a> From<Cow<'a, str>> for Error<'gc> {
+    fn from(val: Cow<'a, str>) -> Error<'gc> {
         Error::RustError(val.into())
     }
 }

--- a/core/src/avm2/globals/flash/display/bitmap.rs
+++ b/core/src/avm2/globals/flash/display/bitmap.rs
@@ -44,14 +44,18 @@ pub fn bitmap_allocator<'gc>(
             .avm2_class_registry()
             .class_symbol(class)
         {
-            if let Some(Character::Bitmap(bitmap)) = activation
+            if let Some(Character::Bitmap {
+                compressed,
+                avm2_bitmapdata_class: _,
+                handle: _,
+            }) = activation
                 .context
                 .library
                 .library_for_movie_mut(movie)
                 .character_by_id(symbol)
                 .cloned()
             {
-                let new_bitmap_data = fill_bitmap_data_from_symbol(activation, &bitmap);
+                let new_bitmap_data = fill_bitmap_data_from_symbol(activation, &compressed);
                 let bitmap_data_obj = BitmapDataObject::from_bitmap_data_internal(
                     activation,
                     BitmapDataWrapper::dummy(activation.context.gc_context),
@@ -66,10 +70,9 @@ pub fn bitmap_allocator<'gc>(
                     new_bitmap_data,
                     false,
                     &activation.caller_movie_or_root(),
-                )
-                .into();
+                );
 
-                let obj = initialize_for_allocator(activation, child, orig_class)?;
+                let obj = initialize_for_allocator(activation, child.into(), orig_class)?;
                 obj.set_public_property("bitmapData", bitmap_data_obj.into(), activation)?;
                 return Ok(obj);
             }

--- a/core/src/character.rs
+++ b/core/src/character.rs
@@ -1,10 +1,14 @@
+use std::cell::RefCell;
+
 use crate::backend::audio::SoundHandle;
 use crate::binary_data::BinaryData;
 use crate::display_object::{
-    Avm1Button, Avm2Button, Bitmap, EditText, Graphic, MorphShape, MovieClip, Text, Video,
+    Avm1Button, Avm2Button, BitmapClass, EditText, Graphic, MorphShape, MovieClip, Text, Video,
 };
 use crate::font::Font;
-use gc_arena::Collect;
+use gc_arena::{Collect, GcCell};
+use ruffle_render::bitmap::{BitmapHandle, BitmapSize};
+use swf::DefineBitsLossless;
 
 #[derive(Clone, Collect, Debug)]
 #[collect(no_drop)]
@@ -12,7 +16,16 @@ pub enum Character<'gc> {
     EditText(EditText<'gc>),
     Graphic(Graphic<'gc>),
     MovieClip(MovieClip<'gc>),
-    Bitmap(Bitmap<'gc>),
+    Bitmap {
+        #[collect(require_static)]
+        compressed: CompressedBitmap,
+        /// A lazily constructed GPU handle, used when performing fills with this bitmap
+        #[collect(require_static)]
+        handle: RefCell<Option<BitmapHandle>>,
+        /// The bitmap class set by `SymbolClass` - this is used when we instantaite
+        /// a `Bitmap` displayobject.
+        avm2_bitmapdata_class: GcCell<'gc, BitmapClass<'gc>>,
+    },
     Avm1Button(Avm1Button<'gc>),
     Avm2Button(Avm2Button<'gc>),
     Font(Font<'gc>),
@@ -21,4 +34,47 @@ pub enum Character<'gc> {
     Sound(#[collect(require_static)] SoundHandle),
     Video(Video<'gc>),
     BinaryData(BinaryData),
+}
+
+/// Holds a bitmap from an SWF tag, plus the decoded width/height.
+/// We avoid decompressing the image until it's actually needed - some pathological SWFS
+/// like 'House' have thousands of highly-compressed (mostly empty) bitmaps, which can
+/// take over 10GB of ram if we decompress them all during preloading.
+#[derive(Clone, Debug)]
+pub enum CompressedBitmap {
+    Jpeg {
+        data: Vec<u8>,
+        alpha: Option<Vec<u8>>,
+        width: u16,
+        height: u16,
+    },
+    Lossless(DefineBitsLossless<'static>),
+}
+
+impl CompressedBitmap {
+    pub fn size(&self) -> BitmapSize {
+        match self {
+            CompressedBitmap::Jpeg { width, height, .. } => BitmapSize {
+                width: *width,
+                height: *height,
+            },
+            CompressedBitmap::Lossless(define_bits_lossless) => BitmapSize {
+                width: define_bits_lossless.width,
+                height: define_bits_lossless.height,
+            },
+        }
+    }
+    pub fn decode(&self) -> Result<ruffle_render::bitmap::Bitmap, ruffle_render::error::Error> {
+        match self {
+            CompressedBitmap::Jpeg {
+                data,
+                alpha,
+                width: _,
+                height: _,
+            } => ruffle_render::utils::decode_define_bits_jpeg(data, alpha.as_deref()),
+            CompressedBitmap::Lossless(define_bits_lossless) => {
+                ruffle_render::utils::decode_define_bits_lossless(define_bits_lossless)
+            }
+        }
+    }
 }

--- a/core/src/debug_ui/movie.rs
+++ b/core/src/debug_ui/movie.rs
@@ -261,7 +261,7 @@ pub fn open_character_button(ui: &mut Ui, character: &Character) {
         Character::EditText(_) => "EditText",
         Character::Graphic(_) => "Graphic",
         Character::MovieClip(_) => "MovieClip",
-        Character::Bitmap(_) => "Bitmap",
+        Character::Bitmap { .. } => "Bitmap",
         Character::Avm1Button(_) => "Avm1Button",
         Character::Avm2Button(_) => "Avm2Button",
         Character::Font(_) => "Font",

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -46,7 +46,7 @@ pub use crate::display_object::container::{
 };
 pub use avm1_button::{Avm1Button, ButtonState, ButtonTracking};
 pub use avm2_button::Avm2Button;
-pub use bitmap::Bitmap;
+pub use bitmap::{Bitmap, BitmapClass};
 pub use edit_text::{AutoSizeMode, EditText, TextSelection};
 pub use graphic::Graphic;
 pub use interactive::{Avm2MousePick, InteractiveObject, TInteractiveObject};

--- a/swf/src/read.rs
+++ b/swf/src/read.rs
@@ -8,6 +8,7 @@ use crate::{
 use bitstream_io::BitRead;
 use byteorder::{LittleEndian, ReadBytesExt};
 use simple_asn1::ASN1Block;
+use std::borrow::Cow;
 use std::io::{self, Read};
 
 /// Parse a decompressed SWF.
@@ -2496,7 +2497,7 @@ impl<'a> Reader<'a> {
             format,
             width,
             height,
-            data,
+            data: Cow::Borrowed(data),
         })
     }
 

--- a/swf/src/test_data.rs
+++ b/swf/src/test_data.rs
@@ -9,6 +9,7 @@ use crate::string::{SwfStr, WINDOWS_1252};
 use crate::tag_code::TagCode;
 use crate::types::*;
 use crate::write::write_swf;
+use std::borrow::Cow;
 use std::fs::File;
 use std::vec::Vec;
 
@@ -165,9 +166,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 format: BitmapFormat::Rgb32,
                 width: 8,
                 height: 8,
-                data: &[
+                data: Cow::Borrowed(&[
                     120, 218, 251, 207, 192, 240, 255, 255, 8, 198, 0, 4, 128, 127, 129,
-                ],
+                ]),
             }),
             read_tag_bytes_from_file(
                 "tests/swfs/DefineBitsLossless.swf",
@@ -182,9 +183,9 @@ pub fn tag_tests() -> Vec<TagTestData> {
                 format: BitmapFormat::Rgb32,
                 width: 8,
                 height: 8,
-                data: &[
+                data: Cow::Borrowed(&[
                     120, 218, 107, 96, 96, 168, 107, 24, 193, 24, 0, 227, 81, 63, 129,
-                ],
+                ]),
             }),
             read_tag_bytes_from_file(
                 "tests/swfs/DefineBitsLossless2.swf",

--- a/swf/src/types.rs
+++ b/swf/src/types.rs
@@ -7,6 +7,7 @@
 use crate::string::SwfStr;
 use bitflags::bitflags;
 use enum_map::Enum;
+use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 use std::num::NonZeroU8;
 use std::str::FromStr;
@@ -1696,7 +1697,7 @@ pub struct DefineBitsLossless<'a> {
     pub format: BitmapFormat,
     pub width: u16,
     pub height: u16,
-    pub data: &'a [u8],
+    pub data: Cow<'a, [u8]>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/swf/src/write.rs
+++ b/swf/src/write.rs
@@ -562,7 +562,7 @@ impl<W: Write> Writer<W> {
                 if let BitmapFormat::ColorMap8 { num_colors } = tag.format {
                     self.write_u8(num_colors)?;
                 }
-                self.output.write_all(tag.data)?;
+                self.output.write_all(&tag.data)?;
             }
 
             Tag::DefineButton(ref button) => self.write_define_button(button)?,


### PR DESCRIPTION
We hit a pathological case in House
(https://github.com/ruffle-rs/ruffle/issues/15154), where eagerly decoding bitmaps during preloading results in over 10GB of ram being used.

With this PR, we store the compressed bitmap, and only decode it each time we instantiate it. In order to support bitmap fills, we store the decoded width/height and a lazily-initialized GPU handle in `Character::Bitmap`