### PR TITLE
chore: Fix false positive clippy lint in rustc 1.78 betas

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::unwrap_used)]
+#![allow(clippy::empty_docs)] //False positive in rustc 1.78 beta
 
 //! Ruffle web frontend.
 mod audio;


### PR DESCRIPTION
Noticed a bunch of PRs were marked as failing. Let's see if this fixes that.