### PR TITLE
avm2: Simplify uses of `GcCell<'gc, Class<'gc>>`

### DIFF
--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -24,7 +24,7 @@ use crate::avm2::{Avm2, Error};
 use crate::context::{GcContext, UpdateContext};
 use crate::string::{AvmAtom, AvmString};
 use crate::tag_utils::SwfMovie;
-use gc_arena::{Gc, GcCell};
+use gc_arena::Gc;
 use smallvec::SmallVec;
 use std::cmp::{min, Ordering};
 use std::sync::Arc;
@@ -779,7 +779,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         &mut self,
         method: Gc<'gc, BytecodeMethod<'gc>>,
         index: Index<AbcClass>,
-    ) -> Result<GcCell<'gc, Class<'gc>>, Error<'gc>> {
+    ) -> Result<Class<'gc>, Error<'gc>> {
         method.translation_unit().load_class(index.0, self)
     }
 
@@ -1723,7 +1723,6 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 .instance_of()
                 .map(|cls| {
                     cls.inner_class_definition()
-                        .read()
                         .name()
                         .to_qualified_name_err_message(self.context.gc_context)
                 })
@@ -2620,10 +2619,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn op_is_type(
-        &mut self,
-        class: GcCell<'gc, Class<'gc>>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn op_is_type(&mut self, class: Class<'gc>) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.pop_stack();
 
         let is_instance_of = value.is_of_type(self, class);
@@ -2652,10 +2648,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         Ok(FrameControl::Continue)
     }
 
-    fn op_as_type(
-        &mut self,
-        class: GcCell<'gc, Class<'gc>>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn op_as_type(&mut self, class: Class<'gc>) -> Result<FrameControl<'gc>, Error<'gc>> {
         let value = self.pop_stack();
 
         if value.is_of_type(self, class) {
@@ -2821,10 +2814,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
     }
 
     /// Implements `Op::Coerce`
-    fn op_coerce(
-        &mut self,
-        class: GcCell<'gc, Class<'gc>>,
-    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+    fn op_coerce(&mut self, class: Class<'gc>) -> Result<FrameControl<'gc>, Error<'gc>> {
         let val = self.pop_stack();
         let x = val.coerce_to_type(self, class)?;
 

--- a/core/src/avm2/amf.rs
+++ b/core/src/avm2/amf.rs
@@ -130,7 +130,7 @@ pub fn serialize_value<'gc>(
                 let name = class_to_alias(activation, class);
 
                 let mut attributes = EnumSet::empty();
-                if !class.inner_class_definition().read().is_sealed() {
+                if !class.inner_class_definition().is_sealed() {
                     attributes.insert(Attribute::Dynamic);
                 }
 

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -37,7 +37,7 @@ struct DomainData<'gc> {
 
     /// A map of all Clasess defined in this domain. Used by ClassObject
     /// to perform early interface resolution.
-    classes: PropertyMap<'gc, GcCell<'gc, Class<'gc>>>,
+    classes: PropertyMap<'gc, Class<'gc>>,
 
     /// The parent domain.
     parent: Option<Domain<'gc>>,
@@ -90,7 +90,7 @@ impl<'gc> Domain<'gc> {
         domain
     }
 
-    pub fn classes(&self) -> Ref<'_, PropertyMap<'gc, GcCell<'gc, Class<'gc>>>> {
+    pub fn classes(&self) -> Ref<'_, PropertyMap<'gc, Class<'gc>>> {
         Ref::map(self.0.read(), |r| &r.classes)
     }
 
@@ -199,7 +199,7 @@ impl<'gc> Domain<'gc> {
         Ok(None)
     }
 
-    fn get_class_inner(self, multiname: &Multiname<'gc>) -> Option<GcCell<'gc, Class<'gc>>> {
+    fn get_class_inner(self, multiname: &Multiname<'gc>) -> Option<Class<'gc>> {
         let read = self.0.read();
         if let Some(class) = read.classes.get_for_multiname(multiname).copied() {
             return Some(class);
@@ -216,7 +216,7 @@ impl<'gc> Domain<'gc> {
         self,
         context: &mut UpdateContext<'_, 'gc>,
         multiname: &Multiname<'gc>,
-    ) -> Option<GcCell<'gc, Class<'gc>>> {
+    ) -> Option<Class<'gc>> {
         let class = self.get_class_inner(multiname);
 
         if let Some(class) = class {
@@ -333,12 +333,7 @@ impl<'gc> Domain<'gc> {
     /// Export a class into the current application domain.
     ///
     /// This does nothing if the definition already exists in this domain or a parent.
-    pub fn export_class(
-        &self,
-        export_name: QName<'gc>,
-        class: GcCell<'gc, Class<'gc>>,
-        mc: &Mutation<'gc>,
-    ) {
+    pub fn export_class(&self, export_name: QName<'gc>, class: Class<'gc>, mc: &Mutation<'gc>) {
         if self.has_class(export_name) {
             return;
         }

--- a/core/src/avm2/error.rs
+++ b/core/src/avm2/error.rs
@@ -100,7 +100,6 @@ pub fn make_reference_error<'gc>(
     let class_name = object_class
         .map(|cls| {
             cls.inner_class_definition()
-                .read()
                 .name()
                 .to_qualified_name_err_message(activation.context.gc_context)
         })

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -11,7 +11,7 @@ use crate::avm2::Namespace;
 use crate::avm2::QName;
 use crate::string::AvmString;
 use crate::tag_utils::{self, ControlFlow, SwfMovie, SwfSlice, SwfStream};
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::{Collect, Mutation};
 use std::sync::Arc;
 use swf::TagCode;
 
@@ -357,7 +357,7 @@ fn dynamic_class<'gc>(
 ) {
     let (_, global, mut domain) = script.init();
     let class = class_object.inner_class_definition();
-    let name = class.read().name();
+    let name = class.name();
 
     global.install_const_late(mc, name, class_object.into(), class_class);
     domain.export_definition(name, script, mc)
@@ -368,17 +368,15 @@ fn dynamic_class<'gc>(
 /// This function returns the class object and class prototype as a class, which
 /// may be stored in `SystemClasses`
 fn class<'gc>(
-    class_def: GcCell<'gc, Class<'gc>>,
+    class_def: Class<'gc>,
     script: Script<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<ClassObject<'gc>, Error<'gc>> {
     let mc = activation.context.gc_context;
     let (_, global, mut domain) = script.init();
 
-    let class_read = class_def.read();
-    let super_class = if let Some(super_class) = class_read.super_class() {
+    let super_class = if let Some(super_class) = class_def.super_class() {
         let super_class = super_class
-            .read()
             .class_object()
             .ok_or_else(|| Error::from("Base class should have been initialized"))?;
 
@@ -387,8 +385,7 @@ fn class<'gc>(
         None
     };
 
-    let class_name = class_read.name();
-    drop(class_read);
+    let class_name = class_def.name();
 
     let class_object = ClassObject::from_class(activation, class_def, super_class)?;
     global.install_const_late(
@@ -422,9 +419,7 @@ fn vector_class<'gc>(
     let generic_vector = activation.avm2().classes().generic_vector;
     generic_vector.add_application(mc, param_class, vector_cls);
     let generic_cls = generic_vector.inner_class_definition();
-    generic_cls
-        .write(mc)
-        .add_application(cls, vector_cls.inner_class_definition());
+    generic_cls.add_application(mc, cls, vector_cls.inner_class_definition());
 
     let legacy_name = QName::new(activation.avm2().vector_internal_namespace, legacy_name);
     global.install_const_late(
@@ -484,24 +479,24 @@ pub fn load_player_globals<'gc>(
     let object_classdef = object::create_class(activation);
     let object_class = ClassObject::from_class_partial(activation, object_classdef, None)?;
     let object_proto = ScriptObject::custom_object(mc, Some(object_class), None);
-    domain.export_class(object_classdef.read().name(), object_classdef, mc);
+    domain.export_class(object_classdef.name(), object_classdef, mc);
 
     let fn_classdef = function::create_class(activation, object_classdef);
     let fn_class = ClassObject::from_class_partial(activation, fn_classdef, Some(object_class))?;
     let fn_proto = ScriptObject::custom_object(mc, Some(fn_class), Some(object_proto));
-    domain.export_class(fn_classdef.read().name(), fn_classdef, mc);
+    domain.export_class(fn_classdef.name(), fn_classdef, mc);
 
     let class_classdef = class::create_class(activation, object_classdef);
     let class_class =
         ClassObject::from_class_partial(activation, class_classdef, Some(object_class))?;
     let class_proto = ScriptObject::custom_object(mc, Some(object_class), Some(object_proto));
-    domain.export_class(class_classdef.read().name(), class_classdef, mc);
+    domain.export_class(class_classdef.name(), class_classdef, mc);
 
     let global_classdef = global_scope::create_class(activation, object_classdef);
     let global_class =
         ClassObject::from_class_partial(activation, global_classdef, Some(object_class))?;
     let global_proto = ScriptObject::custom_object(mc, Some(object_class), Some(object_proto));
-    domain.export_class(global_classdef.read().name(), global_classdef, mc);
+    domain.export_class(global_classdef.name(), global_classdef, mc);
 
     // Now to weave the Gordian knot...
     object_class.link_prototype(activation, object_proto)?;

--- a/core/src/avm2/globals/array.rs
+++ b/core/src/avm2/globals/array.rs
@@ -11,7 +11,6 @@ use crate::avm2::Error;
 use crate::avm2::QName;
 use crate::string::AvmString;
 use bitflags::bitflags;
-use gc_arena::GcCell;
 use std::cmp::{min, Ordering};
 use std::mem::swap;
 
@@ -1242,7 +1241,7 @@ pub fn remove_at<'gc>(
 }
 
 /// Construct `Array`'s class.
-pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Array"),
@@ -1252,23 +1251,24 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         mc,
     );
 
-    let mut write = class.write(mc);
-
-    write.set_instance_allocator(array_allocator);
-    write.set_call_handler(Method::from_builtin(class_call, "<Array call handler>", mc));
+    class.set_instance_allocator(mc, array_allocator);
+    class.set_call_handler(
+        mc,
+        Method::from_builtin(class_call, "<Array call handler>", mc),
+    );
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &str,
         Option<NativeMethodImpl>,
         Option<NativeMethodImpl>,
     )] = &[("length", Some(length), Some(set_length))];
-    write.define_builtin_instance_properties(
+    class.define_builtin_instance_properties(
         mc,
         activation.avm2().public_namespace_base_version,
         PUBLIC_INSTANCE_PROPERTIES,
     );
 
-    write.define_builtin_instance_methods(
+    class.define_builtin_instance_methods(
         mc,
         activation.avm2().as3_namespace,
         PUBLIC_AS3_INSTANCE_METHODS,
@@ -1287,14 +1287,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         ),
         ("UNIQUESORT", SortOptions::UNIQUE_SORT.bits() as u32),
     ];
-    write.define_constant_uint_class_traits(
+    class.define_constant_uint_class_traits(
         activation.avm2().public_namespace_base_version,
         CONSTANTS_UINT,
         activation,
     );
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
-    write.define_constant_int_class_traits(
+    class.define_constant_int_class_traits(
         activation.avm2().public_namespace_base_version,
         CONSTANTS_INT,
         activation,

--- a/core/src/avm2/globals/avmplus.rs
+++ b/core/src/avm2/globals/avmplus.rs
@@ -34,7 +34,6 @@ pub fn describe_type_json<'gc>(
     }
 
     let class = class_obj.inner_class_definition();
-    let class = class.read();
 
     let qualified_name = class
         .name()
@@ -160,7 +159,6 @@ fn describe_internal_body<'gc>(
         while let Some(super_obj) = current_super_obj {
             let super_name = super_obj
                 .inner_class_definition()
-                .read()
                 .name()
                 .to_qualified_name(activation.context.gc_context);
             bases_array.push(super_name.into());
@@ -184,7 +182,6 @@ fn describe_internal_body<'gc>(
     if flags.contains(DescribeTypeFlags::INCLUDE_INTERFACES) && use_instance_traits {
         for interface in class_obj.interfaces() {
             let interface_name = interface
-                .read()
                 .name()
                 .to_qualified_name(activation.context.gc_context);
             interfaces_array.push(interface_name.into());
@@ -294,7 +291,6 @@ fn describe_internal_body<'gc>(
 
                 let declared_by_name = declared_by
                     .inner_class_definition()
-                    .read()
                     .name()
                     .to_qualified_name(activation.context.gc_context);
 
@@ -382,7 +378,6 @@ fn describe_internal_body<'gc>(
                     method_type.to_qualified_name_or_star(activation.context.gc_context);
                 let declared_by = defining_class
                     .inner_class_definition()
-                    .read()
                     .name()
                     .to_qualified_name(activation.context.gc_context);
 

--- a/core/src/avm2/globals/boolean.rs
+++ b/core/src/avm2/globals/boolean.rs
@@ -8,7 +8,6 @@ use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::QName;
-use gc_arena::GcCell;
 
 /// Implements `Boolean`'s instance initializer.
 fn instance_init<'gc>(
@@ -131,7 +130,7 @@ fn value_of<'gc>(
 }
 
 /// Construct `Boolean`'s class.
-pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Boolean"),
@@ -141,30 +140,31 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         mc,
     );
 
-    let mut write = class.write(mc);
-    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
-    write.set_instance_allocator(primitive_allocator);
-    write.set_native_instance_init(Method::from_builtin(
-        native_instance_init,
-        "<Boolean native instance initializer>",
+    class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
+    class.set_instance_allocator(mc, primitive_allocator);
+    class.set_native_instance_init(
         mc,
-    ));
-    write.set_call_handler(Method::from_builtin(
-        call_handler,
-        "<Boolean call handler>",
+        Method::from_builtin(
+            native_instance_init,
+            "<Boolean native instance initializer>",
+            mc,
+        ),
+    );
+    class.set_call_handler(
         mc,
-    ));
+        Method::from_builtin(call_handler, "<Boolean call handler>", mc),
+    );
 
     const AS3_INSTANCE_METHODS: &[(&str, NativeMethodImpl)] =
         &[("toString", to_string), ("valueOf", value_of)];
-    write.define_builtin_instance_methods(
+    class.define_builtin_instance_methods(
         mc,
         activation.avm2().as3_namespace,
         AS3_INSTANCE_METHODS,
     );
 
     const CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
-    write.define_constant_int_class_traits(
+    class.define_constant_int_class_traits(
         activation.avm2().public_namespace_base_version,
         CONSTANTS_INT,
         activation,

--- a/core/src/avm2/globals/class.rs
+++ b/core/src/avm2/globals/class.rs
@@ -7,7 +7,6 @@ use crate::avm2::object::{Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::QName;
-use gc_arena::GcCell;
 
 /// Implements `Class`'s instance initializer.
 ///
@@ -45,8 +44,8 @@ fn prototype<'gc>(
 /// Construct `Class`'s class.
 pub fn create_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    object_class: GcCell<'gc, Class<'gc>>,
-) -> GcCell<'gc, Class<'gc>> {
+    object_class: Class<'gc>,
+) -> Class<'gc> {
     let gc_context = activation.context.gc_context;
     let class_class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Class"),
@@ -56,12 +55,10 @@ pub fn create_class<'gc>(
         gc_context,
     );
 
-    let mut write = class_class.write(gc_context);
-
     // 'length' is a weird undocumented constant in Class.
     // We need to define it, since it shows up in 'describeType'
     const CLASS_CONSTANTS: &[(&str, i32)] = &[("length", 1)];
-    write.define_constant_int_class_traits(
+    class_class.define_constant_int_class_traits(
         activation.avm2().public_namespace_base_version,
         CLASS_CONSTANTS,
         activation,
@@ -72,7 +69,7 @@ pub fn create_class<'gc>(
         Option<NativeMethodImpl>,
         Option<NativeMethodImpl>,
     )] = &[("prototype", Some(prototype), None)];
-    write.define_builtin_instance_properties(
+    class_class.define_builtin_instance_properties(
         gc_context,
         activation.avm2().public_namespace_base_version,
         PUBLIC_INSTANCE_PROPERTIES,

--- a/core/src/avm2/globals/flash/display/bitmap_data.rs
+++ b/core/src/avm2/globals/flash/display/bitmap_data.rs
@@ -92,7 +92,7 @@ pub fn init<'gc>(
 ) -> Result<Value<'gc>, Error<'gc>> {
     // We set the underlying BitmapData instance - we start out with a dummy BitmapDataWrapper,
     // which makes custom classes see a disposed BitmapData before they call super()
-    let name = this.instance_of_class_definition().map(|c| c.read().name());
+    let name = this.instance_of_class_definition().map(|c| c.name());
     let character = this
         .instance_of()
         .and_then(|t| {

--- a/core/src/avm2/globals/flash/display/display_object.rs
+++ b/core/src/avm2/globals/flash/display/display_object.rs
@@ -23,7 +23,7 @@ pub fn display_object_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let class_name = class.inner_class_definition().read().name().local_name();
+    let class_name = class.inner_class_definition().name().local_name();
 
     return Err(Error::AvmError(argument_error(
         activation,

--- a/core/src/avm2/globals/flash/media/sound.rs
+++ b/core/src/avm2/globals/flash/media/sound.rs
@@ -41,7 +41,7 @@ pub fn init<'gc>(
                 let sound = *sound;
                 sound_object.set_sound(&mut activation.context, sound)?;
             } else {
-                tracing::warn!("Attempted to construct subclass of Sound, {}, which is associated with non-Sound character {}", class_object.inner_class_definition().read().name().local_name(), symbol);
+                tracing::warn!("Attempted to construct subclass of Sound, {}, which is associated with non-Sound character {}", class_object.inner_class_definition().name().local_name(), symbol);
             }
         }
     }

--- a/core/src/avm2/globals/flash/media/video.rs
+++ b/core/src/avm2/globals/flash/media/video.rs
@@ -69,7 +69,7 @@ pub fn attach_net_stream<'gc>(
                 "Cannot use value of type {:?} as video source",
                 source
                     .and_then(|o| o.instance_of_class_definition())
-                    .map(|c| c.read().name().local_name())
+                    .map(|c| c.name().local_name())
                     .unwrap_or_else(|| "Object".into())
             )
             .into());

--- a/core/src/avm2/globals/flash/utils.rs
+++ b/core/src/avm2/globals/flash/utils.rs
@@ -208,7 +208,6 @@ pub fn get_qualified_class_name<'gc>(
 
     Ok(class
         .inner_class_definition()
-        .read()
         .name()
         .to_qualified_name(activation.context.gc_context)
         .into())
@@ -236,7 +235,6 @@ pub fn get_qualified_superclass_name<'gc>(
     if let Some(super_class) = class.superclass_object() {
         Ok(super_class
             .inner_class_definition()
-            .read()
             .name()
             .to_qualified_name(activation.context.gc_context)
             .into())

--- a/core/src/avm2/globals/global_scope.rs
+++ b/core/src/avm2/globals/global_scope.rs
@@ -11,7 +11,6 @@ use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::QName;
-use gc_arena::GcCell;
 
 /// Implements `global`'s instance constructor.
 pub fn instance_init<'gc>(
@@ -34,8 +33,8 @@ pub fn class_init<'gc>(
 /// Construct `global`'s class.
 pub fn create_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    object_class: GcCell<'gc, Class<'gc>>,
-) -> GcCell<'gc, Class<'gc>> {
+    object_class: Class<'gc>,
+) -> Class<'gc> {
     let mc = activation.context.gc_context;
     Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "global"),

--- a/core/src/avm2/globals/int.rs
+++ b/core/src/avm2/globals/int.rs
@@ -8,7 +8,6 @@ use crate::avm2::method::{Method, NativeMethodImpl, ParamConfig};
 use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::{AvmString, Error, Multiname, QName};
-use gc_arena::GcCell;
 
 /// Implements `int`'s instance initializer.
 fn instance_init<'gc>(
@@ -212,7 +211,7 @@ fn value_of<'gc>(
 }
 
 /// Construct `int`'s class.
-pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "int"),
@@ -233,15 +232,20 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         mc,
     );
 
-    let mut write = class.write(mc);
-    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
-    write.set_instance_allocator(primitive_allocator);
-    write.set_native_instance_init(Method::from_builtin(
-        native_instance_init,
-        "<int native instance initializer>",
+    class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
+    class.set_instance_allocator(mc, primitive_allocator);
+    class.set_native_instance_init(
         mc,
-    ));
-    write.set_call_handler(Method::from_builtin(call_handler, "<int call handler>", mc));
+        Method::from_builtin(
+            native_instance_init,
+            "<int native instance initializer>",
+            mc,
+        ),
+    );
+    class.set_call_handler(
+        mc,
+        Method::from_builtin(call_handler, "<int call handler>", mc),
+    );
 
     // 'length' is a weird undocumented constant in int.
     // We need to define it, since it shows up in 'describeType'
@@ -250,7 +254,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         ("MIN_VALUE", i32::MIN),
         ("length", 1),
     ];
-    write.define_constant_int_class_traits(
+    class.define_constant_int_class_traits(
         activation.avm2().public_namespace_base_version,
         CLASS_CONSTANTS,
         activation,
@@ -263,7 +267,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    write.define_builtin_instance_methods(
+    class.define_builtin_instance_methods(
         mc,
         activation.avm2().as3_namespace,
         AS3_INSTANCE_METHODS,

--- a/core/src/avm2/globals/number.rs
+++ b/core/src/avm2/globals/number.rs
@@ -8,7 +8,6 @@ use crate::avm2::object::{primitive_allocator, FunctionObject, Object, TObject};
 use crate::avm2::value::Value;
 use crate::avm2::QName;
 use crate::avm2::{AvmString, Error};
-use gc_arena::GcCell;
 
 /// Implements `Number`'s instance initializer.
 fn instance_init<'gc>(
@@ -367,7 +366,7 @@ fn value_of<'gc>(
 }
 
 /// Construct `Number`'s class.
-pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "Number"),
@@ -377,19 +376,20 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         mc,
     );
 
-    let mut write = class.write(mc);
-    write.set_attributes(ClassAttributes::FINAL | ClassAttributes::SEALED);
-    write.set_instance_allocator(primitive_allocator);
-    write.set_native_instance_init(Method::from_builtin(
-        native_instance_init,
-        "<Number native instance initializer>",
+    class.set_attributes(mc, ClassAttributes::FINAL | ClassAttributes::SEALED);
+    class.set_instance_allocator(mc, primitive_allocator);
+    class.set_native_instance_init(
         mc,
-    ));
-    write.set_call_handler(Method::from_builtin(
-        call_handler,
-        "<Number call handler>",
+        Method::from_builtin(
+            native_instance_init,
+            "<Number native instance initializer>",
+            mc,
+        ),
+    );
+    class.set_call_handler(
         mc,
-    ));
+        Method::from_builtin(call_handler, "<Number call handler>", mc),
+    );
 
     const CLASS_CONSTANTS_NUMBER: &[(&str, f64)] = &[
         ("MAX_VALUE", f64::MAX),
@@ -406,14 +406,14 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         ("LOG2E", std::f64::consts::LOG2_E),
         ("LOG10E", std::f64::consts::LOG10_E),
     ];
-    write.define_constant_number_class_traits(
+    class.define_constant_number_class_traits(
         activation.avm2().public_namespace_base_version,
         CLASS_CONSTANTS_NUMBER,
         activation,
     );
 
     const CLASS_CONSTANTS_INT: &[(&str, i32)] = &[("length", 1)];
-    write.define_constant_int_class_traits(
+    class.define_constant_int_class_traits(
         activation.avm2().public_namespace_base_version,
         CLASS_CONSTANTS_INT,
         activation,
@@ -426,7 +426,7 @@ pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Cl
         ("toString", to_string),
         ("valueOf", value_of),
     ];
-    write.define_builtin_instance_methods(
+    class.define_builtin_instance_methods(
         mc,
         activation.avm2().as3_namespace,
         AS3_INSTANCE_METHODS,

--- a/core/src/avm2/globals/vector.rs
+++ b/core/src/avm2/globals/vector.rs
@@ -16,7 +16,6 @@ use crate::avm2::vector::VectorStorage;
 use crate::avm2::Error;
 use crate::avm2::QName;
 use crate::string::AvmString;
-use gc_arena::GcCell;
 use std::cmp::{max, min, Ordering};
 
 pub fn generic_vector_allocator<'gc>(
@@ -265,7 +264,6 @@ pub fn concat<'gc>(
         if !arg.is_of_type(activation, my_base_vector_class.inner_class_definition()) {
             let base_vector_name = my_base_vector_class
                 .inner_class_definition()
-                .read()
                 .name()
                 .to_qualified_name_err_message(activation.context.gc_context);
 
@@ -295,8 +293,8 @@ pub fn concat<'gc>(
                         .ok_or("TypeError: Tried to concat a bare object into a Vector")?;
                     return Err(format!(
                         "TypeError: Cannot coerce Vector value of type {:?} to type {:?}",
-                        other_val_class.read().name(),
-                        val_class.read().name()
+                        other_val_class.name(),
+                        val_class.name()
                     )
                     .into());
                 }
@@ -912,7 +910,7 @@ pub fn splice<'gc>(
 }
 
 /// Construct `Vector`'s class.
-pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().vector_public_namespace, "Vector"),
@@ -922,23 +920,22 @@ pub fn create_generic_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell
         mc,
     );
 
-    let mut write = class.write(mc);
-    write.set_attributes(ClassAttributes::GENERIC | ClassAttributes::FINAL);
-    write.set_instance_allocator(generic_vector_allocator);
+    class.set_attributes(mc, ClassAttributes::GENERIC | ClassAttributes::FINAL);
+    class.set_instance_allocator(mc, generic_vector_allocator);
     class
 }
 
 /// Construct `Vector.<int/uint/Number/*>`'s class.
 pub fn create_builtin_class<'gc>(
     activation: &mut Activation<'_, 'gc>,
-    param: Option<GcCell<'gc, Class<'gc>>>,
-) -> GcCell<'gc, Class<'gc>> {
+    param: Option<Class<'gc>>,
+) -> Class<'gc> {
     let mc = activation.context.gc_context;
 
     // FIXME - we should store a `Multiname` instead of a `QName`, and use the
     // `params` field. For now, this is good enough to get tests passing
     let name = if let Some(param) = param {
-        let name = format!("Vector.<{}>", param.read().name().to_qualified_name(mc));
+        let name = format!("Vector.<{}>", param.name().to_qualified_name(mc));
         QName::new(
             activation.avm2().vector_public_namespace,
             AvmString::new_utf8(mc, name),
@@ -955,20 +952,17 @@ pub fn create_builtin_class<'gc>(
         mc,
     );
 
-    let mut write = class.write(mc);
-
     // TODO: Vector.<*> is also supposed to be final, but currently
     // that'd make it impossible for us to create derived Vector.<MyType>.
     if param.is_some() {
-        write.set_attributes(ClassAttributes::FINAL);
+        class.set_attributes(mc, ClassAttributes::FINAL);
     }
-    write.set_param(Some(param));
-    write.set_instance_allocator(vector_allocator);
-    write.set_call_handler(Method::from_builtin(
-        class_call,
-        "<Vector.<T> call handler>",
+    class.set_param(mc, Some(param));
+    class.set_instance_allocator(mc, vector_allocator);
+    class.set_call_handler(
         mc,
-    ));
+        Method::from_builtin(class_call, "<Vector.<T> call handler>", mc),
+    );
 
     const PUBLIC_INSTANCE_PROPERTIES: &[(
         &str,
@@ -978,7 +972,7 @@ pub fn create_builtin_class<'gc>(
         ("length", Some(length), Some(set_length)),
         ("fixed", Some(fixed), Some(set_fixed)),
     ];
-    write.define_builtin_instance_properties(
+    class.define_builtin_instance_properties(
         mc,
         activation.avm2().public_namespace_base_version,
         PUBLIC_INSTANCE_PROPERTIES,
@@ -1007,7 +1001,7 @@ pub fn create_builtin_class<'gc>(
         ("sort", sort),
         ("splice", splice),
     ];
-    write.define_builtin_instance_methods(
+    class.define_builtin_instance_methods(
         mc,
         activation.avm2().as3_namespace,
         AS3_INSTANCE_METHODS,

--- a/core/src/avm2/globals/void.rs
+++ b/core/src/avm2/globals/void.rs
@@ -8,7 +8,6 @@ use crate::avm2::object::Object;
 use crate::avm2::value::Value;
 use crate::avm2::Error;
 use crate::avm2::QName;
-use gc_arena::GcCell;
 
 fn void_init<'gc>(
     _activation: &mut Activation<'_, 'gc>,
@@ -20,7 +19,7 @@ fn void_init<'gc>(
     Ok(Value::Undefined)
 }
 
-pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> GcCell<'gc, Class<'gc>> {
+pub fn create_class<'gc>(activation: &mut Activation<'_, 'gc>) -> Class<'gc> {
     let mc = activation.context.gc_context;
     let class = Class::new(
         QName::new(activation.avm2().public_namespace_base_version, "void"),

--- a/core/src/avm2/method.rs
+++ b/core/src/avm2/method.rs
@@ -47,7 +47,7 @@ pub struct ResolvedParamConfig<'gc> {
     pub param_name: AvmString<'gc>,
 
     /// The type of the parameter.
-    pub param_type: Option<GcCell<'gc, Class<'gc>>>,
+    pub param_type: Option<Class<'gc>>,
 
     /// The default value for this parameter.
     pub default_value: Option<Value<'gc>>,
@@ -254,7 +254,7 @@ impl<'gc> BytecodeMethod<'gc> {
         &self.signature
     }
 
-    pub fn resolved_return_type(&self) -> Option<GcCell<'gc, Class<'gc>>> {
+    pub fn resolved_return_type(&self) -> Option<Class<'gc>> {
         let verified_info = self.verified_info.read();
 
         verified_info.as_ref().unwrap().return_type

--- a/core/src/avm2/object/class_object.rs
+++ b/core/src/avm2/object/class_object.rs
@@ -40,7 +40,7 @@ pub struct ClassObjectData<'gc> {
     base: ScriptObjectData<'gc>,
 
     /// The class associated with this class object.
-    class: GcCell<'gc, Class<'gc>>,
+    class: Class<'gc>,
 
     /// The associated prototype.
     /// Should always be non-None after initialization.
@@ -94,7 +94,7 @@ pub struct ClassObjectData<'gc> {
     /// from parent classes and superinterfaces (recursively).
     /// TODO - avoid cloning this when a subclass implements the
     /// same interface as its superclass.
-    interfaces: Vec<GcCell<'gc, Class<'gc>>>,
+    interfaces: Vec<Class<'gc>>,
 
     /// VTable used for instances of this class.
     instance_vtable: VTable<'gc>,
@@ -138,7 +138,7 @@ impl<'gc> ClassObject<'gc> {
     /// to be limited to interfaces.
     pub fn from_class(
         activation: &mut Activation<'_, 'gc>,
-        class: GcCell<'gc, Class<'gc>>,
+        class: Class<'gc>,
         superclass_object: Option<ClassObject<'gc>>,
     ) -> Result<Self, Error<'gc>> {
         let class_object = Self::from_class_partial(activation, class, superclass_object)?;
@@ -172,30 +172,29 @@ impl<'gc> ClassObject<'gc> {
     /// allocated.
     pub fn from_class_partial(
         activation: &mut Activation<'_, 'gc>,
-        class: GcCell<'gc, Class<'gc>>,
+        class: Class<'gc>,
         superclass_object: Option<ClassObject<'gc>>,
     ) -> Result<Self, Error<'gc>> {
         let scope = activation.create_scopechain();
         if let Some(base_class) = superclass_object.map(|b| b.inner_class_definition()) {
-            if base_class.read().is_final() {
+            if base_class.is_final() {
                 return Err(format!(
                     "Base class {:?} is final and cannot be extended",
-                    base_class.read().name().local_name()
+                    base_class.name().local_name()
                 )
                 .into());
             }
 
-            if base_class.read().is_interface() {
+            if base_class.is_interface() {
                 return Err(format!(
                     "Base class {:?} is an interface and cannot be extended",
-                    base_class.read().name().local_name()
+                    base_class.name().local_name()
                 )
                 .into());
             }
         }
 
         let instance_allocator = class
-            .read()
             .instance_allocator()
             .or_else(|| superclass_object.and_then(|c| c.instance_allocator()))
             .unwrap_or(scriptobject_allocator);
@@ -210,9 +209,9 @@ impl<'gc> ClassObject<'gc> {
                 instance_scope: scope,
                 superclass_object,
                 instance_allocator: Allocator(instance_allocator),
-                constructor: class.read().instance_init(),
-                native_constructor: class.read().native_instance_init(),
-                call_handler: class.read().call_handler(),
+                constructor: class.instance_init(),
+                native_constructor: class.native_instance_init(),
+                call_handler: class.call_handler(),
                 params: None,
                 applications: Default::default(),
                 interfaces: Vec::new(),
@@ -232,9 +231,7 @@ impl<'gc> ClassObject<'gc> {
             .write(activation.context.gc_context)
             .instance_scope = instance_scope;
 
-        class
-            .write(activation.context.gc_context)
-            .add_class_object(class_object);
+        class.add_class_object(activation.context.gc_context, class_object);
 
         Ok(class_object)
     }
@@ -248,11 +245,11 @@ impl<'gc> ClassObject<'gc> {
             "Cannot finish initialization of core class without it being linked to a type!",
         )?;
 
-        class.read().validate_class(self.superclass_object())?;
+        class.validate_class(self.superclass_object())?;
 
         self.instance_vtable().init_vtable(
             self,
-            class.read().instance_traits(),
+            &class.instance_traits(),
             self.instance_scope(),
             self.superclass_object().map(|cls| cls.instance_vtable()),
             activation,
@@ -287,7 +284,7 @@ impl<'gc> ClassObject<'gc> {
         // class vtable == class traits + Class instance traits
         self.class_vtable().init_vtable(
             self,
-            class.read().class_traits(),
+            &class.class_traits(),
             self.class_scope(),
             Some(self.instance_of().unwrap().instance_vtable()),
             activation,
@@ -332,13 +329,13 @@ impl<'gc> ClassObject<'gc> {
         let class = write.class;
         let scope = write.class_scope;
 
-        let interface_names = class.read().direct_interfaces().to_vec();
+        let interface_names = class.direct_interfaces().to_vec();
         let mut interfaces = Vec::with_capacity(interface_names.len());
 
         let mut dedup = HashSet::new();
         let mut queue = vec![class];
         while let Some(cls) = queue.pop() {
-            for interface_name in cls.read().direct_interfaces() {
+            for interface_name in &*cls.direct_interfaces() {
                 let interface = scope
                     .domain()
                     .get_class(&mut activation.context, interface_name)
@@ -346,10 +343,10 @@ impl<'gc> ClassObject<'gc> {
                         Error::from(format!("Could not resolve interface {interface_name:?}"))
                     })?;
 
-                if !interface.read().is_interface() {
+                if !interface.is_interface() {
                     return Err(format!(
                         "Class {:?} is not an interface and cannot be implemented by classes",
-                        interface.read().name().local_name()
+                        interface.name().local_name()
                     )
                     .into());
                 }
@@ -360,7 +357,7 @@ impl<'gc> ClassObject<'gc> {
                 }
             }
 
-            if let Some(super_class) = cls.read().super_class() {
+            if let Some(super_class) = cls.super_class() {
                 queue.push(super_class);
             }
         }
@@ -374,8 +371,7 @@ impl<'gc> ClassObject<'gc> {
         // Otherwise, our behavior diverges from Flash Player in certain cases.
         // See the ignored test 'tests/tests/swfs/avm2/weird_superinterface_properties/'
         for interface in &read.interfaces {
-            let iface_read = interface.read();
-            for interface_trait in iface_read.instance_traits() {
+            for interface_trait in &*interface.instance_traits() {
                 if !interface_trait.name().namespace().is_public() {
                     let public_name = QName::new(
                         activation.context.avm2.public_namespace_vm_internal,
@@ -421,10 +417,9 @@ impl<'gc> ClassObject<'gc> {
 
         let scope = self.0.read().class_scope;
         let class = self.0.read().class;
-        let class_read = class.read();
 
-        if !class_read.is_class_initialized() {
-            let class_initializer = class_read.class_init();
+        if !class.is_class_initialized() {
+            let class_initializer = class.class_init();
             let class_init_fn = FunctionObject::from_method(
                 activation,
                 class_initializer,
@@ -433,10 +428,7 @@ impl<'gc> ClassObject<'gc> {
                 Some(self),
             );
 
-            drop(class_read);
-            class
-                .write(activation.context.gc_context)
-                .mark_class_initialized();
+            class.mark_class_initialized(activation.context.gc_context);
 
             class_init_fn.call(object.into(), &[], activation)?;
         }
@@ -450,11 +442,11 @@ impl<'gc> ClassObject<'gc> {
     /// interface we are checking against this class.
     ///
     /// To test if a class *instance* is of a given type, see is_of_type.
-    pub fn has_class_in_chain(self, test_class: GcCell<'gc, Class<'gc>>) -> bool {
+    pub fn has_class_in_chain(self, test_class: Class<'gc>) -> bool {
         let mut my_class = Some(self);
 
         while let Some(class) = my_class {
-            if GcCell::ptr_eq(class.inner_class_definition(), test_class) {
+            if class.inner_class_definition() == test_class {
                 return true;
             }
 
@@ -466,9 +458,9 @@ impl<'gc> ClassObject<'gc> {
         // Therefore, we only need to check interfaces once, and we can skip
         // checking them when we processing superclasses in the `while`
         // further down in this method.
-        if test_class.read().is_interface() {
+        if test_class.is_interface() {
             for interface in self.interfaces() {
-                if GcCell::ptr_eq(interface, test_class) {
+                if interface == test_class {
                     return true;
                 }
             }
@@ -545,7 +537,6 @@ impl<'gc> ClassObject<'gc> {
             let qualified_multiname_name = multiname.as_uri(activation.context.gc_context);
             let qualified_class_name = self
                 .inner_class_definition()
-                .read()
                 .name()
                 .to_qualified_name_err_message(activation.context.gc_context);
 
@@ -752,11 +743,11 @@ impl<'gc> ClassObject<'gc> {
     /// in contexts where panicking would be extremely undesirable,
     /// and there's a fallback if we cannot obtain the `Class`
     /// (such as `Debug` impls),
-    pub fn try_inner_class_definition(&self) -> Result<GcCell<'gc, Class<'gc>>, BorrowError> {
+    pub fn try_inner_class_definition(&self) -> Result<Class<'gc>, BorrowError> {
         self.0.try_read().map(|c| c.class)
     }
 
-    pub fn inner_class_definition(self) -> GcCell<'gc, Class<'gc>> {
+    pub fn inner_class_definition(self) -> Class<'gc> {
         self.0.read().class
     }
 
@@ -764,7 +755,7 @@ impl<'gc> ClassObject<'gc> {
         self.0.read().prototype.unwrap()
     }
 
-    pub fn interfaces(self) -> Vec<GcCell<'gc, Class<'gc>>> {
+    pub fn interfaces(self) -> Vec<Class<'gc>> {
         self.0.read().interfaces.clone()
     }
 
@@ -802,7 +793,7 @@ impl<'gc> ClassObject<'gc> {
     pub fn debug_class_name(&self) -> Box<dyn Debug + 'gc> {
         let class_name = self
             .try_inner_class_definition()
-            .and_then(|class| class.try_read().map(|c| c.name()));
+            .and_then(|class| class.try_name());
 
         match class_name {
             Ok(class_name) => Box::new(class_name),
@@ -827,7 +818,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
     fn to_string(&self, activation: &mut Activation<'_, 'gc>) -> Result<Value<'gc>, Error<'gc>> {
         Ok(AvmString::new_utf8(
             activation.context.gc_context,
-            format!("[class {}]", self.0.read().class.read().name().local_name()),
+            format!("[class {}]", self.0.read().class.name().local_name()),
         )
         .into())
     }
@@ -913,14 +904,13 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
     ) -> Result<ClassObject<'gc>, Error<'gc>> {
         let self_class = self.inner_class_definition();
 
-        if !self_class.read().is_generic() {
+        if !self_class.is_generic() {
             return Err(make_error_1127(activation));
         }
 
         if nullable_params.len() != 1 {
             let class_name = self
                 .inner_class_definition()
-                .read()
                 .name()
                 .to_qualified_name(activation.context.gc_context);
 
@@ -950,7 +940,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
                         // Note: FP throws VerifyError #1107 here
                         format!(
                             "Cannot apply class {:?} with non-class parameter",
-                            self_class.read().name()
+                            self_class.name()
                         )
                     })?,
             ),
@@ -965,7 +955,7 @@ impl<'gc> TObject<'gc> for ClassObject<'gc> {
 
         let class_param = object_param.map(|c| c.inner_class_definition());
 
-        let parameterized_class: GcCell<'_, Class<'_>> =
+        let parameterized_class =
             Class::with_type_param(&mut activation.context, self_class, class_param);
 
         // NOTE: this isn't fully accurate, but much simpler.

--- a/core/src/avm2/object/loaderinfo_object.rs
+++ b/core/src/avm2/object/loaderinfo_object.rs
@@ -22,7 +22,7 @@ pub fn loader_info_allocator<'gc>(
     class: ClassObject<'gc>,
     activation: &mut Activation<'_, 'gc>,
 ) -> Result<Object<'gc>, Error<'gc>> {
-    let class_name = class.inner_class_definition().read().name().local_name();
+    let class_name = class.inner_class_definition().name().local_name();
 
     Err(Error::AvmError(argument_error(
         activation,

--- a/core/src/avm2/object/primitive_object.rs
+++ b/core/src/avm2/object/primitive_object.rs
@@ -124,7 +124,7 @@ impl<'gc> TObject<'gc> for PrimitiveObject<'gc> {
             _ => {
                 let class_name = self
                     .instance_of_class_definition()
-                    .map(|c| c.read().name().local_name())
+                    .map(|c| c.name().local_name())
                     .unwrap_or_else(|| "Object".into());
 
                 Ok(AvmString::new_utf8(

--- a/core/src/avm2/object/script_object.rs
+++ b/core/src/avm2/object/script_object.rs
@@ -401,7 +401,7 @@ impl<'gc> ScriptObjectData<'gc> {
 
     pub fn is_sealed(&self) -> bool {
         self.instance_of()
-            .map(|cls| cls.inner_class_definition().read().is_sealed())
+            .map(|cls| cls.inner_class_definition().is_sealed())
             .unwrap_or(false)
     }
 

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -2,7 +2,7 @@ use crate::avm2::class::Class;
 use crate::avm2::multiname::Multiname;
 use crate::string::AvmAtom;
 
-use gc_arena::{Collect, Gc, GcCell};
+use gc_arena::{Collect, Gc};
 use swf::avm2::types::{Class as AbcClass, Exception, Index, LookupSwitch, Method, Namespace};
 
 #[derive(Clone, Collect, Debug)]
@@ -14,7 +14,7 @@ pub enum Op<'gc> {
         num_types: u32,
     },
     AsType {
-        class: GcCell<'gc, Class<'gc>>,
+        class: Class<'gc>,
     },
     AsTypeLate,
     BitAnd,
@@ -66,7 +66,7 @@ pub enum Op<'gc> {
     },
     CheckFilter,
     Coerce {
-        class: GcCell<'gc, Class<'gc>>,
+        class: Class<'gc>,
     },
     CoerceA,
     CoerceB,
@@ -218,7 +218,7 @@ pub enum Op<'gc> {
     },
     InstanceOf,
     IsType {
-        class: GcCell<'gc, Class<'gc>>,
+        class: Class<'gc>,
     },
     IsTypeLate,
     Jump {

--- a/core/src/avm2/property.rs
+++ b/core/src/avm2/property.rs
@@ -5,9 +5,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::TranslationUnit;
 use crate::avm2::Value;
-use gc_arena::GcCell;
-use gc_arena::Mutation;
-use gc_arena::{Collect, Gc};
+use gc_arena::{Collect, Gc, Mutation};
 
 use super::class::Class;
 
@@ -40,7 +38,7 @@ pub enum PropertyClass<'gc> {
     /// `Value::Undefined`, so it needs to be distinguished
     /// from the `Object` class
     Any,
-    Class(GcCell<'gc, Class<'gc>>),
+    Class(Class<'gc>),
     Name(Gc<'gc, (Multiname<'gc>, Option<TranslationUnit<'gc>>)>),
 }
 
@@ -103,7 +101,7 @@ impl<'gc> PropertyClass<'gc> {
     pub fn get_class(
         &mut self,
         activation: &mut Activation<'_, 'gc>,
-    ) -> Result<Option<GcCell<'gc, Class<'gc>>>, Error<'gc>> {
+    ) -> Result<Option<Class<'gc>>, Error<'gc>> {
         match self {
             PropertyClass::Class(class) => Ok(Some(*class)),
             PropertyClass::Name(gc) => {
@@ -131,7 +129,7 @@ impl<'gc> PropertyClass<'gc> {
 
     pub fn get_name(&self, mc: &Mutation<'gc>) -> Multiname<'gc> {
         match self {
-            PropertyClass::Class(class) => class.read().name().into(),
+            PropertyClass::Class(class) => class.name().into(),
             PropertyClass::Name(gc) => gc.0.clone(),
             PropertyClass::Any => Multiname::any(mc),
         }

--- a/core/src/avm2/specification.rs
+++ b/core/src/avm2/specification.rs
@@ -271,20 +271,19 @@ impl Definition {
         let mut definition = Self::default();
         let class = class_object.inner_class_definition();
 
-        if class.read().is_final() {
+        if class.is_final() {
             definition
                 .classinfo
                 .get_or_insert_with(Default::default)
                 .is_final = true;
         }
-        if !class.read().is_sealed() {
+        if !class.is_sealed() {
             definition
                 .classinfo
                 .get_or_insert_with(Default::default)
                 .dynamic = true;
         }
         if let Some(super_name) = class
-            .read()
             .super_class_name()
             .as_ref()
             .and_then(|n| n.local_name())
@@ -322,13 +321,13 @@ impl Definition {
 
         Self::fill_traits(
             activation.avm2(),
-            class.read().class_traits(),
+            &class.class_traits(),
             &mut definition.static_traits,
             stubs,
         );
         Self::fill_traits(
             activation.avm2(),
-            class.read().instance_traits(),
+            &class.instance_traits(),
             &mut definition.instance_traits,
             stubs,
         );
@@ -476,7 +475,6 @@ pub fn capture_specification(context: &mut UpdateContext, output: &Path) {
             if let Some(class) = object.as_class_object() {
                 let class_name = class
                     .inner_class_definition()
-                    .read()
                     .name()
                     .to_qualified_name_err_message(activation.context.gc_context)
                     .to_string();

--- a/core/src/avm2/traits.rs
+++ b/core/src/avm2/traits.rs
@@ -10,7 +10,7 @@ use crate::avm2::Error;
 use crate::avm2::Multiname;
 use crate::avm2::QName;
 use bitflags::bitflags;
-use gc_arena::{Collect, GcCell};
+use gc_arena::Collect;
 use std::ops::Deref;
 use swf::avm2::types::{
     DefaultValue as AbcDefaultValue, Trait as AbcTrait, TraitKind as AbcTraitKind,
@@ -91,10 +91,7 @@ pub enum TraitKind<'gc> {
 
     /// A class property on an object that can be used to construct more
     /// objects.
-    Class {
-        slot_id: u32,
-        class: GcCell<'gc, Class<'gc>>,
-    },
+    Class { slot_id: u32, class: Class<'gc> },
 
     /// A free function (not an instance method) that can be called.
     Function { slot_id: u32, function: Method<'gc> },
@@ -110,8 +107,8 @@ pub enum TraitKind<'gc> {
 }
 
 impl<'gc> Trait<'gc> {
-    pub fn from_class(class: GcCell<'gc, Class<'gc>>) -> Self {
-        let name = class.read().name();
+    pub fn from_class(class: Class<'gc>) -> Self {
+        let name = class.name();
 
         Trait {
             name,

--- a/core/src/avm2/value.rs
+++ b/core/src/avm2/value.rs
@@ -10,7 +10,7 @@ use crate::avm2::Multiname;
 use crate::avm2::Namespace;
 use crate::ecma_conversions::{f64_to_wrapping_i32, f64_to_wrapping_u32};
 use crate::string::{AvmAtom, AvmString, WStr};
-use gc_arena::{Collect, GcCell, Mutation};
+use gc_arena::{Collect, Mutation};
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
 use std::cell::Ref;
@@ -994,50 +994,32 @@ impl<'gc> Value<'gc> {
     pub fn coerce_to_type(
         &self,
         activation: &mut Activation<'_, 'gc>,
-        class: GcCell<'gc, Class<'gc>>,
+        class: Class<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        if GcCell::ptr_eq(
-            class,
-            activation.avm2().classes().int.inner_class_definition(),
-        ) {
+        if class == activation.avm2().classes().int.inner_class_definition() {
             return Ok(self.coerce_to_i32(activation)?.into());
         }
 
-        if GcCell::ptr_eq(
-            class,
-            activation.avm2().classes().uint.inner_class_definition(),
-        ) {
+        if class == activation.avm2().classes().uint.inner_class_definition() {
             return Ok(self.coerce_to_u32(activation)?.into());
         }
 
-        if GcCell::ptr_eq(
-            class,
-            activation.avm2().classes().number.inner_class_definition(),
-        ) {
+        if class == activation.avm2().classes().number.inner_class_definition() {
             return Ok(self.coerce_to_number(activation)?.into());
         }
 
-        if GcCell::ptr_eq(
-            class,
-            activation.avm2().classes().boolean.inner_class_definition(),
-        ) {
+        if class == activation.avm2().classes().boolean.inner_class_definition() {
             return Ok(self.coerce_to_boolean().into());
         }
 
         if matches!(self, Value::Undefined) || matches!(self, Value::Null) {
-            if GcCell::ptr_eq(
-                class,
-                activation.avm2().classes().void.inner_class_definition(),
-            ) {
+            if class == activation.avm2().classes().void.inner_class_definition() {
                 return Ok(Value::Undefined);
             }
             return Ok(Value::Null);
         }
 
-        if GcCell::ptr_eq(
-            class,
-            activation.avm2().classes().string.inner_class_definition(),
-        ) {
+        if class == activation.avm2().classes().string.inner_class_definition() {
             return Ok(self.coerce_to_string(activation)?.into());
         }
 
@@ -1048,7 +1030,6 @@ impl<'gc> Value<'gc> {
         }
 
         let name = class
-            .read()
             .name()
             .to_qualified_name_err_message(activation.context.gc_context);
 
@@ -1116,32 +1097,20 @@ impl<'gc> Value<'gc> {
     pub fn is_of_type(
         &self,
         activation: &mut Activation<'_, 'gc>,
-        type_object: GcCell<'gc, Class<'gc>>,
+        type_object: Class<'gc>,
     ) -> bool {
-        if GcCell::ptr_eq(
-            type_object,
-            activation.avm2().classes().number.inner_class_definition(),
-        ) {
+        if type_object == activation.avm2().classes().number.inner_class_definition() {
             return self.is_number();
         }
-        if GcCell::ptr_eq(
-            type_object,
-            activation.avm2().classes().uint.inner_class_definition(),
-        ) {
+        if type_object == activation.avm2().classes().uint.inner_class_definition() {
             return self.is_u32();
         }
-        if GcCell::ptr_eq(
-            type_object,
-            activation.avm2().classes().int.inner_class_definition(),
-        ) {
+        if type_object == activation.avm2().classes().int.inner_class_definition() {
             return self.is_i32();
         }
 
         if let Value::Undefined = self {
-            if GcCell::ptr_eq(
-                type_object,
-                activation.avm2().classes().void.inner_class_definition(),
-            ) {
+            if type_object == activation.avm2().classes().void.inner_class_definition() {
                 return true;
             }
         }

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -10,7 +10,7 @@ use crate::avm2::script::TranslationUnit;
 use crate::avm2::{Activation, Error, QName};
 use crate::string::AvmAtom;
 
-use gc_arena::{Collect, Gc, GcCell};
+use gc_arena::{Collect, Gc};
 use std::collections::{HashMap, HashSet};
 use swf::avm2::read::Reader;
 use swf::avm2::types::{
@@ -26,7 +26,7 @@ pub struct VerifiedMethodInfo<'gc> {
     pub exceptions: Vec<Exception<'gc>>,
 
     pub param_config: Vec<ResolvedParamConfig<'gc>>,
-    pub return_type: Option<GcCell<'gc, Class<'gc>>>,
+    pub return_type: Option<Class<'gc>>,
 }
 
 #[derive(Collect)]
@@ -37,7 +37,7 @@ pub struct Exception<'gc> {
     pub target_offset: u32,
 
     pub variable_name: Option<QName<'gc>>,
-    pub target_class: Option<GcCell<'gc, Class<'gc>>>,
+    pub target_class: Option<Class<'gc>>,
 }
 
 #[derive(Clone, Debug)]
@@ -636,7 +636,7 @@ pub fn resolve_param_config<'gc>(
 fn resolve_return_type<'gc>(
     activation: &mut Activation<'_, 'gc>,
     return_type: &Multiname<'gc>,
-) -> Result<Option<GcCell<'gc, Class<'gc>>>, Error<'gc>> {
+) -> Result<Option<Class<'gc>>, Error<'gc>> {
     if return_type.has_lazy_component() {
         return Err(make_error_1014(activation, "[]".into()));
     }

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -285,7 +285,6 @@ impl<'gc> VTable<'gc> {
 
         write.protected_namespace = defining_class
             .inner_class_definition()
-            .read()
             .protected_namespace();
 
         if let Some(superclass_vtable) = superclass_vtable {

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -185,7 +185,7 @@ impl Avm2ObjectWindow {
             .spacing([8.0, 8.0])
             .show(ui, |ui| {
                 let definition = class.inner_class_definition();
-                let name = definition.read().name();
+                let name = definition.name();
 
                 ui.label("Namespace");
                 ui.text_edit_singleline(&mut name.namespace().as_uri().to_string().as_str());
@@ -216,7 +216,6 @@ impl Avm2ObjectWindow {
                     for interface in class.interfaces() {
                         ui.text_edit_singleline(
                             &mut interface
-                                .read()
                                 .name()
                                 .to_qualified_name_err_message(activation.context.gc_context)
                                 .to_string()
@@ -434,14 +433,13 @@ fn object_name<'gc>(mc: &Mutation<'gc>, object: Object<'gc>) -> String {
     if let Some(class) = object.as_class_object() {
         class
             .inner_class_definition()
-            .read()
             .name()
             .to_qualified_name_err_message(mc)
             .to_string()
     } else {
         let name = object
             .instance_of_class_definition()
-            .map(|r| Cow::Owned(r.read().name().local_name().to_string()))
+            .map(|r| Cow::Owned(r.name().local_name().to_string()))
             .unwrap_or(Cow::Borrowed("Object"));
         format!("{} {:p}", name, object.as_ptr())
     }

--- a/core/src/debug_ui/domain.rs
+++ b/core/src/debug_ui/domain.rs
@@ -57,15 +57,15 @@ impl DomainListWindow {
                 classes.sort_by_key(|(name, _, _)| *name);
 
                 for (_, _, class) in classes {
-                    let class_name = class.read().name().to_qualified_name(context.gc_context);
+                    let class_name = class.name().to_qualified_name(context.gc_context);
                     if !class_name.to_string().to_ascii_lowercase().contains(search) {
                         continue;
                     }
 
                     CollapsingHeader::new(format!("Class {class_name}"))
-                        .id_source(ui.id().with(class.as_ptr()))
+                        .id_source(ui.id().with(class.0.as_ptr()))
                         .show(ui, |ui| {
-                            for class_obj in class.read().class_objects() {
+                            for class_obj in &*class.class_objects() {
                                 let button = ui.button(format!("{class_obj:?}"));
                                 if button.clicked() {
                                     messages.push(Message::TrackAVM2Object(AVM2ObjectHandle::new(

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -964,7 +964,7 @@ impl<'gc> MovieClip<'gc> {
                                     *avm2_bitmapdata_class.write(activation.context.gc_context) =
                                         bitmap_class;
                                 } else {
-                                    tracing::error!("Associated class {:?} for symbol {} must extend flash.display.Bitmap or BitmapData, does neither", class_object.inner_class_definition().read().name(), self.id());
+                                    tracing::error!("Associated class {:?} for symbol {} must extend flash.display.Bitmap or BitmapData, does neither", class_object.inner_class_definition().name(), self.id());
                                 }
                             }
                             _ => {
@@ -2253,7 +2253,7 @@ impl<'gc> MovieClip<'gc> {
                     e,
                     class_object
                         .try_inner_class_definition()
-                        .map(|c| c.read().name().to_qualified_name(context.gc_context))
+                        .map(|c| c.name().to_qualified_name(context.gc_context))
                         .unwrap_or_else(|_| "[BorrowError!]".into())
                 );
             }


### PR DESCRIPTION
This makes the class refactor much easier