### PR TITLE
core: Make sure that streams progress even with many small-dt ticks

### DIFF
--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -1108,7 +1108,6 @@ impl<'gc> NetStream<'gc> {
         let buffer = slice.data();
 
         let max_time = write.stream_time + dt;
-        let mut last_tag_time = write.stream_time;
         let mut buffer_underrun = false;
         let mut error = false;
         let mut max_lookahead_audio_tags = 5;
@@ -1140,10 +1139,6 @@ impl<'gc> NetStream<'gc> {
                 is_lookahead_tag = tag.timestamp as f64 >= max_time; //FLV timestamps are also ms
                 if is_lookahead_tag && max_lookahead_audio_tags == 0 {
                     break;
-                }
-
-                if !is_lookahead_tag {
-                    last_tag_time = tag.timestamp as f64;
                 }
 
                 let tag_needs_preloading = reader.stream_position().expect("valid position")
@@ -1189,7 +1184,7 @@ impl<'gc> NetStream<'gc> {
             }
         }
 
-        write.stream_time = last_tag_time;
+        write.stream_time = max_time;
         if let Err(e) = self.commit_sound_stream(context, &mut write) {
             //TODO: Fire an error event at AS.
             tracing::error!("Error committing sound stream: {}", e);


### PR DESCRIPTION
This fixed the playback of FLV videos for me on Linux.

Rationale:
Currently, `stream_time` is only advanced when there was at least one tag processed in a tick.
However, in certain conditions (high rendering FPS, low video FPS, large audio chunks), it's possible that no tick ever has a `dt` large enough to bridge the time gap from the last processed tag, to the next. In this case, the stream got stuck.
With this change, any and all `dt` passed into `tick` will be accumulated into `stream_time`, no matter if it triggered any tag processing or not.