### PR TITLE
chore: Deduplicate the `fluent-templates` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,21 +1968,6 @@ dependencies = [
 [[package]]
 name = "fluent-template-macros"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7592cd1f45c1afe9084ce59c62a3a7c266c125c4c2ec97e95b0563c4aa914"
-dependencies = [
- "flume 0.10.14",
- "ignore",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-template-macros"
-version = "0.8.0"
 source = "git+https://github.com/XAMPPRocky/fluent-templates?rev=4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf#4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf"
 dependencies = [
  "flume 0.10.14",
@@ -1997,30 +1982,6 @@ dependencies = [
 [[package]]
 name = "fluent-templates"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3ef2c2152757885365abce32ddf682746062f1b6b3c0824a29fbed6ee4d080"
-dependencies = [
- "arc-swap",
- "fluent",
- "fluent-bundle",
- "fluent-langneg",
- "fluent-syntax",
- "fluent-template-macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "flume 0.10.14",
- "heck",
- "ignore",
- "intl-memoizer",
- "lazy_static",
- "log",
- "once_cell",
- "serde_json",
- "snafu",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-templates"
-version = "0.8.0"
 source = "git+https://github.com/XAMPPRocky/fluent-templates?rev=4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf#4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf"
 dependencies = [
  "arc-swap",
@@ -2028,7 +1989,7 @@ dependencies = [
  "fluent-bundle",
  "fluent-langneg",
  "fluent-syntax",
- "fluent-template-macros 0.8.0 (git+https://github.com/XAMPPRocky/fluent-templates?rev=4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf)",
+ "fluent-template-macros",
  "flume 0.10.14",
  "heck",
  "ignore",
@@ -4451,7 +4412,7 @@ dependencies = [
  "enumset",
  "flash-lso",
  "flate2",
- "fluent-templates 0.8.0 (git+https://github.com/XAMPPRocky/fluent-templates?rev=4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf)",
+ "fluent-templates",
  "flv-rs",
  "fnv",
  "futures",
@@ -4512,7 +4473,7 @@ dependencies = [
  "egui-winit",
  "egui_extras",
  "embed-resource",
- "fluent-templates 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluent-templates",
  "fontdb",
  "futures",
  "futures-lite 2.2.0",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -41,7 +41,7 @@ sys-locale = "0.3.1"
 wgpu = { workspace = true }
 futures = "0.3.30"
 chrono = { version = "0.4", default-features = false, features = [] }
-fluent-templates = "0.8.0"
+fluent-templates = { git = "https://github.com/XAMPPRocky/fluent-templates", rev = "4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf" }
 futures-lite = "2.2.0"
 async-io = "2.3.1"
 async-net = "2.0.0"

--- a/desktop/src/gui.rs
+++ b/desktop/src/gui.rs
@@ -37,10 +37,13 @@ static_loader! {
 }
 
 pub fn text<'a>(locale: &LanguageIdentifier, id: &'a str) -> Cow<'a, str> {
-    TEXTS.lookup(locale, id).map(Cow::Owned).unwrap_or_else(|| {
-        tracing::error!("Unknown desktop text id '{id}'");
-        Cow::Borrowed(id)
-    })
+    TEXTS
+        .try_lookup(locale, id)
+        .map(Cow::Owned)
+        .unwrap_or_else(|| {
+            tracing::error!("Unknown desktop text id '{id}'");
+            Cow::Borrowed(id)
+        })
 }
 
 #[allow(dead_code)]
@@ -50,7 +53,7 @@ pub fn text_with_args<'a, T: AsRef<str>>(
     args: &HashMap<T, FluentValue>,
 ) -> Cow<'a, str> {
     TEXTS
-        .lookup_with_args(locale, id, args)
+        .try_lookup_with_args(locale, id, args)
         .map(Cow::Owned)
         .unwrap_or_else(|| {
             tracing::error!("Unknown desktop text id '{id}'");


### PR DESCRIPTION
This is a fixup for https://github.com/ruffle-rs/ruffle/pull/15280 which forgot to update it in `desktop`.