### PR TITLE
frontend-utils: Parse API improvements

### DIFF
--- a/desktop/src/preferences/read.rs
+++ b/desktop/src/preferences/read.rs
@@ -64,8 +64,8 @@ pub fn read_preferences(input: &str) -> ParseDetails<SavedGlobalPreferences> {
     });
 
     ParseDetails {
-        result: DocumentHolder::new(result, document),
         warnings: cx.warnings,
+        result: DocumentHolder::new(result, document),
     }
 }
 

--- a/frontend-utils/src/bookmarks/read.rs
+++ b/frontend-utils/src/bookmarks/read.rs
@@ -35,8 +35,8 @@ pub fn read_bookmarks(input: &str) -> ParseDetails<Bookmarks> {
     });
 
     ParseDetails {
-        result: DocumentHolder::new(result, document),
         warnings: cx.warnings,
+        result: DocumentHolder::new(result, document),
     }
 }
 

--- a/frontend-utils/src/bundle/info.rs
+++ b/frontend-utils/src/bundle/info.rs
@@ -46,8 +46,8 @@ impl BundleInformation {
             .unwrap_or(Err(BundleInformationParseError::InvalidBundleSection))?;
 
         Ok(ParseDetails {
-            result: DocumentHolder::new(result, document),
             warnings: cx.warnings,
+            result: DocumentHolder::new(result, document),
         })
     }
 }

--- a/frontend-utils/src/parse.rs
+++ b/frontend-utils/src/parse.rs
@@ -237,6 +237,14 @@ pub trait ReadExt<'a> {
 
         result
     }
+
+    fn get_integer(&'a self, cx: &mut ParseContext, key: &'static str) -> Option<i64> {
+        cx.push_key(key);
+        let result = self.get_impl(key).and_then(|x| x.as_integer_or_warn(cx));
+        cx.pop_key();
+
+        result
+    }
 }
 
 /// Extension trait to provide casting methods with warning capabilities.
@@ -244,6 +252,7 @@ pub trait ItemExt<'a> {
     fn as_str_or_warn(&'a self, cx: &mut ParseContext) -> Option<&'a str>;
     fn as_bool_or_warn(&self, cx: &mut ParseContext) -> Option<bool>;
     fn as_float_or_warn(&self, cx: &mut ParseContext) -> Option<f64>;
+    fn as_integer_or_warn(&self, cx: &mut ParseContext) -> Option<i64>;
 }
 
 // Implementations for toml_edit types.
@@ -298,6 +307,16 @@ impl<'a> ItemExt<'a> for Item {
             return Some(value);
         } else {
             cx.unexpected_type("string", self.type_name());
+        }
+
+        None
+    }
+
+    fn as_integer_or_warn(&self, cx: &mut ParseContext) -> Option<i64> {
+        if let Some(value) = self.as_integer() {
+            return Some(value);
+        } else {
+            cx.unexpected_type("integer", self.type_name());
         }
 
         None

--- a/frontend-utils/src/parse.rs
+++ b/frontend-utils/src/parse.rs
@@ -124,14 +124,14 @@ impl fmt::Display for ParseWarning {
 }
 
 #[derive(Default)]
-pub struct ParseContext {
+pub struct ParseContext<'a> {
     pub warnings: Vec<ParseWarning>,
     /// Path of the current item being parsed
-    path: Vec<&'static str>,
+    path: Vec<&'a str>,
 }
 
-impl ParseContext {
-    pub fn push_key(&mut self, key: &'static str) {
+impl<'a> ParseContext<'a> {
+    pub fn push_key(&mut self, key: &'a str) {
         self.path.push(key);
     }
 
@@ -166,9 +166,9 @@ pub trait ReadExt<'a> {
 
     fn get_table_like<R>(
         &'a self,
-        cx: &mut ParseContext,
+        cx: &mut ParseContext<'a>,
         key: &'static str,
-        fun: impl FnOnce(&mut ParseContext, &dyn TableLike) -> R,
+        fun: impl FnOnce(&mut ParseContext<'a>, &'a dyn TableLike) -> R,
     ) -> Option<R> {
         let mut result = None;
         if let Some(item) = self.get_impl(key) {
@@ -187,9 +187,9 @@ pub trait ReadExt<'a> {
 
     fn get_array_of_tables<R>(
         &'a self,
-        cx: &mut ParseContext,
+        cx: &mut ParseContext<'a>,
         key: &'static str,
-        fun: impl FnOnce(&mut ParseContext, &ArrayOfTables) -> R,
+        fun: impl FnOnce(&mut ParseContext<'a>, &'a ArrayOfTables) -> R,
     ) -> Option<R> {
         let mut result = None;
         if let Some(item) = self.get_impl(key) {


### PR DESCRIPTION
This PR should make it easier to parse key-value tables (like `parameters` in the upcoming bundle options).