### PR TITLE
desktop: Add URL decode to desktop window's title (close: #15454)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,6 +4392,7 @@ dependencies = [
  "tracing-tracy",
  "unic-langid",
  "url",
+ "urlencoding",
  "vergen",
  "webbrowser",
  "wgpu",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -48,6 +48,7 @@ async-net = "2.0.0"
 async-channel = "2.2.0"
 toml_edit = { version = "0.22.6", features = ["parse"] }
 gilrs = "0.10"
+urlencoding = "2.1.3"
 
 # Deliberately held back to match tracy client used by profiling crate
 tracing-tracy = { version = "=0.10.4", optional = true }

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -19,6 +19,7 @@ use ruffle_render::backend::RenderBackend;
 use ruffle_render::quality::StageQuality;
 use ruffle_render_wgpu::backend::WgpuRenderBackend;
 use ruffle_render_wgpu::descriptors::Descriptors;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -193,7 +194,7 @@ impl ActivePlayer {
             .unwrap_or_else(|| movie_url.as_str())
             .to_string();
 
-        let readable_name = decode(&name).expect("UTF-8");
+        let readable_name = decode(&name).unwrap_or(Cow::Borrowed(&name));
 
         window.set_title(&format!("Ruffle - {readable_name}"));
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -25,6 +25,7 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 use url::Url;
+use urlencoding::decode;
 use winit::event_loop::EventLoopProxy;
 use winit::window::Window;
 
@@ -192,7 +193,9 @@ impl ActivePlayer {
             .unwrap_or_else(|| movie_url.as_str())
             .to_string();
 
-        window.set_title(&format!("Ruffle - {name}"));
+        let readable_name = decode(&name).expect("UTF-8");
+
+        window.set_title(&format!("Ruffle - {readable_name}"));
 
         SWF_INFO.with(|i| *i.borrow_mut() = Some(name.clone()));
 


### PR DESCRIPTION
Fix so that desktop title properly renders non ASCII characters (the web player uses a static title so no fix is needed there)

issue: https://github.com/ruffle-rs/ruffle/issues/15454

![image](https://github.com/ruffle-rs/ruffle/assets/9028017/4529309d-bec6-4672-b5a2-085ec818170d)