### PR TITLE
avm2: Reduce memcpy overhead in BytecodeMethod calls

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -520,10 +520,10 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         outer: ScopeChain<'gc>,
         caller_domain: Option<Domain<'gc>>,
         caller_movie: Option<Arc<SwfMovie>>,
-    ) -> Result<Self, Error<'gc>> {
+    ) -> Self {
         let local_registers = RegisterSet::new(0);
 
-        Ok(Self {
+        Self {
             ip: 0,
             actions_since_timeout_check: 0,
             local_registers,
@@ -537,7 +537,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
             max_stack_size: 0,
             max_scope_size: 0,
             context,
-        })
+        }
     }
 
     /// Call the superclass's instance initializer.

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -133,7 +133,7 @@ impl<'gc> Executable<'gc> {
                     bm.scope,
                     caller_domain,
                     caller_movie,
-                )?;
+                );
 
                 if arguments.len() > bm.method.signature.len() && !bm.method.is_variadic {
                     return Err(format!(

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -178,8 +178,10 @@ impl<'gc> Executable<'gc> {
 
                 let subclass_object = bm.bound_superclass;
 
-                let mut activation = Activation::from_method(
-                    activation.context.reborrow(),
+                // This used to be a one step called Activation::from_method,
+                // but avoiding moving an Activation around helps perf
+                let mut activation = Activation::from_nothing(activation.context.reborrow());
+                activation.init_from_method(
                     bm.method,
                     bm.scope,
                     receiver,


### PR DESCRIPTION
The tldr is that it changes

```rs
fn from_method() -> Result<Activation> {
    // initialize p1
    let activation = ...;
    // initialize p2
    Ok(activation)
}
let activation = from_method()?;
```
to
```rs
fn from_nothing() -> Activation { ... }

fn init_from_method(&activation) -> Result<()> {
    // initialize p1
    // initialize p2
    Ok(())
}
let activation = from_nothing();
activation.init_from_method()?;
```

Which helps the compiler avoid the work of making an Activation, stuffing it in `Ok()`, then pulling it out with `?`.

This might or might not help with stack use too, didn't check.

Also, it's super ugly design-wise; if you know any ways to make it more idiomatic without losing perf, please let me know :D

I saw 10-15% improvements in a microbenchmark repeatedly calling `function noop(){}`, and 4-5% on a real SWF (that called a _ton_ of small functions, so it's still an above-average improvement).

We'll get way more than that by eventually storing function parameter/return types.