### PR TITLE
ci: run extra clippy step without tests

### DIFF
--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -129,9 +129,13 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Check clippy
+      - name: Check clippy (with tests)
         # Don't fail the build for clippy on nightly, since we get a lot of false-positives
         run: cargo clippy --all --all-features --tests ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
+
+      - name: Check clippy (without tests)
+        # Don't fail the build for clippy on nightly, since we get a lot of false-positives
+        run: cargo clippy --all --all-features ${{ (matrix.rust_version != 'nightly' && '-- -D warnings') || '' }}
 
       - name: Check documentation
         run: cargo doc --no-deps --all-features

--- a/desktop/src/preferences/read.rs
+++ b/desktop/src/preferences/read.rs
@@ -1,7 +1,6 @@
 use crate::preferences::SavedGlobalPreferences;
 use ruffle_frontend_utils::bookmarks::{Bookmark, Bookmarks};
 use ruffle_frontend_utils::parse::{DocumentHolder, ParseContext, ParseResult, ReadExt};
-use std::str::FromStr;
 use toml_edit::DocumentMut;
 
 /// Read the given preferences into a **guaranteed valid** `SavedGlobalPreferences`,
@@ -115,6 +114,7 @@ mod tests {
     use crate::preferences::{storage::StorageBackend, LogPreferences, StoragePreferences};
     use fluent_templates::loader::langid;
     use ruffle_render_wgpu::clap::{GraphicsBackend, PowerPreference};
+    use std::str::FromStr;
     use url::Url;
 
     #[test]


### PR DESCRIPTION
Currently to check if it would have caught the unused import on master.