### PR TITLE
desktop: Add socket tests and fix flush on close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +465,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -2334,6 +2358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,6 +3200,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a82271f7bc033d84bbca59a3ce3e4159938cb08a9c3aebbe54d215131518a13"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3684,6 +3730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
 dependencies = [
  "objc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4414,6 +4469,7 @@ dependencies = [
  "generational-arena",
  "image",
  "isahc",
+ "macro_rules_attribute",
  "os_info",
  "rfd",
  "ruffle_core",
@@ -4421,6 +4477,7 @@ dependencies = [
  "ruffle_render_wgpu",
  "ruffle_video_software",
  "sys-locale",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-tracy",
@@ -4680,6 +4737,12 @@ dependencies = [
 [[package]]
 name = "ruffle_wstr"
 version = "0.1.0"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -5414,6 +5477,28 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
 
 [[package]]
 name = "toml"

--- a/core/src/backend/navigator.rs
+++ b/core/src/backend/navigator.rs
@@ -3,7 +3,7 @@
 use crate::loader::Error;
 use crate::socket::{ConnectionState, SocketAction, SocketHandle};
 use crate::string::WStr;
-use async_channel::Receiver;
+use async_channel::{Receiver, Sender};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -14,7 +14,6 @@ use std::future::Future;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::sync::mpsc::Sender;
 use std::time::Duration;
 use swf::avm1::types::SendVarsMethod;
 use url::{ParseError, Url};
@@ -455,7 +454,7 @@ impl NavigatorBackend for NullNavigatorBackend {
         sender: Sender<SocketAction>,
     ) {
         sender
-            .send(SocketAction::Connect(handle, ConnectionState::Failed))
+            .try_send(SocketAction::Connect(handle, ConnectionState::Failed))
             .expect("working channel send");
     }
 }

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -46,14 +46,14 @@ impl<'gc> Socket<'gc> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ConnectionState {
     Connected,
     Failed,
     TimedOut,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SocketAction {
     Connect(SocketHandle, ConnectionState),
     Data(SocketHandle, Vec<u8>),

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -11,12 +11,11 @@ use crate::{
     context::UpdateContext,
     string::AvmString,
 };
-use async_channel::{unbounded, Sender as AsyncSender};
+use async_channel::{unbounded, Receiver, Sender as AsyncSender, Sender};
 use gc_arena::Collect;
 use generational_arena::{Arena, Index};
 use std::{
     cell::{Cell, RefCell},
-    sync::mpsc::{channel, Receiver, Sender},
     time::Duration,
 };
 
@@ -79,7 +78,7 @@ unsafe impl<'gc> Collect for Sockets<'gc> {
 
 impl<'gc> Sockets<'gc> {
     pub fn empty() -> Self {
-        let (sender, receiver) = channel();
+        let (sender, receiver) = unbounded();
 
         Self {
             sockets: Arena::new(),

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -73,3 +73,7 @@ render_trace = ["ruffle_render_wgpu/render_trace"]
 
 # sandboxing
 sandbox = []
+
+[dev-dependencies]
+macro_rules_attribute = "0.2.0"
+tokio = { version = "1.36.0", features = ["macros", "rt"] }

--- a/desktop/src/executor.rs
+++ b/desktop/src/executor.rs
@@ -2,10 +2,10 @@
 
 use crate::custom_event::RuffleEvent;
 use crate::task::Task;
+use async_channel::{unbounded, Receiver, Sender};
 use generational_arena::{Arena, Index};
 use ruffle_core::backend::navigator::OwnedFuture;
 use ruffle_core::loader::Error;
-use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex, Weak};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use winit::event_loop::EventLoopProxy;
@@ -151,7 +151,7 @@ impl WinitAsyncExecutor {
     pub fn new(
         event_loop: EventLoopProxy<RuffleEvent>,
     ) -> (Arc<Mutex<Self>>, Sender<OwnedFuture<(), Error>>) {
-        let (send, recv) = channel();
+        let (send, recv) = unbounded();
         let new_self = Arc::new_cyclic(|self_ref| {
             Mutex::new(Self {
                 task_queue: Arena::new(),

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -111,11 +111,10 @@ impl ActivePlayer {
             }
         };
 
-        let (executor, channel) = WinitAsyncExecutor::new(event_loop.clone());
+        let (executor, future_spawner) = WinitAsyncExecutor::new(event_loop.clone());
         let navigator = ExternalNavigatorBackend::new(
             opt.base.to_owned().unwrap_or_else(|| movie_url.clone()),
-            channel,
-            event_loop.clone(),
+            future_spawner,
             opt.proxy.clone(),
             opt.upgrade_to_https,
             opt.open_url_mode,


### PR DESCRIPTION
This patch makes sure that any pending data is sent before the socket closes. Without this fix Ruffle ignored the data sent right before calling `socket.close`.