### PR TITLE
web: Don't panic on browsers without ReadableStreamDefaultController

### DIFF
--- a/web/packages/core/src/load-ruffle.ts
+++ b/web/packages/core/src/load-ruffle.ts
@@ -74,11 +74,11 @@ async function fetchRuffle(
         ? new URL("../dist/ruffle_web-wasm_extensions_bg.wasm", import.meta.url)
         : new URL("../dist/ruffle_web_bg.wasm", import.meta.url);
     const wasmResponse = await fetch(wasmUrl);
-    // The Pale Moon browser currently lacks support for ReadableStream.
-    // Unfortunately, currently it also lacks a sufficient WASM runtime.
-    // If this becomes the last thing Pale Moon lacks, allow Ruffle to work.
-    const readableStreamDefined = typeof ReadableStream === "function";
-    if (progressCallback && readableStreamDefined) {
+    // The Pale Moon browser lacks full support for ReadableStream.
+    // However, ReadableStream itself is defined.
+    const readableStreamProperlyDefined =
+        typeof ReadableStreamDefaultController === "function";
+    if (progressCallback && readableStreamProperlyDefined) {
         const contentLength =
             wasmResponse?.headers?.get("content-length") || "";
         let bytesLoaded = 0;


### PR DESCRIPTION
Palemoon "added an initial implementation of the ReadableStreams API, improving web compatibility with sites that apparently use this API in utilitarian fashion," according to http://www.palemoon.org/releasenotes.shtml#v32.5.0.

Unfortunately, that decreased Ruffle's compatibility with Pale Moon, as we rely on the existence of the [ReadableStreamDefaultController](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController) when ReadableStream is defined. Therefore, change the compatibility check for ReadableStream to check for the existence of ReadableStreamDefaultController specifically.