### PR TITLE
avm2: Optimize `findpropstrict`, `findproperty`, and `getlex`

### DIFF
--- a/core/src/avm2.rs
+++ b/core/src/avm2.rs
@@ -585,7 +585,7 @@ impl<'gc> Avm2<'gc> {
 
         if !flags.contains(DoAbc2Flag::LAZY_INITIALIZE) {
             for i in 0..num_scripts {
-                if let Some(mut script) = tunit.get_script(i) {
+                if let Some(script) = tunit.get_script(i) {
                     script.globals(&mut activation.context)?;
                 }
             }

--- a/core/src/avm2/activation.rs
+++ b/core/src/avm2/activation.rs
@@ -922,6 +922,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
                 Op::FindDef { multiname } => self.op_find_def(*multiname),
                 Op::FindProperty { multiname } => self.op_find_property(*multiname),
                 Op::FindPropStrict { multiname } => self.op_find_prop_strict(*multiname),
+                Op::GetScriptGlobals { script } => self.op_get_script_globals(*script),
                 Op::GetDescendants { multiname } => self.op_get_descendants(*multiname),
                 Op::GetSlot { index } => self.op_get_slot(*index),
                 Op::SetSlot { index } => self.op_set_slot(*index),
@@ -1667,7 +1668,7 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         // Verifier ensures that multiname is non-lazy
 
         avm_debug!(self.avm2(), "Resolving {:?}", *multiname);
-        let (_, mut script) = self.domain().find_defining_script(self, &multiname)?;
+        let (_, script) = self.domain().find_defining_script(self, &multiname)?;
         let obj = script.globals(&mut self.context)?;
         self.push_stack(obj);
         Ok(FrameControl::Continue)
@@ -1703,6 +1704,17 @@ impl<'a, 'gc> Activation<'a, 'gc> {
         let result: Value<'gc> = found?.into();
 
         self.push_stack(result);
+
+        Ok(FrameControl::Continue)
+    }
+
+    fn op_get_script_globals(
+        &mut self,
+        script: Script<'gc>,
+    ) -> Result<FrameControl<'gc>, Error<'gc>> {
+        let globals = script.globals(&mut self.context)?;
+
+        self.push_stack(globals);
 
         Ok(FrameControl::Continue)
     }

--- a/core/src/avm2/domain.rs
+++ b/core/src/avm2/domain.rs
@@ -263,7 +263,7 @@ impl<'gc> Domain<'gc> {
         activation: &mut Activation<'_, 'gc>,
         name: QName<'gc>,
     ) -> Result<Value<'gc>, Error<'gc>> {
-        let (name, mut script) = self.find_defining_script(activation, &name.into())?;
+        let (name, script) = self.find_defining_script(activation, &name.into())?;
         let globals = script.globals(&mut activation.context)?;
 
         globals.get_property(&name.into(), activation)

--- a/core/src/avm2/globals.rs
+++ b/core/src/avm2/globals.rs
@@ -24,7 +24,7 @@ mod date;
 mod error;
 pub mod flash;
 mod function;
-mod global_scope;
+pub mod global_scope;
 mod int;
 mod json;
 mod math;
@@ -61,7 +61,6 @@ pub struct SystemClasses<'gc> {
     pub object: ClassObject<'gc>,
     pub function: ClassObject<'gc>,
     pub class: ClassObject<'gc>,
-    pub global: ClassObject<'gc>,
     pub string: ClassObject<'gc>,
     pub boolean: ClassObject<'gc>,
     pub number: ClassObject<'gc>,
@@ -186,17 +185,11 @@ impl<'gc> SystemClasses<'gc> {
     /// the empty object also handed to this function. It is the caller's
     /// responsibility to instantiate each class and replace the empty object
     /// with that.
-    fn new(
-        object: ClassObject<'gc>,
-        function: ClassObject<'gc>,
-        class: ClassObject<'gc>,
-        global: ClassObject<'gc>,
-    ) -> Self {
+    fn new(object: ClassObject<'gc>, function: ClassObject<'gc>, class: ClassObject<'gc>) -> Self {
         SystemClasses {
             object,
             function,
             class,
-            global,
             // temporary initialization
             string: object,
             boolean: object,
@@ -515,12 +508,8 @@ pub fn load_player_globals<'gc>(
     // order to continue initializing the player. The rest of the classes
     // are set to a temporary class until we have a chance to initialize them.
 
-    activation.context.avm2.system_classes = Some(SystemClasses::new(
-        object_class,
-        fn_class,
-        class_class,
-        global_class,
-    ));
+    activation.context.avm2.system_classes =
+        Some(SystemClasses::new(object_class, fn_class, class_class));
 
     // Our activation environment is now functional enough to finish
     // initializing the core class weave. We need to initialize superclasses
@@ -546,7 +535,6 @@ pub fn load_player_globals<'gc>(
 
     globals.set_proto(mc, global_proto);
     globals.set_instance_of(mc, global_class);
-    globals.fork_vtable(mc);
 
     activation.context.avm2.toplevel_global_object = Some(globals);
 

--- a/core/src/avm2/object.rs
+++ b/core/src/avm2/object.rs
@@ -1144,14 +1144,6 @@ pub trait TObject<'gc>: 'gc + Collect + Debug + Into<Object<'gc>> + Clone + Copy
         base.set_vtable(vtable);
     }
 
-    // Duplicates the vtable for modification without subclassing
-    // Note: this detaches the vtable from the original class.
-    fn fork_vtable(&self, mc: &Mutation<'gc>) {
-        let mut base = self.base_mut(mc);
-        let vtable = base.vtable().unwrap().duplicate(mc);
-        base.set_vtable(vtable);
-    }
-
     /// Try to corece this object into a `ClassObject`.
     fn as_class_object(&self) -> Option<ClassObject<'gc>> {
         None

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -134,9 +134,6 @@ pub enum Op<'gc> {
     GetGlobalSlot {
         index: u32,
     },
-    GetLex {
-        multiname: Gc<'gc, Multiname<'gc>>,
-    },
     GetLocal {
         index: u32,
     },

--- a/core/src/avm2/op.rs
+++ b/core/src/avm2/op.rs
@@ -1,5 +1,6 @@
 use crate::avm2::class::Class;
 use crate::avm2::multiname::Multiname;
+use crate::avm2::script::Script;
 use crate::string::AvmAtom;
 
 use gc_arena::{Collect, Gc};
@@ -145,6 +146,9 @@ pub enum Op<'gc> {
     },
     GetScopeObject {
         index: u8,
+    },
+    GetScriptGlobals {
+        script: Script<'gc>,
     },
     GetSlot {
         index: u32,

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -2,7 +2,7 @@ use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::method::{BytecodeMethod, ResolvedParamConfig};
 use crate::avm2::multiname::Multiname;
-use crate::avm2::object::ClassObject;
+use crate::avm2::object::{ClassObject, TObject};
 use crate::avm2::op::Op;
 use crate::avm2::property::Property;
 use crate::avm2::verify::JumpSources;
@@ -791,9 +791,17 @@ pub fn optimize<'gc>(
                         {
                             *op = Op::GetScriptGlobals { script };
 
+
+                            let script_globals = script
+                                .globals(&mut activation.context)
+                                .expect("Script should be resolved if traits exist");
+
                             stack_push_done = true;
-                            // Pushing the `global` class doesn't work because of the `fork_vtable` hack
-                            stack.push_any();
+                            if let Some(global_class) = script_globals.instance_of() {
+                                stack.push_class_object(global_class);
+                            } else {
+                                stack.push_any();
+                            }
                         }
                     }
 

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -798,15 +798,15 @@ pub fn optimize<'gc>(
                         {
                             *op = Op::GetScriptGlobals { script };
 
-                            let script_globals = script
-                                .globals(&mut activation.context)
-                                .expect("Script should be resolved if traits exist");
+                            let script_globals = script.globals_if_init();
 
-                            stack_push_done = true;
-                            if let Some(global_class) = script_globals.instance_of() {
-                                stack.push_class_object(global_class);
-                            } else {
-                                stack.push_any();
+                            if let Some(script_globals) = script_globals {
+                                stack_push_done = true;
+                                if let Some(global_class) = script_globals.instance_of() {
+                                    stack.push_class_object(global_class);
+                                } else {
+                                    stack.push_any();
+                                }
                             }
                         }
                     }

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -730,9 +730,6 @@ pub fn optimize<'gc>(
                 let local_type = local_types.at(*index as usize);
                 stack.push(local_type);
             }
-            Op::GetLex { .. } => {
-                stack.push_any();
-            }
             Op::FindPropStrict { multiname } => {
                 stack.pop_for_multiname(*multiname);
 

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -785,6 +785,8 @@ pub fn optimize<'gc>(
                                     stack.push_any();
                                 }
                             } else {
+                                // If `get_entry_for_multiname` returned `Some(None)`, there was
+                                // a `with` scope in the outer ScopeChain- abort optimization.
                                 stack_push_done = true;
                                 stack.push_any();
                             }

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -1216,17 +1216,15 @@ pub fn optimize<'gc>(
             Op::GetGlobalScope => {
                 let mut stack_push_done = false;
 
-                if has_simple_scoping {
-                    let outer_scope = activation.outer();
-                    if !outer_scope.is_empty() {
-                        let global_scope = outer_scope.get_unchecked(0);
+                let outer_scope = activation.outer();
+                if !outer_scope.is_empty() {
+                    let global_scope = outer_scope.get_unchecked(0);
 
-                        stack_push_done = true;
-                        if let Some(class) = global_scope.values().instance_of() {
-                            stack.push_class_object(class);
-                        } else {
-                            stack.push_any();
-                        }
+                    stack_push_done = true;
+                    if let Some(class) = global_scope.values().instance_of() {
+                        stack.push_class_object(class);
+                    } else {
+                        stack.push_any();
                     }
                 }
 
@@ -1237,32 +1235,30 @@ pub fn optimize<'gc>(
             Op::GetGlobalSlot { index: slot_id } => {
                 let mut stack_push_done = false;
 
-                if has_simple_scoping {
-                    let outer_scope = activation.outer();
-                    if !outer_scope.is_empty() {
-                        let global_scope = outer_scope.get_unchecked(0);
+                let outer_scope = activation.outer();
+                if !outer_scope.is_empty() {
+                    let global_scope = outer_scope.get_unchecked(0);
 
-                        if let Some(class) = global_scope.values().instance_of() {
-                            if !class.inner_class_definition().is_interface() {
-                                let mut value_class =
-                                    class.instance_vtable().slot_classes()[*slot_id as usize];
-                                let resolved_value_class = value_class.get_class(activation);
-                                if let Ok(class) = resolved_value_class {
-                                    stack_push_done = true;
+                    if let Some(class) = global_scope.values().instance_of() {
+                        if !class.inner_class_definition().is_interface() {
+                            let mut value_class =
+                                class.instance_vtable().slot_classes()[*slot_id as usize];
+                            let resolved_value_class = value_class.get_class(activation);
+                            if let Ok(class) = resolved_value_class {
+                                stack_push_done = true;
 
-                                    if let Some(class) = class {
-                                        stack.push_class(class);
-                                    } else {
-                                        stack.push_any();
-                                    }
+                                if let Some(class) = class {
+                                    stack.push_class(class);
+                                } else {
+                                    stack.push_any();
                                 }
-
-                                class.instance_vtable().set_slot_class(
-                                    activation.context.gc_context,
-                                    *slot_id as usize,
-                                    value_class,
-                                );
                             }
+
+                            class.instance_vtable().set_slot_class(
+                                activation.context.gc_context,
+                                *slot_id as usize,
+                                value_class,
+                            );
                         }
                     }
                 }

--- a/core/src/avm2/optimize.rs
+++ b/core/src/avm2/optimize.rs
@@ -795,6 +795,10 @@ pub fn optimize<'gc>(
                         if let Ok(Some((_, script))) =
                             outer_scope.domain().get_defining_script(&multiname)
                         {
+                            // NOTE: avmplus rewrites this into a FindDef, and it caches
+                            // the results of that FindDef at runtime, rather than caching
+                            // the lookup here, in the verifier. However, this discrepancy
+                            // is unlikely to cause any real problems with SWFs.
                             *op = Op::GetScriptGlobals { script };
 
                             let script_globals = script.globals_if_init();

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -237,18 +237,18 @@ impl<'gc> ScopeChain<'gc> {
     pub fn get_entry_for_multiname(
         &self,
         multiname: &Multiname<'gc>,
-    ) -> Option<(Option<ClassObject<'gc>>, u32)> {
+    ) -> Option<Option<(Option<ClassObject<'gc>>, u32)>> {
         if let Some(container) = self.container {
             for (index, scope) in container.scopes.iter().enumerate().skip(1).rev() {
                 if scope.with() {
                     // If this is a `with` scope, stop here because
                     // dynamic properties could be added at any time
-                    return None;
+                    return Some(None);
                 }
 
                 let values = scope.values();
                 if values.has_trait(&multiname) {
-                    return Some((values.instance_of(), index as u32));
+                    return Some(Some((values.instance_of(), index as u32)));
                 }
             }
         }

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -247,7 +247,7 @@ impl<'gc> ScopeChain<'gc> {
                 }
 
                 let values = scope.values();
-                if values.has_trait(&multiname) {
+                if values.has_trait(multiname) {
                     return Some(Some((values.instance_of(), index as u32)));
                 }
             }

--- a/core/src/avm2/scope.rs
+++ b/core/src/avm2/scope.rs
@@ -253,6 +253,8 @@ impl<'gc> ScopeChain<'gc> {
             }
         }
 
+        // Nothing was found, and we can be sure that nothing will be
+        // found here at all (there were no `with` scopes).
         None
     }
 

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -18,6 +18,7 @@ use crate::tag_utils::SwfMovie;
 use crate::PlayerRuntime;
 use gc_arena::{Collect, Gc, GcCell, Mutation};
 use std::cell::Ref;
+use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::Arc;
 use swf::avm2::types::{
@@ -558,10 +559,7 @@ impl<'gc> Script<'gc> {
     ///
     /// If the script has not yet been initialized, this will initialize it on
     /// the same stack.
-    pub fn globals(
-        &mut self,
-        context: &mut UpdateContext<'_, 'gc>,
-    ) -> Result<Object<'gc>, Error<'gc>> {
+    pub fn globals(&self, context: &mut UpdateContext<'_, 'gc>) -> Result<Object<'gc>, Error<'gc>> {
         let mut write = self.0.write(context.gc_context);
 
         if !write.initialized {
@@ -604,5 +602,13 @@ impl<'gc> Script<'gc> {
         }
 
         Ok(Ref::map(read, |read| &read.traits[..]))
+    }
+}
+
+impl<'gc> Debug for Script<'gc> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_struct("Script")
+            .field("ptr", &self.0.as_ptr())
+            .finish()
     }
 }

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -4,8 +4,9 @@ use super::api_version::ApiVersion;
 use crate::avm2::activation::Activation;
 use crate::avm2::class::Class;
 use crate::avm2::domain::Domain;
+use crate::avm2::globals::global_scope;
 use crate::avm2::method::{BytecodeMethod, Method};
-use crate::avm2::object::{Object, TObject};
+use crate::avm2::object::{ClassObject, Object, TObject};
 use crate::avm2::scope::ScopeChain;
 use crate::avm2::traits::{Trait, TraitKind};
 use crate::avm2::value::Value;
@@ -247,9 +248,15 @@ impl<'gc> TranslationUnit<'gc> {
 
         drop(read);
 
-        let global_class = activation.avm2().classes().global;
+        let object_class = activation.avm2().classes().object;
+
+        let global_classdef =
+            global_scope::create_class(activation, object_class.inner_class_definition());
+
+        let global_class =
+            ClassObject::from_class(activation, global_classdef, Some(object_class))?;
+
         let global_obj = global_class.construct(activation, &[])?;
-        global_obj.fork_vtable(activation.context.gc_context);
 
         let mut script =
             Script::from_abc_index(self, script_index, global_obj, domain, activation)?;

--- a/core/src/avm2/script.rs
+++ b/core/src/avm2/script.rs
@@ -597,6 +597,19 @@ impl<'gc> Script<'gc> {
         }
     }
 
+    /// Return the global scope for the script.
+    ///
+    /// If the script has not yet been initialized, this will return None.
+    pub fn globals_if_init(&self) -> Option<Object<'gc>> {
+        let read = self.0.read();
+
+        if !read.initialized {
+            None
+        } else {
+            Some(read.globals)
+        }
+    }
+
     /// Return traits for this script.
     ///
     /// This function will return an error if it is incorrectly called before

--- a/core/src/avm2/verify.rs
+++ b/core/src/avm2/verify.rs
@@ -331,6 +331,14 @@ pub fn verify_method<'gc>(
                         )?));
                     }
 
+                    // Split this `GetLex` into a `FindPropStrict` and a `GetProperty`.
+                    // A `GetLex` is guaranteed to take up at least 2 bytes. We need
+                    // one byte for the opcode and at least one byte for the multiname
+                    // index. Overwrite the op registered at the opcode byte with a
+                    // `FindPropStrict` op, and register a non-jumpable `GetProperty`
+                    // op at the next byte. This isn't the best way to do it, but it's
+                    // simpler than actually emitting ops and rewriting the jump offsets
+                    // to match.
                     assert!(bytes_read > 1);
                     byte_info[previous_position as usize] =
                         ByteInfo::OpStart(AbcOp::FindPropStrict { index });


### PR DESCRIPTION
Also propagate types from `getslot`, `getglobalscope`, and `getglobalslot`.

A single `getlex QName(PackageNamespace(""), "Math")` executes about 2.5x faster with this PR.

New stats for box2d:
```
FindPropStrict -> GetScriptGlobals : 45.16%
FindPropStrict -> GetOuterScope : 7.87%
FindPropStrict -> GetScopeObject : 1.69%

FindProperty -> GetOuterScope : 2.83%
FindProperty -> GetScopeObject : 5.66%

InitProperty -> SetSlot : 38.15%
InitProperty -> SetSlotNoCoerce : 37.87%

SetProperty -> SetSlot : 15.03%
SetProperty -> SetSlotNoCoerce : 30.42%
SetProperty -> CallMethod : 1.57%

GetProperty -> GetSlot : 59.69%
GetProperty -> CallMethod : 0.34%

CallProperty -> CallMethod : 31.45%

CallPropVoid -> CallMethod : 61.74%

Coerce -> Nop : 46.95%

CoerceD -> Nop : 78.36%

CoerceB -> Nop : 8.11%

CoerceU -> Nop: 32.46%

CoerceI -> Nop : 2%

ReturnValue -> ReturnValueNoCoerce : 65.14%
```

(note: `getproperty` probably went down in percentage because we now split `getlex` into `findpropstrict` and `getproperty`, and the `getproperty` doesn't always optimize to a `getslot`- so the percentage looks like it went down, even though the getlex is faster)

Overall any optimization improvements other than the early scope resolution are tiny. Stockfish seems to start a little faster.

TODO:
- [x] Handle lazy multiname passed to `findproperty`/`findpropstrict`
- [x] Appease clippy