### PR TITLE
ci: Remove web/packages/*/dist and target from reproducable source zips

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -356,7 +356,7 @@ jobs:
         if: ${{ !matrix.demo }}
         shell: bash -l {0}
         run: |
-          zip -r reproducible-source.zip . -x '/web/node_modules/*' -x '/web/*/node_modules/*' -x '/.git/*' -x '/tests/tests/swfs/*'
+          zip -r reproducible-source.zip . -x '/web/node_modules/*' -x '/web/*/node_modules/*' -x '/web/packages/*/dist' -x '/target' -x '/.git/*' -x '/tests/tests/swfs/*'
           cp reproducible-source.zip "${{ needs.create-nightly-release.outputs.package_prefix }}-reproducible-source.zip"
 
       - name: Upload reproducible source archive


### PR DESCRIPTION
The zip goes from 837 MB to 27 MB