### PR TITLE
extension: Remove Ruffle's own script tag onload

### DIFF
--- a/web/packages/extension/src/content.ts
+++ b/web/packages/extension/src/content.ts
@@ -63,7 +63,10 @@ function injectScriptRaw(src: string) {
 function injectScriptURL(url: string): Promise<void> {
     const script = document.createElement("script");
     const promise = new Promise<void>((resolve, reject) => {
-        script.addEventListener("load", () => resolve());
+        script.addEventListener("load", function () {
+            resolve();
+            this.remove();
+        });
         script.addEventListener("error", (e) => reject(e));
     });
     script.charset = "utf-8";


### PR DESCRIPTION
This is almost identical to "Method 1: Inject another file" from https://stackoverflow.com/questions/9515704/access-variables-and-functions-defined-in-page-context-from-an-extension/9517879#9517879, but uses `addEventListener` instead of `onload`.
When merged alongside #15958, fixes #15862.