### PR TITLE
chore: Update `wasm-bindgen` to `v0.2.92`

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -313,7 +313,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in test_web.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.91
+        run: cargo install wasm-bindgen-cli --version 0.2.92
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test_extension_dockerfile.yml
+++ b/.github/workflows/test_extension_dockerfile.yml
@@ -29,7 +29,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.91
+        run: cargo install wasm-bindgen-cli --version 0.2.92
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -61,7 +61,7 @@ jobs:
       # wasm-bindgen-cli version must match wasm-bindgen crate version.
       # Be sure to update in release_nightly.yml, web/Cargo.toml and web/README.md.
       - name: Install wasm-bindgen
-        run: cargo install wasm-bindgen-cli --version 0.2.91
+        run: cargo install wasm-bindgen-cli --version 0.2.92
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6213,9 +6213,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -6019,9 +6019,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6029,9 +6029,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -6044,9 +6044,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6056,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6066,9 +6066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6079,9 +6079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-streams"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -71,7 +71,7 @@ id3 = "1.12.0"
 version = "0.3.30"
 
 [target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen-futures]
-version = "0.4.41"
+version = "0.4.42"
 
 [features]
 default = []

--- a/render/Cargo.toml
+++ b/render/Cargo.toml
@@ -22,7 +22,7 @@ downcast-rs = "1.2.0"
 lyon = { version = "1.0.1", optional = true }
 lyon_geom = "1.0.5"
 thiserror = "1.0"
-wasm-bindgen = { version = "=0.2.91", optional = true }
+wasm-bindgen = { version = "=0.2.92", optional = true }
 enum-map = "2.7.3"
 serde = { version = "1.0.197", features = ["derive"] }
 clap = { version = "4.5.1", features = ["derive"], optional = true }

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 js-sys = "0.3.68"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
-wasm-bindgen = "=0.2.91"
+wasm-bindgen = "=0.2.92"
 fnv = "1.0.7"
 ruffle_render = { path = "..", features = ["web"] }
 swf = { path = "../../swf" }

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-js-sys = "0.3.68"
+js-sys = "0.3.69"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 wasm-bindgen = "=0.2.92"
@@ -21,7 +21,7 @@ swf = { path = "../../swf" }
 downcast-rs = "1.2.0"
 
 [dependencies.web-sys]
-version = "0.3.68"
+version = "0.3.69"
 features = [
     "CanvasGradient", "CanvasPattern", "CanvasRenderingContext2d", "CanvasWindingRule", "CssStyleDeclaration",
     "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageData", "Navigator", "Path2d", "SvgMatrix",

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -15,7 +15,7 @@ js-sys = "0.3.68"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 ruffle_render = { path = "..", features = ["tessellator", "web"] }
-wasm-bindgen = "=0.2.91"
+wasm-bindgen = "=0.2.92"
 bytemuck = { version = "1.14.3", features = ["derive"] }
 fnv = "1.0.7"
 swf = { path = "../../swf" }

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-js-sys = "0.3.68"
+js-sys = "0.3.69"
 log = "0.4"
 ruffle_web_common = { path = "../../web/common" }
 ruffle_render = { path = "..", features = ["tessellator", "web"] }
@@ -23,7 +23,7 @@ thiserror = "1.0"
 downcast-rs = "1.2.0"
 
 [dependencies.web-sys]
-version = "0.3.68"
+version = "0.3.69"
 features = [
     "HtmlCanvasElement", "OesVertexArrayObject", "WebGl2RenderingContext", "WebGlBuffer", "WebglDebugRendererInfo",
     "WebGlFramebuffer", "WebGlProgram", "WebGlRenderbuffer", "WebGlRenderingContext", "WebGlShader", "WebGlTexture",

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.3.30"
 
 # wasm
 [target.'cfg(target_family = "wasm")'.dependencies.web-sys]
-version = "0.3.68"
+version = "0.3.69"
 features = ["HtmlCanvasElement"]
 
 [features]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -33,7 +33,7 @@ profiling = []
 [dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }
 slotmap = { workspace = true }
-js-sys = "0.3.68"
+js-sys = "0.3.69"
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["registry"] }
 tracing-log = "0.2.0"
@@ -65,7 +65,7 @@ path = "../core"
 features = ["audio", "mp3", "nellymoser", "default_compatibility_rules", "default_font"]
 
 [dependencies.web-sys]
-version = "0.3.68"
+version = "0.3.69"
 features = [
     "AddEventListenerOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioContext",
     "AudioDestinationNode", "AudioNode", "AudioParam", "Blob", "BlobPropertyBag",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -45,8 +45,8 @@ ruffle_render_webgl = { path = "../render/webgl", optional = true }
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
 ruffle_video_software = { path = "../video/software" }
 url = "2.5.0"
-wasm-bindgen = "=0.2.91"
-wasm-bindgen-futures = "0.4.41"
+wasm-bindgen = "=0.2.92"
+wasm-bindgen-futures = "0.4.42"
 serde-wasm-bindgen = "0.6.5"
 chrono = { version = "0.4", default-features = false, features = ["wasmbind", "clock"] }
 getrandom = { version = "0.2", features = ["js"] }

--- a/web/README.md
+++ b/web/README.md
@@ -65,7 +65,7 @@ Note that npm 7 or newer is required. It should come bundled with Node.js 15 or 
 
 <!-- Be sure to also update the wasm-bindgen-cli version in `.github/workflows/*.yml` and `web/Cargo.toml`. -->
 
-This can be installed with `cargo install wasm-bindgen-cli --version 0.2.91`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
+This can be installed with `cargo install wasm-bindgen-cli --version 0.2.92`. Be sure to install this specific version of `wasm-bindgen-cli` to match the version used by Ruffle.
 
 #### Binaryen
 

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -9,10 +9,10 @@ license = "MIT OR Apache-2.0"
 workspace = true
 
 [dependencies]
-js-sys = "0.3.68"
+js-sys = "0.3.69"
 tracing = { workspace = true }
 wasm-bindgen = "=0.2.92"
 
 [dependencies.web-sys]
-version = "0.3.68"
+version = "0.3.69"
 features = ["Window"]

--- a/web/common/Cargo.toml
+++ b/web/common/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 js-sys = "0.3.68"
 tracing = { workspace = true }
-wasm-bindgen = "=0.2.91"
+wasm-bindgen = "=0.2.92"
 
 [dependencies.web-sys]
 version = "0.3.68"

--- a/web/docker/Dockerfile
+++ b/web/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM node:20
 # Installing Rust using rustup:
 RUN wget 'https://sh.rustup.rs' --quiet -O- | sh -s -- -y --profile minimal --target wasm32-unknown-unknown
 ENV PATH="/root/.cargo/bin:$PATH"
-RUN cargo install wasm-bindgen-cli --version 0.2.91
+RUN cargo install wasm-bindgen-cli --version 0.2.92
 # Building Ruffle:
 COPY . ruffle
 WORKDIR ruffle/web


### PR DESCRIPTION
This brings in https://github.com/rustwasm/wasm-bindgen/pull/3851, which will hopefully bring us closer to deterministic WASM modules for AMO.
It wasn't trivial: https://github.com/rustwasm/wasm-bindgen/pull/3870