### PR TITLE
chore: Bump `image` to `v0.25`, without the `dxt` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ checksum = "3f4a6962241a76da5be5e64e41b851ee1c95fda11f76635522a3c82b119b5475"
 dependencies = [
  "egui",
  "enum-map",
- "image",
+ "image 0.24.9",
  "log",
  "mime_guess2",
  "serde",
@@ -1795,7 +1795,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
- "image",
+ "image 0.25.0",
  "indicatif",
  "log",
  "rayon",
@@ -2621,6 +2621,17 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "num-traits",
+]
+
+[[package]]
+name = "image"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b4f005360d32e9325029b38ba47ebd7a56f3316df09249368939562d518645"
+dependencies = [
+ "bytemuck",
+ "byteorder",
  "num-traits",
  "png",
  "tiff",
@@ -4203,7 +4214,7 @@ dependencies = [
  "futures",
  "hashbrown 0.14.3",
  "id3",
- "image",
+ "image 0.25.0",
  "indexmap",
  "jpegxr",
  "linkme",
@@ -4263,7 +4274,7 @@ dependencies = [
  "futures",
  "futures-lite 2.3.0",
  "gilrs",
- "image",
+ "image 0.25.0",
  "isahc",
  "macro_rules_attribute",
  "os_info",
@@ -4387,7 +4398,7 @@ dependencies = [
  "enum-map",
  "fnv",
  "futures",
- "image",
+ "image 0.25.0",
  "indexmap",
  "lru",
  "naga",
@@ -4438,7 +4449,7 @@ dependencies = [
  "async-channel 2.2.0",
  "chrono",
  "futures",
- "image",
+ "image 0.25.0",
  "percent-encoding",
  "pretty_assertions",
  "regex",
@@ -5135,7 +5146,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "futures",
- "image",
+ "image 0.25.0",
  "libtest-mimic",
  "ruffle_core",
  "ruffle_render_wgpu",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -60,7 +60,7 @@ png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = "2.2.0"
 jpegxr = { git = "https://github.com/ruffle-rs/jpegxr", branch = "ruffle", optional = true }
-image = { version = "0.24.9", default-features = false, features = ["tiff", "dxt"] }
+image = { version = "0.25.0", default-features = false, features = ["tiff"] }
 enum-map = "2.7.3"
 ttf-parser = "0.20"
 num-bigint = "0.4"

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -16,7 +16,7 @@ cpal = "0.15.3"
 egui = { workspace = true }
 egui_extras = { version = "0.26.2", features = ["image"] }
 egui-wgpu = { version = "0.26.2", features = ["winit"] }
-image = { version = "0.24", default-features = false, features = ["png"] }
+image = { version = "0.25.0", default-features = false, features = ["png"] }
 egui-winit = "0.26.2"
 fontdb = "0.16"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -15,7 +15,7 @@ clap = { workspace = true }
 futures = "0.3"
 ruffle_core = { path = "../core", features = ["deterministic", "default_font"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
-image = { version = "0.24.9", default-features = false, features = ["png"] }
+image = { version = "0.25.0", default-features = false, features = ["png"] }
 log = "0.4"
 walkdir = "2.5.0"
 indicatif = "0.17"

--- a/exporter/src/main.rs
+++ b/exporter/src/main.rs
@@ -244,10 +244,7 @@ fn capture_single_swf(descriptors: Arc<Descriptors>, opt: &Opt) -> Result<()> {
         if opt.output_path == Some(PathBuf::from("-")) {
             let mut bytes: Vec<u8> = Vec::new();
             image
-                .write_to(
-                    &mut io::Cursor::new(&mut bytes),
-                    image::ImageOutputFormat::Png,
-                )
+                .write_to(&mut io::Cursor::new(&mut bytes), image::ImageFormat::Png)
                 .expect("Encoding failed");
             io::stdout()
                 .write_all(bytes.as_slice())

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.5.3", features = ["derive"], optional = true }
 enum-map = "2.7.3"
 fnv = "1.0.7"
 swf = { path = "../../swf" }
-image = { version = "0.24.9", default-features = false }
+image = { version = "0.25.0", default-features = false }
 naga_oil = { workspace = true }
 naga-agal = { path = "../naga-agal" }
 naga-pixelbender = { path = "../naga-pixelbender" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,7 +27,7 @@ ruffle_test_framework = { path = "framework" }
 libtest-mimic = "0.7.0"
 walkdir = "2.5.0"
 anyhow = "1.0.81"
-image = { version = "0.24.9", default-features = false, features  = ["png"] }
+image = { version = "0.25.0", default-features = false, features  = ["png"] }
 futures = "0.3.30"
 env_logger = "0.11.3"
 tracing = { workspace = true }

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -17,7 +17,7 @@ ruffle_render = { path = "../../render" }
 ruffle_input_format = { path = "../input-format" }
 ruffle_socket_format = { path = "../socket-format" }
 ruffle_video_software = { path = "../../video/software", optional = true }
-image = { version = "0.24.9", default-features = false, features  = ["png"] }
+image = { version = "0.25.0", default-features = false, features  = ["png"] }
 regex = "1.10.3"
 url = "2.5.0"
 chrono = "0.4.35"

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -4,7 +4,7 @@ use crate::image_trigger::ImageTrigger;
 use crate::util::write_image;
 use anyhow::{anyhow, Result};
 use approx::relative_eq;
-use image::ImageOutputFormat;
+use image::ImageFormat;
 use regex::Regex;
 use ruffle_core::tag_utils::SwfMovie;
 use ruffle_core::{PlayerBuilder, PlayerRuntime, ViewportDimensions};
@@ -246,7 +246,7 @@ impl ImageComparison {
                 write_image(
                     &test_path.join(format!("{name}.actual-{environment_name}.png"))?,
                     &actual_image,
-                    ImageOutputFormat::Png,
+                    ImageFormat::Png,
                 )
             } else {
                 Ok(())
@@ -324,7 +324,7 @@ impl ImageComparison {
                 write_image(
                     &test_path.join(format!("{name}.difference-color-{environment_name}.png"))?,
                     &difference_image,
-                    ImageOutputFormat::Png,
+                    ImageFormat::Png,
                 )?;
             }
 
@@ -348,7 +348,7 @@ impl ImageComparison {
                         &test_path
                             .join(format!("{name}.difference-alpha-{environment_name}.png"))?,
                         &difference_image,
-                        ImageOutputFormat::Png,
+                        ImageFormat::Png,
                     )?;
                 }
             }

--- a/tests/framework/src/runner.rs
+++ b/tests/framework/src/runner.rs
@@ -6,7 +6,7 @@ use crate::options::{ImageComparison, TestOptions};
 use crate::test::Test;
 use crate::util::{read_bytes, write_image};
 use anyhow::{anyhow, Result};
-use image::ImageOutputFormat;
+use image::ImageFormat;
 use pretty_assertions::Comparison;
 use ruffle_core::backend::navigator::NullExecutor;
 use ruffle_core::events::MouseButton as RuffleMouseButton;
@@ -169,7 +169,7 @@ impl TestRunner {
         self.executor.run();
     }
 
-    /// After a tick, run any custom fdcommands that were queued up and perform any scheduled tests.  
+    /// After a tick, run any custom fdcommands that were queued up and perform any scheduled tests.
     pub fn test(&mut self) -> Result<TestStatus> {
         for command in self.fs_commands.try_iter() {
             match command {
@@ -455,7 +455,7 @@ fn capture_and_compare_image(
             ));
         } else {
             // If we're expecting this to be wrong, don't save a likely wrong image
-            write_image(&expected_image_path, &actual_image, ImageOutputFormat::Png)?;
+            write_image(&expected_image_path, &actual_image, ImageFormat::Png)?;
         }
     } else if known_failure {
         // It's possible that the trace output matched but the image might not.

--- a/tests/framework/src/util.rs
+++ b/tests/framework/src/util.rs
@@ -1,4 +1,4 @@
-use image::{EncodableLayout, ImageBuffer, ImageOutputFormat, Pixel, PixelWithColorType};
+use image::{EncodableLayout, ImageBuffer, ImageFormat, Pixel, PixelWithColorType};
 use std::io::{Cursor, Read, Write};
 use std::ops::Deref;
 use vfs::{VfsError, VfsPath};
@@ -17,7 +17,7 @@ pub fn write_bytes(path: &VfsPath, data: &[u8]) -> Result<(), VfsError> {
 pub fn write_image<P, Container>(
     path: &VfsPath,
     image: &ImageBuffer<P, Container>,
-    format: ImageOutputFormat,
+    format: ImageFormat,
 ) -> anyhow::Result<()>
 where
     P: Pixel + PixelWithColorType,


### PR DESCRIPTION
I hope some visual tests will fail on this, at least on Windows.
To be fixed by an alternative implementation based on https://github.com/jansol/texpresso, as recommended.