### PR TITLE
debug_ui: Add a tab for interactive objects

### DIFF
--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -472,32 +472,36 @@ impl DisplayObjectWindow {
             .num_columns(2)
             .show(ui, |ui| {
                 ui.label("Current Focus");
-                if let Some(focus) = focus.map(|o| o.as_displayobject()) {
-                    open_display_object_button(
-                        ui,
-                        context,
-                        messages,
-                        focus,
-                        &mut self.hovered_debug_rect,
-                    );
-                    if ui.button("Clear").clicked() {
-                        focus_tracker.set(None, context);
+                ui.vertical(|ui| {
+                    if let Some(focus) = focus.map(|o| o.as_displayobject()) {
+                        open_display_object_button(
+                            ui,
+                            context,
+                            messages,
+                            focus,
+                            &mut self.hovered_debug_rect,
+                        );
+                        ui.horizontal(|ui| {
+                            if ui.button("Clear").clicked() {
+                                focus_tracker.set(None, context);
+                            }
+                            if ui.button("Re-focus").clicked() {
+                                focus_tracker.set(None, context);
+                                focus_tracker.set(focus.as_interactive(), context);
+                            }
+                        });
+                    } else {
+                        ui.label("None");
                     }
-                    if ui.button("Re-focus").clicked() {
-                        focus_tracker.set(None, context);
-                        focus_tracker.set(focus.as_interactive(), context);
-                    }
-                } else {
-                    ui.label("None");
-                }
+                });
                 ui.end_row();
 
                 let highlight = focus_tracker.highlight();
                 ui.label("Focus Highlight");
                 let highlight_text = match highlight {
-                    Highlight::Inactive => "inactive",
-                    Highlight::ActiveHidden => "active, hidden",
-                    Highlight::ActiveVisible => "active, visible",
+                    Highlight::Inactive => "Inactive",
+                    Highlight::ActiveHidden => "Active, Hidden",
+                    Highlight::ActiveVisible => "Active, Visible",
                 };
                 ui.label(highlight_text);
                 ui.end_row();

--- a/core/src/debug_ui/display_object.rs
+++ b/core/src/debug_ui/display_object.rs
@@ -471,6 +471,14 @@ impl DisplayObjectWindow {
         Grid::new(ui.id().with("stage"))
             .num_columns(2)
             .show(ui, |ui| {
+                ui.label("Stage Focus Rect");
+                let mut new_stage_focus_rect = object.stage_focus_rect();
+                ui.checkbox(&mut new_stage_focus_rect, "Enabled");
+                if new_stage_focus_rect != object.stage_focus_rect() {
+                    object.set_stage_focus_rect(context.gc(), new_stage_focus_rect);
+                }
+                ui.end_row();
+
                 ui.label("Current Focus");
                 ui.vertical(|ui| {
                     if let Some(focus) = focus.map(|o| o.as_displayobject()) {

--- a/core/src/display_object.rs
+++ b/core/src/display_object.rs
@@ -2487,6 +2487,22 @@ pub trait TDisplayObject<'gc>:
             false
         }
     }
+
+    fn set_avm1_property(
+        self,
+        context: &mut UpdateContext<'_, 'gc>,
+        name: &'static str,
+        value: Avm1Value<'gc>,
+    ) {
+        if let Avm1Value::Object(object) = self.object() {
+            let mut activation = Activation::from_nothing(
+                context.reborrow(),
+                Avm1ActivationIdentifier::root("[AVM1 Property Set]"),
+                self.avm1_root(),
+            );
+            let _ = object.set(name, value, &mut activation);
+        }
+    }
 }
 
 pub enum DisplayObjectPtr {}

--- a/core/src/display_object/avm1_button.rs
+++ b/core/src/display_object/avm1_button.rs
@@ -599,8 +599,8 @@ impl<'gc> TInteractiveObject<'gc> for Avm1Button<'gc> {
         }
     }
 
-    fn tab_enabled_avm1(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        self.get_avm1_boolean_property(context, "tabEnabled", |_| true)
+    fn tab_enabled_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
+        true
     }
 
     fn highlight_bounds(self) -> Rectangle<Twips> {

--- a/core/src/display_object/avm2_button.rs
+++ b/core/src/display_object/avm2_button.rs
@@ -821,7 +821,7 @@ impl<'gc> TInteractiveObject<'gc> for Avm2Button<'gc> {
         }
     }
 
-    fn tab_enabled_avm2_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
+    fn tab_enabled_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
         true
     }
 }

--- a/core/src/display_object/edit_text.rs
+++ b/core/src/display_object/edit_text.rs
@@ -2459,11 +2459,7 @@ impl<'gc> TInteractiveObject<'gc> for EditText<'gc> {
         self.tab_enabled(context)
     }
 
-    fn tab_enabled_avm1(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        self.get_avm1_boolean_property(context, "tabEnabled", |_| true)
-    }
-
-    fn tab_enabled_avm2_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
+    fn tab_enabled_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
         self.is_editable()
     }
 }

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -658,7 +658,8 @@ pub trait TInteractiveObject<'gc>:
         if context.swf.is_action_script_3() {
             self.raw_interactive_mut(context.gc()).tab_enabled = Some(value)
         } else {
-            tracing::warn!("Trying to set tab_enabled on an AVM1 object, this has no effect")
+            self.as_displayobject()
+                .set_avm1_property(context, "tabEnabled", value.into());
         }
     }
 

--- a/core/src/display_object/interactive.rs
+++ b/core/src/display_object/interactive.rs
@@ -641,20 +641,16 @@ pub trait TInteractiveObject<'gc>:
         if context.swf.is_action_script_3() {
             self.raw_interactive()
                 .tab_enabled
-                .unwrap_or_else(|| self.tab_enabled_avm2_default(context))
+                .unwrap_or_else(|| self.tab_enabled_default(context))
         } else {
-            self.tab_enabled_avm1(context)
+            self.as_displayobject()
+                .get_avm1_boolean_property(context, "tabEnabled", |context| {
+                    self.tab_enabled_default(context)
+                })
         }
     }
 
-    /// Look up the `tabEnabled` property from AVM1.
-    ///
-    /// Do not use this directly, use [`Self::is_tabbable()`] or [`Self::tab_enabled()`].
-    fn tab_enabled_avm1(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
-        false
-    }
-
-    fn tab_enabled_avm2_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
+    fn tab_enabled_default(&self, _context: &mut UpdateContext<'_, 'gc>) -> bool {
         false
     }
 

--- a/core/src/display_object/movie_clip.rs
+++ b/core/src/display_object/movie_clip.rs
@@ -3369,14 +3369,17 @@ impl<'gc> TInteractiveObject<'gc> for MovieClip<'gc> {
         }
     }
 
-    fn tab_enabled_avm1(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        self.get_avm1_boolean_property(context, "tabEnabled", |context| {
-            self.tab_index().is_some() || self.is_button_mode(context)
-        })
-    }
+    fn tab_enabled_default(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
+        if self.is_button_mode(context) {
+            return true;
+        }
 
-    fn tab_enabled_avm2_default(&self, context: &mut UpdateContext<'_, 'gc>) -> bool {
-        self.is_button_mode(context)
+        let is_avm1 = !context.swf.is_action_script_3();
+        if is_avm1 && self.tab_index().is_some() {
+            return true;
+        }
+
+        false
     }
 }
 


### PR DESCRIPTION
Newly implemented "Interactive" tab:

![image](https://github.com/ruffle-rs/ruffle/assets/1507072/3c56654d-21c4-485d-a841-92829fbbbbda)

Some visual improvements for "Stage" tab:
![image](https://github.com/ruffle-rs/ruffle/assets/1507072/bb7de487-590e-4024-959a-47925c6acc7a)
