### PR TITLE
avm2: More performance improvements

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -295,12 +295,19 @@ impl<'gc> Avm2<'gc> {
         let (method, scope, _domain) = script.init();
         match method {
             Method::Native(method) => {
-                //This exists purely to check if the builtin is OK with being called with
-                //no parameters.
+                if method.resolved_signature.read().is_none() {
+                    method.resolve_signature(&mut init_activation)?;
+                }
+
+                let resolved_signature = method.resolved_signature.read();
+                let resolved_signature = resolved_signature.as_ref().unwrap();
+
+                // This exists purely to check if the builtin is OK with being called with
+                // no parameters.
                 init_activation.resolve_parameters(
                     Method::Native(method),
                     &[],
-                    &method.signature,
+                    resolved_signature,
                     None,
                 )?;
                 init_activation

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -911,7 +911,11 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::SetLocal { index } => self.op_set_local(*index),
                 Op::Kill { index } => self.op_kill(*index),
                 Op::Call { num_args } => self.op_call(*num_args),
-                Op::CallMethod { index, num_args } => self.op_call_method(*index, *num_args),
+                Op::CallMethod {
+                    index,
+                    num_args,
+                    push_return_value,
+                } => self.op_call_method(*index, *num_args, *push_return_value),
                 Op::CallProperty {
                     multiname,
                     num_args,
@@ -1205,6 +1209,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         &mut self,
         index: u32,
         arg_count: u32,
+        push_return_value: bool,
     ) -> Result<FrameControl<'gc>, Error<'gc>> {
         // The entire implementation of VTable assumes that
         // call_method is never encountered in user code. (see the long comment there)
@@ -1218,7 +1223,9 @@ impl<'a, 'gc> Activation<'a, 'gc> {
 
         let value = receiver.call_method(index, &args, self)?;
 
-        self.push_stack(value);
+        if push_return_value {
+            self.push_stack(value);
+        }
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -819,10 +819,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let verified_info = method.verified_info.read();
         let verified_code = verified_info.as_ref().unwrap().parsed_code.as_slice();
 
-        if verified_code.is_empty() {
-            return Ok(Value::Undefined);
-        }
-
         self.ip = 0;
 
         let val = loop {

--- a/core/src/avm2/function.rs
+++ b/core/src/avm2/function.rs
@@ -145,10 +145,17 @@ impl<'gc> Executable<'gc> {
                     .into());
                 }
 
+                if bm.method.resolved_signature.read().is_none() {
+                    bm.method.resolve_signature(&mut activation)?;
+                }
+
+                let resolved_signature = bm.method.resolved_signature.read();
+                let resolved_signature = resolved_signature.as_ref().unwrap();
+
                 let arguments = activation.resolve_parameters(
                     Method::Native(bm.method),
                     arguments,
-                    &bm.method.signature,
+                    resolved_signature,
                     Some(callee),
                 )?;
                 activation

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -597,6 +597,17 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         base.set_slot(id, value, activation.gc())
     }
 
+    fn set_slot_no_coerce(
+        self,
+        id: u32,
+        value: Value<'gc>,
+        mc: &Mutation<'gc>,
+    ) -> Result<(), Error<'gc>> {
+        let mut base = self.base_mut(mc);
+
+        base.set_slot(id, value, mc)
+    }
+
     /// Call a method by its index.
     ///
     /// This directly corresponds with the AVM2 operation `callmethod`.

--- a/core/src/avm2/object/function_object.rs
+++ b/core/src/avm2/object/function_object.rs
@@ -31,6 +31,7 @@ pub fn function_allocator<'gc>(
             method: |_, _, _| Ok(Value::Undefined),
             name: "<Empty Function>",
             signature: vec![],
+            resolved_signature: GcCell::new(activation.context.gc_context, None),
             return_type: Multiname::any(activation.context.gc_context),
             is_variadic: true,
         },

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -32,8 +32,8 @@ pub enum Op<'gc> {
     },
     CallMethod {
         index: u32,
-
         num_args: u32,
+        push_return_value: bool,
     },
     CallProperty {
         multiname: Gc<'gc, Multiname<'gc>>,

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -296,6 +296,7 @@ pub enum Op<'gc> {
     PushUndefined,
     PushWith,
     ReturnValue,
+    ReturnValueNoCoerce,
     ReturnVoid,
     RShift,
     SetGlobalSlot {
@@ -308,6 +309,9 @@ pub enum Op<'gc> {
         multiname: Gc<'gc, Multiname<'gc>>,
     },
     SetSlot {
+        index: u32,
+    },
+    SetSlotNoCoerce {
         index: u32,
     },
     SetSuper {

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -3,9 +3,7 @@ use crate::avm2::multiname::Multiname;
 use crate::string::AvmAtom;
 
 use gc_arena::{Collect, Gc, GcCell};
-use swf::avm2::types::{
-    Class as AbcClass, Exception, Index, LookupSwitch, Method, Multiname as AbcMultiname, Namespace,
-};
+use swf::avm2::types::{Class as AbcClass, Exception, Index, LookupSwitch, Method, Namespace};
 
 #[derive(Clone, Collect, Debug)]
 #[collect(no_drop)]
@@ -41,8 +39,7 @@ pub enum Op<'gc> {
         num_args: u32,
     },
     CallPropLex {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
 
         num_args: u32,
     },
@@ -58,14 +55,12 @@ pub enum Op<'gc> {
         num_args: u32,
     },
     CallSuper {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
 
         num_args: u32,
     },
     CallSuperVoid {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
 
         num_args: u32,
     },
@@ -133,8 +128,7 @@ pub enum Op<'gc> {
         multiname: Gc<'gc, Multiname<'gc>>,
     },
     GetDescendants {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     GetGlobalScope,
     GetGlobalSlot {
@@ -159,8 +153,7 @@ pub enum Op<'gc> {
         index: u32,
     },
     GetSuper {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     GreaterEquals,
     GreaterThan,
@@ -318,8 +311,7 @@ pub enum Op<'gc> {
         index: u32,
     },
     SetSuper {
-        #[collect(require_static)]
-        index: Index<AbcMultiname>,
+        multiname: Gc<'gc, Multiname<'gc>>,
     },
     Sf32,
     Sf64,

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -989,30 +989,6 @@ impl<'gc> Value<'gc> {
         }
     }
 
-    /// Like `coerce_to_type`, but also performs resolution of the type name.
-    /// This is used to allow coercing to a class while the ClassObject is still
-    /// being initialized. We should eventually be able to remove this, once
-    /// our Class/ClassObject representation is refactored.
-    pub fn coerce_to_type_name(
-        &self,
-        activation: &mut Activation<'_, 'gc>,
-        type_name: &Multiname<'gc>,
-    ) -> Result<Value<'gc>, Error<'gc>> {
-        if type_name.is_any_name() {
-            return Ok(*self);
-        }
-        let param_type = activation
-            .domain()
-            .get_class(type_name, activation.context.gc_context)
-            .ok_or_else(|| {
-                Error::RustError(
-                    format!("Failed to lookup class {:?} during coercion", type_name).into(),
-                )
-            })?;
-
-        self.coerce_to_type(activation, param_type)
-    }
-
     /// Coerce the value to another value by type name.
     ///
     /// This function implements a handful of coercion rules that appear to be

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -741,7 +741,11 @@ fn resolve_op<'gc>(
         AbcOp::SetLocal { index } => Op::SetLocal { index },
         AbcOp::Kill { index } => Op::Kill { index },
         AbcOp::Call { num_args } => Op::Call { num_args },
-        AbcOp::CallMethod { index, num_args } => Op::CallMethod { index, num_args },
+        AbcOp::CallMethod { index, num_args } => Op::CallMethod {
+            index,
+            num_args,
+            push_return_value: true,
+        },
         AbcOp::CallProperty { index, num_args } => {
             let multiname = pool_multiname(activation, translation_unit, index)?;
 

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -832,7 +832,14 @@ fn resolve_op<'gc>(
                 num_args,
             }
         }
-        AbcOp::CallPropLex { index, num_args } => Op::CallPropLex { index, num_args },
+        AbcOp::CallPropLex { index, num_args } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+
+            Op::CallPropLex {
+                multiname,
+                num_args,
+            }
+        }
         AbcOp::CallPropVoid { index, num_args } => {
             let multiname = pool_multiname(activation, translation_unit, index)?;
 
@@ -842,8 +849,22 @@ fn resolve_op<'gc>(
             }
         }
         AbcOp::CallStatic { index, num_args } => Op::CallStatic { index, num_args },
-        AbcOp::CallSuper { index, num_args } => Op::CallSuper { index, num_args },
-        AbcOp::CallSuperVoid { index, num_args } => Op::CallSuperVoid { index, num_args },
+        AbcOp::CallSuper { index, num_args } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+
+            Op::CallSuper {
+                multiname,
+                num_args,
+            }
+        }
+        AbcOp::CallSuperVoid { index, num_args } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+
+            Op::CallSuperVoid {
+                multiname,
+                num_args,
+            }
+        }
         AbcOp::ReturnValue => Op::ReturnValue,
         AbcOp::ReturnVoid => Op::ReturnVoid,
         AbcOp::GetProperty { index } => {
@@ -866,8 +887,16 @@ fn resolve_op<'gc>(
 
             Op::DeleteProperty { multiname }
         }
-        AbcOp::GetSuper { index } => Op::GetSuper { index },
-        AbcOp::SetSuper { index } => Op::SetSuper { index },
+        AbcOp::GetSuper { index } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+
+            Op::GetSuper { multiname }
+        }
+        AbcOp::SetSuper { index } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+
+            Op::SetSuper { multiname }
+        }
         AbcOp::In => Op::In,
         AbcOp::PushScope => Op::PushScope,
         AbcOp::NewCatch { index } => Op::NewCatch { index },
@@ -898,7 +927,11 @@ fn resolve_op<'gc>(
 
             Op::GetLex { multiname }
         }
-        AbcOp::GetDescendants { index } => Op::GetDescendants { index },
+        AbcOp::GetDescendants { index } => {
+            let multiname = pool_multiname(activation, translation_unit, index)?;
+
+            Op::GetDescendants { multiname }
+        }
         AbcOp::GetSlot { index } => Op::GetSlot { index },
         AbcOp::SetSlot { index } => Op::SetSlot { index },
         AbcOp::GetGlobalSlot { index } => Op::GetGlobalSlot { index },

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -580,6 +580,7 @@ pub fn verify_method<'gc>(
             activation,
             method,
             &mut verified_code,
+            &resolved_param_config,
             potential_jump_targets,
         );
     }

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -581,6 +581,7 @@ pub fn verify_method<'gc>(
             method,
             &mut verified_code,
             &resolved_param_config,
+            resolved_return_type,
             potential_jump_targets,
         );
     }


### PR DESCRIPTION
`CallPropVoid` optimizes to `CallMethod` surprisingly well, sometimes around 60%.

The second commit turns out to be a little more complicated than #11954: FP does verification _before_ validating the user-passed arguments vs the function signature, so this requires some juggling in `Activation::init_from_method`. Specifically, we need the number of local registers to be known before initializing the Activation, but we also need that initialized Activation to resolve the arguments (which are put into local registers) in the verifier. This ended up being a good thing: we now allocate fewer locals (specifically, we now only do `num_locals + 1`, while previously we were doing `num_locals + num_declared_arguments + arg_register + 1`).

I noticed #15485 starts about 3 seconds faster for me. A microbenchmark of calling a function `public function fn(a:int, b:MovieClip, c:Boolean, d:Number, e:Test, ... rest) : void` in a tight loop shows a 20% performance improvement.

A tight loop of `setproperty` with values set to the same type as the field's type shows performance improvements of about 30%.

New stats for box2d:
```
InitProperty -> SetSlot : 37.6%
InitProperty -> SetSlotNoCoerce : 36.78%

SetProperty -> SetSlot : 15.73%
SetProperty -> SetSlotNoCoerce : 29.72%
SetProperty -> CallMethod : 1.57%

GetProperty -> GetSlot : 62.97%
GetProperty -> CallMethod : 0.36%

CallProperty -> CallMethod : 31.05%

CallPropVoid -> CallMethod : 60.61%

Coerce -> Nop : 46.66%

CoerceD -> Nop : 78.36%

CoerceB -> Nop : 8.11%

CoerceU -> Nop : 32.46%

CoerceI -> Nop : 2%

ReturnValue -> ReturnValueNoCoerce : 65.14%
```