### PR TITLE
ci: Split cargo-deny into its own job, add cargo-machete

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -153,6 +153,11 @@ jobs:
       - name: Check licenses, duplicates, and advisories
         uses: EmbarkStudios/cargo-deny-action@v1
 
+      - name: Check unused dependencies
+        uses: bnjbvr/cargo-machete@main
+        # So the previous step failing doesn't prevent this one from running.
+        if: always()
+
   check-required:
     needs: changes
     if: needs.changes.outputs.should_run == 'false'

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -31,7 +31,7 @@ jobs:
 
   build:
     needs: changes
-    if: needs.changes.outputs.should_run== 'true'
+    if: needs.changes.outputs.should_run == 'true'
     name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
@@ -103,7 +103,7 @@ jobs:
 
   lints:
     needs: changes
-    if: needs.changes.outputs.should_run== 'true'
+    if: needs.changes.outputs.should_run == 'true'
     name: Lints with Rust ${{ matrix.rust_version }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.rust_version == 'nightly' || matrix.rust_version == 'beta' }}
@@ -133,14 +133,25 @@ jobs:
         # Don't fail the build for clippy on nightly, since we get a lot of false-positives
         run: cargo clippy --all --all-features --tests ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
 
-      - name: Check licensing and duplicates in used crates
-        if: ${{ matrix.rust_version == 'stable' }}
-        uses: EmbarkStudios/cargo-deny-action@v1
-
       - name: Check documentation
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -D warnings
+
+  dependencies:
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    name: Check dependencies
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Check licenses, duplicates, and advisories
+        uses: EmbarkStudios/cargo-deny-action@v1
 
   check-required:
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,7 +1787,6 @@ dependencies = [
  "futures",
  "image 0.25.0",
  "indicatif",
- "log",
  "rayon",
  "ruffle_core",
  "ruffle_render_wgpu",
@@ -3273,11 +3272,9 @@ name = "naga-pixelbender"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags 2.5.0",
  "naga",
  "naga_oil",
  "ruffle_render",
- "tracing",
 ]
 
 [[package]]
@@ -4341,7 +4338,6 @@ dependencies = [
 name = "ruffle_render_canvas"
 version = "0.1.0"
 dependencies = [
- "downcast-rs",
  "js-sys",
  "log",
  "ruffle_render",
@@ -4356,7 +4352,6 @@ name = "ruffle_render_webgl"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
- "downcast-rs",
  "js-sys",
  "log",
  "ruffle_render",
@@ -4373,7 +4368,6 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "clap",
- "downcast-rs",
  "enum-map",
  "fnv",
  "futures",
@@ -4385,7 +4379,6 @@ dependencies = [
  "naga-pixelbender",
  "naga_oil",
  "profiling",
- "raw-window-handle 0.6.0",
  "ruffle_render",
  "swf",
  "tracing",
@@ -4427,7 +4420,6 @@ dependencies = [
  "approx",
  "async-channel 2.2.0",
  "chrono",
- "futures",
  "image 0.25.0",
  "percent-encoding",
  "pretty_assertions",

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3"
 ruffle_core = { path = "../core", features = ["deterministic", "default_font"] }
 ruffle_render_wgpu = { path = "../render/wgpu", features = ["clap"] }
 image = { version = "0.25.0", default-features = false, features = ["png"] }
-log = "0.4"
 walkdir = "2.5.0"
 indicatif = "0.17"
 rayon = "1.10.0"

--- a/render/canvas/Cargo.toml
+++ b/render/canvas/Cargo.toml
@@ -17,7 +17,6 @@ ruffle_web_common = { path = "../../web/common" }
 wasm-bindgen = "=0.2.92"
 ruffle_render = { path = "..", features = ["web"] }
 swf = { path = "../../swf" }
-downcast-rs = "1.2.0"
 
 [dependencies.web-sys]
 version = "0.3.69"

--- a/render/naga-pixelbender/Cargo.toml
+++ b/render/naga-pixelbender/Cargo.toml
@@ -14,7 +14,5 @@ workspace = true
 ruffle_render = { path = "../" }
 naga = { workspace = true }
 naga_oil = { workspace = true }
-tracing = { workspace = true }
 anyhow = "1.0.81"
-bitflags = "2.5.0"
 

--- a/render/webgl/Cargo.toml
+++ b/render/webgl/Cargo.toml
@@ -19,7 +19,6 @@ wasm-bindgen = "=0.2.92"
 bytemuck = { version = "1.15.0", features = ["derive"] }
 swf = { path = "../../swf" }
 thiserror = "1.0"
-downcast-rs = "1.2.0"
 
 [dependencies.web-sys]
 version = "0.3.69"

--- a/render/wgpu/Cargo.toml
+++ b/render/wgpu/Cargo.toml
@@ -15,7 +15,6 @@ wgpu = { workspace = true, features = ["naga-ir"] }
 tracing = { workspace = true }
 ruffle_render = { path = "..", features = ["tessellator", "wgpu"] }
 bytemuck = { version = "1.15.0", features = ["derive"] }
-raw-window-handle = "0.6.0"
 clap = { version = "4.5.4", features = ["derive"], optional = true }
 enum-map = "2.7.3"
 fnv = "1.0.7"
@@ -24,7 +23,6 @@ image = { version = "0.25.0", default-features = false }
 naga_oil = { workspace = true }
 naga-agal = { path = "../naga-agal" }
 naga-pixelbender = { path = "../naga-pixelbender" }
-downcast-rs = "1.2.0"
 profiling = { version = "1.0", default-features = false, optional = true }
 lru = "0.12.3"
 naga = { workspace = true }
@@ -44,3 +42,9 @@ render_debug_labels = []
 render_trace = ["wgpu/trace"]
 webgl = ["wgpu/webgl"]
 profile-with-tracy = ["profiling", "profiling/profile-with-tracy"]
+
+[package.metadata.cargo-machete]
+ignored = [
+    # Not used directly, declared only to enable its `profile-with-tracy` feature.
+    "profiling"
+]

--- a/tests/framework/Cargo.toml
+++ b/tests/framework/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-futures = "0.3.30"
 ruffle_core = { path = "../../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font"] }
 ruffle_render = { path = "../../render" }
 ruffle_input_format = { path = "../input-format" }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -74,3 +74,9 @@ features = [
     "HtmlInputElement", "HtmlTextAreaElement", "KeyboardEvent", "Location", "PointerEvent",
     "Request", "RequestInit", "Response", "Storage", "WheelEvent", "Window", "ReadableStream", "RequestCredentials"
 ]
+
+[package.metadata.cargo-machete]
+ignored = [
+    # Not used directly, declared only to enable its `js` feature.
+    "getrandom"
+]


### PR DESCRIPTION
Contrary to the source branch name, I went with `cargo-machete` instead of `cargo-udeps`: https://blog.benj.me/2022/04/27/cargo-machete/

Unfortunately, both point to a couple false positives, so they would need some manual handholding, polluting our `Cargo.toml` files. ( https://github.com/bnjbvr/cargo-machete/issues/118 )

~~Do we even need this...? :/~~