### PR TITLE
avm1: made the context menu work for all avm1 objects

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -322,7 +322,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
     }
 
-    /// Construct an empty stack frame with no code running on the root move in
+    /// Construct an empty stack frame with no code running on the root movie in
     /// layer 0.
     pub fn from_stub(context: UpdateContext<'a, 'gc>, id: ActivationIdentifier<'a>) -> Self {
         // [NA]: we have 3 options here:

--- a/core/src/avm1/globals/context_menu.rs
+++ b/core/src/avm1/globals/context_menu.rs
@@ -6,6 +6,7 @@ use crate::avm1::Object;
 use crate::avm1::{ScriptObject, Value};
 use crate::context::GcContext;
 use crate::context_menu;
+use crate::display_object::DisplayObject;
 
 const PROTO_DECLS: &[Declaration] = declare_properties! {
     "copy" => method(copy; DONT_ENUM | DONT_DELETE);
@@ -152,9 +153,12 @@ pub fn create_proto<'gc>(
 
 pub fn make_context_menu_state<'gc>(
     menu: Option<Object<'gc>>,
+    object: Option<DisplayObject<'gc>>,
     activation: &mut Activation<'_, 'gc>,
 ) -> context_menu::ContextMenuState<'gc> {
     let mut result = context_menu::ContextMenuState::new();
+
+    result.set_display_object(object);
 
     let mut builtin_items = context_menu::BuiltInItemFlags::for_stage(activation.context.stage);
     if let Some(menu) = menu {
@@ -219,6 +223,14 @@ pub fn make_context_menu_state<'gc>(
                         );
 
                         if !visible {
+                            continue;
+                        }
+
+                        if result
+                            .info()
+                            .iter()
+                            .any(|menu_item| menu_item.caption == caption.to_string())
+                        {
                             continue;
                         }
 

--- a/core/src/avm2/globals/flash/ui/context_menu.rs
+++ b/core/src/avm2/globals/flash/ui/context_menu.rs
@@ -3,6 +3,7 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::context_menu;
+use crate::display_object::DisplayObject;
 
 pub fn hide_built_in_items<'gc>(
     activation: &mut Activation<'_, 'gc>,
@@ -26,9 +27,12 @@ pub fn hide_built_in_items<'gc>(
 
 pub fn make_context_menu_state<'gc>(
     menu: Option<Object<'gc>>,
+    object: Option<DisplayObject<'gc>>,
     activation: &mut Activation<'_, 'gc>,
 ) -> context_menu::ContextMenuState<'gc> {
     let mut result = context_menu::ContextMenuState::new();
+
+    result.set_display_object(object);
 
     macro_rules! check_bool {
         ( $obj:expr, $name:expr, $value:expr ) => {

--- a/core/src/context_menu.rs
+++ b/core/src/context_menu.rs
@@ -7,8 +7,8 @@
 use crate::avm1;
 use crate::avm2;
 use crate::context::UpdateContext;
+use crate::display_object::{DisplayObject, InteractiveObject, TDisplayObject};
 use crate::display_object::{EditText, Stage};
-use crate::display_object::{InteractiveObject, TDisplayObject};
 use crate::events::TextControlCode;
 use crate::i18n::core_text;
 use gc_arena::Collect;
@@ -20,6 +20,7 @@ pub struct ContextMenuState<'gc> {
     #[collect(require_static)]
     info: Vec<ContextMenuItem>,
     callbacks: Vec<ContextMenuCallback<'gc>>,
+    object: Option<DisplayObject<'gc>>,
 }
 
 impl<'gc> ContextMenuState<'gc> {
@@ -38,6 +39,14 @@ impl<'gc> ContextMenuState<'gc> {
 
     pub fn callback(&self, index: usize) -> &ContextMenuCallback<'gc> {
         &self.callbacks[index]
+    }
+
+    pub fn get_display_object(&self) -> Option<DisplayObject<'gc>> {
+        self.object
+    }
+
+    pub fn set_display_object(&mut self, object: Option<DisplayObject<'gc>>) {
+        self.object = object;
     }
 
     pub fn build_builtin_items(


### PR DESCRIPTION
Made the context menu work on all AVM1 objects, was only the root before. 
Shows the context menu when clicking instead of releasing on desktop like flash player did.
Don't add a context menu item when there already is a item with the same caption present. (avm1)

.swf and .fla used for testing:
[context menu.zip](https://github.com/ruffle-rs/ruffle/files/14652961/context.menu.zip)
