### PR TITLE
avm2: Properly push coerced value back to stack in optimizer for Coerce op

### DIFF
--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -560,6 +560,8 @@ pub fn optimize<'gc>(
             }
             Op::Coerce { class } => {
                 let stack_value = stack.pop_or_any();
+                stack.push_class(*class);
+
                 if stack_value.guaranteed_null {
                     // Coercing null to a non-primitive or void is a noop.
                     if !GcCell::ptr_eq(*class, types.int.inner_class_definition())


### PR DESCRIPTION
This was accidentally removed in #15476. Adding it back significantly improves optimizations for Box2D.