### PR TITLE
input: Add support for `NumLock`

### DIFF
--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -492,6 +492,7 @@ pub enum KeyCode {
     F22 = 133, // undocumented
     F23 = 134, // undocumented
     F24 = 135, // undocumented
+    NumLock = 144,
     ScrollLock = 145,
     Semicolon = 186,
     Equals = 187,

--- a/desktop/src/util.rs
+++ b/desktop/src/util.rs
@@ -144,6 +144,7 @@ pub fn winit_to_ruffle_key_code(event: &KeyEvent) -> KeyCode {
         Key::Named(NamedKey::Insert) => KeyCode::Insert,
         Key::Named(NamedKey::Delete) => KeyCode::Delete,
         Key::Named(NamedKey::Pause) => KeyCode::Pause,
+        Key::Named(NamedKey::NumLock) => KeyCode::NumLock,
         Key::Named(NamedKey::ScrollLock) => KeyCode::ScrollLock,
         Key::Named(NamedKey::F1) => KeyCode::F1,
         Key::Named(NamedKey::F2) => KeyCode::F2,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1881,6 +1881,7 @@ fn web_to_ruffle_key_code(key_code: &str) -> KeyCode {
         "Insert" => KeyCode::Insert,
         "Delete" => KeyCode::Delete,
         "Pause" => KeyCode::Pause,
+        "NumLock" => KeyCode::NumLock,
         "ScrollLock" => KeyCode::ScrollLock,
         "F1" => KeyCode::F1,
         "F2" => KeyCode::F2,


### PR DESCRIPTION
This patch adds support for <kbd>NumLock</kbd>, which was missing.

Now <kbd>NumLock</kbd> (144) may be used as a parameter in methods from the `Key` class.