### PR TITLE
ci: Properly exclude large stuff from the reproducible FF extension source zip

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -356,7 +356,7 @@ jobs:
         if: ${{ !matrix.demo }}
         shell: bash -l {0}
         run: |
-          zip -r reproducible-source.zip . -x '/web/node_modules/*' -x '/web/*/node_modules/*' -x '/web/packages/*/dist' -x '/target' -x '/.git/*' -x '/tests/tests/swfs/*'
+          zip -r reproducible-source.zip . -x '/web/node_modules/*' '/web/*/node_modules/*' '/web/packages/*/dist/*' '/web/docker/docker_builds/*' '/target/*' '/.git/*' '/tests/tests/swfs/*'
           cp reproducible-source.zip "${{ needs.create-nightly-release.outputs.package_prefix }}-reproducible-source.zip"
 
       - name: Upload reproducible source archive


### PR DESCRIPTION
This is a fixup for https://github.com/ruffle-rs/ruffle/pull/15518 and https://github.com/ruffle-rs/ruffle/pull/15066, because the reproducible source zip in https://github.com/ruffle-rs/ruffle/releases/tag/nightly-2024-03-12 is still 800M+.

Turns out, `zip` doesn't exclude an entire folder unless the exclusion pattern ends with `/*` - looks like it does a sort of string matching, rather than the usual recursive FS globbing?
Also, `-x` takes a list of patterns, no need to specify it multiple times.
I've also added the `web/docker/docker_builds` folder to the exclusion list, just to be safe.