### PR TITLE
ci: Fix the name of the no-op `check-required` job in the `Test Web` workflow

### DIFF
--- a/.github/workflows/test_web.yml
+++ b/.github/workflows/test_web.yml
@@ -98,12 +98,11 @@ jobs:
   check-required:
     needs: changes
     if: needs.changes.outputs.should_run == 'false'
-    name: Test Node.js ${{ matrix.node_version }} / Rust ${{ matrix.rust_version }} / ${{ matrix.os }}
+    name: Test Node.js ${{ matrix.node_version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node_version: ["20", "21"]
-        rust_version: [stable] # We most likely don't care about Rust versions here, we'll catch those issues in test_rust.yml.
         os: [ubuntu-22.04, windows-latest]
 
     steps:


### PR DESCRIPTION
The mismatch was introduced by https://github.com/ruffle-rs/ruffle/pull/15217.
For explanation: https://github.com/ruffle-rs/ruffle/pull/15782#issuecomment-2020541422

Thanks for noticing, @danielhjacobs!

This will hopefully unblock the CI run for https://github.com/ruffle-rs/ruffle/pull/15839.