### PR TITLE
core,render: Improve performance of "round to nearest, ties to even" float operations

### DIFF
--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -45,17 +45,11 @@ pub fn f64_to_wrapping_i32(n: f64) -> i32 {
 
 /// Implements the IEEE-754 "Round to nearest, ties to even" rounding rule.
 /// (e.g., both 1.5 and 2.5 will round to 2).
-/// Although this is easy to do on most architectures, Rust provides no standard
-/// way to round in this manner (`f64::round` always rounds away from zero).
-/// For more info and the below code snippet, see: https://github.com/rust-lang/rust/issues/55107
 /// This also clamps out-of-range values and NaN to `i32::MIN`.
-/// TODO: Investigate using SSE/wasm intrinsics for this.
 pub fn round_to_even(n: f64) -> i32 {
-    let k = 1.0 / f64::EPSILON;
-    let a = n.abs();
-    let out = if a < k { ((a + k) - k).copysign(n) } else { n };
+    let out = n.round_ties_even();
     // Clamp out-of-range values to `i32::MIN`.
-    if out.is_finite() && out >= i32::MIN.into() && out <= i32::MAX.into() {
+    if out.is_finite() && out <= i32::MAX.into() {
         out as i32
     } else {
         i32::MIN

--- a/core/src/ecma_conversions.rs
+++ b/core/src/ecma_conversions.rs
@@ -61,3 +61,38 @@ pub fn round_to_even(n: f64) -> i32 {
         i32::MIN
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::round_to_even;
+
+    #[test]
+    fn test_round_to_even() {
+        assert_eq!(round_to_even(0.0), 0);
+        assert_eq!(round_to_even(2.0), 2);
+        assert_eq!(round_to_even(2.1), 2);
+        assert_eq!(round_to_even(2.5), 2);
+        assert_eq!(round_to_even(2.9), 3);
+        assert_eq!(round_to_even(3.0), 3);
+        assert_eq!(round_to_even(3.1), 3);
+        assert_eq!(round_to_even(3.5), 4);
+        assert_eq!(round_to_even(3.9), 4);
+        assert_eq!(round_to_even(4.0), 4);
+        assert_eq!(round_to_even(-2.0), -2);
+        assert_eq!(round_to_even(-2.1), -2);
+        assert_eq!(round_to_even(-2.5), -2);
+        assert_eq!(round_to_even(-2.9), -3);
+        assert_eq!(round_to_even(-3.0), -3);
+        assert_eq!(round_to_even(-3.1), -3);
+        assert_eq!(round_to_even(-3.5), -4);
+        assert_eq!(round_to_even(-3.9), -4);
+        assert_eq!(round_to_even(-4.0), -4);
+        assert_eq!(round_to_even(f64::NAN), i32::MIN);
+        assert_eq!(round_to_even(f64::INFINITY), i32::MIN);
+        assert_eq!(round_to_even(f64::NEG_INFINITY), i32::MIN);
+        assert_eq!(round_to_even(-2147483648f64), i32::MIN);
+        assert_eq!(round_to_even(-2247483648f64), i32::MIN);
+        assert_eq!(round_to_even(2147483647f64), i32::MAX);
+        assert_eq!(round_to_even(2247483647f64), i32::MIN);
+    }
+}

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -1,5 +1,7 @@
 use swf::{Fixed16, Point, PointDelta, Rectangle, Twips};
 
+/// TODO: Consider using portable SIMD when it's stable (https://doc.rust-lang.org/std/simd/index.html).
+
 /// The transformation matrix used by Flash display objects.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Matrix {
@@ -286,18 +288,11 @@ impl From<Matrix> for swf::Matrix {
 /// Implements the IEEE-754 "Round to nearest, ties to even" rounding rule.
 /// (e.g., both 1.5 and 2.5 will round to 2).
 /// This is the rounding method used by Flash for the above transforms.
-/// Although this is easy to do on most architectures, Rust provides no standard
-/// way to round in this manner (`f32::round` always rounds away from zero).
-/// For more info and the below code snippet, see: https://github.com/rust-lang/rust/issues/55107
 /// This also clamps out-of-range values and NaN to `i32::MIN`.
-/// TODO: Investigate using SSE/wasm intrinsics for this.
 fn round_to_i32(f: f32) -> i32 {
     if f.is_finite() {
-        let a = f.abs();
         if f < 2_147_483_648.0_f32 {
-            let k = 1.0 / f32::EPSILON;
-            let out = if a < k { ((a + k) - k).copysign(f) } else { f };
-            out as i32
+            f.round_ties_even() as i32
         } else {
             // Out-of-range clamps to MIN.
             i32::MIN

--- a/render/src/matrix.rs
+++ b/render/src/matrix.rs
@@ -957,4 +957,36 @@ mod tests {
             PointDelta::new(Twips::new(141), Twips::new(-7)),
         ),
     );
+
+    #[test]
+    fn test_round_to_i32() {
+        assert_eq!(round_to_i32(0.0), 0);
+        assert_eq!(round_to_i32(2.0), 2);
+        assert_eq!(round_to_i32(2.1), 2);
+        assert_eq!(round_to_i32(2.5), 2);
+        assert_eq!(round_to_i32(2.9), 3);
+        assert_eq!(round_to_i32(3.0), 3);
+        assert_eq!(round_to_i32(3.1), 3);
+        assert_eq!(round_to_i32(3.5), 4);
+        assert_eq!(round_to_i32(3.9), 4);
+        assert_eq!(round_to_i32(4.0), 4);
+        assert_eq!(round_to_i32(-2.0), -2);
+        assert_eq!(round_to_i32(-2.1), -2);
+        assert_eq!(round_to_i32(-2.5), -2);
+        assert_eq!(round_to_i32(-2.9), -3);
+        assert_eq!(round_to_i32(-3.0), -3);
+        assert_eq!(round_to_i32(-3.1), -3);
+        assert_eq!(round_to_i32(-3.5), -4);
+        assert_eq!(round_to_i32(-3.9), -4);
+        assert_eq!(round_to_i32(-4.0), -4);
+        assert_eq!(round_to_i32(f32::NAN), 0);
+        assert_eq!(round_to_i32(f32::INFINITY), 0);
+        assert_eq!(round_to_i32(f32::NEG_INFINITY), 0);
+        assert_eq!(round_to_i32(-2147483520f32), -2147483520);
+        assert_eq!(round_to_i32(-2147483648f32), i32::MIN);
+        assert_eq!(round_to_i32(-2147483904f32), i32::MIN);
+        assert_eq!(round_to_i32(2147483520f32), 2147483520);
+        assert_eq!(round_to_i32(2147483648f32), i32::MIN);
+        assert_eq!(round_to_i32(2147483904f32), i32::MIN);
+    }
 }


### PR DESCRIPTION
This patch improves performance of `ecma_conversions::round_to_even()` and `matrix::round_to_i32()`:
1. by using `f64::round_ties_even()`/`f32::round_ties_even()`, which have been stable since 1.77.0, instead of a custom algorithm; and
2. by removing an unnecessary comparison to `i32::MIN`, as casting a float to an integer automatically saturates values smaller than the minimum integer value to the minimum value of the integer type.

A primitive benchmark shows around 20% faster execution of these operations. In the case of `matrix::round_to_i32()` we can potentially expect noticeable improvements in overall performance as this operation is quite commonly used.

| Platform | Operation | Type | Improvement |
| -------- | --------- | ---- | ------- |
| amd64    | `ecma_conversions::round_to_even()` | `f64` | ~21% |
| WASM amd64 | `ecma_conversions::round_to_even()` | `f64` | ~20% |
| amd64    | `matrix::round_to_i32()` | `f32` | ~22% |
| WASM amd64 | `matrix::round_to_i32()` | `f32` | ~23% |

Those functions have been covered by tests to ensure the behavior hasn't changed.
