### PR TITLE
nits: Silence nightly lints

### DIFF
--- a/core/src/backend/audio/mixer.rs
+++ b/core/src/backend/audio/mixer.rs
@@ -207,7 +207,7 @@ impl SoundInstance {
             left_transform: [1.0, 0.0],
             right_transform: [0.0, 1.0],
             peak: [0.0, 0.0],
-            range: ([std::f32::INFINITY; 2], [std::f32::NEG_INFINITY; 2]),
+            range: ([f32::INFINITY; 2], [f32::NEG_INFINITY; 2]),
         }
     }
 
@@ -222,7 +222,7 @@ impl SoundInstance {
             left_transform: [1.0, 0.0],
             right_transform: [0.0, 1.0],
             peak: [0.0, 0.0],
-            range: ([std::f32::INFINITY; 2], [std::f32::NEG_INFINITY; 2]),
+            range: ([f32::INFINITY; 2], [f32::NEG_INFINITY; 2]),
         }
     }
 
@@ -231,7 +231,7 @@ impl SoundInstance {
         self.peak[0] = (self.range.1[0] - self.range.0[0]) / 2.0;
         self.peak[1] = (self.range.1[1] - self.range.0[1]) / 2.0;
 
-        self.range = ([std::f32::INFINITY; 2], [std::f32::NEG_INFINITY; 2]);
+        self.range = ([f32::INFINITY; 2], [f32::NEG_INFINITY; 2]);
     }
 }
 

--- a/core/src/display_object/graphic.rs
+++ b/core/src/display_object/graphic.rs
@@ -49,13 +49,11 @@ impl<'gc> Graphic<'gc> {
         let static_data = GraphicStatic {
             id: swf_shape.id,
             bounds: swf_shape.shape_bounds.clone(),
-            render_handle: Some(context.renderer.register_shape(
-                (&swf_shape).into(),
-                &MovieLibrarySource {
-                    library,
-                    gc_context: context.gc_context,
-                },
-            )),
+            render_handle: Some(
+                context
+                    .renderer
+                    .register_shape((&swf_shape).into(), &MovieLibrarySource { library }),
+            ),
             shape: swf_shape,
             movie,
         };

--- a/core/src/display_object/morph_shape.rs
+++ b/core/src/display_object/morph_shape.rs
@@ -238,13 +238,9 @@ impl MorphShapeStatic {
             handle
         } else {
             let library = library.library_for_movie(self.movie.clone()).unwrap();
-            let handle = context.renderer.register_shape(
-                (&frame.shape).into(),
-                &MovieLibrarySource {
-                    library,
-                    gc_context: context.gc_context,
-                },
-            );
+            let handle = context
+                .renderer
+                .register_shape((&frame.shape).into(), &MovieLibrarySource { library });
             frame.shape_handle = Some(handle.clone());
             handle
         }

--- a/core/src/library.rs
+++ b/core/src/library.rs
@@ -346,7 +346,6 @@ impl<'gc> MovieLibrary<'gc> {
 
 pub struct MovieLibrarySource<'a, 'gc> {
     pub library: &'a MovieLibrary<'gc>,
-    pub gc_context: &'a Mutation<'gc>,
 }
 
 impl<'a, 'gc> ruffle_render::bitmap::BitmapSource for MovieLibrarySource<'a, 'gc> {

--- a/core/src/streams.rs
+++ b/core/src/streams.rs
@@ -164,6 +164,7 @@ impl<'gc> Eq for NetStream<'gc> {}
 pub enum NetStreamType {
     /// The stream is an FLV.
     Flv {
+        #[allow(dead_code)] // set but never read
         header: FlvHeader,
 
         /// The currently playing video track's stream instance.

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -247,6 +247,7 @@ impl VertexAttributeFormat {
 pub struct ShaderConfig<'a> {
     pub shader_type: ShaderType,
     pub vertex_attributes: &'a [Option<VertexAttributeFormat>; 8],
+    #[allow(dead_code)] // set but never read
     pub sampler_configs: &'a [SamplerConfig; 8],
     pub version: AgalVersion,
 }

--- a/wstr/src/ptr.rs
+++ b/wstr/src/ptr.rs
@@ -165,7 +165,10 @@ pub const unsafe fn from_units(units: Units<*const [u8], *const [u16]>) -> *cons
 #[inline(always)]
 pub const unsafe fn from_units_mut(units: Units<*mut [u8], *mut [u16]>) -> *mut WStr {
     // SAFETY: `Units` is `repr(C)` so the transmute is sound.
-    from_units(transmute(units)) as *mut WStr
+    from_units(transmute::<
+        Units<*mut [u8], *mut [u16]>,
+        Units<*const [u8], *const [u16]>,
+    >(units)) as *mut WStr
 }
 
 /// Gets a pointer to the buffer designated by `ptr`.


### PR DESCRIPTION
As seen in: https://github.com/ruffle-rs/ruffle/actions/runs/8760095373/job/24044462484#step:6:709 (and all the way through the end of that step)

The `dead_code` lint is just silenced twice, because it seemed that the fields hold some kind of useful info that might be needed for future enhancements; while the third time I removed the field, because it looked like just a leftover technicality.

These lints are invisible, because we don't error out on them ( https://github.com/ruffle-rs/ruffle/actions/runs/8760095373/workflow#L134 ), but are also not printed as annotations either. The latter could be a TODO for later?

