### PR TITLE
desktop: Fix window title after closing the file

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -471,6 +471,7 @@ impl App {
                 }
 
                 winit::event::Event::UserEvent(RuffleEvent::CloseFile) => {
+                    self.window.set_title("Ruffle"); // Reset title since file has been closed.
                     self.player.destroy();
                 }
 


### PR DESCRIPTION
Previously the title showed the filename in the title even after the file had been long closed.