### PR TITLE
chore(deps): update node.js dependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,8 +12,8 @@
                 "./packages/*"
             ],
             "devDependencies": {
-                "@typescript-eslint/eslint-plugin": "^6.21.0",
-                "@typescript-eslint/parser": "^6.21.0",
+                "@typescript-eslint/eslint-plugin": "^7.1.0",
+                "@typescript-eslint/parser": "^7.1.0",
                 "@wdio/cli": "^8.32.3",
                 "@wdio/local-runner": "^8.32.3",
                 "@wdio/mocha-framework": "^8.32.3",
@@ -38,7 +38,7 @@
                 "webpack-cli": "^5.1.4"
             },
             "optionalDependencies": {
-                "chromedriver": "^121.0.2"
+                "chromedriver": "^122.0.4"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1690,7 +1690,7 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
@@ -1783,9 +1783,9 @@
             }
         },
         "node_modules/@types/bonjour": {
-            "version": "3.5.10",
-            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz",
-            "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
+            "version": "3.5.13",
+            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+            "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -1823,9 +1823,9 @@
             }
         },
         "node_modules/@types/connect-history-api-fallback": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-            "integrity": "sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+            "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
             "dev": true,
             "dependencies": {
                 "@types/express-serve-static-core": "*",
@@ -1859,9 +1859,9 @@
             "dev": true
         },
         "node_modules/@types/express": {
-            "version": "4.17.17",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-            "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
@@ -1996,6 +1996,15 @@
             "integrity": "sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==",
             "devOptional": true
         },
+        "node_modules/@types/node-forge": {
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+            "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -2076,9 +2085,9 @@
             }
         },
         "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true
         },
         "node_modules/@types/scheduler": {
@@ -2088,9 +2097,9 @@
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-            "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/send": {
@@ -2104,18 +2113,18 @@
             }
         },
         "node_modules/@types/serve-index": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
-            "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+            "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
             "dev": true,
             "dependencies": {
                 "@types/express": "*"
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
-            "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+            "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
             "dev": true,
             "dependencies": {
                 "@types/http-errors": "*",
@@ -2124,9 +2133,9 @@
             }
         },
         "node_modules/@types/sockjs": {
-            "version": "0.3.33",
-            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
-            "integrity": "sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==",
+            "version": "0.3.36",
+            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+            "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -2151,9 +2160,9 @@
             "dev": true
         },
         "node_modules/@types/ws": {
-            "version": "8.5.5",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-            "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+            "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -2184,16 +2193,16 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-            "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.1.0.tgz",
+            "integrity": "sha512-j6vT/kCulhG5wBmGtstKeiVr1rdXE4nk+DT1k6trYkwlrvW9eOF5ZbgKnd/YR6PcM4uTEXa0h6Fcvf6X7Dxl0w==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/type-utils": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.1.0",
+                "@typescript-eslint/type-utils": "7.1.0",
+                "@typescript-eslint/utils": "7.1.0",
+                "@typescript-eslint/visitor-keys": "7.1.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -2209,8 +2218,8 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-                "eslint": "^7.0.0 || ^8.0.0"
+                "@typescript-eslint/parser": "^7.0.0",
+                "eslint": "^8.56.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -2219,15 +2228,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.1.0.tgz",
+            "integrity": "sha512-V1EknKUubZ1gWFjiOZhDSNToOjs63/9O0puCgGS8aDOgpZY326fzFu15QAUjwaXzRZjf/qdsdBrckYdv9YxB8w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.1.0",
+                "@typescript-eslint/types": "7.1.0",
+                "@typescript-eslint/typescript-estree": "7.1.0",
+                "@typescript-eslint/visitor-keys": "7.1.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -2238,7 +2247,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.56.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -2247,13 +2256,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.1.0.tgz",
+            "integrity": "sha512-6TmN4OJiohHfoOdGZ3huuLhpiUgOGTpgXNUPJgeZOZR3DnIpdSgtt83RS35OYNNXxM4TScVlpVKC9jyQSETR1A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0"
+                "@typescript-eslint/types": "7.1.0",
+                "@typescript-eslint/visitor-keys": "7.1.0"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -2264,13 +2273,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-            "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.1.0.tgz",
+            "integrity": "sha512-UZIhv8G+5b5skkcuhgvxYWHjk7FW7/JP5lPASMEUoliAPwIH/rxoUSQPia2cuOj9AmDZmwUl1usKm85t5VUMew==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
+                "@typescript-eslint/typescript-estree": "7.1.0",
+                "@typescript-eslint/utils": "7.1.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -2282,7 +2291,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.56.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -2291,9 +2300,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.1.0.tgz",
+            "integrity": "sha512-qTWjWieJ1tRJkxgZYXx6WUYtWlBc48YRxgY2JN1aGeVpkhmnopq+SUC8UEVGNXIvWH7XyuTjwALfG6bFEgCkQA==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -2304,13 +2313,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.1.0.tgz",
+            "integrity": "sha512-k7MyrbD6E463CBbSpcOnwa8oXRdHzH1WiVzOipK3L5KSML92ZKgUBrTlehdi7PEIMT8k0bQixHUGXggPAlKnOQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
+                "@typescript-eslint/types": "7.1.0",
+                "@typescript-eslint/visitor-keys": "7.1.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -2356,17 +2365,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.1.0.tgz",
+            "integrity": "sha512-WUFba6PZC5OCGEmbweGpnNJytJiLG7ZvDBJJoUcX4qZYf1mGZ97mO2Mps6O2efxJcJdRNpqweCistDbZMwIVHw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
+                "@typescript-eslint/scope-manager": "7.1.0",
+                "@typescript-eslint/types": "7.1.0",
+                "@typescript-eslint/typescript-estree": "7.1.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -2377,16 +2386,16 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.56.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.1.0.tgz",
+            "integrity": "sha512-FhUqNWluiGNzlvnDZiXad4mZRhtghdoKW6e98GoEOYSu5cND+E39rG5KwJMUzeENwm1ztYBRqof8wMLP+wNPIA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
+                "@typescript-eslint/types": "7.1.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -2881,6 +2890,18 @@
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dev": true,
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2934,15 +2955,15 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "optional": true,
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "devOptional": true,
             "dependencies": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -3254,7 +3275,7 @@
             "version": "0.13.4",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -3372,7 +3393,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
             "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -3480,22 +3501,14 @@
             "dev": true
         },
         "node_modules/bonjour-service": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
-            "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
+            "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
             "dev": true,
             "dependencies": {
-                "array-flatten": "^2.1.2",
-                "dns-equal": "^1.0.0",
                 "fast-deep-equal": "^3.1.3",
                 "multicast-dns": "^7.2.5"
             }
-        },
-        "node_modules/bonjour-service/node_modules/array-flatten": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
-            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -3627,6 +3640,21 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3838,17 +3866,17 @@
             }
         },
         "node_modules/chromedriver": {
-            "version": "121.0.2",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-121.0.2.tgz",
-            "integrity": "sha512-58MUSCEE3oB3G3Y/Jo3URJ2Oa1VLHcVBufyYt7vNfGrABSJm7ienQLF9IQ8LPDlPVgLUXt2OBfggK3p2/SlEBg==",
+            "version": "122.0.4",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-122.0.4.tgz",
+            "integrity": "sha512-MxkaWaxCqefHyh9UorGzl1F6ZNBgC7pqgT0piAysLZdw20ojSgJ62ljG8SFbhDJqBTegKbmuioa6MQ1m4Czdsg==",
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
                 "@testim/chrome-version": "^1.1.4",
-                "axios": "^1.6.5",
+                "axios": "^1.6.7",
                 "compare-versions": "^6.1.0",
                 "extract-zip": "^2.0.1",
-                "https-proxy-agent": "^5.0.1",
+                "proxy-agent": "^6.4.0",
                 "proxy-from-env": "^1.1.0",
                 "tcp-port-used": "^1.0.2"
             },
@@ -3857,6 +3885,34 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/chromedriver/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+            "optional": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/chromedriver/node_modules/proxy-agent": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "optional": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/chromium-bidi": {
@@ -4649,6 +4705,34 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/default-browser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "dev": true,
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/default-gateway": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -4771,11 +4855,23 @@
                 "node": ">=10"
             }
         },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/degenerator": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -4864,16 +4960,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/dns-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-            "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
-            "dev": true
-        },
         "node_modules/dns-packet": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.0.tgz",
-            "integrity": "sha512-rza3UH1LwdHh9qyPXp8lkwpjSNk/AMD3dPytUoRoqnypDUhY0xvbdmVhWOfxO68frEfV9BU8V12Ez7ZsHGZpCQ==",
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+            "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
             "dev": true,
             "dependencies": {
                 "@leichtgewicht/ip-codec": "^2.0.1"
@@ -5226,7 +5316,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -5531,7 +5621,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -5568,7 +5658,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -5577,7 +5667,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5589,6 +5679,15 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/eventemitter3": {
@@ -6202,12 +6301,6 @@
                 "node": ">=14.14"
             }
         },
-        "node_modules/fs-monkey": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.4.tgz",
-            "integrity": "sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==",
-            "dev": true
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6316,31 +6409,6 @@
                 "node": "^16.13 || >=18 || >=20"
             }
         },
-        "node_modules/geckodriver/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/geckodriver/node_modules/https-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/geckodriver/node_modules/isexe": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -6435,7 +6503,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.1.tgz",
             "integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^5.0.1",
@@ -6450,7 +6518,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
             "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -6459,7 +6527,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
             "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
@@ -6473,7 +6541,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "dev": true,
+            "devOptional": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -6482,7 +6550,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -6708,7 +6776,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/grapheme-splitter": {
             "version": "1.0.4",
@@ -6936,24 +7004,12 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
-            "dev": true,
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "devOptional": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/http-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dev": true,
-            "dependencies": {
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -7025,16 +7081,16 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "optional": true,
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "devOptional": true,
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -7218,7 +7274,7 @@
             "version": "1.1.9",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
             "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/ip-regex": {
             "version": "4.3.0",
@@ -7283,6 +7339,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7313,6 +7384,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-interactive": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -7320,6 +7409,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.0.1.tgz",
+            "integrity": "sha512-OwQXkwBJeESyhFw+OumbJVD58BFBJJI5OM5S1+eyrDKlgDZPX2XNT5gXS56GSD3NPbbwUuMlR1Q71SRp5SobuQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-number": {
@@ -7398,27 +7499,15 @@
             "devOptional": true
         },
         "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "dev": true,
             "dependencies": {
-                "is-docker": "^2.0.0"
+                "is-inside-container": "^1.0.0"
             },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-wsl/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -8096,13 +8185,13 @@
             }
         },
         "node_modules/launch-editor": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
-            "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
+            "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
             "dev": true,
             "dependencies": {
                 "picocolors": "^1.0.0",
-                "shell-quote": "^1.7.3"
+                "shell-quote": "^1.8.1"
             }
         },
         "node_modules/lazystream": {
@@ -8531,15 +8620,19 @@
             }
         },
         "node_modules/memfs": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-            "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.7.7.tgz",
+            "integrity": "sha512-x9qc6k88J/VVwnfTkJV8pRRswJ2156Rc4w5rciRqKceFDZ0y1MqsNL9pkg5sE0GOcDzZYbonreALhaHzg1siFw==",
             "dev": true,
             "dependencies": {
-                "fs-monkey": "^1.0.4"
+                "tslib": "^2.0.0"
             },
             "engines": {
                 "node": ">= 4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
             }
         },
         "node_modules/meow": {
@@ -9032,7 +9125,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -9230,6 +9323,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/open": {
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.0.4.tgz",
+            "integrity": "sha512-oujJ/FFr7ra6/7gJuQ4ZJJ8Gf2VHM0J3J/W7IvH++zaqEzacWVxzK++NiVY5NLHTTj7u/jNH5H3Ei9biL31Lng==",
+            "dev": true,
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -9392,16 +9503,20 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+            "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
             "dev": true,
             "dependencies": {
-                "@types/retry": "0.12.0",
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
                 "retry": "^0.13.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-try": {
@@ -9414,44 +9529,19 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-t4tRAMx0uphnZrio0S0Jw9zg3oDbz1zVhQ/Vy18FjLfP1XOLNUEjaVxYCYRI6NS+BsMBXKIzV6cTLOkO9AtywA==",
-            "dev": true,
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+            "devOptional": true,
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
                 "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/pac-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
+                "socks-proxy-agent": "^8.0.2"
             },
             "engines": {
                 "node": ">= 14"
@@ -9461,7 +9551,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
             "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "ip": "^1.1.8",
@@ -9884,6 +9974,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9925,31 +10024,6 @@
                 "pac-proxy-agent": "^7.0.0",
                 "proxy-from-env": "^1.1.0",
                 "socks-proxy-agent": "^8.0.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
-            "dev": true,
-            "dependencies": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
             },
             "engines": {
                 "node": ">= 14"
@@ -10842,6 +10916,18 @@
             "resolved": "packages/selfhosted",
             "link": true
         },
+        "node_modules/run-applescript": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/run-async": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
@@ -10983,11 +11069,12 @@
             "dev": true
         },
         "node_modules/selfsigned": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
-            "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
             "dev": true,
             "dependencies": {
+                "@types/node-forge": "^1.3.0",
                 "node-forge": "^1"
             },
             "engines": {
@@ -11362,7 +11449,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">= 6.0.0",
                 "npm": ">= 3.0.0"
@@ -11392,7 +11479,7 @@
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
             "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "ip": "^2.0.0",
                 "smart-buffer": "^4.2.0"
@@ -11403,26 +11490,14 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
-            "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
-            "dev": true,
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+            "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+            "devOptional": true,
             "dependencies": {
-                "agent-base": "^7.0.1",
+                "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "socks": "^2.7.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/socks-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-            "dev": true,
-            "dependencies": {
-                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">= 14"
@@ -11432,13 +11507,13 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
             "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12276,12 +12351,12 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-            "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+            "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
             "dev": true,
             "engines": {
-                "node": ">=16.13.0"
+                "node": ">=16"
             },
             "peerDependencies": {
                 "typescript": ">=4.2.0"
@@ -12421,7 +12496,7 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -13156,77 +13231,82 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.0.0.tgz",
+            "integrity": "sha512-tZ5hqsWwww/8DislmrzXE3x+4f+v10H1z57mA2dWFrILb4i3xX+dPhTkcdR0DLyQztrhF2AUmO5nN085UYjd/Q==",
             "dev": true,
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
+                "memfs": "^4.6.0",
                 "mime-types": "^2.1.31",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
-            "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.0.2.tgz",
+            "integrity": "sha512-IVj3qsQhiLJR82zVg3QdPtngMD05CYP/Am+9NG5QSl+XwUR/UPtFwllRBKrMwM9ttzFsC6Zj3DMgniPyn/Z0hQ==",
             "dev": true,
             "dependencies": {
-                "@types/bonjour": "^3.5.9",
-                "@types/connect-history-api-fallback": "^1.3.5",
-                "@types/express": "^4.17.13",
-                "@types/serve-index": "^1.9.1",
-                "@types/serve-static": "^1.13.10",
-                "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.5",
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.0.11",
-                "chokidar": "^3.5.3",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^2.0.0",
                 "default-gateway": "^6.0.3",
                 "express": "^4.17.3",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.3.2",
+                "html-entities": "^2.4.0",
                 "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.0.1",
-                "launch-editor": "^2.6.0",
-                "open": "^8.0.9",
-                "p-retry": "^4.5.0",
-                "rimraf": "^3.0.2",
-                "schema-utils": "^4.0.0",
-                "selfsigned": "^2.1.1",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.6.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "rimraf": "^5.0.5",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^2.4.1",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.1",
-                "ws": "^8.13.0"
+                "webpack-dev-middleware": "^7.0.0",
+                "ws": "^8.16.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
+                "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -13237,13 +13317,28 @@
                 }
             }
         },
-        "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+        "node_modules/webpack-dev-server/node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
@@ -13255,36 +13350,43 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "dev": true,
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+        "node_modules/webpack-dev-server/node_modules/rimraf": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
+            "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
             "dev": true,
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/ws": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-merge": {
@@ -13755,8 +13857,8 @@
             "devDependencies": {
                 "@types/react": "^18.2.61",
                 "@types/react-dom": "^18.2.19",
-                "@typescript-eslint/eslint-plugin": "^6.21.0",
-                "@typescript-eslint/parser": "^6.21.0",
+                "@typescript-eslint/eslint-plugin": "^7.1.0",
+                "@typescript-eslint/parser": "^7.1.0",
                 "@vitejs/plugin-react": "^4.2.1",
                 "eslint": "^8.57.0",
                 "eslint-plugin-react-hooks": "^4.6.0",
@@ -13781,13 +13883,187 @@
                 "@types/jsonwebtoken": "^9.0.6",
                 "@types/mz": "^2.7.8",
                 "@types/request": "^2.48.12",
-                "archiver": "^6.0.2",
+                "archiver": "^7.0.0",
                 "json5": "^2.2.3",
                 "sign-addon": "^6.4.0",
                 "temp-dir": "^3.0.0",
                 "ts-loader": "^9.5.1",
                 "typescript": "^5.3.3",
                 "webpack-cli": "^5.1.4"
+            }
+        },
+        "packages/extension/node_modules/archiver": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.0.tgz",
+            "integrity": "sha512-R9HM9egs8FfktSqUqyjlKmvF4U+CWNqm/2tlROV+lOFg79MLdT67ae1l3hU47pGy8twSXxHoiefMCh43w0BriQ==",
+            "dev": true,
+            "dependencies": {
+                "archiver-utils": "^5.0.0",
+                "async": "^3.2.4",
+                "buffer-crc32": "^1.0.0",
+                "readable-stream": "^4.0.0",
+                "readdir-glob": "^1.1.2",
+                "tar-stream": "^3.0.0",
+                "zip-stream": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "packages/extension/node_modules/archiver-utils": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.1.tgz",
+            "integrity": "sha512-MMAoLdMvT/nckofX1tCLrf7uJce4jTNkiT6smA2u57AOImc1nce7mR3EDujxL5yv6/MnILuQH4sAsPtDS8kTvg==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^10.0.0",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.17.15",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "packages/extension/node_modules/archiver/node_modules/readable-stream": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+            "dev": true,
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "packages/extension/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "packages/extension/node_modules/buffer-crc32": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+            "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "packages/extension/node_modules/compress-commons": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.1.tgz",
+            "integrity": "sha512-l7occIJn8YwlCEbWUCrG6gPms9qnJTCZSaznCa5HaV+yJMH4kM8BDc7q9NyoQuoiB2O6jKgTcTeY462qw6MyHw==",
+            "dev": true,
+            "dependencies": {
+                "crc-32": "^1.2.0",
+                "crc32-stream": "^6.0.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "packages/extension/node_modules/compress-commons/node_modules/readable-stream": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+            "dev": true,
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "packages/extension/node_modules/crc32-stream": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+            "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+            "dev": true,
+            "dependencies": {
+                "crc-32": "^1.2.0",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "packages/extension/node_modules/crc32-stream/node_modules/readable-stream": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+            "dev": true,
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "packages/extension/node_modules/zip-stream": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.0.tgz",
+            "integrity": "sha512-X0WFquRRDtL9HR9hc1OrabOP/VKJEX7gAr2geayt3b7dLgXgSXI6ucC4CphLQP/aQt2GyHIYgmXxtC+dVdghAQ==",
+            "dev": true,
+            "dependencies": {
+                "archiver-utils": "^5.0.0",
+                "compress-commons": "^6.0.0",
+                "readable-stream": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "packages/extension/node_modules/zip-stream/node_modules/readable-stream": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+            "dev": true,
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "packages/selfhosted": {
@@ -13803,7 +14079,7 @@
                 "webdriverio": "^8.32.3",
                 "webpack": "^5.90.3",
                 "webpack-cli": "^5.1.4",
-                "webpack-dev-server": "^4.15.1"
+                "webpack-dev-server": "^5.0.2"
             }
         }
     }

--- a/web/package.json
+++ b/web/package.json
@@ -8,8 +8,8 @@
         "./packages/*"
     ],
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
+        "@typescript-eslint/eslint-plugin": "^7.1.0",
+        "@typescript-eslint/parser": "^7.1.0",
         "@wdio/cli": "^8.32.3",
         "@wdio/local-runner": "^8.32.3",
         "@wdio/mocha-framework": "^8.32.3",
@@ -34,7 +34,7 @@
         "webpack-cli": "^5.1.4"
     },
     "optionalDependencies": {
-        "chromedriver": "^121.0.2"
+        "chromedriver": "^122.0.4"
     },
     "scripts": {
         "build": "npm run build --workspace=ruffle-core && npm run build --workspace=ruffle-demo --workspace=ruffle-extension --workspace=ruffle-selfhosted",

--- a/web/packages/demo/package.json
+++ b/web/packages/demo/package.json
@@ -19,8 +19,8 @@
     "devDependencies": {
         "@types/react": "^18.2.61",
         "@types/react-dom": "^18.2.19",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
+        "@typescript-eslint/eslint-plugin": "^7.1.0",
+        "@typescript-eslint/parser": "^7.1.0",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/web/packages/extension/package.json
+++ b/web/packages/extension/package.json
@@ -23,7 +23,7 @@
         "@types/jsonwebtoken": "^9.0.6",
         "@types/mz": "^2.7.8",
         "@types/request": "^2.48.12",
-        "archiver": "^6.0.2",
+        "archiver": "^7.0.0",
         "json5": "^2.2.3",
         "sign-addon": "^6.4.0",
         "temp-dir": "^3.0.0",

--- a/web/packages/selfhosted/package.json
+++ b/web/packages/selfhosted/package.json
@@ -25,6 +25,6 @@
         "json5": "^2.2.3",
         "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^4.15.1"
+        "webpack-dev-server": "^5.0.2"
     }
 }


### PR DESCRIPTION
Same as https://github.com/ruffle-rs/ruffle/pull/15365, but excluding the `chai` and `chai-html` bumps.