### PR TITLE
core: Remove time limit from ExecutionLimit

### DIFF
--- a/core/src/limits.rs
+++ b/core/src/limits.rs
@@ -1,36 +1,19 @@
 use crate::context::UpdateContext;
-use std::time::Duration;
 
 /// Indication of how long execution is allowed to take.
 ///
-/// Execution is limited by two mechanisms:
-///
-/// 1. An *operation limit*, or oplimit, which is a certain number of actions
-///    executed, bytes processed, or other things that can be done before
-///    checking...
-/// 2. A *time limit*, which is checked every time the oplimit runs out.
-///    If it has not yet expired, then the oplimit is refreshed and we
-///    continue.
-///
-/// This two-tiered system is intended to reduce the overhead of enforcing
-/// execution limits.
+/// Execution is limited by *operation limit*, or oplimit,
+/// which is a certain number of actions
+/// executed, bytes processed, or other things that can be done.
 ///
 /// What constitutes an "operation" is up to the user of this structure. It may
 /// cover individual interpreter opcodes, bytes decoded in a data stream, or so
 /// on.
 pub struct ExecutionLimit {
-    /// How many operations remain before the next timelimit check.
+    /// How many operations remain before the limit is reached.
     ///
-    /// If `None`, then the execution limit is not enforced.
+    /// If `None`, then an execution limit is not enforced.
     current_oplimit: Option<usize>,
-
-    /// The number of operations allowed between timelimit checks.
-    ///
-    /// If `None`, then the execution limit is not enforced.
-    max_ops_per_check: Option<usize>,
-
-    /// The amount of time allowed to be taken regardless of the opcount.
-    time_limit: Duration,
 }
 
 impl ExecutionLimit {
@@ -38,18 +21,12 @@ impl ExecutionLimit {
     pub fn none() -> ExecutionLimit {
         Self {
             current_oplimit: None,
-            max_ops_per_check: None,
-            time_limit: Duration::MAX,
         }
     }
 
-    /// Construct an execution limit that checks the current wall-clock time
-    /// after a certain number of operations are executed.
-    pub fn with_max_ops_and_time(ops: usize, time_limit: Duration) -> ExecutionLimit {
+    pub fn with_max_ops(ops: usize) -> ExecutionLimit {
         Self {
             current_oplimit: Some(ops),
-            max_ops_per_check: Some(ops),
-            time_limit,
         }
     }
 
@@ -57,8 +34,6 @@ impl ExecutionLimit {
     pub fn exhausted() -> ExecutionLimit {
         Self {
             current_oplimit: Some(0),
-            max_ops_per_check: Some(0),
-            time_limit: Duration::from_secs(0),
         }
     }
 
@@ -67,25 +42,15 @@ impl ExecutionLimit {
     ///
     /// This is intended to be called after the given operations have been
     /// executed. The ops will be deducted from the operation limit and, if
-    /// that limit is zero, the time limit will be checked. If both limits have
-    /// been breached, this returns `true`. Otherwise, this returns `false`,
-    /// and if the operation limit was exhausted, it will be returned to the
-    /// starting maximum.
+    /// that limit has been breached, this returns 'true'
     pub fn did_ops_breach_limit(
         &mut self,
-        context: &mut UpdateContext<'_, '_>,
+        _context: &mut UpdateContext<'_, '_>,
         ops: usize,
     ) -> bool {
         if let Some(oplimit) = &mut self.current_oplimit {
             *oplimit = oplimit.saturating_sub(ops);
-
-            if *oplimit == 0 {
-                if context.update_start.elapsed() >= self.time_limit {
-                    return true;
-                }
-
-                self.current_oplimit = self.max_ops_per_check;
-            }
+            return *oplimit == 0;
         }
 
         false

--- a/core/src/loader.rs
+++ b/core/src/loader.rs
@@ -1929,7 +1929,7 @@ impl<'gc> Loader<'gc> {
                     Loader::preload_tick(
                         handle,
                         uc,
-                        &mut ExecutionLimit::with_max_ops_and_time(10000, Duration::from_millis(1)),
+                        &mut ExecutionLimit::with_max_ops(10000),
                         status,
                         redirected,
                     )?;

--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -1590,16 +1590,9 @@ impl Player {
 
     #[instrument(level = "debug", skip_all)]
     pub fn run_frame(&mut self) {
-        let frame_time = Duration::from_nanos((750_000_000.0 / self.frame_rate) as u64);
         let (mut execution_limit, may_execute_while_streaming) = match self.load_behavior {
-            LoadBehavior::Streaming => (
-                ExecutionLimit::with_max_ops_and_time(10000, frame_time),
-                true,
-            ),
-            LoadBehavior::Delayed => (
-                ExecutionLimit::with_max_ops_and_time(10000, frame_time),
-                false,
-            ),
+            LoadBehavior::Streaming => (ExecutionLimit::with_max_ops(10000), true),
+            LoadBehavior::Delayed => (ExecutionLimit::with_max_ops(10000), false),
             LoadBehavior::Blocking => (ExecutionLimit::none(), false),
         };
         let preload_finished = self.preload(&mut execution_limit);


### PR DESCRIPTION
The time limit check was inherently non-deterministic. Since the 'progress' events depend on how often the execution limit is hit (which determines how many frames a movie will take to preload), runtime behavior could change between different machines.

In the case of Spinin, my lazy-image-decoding change made preloading fast enough (in terms of wall-clock time) that the entire movie preloaded at once, breaking the game.