### PR TITLE
tests: Improve test lookup and add support for test kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5248,6 +5248,7 @@ dependencies = [
  "futures",
  "image 0.25.1",
  "libtest-mimic",
+ "regex",
  "ruffle_core",
  "ruffle_render_wgpu",
  "ruffle_test_framework",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,6 +20,7 @@ lzma = ["ruffle_test_framework/lzma"]
 
 [dependencies]
 ruffle_render_wgpu = { path = "../render/wgpu", optional = true }
+regex = "1.10.4"
 
 [dev-dependencies]
 ruffle_core = { path = "../core", features = ["deterministic", "timeline_debug", "avm_debug", "audio", "mp3", "default_font"] }


### PR DESCRIPTION
Regression tests were looked up using full directory walk regardless of whether there was an exact match or not. This patch looks up the test on exact match without scanning for all tests. This improvement is important due to how nextest executes tests: one by one using exact matches.

Additionally, this PR adds support for test kinds: `libtest_mimic` adds test kind as a prefix (e.g. `[kind] test` instead of `test`), which has to be taken into account when filtering for possible test candidates. This patch ensures compatibility with `libtest_mimic` when using test kinds.

Related comment: https://github.com/ruffle-rs/ruffle/pull/15950#issuecomment-2052141069