### PR TITLE
desktop: Fix gui scale on launch on wayland

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -419,7 +419,15 @@ impl App {
                         self.window.scale_factor(),
                     );
 
-                    let _ = self.window.request_inner_size(window_size);
+                    let viewport_size = self.window.inner_size();
+
+                    if let Some(new_viewport_size) = self.window.request_inner_size(window_size) {
+                        if new_viewport_size != viewport_size {
+                            self.gui.borrow_mut().resize(new_viewport_size);
+                        } else {
+                            tracing::warn!("Unable to resize window");
+                        }
+                    }
                     self.window.set_fullscreen(if self.start_fullscreen {
                         Some(Fullscreen::Borderless(None))
                     } else {

--- a/desktop/src/gui/controller.rs
+++ b/desktop/src/gui/controller.rs
@@ -141,31 +141,35 @@ impl GuiController {
         &self.descriptors
     }
 
+    pub fn resize(&mut self, size: PhysicalSize<u32>) {
+        if size.width > 0 && size.height > 0 {
+            self.surface.configure(
+                &self.descriptors.device,
+                &wgpu::SurfaceConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    format: self.surface_format,
+                    width: size.width,
+                    height: size.height,
+                    present_mode: Default::default(),
+                    desired_maximum_frame_latency: 2,
+                    alpha_mode: Default::default(),
+                    view_formats: Default::default(),
+                },
+            );
+            self.movie_view_renderer.update_resolution(
+                &self.descriptors,
+                self.window.fullscreen().is_none() && !self.no_gui,
+                size.height,
+                self.window.scale_factor(),
+            );
+            self.size = size;
+        }
+    }
+
     #[must_use]
     pub fn handle_event(&mut self, event: &WindowEvent) -> bool {
         if let WindowEvent::Resized(size) = &event {
-            if size.width > 0 && size.height > 0 {
-                self.surface.configure(
-                    &self.descriptors.device,
-                    &wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: self.surface_format,
-                        width: size.width,
-                        height: size.height,
-                        present_mode: Default::default(),
-                        desired_maximum_frame_latency: 2,
-                        alpha_mode: Default::default(),
-                        view_formats: Default::default(),
-                    },
-                );
-                self.movie_view_renderer.update_resolution(
-                    &self.descriptors,
-                    self.window.fullscreen().is_none() && !self.no_gui,
-                    size.height,
-                    self.window.scale_factor(),
-                );
-                self.size = *size;
-            }
+            self.resize(*size);
         }
 
         if let WindowEvent::ThemeChanged(theme) = &event {


### PR DESCRIPTION
On platforms that support synchronous resizing such as wayland `request_inner_size` returns the new window size and no `WindowEvent::Resize`  is generated ([documented here](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.request_inner_size)).

This MR resizes the gui if `request_inner_size` returns a value different from its original value.

| before | after |
|-|-|
| ![Screenshot from 2024-03-26 12-49-02](https://github.com/ruffle-rs/ruffle/assets/334272/a3e07c86-bf44-4977-936b-d2f8d51f8335) | ![Screenshot from 2024-03-26 12-44-55](https://github.com/ruffle-rs/ruffle/assets/334272/7dce39e2-286b-430b-82de-14e9a083d953) |