### PR TITLE
web: No longer set the `web_sys_unstable_apis` config variable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,3 @@
-[target.'cfg(all())']
-# NOTE that the web build overrides this setting in package.json via the RUSTFLAGS environment variable
-rustflags = [
-    # We need to specify this flag for all targets because Clippy checks all of our code against all targets
-    # and our web code does not compile without this flag
-    "--cfg=web_sys_unstable_apis",
-]
-
 [target.x86_64-pc-windows-msvc]
 # Use the LLD linker, it should be faster than the default.
 # See: https://github.com/rust-lang/rust/issues/71520

--- a/web/packages/core/tools/build_wasm.js
+++ b/web/packages/core/tools/build_wasm.js
@@ -60,7 +60,7 @@ function cargoBuild({ profile, features, rustFlags }) {
     });
 }
 function buildWasm(profile, filename, optimise, extensions, wasmSource) {
-    const rustFlags = ["--cfg=web_sys_unstable_apis", "-Aunknown_lints"];
+    const rustFlags = ["-Aunknown_lints"];
     const wasmBindgenFlags = [];
     const wasmOptFlags = [];
     const flavor = extensions ? "extensions" : "vanilla";


### PR DESCRIPTION
At least `wgpu` no longer requires this as of `0.19.3` (even for WebGPU).
Let's see whether everything else keeps working without it...
Referencing: https://github.com/ruffle-rs/ruffle/pull/5250