### PR TITLE
tests: Schedule slow tests at the beginning

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,3 +7,17 @@ test(avm2/graphics_round_rects) or \
 test(avm1/netstream_play_flv) or \
 test(avm1/netstream_play_flv_screen)"""
 retries = 4
+
+# Run tests that take more time first
+# NOTE: Make sure to synchronize this with TestKind::priority
+[[profile.default.overrides]]
+filter = "test([realtime] )"
+priority = 3
+
+[[profile.default.overrides]]
+filter = "test([large] )"
+priority = 2
+
+[[profile.default.overrides]]
+filter = "test([render] )"
+priority = 1

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,6 +21,8 @@ imgtests = [
 ]
 jpegxr = ["ruffle_test_framework/jpegxr"]
 lzma = ["ruffle_test_framework/lzma"]
+# Log how long each test took
+times = []
 
 [dependencies]
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,10 @@ known_failure = false # If true, this test is known to fail and the result will 
 output_path = "output.txt" # Path (relative to the directory containing test.toml) to the expected output
 log_fetch = false # If true, all network requests will be included in the output.
 
+# Used to mark larger tests as `size = "large"`. Larger tests will be executed
+# at the beginning to improve test execution time.
+size = "regular"
+
 # Sometimes floating point math doesn't exactly 100% match between flash and rust.
 # If you encounter this in a test, the following section will change the output testing from "exact" to "approximate"
 # (when it comes to floating point numbers, at least.)

--- a/tests/framework/src/options.rs
+++ b/tests/framework/src/options.rs
@@ -17,6 +17,14 @@ use std::time::Duration;
 use vfs::VfsPath;
 
 #[derive(Clone, Deserialize)]
+pub enum TestSize {
+    #[serde(rename = "regular")]
+    Regular,
+    #[serde(rename = "large")]
+    Large,
+}
+
+#[derive(Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TestOptions {
     pub num_frames: Option<u32>,
@@ -32,6 +40,7 @@ pub struct TestOptions {
     pub log_fetch: bool,
     pub required_features: RequiredFeatures,
     pub fonts: HashMap<String, FontOptions>,
+    pub size: TestSize,
 }
 
 impl Default for TestOptions {
@@ -50,6 +59,7 @@ impl Default for TestOptions {
             log_fetch: false,
             required_features: RequiredFeatures::default(),
             fonts: Default::default(),
+            size: TestSize::Regular,
         }
     }
 }
@@ -226,6 +236,10 @@ impl PlayerOptions {
                 height: movie.height().to_pixels() as u32,
                 scale_factor: 1.0,
             })
+    }
+
+    pub fn has_renderer(&self) -> bool {
+        self.with_renderer.is_some()
     }
 
     pub fn create_renderer(

--- a/tests/framework/src/test.rs
+++ b/tests/framework/src/test.rs
@@ -30,6 +30,21 @@ impl TestKind {
             TestKind::Render => "render",
         }
     }
+
+    pub fn priority(kind: &str) -> isize {
+        // NOTE: Make sure to synchronize this with the nextest config
+        match kind {
+            "realtime" => 3,
+            "large" => 2,
+            // Render tests are slower on Windows and sometimes on nextest
+            "render" => 1,
+            _ => 0,
+        }
+    }
+
+    pub fn ord(kind: &str) -> impl Ord {
+        -Self::priority(kind)
+    }
 }
 
 pub struct Test {

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -11,7 +11,7 @@ use libtest_mimic::Trial;
 use ruffle_fs_tests_runner::{FsTestsRunner, TestLoaderParams};
 use ruffle_test_framework::options::TestOptions;
 use ruffle_test_framework::runner::TestStatus;
-use ruffle_test_framework::test::Test;
+use ruffle_test_framework::test::{Test, TestKind};
 use std::borrow::Cow;
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
@@ -60,6 +60,8 @@ fn main() {
     runner.with_additional_test(Trial::test("external_interface_avm2", || {
         external_interface_avm2(&NativeEnvironment)
     }));
+
+    runner.with_test_ordering_by_key(|t| (TestKind::ord(t.kind()), t.name().to_owned()));
 
     runner.run()
 }

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -80,6 +80,7 @@ fn load_test(params: TestLoaderParams) -> Trial {
     .unwrap();
 
     let ignore = !test.should_run(!args.list, &NativeEnvironment);
+    let kind = test.kind();
 
     let mut trial = Trial::test(test.name.to_string(), move || {
         let test = AssertUnwindSafe(test);
@@ -111,6 +112,9 @@ fn load_test(params: TestLoaderParams) -> Trial {
             }
         }
     });
+    if let Some(kind) = kind {
+        trial = trial.with_kind(kind.name());
+    }
     if ignore {
         trial = trial.with_ignored_flag(true);
     }

--- a/tests/tests/regression_tests.rs
+++ b/tests/tests/regression_tests.rs
@@ -73,7 +73,12 @@ fn load_test(params: TestLoaderParams) -> Trial {
 
     let test = Test::from_options(
         TestOptions::read(&root.join("test.toml").unwrap())
-            .context("Couldn't load test options")
+            .with_context(|| {
+                format!(
+                    "Couldn't load test options for {}",
+                    params.test_dir_real.to_string_lossy()
+                )
+            })
             .unwrap(),
         root,
         name.to_string(),

--- a/tests/tests/swfs/avm1/bitmap_data_pixeldissolve/test.toml
+++ b/tests/tests/swfs/avm1/bitmap_data_pixeldissolve/test.toml
@@ -1,1 +1,2 @@
 num_frames = 1
+size = "large"

--- a/tests/tests/swfs/avm1/from_shumway/depth/test.toml
+++ b/tests/tests/swfs/avm1/from_shumway/depth/test.toml
@@ -1,3 +1,4 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/avm1/depth
 
 num_frames = 1
+size = "large"

--- a/tests/tests/swfs/avm1/timeout/test.toml
+++ b/tests/tests/swfs/avm1/timeout/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
+size = "large"
 
 [player_options]
 max_execution_duration = { secs = 5, nanos = 0 }

--- a/tests/tests/swfs/avm2/away3d_advanced_shallow_water_demo/test.toml
+++ b/tests/tests/swfs/avm2/away3d_advanced_shallow_water_demo/test.toml
@@ -1,4 +1,5 @@
 num_ticks = 20
+size = "large"
 
 [image_comparisons.output]
 tolerance = 30

--- a/tests/tests/swfs/avm2/bitmapdata_copypixels_blend_over/test.toml
+++ b/tests/tests/swfs/avm2/bitmapdata_copypixels_blend_over/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/avm2/displayobject_hittestpoint_boundary/test.toml
+++ b/tests/tests/swfs/avm2/displayobject_hittestpoint_boundary/test.toml
@@ -1,4 +1,5 @@
 num_ticks = 1
+size = "large"
 
 [image_comparisons.output]
 tolerance = 0

--- a/tests/tests/swfs/avm2/edittext_get_char_index_at_point/test.toml
+++ b/tests/tests/swfs/avm2/edittext_get_char_index_at_point/test.toml
@@ -1,4 +1,5 @@
 num_ticks = 1
+size = "large"
 
 [image_comparisons.output]
 tolerance = 0

--- a/tests/tests/swfs/avm2/edittext_max_scroll_h_basic/test.toml
+++ b/tests/tests/swfs/avm2/edittext_max_scroll_h_basic/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/avm2/large_preload_image_from_bytes/test.toml
+++ b/tests/tests/swfs/avm2/large_preload_image_from_bytes/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 4
+size = "large"

--- a/tests/tests/swfs/avm2/pixelbender_parameters/test.toml
+++ b/tests/tests/swfs/avm2/pixelbender_parameters/test.toml
@@ -1,4 +1,5 @@
 num_ticks = 1
+size = "large"
 
 [player_options]
 with_renderer = { optional = false, sample_count = 4 }

--- a/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_raytrace/test.toml
@@ -3,6 +3,7 @@
 # All of the necessary files were copied into this directory.
 
 num_frames = 80
+size = "large"
 
 [image_comparisons.output]
 tolerance = 8

--- a/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
+++ b/tests/tests/swfs/avm2/stage3d_rotating_cube/test.toml
@@ -1,4 +1,5 @@
 num_frames = 40
+size = "large"
 
 [image_comparisons.output]
 tolerance = 1

--- a/tests/tests/swfs/from_avmplus/as3/Vector/initializer_large_vector/test.toml
+++ b/tests/tests/swfs/from_avmplus/as3/Vector/initializer_large_vector/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/e4x/Global/e13_1_2_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/e4x/Global/e13_1_2_1/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_10/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_10/test.toml
@@ -1,2 +1,3 @@
 num_ticks = 1
+size = "large"
 known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_14/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_14/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_16/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_16/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_18/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_18/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_20/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_20/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_22_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_22_1/test.toml
@@ -1,2 +1,3 @@
 num_ticks = 1
+size = "large"
 known_failure = true

--- a/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_22_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Date/e15_9_5_22_2/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_10_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_10_2/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_10_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_10_3/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_7_1/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_7_1/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_7_2/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_7_2/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_7_3/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Expressions/e11_7_3/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Function/apply_001/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Function/apply_001/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/u3400_CJKUnifiedIdeographsExtensionA/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/u3400_CJKUnifiedIdeographsExtensionA/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/u5000_CJKUnifiedIdeographs/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/u5000_CJKUnifiedIdeographs/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/u6000_CJKUnifiedIdeographs/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/u6000_CJKUnifiedIdeographs/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/u7000_CJKUnifiedIdeographs/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/u7000_CJKUnifiedIdeographs/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/u8000_CJKUnifiedIdeographs/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/u8000_CJKUnifiedIdeographs/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/u9000_CJKUnifiedIdeographs/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/u9000_CJKUnifiedIdeographs/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/uA000_YiSyllables/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/uA000_YiSyllables/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/uAC00_HangulSyllables/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/uAC00_HangulSyllables/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/ecma3/Unicode/uE000_PrivateUseArea/test.toml
+++ b/tests/tests/swfs/from_avmplus/ecma3/Unicode/uE000_PrivateUseArea/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/mops/mops_basics/test.toml
+++ b/tests/tests/swfs/from_avmplus/mops/mops_basics/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/from_avmplus/regress/bug_483783/test.toml
+++ b/tests/tests/swfs/from_avmplus/regress/bug_483783/test.toml
@@ -1,1 +1,2 @@
 num_ticks = 1
+size = "large"

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_big/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_big/test.toml
@@ -1,6 +1,7 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/acid
 
 num_frames = 300
+size = "large"
 
 [image_comparisons.output]
 tolerance = 50

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_color/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_color/test.toml
@@ -1,6 +1,7 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/acid
 
 num_frames = 10
+size = "large"
 
 [image_comparisons.output]
 tolerance = 3

--- a/tests/tests/swfs/visual/shumway_acid_tests/acid_large/test.toml
+++ b/tests/tests/swfs/visual/shumway_acid_tests/acid_large/test.toml
@@ -1,6 +1,7 @@
 # Test adapted from Shumway at https://github.com/mozilla/shumway/tree/master/test/swfs/acid
 
 num_frames = 500
+size = "large"
 
 [image_comparisons.output]
 tolerance = 11

--- a/tests/tests/swfs/visual/simple_shapes/heavy_tesselation/test.toml
+++ b/tests/tests/swfs/visual/simple_shapes/heavy_tesselation/test.toml
@@ -1,4 +1,5 @@
 num_frames = 1
+size = "large"
 
 [image_comparisons.output]
 tolerance = 0


### PR DESCRIPTION
By setting `size = "large"`, a test may be marked as large, which means that the duration of its execution is exceptionally long compared to other tests.

In order to minimize the duration of `cargo test`, slow tests should be executed at the beginning. This maximizes load on multithreaded CPUs by fully utilizing all threads and preventing late slow tests from stalling the whole suite.

Note: the following values are outdated.

| Test Command                  | Before  | After         | After with `fast` |
|-------------------------------|---------|---------------|-------------------|
| `cargo test`                  | ~~106.74s~~ | ~~77.45s **(-27%)**~~ | ~~43.55s **(-59%)**~~ |
| `cargo test -F imgtests`      | ~~115.94s~~ | ~~80.55s **(-31%)**~~ | ~~52.22s **(-55%)**~~ |
| `cargo nextest run`                  | ~~118.382s~~ | ~~80.872s **(-32%)**~~ | ~~49.526s **(-58%)**~~ |
| `cargo nextest run -F imgtests`      | ~~132.738s~~ | ~~91.500s **(-31%)**~~ | ~~69.857s **(-47%)**~~ |
| `cargo nextest run --cargo-profile ci` | ~~23.916s~~ | ~~13.178s **(-45%)**~~ | ~~10.070s **(-58%)**~~ |
| CI ubuntu      | ~~118.932s~~ | ~~82.319s **(-31%)**~~ | N/A |
| CI macos       | ~~69.940s~~  | ~~29.981s **(-57%)**~~ | N/A |
| CI windows     | ~~310.591s~~ | ~~217.358s **(-30%)**~~ | N/A |
