### PR TITLE
chore: Switch `fluent-templates` back from `master` to `v0.9.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,8 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-template-macros"
-version = "0.8.0"
-source = "git+https://github.com/XAMPPRocky/fluent-templates?rev=4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf#4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c58fd7421bad2b89506827409317a3088b74d0d637202003f2e87efdc43ae8e"
 dependencies = [
  "flume 0.10.14",
  "ignore",
@@ -1981,8 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-templates"
-version = "0.8.0"
-source = "git+https://github.com/XAMPPRocky/fluent-templates?rev=4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf#4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc023356542b155925aa5e433806ddd33acb46f0218541f869b342676332cd79"
 dependencies = [
  "arc-swap",
  "fluent",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ clap = { version = "4.5.1", features = ["derive"], optional=true }
 realfft = "3.3.0"
 hashbrown = { version = "0.14.3", features = ["raw"] }
 scopeguard = "1.2.0"
-fluent-templates = { git = "https://github.com/XAMPPRocky/fluent-templates", rev = "4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf" }
+fluent-templates = "0.9.0"
 egui = { workspace = true, optional = true }
 egui_extras = { version = "0.26.2", optional = true }
 png = { version = "0.17.13", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -71,5 +71,4 @@ unknown-git = "deny"
 #  github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
-    "XAMPPRocky" # Remove once there's a new release of fluent-templates
 ]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -41,7 +41,7 @@ sys-locale = "0.3.1"
 wgpu = { workspace = true }
 futures = "0.3.30"
 chrono = { version = "0.4", default-features = false, features = [] }
-fluent-templates = { git = "https://github.com/XAMPPRocky/fluent-templates", rev = "4ed6eebae897c19c4bc7e80800f54d7b8e65a9cf" }
+fluent-templates = "0.9.0"
 futures-lite = "2.2.0"
 async-io = "2.3.1"
 async-net = "2.0.0"


### PR DESCRIPTION
It just came out!