### PR TITLE
ci: Try to speed up CI runs on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,8 @@ rustflags = [
     # and our web code does not compile without this flag
     "--cfg=web_sys_unstable_apis",
 ]
+
+[target.x86_64-pc-windows-msvc]
+# Use the LLD linker, it should be faster than the default.
+# See: https://github.com/rust-lang/rust/issues/71520
+linker = "rust-lld.exe"

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -78,6 +78,9 @@ jobs:
         # See: https://github.com/nextest-rs/nextest/issues/1172
         run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
         env:
+          # This is to counteract the disabling by rust-cache.
+          # See: https://github.com/Swatinem/rust-cache/issues/43
+          CARGO_INCREMENTAL: '1'
           # Supposedly makes "Updating crates.io index" faster on Windows.
           # See: https://github.com/rust-lang/cargo/issues/9167
           CARGO_NET_GIT_FETCH_WITH_CLI: 'true'

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -78,6 +78,9 @@ jobs:
         # See: https://github.com/nextest-rs/nextest/issues/1172
         run: cargo nextest run --cargo-profile ci --workspace --locked --no-fail-fast --retries 2 -j 4 --features imgtests,lzma,jpegxr
         env:
+          # Supposedly makes "Updating crates.io index" faster on Windows.
+          # See: https://github.com/rust-lang/cargo/issues/9167
+          CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
           XDG_RUNTIME_DIR: '' # dummy value, just to silence warnings about it missing
 
       - name: Run tests without image tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,8 +100,13 @@ inherits = "release"
 
 [profile.ci]
 inherits = "release"
-opt-level = 2
 debug-assertions = true
 overflow-checks = true
+# "Not too slow to compile, fast enough to run."
+opt-level = 2
+# Takes too long, especially on Windows, with marginal benefit otherwise.
+lto = "off"
 # This is also set with higher authority in `test_rust.yml`.
 incremental = true
+# Right between the defaults of 16 and 256, for crate fragment caching.
+codegen-units = 64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,4 +103,5 @@ inherits = "release"
 opt-level = 2
 debug-assertions = true
 overflow-checks = true
+# This is also set with higher authority in `test_rust.yml`.
 incremental = true


### PR DESCRIPTION
With these tweaks, I clocked in a sub 13 minute run on Windows, in an ideal scenario: https://github.com/torokati44/ruffle/actions/runs/8063891683
For reference, currently we are in the 15..17 minute (or 13..20 including outliers) range.

While I discarded them earlier, this does include the changes in both https://github.com/ruffle-rs/ruffle/pull/15324 and https://github.com/ruffle-rs/ruffle/pull/15325.
And admittedly, a few more random changes, and I regretfully admit that I can't empirically show exactly which ones help how much.
But overall, none of them should be too risky, while all of them have a chance to help _somewhat_.