### PR TITLE
Revert "avm2: Store Class instead of QName as superclass of Class"

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -326,6 +326,15 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         }
     }
 
+    pub fn lookup_class_in_domain(
+        &mut self,
+        name: &Multiname<'gc>,
+    ) -> Result<GcCell<'gc, Class<'gc>>, Error<'gc>> {
+        self.domain()
+            .get_class(name, self.context.gc_context)
+            .ok_or_else(|| format!("Attempted to resolve nonexistent type {name:?}").into())
+    }
+
     /// Resolve a single parameter value.
     ///
     /// Given an individual parameter value and the associated parameter's

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -10,7 +10,6 @@ use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::QName;
-use crate::context::UpdateContext;
 use gc_arena::{Collect, GcCell, GcWeakCell, Mutation};
 use ruffle_wstr::WStr;
 
@@ -214,20 +213,20 @@ impl<'gc> Domain<'gc> {
 
     pub fn get_class(
         self,
-        context: &mut UpdateContext<'_, 'gc>,
         multiname: &Multiname<'gc>,
+        mc: &Mutation<'gc>,
     ) -> Option<GcCell<'gc, Class<'gc>>> {
         let class = self.get_class_inner(multiname);
 
         if let Some(class) = class {
             if let Some(param) = multiname.param() {
                 if !param.is_any_name() {
-                    if let Some(resolved_param) = self.get_class(context, &param) {
-                        return Some(Class::with_type_param(context, class, Some(resolved_param)));
+                    if let Some(resolved_param) = self.get_class(&param, mc) {
+                        return Some(Class::with_type_param(class, Some(resolved_param), mc));
                     }
                     return None;
                 } else {
-                    return Some(Class::with_type_param(context, class, None));
+                    return Some(Class::with_type_param(class, None, mc));
                 }
             }
         }

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -8,6 +8,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{array_allocator, ArrayObject, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::string::AvmString;
 use bitflags::bitflags;
@@ -1246,7 +1247,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Array"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Array instance initializer>", mc),
         Method::from_builtin(class_init, "<Array class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -7,6 +7,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use gc_arena::GcCell;
 
@@ -135,7 +136,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Boolean"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Boolean instance initializer>", mc),
         Method::from_builtin(class_init, "<Boolean class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -6,6 +6,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use gc_arena::GcCell;
 
@@ -43,14 +44,14 @@ fn prototype<'gc>(
 }
 
 /// Construct `Class`'s class.
-pub fn create_class<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    object_class: GcCell<'gc, Class<'gc>>,
-) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
     let gc_context = activation.context.gc_context;
     let class_class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Class"),
-        Some(object_class),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Class instance initializer>", gc_context),
         Method::from_builtin(class_init, "<Class class initializer>", gc_context),
         gc_context,

--- a/core/src/avm2/globals/date.rs
+++ b/core/src/avm2/globals/date.rs
@@ -6,6 +6,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{date_allocator, DateObject, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::locale::{get_current_date_time, get_timezone};
 use crate::string::{utils as string_utils, AvmString, WStr};
@@ -1326,7 +1327,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Date"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Date instance initializer>", mc),
         Method::from_builtin(class_init, "<Date class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/function.rs
+++ b/core/src/avm2/globals/function.rs
@@ -8,6 +8,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{function_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use gc_arena::GcCell;
 
@@ -221,14 +222,14 @@ fn set_prototype<'gc>(
 }
 
 /// Construct `Function`'s class.
-pub fn create_class<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    object_classdef: GcCell<'gc, Class<'gc>>,
-) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
     let gc_context = activation.context.gc_context;
     let function_class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Function"),
-        Some(object_classdef),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Function instance initializer>", gc_context),
         Method::from_builtin(class_init, "<Function class initializer>", gc_context),
         gc_context,

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -10,6 +10,7 @@ use crate::avm2::method::Method;
 use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use gc_arena::GcCell;
 
@@ -32,14 +33,14 @@ pub fn class_init<'gc>(
 }
 
 /// Construct `global`'s class.
-pub fn create_class<'gc>(
-    activation: &mut Activation<'_, 'gc>,
-    object_class: GcCell<'gc, Class<'gc>>,
-) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
     let mc = activation.context.gc_context;
     Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "global"),
-        Some(object_class),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<global instance initializer>", mc),
         Method::from_builtin(class_init, "<global class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -216,7 +216,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "int"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin_and_params(
             instance_init,
             "<int instance initializer>",

--- a/core/src/avm2/globals/namespace.rs
+++ b/core/src/avm2/globals/namespace.rs
@@ -6,6 +6,7 @@ use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{namespace_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::{avm2_stub_constructor, avm2_stub_getter};
@@ -132,7 +133,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Namespace"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Namespace instance initializer>", mc),
         Method::from_builtin(class_init, "<Namespace class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -6,6 +6,7 @@ use crate::avm2::error::{make_error_1002, make_error_1003, make_error_1004};
 use crate::avm2::method::{Method, NativeMethodImpl};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
 use gc_arena::GcCell;
@@ -371,7 +372,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Number"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Number instance initializer>", mc),
         Method::from_builtin(class_init, "<Number class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/string.rs
+++ b/core/src/avm2/globals/string.rs
@@ -8,6 +8,7 @@ use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::regexp::RegExpFlags;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::avm2::{ArrayObject, ArrayStorage};
 use crate::string::{AvmString, WString};
@@ -671,7 +672,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "String"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<String instance initializer>", mc),
         Method::from_builtin(class_init, "<String class initializer>", mc),
         mc,

--- a/core/src/avm2/globals/uint.rs
+++ b/core/src/avm2/globals/uint.rs
@@ -217,7 +217,10 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "uint"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin_and_params(
             instance_init,
             "<uint instance initializer>",

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -14,6 +14,7 @@ use crate::avm2::object::{
 use crate::avm2::value::Value;
 use crate::avm2::vector::VectorStorage;
 use crate::avm2::Error;
+use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::string::AvmString;
 use gc_arena::GcCell;
@@ -916,7 +917,10 @@ pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().vector_public_namespace, "Vector"),
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(generic_init, "<Vector instance initializer>", mc),
         Method::from_builtin(generic_init, "<Vector class initializer>", mc),
         mc,
@@ -949,7 +953,10 @@ pub fn create_builtin_class<'gc>(
 
     let class = Class::new(
         name,
-        Some(activation.avm2().classes().object.inner_class_definition()),
+        Some(Multiname::new(
+            activation.avm2().public_namespace_base_version,
+            "Object",
+        )),
         Method::from_builtin(instance_init, "<Vector.<T> instance initializer>", mc),
         Method::from_builtin(class_init, "<Vector.<T> class initializer>", mc),
         mc,

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -12,10 +12,10 @@ use crate::avm2::property::Property;
 use crate::avm2::scope::{Scope, ScopeChain};
 use crate::avm2::value::Value;
 use crate::avm2::vtable::{ClassBoundMethod, VTable};
-use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::QName;
 use crate::avm2::TranslationUnit;
+use crate::avm2::{Domain, Error};
 use crate::string::AvmString;
 use fnv::FnvHashMap;
 use gc_arena::{Collect, GcCell, GcWeakCell, Mutation};
@@ -339,12 +339,11 @@ impl<'gc> ClassObject<'gc> {
         let mut queue = vec![class];
         while let Some(cls) = queue.pop() {
             for interface_name in cls.read().direct_interfaces() {
-                let interface = scope
-                    .domain()
-                    .get_class(&mut activation.context, interface_name)
-                    .ok_or_else(|| {
-                        Error::from(format!("Could not resolve interface {interface_name:?}"))
-                    })?;
+                let interface = self.early_resolve_class(
+                    scope.domain(),
+                    interface_name,
+                    activation.context.gc_context,
+                )?;
 
                 if !interface.read().is_interface() {
                     return Err(format!(
@@ -360,8 +359,12 @@ impl<'gc> ClassObject<'gc> {
                 }
             }
 
-            if let Some(super_class) = cls.read().super_class() {
-                queue.push(super_class);
+            if let Some(superclass_name) = cls.read().super_class_name() {
+                queue.push(self.early_resolve_class(
+                    scope.domain(),
+                    superclass_name,
+                    activation.context.gc_context,
+                )?);
             }
         }
         write.interfaces = interfaces;
@@ -391,6 +394,20 @@ impl<'gc> ClassObject<'gc> {
         }
 
         Ok(())
+    }
+
+    // Looks up a class by name, without using `ScopeChain.resolve`
+    // This lets us look up an class before its `ClassObject` has been constructed,
+    // which is needed to resolve classes when constructing a (different) `ClassObject`.
+    fn early_resolve_class(
+        &self,
+        domain: Domain<'gc>,
+        class_name: &Multiname<'gc>,
+        mc: &Mutation<'gc>,
+    ) -> Result<GcCell<'gc, Class<'gc>>, Error<'gc>> {
+        domain
+            .get_class(class_name, mc)
+            .ok_or_else(|| format!("Could not resolve class {class_name:?}").into())
     }
 
     /// Manually set the type of this `Class`.
@@ -966,7 +983,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
         let class_param = object_param.map(|c| c.inner_class_definition());
 
         let parameterized_class: GcCell<'_, Class<'_>> =
-            Class::with_type_param(&mut activation.context, self_class, class_param);
+            Class::with_type_param(self_class, class_param, activation.context.gc_context);
 
         // NOTE: this isn't fully accurate, but much simpler.
         // FP's Vector is more of special case that literally copies some parent class's properties

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -77,7 +77,7 @@ impl<'gc> PropertyClass<'gc> {
                     // so use that domain if we don't have a translation unit.
                     let domain =
                         unit.map_or(activation.avm2().playerglobals_domain, |u| u.domain());
-                    if let Some(class) = domain.get_class(&mut activation.context, name) {
+                    if let Some(class) = domain.get_class(name, activation.context.gc_context) {
                         *self = PropertyClass::Class(class);
                         (Some(class), true)
                     } else {
@@ -114,7 +114,7 @@ impl<'gc> PropertyClass<'gc> {
                 } else {
                     let domain =
                         unit.map_or(activation.avm2().playerglobals_domain, |u| u.domain());
-                    if let Some(class) = domain.get_class(&mut activation.context, name) {
+                    if let Some(class) = domain.get_class(name, activation.context.gc_context) {
                         *self = PropertyClass::Class(class);
                         Ok(Some(class))
                     } else {

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -232,10 +232,6 @@ impl<'gc> TranslationUnit<'gc> {
         drop(read);
 
         let mut activation = Activation::from_domain(uc.reborrow(), domain);
-        // Make sure we have the correct domain for code that tries to access it
-        // using `activation.domain()`
-        activation.set_outer(ScopeChain::new(domain));
-
         let global_class = activation.avm2().classes().global;
         let global_obj = global_class.construct(&mut activation, &[])?;
         global_obj.fork_vtable(activation.context.gc_context);

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -330,7 +330,7 @@ pub fn verify_method<'gc>(
 
                     activation
                         .domain()
-                        .get_class(&mut activation.context, &multiname)
+                        .get_class(&multiname, activation.context.gc_context)
                         .ok_or_else(|| {
                             make_error_1014(
                                 activation,
@@ -448,7 +448,7 @@ pub fn verify_method<'gc>(
 
             let resolved_type = activation
                 .domain()
-                .get_class(&mut activation.context, &pooled_type_name)
+                .get_class(&pooled_type_name, activation.context.gc_context)
                 .ok_or_else(|| {
                     make_error_1014(
                         activation,
@@ -610,7 +610,7 @@ pub fn resolve_param_config<'gc>(
         } else {
             let lookedup_class = activation
                 .domain()
-                .get_class(&mut activation.context, &param.param_type_name)
+                .get_class(&param.param_type_name, activation.context.gc_context)
                 .ok_or_else(|| {
                     make_error_1014(
                         activation,
@@ -648,7 +648,7 @@ fn resolve_return_type<'gc>(
     Ok(Some(
         activation
             .domain()
-            .get_class(&mut activation.context, return_type)
+            .get_class(return_type, activation.context.gc_context)
             .ok_or_else(|| {
                 make_error_1014(
                     activation,
@@ -1028,7 +1028,7 @@ fn resolve_op<'gc>(
 
             let class = activation
                 .domain()
-                .get_class(&mut activation.context, &multiname)
+                .get_class(&multiname, activation.context.gc_context)
                 .unwrap();
             // Verifier guarantees that class exists
 
@@ -1041,7 +1041,7 @@ fn resolve_op<'gc>(
 
             let class = activation
                 .domain()
-                .get_class(&mut activation.context, &multiname)
+                .get_class(&multiname, activation.context.gc_context)
                 .unwrap();
             // Verifier guarantees that class exists
 
@@ -1088,7 +1088,7 @@ fn resolve_op<'gc>(
 
             let class = activation
                 .domain()
-                .get_class(&mut activation.context, &multiname)
+                .get_class(&multiname, activation.context.gc_context)
                 .unwrap();
             // Verifier guarantees that class exists
 


### PR DESCRIPTION
Reverts ruffle-rs/ruffle#15986

Just temporarily, to prevent regression propagating into next nightly until the bug is fixed.