### PR TITLE
chore: Update `cargo-deny` configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,10 +1,9 @@
-
+[graph]
 # If true, metadata will be collected with `--all-features`.
 all-features = true
 
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
+version = 2
 
 # List of explicitly allowed licenses
 allow = [
@@ -16,18 +15,12 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "MPL-2.0",
     "BSL-1.0",
     "CC0-1.0",
     "OFL-1.1",
     "LicenseRef-UFL-1.0",
-]
-
-# List of explicitly disallowed licenses
-deny = [
-    "GPL-1.0",
-    "GPL-2.0",
-    "GPL-3.0",
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -72,3 +65,6 @@ unknown-git = "deny"
 github = [
     "ruffle-rs",
 ]
+
+[advisories]
+version = 2


### PR DESCRIPTION
Makes CI check go green.

Reason is: https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v1.6.0

Explanation of changes:
 - `all-features` got moved under `graph`: https://github.com/EmbarkStudios/cargo-deny/pull/605
 - The Unicode 3.0 license is what superseded the previous DFS license: https://opensource.org/license/unicode-inc-license-agreement-data-files-and-software
  - `licenses.unlicensed` and `licenses.deny` got deprecated, as `deny` is now the default policy: https://github.com/EmbarkStudios/cargo-deny/pull/606
  - Updating to new config version: https://github.com/EmbarkStudios/cargo-deny/pull/611