### PR TITLE
avm2: Add Function.prototype.toString and toLocaleString 

### DIFF
--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -78,6 +78,30 @@ pub fn class_init<'gc>(
         .into(),
         activation,
     )?;
+    function_proto.set_string_property_local(
+        "toString",
+        FunctionObject::from_method(
+            activation,
+            Method::from_builtin(to_string, "toString", activation.context.gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
+    function_proto.set_string_property_local(
+        "toLocaleString",
+        FunctionObject::from_method(
+            activation,
+            Method::from_builtin(to_string, "toLocaleString", activation.context.gc_context),
+            scope,
+            None,
+            Some(this_class),
+        )
+        .into(),
+        activation,
+    )?;
     function_proto.set_local_property_is_enumerable(
         activation.context.gc_context,
         "call".into(),
@@ -86,6 +110,16 @@ pub fn class_init<'gc>(
     function_proto.set_local_property_is_enumerable(
         activation.context.gc_context,
         "apply".into(),
+        false,
+    );
+    function_proto.set_local_property_is_enumerable(
+        activation.context.gc_context,
+        "toString".into(),
+        false,
+    );
+    function_proto.set_local_property_is_enumerable(
+        activation.context.gc_context,
+        "toLocaleString".into(),
         false,
     );
 
@@ -135,6 +169,15 @@ fn apply<'gc>(
     };
 
     func.call(this, &resolved_args, activation)
+}
+
+/// Implements `Function.prototype.toString` and `Function.prototype.toLocaleString`
+fn to_string<'gc>(
+    _activation: &mut Activation<'_, 'gc>,
+    _this: Object<'gc>,
+    _args: &[Value<'gc>],
+) -> Result<Value<'gc>, Error<'gc>> {
+    Ok("function Function() {}".into())
 }
 
 fn length<'gc>(

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -157,10 +157,6 @@ impl<'gc> TObject<'gc> for FunctionObject<'gc> {
         self.0.as_ptr() as *const ObjectPtr
     }
 
-    fn to_string(&self, _activation: &mut Activation<'_, 'gc>) -> Result<Value<'gc>, Error<'gc>> {
-        Ok("function Function() {}".into())
-    }
-
     fn to_locale_string(
         &self,
         activation: &mut Activation<'_, 'gc>,

--- a/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_4_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/FunctionObjects/e15_3_4_2/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/class_006/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/ObjectObjects/class_006/test.toml
@@ -1,2 +1,1 @@
 num_ticks = 1
-known_failure = true


### PR DESCRIPTION
Part of https://github.com/ruffle-rs/ruffle/issues/15474