### PR TITLE
desktop: Log to disk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Ruffle is a young project, and there is still much Flash functionality that is u
 
 ## Debugging ActionScript Content
 
-To enable debug logging, set `RUST_LOG=warn,ruffle_core=debug,avm_trace=trace` and run Ruffle from the command line. 
+To enable debug logging, set `RUST_LOG=warn,ruffle=info,ruffle_core=debug,avm_trace=info` and run Ruffle from the command line. 
 This will also enable printing `trace()` statements.
 
 Additionally, if you build Ruffle with `--features avm_debug` then you will activate a few more built-in debugging utilities inside Ruffle, listed below.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4388,6 +4388,7 @@ dependencies = [
  "tokio",
  "toml_edit 0.22.6",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-tracy",
  "unic-langid",
@@ -5464,6 +5465,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -25,6 +25,7 @@ ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 ruffle_video_software = { path = "../video/software", optional = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+tracing-appender = "0.2.3"
 slotmap = { workspace = true }
 winit = "0.29.14"
 webbrowser = "0.8.13"

--- a/desktop/assets/texts/en-US/preferences_dialog.ftl
+++ b/desktop/assets/texts/en-US/preferences_dialog.ftl
@@ -13,3 +13,7 @@ language = Language
 
 audio-output-device = Audio Output Device
 audio-output-device-default = System Default
+
+log-filename-pattern = Log Filename
+log-filename-pattern-single-file = Single File (ruffle.log)
+log-filename-pattern-with-timestamp = With Timestamp

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -1,4 +1,3 @@
-use crate::cli::Opt;
 use crate::custom_event::RuffleEvent;
 use crate::gui::{GuiController, MENU_HEIGHT};
 use crate::player::{PlayerController, PlayerOptions};
@@ -37,20 +36,20 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(opt: Opt) -> Result<Self, Error> {
-        let movie_url = opt.movie_url.clone();
+    pub fn new(preferences: GlobalPreferences) -> Result<Self, Error> {
+        let movie_url = preferences.cli.movie_url.clone();
         let icon_bytes = include_bytes!("../assets/favicon-32.rgba");
         let icon =
             Icon::from_rgba(icon_bytes.to_vec(), 32, 32).context("Couldn't load app icon")?;
 
         let event_loop = EventLoopBuilder::with_user_event().build()?;
 
-        let no_gui = opt.no_gui;
+        let no_gui = preferences.cli.no_gui;
         let min_window_size = (16, if no_gui { 16 } else { MENU_HEIGHT + 16 }).into();
         let max_window_size = get_screen_size(&event_loop);
-        let preferred_width = opt.width;
-        let preferred_height = opt.height;
-        let start_fullscreen = opt.fullscreen;
+        let preferred_width = preferences.cli.width;
+        let preferred_height = preferences.cli.height;
+        let start_fullscreen = preferences.cli.fullscreen;
 
         let window = WindowBuilder::new()
             .with_visible(false)
@@ -64,7 +63,6 @@ impl App {
         let mut font_database = fontdb::Database::default();
         font_database.load_system_fonts();
 
-        let preferences = GlobalPreferences::load(opt)?;
         let mut gui = GuiController::new(
             window.clone(),
             &event_loop,

--- a/desktop/src/log.rs
+++ b/desktop/src/log.rs
@@ -1,0 +1,40 @@
+use chrono::Utc;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug, Default)]
+pub enum FilenamePattern {
+    #[default]
+    SingleFile,
+    WithTimestamp,
+}
+
+impl FromStr for FilenamePattern {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "single_file" => Ok(FilenamePattern::SingleFile),
+            "with_timestamp" => Ok(FilenamePattern::WithTimestamp),
+            _ => Err(()),
+        }
+    }
+}
+
+impl FilenamePattern {
+    pub fn create_path(&self, directory: &Path) -> PathBuf {
+        match self {
+            FilenamePattern::SingleFile => directory.join("ruffle.log"),
+            FilenamePattern::WithTimestamp => {
+                directory.join(Utc::now().format("ruffle_%F_%H-%M-%S.log").to_string())
+            }
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FilenamePattern::SingleFile => "single_file",
+            FilenamePattern::WithTimestamp => "with_timestamp",
+        }
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -12,6 +12,7 @@ mod cli;
 mod custom_event;
 mod executor;
 mod gui;
+mod log;
 mod player;
 mod preferences;
 mod task;
@@ -155,7 +156,9 @@ fn main() -> Result<(), Error> {
 
     // [NA] `_guard` cannot be `_` or it'll immediately drop
     // https://docs.rs/tracing-appender/latest/tracing_appender/non_blocking/index.html
-    let log_path = preferences.cli.config.join("ruffle.log");
+    let log_path = preferences
+        .log_filename_pattern()
+        .create_path(&preferences.cli.config);
     let (non_blocking_file, _file_guard) = tracing_appender::non_blocking(File::create(log_path)?);
     let (non_blocking_stdout, _stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -27,6 +27,7 @@ use cli::Opt;
 use rfd::MessageDialogResult;
 use ruffle_core::StaticCallstack;
 use std::cell::RefCell;
+use std::env;
 use std::fs::File;
 use std::panic::PanicInfo;
 use tracing_subscriber::fmt::Layer;
@@ -162,7 +163,11 @@ fn main() -> Result<(), Error> {
     let (non_blocking_file, _file_guard) = tracing_appender::non_blocking(File::create(log_path)?);
     let (non_blocking_stdout, _stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
 
-    let env_filter = tracing_subscriber::EnvFilter::from_default_env();
+    let env_filter = tracing_subscriber::EnvFilter::builder().parse_lossy(
+        env::var("RUST_LOG")
+            .as_deref()
+            .unwrap_or("warn,ruffle=info,avm_trace=info"),
+    );
 
     let subscriber = tracing_subscriber::registry()
         .with(env_filter)

--- a/desktop/src/preferences.rs
+++ b/desktop/src/preferences.rs
@@ -2,6 +2,7 @@ mod read;
 mod write;
 
 use crate::cli::Opt;
+use crate::log::FilenamePattern;
 use crate::preferences::read::read_preferences;
 use crate::preferences::write::PreferencesWriter;
 use anyhow::{Context, Error};
@@ -117,6 +118,15 @@ impl GlobalPreferences {
         })
     }
 
+    pub fn log_filename_pattern(&self) -> FilenamePattern {
+        self.preferences
+            .lock()
+            .expect("Preferences is not reentrant")
+            .values
+            .log
+            .filename_pattern
+    }
+
     pub fn write_preferences(&self, fun: impl FnOnce(&mut PreferencesWriter)) -> Result<(), Error> {
         let mut preferences = self
             .preferences
@@ -158,6 +168,7 @@ pub struct SavedGlobalPreferences {
     pub output_device: Option<String>,
     pub mute: bool,
     pub volume: f32,
+    pub log: LogPreferences,
 }
 
 impl Default for SavedGlobalPreferences {
@@ -173,6 +184,12 @@ impl Default for SavedGlobalPreferences {
             output_device: None,
             mute: false,
             volume: 1.0,
+            log: Default::default(),
         }
     }
+}
+
+#[derive(PartialEq, Debug, Default)]
+pub struct LogPreferences {
+    pub filename_pattern: FilenamePattern,
 }

--- a/desktop/src/preferences/write.rs
+++ b/desktop/src/preferences/write.rs
@@ -1,3 +1,4 @@
+use crate::log::FilenamePattern;
 use crate::preferences::PreferencesAndDocument;
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use toml_edit::value;
@@ -43,11 +44,17 @@ impl<'a> PreferencesWriter<'a> {
         self.0.toml_document["volume"] = value(volume as f64);
         self.0.values.volume = volume;
     }
+
+    pub fn set_log_filename_pattern(&mut self, pattern: FilenamePattern) {
+        self.0.toml_document["log"]["filename_pattern"] = value(pattern.as_str());
+        self.0.values.log.filename_pattern = pattern;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::log::FilenamePattern;
     use crate::preferences::read::read_preferences;
     use fluent_templates::loader::langid;
 
@@ -147,6 +154,25 @@ mod tests {
             "mute = true",
             |writer| writer.set_mute(false),
             "mute = false\n",
+        );
+    }
+
+    #[test]
+    fn set_log_filename_pattern() {
+        test(
+            "",
+            |writer| writer.set_log_filename_pattern(FilenamePattern::WithTimestamp),
+            "log = { filename_pattern = \"with_timestamp\" }\n",
+        );
+        test(
+            "log = { filename_pattern = \"with_timestamp\" }\n",
+            |writer| writer.set_log_filename_pattern(FilenamePattern::SingleFile),
+            "log = { filename_pattern = \"single_file\" }\n",
+        );
+        test(
+            "[log]\nfilename_pattern = \"with_timestamp\"\n",
+            |writer| writer.set_log_filename_pattern(FilenamePattern::SingleFile),
+            "[log]\nfilename_pattern = \"single_file\"\n",
         );
     }
 }


### PR DESCRIPTION
Ruffle now logs to `ruffle.log` by default, with the same filter as CLI (`RUST_LOG`). `RUST_LOG` now also defaults to `warn,ruffle=info,avm_trace=info` when not specified.

The preferences dialog also contains an option for whether to log to a single file (best for users) or multiple timestamped files (best for devs).

This does not add any way to change the filtering outside of environment variable because no consensus can be reached on discord on how to make this possible.