### PR TITLE
desktop: Add preference to change storage backend

### DIFF
--- a/core/src/player.rs
+++ b/core/src/player.rs
@@ -2268,8 +2268,8 @@ impl PlayerBuilder {
 
     /// Sets the storage backend of the player.
     #[inline]
-    pub fn with_storage(mut self, storage: impl 'static + StorageBackend) -> Self {
-        self.storage = Some(Box::new(storage));
+    pub fn with_storage(mut self, storage: Box<dyn StorageBackend>) -> Self {
+        self.storage = Some(storage);
         self
     }
 

--- a/desktop/assets/texts/en-US/preferences_dialog.ftl
+++ b/desktop/assets/texts/en-US/preferences_dialog.ftl
@@ -17,3 +17,7 @@ audio-output-device-default = System Default
 log-filename-pattern = Log Filename
 log-filename-pattern-single-file = Single File (ruffle.log)
 log-filename-pattern-with-timestamp = With Timestamp
+
+storage-backend = Save-File Location
+storage-backend-disk = Disk
+storage-backend-memory = Memory

--- a/desktop/src/cli.rs
+++ b/desktop/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::preferences::storage::StorageBackend;
 use crate::RUFFLE_VERSION;
 use anyhow::{anyhow, Error};
 use clap::{Parser, ValueEnum};
@@ -54,6 +55,12 @@ pub struct Opt {
     #[clap(long, short)]
     pub power: Option<PowerPreference>,
 
+    /// Type of storage backend to use. This determines where local storage data is saved (e.g. shared objects).
+    ///
+    /// This option temporarily overrides any stored preference.
+    #[clap(long)]
+    pub storage: Option<StorageBackend>,
+
     /// Width of window in pixels.
     #[clap(long, display_order = 1)]
     pub width: Option<f64>,
@@ -101,6 +108,8 @@ pub struct Opt {
     trace_path: Option<std::path::PathBuf>,
 
     /// Location to store save data for games.
+    ///
+    /// This option has no effect if `storage` is not `disk`.
     #[clap(long, default_value_os_t=get_default_save_directory())]
     pub save_directory: std::path::PathBuf,
 

--- a/desktop/src/player.rs
+++ b/desktop/src/player.rs
@@ -1,6 +1,6 @@
 use crate::backends::{
     CpalAudioBackend, DesktopExternalInterfaceProvider, DesktopFSCommandProvider, DesktopUiBackend,
-    DiskStorageBackend, ExternalNavigatorBackend,
+    ExternalNavigatorBackend,
 };
 use crate::custom_event::RuffleEvent;
 use crate::executor::WinitAsyncExecutor;
@@ -159,7 +159,7 @@ impl ActivePlayer {
         builder = builder
             .with_navigator(navigator)
             .with_renderer(renderer)
-            .with_storage(DiskStorageBackend::new(opt.save_directory.clone()))
+            .with_storage(preferences.storage_backend().create_backend(opt))
             .with_fs_commands(Box::new(DesktopFSCommandProvider {
                 event_loop: event_loop.clone(),
                 window: window.clone(),

--- a/desktop/src/preferences/storage.rs
+++ b/desktop/src/preferences/storage.rs
@@ -1,0 +1,41 @@
+use crate::{backends::DiskStorageBackend, player::PlayerOptions};
+use ruffle_core::backend::storage::MemoryStorageBackend;
+use std::str::FromStr;
+
+#[derive(clap::ValueEnum, Copy, Clone, PartialEq, Eq, Debug, Default)]
+pub enum StorageBackend {
+    #[default]
+    Disk,
+    Memory,
+}
+
+impl FromStr for StorageBackend {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disk" => Ok(StorageBackend::Disk),
+            "memory" => Ok(StorageBackend::Memory),
+            _ => Err(()),
+        }
+    }
+}
+
+impl StorageBackend {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StorageBackend::Disk => "disk",
+            StorageBackend::Memory => "memory",
+        }
+    }
+
+    pub fn create_backend(
+        &self,
+        opt: &PlayerOptions,
+    ) -> Box<dyn ruffle_core::backend::storage::StorageBackend> {
+        match self {
+            StorageBackend::Disk => Box::new(DiskStorageBackend::new(opt.save_directory.clone())),
+            StorageBackend::Memory => Box::new(MemoryStorageBackend::new()),
+        }
+    }
+}

--- a/desktop/src/preferences/write.rs
+++ b/desktop/src/preferences/write.rs
@@ -1,4 +1,5 @@
 use crate::log::FilenamePattern;
+use crate::preferences::storage::StorageBackend;
 use crate::preferences::{Bookmark, BookmarksAndDocument, PreferencesAndDocument};
 use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
 use toml_edit::{array, value, ArrayOfTables, Table};
@@ -48,6 +49,11 @@ impl<'a> PreferencesWriter<'a> {
     pub fn set_log_filename_pattern(&mut self, pattern: FilenamePattern) {
         self.0.toml_document["log"]["filename_pattern"] = value(pattern.as_str());
         self.0.values.log.filename_pattern = pattern;
+    }
+
+    pub fn set_storage_backend(&mut self, backend: StorageBackend) {
+        self.0.toml_document["storage"]["backend"] = value(backend.as_str());
+        self.0.values.storage.backend = backend;
     }
 }
 
@@ -240,6 +246,25 @@ mod tests {
                 "[log]\nfilename_pattern = \"with_timestamp\"\n",
                 |writer| writer.set_log_filename_pattern(FilenamePattern::SingleFile),
                 "[log]\nfilename_pattern = \"single_file\"\n",
+            );
+        }
+
+        #[test]
+        fn set_storage_backend() {
+            test(
+                "",
+                |writer| writer.set_storage_backend(StorageBackend::Disk),
+                "storage = { backend = \"disk\" }\n",
+            );
+            test(
+                "storage = { backend = \"disk\" }\n",
+                |writer| writer.set_storage_backend(StorageBackend::Memory),
+                "storage = { backend = \"memory\" }\n",
+            );
+            test(
+                "[storage]\nbackend = \"disk\"\n",
+                |writer| writer.set_storage_backend(StorageBackend::Memory),
+                "[storage]\nbackend = \"memory\"\n",
             );
         }
     }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -644,7 +644,7 @@ impl Ruffle {
 
         match window.local_storage() {
             Ok(Some(s)) => {
-                builder = builder.with_storage(storage::LocalStorageBackend::new(s));
+                builder = builder.with_storage(Box::new(storage::LocalStorageBackend::new(s)));
             }
             err => {
                 tracing::warn!("Unable to use localStorage: {:?}\nData will not save.", err);


### PR DESCRIPTION
Implements #12943 and expands on it by adding it to preferences.

Unresolved questions:

Should we keep these preferences as `save`, rename to `storage` or something different entirely?