### PR TITLE
build: Use LLD for linking on Windows, for improved build speed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,7 @@ rustflags = [
     # and our web code does not compile without this flag
     "--cfg=web_sys_unstable_apis",
 ]
+
+[target.x86_64-pc-windows-msvc]
+# Use the LLD linker, it's not as slow as the default.
+linker = "rust-lld.exe"


### PR DESCRIPTION
I was looking at the timestamps of the log messages in our CI runs on Windows, and saw that linking is what takes a really long time, and isn't cached.

As seen on: https://github.com/bevyengine/bevy/blob/9bd6cc0a5e8d269eb1fb6446ddd0824c446d966b/.cargo/config_fast_builds.toml#L30-L31
See also: https://github.com/rust-lang/rust/issues/39915