### PR TITLE
core: Close sockets and timers when replacing the root movie

### DIFF
--- a/core/src/backend/audio.rs
+++ b/core/src/backend/audio.rs
@@ -518,11 +518,11 @@ impl<'gc> AudioManager<'gc> {
         audio.stop_all_sounds();
     }
 
-    pub fn is_sound_playing(&mut self, sound: SoundInstanceHandle) -> bool {
+    pub fn is_sound_playing(&self, sound: SoundInstanceHandle) -> bool {
         self.sounds.iter().any(|other| other.instance == sound)
     }
 
-    pub fn is_sound_playing_with_handle(&mut self, sound: SoundHandle) -> bool {
+    pub fn is_sound_playing_with_handle(&self, sound: SoundHandle) -> bool {
         self.sounds.iter().any(|other| other.sound == Some(sound))
     }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -321,11 +321,11 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
         self.audio_manager.stop_all_sounds(self.audio)
     }
 
-    pub fn is_sound_playing(&mut self, sound: SoundInstanceHandle) -> bool {
+    pub fn is_sound_playing(&self, sound: SoundInstanceHandle) -> bool {
         self.audio_manager.is_sound_playing(sound)
     }
 
-    pub fn is_sound_playing_with_handle(&mut self, sound: SoundHandle) -> bool {
+    pub fn is_sound_playing_with_handle(&self, sound: SoundHandle) -> bool {
         self.audio_manager.is_sound_playing_with_handle(sound)
     }
 
@@ -348,7 +348,7 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
     ///
     /// This should only be called once, as it makes no attempt at removing
     /// previous stage contents. If you need to load a new root movie, you
-    /// should destroy and recreate the player instance.
+    /// should use `replace_root_movie`.
     pub fn set_root_movie(&mut self, movie: SwfMovie) {
         if !self.forced_frame_rate {
             *self.frame_rate = movie.frame_rate().into();
@@ -452,6 +452,17 @@ impl<'a, 'gc> UpdateContext<'a, 'gc> {
         drop(activation);
 
         self.audio.set_frame_rate(*self.frame_rate);
+    }
+
+    pub fn replace_root_movie(&mut self, movie: SwfMovie) {
+        // FIXME Use RAII here, e.g. destroy and recreate
+        //       the player instance instead of cleaning up.
+
+        // Clean up the stage before loading another root movie.
+        self.sockets.close_all();
+        self.timers.remove_all();
+
+        self.set_root_movie(movie);
     }
 }
 

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1019,7 +1019,7 @@ impl<'gc> Loader<'gc> {
 
                     let movie = SwfMovie::from_data(&body, url.to_string(), loader_url)?;
                     player.lock().unwrap().mutate_with_update_context(|uc| {
-                        uc.set_root_movie(movie);
+                        uc.replace_root_movie(movie);
                     });
                     return Ok(());
                 }
@@ -1102,7 +1102,7 @@ impl<'gc> Loader<'gc> {
                 "loadBytes",
                 "replacing root movie"
             );
-            uc.set_root_movie(movie);
+            uc.replace_root_movie(movie);
             return Ok(());
         }
 

--- a/core/src/timer.rs
+++ b/core/src/timer.rs
@@ -258,6 +258,10 @@ impl<'gc> Timers<'gc> {
         len < old_len
     }
 
+    pub fn remove_all(&mut self) {
+        self.timers.clear()
+    }
+
     /// Changes the delay of a timer.
     pub fn set_delay(&mut self, id: i32, interval: i32) {
         // SANITY: Set a minimum interval so we don't spam too much.

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -93,7 +93,7 @@ impl From<&GlobalPreferences> for PlayerOptions {
 /// which may be lost when this Player is closed (dropped)
 struct ActivePlayer {
     player: Arc<Mutex<Player>>,
-    executor: Arc<Mutex<WinitAsyncExecutor>>,
+    executor: Arc<WinitAsyncExecutor>,
 }
 
 impl ActivePlayer {
@@ -342,11 +342,7 @@ impl PlayerController {
 
     pub fn poll(&self) {
         if let Some(player) = &self.player {
-            player
-                .executor
-                .lock()
-                .expect("Executor lock must be available")
-                .poll_all()
+            player.executor.poll_all()
         }
     }
 }


### PR DESCRIPTION
Turns out that the comment from `set_root_movie` was right all along! `set_root_movie` should not be used when replacing the root movie, because it will leave out unclosed resources. This patch introduces `replace_root_movie`, which is dedicated to be used when replacing (instead of just setting) the root movie.

The best solution would be to use RAII, e.g. destroy and recreate the whole Player instance, but this patch is a first step towards proper resource control.

Additionally, I made WinitAsyncExecutor thread-safe and fixed potential deadlocks, because they started happening when sockets were closed during a task poll.
