### PR TITLE
render,desktop: Port to `wgpu` `v0.20.0`, switch to `egui` `master`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,9 +1165,9 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
  "bitflags 2.5.0",
  "libloading 0.8.3",
@@ -1434,8 +1434,7 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1444,11 +1443,11 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "accesskit",
  "ahash",
+ "emath",
  "epaint",
  "log",
  "nohash-hasher",
@@ -1458,8 +1457,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469ff65843f88a702b731a1532b7d03b0e8e96d283e70f3a22b0e06c46cb9b37"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "bytemuck",
  "document-features",
@@ -1476,28 +1474,26 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "arboard",
  "egui",
  "log",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "smithay-clipboard",
  "web-time 0.2.4",
- "webbrowser 0.8.15",
+ "webbrowser",
  "winit",
 ]
 
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b78779f35ded1a853786c9ce0b43fe1053e10a21ea3b23ebea411805ce41593"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "egui",
  "enum-map",
- "image 0.24.9",
+ "image",
  "log",
  "mime_guess2",
  "serde",
@@ -1512,8 +1508,7 @@ checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1654,8 +1649,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b381f8b149657a4acf837095351839f32cd5c4aec1817fc4df84e18d76334176"
+source = "git+https://github.com/emilk/egui.git?rev=738ea75453567c5f17a543e68aec8c48097cae7b#738ea75453567c5f17a543e68aec8c48097cae7b"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -1757,7 +1751,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
- "image 0.25.1",
+ "image",
  "indicatif",
  "rayon",
  "ruffle_core",
@@ -2329,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
  "bitflags 2.5.0",
  "gpu-descriptor-types",
@@ -2340,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -2652,18 +2646,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "num-traits",
 ]
 
 [[package]]
@@ -3192,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
  "bitflags 2.5.0",
  "block",
@@ -3261,10 +3243,11 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
  "bit-set",
  "bitflags 2.5.0",
  "codespan-reporting",
@@ -3311,7 +3294,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -3509,7 +3492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -3569,15 +3551,6 @@ checksum = "cfaefe14254871ea16c7d88968c0ff14ba554712a20d76421eec52f0a7fb8904"
 dependencies = [
  "block2 0.5.0",
  "objc2 0.5.1",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3976,12 +3949,6 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "raw-window-handle"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cc3bcbdb1ddfc11e700e62968e6b4cc9c75bb466464ad28fb61c5b2c964418b"
@@ -4180,7 +4147,7 @@ dependencies = [
  "objc-foundation",
  "objc_id",
  "pollster",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4255,7 +4222,7 @@ dependencies = [
  "futures",
  "hashbrown",
  "id3",
- "image 0.25.1",
+ "image",
  "indexmap",
  "jpegxr",
  "linkme",
@@ -4311,7 +4278,7 @@ dependencies = [
  "fontdb",
  "futures",
  "gilrs",
- "image 0.25.1",
+ "image",
  "os_info",
  "rand",
  "rfd",
@@ -4330,7 +4297,7 @@ dependencies = [
  "unic-langid",
  "url",
  "vergen",
- "webbrowser 1.0.1",
+ "webbrowser",
  "wgpu",
  "winapi",
  "winit",
@@ -4357,7 +4324,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
- "webbrowser 1.0.1",
+ "webbrowser",
  "zip",
 ]
 
@@ -4452,7 +4419,7 @@ dependencies = [
  "enum-map",
  "fnv",
  "futures",
- "image 0.25.1",
+ "image",
  "indexmap",
  "lru",
  "naga",
@@ -4500,7 +4467,7 @@ dependencies = [
  "approx",
  "async-channel",
  "chrono",
- "image 0.25.1",
+ "image",
  "percent-encoding",
  "pretty_assertions",
  "regex",
@@ -5229,7 +5196,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "futures",
- "image 0.25.1",
+ "image",
  "libtest-mimic",
  "regex",
  "ruffle_core",
@@ -6151,23 +6118,6 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67ae75a9405634f5882791678772c94ff5f16a66535aae186e26aa0841fc8b"
-dependencies = [
- "core-foundation",
- "home",
- "jni",
- "log",
- "ndk-context",
- "objc",
- "raw-window-handle 0.5.2",
- "url",
- "web-sys",
-]
-
-[[package]]
-name = "webbrowser"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
@@ -6201,19 +6151,20 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.19.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
+checksum = "32ff1bfee408e1028e2e3acbf6d32d98b08a5a059ccbf5f33305534453ba5d3e"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "cfg_aliases",
+ "document-features",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "serde",
  "smallvec",
  "static_assertions",
@@ -6227,22 +6178,23 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
+checksum = "ac6a86eaa5e763e59c73cf9e97d55fffd4dfda69fd8bda19589fcf851ddfef1f"
 dependencies = [
  "arrayvec",
  "bit-vec",
  "bitflags 2.5.0",
  "cfg_aliases",
  "codespan-reporting",
+ "document-features",
  "indexmap",
  "log",
  "naga",
  "once_cell",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "ron",
  "rustc-hash",
  "serde",
@@ -6255,9 +6207,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1a4924366df7ab41a5d8546d6534f1f33231aa5b3f72b9930e300f254e39c3"
+checksum = "4d71c8ae05170583049b65ee562fd839fdc0b3e9ddb84f4e40c9d5f8ea0d4c8c"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6287,7 +6239,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash",
  "smallvec",
@@ -6300,9 +6252,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
  "bitflags 2.5.0",
  "js-sys",
@@ -6649,7 +6601,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.6.1",
+ "raw-window-handle",
  "redox_syscall 0.3.5",
  "rustix",
  "sctk-adwaita",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ version = "0.1.0"
 [workspace.dependencies]
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-naga = { version = "0.19.2", features = ["wgsl-out"] }
-wgpu = "0.19.4"
-egui = "0.27.2"
+naga = { version = "0.20.0", features = ["wgsl-out"] }
+wgpu = "0.20.0"
+egui = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b" }
 clap = { version = "4.5.4", features = ["derive"] }
 anyhow = "1.0"
 slotmap = "1.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,7 +55,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 scopeguard = "1.2.0"
 fluent-templates = "0.9.4"
 egui = { workspace = true, optional = true }
-egui_extras = { version = "0.27.2", optional = true }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b", optional = true }
 png = { version = "0.17.13", optional = true }
 flv-rs = { path = "../flv" }
 async-channel = { workspace = true }

--- a/core/src/debug_ui/avm1.rs
+++ b/core/src/debug_ui/avm1.rs
@@ -32,7 +32,7 @@ impl Avm1ObjectWindow {
         Window::new(object_name(object))
             .id(Id::new(object.as_ptr()))
             .open(&mut keep_open)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(egui_ctx, |ui| {
                 Grid::new(ui.id().with("properties"))
                     .num_columns(2)

--- a/core/src/debug_ui/avm2.rs
+++ b/core/src/debug_ui/avm2.rs
@@ -48,7 +48,7 @@ impl Avm2ObjectWindow {
         Window::new(object_name(activation.context.gc_context, object))
             .id(Id::new(object.as_ptr()))
             .open(&mut keep_open)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(egui_ctx, |ui| {
                 ui.horizontal(|ui| {
                     ui.selectable_value(&mut self.open_panel, Panel::Information, "Information");

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -120,7 +120,7 @@ impl DisplayObjectWindow {
         Window::new(summary_name(object))
             .id(Id::new(object.as_ptr()))
             .open(&mut keep_open)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(egui_ctx, |ui| {
                 ui.horizontal(|ui| {
                     ui.selectable_value(&mut self.open_panel, Panel::Position, "Position");

--- a/core/src/debug_ui/display_object/search.rs
+++ b/core/src/debug_ui/display_object/search.rs
@@ -56,7 +56,7 @@ impl DisplayObjectSearchWindow {
 
         Window::new("Display Object Picker")
             .open(&mut keep_open)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(egui_ctx, |ui| {
                 ui.horizontal(|ui| {
                     ui.checkbox(&mut self.include_hidden, "Include Hidden");

--- a/core/src/debug_ui/movie.rs
+++ b/core/src/debug_ui/movie.rs
@@ -28,7 +28,7 @@ impl MovieListWindow {
 
         Window::new("Known Movie List")
             .open(&mut keep_open)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(egui_ctx, |ui| {
                 let movies = context.library.known_movies();
 
@@ -81,7 +81,7 @@ impl MovieWindow {
         Window::new(movie_name(&movie))
             .id(Id::new(Arc::as_ptr(&movie)))
             .open(&mut keep_open)
-            .scroll2([true, true])
+            .scroll([true, true])
             .show(egui_ctx, |ui| {
                 ui.horizontal(|ui| {
                     ui.selectable_value(&mut self.open_panel, Panel::Information, "Information");

--- a/deny.toml
+++ b/deny.toml
@@ -56,9 +56,14 @@ license-files = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 
-# We are manually pinning `tracing-tracy` to match the version used by
-# `profiling`, but this can get stale easily.
-deny = [{ name = "tracy-client", deny-multiple-versions = true }]
+deny = [
+    # We are manually pinning `tracing-tracy` to match the version used by
+    # `profiling`, but this can get stale easily.
+    { name = "tracy-client", deny-multiple-versions = true },
+    # Having multiple versions of this can silently cause images (such as
+    # the logo in the about dialog) in egui to not appear.
+    { name = "image", deny-multiple-versions = true },
+]
 
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,9 @@ unknown-git = "deny"
 #  github.com organizations to allow git sources for
 github = [
     "ruffle-rs",
+    # TODO: Remove once egui is updated to the first release
+    # with https://github.com/emilk/egui/pull/4160 in it.
+    "emilk",
 ]
 
 [advisories]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 clap = { workspace = true }
 cpal = "0.15.3"
 egui = { workspace = true }
-egui_extras = { version = "0.27.2", features = ["image"] }
-egui-wgpu = { version = "0.27.2", features = ["winit"] }
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b", features = ["image"] }
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b", features = ["winit"] }
 image = { workspace = true, features = ["png"] }
-egui-winit = "0.27.2"
+egui-winit = { git = "https://github.com/emilk/egui.git", rev = "738ea75453567c5f17a543e68aec8c48097cae7b" }
 fontdb = "0.17"
 ruffle_core = { path = "../core", features = ["audio", "clap", "mp3", "nellymoser", "default_compatibility_rules", "egui"] }
 ruffle_render = { path = "../render", features = ["clap"] }

--- a/desktop/src/gui/movie.rs
+++ b/desktop/src/gui/movie.rs
@@ -87,6 +87,7 @@ impl MovieViewRenderer {
                     // 1: vec2 texture coordinates
                     attributes: &wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x2],
                 }],
+                compilation_options: Default::default(),
             },
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
@@ -116,6 +117,7 @@ impl MovieViewRenderer {
                     blend: Some(wgpu::BlendState::REPLACE),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
+                compilation_options: Default::default(),
             }),
             multiview: None,
         });

--- a/render/naga-agal/src/builder.rs
+++ b/render/naga-agal/src/builder.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 use naga::{
     AddressSpace, ArraySize, Block, BuiltIn, Constant, DerivativeControl, EntryPoint,
     FunctionArgument, FunctionResult, GlobalVariable, ImageClass, ImageDimension, Literal,
-    Override, ResourceBinding, Scalar, ShaderStage, StructMember, SwizzleComponent, UnaryOperator,
+    ResourceBinding, Scalar, ShaderStage, StructMember, SwizzleComponent, UnaryOperator,
 };
 use naga::{BinaryOperator, MathFunction};
 use naga::{
@@ -185,13 +185,12 @@ impl VertexAttributeFormat {
 
                 let const_expr_f32_zero = builder
                     .module
-                    .const_expressions
+                    .global_expressions
                     .append(Expression::Literal(Literal::F32(0.0)), Span::UNDEFINED);
 
                 let constant_zero = builder.module.constants.append(
                     Constant {
                         name: None,
-                        r#override: Override::None,
                         ty: builder.f32_type,
                         init: const_expr_f32_zero,
                     },
@@ -209,13 +208,12 @@ impl VertexAttributeFormat {
 
                 let const_expr_f32_1 = builder
                     .module
-                    .const_expressions
+                    .global_expressions
                     .append(Expression::Literal(Literal::F32(1.0)), Span::UNDEFINED);
 
                 let constant_one = builder.module.constants.append(
                     Constant {
                         name: None,
-                        r#override: Override::None,
                         ty: builder.f32_type,
                         init: const_expr_f32_1,
                     },
@@ -683,14 +681,13 @@ impl<'a> NagaBuilder<'a> {
     }
 
     fn emit_const_register_load(&mut self, index: usize) -> Result<Handle<Expression>> {
-        let const_value_expr = self.module.const_expressions.append(
+        let const_value_expr = self.module.global_expressions.append(
             Expression::Literal(Literal::U32(index as u32)),
             Span::UNDEFINED,
         );
         let index_const = self.module.constants.append(
             Constant {
                 name: None,
-                r#override: Override::None,
                 ty: self.u32_type,
                 init: const_value_expr,
             },
@@ -859,7 +856,7 @@ impl<'a> NagaBuilder<'a> {
                             convert: Some(4),
                         });
 
-                        let const_indirect_offset = self.module.const_expressions.append(
+                        let const_indirect_offset = self.module.global_expressions.append(
                             Expression::Literal(Literal::U32(source.indirect_offset as u32)),
                             Span::UNDEFINED,
                         );
@@ -867,7 +864,6 @@ impl<'a> NagaBuilder<'a> {
                         let offset_constant = self.module.constants.append(
                             Constant {
                                 name: None,
-                                r#override: Override::None,
                                 ty: self.u32_type,
                                 init: const_indirect_offset,
                             },
@@ -1602,14 +1598,13 @@ impl<'a> NagaBuilder<'a> {
 
                 let constant_f32_zero = self
                     .module
-                    .const_expressions
+                    .global_expressions
                     .append(Expression::Literal(Literal::F32(0.0)), Span::UNDEFINED);
 
                 // Check `source < 0.0`.
                 let constant_zero = self.module.constants.append(
                     Constant {
                         name: None,
-                        r#override: Override::None,
                         ty: self.f32_type,
                         init: constant_f32_zero,
                     },

--- a/render/wgpu/src/context3d/current_pipeline.rs
+++ b/render/wgpu/src/context3d/current_pipeline.rs
@@ -508,6 +508,7 @@ impl CurrentPipeline {
                     module: &compiled_shaders.vertex_module,
                     entry_point: naga_agal::SHADER_ENTRY_POINT,
                     buffers: &wgpu_vertex_buffers,
+                    compilation_options: Default::default(),
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &compiled_shaders.fragment_module,
@@ -520,6 +521,7 @@ impl CurrentPipeline {
                         }),
                         write_mask: self.color_mask,
                     })],
+                    compilation_options: Default::default(),
                 }),
                 primitive: wgpu::PrimitiveState {
                     // Stage3d appears to use clockwise winding:

--- a/render/wgpu/src/descriptors.rs
+++ b/render/wgpu/src/descriptors.rs
@@ -96,6 +96,7 @@ impl Descriptors {
                                 module: &self.shaders.copy_srgb_shader,
                                 entry_point: "main_vertex",
                                 buffers: &VERTEX_BUFFERS_DESCRIPTION_POS,
+                                compilation_options: Default::default(),
                             },
                             fragment: Some(wgpu::FragmentState {
                                 module: &self.shaders.copy_srgb_shader,
@@ -107,6 +108,7 @@ impl Descriptors {
                                     blend: Some(wgpu::BlendState::REPLACE),
                                     write_mask: Default::default(),
                                 })],
+                                compilation_options: Default::default(),
                             }),
                             primitive: wgpu::PrimitiveState {
                                 topology: wgpu::PrimitiveTopology::TriangleList,
@@ -163,6 +165,7 @@ impl Descriptors {
                                 module: &self.shaders.copy_shader,
                                 entry_point: "main_vertex",
                                 buffers: &VERTEX_BUFFERS_DESCRIPTION_POS,
+                                compilation_options: Default::default(),
                             },
                             fragment: Some(wgpu::FragmentState {
                                 module: &self.shaders.copy_shader,
@@ -174,6 +177,7 @@ impl Descriptors {
                                     blend: Some(wgpu::BlendState::REPLACE),
                                     write_mask: Default::default(),
                                 })],
+                                compilation_options: Default::default(),
                             }),
                             primitive: wgpu::PrimitiveState {
                                 topology: wgpu::PrimitiveTopology::TriangleList,

--- a/render/wgpu/src/filters/bevel.rs
+++ b/render/wgpu/src/filters/bevel.rs
@@ -122,6 +122,7 @@ impl BevelFilter {
                         module: &descriptors.shaders.bevel_filter,
                         entry_point: "main_vertex",
                         buffers: &VERTEX_BUFFERS_DESCRIPTION_FILTERS_WITH_DOUBLE_BLUR,
+                        compilation_options: Default::default(),
                     },
                     primitive: wgpu::PrimitiveState {
                         topology: wgpu::PrimitiveTopology::TriangleList,
@@ -142,6 +143,7 @@ impl BevelFilter {
                         module: &descriptors.shaders.bevel_filter,
                         entry_point: "main_fragment",
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
+                        compilation_options: Default::default(),
                     }),
                     multiview: None,
                 })

--- a/render/wgpu/src/filters/blur.rs
+++ b/render/wgpu/src/filters/blur.rs
@@ -117,6 +117,7 @@ impl BlurFilter {
                         module: &descriptors.shaders.blur_filter,
                         entry_point: "main_vertex",
                         buffers: &VERTEX_BUFFERS_DESCRIPTION_FILTERS,
+                        compilation_options: Default::default(),
                     },
                     primitive: wgpu::PrimitiveState {
                         topology: wgpu::PrimitiveTopology::TriangleList,
@@ -137,6 +138,7 @@ impl BlurFilter {
                         module: &descriptors.shaders.blur_filter,
                         entry_point: "main_fragment",
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
+                        compilation_options: Default::default(),
                     }),
                     multiview: None,
                 })

--- a/render/wgpu/src/filters/color_matrix.rs
+++ b/render/wgpu/src/filters/color_matrix.rs
@@ -98,6 +98,7 @@ impl ColorMatrixFilter {
                         module: &descriptors.shaders.color_matrix_filter,
                         entry_point: "main_vertex",
                         buffers: &VERTEX_BUFFERS_DESCRIPTION_FILTERS,
+                        compilation_options: Default::default(),
                     },
                     primitive: wgpu::PrimitiveState {
                         topology: wgpu::PrimitiveTopology::TriangleList,
@@ -118,6 +119,7 @@ impl ColorMatrixFilter {
                         module: &descriptors.shaders.color_matrix_filter,
                         entry_point: "main_fragment",
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
+                        compilation_options: Default::default(),
                     }),
                     multiview: None,
                 })

--- a/render/wgpu/src/filters/displacement_map.rs
+++ b/render/wgpu/src/filters/displacement_map.rs
@@ -135,6 +135,7 @@ impl DisplacementMapFilter {
                         module: &descriptors.shaders.displacement_map_filter,
                         entry_point: "main_vertex",
                         buffers: &VERTEX_BUFFERS_DESCRIPTION_FILTERS,
+                        compilation_options: Default::default(),
                     },
                     primitive: wgpu::PrimitiveState {
                         topology: wgpu::PrimitiveTopology::TriangleList,
@@ -155,6 +156,7 @@ impl DisplacementMapFilter {
                         module: &descriptors.shaders.displacement_map_filter,
                         entry_point: "main_fragment",
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
+                        compilation_options: Default::default(),
                     }),
                     multiview: None,
                 })

--- a/render/wgpu/src/filters/glow.rs
+++ b/render/wgpu/src/filters/glow.rs
@@ -121,6 +121,7 @@ impl GlowFilter {
                         module: &descriptors.shaders.glow_filter,
                         entry_point: "main_vertex",
                         buffers: &VERTEX_BUFFERS_DESCRIPTION_FILTERS_WITH_BLUR,
+                        compilation_options: Default::default(),
                     },
                     primitive: wgpu::PrimitiveState {
                         topology: wgpu::PrimitiveTopology::TriangleList,
@@ -141,6 +142,7 @@ impl GlowFilter {
                         module: &descriptors.shaders.glow_filter,
                         entry_point: "main_fragment",
                         targets: &[Some(wgpu::TextureFormat::Rgba8Unorm.into())],
+                        compilation_options: Default::default(),
                     }),
                     multiview: None,
                 })

--- a/render/wgpu/src/pipelines.rs
+++ b/render/wgpu/src/pipelines.rs
@@ -243,11 +243,13 @@ fn create_pipeline_descriptor<'a>(
             module: vertex_shader,
             entry_point: "main_vertex",
             buffers: vertex_buffer_layout,
+            compilation_options: Default::default(),
         },
         fragment: Some(wgpu::FragmentState {
             module: fragment_shader,
             entry_point: "main_fragment",
             targets: color_target_state,
+            compilation_options: Default::default(),
         }),
         primitive: wgpu::PrimitiveState {
             topology: wgpu::PrimitiveTopology::TriangleList,

--- a/render/wgpu/src/pixel_bender.rs
+++ b/render/wgpu/src/pixel_bender.rs
@@ -65,6 +65,7 @@ impl PixelBenderWgpuShader {
                                 module: &self.vertex_shader,
                                 entry_point: naga_pixelbender::VERTEX_SHADER_ENTRYPOINT,
                                 buffers: &VERTEX_BUFFERS_DESCRIPTION_FILTERS,
+                                compilation_options: Default::default(),
                             },
                             fragment: Some(wgpu::FragmentState {
                                 module: &self.fragment_shader,
@@ -78,6 +79,7 @@ impl PixelBenderWgpuShader {
                                     }),
                                     write_mask: ColorWrites::all(),
                                 })],
+                                compilation_options: Default::default(),
                             }),
                             primitive: Default::default(),
                             depth_stencil: None,


### PR DESCRIPTION
~~Depends on https://github.com/emilk/egui/pull/4433 and https://github.com/bevyengine/naga_oil/pull/87/~~.
~~Also includes https://github.com/ruffle-rs/ruffle/pull/16077 because https://github.com/emilk/egui/pull/4394 is in `egui` `master`.~~

Builds on top of https://github.com/ruffle-rs/ruffle/pull/16330.
Fixes #15836 by switching to `egui` `master`.