### PR TITLE
extension: Cleanup plugin-polyfill inline script on Firefox

### DIFF
--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -53,6 +53,7 @@ function injectScriptRaw(src: string) {
     const script = document.createElement("script");
     script.textContent = src;
     (document.head || document.documentElement).append(script);
+    script.remove();
 }
 
 /**


### PR DESCRIPTION
The easier half of #15862, which does not apply in other browsers because other browsers don't inject an inline script for this purpose.

This matches Method 2: Inject embedded code (MV2) from https://stackoverflow.com/questions/9515704/access-variables-and-functions-defined-in-page-context-from-an-extension/9517879#9517879