### PR TITLE
desktop: Skip waiting for resize event after resize fails

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -440,8 +440,8 @@ impl App {
                     let viewport_size = self.window.inner_size();
 
                     // On X11 (and possibly other platforms), the window size is not updated immediately.
-                    // Wait for the window to be resized to the requested size before we start running
-                    // the SWF (which can observe the viewport size in "noScale" mode)
+                    // On a successful resize request, wait for the window to be resized to the requested size
+                    // before we start running the SWF (which can observe the viewport size in "noScale" mode)
                     if !window_resize_denied && window_size != viewport_size.into() {
                         loaded = LoadingState::WaitingForResize;
                     } else {

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -420,12 +420,14 @@ impl App {
                     );
 
                     let viewport_size = self.window.inner_size();
+                    let mut window_resize_denied = false;
 
                     if let Some(new_viewport_size) = self.window.request_inner_size(window_size) {
                         if new_viewport_size != viewport_size {
                             self.gui.borrow_mut().resize(new_viewport_size);
                         } else {
                             tracing::warn!("Unable to resize window");
+                            window_resize_denied = true;
                         }
                     }
                     self.window.set_fullscreen(if self.start_fullscreen {
@@ -440,7 +442,7 @@ impl App {
                     // On X11 (and possibly other platforms), the window size is not updated immediately.
                     // Wait for the window to be resized to the requested size before we start running
                     // the SWF (which can observe the viewport size in "noScale" mode)
-                    if window_size != viewport_size.into() {
+                    if !window_resize_denied && window_size != viewport_size.into() {
                         loaded = LoadingState::WaitingForResize;
                     } else {
                         loaded = LoadingState::Loaded;


### PR DESCRIPTION
Under hyprland tiling window manager, the resize event fails and the loading stops until the user manually resizes the window to trigger a resize event. 

This should fix that by not waiting for a resize event to continue loading if we know the resize failed.

The resize also fails even if the window is floating, so that may be something worth looking into separately.