### PR TITLE
chore: Replace `generational-arena` with `slotmap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,15 +2273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generational-arena"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "generator"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4464,7 +4455,6 @@ dependencies = [
  "flv-rs",
  "fnv",
  "futures",
- "generational-arena",
  "hashbrown 0.14.3",
  "image",
  "indexmap",
@@ -4489,6 +4479,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "slotmap",
  "smallvec",
  "swf",
  "symphonia",
@@ -4525,7 +4516,6 @@ dependencies = [
  "fontdb",
  "futures",
  "futures-lite 2.2.0",
- "generational-arena",
  "gilrs",
  "image",
  "isahc",
@@ -4536,6 +4526,7 @@ dependencies = [
  "ruffle_render",
  "ruffle_render_wgpu",
  "ruffle_video_software",
+ "slotmap",
  "sys-locale",
  "tokio",
  "tracing",
@@ -4717,8 +4708,8 @@ dependencies = [
 name = "ruffle_video"
 version = "0.1.0"
 dependencies = [
- "generational-arena",
  "ruffle_render",
+ "slotmap",
  "swf",
  "thiserror",
 ]
@@ -4728,7 +4719,6 @@ name = "ruffle_video_software"
 version = "0.1.0"
 dependencies = [
  "flate2",
- "generational-arena",
  "h263-rs",
  "h263-rs-deblock",
  "log",
@@ -4737,6 +4727,7 @@ dependencies = [
  "nihav_duck",
  "ruffle_render",
  "ruffle_video",
+ "slotmap",
  "swf",
  "thiserror",
 ]
@@ -4751,7 +4742,6 @@ dependencies = [
  "console_error_panic_hook",
  "futures",
  "futures-util",
- "generational-arena",
  "getrandom",
  "gloo-net",
  "js-sys",
@@ -4765,6 +4755,7 @@ dependencies = [
  "ruffle_web_common",
  "serde",
  "serde-wasm-bindgen",
+ "slotmap",
  "thiserror",
  "tracing",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ wgpu = "0.19.3"
 egui = "0.26.2"
 clap = { version = "4.5.1", features = ["derive"] }
 anyhow = "1.0"
+slotmap = "1.0.7"
 
 [workspace.lints.rust]
 # Clippy nightly often adds new/buggy lints that we want to ignore.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ bitstream-io = "2.2.0"
 flate2 = "1.0.28"
 fnv = "1.0.7"
 gc-arena = { package = "ruffle_gc_arena", path = "../ruffle_gc_arena" }
-generational-arena = "0.2.9"
+slotmap = { workspace = true }
 indexmap = "2.2.5"
 tracing = { workspace = true }
 ruffle_render = { path = "../render", features = ["tessellator"] }

--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use downcast_rs::Downcast;
 use gc_arena::Collect;
-use generational_arena::{Arena, Index};
+use slotmap::{DefaultKey, Key, SlotMap};
 
 #[cfg(feature = "audio")]
 pub mod decoders;
@@ -35,8 +35,8 @@ mod decoders {
 use thiserror::Error;
 use web_time::Duration;
 
-pub type SoundHandle = Index;
-pub type SoundInstanceHandle = Index;
+pub type SoundHandle = DefaultKey;
+pub type SoundInstanceHandle = DefaultKey;
 pub type DecodeError = decoders::Error;
 
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
@@ -205,14 +205,14 @@ struct NullSound {
 
 /// Audio backend that ignores all audio.
 pub struct NullAudioBackend {
-    sounds: Arena<NullSound>,
+    sounds: SlotMap<SoundHandle, NullSound>,
     volume: f32,
 }
 
 impl NullAudioBackend {
     pub fn new() -> NullAudioBackend {
         NullAudioBackend {
-            sounds: Arena::new(),
+            sounds: SlotMap::new(),
             volume: 1.0,
         }
     }
@@ -259,7 +259,7 @@ impl AudioBackend for NullAudioBackend {
         _sound: SoundHandle,
         _sound_info: &swf::SoundInfo,
     ) -> Result<SoundInstanceHandle, DecodeError> {
-        Ok(SoundInstanceHandle::from_raw_parts(0, 0))
+        Ok(SoundInstanceHandle::null())
     }
 
     fn start_stream(
@@ -267,7 +267,7 @@ impl AudioBackend for NullAudioBackend {
         _clip_data: crate::tag_utils::SwfSlice,
         _handle: &swf::SoundStreamHead,
     ) -> Result<SoundInstanceHandle, DecodeError> {
-        Ok(SoundInstanceHandle::from_raw_parts(0, 0))
+        Ok(SoundInstanceHandle::null())
     }
 
     fn start_substream(
@@ -275,7 +275,7 @@ impl AudioBackend for NullAudioBackend {
         _stream_data: Substream,
         _handle: &SoundStreamInfo,
     ) -> Result<SoundInstanceHandle, DecodeError> {
-        Ok(SoundInstanceHandle::from_raw_parts(0, 0))
+        Ok(SoundInstanceHandle::null())
     }
 
     fn stop_sound(&mut self, _sound: SoundInstanceHandle) {}

--- a/core/src/local_connection.rs
+++ b/core/src/local_connection.rs
@@ -2,9 +2,9 @@ use crate::avm1::Object as Avm1Object;
 use crate::avm2::object::LocalConnectionObject;
 use crate::string::AvmString;
 use gc_arena::Collect;
-use generational_arena::{Arena, Index};
+use slotmap::{DefaultKey, SlotMap};
 
-pub type LocalConnectionHandle = Index;
+pub type LocalConnectionHandle = DefaultKey;
 
 #[derive(Collect)]
 #[collect(no_drop)]
@@ -41,7 +41,7 @@ impl<'gc> LocalConnection<'gc> {
 
 /// Manages the collection of local connections.
 pub struct LocalConnections<'gc> {
-    connections: Arena<LocalConnection<'gc>>,
+    connections: SlotMap<LocalConnectionHandle, LocalConnection<'gc>>,
 }
 
 unsafe impl<'gc> Collect for LocalConnections<'gc> {
@@ -55,7 +55,7 @@ unsafe impl<'gc> Collect for LocalConnections<'gc> {
 impl<'gc> LocalConnections<'gc> {
     pub fn empty() -> Self {
         Self {
-            connections: Arena::new(),
+            connections: SlotMap::new(),
         }
     }
 

--- a/core/src/net_connection.rs
+++ b/core/src/net_connection.rs
@@ -10,12 +10,12 @@ use crate::Player;
 use flash_lso::packet::{Header, Message, Packet};
 use flash_lso::types::{AMFVersion, Value as AmfValue};
 use gc_arena::{Collect, DynamicRoot, Rootable};
-use generational_arena::{Arena, Index};
+use slotmap::{DefaultKey, SlotMap};
 use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
 use std::sync::{Mutex, Weak};
 
-pub type NetConnectionHandle = Index;
+pub type NetConnectionHandle = DefaultKey;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum ResponderCallback {
@@ -76,7 +76,7 @@ impl<'gc> From<Avm2NetConnectionObject<'gc>> for NetConnectionObject<'gc> {
 
 /// Manages the collection of NetConnections.
 pub struct NetConnections<'gc> {
-    connections: Arena<NetConnection<'gc>>,
+    connections: SlotMap<NetConnectionHandle, NetConnection<'gc>>,
 }
 
 unsafe impl<'gc> Collect for NetConnections<'gc> {
@@ -90,7 +90,7 @@ unsafe impl<'gc> Collect for NetConnections<'gc> {
 impl<'gc> Default for NetConnections<'gc> {
     fn default() -> Self {
         Self {
-            connections: Arena::new(),
+            connections: SlotMap::new(),
         }
     }
 }

--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 use async_channel::{unbounded, Receiver, Sender as AsyncSender, Sender};
 use gc_arena::Collect;
-use generational_arena::{Arena, Index};
+use slotmap::{DefaultKey, SlotMap};
 use std::{
     cell::{Cell, RefCell},
     time::Duration,
 };
 
-pub type SocketHandle = Index;
+pub type SocketHandle = DefaultKey;
 
 #[derive(Copy, Clone, Collect)]
 #[collect(no_drop)]
@@ -62,7 +62,7 @@ pub enum SocketAction {
 
 /// Manages the collection of Sockets.
 pub struct Sockets<'gc> {
-    sockets: Arena<Socket<'gc>>,
+    sockets: SlotMap<SocketHandle, Socket<'gc>>,
 
     receiver: Receiver<SocketAction>,
     sender: Sender<SocketAction>,
@@ -81,7 +81,7 @@ impl<'gc> Sockets<'gc> {
         let (sender, receiver) = unbounded();
 
         Self {
-            sockets: Arena::new(),
+            sockets: SlotMap::new(),
             receiver,
             sender,
         }

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -25,7 +25,7 @@ ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true }
-generational-arena = "0.2.9"
+slotmap = { workspace = true }
 winit = "0.29.13"
 webbrowser = "0.8.12"
 url = "2.5.0"

--- a/desktop/src/backends/navigator.rs
+++ b/desktop/src/backends/navigator.rs
@@ -677,7 +677,7 @@ mod tests {
 
     macro_rules! dummy_handle {
         () => {
-            SocketHandle::from_raw_parts(4, 2)
+            SocketHandle::default()
         };
     }
 

--- a/video/Cargo.toml
+++ b/video/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 swf = { path = "../swf" }
 ruffle_render = { path = "../render" }
-generational-arena = "0.2.9"
+slotmap = { workspace = true }
 thiserror = "1.0"
 
 [features]

--- a/video/software/Cargo.toml
+++ b/video/software/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 ruffle_render = { path = "../../render" }
 ruffle_video = { path = ".." }
 swf = { path = "../../swf" }
-generational-arena = "0.2.9"
+slotmap = { workspace = true }
 thiserror = "1.0"
 flate2 = "1.0.28"
 log = "0.4"

--- a/video/software/src/backend.rs
+++ b/video/software/src/backend.rs
@@ -1,17 +1,17 @@
 use crate::decoder::VideoDecoder;
-use generational_arena::Arena;
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::bitmap::{BitmapHandle, BitmapInfo, PixelRegion};
 use ruffle_video::backend::VideoBackend;
 use ruffle_video::error::Error;
 use ruffle_video::frame::{EncodedFrame, FrameDependency};
 use ruffle_video::VideoStreamHandle;
+use slotmap::SlotMap;
 use swf::{VideoCodec, VideoDeblocking};
 
 /// Software video backend that proxies to CPU-only codec implementations that
 /// ship with Ruffle.
 pub struct SoftwareVideoBackend {
-    streams: Arena<VideoStream>,
+    streams: SlotMap<VideoStreamHandle, VideoStream>,
 }
 
 impl Default for SoftwareVideoBackend {
@@ -23,7 +23,7 @@ impl Default for SoftwareVideoBackend {
 impl SoftwareVideoBackend {
     pub fn new() -> Self {
         Self {
-            streams: Arena::new(),
+            streams: SlotMap::new(),
         }
     }
 }

--- a/video/src/lib.rs
+++ b/video/src/lib.rs
@@ -1,10 +1,10 @@
 #![deny(clippy::unwrap_used)]
 
-use generational_arena::Index;
+use slotmap::DefaultKey;
 
 pub mod backend;
 pub mod error;
 pub mod frame;
 pub mod null;
 
-pub type VideoStreamHandle = Index;
+pub type VideoStreamHandle = DefaultKey;

--- a/video/src/null.rs
+++ b/video/src/null.rs
@@ -2,13 +2,13 @@ use crate::backend::VideoBackend;
 use crate::error::Error;
 use crate::frame::{EncodedFrame, FrameDependency};
 use crate::VideoStreamHandle;
-use generational_arena::Arena;
 use ruffle_render::backend::RenderBackend;
 use ruffle_render::bitmap::BitmapInfo;
+use slotmap::SlotMap;
 use swf::{VideoCodec, VideoDeblocking};
 
 pub struct NullVideoBackend {
-    streams: Arena<()>,
+    streams: SlotMap<VideoStreamHandle, ()>,
 }
 
 /// Implementation of video that does not decode any video.
@@ -22,7 +22,7 @@ pub struct NullVideoBackend {
 impl NullVideoBackend {
     pub fn new() -> Self {
         Self {
-            streams: Arena::new(),
+            streams: SlotMap::new(),
         }
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -32,7 +32,7 @@ profiling = []
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }
-generational-arena = "0.2.9"
+slotmap = { workspace = true }
 js-sys = "0.3.68"
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["registry"] }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -7,7 +7,6 @@ mod navigator;
 mod storage;
 mod ui;
 
-use generational_arena::{Arena, Index};
 use js_sys::{Array, Error as JsError, Function, Object, Promise, Uint8Array};
 use ruffle_core::backend::navigator::OpenURLMode;
 use ruffle_core::backend::ui::FontDefinition;
@@ -29,6 +28,7 @@ use ruffle_render::quality::StageQuality;
 use ruffle_video_software::backend::SoftwareVideoBackend;
 use ruffle_web_common::JsResult;
 use serde::{Deserialize, Serialize};
+use slotmap::{DefaultKey, SlotMap};
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -52,7 +52,7 @@ thread_local! {
     /// We store the actual instances of the ruffle core in a static pool.
     /// This gives us a clear boundary between the JS side and Rust side, avoiding
     /// issues with lifetimes and type parameters (which cannot be exported with wasm-bindgen).
-    static INSTANCES: RefCell<Arena<RefCell<RuffleInstance>>> = RefCell::new(Arena::new());
+    static INSTANCES: RefCell<SlotMap<DefaultKey, RefCell<RuffleInstance>>> = RefCell::new(SlotMap::new());
 
     static CURRENT_CONTEXT: RefCell<Option<*mut UpdateContext<'static, 'static>>> = const { RefCell::new(None) };
 }
@@ -339,7 +339,7 @@ struct MovieMetadata {
 /// This type is exported to JS, and is used to interact with the library.
 #[wasm_bindgen]
 #[derive(Clone, Copy)]
-pub struct Ruffle(Index);
+pub struct Ruffle(DefaultKey);
 
 #[wasm_bindgen]
 impl Ruffle {


### PR DESCRIPTION
Because `generational-arena` is unmaintained, and `slotmap` is the recommended alternative.

Most of it was a trivial search-and-replace, except for:
- That `.rev()` from `LoadManager` is gone, because this iterator type does not support it.
  - Note that iteration order was undefined before, and is undefined now. Therefore, we shouldn't have been relying on this already.
  - Replaced by a clumsy hand-cranked reversing solution, but it should behave the same (undefined, but accidentally usually correct) way.
- `loader.rs` has sometimes used `Index` instead of the `Handle` type it defines, in its API.
  - We should probably also rename that to match the convention of the rest of the handle types.
- The dummy handle in the socket tests was replaced by the default, I hope that's fine, @kjarosh.

In the future, we could consider:
- Using more specialized implementations for faster iteration
  - https://docs.rs/slotmap/latest/slotmap/index.html#choosing-slotmap-hopslotmap-or-denseslotmap
- Defining different key types for the different handles, as is the proper intended usage
  - Instead of using `DefaultKey` everywhere
- Introducing a named key/handle type (or alias, for now) in `desktop/executor.rs` and `web/lib.rs` as well.