### PR TITLE
avm2: Lookup multinames in verifier and store them in `Op`

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -935,7 +935,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::GetOuterScope { index } => self.op_get_outer_scope(*index),
                 Op::GetScopeObject { index } => self.op_get_scope_object(*index),
                 Op::GetGlobalScope => self.op_get_global_scope(),
-                Op::FindDef { index } => self.op_find_def(method, *index),
+                Op::FindDef { multiname } => self.op_find_def(*multiname),
                 Op::FindProperty { multiname } => self.op_find_property(*multiname),
                 Op::FindPropStrict { multiname } => self.op_find_prop_strict(*multiname),
                 Op::GetLex { multiname } => self.op_get_lex(*multiname),
@@ -1649,10 +1649,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_find_def(
         &mut self,
-        method: Gc<'gc, BytecodeMethod<'gc>>,
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
-        let multiname = self.pool_multiname_static(method, index)?;
+        // Verifier ensures that multiname is non-lazy
+
         avm_debug!(self.avm2(), "Resolving {:?}", *multiname);
         let (_, mut script) = self.domain().find_defining_script(self, &multiname)?;
         let obj = script.globals(&mut self.context)?;

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -1192,7 +1192,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
     fn op_call_method(
         &mut self,
-        index: Index<AbcMethod>,
+        index: u32,
         arg_count: u32,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         // The entire implementation of VTable assumes that
@@ -1205,7 +1205,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let args = self.pop_stack_args(arg_count);
         let receiver = self.pop_stack().coerce_to_object_or_typeerror(self, None)?;
 
-        let value = receiver.call_method(index.0, &args, self)?;
+        let value = receiver.call_method(index, &args, self)?;
 
         self.push_stack(value);
 

--- a/core/src/avm2/class.rs
+++ b/core/src/avm2/class.rs
@@ -166,6 +166,12 @@ pub struct Class<'gc> {
     class_objects: Vec<ClassObject<'gc>>,
 }
 
+impl<'gc> core::fmt::Debug for Class<'gc> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("Class").field("name", &self.name()).finish()
+    }
+}
+
 /// Allows using a `GcCell<'gc, Class<'gc>>` as a HashMap key,
 /// using the pointer address for hashing/equality.
 #[derive(Collect, Copy, Clone)]

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -206,6 +206,24 @@ pub fn make_error_1010<'gc>(
 
 #[inline(never)]
 #[cold]
+pub fn make_error_1014<'gc>(
+    activation: &mut Activation<'_, 'gc>,
+    class_name: AvmString<'gc>,
+) -> Error<'gc> {
+    let err = verify_error(
+        activation,
+        &format!("Error #1014: Class {} could not be found.", class_name),
+        1014,
+    );
+
+    match err {
+        Ok(err) => Error::AvmError(err),
+        Err(err) => err,
+    }
+}
+
+#[inline(never)]
+#[cold]
 pub fn make_error_1021<'gc>(activation: &mut Activation<'_, 'gc>) -> Error<'gc> {
     let err = verify_error(
         activation,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -1,5 +1,6 @@
 use crate::avm2::class::Class;
 use crate::avm2::multiname::Multiname;
+use crate::string::AvmAtom;
 
 use gc_arena::{Collect, Gc, GcCell};
 use swf::avm2::types::{
@@ -95,13 +96,11 @@ pub enum Op<'gc> {
     ConvertS,
     Debug {
         is_local_register: bool,
-        #[collect(require_static)]
-        register_name: Index<String>,
+        register_name: AvmAtom<'gc>,
         register: u8,
     },
     DebugFile {
-        #[collect(require_static)]
-        file_name: Index<String>,
+        file_name: AvmAtom<'gc>,
     },
     DebugLine {
         line_num: u32,
@@ -120,8 +119,7 @@ pub enum Op<'gc> {
     Divide,
     Dup,
     Dxns {
-        #[collect(require_static)]
-        index: Index<String>,
+        string: AvmAtom<'gc>,
     },
     DxnsLate,
     Equals,
@@ -300,8 +298,7 @@ pub enum Op<'gc> {
         value: i16,
     },
     PushString {
-        #[collect(require_static)]
-        value: Index<String>,
+        string: AvmAtom<'gc>,
     },
     PushTrue,
     PushUint {

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -1,14 +1,22 @@
-use swf::avm2::types::{Class, Exception, Index, LookupSwitch, Method, Multiname, Namespace};
+use crate::avm2::class::Class;
+use crate::avm2::multiname::Multiname;
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum Op {
+use gc_arena::{Collect, Gc, GcCell};
+use swf::avm2::types::{
+    Class as AbcClass, Exception, Index, LookupSwitch, Method, Multiname as AbcMultiname, Namespace,
+};
+
+#[derive(Clone, Collect, Debug)]
+#[collect(no_drop)]
+pub enum Op<'gc> {
     Add,
     AddI,
     ApplyType {
         num_types: u32,
     },
     AsType {
-        type_name: Index<Multiname>,
+        #[collect(require_static)]
+        type_name: Index<AbcMultiname>,
     },
     AsTypeLate,
     BitAnd,
@@ -23,36 +31,48 @@ pub enum Op {
         num_args: u32,
     },
     CallMethod {
+        #[collect(require_static)]
         index: Index<Method>,
+
         num_args: u32,
     },
     CallProperty {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
+
         num_args: u32,
     },
     CallPropLex {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
+
         num_args: u32,
     },
     CallPropVoid {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
+
         num_args: u32,
     },
     CallStatic {
+        #[collect(require_static)]
         index: Index<Method>,
+
         num_args: u32,
     },
     CallSuper {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
+
         num_args: u32,
     },
     CallSuperVoid {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
+
         num_args: u32,
     },
     CheckFilter,
     Coerce {
-        index: Index<Multiname>,
+        class: GcCell<'gc, Class<'gc>>,
     },
     CoerceA,
     CoerceB,
@@ -65,7 +85,7 @@ pub enum Op {
         num_args: u32,
     },
     ConstructProp {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
         num_args: u32,
     },
     ConstructSuper {
@@ -75,10 +95,12 @@ pub enum Op {
     ConvertS,
     Debug {
         is_local_register: bool,
+        #[collect(require_static)]
         register_name: Index<String>,
         register: u8,
     },
     DebugFile {
+        #[collect(require_static)]
         file_name: Index<String>,
     },
     DebugLine {
@@ -93,11 +115,12 @@ pub enum Op {
     Decrement,
     DecrementI,
     DeleteProperty {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     Divide,
     Dup,
     Dxns {
+        #[collect(require_static)]
         index: Index<String>,
     },
     DxnsLate,
@@ -105,23 +128,25 @@ pub enum Op {
     EscXAttr,
     EscXElem,
     FindDef {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
     },
     FindProperty {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     FindPropStrict {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     GetDescendants {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
     },
     GetGlobalScope,
     GetGlobalSlot {
         index: u32,
     },
     GetLex {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     GetLocal {
         index: u32,
@@ -130,7 +155,7 @@ pub enum Op {
         index: u32,
     },
     GetProperty {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     GetScopeObject {
         index: u8,
@@ -139,7 +164,8 @@ pub enum Op {
         index: u32,
     },
     GetSuper {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
     },
     GreaterEquals,
     GreaterThan,
@@ -200,11 +226,12 @@ pub enum Op {
     Increment,
     IncrementI,
     InitProperty {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     InstanceOf,
     IsType {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
     },
     IsTypeLate,
     Jump {
@@ -220,7 +247,7 @@ pub enum Op {
     Li16,
     Li32,
     Li8,
-    LookupSwitch(Box<LookupSwitch>),
+    LookupSwitch(#[collect(require_static)] Box<LookupSwitch>),
     LShift,
     Modulo,
     Multiply,
@@ -232,12 +259,15 @@ pub enum Op {
         num_args: u32,
     },
     NewCatch {
+        #[collect(require_static)]
         index: Index<Exception>,
     },
     NewClass {
-        index: Index<Class>,
+        #[collect(require_static)]
+        index: Index<AbcClass>,
     },
     NewFunction {
+        #[collect(require_static)]
         index: Index<Method>,
     },
     NewObject {
@@ -260,6 +290,7 @@ pub enum Op {
         value: i32,
     },
     PushNamespace {
+        #[collect(require_static)]
         value: Index<Namespace>,
     },
     PushNaN,
@@ -269,6 +300,7 @@ pub enum Op {
         value: i16,
     },
     PushString {
+        #[collect(require_static)]
         value: Index<String>,
     },
     PushTrue,
@@ -287,13 +319,14 @@ pub enum Op {
         index: u32,
     },
     SetProperty {
-        index: Index<Multiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     SetSlot {
         index: u32,
     },
     SetSuper {
-        index: Index<Multiname>,
+        #[collect(require_static)]
+        index: Index<AbcMultiname>,
     },
     Sf32,
     Sf64,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -16,8 +16,7 @@ pub enum Op<'gc> {
         num_types: u32,
     },
     AsType {
-        #[collect(require_static)]
-        type_name: Index<AbcMultiname>,
+        class: GcCell<'gc, Class<'gc>>,
     },
     AsTypeLate,
     BitAnd,
@@ -228,8 +227,7 @@ pub enum Op<'gc> {
     },
     InstanceOf,
     IsType {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        class: GcCell<'gc, Class<'gc>>,
     },
     IsTypeLate,
     Jump {

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -125,8 +125,7 @@ pub enum Op<'gc> {
     EscXAttr,
     EscXElem,
     FindDef {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     FindProperty {
         multiname: Gc<'gc, Multiname<'gc>>,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -31,8 +31,7 @@ pub enum Op<'gc> {
         num_args: u32,
     },
     CallMethod {
-        #[collect(require_static)]
-        index: Index<Method>,
+        index: u32,
 
         num_args: u32,
     },

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -622,7 +622,9 @@ pub fn optimize<'gc>(
                                         value_class,
                                     );
                                 }
-                                Some(Property::Virtual { get: Some(disp_id), .. }) => {
+                                Some(Property::Virtual {
+                                    get: Some(disp_id), ..
+                                }) => {
                                     *op = Op::CallMethod {
                                         num_args: 0,
                                         index: disp_id,

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -8,7 +8,6 @@ use crate::avm2::property::Property;
 
 use gc_arena::{Gc, GcCell};
 use std::collections::HashSet;
-use swf::avm2::types::Index;
 
 #[derive(Clone, Copy, Debug)]
 enum ValueType<'gc> {
@@ -623,10 +622,10 @@ pub fn optimize<'gc>(
                                         value_class,
                                     );
                                 }
-                                Some(Property::Virtual { get: Some(get), .. }) => {
+                                Some(Property::Virtual { get: Some(disp_id), .. }) => {
                                     *op = Op::CallMethod {
                                         num_args: 0,
-                                        index: Index::new(get),
+                                        index: disp_id,
                                     };
                                 }
                                 _ => {}
@@ -737,7 +736,7 @@ pub fn optimize<'gc>(
                                 Some(Property::Method { disp_id }) => {
                                     *op = Op::CallMethod {
                                         num_args: *num_args,
-                                        index: Index::new(disp_id),
+                                        index: disp_id,
                                     };
                                 }
                                 _ => {}

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -487,34 +487,12 @@ pub fn optimize<'gc>(
                 stack.pop();
                 stack.push_any();
             }
-            Op::AsType {
-                type_name: name_index,
-            } => {
-                let multiname = method
-                    .translation_unit()
-                    .pool_maybe_uninitialized_multiname(*name_index, &mut activation.context);
-
-                let resolved_type = if let Ok(multiname) = multiname {
-                    if !multiname.has_lazy_component() {
-                        activation
-                            .domain()
-                            .get_class(&multiname, activation.context.gc_context)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                };
-
+            Op::AsType { class } => {
                 let stack_value = stack.pop();
-                if resolved_type.is_some() && matches!(stack_value, Some(ValueType::Null)) {
-                    *op = Op::Nop;
-                }
+                stack.push_class(*class);
 
-                if let Some(resolved_type) = resolved_type {
-                    stack.push_class(resolved_type);
-                } else {
-                    stack.push_any();
+                if matches!(stack_value, Some(ValueType::Null)) {
+                    *op = Op::Nop;
                 }
             }
             Op::Coerce { class } => {

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -247,7 +247,7 @@ pub fn verify_method<'gc>(
 
                 // Misc opcode verification
                 AbcOp::CallMethod { index, .. } => {
-                    return Err(Error::AvmError(if index.as_u30() == 0 {
+                    return Err(Error::AvmError(if index == 0 {
                         verify_error(activation, "Error #1072: Disp_id 0 is illegal.", 1072)?
                     } else {
                         verify_error(

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -1,7 +1,7 @@
 use crate::avm2::class::Class;
 use crate::avm2::error::{
-    make_error_1021, make_error_1025, make_error_1032, make_error_1054, make_error_1107,
-    verify_error,
+    make_error_1014, make_error_1021, make_error_1025, make_error_1032, make_error_1054,
+    make_error_1107, verify_error,
 };
 use crate::avm2::method::BytecodeMethod;
 use crate::avm2::multiname::Multiname;
@@ -299,27 +299,16 @@ pub fn verify_method<'gc>(
 
                     if multiname.has_lazy_component() {
                         // This matches FP's error message
-                        return Err(Error::AvmError(verify_error(
-                            activation,
-                            "Error #1014: Class [] could not be found.",
-                            1014,
-                        )?));
+                        return Err(make_error_1014(activation, "[]".into()));
                     }
 
                     activation
                         .domain()
                         .get_class(&multiname, activation.context.gc_context)
                         .ok_or_else(|| {
-                            Error::AvmError(
-                                verify_error(
-                                    activation,
-                                    &format!(
-                                        "Error #1014: Class {} could not be found.",
-                                        multiname.to_qualified_name(activation.context.gc_context)
-                                    ),
-                                    1014,
-                                )
-                                .expect("Error should construct"),
+                            make_error_1014(
+                                activation,
+                                multiname.to_qualified_name(activation.context.gc_context),
                             )
                         })?;
                 }
@@ -419,27 +408,16 @@ pub fn verify_method<'gc>(
 
             if pooled_type_name.has_lazy_component() {
                 // This matches FP's error message
-                return Err(Error::AvmError(verify_error(
-                    activation,
-                    "Error #1014: Class [] could not be found.",
-                    1014,
-                )?));
+                return Err(make_error_1014(activation, "[]".into()));
             }
 
             let resolved_type = activation
                 .domain()
                 .get_class(&pooled_type_name, activation.context.gc_context)
                 .ok_or_else(|| {
-                    Error::AvmError(
-                        verify_error(
-                            activation,
-                            &format!(
-                                "Error #1014: Class {} could not be found.",
-                                pooled_type_name.to_qualified_name(activation.context.gc_context)
-                            ),
-                            1014,
-                        )
-                        .expect("Error should construct"),
+                    make_error_1014(
+                        activation,
+                        pooled_type_name.to_qualified_name(activation.context.gc_context),
                     )
                 })?;
 

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -272,7 +272,7 @@ pub fn verify_method<'gc>(
                     }
                 }
 
-                AbcOp::GetLex { index } => {
+                AbcOp::GetLex { index } | AbcOp::FindDef { index } => {
                     let multiname = method
                         .translation_unit()
                         .pool_maybe_uninitialized_multiname(index, &mut activation.context)?;
@@ -712,7 +712,12 @@ fn resolve_op<'gc>(
         AbcOp::GetOuterScope { index } => Op::GetOuterScope { index },
         AbcOp::GetScopeObject { index } => Op::GetScopeObject { index },
         AbcOp::GetGlobalScope => Op::GetGlobalScope,
-        AbcOp::FindDef { index } => Op::FindDef { index },
+        AbcOp::FindDef { index } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+            // Verifier guarantees that multiname was non-lazy
+
+            Op::FindDef { multiname }
+        }
         AbcOp::FindProperty { index } => {
             let multiname = pool_multiname(activation, translation_unit, index)?;
 

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -819,9 +819,31 @@ fn resolve_op<'gc>(
         },
         AbcOp::NextName => Op::NextName,
         AbcOp::NextValue => Op::NextValue,
-        AbcOp::IsType { index } => Op::IsType { index },
+        AbcOp::IsType { index } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+            // Verifier guarantees that multiname was non-lazy
+
+            let class = activation
+                .domain()
+                .get_class(&multiname, activation.context.gc_context)
+                .unwrap();
+            // Verifier guarantees that class exists
+
+            Op::IsType { class }
+        }
         AbcOp::IsTypeLate => Op::IsTypeLate,
-        AbcOp::AsType { type_name } => Op::AsType { type_name },
+        AbcOp::AsType { type_name } => {
+            let multiname = pool_multiname(activation, translation_unit, type_name)?;
+            // Verifier guarantees that multiname was non-lazy
+
+            let class = activation
+                .domain()
+                .get_class(&multiname, activation.context.gc_context)
+                .unwrap();
+            // Verifier guarantees that class exists
+
+            Op::AsType { class }
+        }
         AbcOp::AsTypeLate => Op::AsTypeLate,
         AbcOp::InstanceOf => Op::InstanceOf,
         AbcOp::Label => Op::Nop,

--- a/swf/src/avm2/read.rs
+++ b/swf/src/avm2/read.rs
@@ -544,7 +544,7 @@ impl<'a> Reader<'a> {
                 num_args: self.read_u30()?,
             },
             OpCode::CallMethod => Op::CallMethod {
-                index: self.read_index()?,
+                index: self.read_u30()?,
                 num_args: self.read_u30()?,
             },
             OpCode::CallProperty => Op::CallProperty {

--- a/swf/src/avm2/types.rs
+++ b/swf/src/avm2/types.rs
@@ -275,7 +275,7 @@ pub enum Op {
         num_args: u32,
     },
     CallMethod {
-        index: Index<Method>,
+        index: u32,
         num_args: u32,
     },
     CallProperty {

--- a/swf/src/avm2/write.rs
+++ b/swf/src/avm2/write.rs
@@ -615,12 +615,9 @@ impl<W: Write> Writer<W> {
                 self.write_opcode(OpCode::Call)?;
                 self.write_u30(num_args)?;
             }
-            Op::CallMethod {
-                ref index,
-                num_args,
-            } => {
+            Op::CallMethod { index, num_args } => {
                 self.write_opcode(OpCode::CallMethod)?;
-                self.write_index(index)?;
+                self.write_u30(index)?;
                 self.write_u30(num_args)?;
             }
             Op::CallProperty {
@@ -1119,7 +1116,7 @@ pub mod tests {
 
         assert_eq!(
             write(Op::CallMethod {
-                index: Index::new(1),
+                index: 1,
                 num_args: 2
             }),
             b"\x43\x01\x02"


### PR DESCRIPTION
Most common ops now no longer call `pool_maybe_uninitialized_multiname` or similar functions. As a result, `pool_maybe_uninitialized_multiname` practically disappears from profiles for most SWFs. 

TODO:
- [x] Lookup classes for `AsType` and `IsType`
- [x] Move all string lookups to `verify.rs`
- [x] Lookup exception classes and multinames