### PR TITLE
ci: Cleanup "skipped" test jobs

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -145,17 +145,8 @@ jobs:
   check-required:
     needs: changes
     if: needs.changes.outputs.should_run == 'false'
-    name: Test Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        rust_version: [stable]
-        os: [ubuntu-22.04, windows-latest, macos-14]
-        include:
-          - rust_version: nightly
-            os: ubuntu-22.04
-          - rust_version: beta
-            os: ubuntu-22.04
+    name: Dummy for Test Rust
+    runs-on: ubuntu-22.04
 
     steps:
       - name: No-op

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -142,7 +142,7 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
-  check-required:
+  dummy:
     needs: changes
     if: needs.changes.outputs.should_run == 'false'
     name: Dummy for Test Rust

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -95,7 +95,7 @@ jobs:
         working-directory: web
         run: npm test
 
-  check-required:
+  dummy:
     needs: changes
     if: needs.changes.outputs.should_run == 'false'
     name: Dummy for Test Node.js

--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -98,13 +98,8 @@ jobs:
   check-required:
     needs: changes
     if: needs.changes.outputs.should_run == 'false'
-    name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node_version: ["20", "21"]
-        rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
-        os: [ubuntu-22.04, windows-latest]
+    name: Dummy for Test Node.js
+    runs-on: ubuntu-22.04
 
     steps:
       - name: No-op


### PR DESCRIPTION
The non-expanded `${{ expressions }}` in the check names annoyed me incredibly.

Also, I don't think there is any need for the matrix to be there - but we'll see.

Cc: @midgleyc, who set this up IIRC. (Also Cc: @relrelb, just in case.)