### PR TITLE
desktop: show translated string for currently selected language

### DIFF
--- a/desktop/src/gui/preferences_dialog.rs
+++ b/desktop/src/gui/preferences_dialog.rs
@@ -207,13 +207,14 @@ impl PreferencesDialog {
         ui.label(text(locale, "language"));
         let previous = self.language.clone();
         ComboBox::from_id_source("language")
-            .selected_text(self.language.to_string())
+            .selected_text(language_name(&self.language))
             .show_ui(ui, |ui| {
                 for language in available_languages() {
-                    let name = optional_text(language, "language-name")
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| language.to_string());
-                    ui.selectable_value(&mut self.language, language.clone(), name);
+                    ui.selectable_value(
+                        &mut self.language,
+                        language.clone(),
+                        language_name(language),
+                    );
                 }
             });
         if self.language != previous {
@@ -305,6 +306,12 @@ fn graphics_power_name(locale: &LanguageIdentifier, power_preference: PowerPrefe
         PowerPreference::Low => text(locale, "graphics-power-low"),
         PowerPreference::High => text(locale, "graphics-power-high"),
     }
+}
+
+fn language_name(language: &LanguageIdentifier) -> String {
+    optional_text(language, "language-name")
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| language.to_string())
 }
 
 fn filename_pattern_name(locale: &LanguageIdentifier, pattern: FilenamePattern) -> Cow<str> {


### PR DESCRIPTION
Before:
![image](https://github.com/ruffle-rs/ruffle/assets/131554884/1aaeaba1-7c34-4700-8967-2dfb8d917ec1)

After:
![image](https://github.com/ruffle-rs/ruffle/assets/131554884/243887c4-b232-474a-bcb0-594c0d033a89)
