### PR TITLE
web: Don't generate random name of wasm files in extension

### DIFF
--- a/web/packages/extension/webpack.config.js
+++ b/web/packages/extension/webpack.config.js
@@ -90,6 +90,7 @@ export default function (/** @type {Record<string, any>} */ env, _argv) {
             path: url.fileURLToPath(new URL("assets/dist/", import.meta.url)),
             publicPath: "",
             clean: true,
+            assetModuleFilename: "assets/[name][ext][query]",
         },
         module: {
             rules: [


### PR DESCRIPTION
Instead of [big random hash] it'll be the actual name of the wasm file.
This way `player.js` will not make a diff because the filename changed, and it'll also be clear which wasm file is which