### PR TITLE
core: Add focus tracker to debug UI

### DIFF
--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -1914,6 +1914,12 @@ pub trait TDisplayObject<'gc>:
         false
     }
 
+    /// Whether this object may be highlighted when focused.
+    fn is_highlightable(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
+        self.as_interactive()
+            .is_some_and(|o| o.is_highlight_enabled(context))
+    }
+
     /// Whether this object is included in tab ordering.
     fn is_tabbable(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
         false

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -302,7 +302,7 @@ impl<'gc> EditText<'gc> {
         );
         let line_data = get_line_data(&layout);
 
-        let mut base = InteractiveObjectBase::new(false);
+        let mut base = InteractiveObjectBase::default();
 
         base.base.matrix_mut().tx = swf_tag.bounds().x_min;
         base.base.matrix_mut().ty = swf_tag.bounds().y_min;
@@ -2347,12 +2347,16 @@ impl<'gc> TDisplayObject<'gc> for EditText<'gc> {
         true
     }
 
+    fn is_highlightable(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
+        // TextField is incapable of rendering a highlight.
+        false
+    }
+
     fn is_tabbable(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
         if !self.is_editable() {
             // Non-editable text fields are never tabbable.
             return false;
         }
-
         self.get_avm1_boolean_property(context, "tabEnabled", |_| true)
     }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -92,28 +92,17 @@ pub struct InteractiveObjectBase<'gc> {
 
     /// Specifies whether this object displays a yellow rectangle when focused.
     focus_rect: Option<bool>,
-
-    /// Specifies whether focus_rect should be considered.
-    /// When set to `false`, no highlight is rendered ever.
-    focus_rect_supported: bool,
 }
 
-impl<'gc> InteractiveObjectBase<'gc> {
-    pub fn new(focus_rect_supported: bool) -> Self {
+impl<'gc> Default for InteractiveObjectBase<'gc> {
+    fn default() -> Self {
         Self {
             base: Default::default(),
             flags: InteractiveObjectFlags::MOUSE_ENABLED,
             context_menu: Avm2Value::Null,
             last_click: None,
             focus_rect: None,
-            focus_rect_supported,
         }
-    }
-}
-
-impl<'gc> Default for InteractiveObjectBase<'gc> {
-    fn default() -> Self {
-        InteractiveObjectBase::new(true)
     }
 }
 
@@ -518,11 +507,12 @@ pub trait TInteractiveObject<'gc>:
         MouseCursor::Hand
     }
 
-    /// Whether this object may be highlighted when focused.
+    /// Whether highlight is enabled for this object.
+    ///
+    /// Note: This value does not mean that a highlight should actually be rendered,
+    /// for that see [`TDisplayObject::is_highlightable()`].
     fn is_highlight_enabled(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        if !self.raw_interactive().focus_rect_supported {
-            false
-        } else if context.swf.version() >= 6 {
+        if context.swf.version() >= 6 {
             self.focus_rect()
                 .unwrap_or_else(|| context.stage.stage_focus_rect())
         } else {

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -1,7 +1,6 @@
 use crate::avm1::Avm1;
 use crate::avm1::Value;
 use crate::context::{RenderContext, UpdateContext};
-use crate::display_object::TInteractiveObject;
 pub use crate::display_object::{
     DisplayObject, TDisplayObject, TDisplayObjectContainer, TextSelection,
 };
@@ -153,10 +152,7 @@ impl<'gc> FocusTracker<'gc> {
             return Highlight::Inactive;
         };
 
-        if !focus
-            .as_interactive()
-            .is_some_and(|o| o.is_highlight_enabled(context))
-        {
+        if !focus.is_highlightable(context) {
             return Highlight::Inactive;
         }
 

--- a/core/src/focus_tracker.rs
+++ b/core/src/focus_tracker.rs
@@ -47,6 +47,10 @@ impl<'gc> FocusTracker<'gc> {
         ))
     }
 
+    pub fn is_highlight_active(&self) -> bool {
+        matches!(*self.0.highlight.borrow(), Highlight::Active(_))
+    }
+
     pub fn reset_highlight(&self) {
         self.0.highlight.replace(Highlight::Inactive);
     }
@@ -143,7 +147,7 @@ impl<'gc> FocusTracker<'gc> {
         }
     }
 
-    fn update_highlight(&self, context: &mut UpdateContext<'_, 'gc>) {
+    pub fn update_highlight(&self, context: &mut UpdateContext<'_, 'gc>) {
         self.0.highlight.replace(self.redraw_highlight(context));
     }
 


### PR DESCRIPTION
This makes debugging easier, especially related to tab ordering :eyes: :eyes: :eyes: 

<img src="https://github.com/ruffle-rs/ruffle/assets/1507072/63af7ab5-a1fc-478e-8d3e-b79e1e7075fd" width="400"/>
