### PR TITLE
chore: Fix Dependabot `npm` path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
         - "naga_oil"
         - "egui*"
         - "raw-window-handle"
-      wasm-bindgen-dependencies:
+      wasm-bindgen:
         patterns:
         - "wasm-bindgen"
         - "js-sys"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     allow:
       - dependency-type: "all"
-    directory: "/"
+    directory: "/web/"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
See: https://github.com/ruffle-rs/ruffle/network/updates/810167068

Fixup for https://github.com/ruffle-rs/ruffle/pull/15869, which was a fixup for https://github.com/ruffle-rs/ruffle/pull/14146.