### PR TITLE
web: Include wasm file in docker builds as Mozilla say this is okay

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -341,6 +341,17 @@ jobs:
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
         run: npm run version-seal
 
+      - name: Build web
+        env:
+          BUILD_ID: ${{ github.run_number }}
+          # Build web demo with WebGPU support for testing in Chrome origin trial on ruffle.rs
+          CARGO_FEATURES: jpegxr${{ matrix.demo && ',webgpu' || '' }}
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
+          WASM_SOURCE: cargo_and_store
+        working-directory: web
+        shell: bash -l {0}
+        run: npm run build:repro
+
       - name: Produce reproducible source archive
         if: ${{ !matrix.demo }}
         shell: bash -l {0}
@@ -358,17 +369,9 @@ jobs:
           package_file="${{ needs.create-nightly-release.outputs.package_prefix }}-reproducible-source.zip"
           gh release upload "$tag_name" "$package_file"
 
-      - name: Build web
-        env:
-          BUILD_ID: ${{ github.run_number }}
-          # Build web demo with WebGPU support for testing in Chrome origin trial on ruffle.rs
-          CARGO_FEATURES: jpegxr${{ matrix.demo && ',webgpu' || '' }}
-          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }} # Needed to inject into manifest.json
+      - name: Build web docs
         working-directory: web
-        shell: bash -l {0}
-        run: |
-          npm run build:repro
-          npm run docs
+        run: npm run docs
 
       - name: Publish npm package
         if: ${{ !matrix.demo }}

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Install node packages
         working-directory: web
         shell: bash -l {0}
-        run: |
-          npm ci
+        run: npm ci
 
       - name: Seal version data
         shell: bash -l {0}
@@ -55,6 +54,14 @@ jobs:
         env:
           ENABLE_VERSION_SEAL: "true"
         run: npm run version-seal
+
+      - name: Build web normally
+        working-directory: web
+        shell: bash -l {0}
+        env:
+          CARGO_FEATURES: jpegxr
+          WASM_SOURCE: cargo_and_store
+        run: npm run build:repro
 
       - name: Build Docker image with Ruffle in it
         run: docker build --tag ruffle-web-docker -f web/docker/Dockerfile .
@@ -65,11 +72,6 @@ jobs:
       - name: Check that the Firefox extension was built
         run: test -f web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi
 
-      - name: Build web normally
-        working-directory: web
-        shell: bash -l {0}
-        run: npm run build:repro
-
       - name: Compare the two extensions
         run: |
           mkdir firefox_extensions
@@ -77,12 +79,12 @@ jobs:
           mkdir firefox_extensions/normal_build
           unzip -d firefox_extensions/normal_build "./web/packages/extension/dist/firefox_unsigned.xpi"
           unzip -d firefox_extensions/docker_build "./web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi"
-          fclones group --unique firefox_extensions/normal_build firefox_extensions/docker_build -o result.txt -f fdupes
-          fclones group --unique firefox_extensions/normal_build firefox_extensions/docker_build -o firefox_extensions/differences.txt
+          fclones group --unique firefox_extensions/normal_build firefox_extensions/docker_build --exclude "**.wasm" -o result.txt -f fdupes
+          fclones group --unique firefox_extensions/normal_build firefox_extensions/docker_build --exclude "**.wasm" -o firefox_extensions/differences.txt
           cat result.txt
 
       - name: Check that the comparison was identical
-        run: test -s firefox_extensions/result.txt
+        run: test ! -s result.txt
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -2,26 +2,7 @@
 # rm -rf web/docker/docker_builds/*
 # docker build --tag ruffle-web-docker -f web/docker/Dockerfile .
 # docker cp $(docker create ruffle-web-docker:latest):/ruffle/web/packages web/docker/docker_builds/packages
-FROM ubuntu:22.04
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y
-RUN apt-get -y full-upgrade
-# Installing dependencies:
-RUN apt-get install -y apt-utils
-RUN apt-get install -y wget git openssl libssl-dev gcc clang gzip tar default-jre-headless pkg-config
-# Installing Node.js from the nodesource repo according to their instructions:
-RUN apt-get install -y ca-certificates curl gnupg
-RUN mkdir -p /etc/apt/keyrings
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-ENV NODE_MAJOR=20
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -y
-RUN apt-get install -y nodejs
-# Getting Miniconda from their website:
-RUN wget 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh'
-RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda
-ENV PATH="/miniconda/bin:$PATH"
-RUN conda install -y -c conda-forge binaryen
+FROM node:20
 # Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
 ENV PATH="/root/.cargo/bin:$PATH"
@@ -30,5 +11,6 @@ RUN cargo install wasm-bindgen-cli --version 0.2.91
 COPY . ruffle
 WORKDIR ruffle/web
 ENV CARGO_FEATURES=jpegxr
-RUN npm install
+ENV WASM_SOURCE=existing
+RUN npm ci
 RUN npm run build:repro

--- a/web/package.json
+++ b/web/package.json
@@ -40,7 +40,7 @@
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",
         "build:debug": "cross-env NODE_ENV=development CARGO_FEATURES=avm_debug npm run build",
         "build:dual-wasm": "cross-env ENABLE_WASM_EXTENSIONS=true npm run build",
-        "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_CARGO_CLEAN=true ENABLE_VERSION_SEAL=true npm run build",
+        "build:repro": "cross-env ENABLE_WASM_EXTENSIONS=true ENABLE_VERSION_SEAL=true npm run build",
         "demo": "npm run preview --workspace ruffle-demo",
         "test": "npm test --workspaces --if-present",
         "docs": "npm run docs --workspaces --if-present",

--- a/web/packages/extension/tools/sign_xpi.js
+++ b/web/packages/extension/tools/sign_xpi.js
@@ -81,10 +81,7 @@ sudo docker cp $(sudo docker create ruffle-web-docker:latest):/ruffle/web/packag
 \n\
 These commands are run at the root of the project. The compiled XPI will be in web/docker/docker_builds/packages/extension/dist/firefox_unsigned.xpi. Please take care to use this file (and not the surrounding packages directory) when comparing against the extension submission.\n\
 \n\
-Alternatively, you may also attempt building using npm and cargo. However, this workflow is more complicated to set up. It is documented here:\n\
-https://github.com/ruffle-rs/ruffle/blob/master/web/README.md\n\
-\n\
-Note that the commands for the npm/cargo workflow are run in the web subdirectory. If you're working with the Dockerfile you should be in the root of the project.\n\
+Note that the wasm files will not match, but we have been informed previously by Mozilla that this is allowed. The JavaScript and all other files should match. 
 \n\
 The compiled version of this extension was built on Ubuntu 22.04 by our CI runner.\n\
 \n\


### PR DESCRIPTION
It's a solution to the reproducible extension issue.

Unexpected, but allowed. We'll include the wasm in the source we send them, and then the JS will match.

The final wasm files inside the build they make will **not** match, until https://github.com/rustwasm/wasm-bindgen/pull/3851 - we're told this is okay though, so I've just removed the wasm-opt step too for brevity.