### PR TITLE
Request highest 'max_inter_stage_shader_components' supported by adapter

### DIFF
--- a/render/wgpu/src/backend.rs
+++ b/render/wgpu/src/backend.rs
@@ -1128,6 +1128,7 @@ async fn request_device(
     limits = limits.using_resolution(adapter.limits());
     limits = limits.using_alignment(adapter.limits());
     limits.max_uniform_buffer_binding_size = adapter.limits().max_uniform_buffer_binding_size;
+    limits.max_inter_stage_shader_components = adapter.limits().max_inter_stage_shader_components;
 
     let mut features = Default::default();
 


### PR DESCRIPTION
We're currently always requesting a maximum of 31 components, which is too low for some SWFs.