### PR TITLE
web: Don't append and subsequently remove link just to download files

### DIFF
--- a/web/packages/core/src/ruffle-player.ts
+++ b/web/packages/core/src/ruffle-player.ts
@@ -1152,11 +1152,8 @@ export class RufflePlayer extends HTMLElement {
         const blobURL = URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = blobURL;
-        link.style.display = "none";
         link.download = name;
-        document.body.appendChild(link);
         link.click();
-        document.body.removeChild(link);
         URL.revokeObjectURL(blobURL);
     }
 


### PR DESCRIPTION
The `download_as_file` function in #16178, which is the `web_sys` version of this function just with `&[u8]` as input instead of a blob, made me realize this is unnecessary as it's not done in that function.