### PR TITLE
frontend-utils: Add TableExt trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4286,6 +4286,7 @@ name = "ruffle_frontend_utils"
 version = "0.1.0"
 dependencies = [
  "toml_edit 0.22.9",
+ "tracing",
  "url",
 ]
 

--- a/frontend-utils/Cargo.toml
+++ b/frontend-utils/Cargo.toml
@@ -13,3 +13,4 @@ workspace = true
 [dependencies]
 toml_edit = { version = "0.22.9", features = ["parse"] }
 url = { workspace = true }
+tracing = { workspace = true }

--- a/frontend-utils/src/lib.rs
+++ b/frontend-utils/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod bookmarks;
 pub mod parse;
+pub mod write;

--- a/frontend-utils/src/write.rs
+++ b/frontend-utils/src/write.rs
@@ -1,0 +1,22 @@
+use toml_edit::{array, ArrayOfTables, Table};
+
+pub trait TableExt {
+    /// Gets an existing array of tables, or creates a new one if it does not exist or type is different.
+    fn get_or_create_array_of_tables(&mut self, key: &str) -> &mut ArrayOfTables;
+}
+
+impl TableExt for Table {
+    fn get_or_create_array_of_tables(&mut self, key: &str) -> &mut ArrayOfTables {
+        if self.contains_array_of_tables(key) {
+            return self[key]
+                .as_array_of_tables_mut()
+                .expect("type was just verified");
+        }
+
+        tracing::warn!("missing or invalid '{key}' array, recreating..");
+        self.insert(key, array());
+        self[key]
+            .as_array_of_tables_mut()
+            .expect("type was just created")
+    }
+}


### PR DESCRIPTION
This moves the logic previously found in BookmarkWriter's `with_underlying_table` into a common trait to be reused by other writers.