### PR TITLE
avm1: Remove unnecessary MovieClip coercions

### DIFF
--- a/core/src/avm1/activation.rs
+++ b/core/src/avm1/activation.rs
@@ -777,12 +777,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         let variable = self.get_variable(fn_name)?;
@@ -807,12 +802,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         // Can not call method on undefined/null.
@@ -1707,12 +1697,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         // Can not call method on undefined/null.
@@ -1759,12 +1744,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let num_args = num_args.min(self.context.avm1.stack_len());
         let mut args = Vec::with_capacity(num_args);
         for _ in 0..num_args {
-            let arg = self.context.avm1.pop();
-            if let Value::MovieClip(_) = arg {
-                args.push(Value::Object(arg.coerce_to_object(self)));
-            } else {
-                args.push(arg);
-            }
+            args.push(self.context.avm1.pop());
         }
 
         let name_value: Value<'gc> = self.resolve(fn_name)?.into();

--- a/tests/tests/swfs/avm1/string_paths_reference_launder/test.toml
+++ b/tests/tests/swfs/avm1/string_paths_reference_launder/test.toml
@@ -1,2 +1,1 @@
 num_frames = 1
-known_failure = true # See the comment in `stack_push` in avm1/activiation.rs for details


### PR DESCRIPTION
Previously, removed MovieClips that were passed to a function using one of CallFunction/CallMethod/NewObject/NewMethod were coerced to a boxed undefined object. Here's an example:
```as
var mc = this.createEmptyMovieClip("mc", 1);
removeMovieClip(mc);

// CallFunction
f(mc);

// CallMethod
_root.f(mc);

// NewObject
new f(mc);

// NewMethod
new _root.f(mc);

function f(a) {
    trace(a == undefined); // false in Flash, true in Ruffle
    trace(typeof a); // movieclip in Flash, object in Ruffle
}
```

Fixes #15265.