### PR TITLE
avm2: share binding skip optimization with `call_method`

### DIFF
--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -249,15 +249,16 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
                 if let Some(bound_method) = self.get_bound_method(disp_id) {
                     return Ok(bound_method.into());
                 }
-                let vtable = self.vtable().unwrap();
-                if let Some(bound_method) =
-                    vtable.make_bound_method(activation, self.into(), disp_id)
-                {
-                    self.install_bound_method(activation.context.gc_context, disp_id, bound_method);
-                    Ok(bound_method.into())
-                } else {
-                    Err("Method not found".into())
-                }
+
+                let bound_method = self
+                    .vtable()
+                    .expect("object to have a vtable")
+                    .make_bound_method(activation, self.into(), disp_id)
+                    .ok_or_else(|| format!("Method not found with id {disp_id}"))?;
+
+                self.install_bound_method(activation.context.gc_context, disp_id, bound_method);
+
+                Ok(bound_method.into())
             }
             Some(Property::Virtual { get: Some(get), .. }) => {
                 self.call_method(get, &[], activation)
@@ -501,43 +502,7 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
 
                 obj.call(Value::from(self.into()), arguments, activation)
             }
-            Some(Property::Method { disp_id }) => {
-                let vtable = self.vtable().unwrap();
-                if let Some(ClassBoundMethod {
-                    class,
-                    scope,
-                    method,
-                }) = vtable.get_full_method(disp_id)
-                {
-                    if !method.needs_arguments_object() {
-                        Executable::from_method(method, scope, None, Some(class)).exec(
-                            Value::from(self.into()),
-                            arguments,
-                            activation,
-                            class.into(), //Deliberately invalid.
-                        )
-                    } else {
-                        if let Some(bound_method) = self.get_bound_method(disp_id) {
-                            return bound_method.call(
-                                Value::from(self.into()),
-                                arguments,
-                                activation,
-                            );
-                        }
-                        let bound_method = vtable
-                            .make_bound_method(activation, self.into(), disp_id)
-                            .unwrap();
-                        self.install_bound_method(
-                            activation.context.gc_context,
-                            disp_id,
-                            bound_method,
-                        );
-                        bound_method.call(Value::from(self.into()), arguments, activation)
-                    }
-                } else {
-                    Err("Method not found".into())
-                }
-            }
+            Some(Property::Method { disp_id }) => self.call_method(disp_id, arguments, activation),
             Some(Property::Virtual { get: Some(get), .. }) => {
                 let obj = self.call_method(get, &[], activation)?.as_callable(
                     activation,
@@ -611,27 +576,43 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
     /// Call a method by its index.
     ///
     /// This directly corresponds with the AVM2 operation `callmethod`.
-    #[allow(unused_mut)] //Not unused.
     fn call_method(
-        mut self,
+        self,
         id: u32,
         arguments: &[Value<'gc>],
         activation: &mut Activation<'_, 'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        if self.get_bound_method(id).is_none() {
-            if let Some(vtable) = self.vtable() {
-                if let Some(bound_method) = vtable.make_bound_method(activation, self.into(), id) {
-                    self.install_bound_method(activation.context.gc_context, id, bound_method);
-                }
-            }
+        if let Some(bound_method) = self.get_bound_method(id) {
+            return bound_method.call(Value::from(self.into()), arguments, activation);
         }
 
-        let bound_method = self.get_bound_method(id);
-        if let Some(method_object) = bound_method {
-            return method_object.call(Value::from(self.into()), arguments, activation);
+        let full_method = self
+            .vtable()
+            .expect("method to have a vtable")
+            .get_full_method(id)
+            .ok_or_else(|| format!("Cannot call unknown method id {id}"))?;
+
+        // Execute immediately if this method doesn't require binding
+        if !full_method.method.needs_arguments_object() {
+            let ClassBoundMethod {
+                method,
+                scope,
+                class,
+            } = full_method;
+
+            return Executable::from_method(method, scope, None, Some(class)).exec(
+                Value::from(self.into()),
+                arguments,
+                activation,
+                class.into(), //Deliberately invalid.
+            );
         }
 
-        Err(format!("Cannot call unknown method id {id}").into())
+        let bound_method = VTable::bind_method(activation, self.into(), full_method);
+
+        self.install_bound_method(activation.context.gc_context, id, bound_method);
+
+        bound_method.call(Value::from(self.into()), arguments, activation)
     }
 
     /// Implements the `in` opcode and AS3 operator.

--- a/core/src/avm2/vtable.rs
+++ b/core/src/avm2/vtable.rs
@@ -532,22 +532,23 @@ impl<'gc> VTable<'gc> {
         receiver: Object<'gc>,
         disp_id: u32,
     ) -> Option<FunctionObject<'gc>> {
-        if let Some(ClassBoundMethod {
+        self.get_full_method(disp_id)
+            .map(|method| Self::bind_method(activation, receiver, method))
+    }
+
+    /// Bind an instance method to a receiver, allowing it to be used as a value. See `VTable::make_bound_method`
+    pub fn bind_method(
+        activation: &mut Activation<'_, 'gc>,
+        receiver: Object<'gc>,
+        method: ClassBoundMethod<'gc>,
+    ) -> FunctionObject<'gc> {
+        let ClassBoundMethod {
             class,
             scope,
             method,
-        }) = self.get_full_method(disp_id)
-        {
-            Some(FunctionObject::from_method(
-                activation,
-                method,
-                scope,
-                Some(receiver),
-                Some(class),
-            ))
-        } else {
-            None
-        }
+        } = method;
+
+        FunctionObject::from_method(activation, method, scope, Some(receiver), Some(class))
     }
 
     /// Install a const trait on the global object.


### PR DESCRIPTION
This PR shares the optimization from `call_property` which skips binding methods that don't need receivers with `call_method`. Currently, for example, Chess Demons allocates almost 1GB of unnecessary function objects during loading, this patch fixes that:
```
Command                            USS 
./ruffle_desktop_opt cd.swf       1.5G 
./ruffle_desktop_no_opt cd.swf    2.5G
```
A quick `perf stat` run shows a small decrease in loading time and page faults cut in half:
```
Performance counter stats for './ruffle_desktop_opt cd.swf':

        20,082.41 msec task-clock:u                     #    0.582 CPUs utilized             
                0      context-switches:u               #    0.000 /sec                      
                0      cpu-migrations:u                 #    0.000 /sec                      
          376,719      page-faults:u                    #   18.759 K/sec                     
   94,845,384,958      cycles:u                         #    4.723 GHz                       
  182,895,351,746      instructions:u                   #    1.93  insn per cycle            
   29,683,116,696      branches:u                       #    1.478 G/sec                     
      199,608,906      branch-misses:u                  #    0.67% of all branches           

     34.511689417 seconds time elapsed

     18.827233000 seconds user
      1.218733000 seconds sys
```
```
Performance counter stats for './ruffle_desktop_no_opt cd.swf':

        21,512.53 msec task-clock:u                     #    0.592 CPUs utilized             
                0      context-switches:u               #    0.000 /sec                      
                0      cpu-migrations:u                 #    0.000 /sec                      
          634,737      page-faults:u                    #   29.505 K/sec                     
  100,060,811,478      cycles:u                         #    4.651 GHz                       
  187,065,447,138      instructions:u                   #    1.87  insn per cycle            
   30,586,698,113      branches:u                       #    1.422 G/sec                     
      189,874,657      branch-misses:u                  #    0.62% of all branches           

     36.345462896 seconds time elapsed

     19.933122000 seconds user
      1.542323000 seconds sys
```
Thanks to @adrian17 for figuring out the problem and suggesting this fix! 